### PR TITLE
Feature/transaction kernel

### DIFF
--- a/algorithms/src/commitment_tree/commitment_tree.rs
+++ b/algorithms/src/commitment_tree/commitment_tree.rs
@@ -25,7 +25,8 @@ use std::io::{Read, Result as IoResult, Write};
 #[derivative(
     Clone(bound = "C: CommitmentScheme, H: CRH"),
     PartialEq(bound = "C: CommitmentScheme, H: CRH"),
-    Eq(bound = "C: CommitmentScheme, H: CRH")
+    Eq(bound = "C: CommitmentScheme, H: CRH"),
+    Debug(bound = "C: CommitmentScheme, H: CRH")
 )]
 pub struct CommitmentMerkleTree<C: CommitmentScheme, H: CRH> {
     /// The computed root of the full Merkle tree.
@@ -38,7 +39,7 @@ pub struct CommitmentMerkleTree<C: CommitmentScheme, H: CRH> {
     leaves: [<C as CommitmentScheme>::Output; 4],
 
     /// The CRH parameters used to construct the Merkle tree
-    #[derivative(PartialEq = "ignore")]
+    #[derivative(PartialEq = "ignore", Debug = "ignore")]
     parameters: H,
 }
 

--- a/algorithms/src/commitment_tree/commitment_tree.rs
+++ b/algorithms/src/commitment_tree/commitment_tree.rs
@@ -17,7 +17,9 @@
 use crate::commitment_tree::CommitmentMerklePath;
 use snarkvm_errors::algorithms::MerkleError;
 use snarkvm_models::algorithms::{CommitmentScheme, CRH};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+
+use std::io::{Read, Result as IoResult, Write};
 
 #[derive(Derivative)]
 #[derivative(
@@ -96,6 +98,51 @@ impl<C: CommitmentScheme, H: CRH> CommitmentMerkleTree<C, H> {
         let inner_hashes = self.inner_hashes.clone();
 
         Ok(CommitmentMerklePath { leaves, inner_hashes })
+    }
+
+    pub fn from_bytes<R: Read>(mut reader: R, parameters: H) -> IoResult<Self> {
+        let root = <H as CRH>::Output::read(&mut reader)?;
+
+        let left_inner_hash = <H as CRH>::Output::read(&mut reader)?;
+        let right_inner_hash = <H as CRH>::Output::read(&mut reader)?;
+
+        let inner_hashes = (left_inner_hash, right_inner_hash);
+
+        let mut leaves = vec![];
+        for _ in 0..4 {
+            let leaf = <C as CommitmentScheme>::Output::read(&mut reader)?;
+            leaves.push(leaf);
+        }
+
+        assert_eq!(leaves.len(), 4);
+
+        let leaves = [
+            leaves[0].clone(),
+            leaves[1].clone(),
+            leaves[2].clone(),
+            leaves[3].clone(),
+        ];
+
+        Ok(Self {
+            root,
+            inner_hashes,
+            leaves,
+            parameters,
+        })
+    }
+}
+
+impl<C: CommitmentScheme, H: CRH> ToBytes for CommitmentMerkleTree<C, H> {
+    #[inline]
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.root.write(&mut writer)?;
+        self.inner_hashes.0.write(&mut writer)?;
+        self.inner_hashes.1.write(&mut writer)?;
+        for leaf in &self.leaves {
+            leaf.write(&mut writer)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/algorithms/src/commitment_tree/tests.rs
+++ b/algorithms/src/commitment_tree/tests.rs
@@ -101,6 +101,21 @@ fn commitment_tree_bad_root_test() {
 }
 
 #[test]
+fn test_serialize_commitment_merkle_tree() {
+    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+
+    let commitment = C::setup(rng);
+    let crh = H::setup(rng);
+
+    let merkle_tree = generate_merkle_tree(&commitment, &crh, rng);
+
+    let merkle_tree_bytes = to_bytes![merkle_tree].unwrap();
+    let recovered_merkle_tree = CommitmentMerkleTree::<C, H>::from_bytes(&merkle_tree_bytes[..], crh).unwrap();
+
+    assert!(merkle_tree == recovered_merkle_tree);
+}
+
+#[test]
 fn test_serialize_commitment_path() {
     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
 

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -259,7 +259,7 @@ impl<Components: BaseDPCComponents> FromBytes for TransactionKernel<Components> 
                 &system_parameters.account_commitment,
                 &private_key_seed,
             )
-                .expect("could not load private key");
+            .expect("could not load private key");
             old_account_private_keys.push(old_account_private_key);
         }
 
@@ -340,7 +340,7 @@ impl<Components: BaseDPCComponents> FromBytes for TransactionKernel<Components> 
                 &mut reader,
                 system_parameters.local_data_crh.clone(),
             )
-                .expect("Could not load local data merkle tree");
+            .expect("Could not load local data merkle tree");
 
         let mut local_data_commitment_randomizers = vec![];
         for _ in 0..4 {
@@ -558,7 +558,6 @@ where
     >,
 {
     type Account = Account<Components>;
-    type TransactionKernel = TransactionKernel<Components>;
     type LocalData = LocalData<Components>;
     type Metadata = [u8; 32];
     type Parameters = PublicParameters<Components>;
@@ -567,6 +566,7 @@ where
     type Record = DPCRecord<Components>;
     type SystemParameters = SystemParameters<Components>;
     type Transaction = DPCTransaction<Components>;
+    type TransactionKernel = TransactionKernel<Components>;
 
     fn setup<R: Rng>(
         ledger_parameters: &Components::MerkleParameters,

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -42,11 +42,15 @@ use snarkvm_utilities::{
     has_duplicates,
     rand::UniformRand,
     to_bytes,
+    variable_length_integer::*,
 };
 
 use itertools::{izip, Itertools};
 use rand::Rng;
-use std::marker::PhantomData;
+use std::{
+    io::{Read, Result as IoResult, Write},
+    marker::PhantomData,
+};
 
 pub mod inner_circuit;
 pub use inner_circuit::*;
@@ -171,6 +175,208 @@ impl<Components: BaseDPCComponents> TransactionKernel<Components> {
             memorandum: self.memorandum,
             network_id: self.network_id,
         }
+    }
+}
+
+impl<Components: BaseDPCComponents> ToBytes for TransactionKernel<Components> {
+    #[inline]
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write old record components
+
+        for old_account_private_key in &self.old_account_private_keys {
+            let private_key_seed = old_account_private_key.seed;
+            private_key_seed.write(&mut writer)?;
+        }
+
+        for old_record in &self.old_records {
+            old_record.write(&mut writer)?;
+        }
+
+        for old_serial_number in &self.old_serial_numbers {
+            old_serial_number.write(&mut writer)?;
+        }
+
+        for old_randomizer in &self.old_randomizers {
+            variable_length_integer(old_randomizer.len() as u64).write(&mut writer)?;
+            old_randomizer.write(&mut writer)?;
+        }
+
+        // Write new record components
+
+        for new_record in &self.new_records {
+            new_record.write(&mut writer)?;
+        }
+
+        for new_sn_nonce_randomness in &self.new_sn_nonce_randomness {
+            new_sn_nonce_randomness.write(&mut writer)?;
+        }
+
+        for new_commitment in &self.new_commitments {
+            new_commitment.write(&mut writer)?;
+        }
+
+        for new_records_encryption_randomness in &self.new_records_encryption_randomness {
+            new_records_encryption_randomness.write(&mut writer)?;
+        }
+
+        for new_encrypted_record in &self.new_encrypted_records {
+            new_encrypted_record.write(&mut writer)?;
+        }
+
+        for new_encrypted_record_hash in &self.new_encrypted_record_hashes {
+            new_encrypted_record_hash.write(&mut writer)?;
+        }
+
+        // Write transaction components
+
+        self.program_commitment.write(&mut writer)?;
+        self.program_randomness.write(&mut writer)?;
+
+        self.local_data_merkle_tree.write(&mut writer)?;
+
+        for local_data_commitment_randomizer in &self.local_data_commitment_randomizers {
+            local_data_commitment_randomizer.write(&mut writer)?;
+        }
+
+        self.value_balance.write(&mut writer)?;
+        self.memorandum.write(&mut writer)?;
+        self.network_id.write(&mut writer)
+    }
+}
+
+impl<Components: BaseDPCComponents> FromBytes for TransactionKernel<Components> {
+    #[inline]
+    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+        let system_parameters = SystemParameters::<Components>::load().expect("Could not load system parameters");
+
+        // Read old record components
+
+        let mut old_account_private_keys = vec![];
+        for _ in 0..Components::NUM_INPUT_RECORDS {
+            let private_key_seed: [u8; 32] = FromBytes::read(&mut reader)?;
+            let old_account_private_key = AccountPrivateKey::<Components>::from_seed(
+                &system_parameters.account_signature,
+                &system_parameters.account_commitment,
+                &private_key_seed,
+            )
+                .expect("could not load private key");
+            old_account_private_keys.push(old_account_private_key);
+        }
+
+        let mut old_records = vec![];
+        for _ in 0..Components::NUM_INPUT_RECORDS {
+            let old_record: DPCRecord<Components> = FromBytes::read(&mut reader)?;
+            old_records.push(old_record);
+        }
+
+        let mut old_serial_numbers = vec![];
+        for _ in 0..Components::NUM_INPUT_RECORDS {
+            let old_serial_number: <Components::AccountSignature as SignatureScheme>::PublicKey =
+                FromBytes::read(&mut reader)?;
+            old_serial_numbers.push(old_serial_number);
+        }
+
+        let mut old_randomizers = vec![];
+        for _ in 0..Components::NUM_INPUT_RECORDS {
+            let num_bytes = read_variable_length_integer(&mut reader)?;
+            let mut randomizer = vec![];
+            for _ in 0..num_bytes {
+                let byte: u8 = FromBytes::read(&mut reader)?;
+                randomizer.push(byte);
+            }
+
+            old_randomizers.push(randomizer);
+        }
+
+        // Read new record components
+
+        let mut new_records = vec![];
+        for _ in 0..Components::NUM_OUTPUT_RECORDS {
+            let new_record: DPCRecord<Components> = FromBytes::read(&mut reader)?;
+            new_records.push(new_record);
+        }
+
+        let mut new_sn_nonce_randomness = vec![];
+        for _ in 0..Components::NUM_OUTPUT_RECORDS {
+            let randomness: [u8; 32] = FromBytes::read(&mut reader)?;
+            new_sn_nonce_randomness.push(randomness);
+        }
+
+        let mut new_commitments = vec![];
+        for _ in 0..Components::NUM_OUTPUT_RECORDS {
+            let new_commitment: <Components::RecordCommitment as CommitmentScheme>::Output =
+                FromBytes::read(&mut reader)?;
+            new_commitments.push(new_commitment);
+        }
+
+        let mut new_records_encryption_randomness = vec![];
+        for _ in 0..Components::NUM_OUTPUT_RECORDS {
+            let encryption_randomness: <Components::AccountEncryption as EncryptionScheme>::Randomness =
+                FromBytes::read(&mut reader)?;
+            new_records_encryption_randomness.push(encryption_randomness);
+        }
+
+        let mut new_encrypted_records = vec![];
+        for _ in 0..Components::NUM_OUTPUT_RECORDS {
+            let encrypted_record: EncryptedRecord<Components> = FromBytes::read(&mut reader)?;
+            new_encrypted_records.push(encrypted_record);
+        }
+
+        let mut new_encrypted_record_hashes = vec![];
+        for _ in 0..Components::NUM_OUTPUT_RECORDS {
+            let encrypted_record_hash: <Components::EncryptedRecordCRH as CRH>::Output = FromBytes::read(&mut reader)?;
+            new_encrypted_record_hashes.push(encrypted_record_hash);
+        }
+
+        // Read transaction components
+
+        let program_commitment: <Components::ProgramVerificationKeyCommitment as CommitmentScheme>::Output =
+            FromBytes::read(&mut reader)?;
+        let program_randomness: <Components::ProgramVerificationKeyCommitment as CommitmentScheme>::Randomness =
+            FromBytes::read(&mut reader)?;
+
+        let local_data_merkle_tree =
+            CommitmentMerkleTree::<Components::LocalDataCommitment, Components::LocalDataCRH>::from_bytes(
+                &mut reader,
+                system_parameters.local_data_crh.clone(),
+            )
+                .expect("Could not load local data merkle tree");
+
+        let mut local_data_commitment_randomizers = vec![];
+        for _ in 0..4 {
+            let local_data_commitment_randomizer: <Components::LocalDataCommitment as CommitmentScheme>::Randomness =
+                FromBytes::read(&mut reader)?;
+            local_data_commitment_randomizers.push(local_data_commitment_randomizer);
+        }
+
+        let value_balance: AleoAmount = FromBytes::read(&mut reader)?;
+        let memorandum: <DPCTransaction<Components> as Transaction>::Memorandum = FromBytes::read(&mut reader)?;
+        let network_id: u8 = FromBytes::read(&mut reader)?;
+
+        Ok(Self {
+            system_parameters,
+
+            old_records,
+            old_account_private_keys,
+            old_serial_numbers,
+            old_randomizers,
+
+            new_records,
+            new_sn_nonce_randomness,
+            new_commitments,
+
+            new_records_encryption_randomness,
+            new_encrypted_records,
+            new_encrypted_record_hashes,
+
+            program_commitment,
+            program_randomness,
+            local_data_merkle_tree,
+            local_data_commitment_randomizers,
+            value_balance,
+            memorandum,
+            network_id,
+        })
     }
 }
 

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -498,7 +498,7 @@ impl<Components: BaseDPCComponents> DPC<Components> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn generate_record<R: Rng>(
-        system_parameters: SystemParameters<Components>,
+        system_parameters: &SystemParameters<Components>,
         sn_nonce: <Components::SerialNumberNonceCRH as CRH>::Output,
         owner: AccountAddress<Components>,
         is_dummy: bool,
@@ -712,7 +712,7 @@ where
             end_timer!(sn_nonce_time);
 
             let record = Self::generate_record(
-                parameters.clone(),
+                &parameters,
                 sn_nonce,
                 new_record_owner,
                 new_is_dummy_flags[j],

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -124,7 +124,7 @@ pub struct DPC<Components: BaseDPCComponents> {
 /// final transaction after `execute_offline` has created old serial numbers,
 /// new records and commitments. For convenience, it also
 /// stores references to existing information like old records and secret keys.
-pub struct ExecuteContext<Components: BaseDPCComponents> {
+pub struct TransactionKernel<Components: BaseDPCComponents> {
     system_parameters: SystemParameters<Components>,
 
     // Old record stuff
@@ -154,7 +154,7 @@ pub struct ExecuteContext<Components: BaseDPCComponents> {
     network_id: u8,
 }
 
-impl<Components: BaseDPCComponents> ExecuteContext<Components> {
+impl<Components: BaseDPCComponents> TransactionKernel<Components> {
     #[allow(clippy::wrong_self_convention)]
     pub fn into_local_data(&self) -> LocalData<Components> {
         LocalData {
@@ -352,7 +352,7 @@ where
     >,
 {
     type Account = Account<Components>;
-    type ExecuteContext = ExecuteContext<Components>;
+    type TransactionKernel = TransactionKernel<Components>;
     type LocalData = LocalData<Components>;
     type Metadata = [u8; 32];
     type Parameters = PublicParameters<Components>;
@@ -448,7 +448,7 @@ where
         memorandum: <Self::Transaction as Transaction>::Memorandum,
         network_id: u8,
         rng: &mut R,
-    ) -> anyhow::Result<Self::ExecuteContext> {
+    ) -> anyhow::Result<Self::TransactionKernel> {
         assert_eq!(Components::NUM_INPUT_RECORDS, old_records.len());
         assert_eq!(Components::NUM_INPUT_RECORDS, old_account_private_keys.len());
 
@@ -617,7 +617,7 @@ where
             new_encrypted_record_hashes.push(encrypted_record_hash);
         }
 
-        let context = ExecuteContext {
+        let context = TransactionKernel {
             system_parameters: parameters,
 
             old_records,
@@ -647,7 +647,7 @@ where
 
     fn execute_online<R: Rng>(
         parameters: &Self::Parameters,
-        context: Self::ExecuteContext,
+        context: Self::TransactionKernel,
         old_death_program_proofs: Vec<Self::PrivateProgramInput>,
         new_birth_program_proofs: Vec<Self::PrivateProgramInput>,
         ledger: &L,
@@ -658,7 +658,7 @@ where
 
         let exec_time = start_timer!(|| "BaseDPC::execute_online");
 
-        let ExecuteContext {
+        let TransactionKernel {
             system_parameters,
 
             old_records,

--- a/dpc/src/base_dpc/record/encrypted_record.rs
+++ b/dpc/src/base_dpc/record/encrypted_record.rs
@@ -30,7 +30,8 @@ use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 #[derivative(
     Clone(bound = "C: BaseDPCComponents"),
     PartialEq(bound = "C: BaseDPCComponents"),
-    Eq(bound = "C: BaseDPCComponents")
+    Eq(bound = "C: BaseDPCComponents"),
+    Debug(bound = "C: BaseDPCComponents")
 )]
 pub struct EncryptedRecord<C: BaseDPCComponents> {
     pub encrypted_record: Vec<<<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text>,

--- a/dpc/src/base_dpc/record/tests.rs
+++ b/dpc/src/base_dpc/record/tests.rs
@@ -62,7 +62,7 @@ fn test_record_serialization() {
             let payload: [u8; 32] = rng.gen();
 
             let given_record = DPC::generate_record(
-                system_parameters.clone(),
+                &system_parameters,
                 SerialNumberNonce::hash(&system_parameters.serial_number_nonce, &sn_nonce_input).unwrap(),
                 dummy_account.address,
                 false,
@@ -129,7 +129,7 @@ fn test_record_encryption() {
             let payload: [u8; 32] = rng.gen();
 
             let given_record = DPC::generate_record(
-                system_parameters.clone(),
+                &system_parameters,
                 SerialNumberNonce::hash(&system_parameters.serial_number_nonce, &sn_nonce_input).unwrap(),
                 dummy_account.address,
                 false,

--- a/dpc/src/base_dpc/test.rs
+++ b/dpc/src/base_dpc/test.rs
@@ -118,7 +118,7 @@ fn test_execute_base_dpc_constraints() {
 
     let sn_nonce = SerialNumberNonce::hash(&system_parameters.serial_number_nonce, &[0u8; 1]).unwrap();
     let old_record = DPC::generate_record(
-        system_parameters.clone(),
+        &system_parameters,
         sn_nonce,
         dummy_account.address,
         true,

--- a/dpc/src/base_dpc/test.rs
+++ b/dpc/src/base_dpc/test.rs
@@ -23,7 +23,7 @@ use crate::base_dpc::{
     record::record_encryption::*,
     record_payload::RecordPayload,
     BaseDPCComponents,
-    ExecuteContext,
+    TransactionKernel,
     DPC,
 };
 use snarkvm_algorithms::merkle_tree::MerklePath;
@@ -210,7 +210,7 @@ fn test_execute_base_dpc_constraints() {
         new_proof_and_vk.push(private_input);
     }
 
-    let ExecuteContext {
+    let TransactionKernel {
         system_parameters: _,
 
         old_records,

--- a/dpc/src/base_dpc/test.rs
+++ b/dpc/src/base_dpc/test.rs
@@ -19,6 +19,7 @@ use crate::base_dpc::{
     execute_inner_proof_gadget,
     execute_outer_proof_gadget,
     inner_circuit::InnerCircuit,
+    parameters::{NoopProgramSNARKParameters, SystemParameters},
     program::*,
     record::record_encryption::*,
     record_payload::RecordPayload,
@@ -45,13 +46,109 @@ use snarkvm_objects::{
     ProofOfSuccinctWork,
 };
 use snarkvm_testing::storage::*;
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{
+    bytes::{FromBytes, ToBytes},
+    to_bytes,
+};
 
 use itertools::Itertools;
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 type L = Ledger<Tx, CommitmentMerkleParameters>;
+
+/// Generates and returns noop program parameters and its corresponding program id.
+fn generate_test_noop_program_parameters<R: Rng>(
+    system_parameters: &SystemParameters<Components>,
+    rng: &mut R,
+) -> (NoopProgramSNARKParameters<Components>, Vec<u8>) {
+    let noop_program_snark_pp =
+        InstantiatedDPC::generate_noop_program_snark_parameters(&system_parameters, rng).unwrap();
+
+    let noop_program_id = to_bytes![
+        ProgramVerificationKeyCRH::hash(
+            &system_parameters.program_verification_key_crh,
+            &to_bytes![noop_program_snark_pp.verification_key].unwrap()
+        )
+        .unwrap()
+    ]
+    .unwrap();
+
+    (noop_program_snark_pp, noop_program_id)
+}
+
+#[test]
+fn test_transaction_kernel_serialization() {
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+    // Generate parameters for the ledger, commitment schemes, CRH, and the
+    // "always-accept" program.
+    let system_parameters = InstantiatedDPC::generate_system_parameters(&mut rng).unwrap();
+
+    let (_noop_program_snark_pp, noop_program_id) = generate_test_noop_program_parameters(&system_parameters, &mut rng);
+
+    // Generate metadata and an account for a dummy initial record.
+    let test_account = Account::new(
+        &system_parameters.account_signature,
+        &system_parameters.account_commitment,
+        &system_parameters.account_encryption,
+        &mut rng,
+    )
+    .unwrap();
+
+    let sn_nonce = SerialNumberNonce::hash(&system_parameters.serial_number_nonce, &[0u8; 1]).unwrap();
+    let old_record = DPC::generate_record(
+        &system_parameters,
+        sn_nonce,
+        test_account.address.clone(),
+        true,
+        0,
+        RecordPayload::default(),
+        noop_program_id.clone(),
+        noop_program_id.clone(),
+        &mut rng,
+    )
+    .unwrap();
+
+    // Set the input records for our transaction to be the initial dummy records.
+    let old_records = vec![old_record; NUM_INPUT_RECORDS];
+    let old_account_private_keys = vec![test_account.private_key.clone(); NUM_INPUT_RECORDS];
+
+    // Construct new records.
+
+    let new_record_owners = vec![test_account.address; NUM_OUTPUT_RECORDS];
+    let new_is_dummy_flags = vec![false; NUM_OUTPUT_RECORDS];
+    let new_values = vec![10; NUM_OUTPUT_RECORDS];
+    let new_payloads = vec![RecordPayload::default(); NUM_OUTPUT_RECORDS];
+    let new_birth_program_ids = vec![noop_program_id.clone(); NUM_OUTPUT_RECORDS];
+    let new_death_program_ids = vec![noop_program_id.clone(); NUM_OUTPUT_RECORDS];
+    let memo = [0u8; 32];
+
+    // Generate transaction kernel
+    let transaction_kernel = <InstantiatedDPC as DPCScheme<L>>::execute_offline(
+        system_parameters.clone(),
+        old_records,
+        old_account_private_keys,
+        new_record_owners,
+        &new_is_dummy_flags,
+        &new_values,
+        new_payloads,
+        new_birth_program_ids,
+        new_death_program_ids,
+        memo,
+        0,
+        &mut rng,
+    )
+    .unwrap();
+
+    // Serialize the transaction kernel
+    let transaction_kernel_bytes = to_bytes![&transaction_kernel].unwrap();
+
+    let recovered_transaction_kernel: <InstantiatedDPC as DPCScheme<L>>::TransactionKernel =
+        FromBytes::read(&transaction_kernel_bytes[..]).unwrap();
+
+    assert_eq!(transaction_kernel, recovered_transaction_kernel);
+}
 
 #[test]
 fn test_execute_base_dpc_constraints() {
@@ -64,28 +161,10 @@ fn test_execute_base_dpc_constraints() {
     // "always-accept" program.
     let ledger_parameters = CommitmentMerkleParameters::setup(&mut rng);
     let system_parameters = InstantiatedDPC::generate_system_parameters(&mut rng).unwrap();
-    let noop_program_snark_pp =
-        InstantiatedDPC::generate_noop_program_snark_parameters(&system_parameters, &mut rng).unwrap();
-    let alternate_noop_program_snark_pp =
-        InstantiatedDPC::generate_noop_program_snark_parameters(&system_parameters, &mut rng).unwrap();
 
-    let noop_program_id = to_bytes![
-        ProgramVerificationKeyCRH::hash(
-            &system_parameters.program_verification_key_crh,
-            &to_bytes![noop_program_snark_pp.verification_key].unwrap()
-        )
-        .unwrap()
-    ]
-    .unwrap();
-
-    let alternate_noop_program_id = to_bytes![
-        ProgramVerificationKeyCRH::hash(
-            &system_parameters.program_verification_key_crh,
-            &to_bytes![alternate_noop_program_snark_pp.verification_key].unwrap()
-        )
-        .unwrap()
-    ]
-    .unwrap();
+    let (noop_program_snark_pp, noop_program_id) = generate_test_noop_program_parameters(&system_parameters, &mut rng);
+    let (alternate_noop_program_snark_pp, alternate_noop_program_id) =
+        generate_test_noop_program_parameters(&system_parameters, &mut rng);
 
     let signature_parameters = &system_parameters.account_signature;
     let commitment_parameters = &system_parameters.account_commitment;
@@ -156,7 +235,7 @@ fn test_execute_base_dpc_constraints() {
     let new_death_program_ids = vec![noop_program_id.clone(); NUM_OUTPUT_RECORDS];
     let memo = [0u8; 32];
 
-    let context = <InstantiatedDPC as DPCScheme<L>>::execute_offline(
+    let transaction_kernel = <InstantiatedDPC as DPCScheme<L>>::execute_offline(
         system_parameters.clone(),
         old_records,
         old_account_private_keys,
@@ -172,7 +251,7 @@ fn test_execute_base_dpc_constraints() {
     )
     .unwrap();
 
-    let local_data = context.into_local_data();
+    let local_data = transaction_kernel.into_local_data();
 
     // Generate the program proofs
 
@@ -233,7 +312,7 @@ fn test_execute_base_dpc_constraints() {
         value_balance,
         memorandum,
         network_id,
-    } = context;
+    } = transaction_kernel;
 
     let local_data_root = local_data_merkle_tree.root();
 

--- a/dpc/tests/base_dpc.rs
+++ b/dpc/tests/base_dpc.rs
@@ -99,7 +99,7 @@ fn base_dpc_integration_test() {
         )
         .unwrap();
         let old_record = DPC::generate_record(
-            parameters.system_parameters.clone(),
+            &parameters.system_parameters,
             old_sn_nonce,
             genesis_account.address.clone(),
             true, // The input record is dummy

--- a/dpc/tests/base_dpc.rs
+++ b/dpc/tests/base_dpc.rs
@@ -125,8 +125,8 @@ fn base_dpc_integration_test() {
 
     let memo = [4u8; 32];
 
-    // Offline execution to generate a DPC transaction
-    let execute_context = <InstantiatedDPC as DPCScheme<L>>::execute_offline(
+    // Offline execution to generate a DPC transaction kernel
+    let transaction_kernel = <InstantiatedDPC as DPCScheme<L>>::execute_offline(
         parameters.system_parameters.clone(),
         old_records,
         old_account_private_keys,
@@ -142,7 +142,7 @@ fn base_dpc_integration_test() {
     )
     .unwrap();
 
-    let local_data = execute_context.into_local_data();
+    let local_data = transaction_kernel.into_local_data();
 
     // Generate the program proofs
 
@@ -180,7 +180,7 @@ fn base_dpc_integration_test() {
 
     let (new_records, transaction) = InstantiatedDPC::execute_online(
         &parameters,
-        execute_context,
+        transaction_kernel,
         old_death_program_proofs,
         new_birth_program_proofs,
         &ledger,

--- a/models/src/dpc/dpc.rs
+++ b/models/src/dpc/dpc.rs
@@ -31,7 +31,7 @@ pub trait DPCScheme<L: LedgerScheme> {
     type SystemParameters;
     type Transaction: Transaction<SerialNumber = <Self::Record as Record>::SerialNumber>;
     type LocalData;
-    type ExecuteContext;
+    type TransactionKernel;
 
     /// Returns public parameters for the DPC.
     fn setup<R: Rng>(ledger_parameters: &L::MerkleParameters, rng: &mut R) -> anyhow::Result<Self::Parameters>;
@@ -54,13 +54,13 @@ pub trait DPCScheme<L: LedgerScheme> {
         memorandum: <Self::Transaction as Transaction>::Memorandum,
         network_id: u8,
         rng: &mut R,
-    ) -> anyhow::Result<Self::ExecuteContext>;
+    ) -> anyhow::Result<Self::TransactionKernel>;
 
     /// Returns new records and a transaction based on the authorized
     /// consumption of old records.
     fn execute_online<R: Rng>(
         parameters: &Self::Parameters,
-        execute_context: Self::ExecuteContext,
+        transaction_kernel: Self::TransactionKernel,
         old_death_program_proofs: Vec<Self::PrivateProgramInput>,
         new_birth_program_proofs: Vec<Self::PrivateProgramInput>,
         ledger: &L,

--- a/models/src/dpc/dpc_components.rs
+++ b/models/src/dpc/dpc_components.rs
@@ -70,10 +70,8 @@ pub trait DPCComponents: 'static + Sized {
     type ProgramVerificationKeyCommitment: CommitmentScheme;
     /// Used to commit to hashes of verification keys on the smaller curve and to decommit hashes
     /// of verification keys on the larger curve
-    type ProgramVerificationKeyCommitmentGadget: CommitmentGadget<
-        Self::ProgramVerificationKeyCommitment,
-        Self::InnerField,
-    > + CommitmentGadget<Self::ProgramVerificationKeyCommitment, Self::OuterField>;
+    type ProgramVerificationKeyCommitmentGadget: CommitmentGadget<Self::ProgramVerificationKeyCommitment, Self::InnerField>
+        + CommitmentGadget<Self::ProgramVerificationKeyCommitment, Self::OuterField>;
 
     /// PRF for computing serial numbers. Invoked only over `Self::InnerField`.
     type PRF: PRF;

--- a/models/src/dpc/dpc_components.rs
+++ b/models/src/dpc/dpc_components.rs
@@ -70,8 +70,10 @@ pub trait DPCComponents: 'static + Sized {
     type ProgramVerificationKeyCommitment: CommitmentScheme;
     /// Used to commit to hashes of verification keys on the smaller curve and to decommit hashes
     /// of verification keys on the larger curve
-    type ProgramVerificationKeyCommitmentGadget: CommitmentGadget<Self::ProgramVerificationKeyCommitment, Self::InnerField>
-        + CommitmentGadget<Self::ProgramVerificationKeyCommitment, Self::OuterField>;
+    type ProgramVerificationKeyCommitmentGadget: CommitmentGadget<
+        Self::ProgramVerificationKeyCommitment,
+        Self::InnerField,
+    > + CommitmentGadget<Self::ProgramVerificationKeyCommitment, Self::OuterField>;
 
     /// PRF for computing serial numbers. Invoked only over `Self::InnerField`.
     type PRF: PRF;


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR renames `execute context` to `transaction kernel`, implements transaction kernel (de)serialization, and removed unnecessary parameter cloning in proof execution

