### PR TITLE
Implements compressed Groth16 and GM17 proof serialization

### DIFF
--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -52,12 +52,16 @@ pub struct Proof<E: PairingEngine> {
     pub a: E::G1Affine,
     pub b: E::G2Affine,
     pub c: E::G1Affine,
+    pub(crate) compressed: bool,
 }
 
 impl<E: PairingEngine> ToBytes for Proof<E> {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.write(&mut writer)
+        match self.compressed {
+            true => self.write_compressed(&mut writer),
+            false => self.write_uncompressed(&mut writer),
+        }
     }
 }
 
@@ -80,6 +84,7 @@ impl<E: PairingEngine> Default for Proof<E> {
             a: E::G1Affine::default(),
             b: E::G2Affine::default(),
             c: E::G1Affine::default(),
+            compressed: true,
         }
     }
 }
@@ -87,7 +92,7 @@ impl<E: PairingEngine> Default for Proof<E> {
 impl<E: PairingEngine> Proof<E> {
     /// Serialize the proof into bytes in compressed form, for storage
     /// on disk or transmission over the network.
-    pub fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    pub fn write_compressed<W: Write>(&self, mut writer: W) -> IoResult<()> {
         CanonicalSerialize::serialize(self, &mut writer)?;
 
         Ok(())
@@ -102,7 +107,7 @@ impl<E: PairingEngine> Proof<E> {
     }
 
     /// Deserialize the proof from compressed bytes.
-    pub fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    pub fn read_compressed<R: Read>(mut reader: R) -> IoResult<Self> {
         Ok(CanonicalDeserialize::deserialize(&mut reader)?)
     }
 
@@ -112,7 +117,49 @@ impl<E: PairingEngine> Proof<E> {
         let b: E::G2Affine = FromBytes::read(&mut reader)?;
         let c: E::G1Affine = FromBytes::read(&mut reader)?;
 
-        Ok(Self { a, b, c })
+        Ok(Self {
+            a,
+            b,
+            c,
+            compressed: false,
+        })
+    }
+
+    /// Deserialize a proof from compressed or uncompressed bytes.
+    pub fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Construct the compressed reader
+        let compressed_proof_size = Self::compressed_proof_size()?;
+        let mut compressed_reader = vec![0u8; compressed_proof_size];
+        reader.read(&mut compressed_reader)?;
+        let duplicate_compressed_reader = compressed_reader.clone();
+
+        // Attempt to read the compressed the proof.
+        if let Ok(proof) = Self::read_compressed(&compressed_reader[..]) {
+            return Ok(proof);
+        }
+
+        // Construct the uncompressed reader.
+        let uncompressed_proof_size = Self::uncompressed_proof_size()?;
+        let mut uncompressed_reader = vec![0u8; uncompressed_proof_size - compressed_proof_size];
+        reader.read(&mut compressed_reader)?;
+        uncompressed_reader = [duplicate_compressed_reader, uncompressed_reader].concat();
+
+        // Attempt to read the uncompressed proof.
+        Self::read_uncompressed(&uncompressed_reader[..])
+    }
+
+    /// Returns the number of bytes in a compressed proof serialization.
+    pub fn compressed_proof_size() -> IoResult<usize> {
+        let mut buffer = Vec::new();
+        Self::default().write_compressed(&mut buffer)?;
+        Ok(buffer.len())
+    }
+
+    /// Returns the number of bytes in an uncompressed proof serialization.
+    pub fn uncompressed_proof_size() -> IoResult<usize> {
+        let mut buffer = Vec::new();
+        Self::default().write_uncompressed(&mut buffer)?;
+        Ok(buffer.len())
     }
 }
 

--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -133,7 +133,7 @@ impl<E: PairingEngine> Proof<E> {
         reader.read(&mut compressed_reader)?;
         let duplicate_compressed_reader = compressed_reader.clone();
 
-        // Attempt to read the compressed the proof.
+        // Attempt to read the compressed proof.
         if let Ok(proof) = Self::read_compressed(&compressed_reader[..]) {
             return Ok(proof);
         }

--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -141,7 +141,7 @@ impl<E: PairingEngine> Proof<E> {
         // Construct the uncompressed reader.
         let uncompressed_proof_size = Self::uncompressed_proof_size()?;
         let mut uncompressed_reader = vec![0u8; uncompressed_proof_size - compressed_proof_size];
-        reader.read(&mut compressed_reader)?;
+        reader.read(&mut uncompressed_reader)?;
         uncompressed_reader = [duplicate_compressed_reader, uncompressed_reader].concat();
 
         // Attempt to read the uncompressed proof.

--- a/algorithms/src/snark/gm17/prover.rs
+++ b/algorithms/src/snark/gm17/prover.rs
@@ -348,5 +348,6 @@ where
         a: g_a.into_affine(),
         b: g_b.into_affine(),
         c: g_c.into_affine(),
+        compressed: true,
     })
 }

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -137,7 +137,7 @@ impl<E: PairingEngine> Proof<E> {
         reader.read(&mut compressed_reader)?;
         let duplicate_compressed_reader = compressed_reader.clone();
 
-        // Attempt to read the compressed the proof.
+        // Attempt to read the compressed proof.
         if let Ok(proof) = Self::read_compressed(&compressed_reader[..]) {
             return Ok(proof);
         }

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -152,14 +152,14 @@ impl<E: PairingEngine> Proof<E> {
         Self::read_uncompressed(&uncompressed_reader[..])
     }
 
-    /// Returns the number of bytes in a (compressed) serialized proof.
+    /// Returns the number of bytes in a compressed proof serialization.
     pub fn compressed_proof_size() -> IoResult<usize> {
         let mut buffer = Vec::new();
         Self::default().write_compressed(&mut buffer)?;
         Ok(buffer.len())
     }
 
-    /// Returns the number of bytes in a (compressed) serialized proof.
+    /// Returns the number of bytes in an uncompressed proof serialization.
     pub fn uncompressed_proof_size() -> IoResult<usize> {
         let mut buffer = Vec::new();
         Self::default().write_uncompressed(&mut buffer)?;

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -145,7 +145,7 @@ impl<E: PairingEngine> Proof<E> {
         // Construct the uncompressed reader.
         let uncompressed_proof_size = Self::uncompressed_proof_size()?;
         let mut uncompressed_reader = vec![0u8; uncompressed_proof_size - compressed_proof_size];
-        reader.read(&mut compressed_reader)?;
+        reader.read(&mut uncompressed_reader)?;
         uncompressed_reader = [duplicate_compressed_reader, uncompressed_reader].concat();
 
         // Attempt to read the uncompressed proof.

--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -225,6 +225,7 @@ where
         a: g_a.into_affine(),
         b: g2_b.into_affine(),
         c: g_c.into_affine(),
+        compressed: true,
     })
 }
 

--- a/algorithms/src/snark/groth16/tests.rs
+++ b/algorithms/src/snark/groth16/tests.rs
@@ -62,7 +62,8 @@ mod bls12_377 {
     fn prove_and_verify() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let parameters =
+            generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         for _ in 0..100 {
             let a = Fr::rand(rng);
@@ -70,8 +71,8 @@ mod bls12_377 {
             let mut c = a;
             c.mul_assign(&b);
 
-            let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
-            let pvk = prepare_verifying_key::<Bls12_377>(params.vk.clone());
+            let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
+            let pvk = prepare_verifying_key::<Bls12_377>(parameters.vk.clone());
 
             assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
             assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
@@ -90,21 +91,22 @@ mod bw6_761 {
     fn prove_and_verify() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<BW6_761, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let parameters =
+            generate_random_parameters::<BW6_761, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let a = Fr::rand(rng);
         let b = Fr::rand(rng);
         let c = a * &b;
 
-        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
-        let pvk = prepare_verifying_key::<BW6_761>(params.vk);
+        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
+        let pvk = prepare_verifying_key::<BW6_761>(parameters.vk);
 
         assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
         assert!(!verify_proof(&pvk, &proof, &[Fr::zero()]).unwrap());
     }
 }
 
-mod proof_serialization {
+mod serialization {
     use super::*;
     use crate::snark::groth16::{create_random_proof, generate_random_parameters, Proof};
     use snarkvm_curves::bls12_377::{Bls12_377, Fr};
@@ -115,15 +117,16 @@ mod proof_serialization {
     };
 
     #[test]
-    fn test_compressed_serialization() {
+    fn test_compressed_proof_serialization() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let parameters =
+            generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let a = Fr::rand(rng);
         let b = Fr::rand(rng);
 
-        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
 
         let compressed_serialization = to_bytes![proof].unwrap();
 
@@ -138,15 +141,16 @@ mod proof_serialization {
     }
 
     #[test]
-    fn test_uncompressed_serialization() {
+    fn test_uncompressed_proof_serialization() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let parameters =
+            generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let a = Fr::rand(rng);
         let b = Fr::rand(rng);
 
-        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
 
         let mut uncompressed_serialization = Vec::new();
         proof.write_uncompressed(&mut uncompressed_serialization).unwrap();

--- a/errors/src/serialization/serialization.rs
+++ b/errors/src/serialization/serialization.rs
@@ -35,3 +35,9 @@ pub enum SerializationError {
     #[error(transparent)]
     BincodeError(#[from] bincode::Error),
 }
+
+impl From<SerializationError> for std::io::Error {
+    fn from(error: SerializationError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::Other, format!("{}", error))
+    }
+}

--- a/gadgets/src/algorithms/snark/gm17.rs
+++ b/gadgets/src/algorithms/snark/gm17.rs
@@ -309,7 +309,7 @@ impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> AllocGadget
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c } = proof.borrow().clone();
+            let Proof { a, b, c, .. } = proof.borrow().clone();
             let a = P::G1Gadget::alloc_checked(cs.ns(|| "a"), || Ok(a.into_projective()))?;
             let b = P::G2Gadget::alloc_checked(cs.ns(|| "b"), || Ok(b.into_projective()))?;
             let c = P::G1Gadget::alloc_checked(cs.ns(|| "c"), || Ok(c.into_projective()))?;
@@ -323,7 +323,7 @@ impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> AllocGadget
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c } = proof.borrow().clone();
+            let Proof { a, b, c, .. } = proof.borrow().clone();
             // We don't need to check here because the prime order check can be performed
             // in plain.
             let a = P::G1Gadget::alloc_input(cs.ns(|| "a"), || Ok(a.into_projective()))?;

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -316,7 +316,7 @@ where
         T: Borrow<Proof<PairingE>>,
     {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c } = proof.borrow();
+            let Proof { a, b, c, compressed } = proof.borrow();
             let a = P::G1Gadget::alloc_checked(cs.ns(|| "a"), || Ok(a.into_projective()))?;
             let b = P::G2Gadget::alloc_checked(cs.ns(|| "b"), || Ok(b.into_projective()))?;
             let c = P::G1Gadget::alloc_checked(cs.ns(|| "c"), || Ok(c.into_projective()))?;
@@ -331,7 +331,7 @@ where
         T: Borrow<Proof<PairingE>>,
     {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c } = proof.borrow();
+            let Proof { a, b, c, compressed } = proof.borrow();
             // We don't need to check here because the prime order check can be performed
             // in plain.
             let a = P::G1Gadget::alloc_input(cs.ns(|| "a"), || Ok(a.into_projective()))?;

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -316,7 +316,7 @@ where
         T: Borrow<Proof<PairingE>>,
     {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c, compressed } = proof.borrow();
+            let Proof { a, b, c, .. } = proof.borrow();
             let a = P::G1Gadget::alloc_checked(cs.ns(|| "a"), || Ok(a.into_projective()))?;
             let b = P::G2Gadget::alloc_checked(cs.ns(|| "b"), || Ok(b.into_projective()))?;
             let c = P::G1Gadget::alloc_checked(cs.ns(|| "c"), || Ok(c.into_projective()))?;
@@ -331,7 +331,7 @@ where
         T: Borrow<Proof<PairingE>>,
     {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c, compressed } = proof.borrow();
+            let Proof { a, b, c, .. } = proof.borrow();
             // We don't need to check here because the prime order check can be performed
             // in plain.
             let a = P::G1Gadget::alloc_input(cs.ns(|| "a"), || Ok(a.into_projective()))?;


### PR DESCRIPTION
## Motivation

The `groth16` and `gm17` proof serialization is now compressed by default using the `CanonicalSerialize` and `CanonicalDeserialize` form. This will significantly reduce the size of transactions, as the transaction proofs sizes are cut in half.

The uncompressed serialization of the proofs is still supported for backwards compatibility in the network.

## Test Plan

Tests have been added to test that proof serialization is valid and the serialization format (compressed or uncompressed) is preserved.
