### PR TITLE
feat(derives): add test with metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,9 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "fxhash"
@@ -982,9 +982,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pkg-config"
@@ -1009,6 +1009,38 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1493,6 +1525,8 @@ dependencies = [
 name = "snarkvm-derives"
 version = "0.0.2"
 dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -2023,7 +2057,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tracing-core",
 ]
 

--- a/derives/Cargo.toml
+++ b/derives/Cargo.toml
@@ -21,6 +21,8 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
+proc-macro-crate = { version = "0.1" }
+proc-macro-error = { version = "1", default-features = false }
 proc-macro2 = "1.0"
-syn = "1.0"
+syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use proc_macro2::TokenStream;
-use syn::{parse_macro_input, Data, DeriveInput, Index, Type};
+use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro_crate::crate_name;
+use proc_macro_error::{abort_call_site, proc_macro_error};
+use syn::*;
 
 use quote::{quote, ToTokens};
 
@@ -248,4 +250,38 @@ fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
         }
     };
     gen
+}
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn test_with_metrics(_: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    match parse::<ItemFn>(item.clone()) {
+        Ok(function) => {
+            fn generate_test_function(function: ItemFn, crate_name: Ident) -> proc_macro::TokenStream {
+                let name = &function.sig.ident;
+                let statements = function.block.stmts;
+                (quote! {
+                    // Generates a new test with Prometheus registry checks, and enforces
+                    // that the test runs serially with other tests that use metrics.
+                    #[test]
+                    #[serial]
+                    fn #name() {
+                        // Initialize Prometheus once in the test environment.
+                        #crate_name::testing::initialize_prometheus_for_testing();
+                        // Check that all metrics are 0 or empty.
+                        assert_eq!(0, #crate_name::Metrics::get_connected_peers());
+                        // Run the test logic.
+                        #(#statements)*
+                        // Check that all metrics are reset to 0 or empty (for next test).
+                        assert_eq!(0, Metrics::get_connected_peers());
+                    }
+                })
+                .into()
+            }
+            let name = crate_name("snarkos-metrics").unwrap_or("crate".to_string());
+            let crate_name = Ident::new(&name, Span::call_site());
+            generate_test_function(function, crate_name)
+        }
+        _ => abort_call_site!("test_with_metrics only works on functions"),
+    }
 }


### PR DESCRIPTION
This PR adds the `test_with_metrics` macros initially featured in SnarkOS. This change fell through the cracks when the split was undertaken. 

Another PR (AleoHQ/SnarkOS#582) will be ready to go in SnarkOS to point the `metrics` crate to the SnarkVM `derives` as the new dependency once this is merged (commit hash will be needed to make sure the dependency is up to date). 