### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -32,7 +32,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -152,12 +152,6 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -212,7 +206,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -258,7 +252,7 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -273,7 +267,7 @@ dependencies = [
  "regex",
  "terminal_size",
  "unicode-width",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -430,7 +424,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -445,7 +439,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -559,50 +553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "futures"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
-
-[[package]]
-name = "futures"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -612,33 +568,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -661,17 +594,12 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -746,7 +674,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -754,7 +682,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.2.0",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -802,7 +730,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -813,7 +741,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
 ]
 
@@ -844,7 +772,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -856,7 +784,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.5",
  "socket2",
- "tokio 1.2.0",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -868,10 +796,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "hyper",
  "native-tls",
- "tokio 1.2.0",
+ "tokio",
  "tokio-native-tls",
 ]
 
@@ -915,15 +843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -975,42 +894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-core"
-version = "14.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
-dependencies = [
- "futures 0.1.30",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-core"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
-dependencies = [
- "futures 0.3.12",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,7 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1109,69 +992,15 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.6",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio 0.6.23",
- "miow 0.3.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1181,7 +1010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1200,17 +1029,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1235,7 +1053,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1352,7 +1170,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.1.57",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1415,12 +1233,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
@@ -1506,18 +1318,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1715,7 +1515,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1725,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1740,11 +1540,11 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.2.0",
+ "tokio",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -1821,7 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1976,15 +1776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,79 +1788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
-name = "snarkos-consensus"
-version = "1.1.4"
-source = "git+https://github.com/AleoHQ/snarkOS.git?rev=20a8495#20a8495d591f9a950201057e2129dee461a86be5"
-dependencies = [
- "anyhow",
- "bincode",
- "chrono",
- "hex",
- "rand 0.7.3",
- "serde",
- "snarkos-posw",
- "snarkos-profiler",
- "snarkos-storage",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-curves 0.0.1",
- "snarkvm-dpc 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-objects 0.0.1",
- "snarkvm-utilities 0.0.1",
- "thiserror",
- "tokio 0.2.25",
- "tracing",
-]
-
-[[package]]
-name = "snarkos-posw"
-version = "1.1.4"
-source = "git+https://github.com/AleoHQ/snarkOS.git?rev=20a8495#20a8495d591f9a950201057e2129dee461a86be5"
-dependencies = [
- "blake2",
- "rand 0.7.3",
- "snarkos-profiler",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-curves 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-gadgets 0.0.1",
- "snarkvm-marlin 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-objects 0.0.1",
- "snarkvm-parameters 0.0.1",
- "snarkvm-polycommit 0.0.1",
- "snarkvm-utilities 0.0.1",
- "thiserror",
-]
-
-[[package]]
-name = "snarkos-profiler"
-version = "1.1.4"
-source = "git+https://github.com/AleoHQ/snarkOS.git?rev=20a8495#20a8495d591f9a950201057e2129dee461a86be5"
-
-[[package]]
-name = "snarkos-storage"
-version = "1.1.4"
-source = "git+https://github.com/AleoHQ/snarkOS.git?rev=20a8495#20a8495d591f9a950201057e2129dee461a86be5"
-dependencies = [
- "anyhow",
- "bincode",
- "hex",
- "parking_lot",
- "rand 0.7.3",
- "rocksdb",
- "serde",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-objects 0.0.1",
- "snarkvm-parameters 0.0.1",
- "snarkvm-utilities 0.0.1",
- "thiserror",
-]
-
-[[package]]
 name = "snarkvm"
 version = "0.0.4"
 dependencies = [
@@ -2079,26 +1797,6 @@ dependencies = [
  "self_update",
  "structopt",
  "thiserror",
-]
-
-[[package]]
-name = "snarkvm-algorithms"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "blake2",
- "derivative",
- "digest 0.8.1",
- "itertools 0.9.0",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rayon",
- "sha2",
- "smallvec",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-profiler 0.0.1",
- "snarkvm-utilities 0.0.1",
 ]
 
 [[package]]
@@ -2117,26 +1815,11 @@ dependencies = [
  "rayon",
  "sha2",
  "smallvec",
- "snarkvm-curves 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-profiler 0.0.4",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-curves"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "derivative",
- "rand 0.7.3",
- "rand_xorshift",
- "rustc_version 0.2.3",
- "serde",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-utilities 0.0.1",
+ "snarkvm-curves",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-profiler",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2149,19 +1832,9 @@ dependencies = [
  "rand_xorshift",
  "rustc_version 0.3.3",
  "serde",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-derives"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2177,64 +1850,25 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "anyhow",
- "blake2",
- "derivative",
- "hex",
- "itertools 0.9.0",
- "rand 0.7.3",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-curves 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-gadgets 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-objects 0.0.1",
- "snarkvm-parameters 0.0.1",
- "snarkvm-profiler 0.0.1",
- "snarkvm-utilities 0.0.1",
-]
-
-[[package]]
-name = "snarkvm-dpc"
 version = "0.0.4"
 dependencies = [
  "anyhow",
  "blake2",
- "criterion",
  "derivative",
  "hex",
  "itertools 0.10.0",
  "rand 0.7.3",
  "rand_xorshift",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-gadgets 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-objects 0.0.4",
- "snarkvm-parameters 0.0.4",
- "snarkvm-profiler 0.0.4",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-errors",
+ "snarkvm-gadgets",
+ "snarkvm-models",
+ "snarkvm-objects",
+ "snarkvm-parameters",
+ "snarkvm-profiler",
  "snarkvm-testing",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-errors"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "base58",
- "bech32",
- "bincode",
- "curl",
- "hex",
- "jsonrpc-core 14.2.0",
- "rocksdb",
- "thiserror",
- "toml",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2246,25 +1880,7 @@ dependencies = [
  "bincode",
  "curl",
  "hex",
- "jsonrpc-core 17.0.0",
- "rocksdb",
  "thiserror",
- "toml",
-]
-
-[[package]]
-name = "snarkvm-gadgets"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "derivative",
- "digest 0.8.1",
- "itertools 0.9.0",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-curves 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-utilities 0.0.1",
 ]
 
 [[package]]
@@ -2277,30 +1893,11 @@ dependencies = [
  "itertools 0.10.0",
  "rand 0.7.3",
  "rand_xorshift",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-marlin"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "blake2",
- "derivative",
- "digest 0.8.1",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rayon",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-polycommit 0.0.1",
- "snarkvm-profiler 0.0.1",
- "snarkvm-utilities 0.0.1",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2313,32 +1910,13 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rayon",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-polycommit 0.0.4",
- "snarkvm-profiler 0.0.4",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-models"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "anyhow",
- "bincode",
- "cfg-if 0.1.10",
- "derivative",
- "fxhash",
- "indexmap",
- "itertools 0.9.0",
- "rand 0.7.3",
- "rand_xorshift",
- "serde",
- "snarkvm-errors 0.0.1",
- "snarkvm-utilities 0.0.1",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-polycommit",
+ "snarkvm-profiler",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2356,29 +1934,8 @@ dependencies = [
  "rand 0.7.3",
  "rand_xorshift",
  "serde",
- "snarkvm-errors 0.0.4",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-objects"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "base58",
- "bech32",
- "chrono",
- "derivative",
- "hex",
- "once_cell",
- "rand 0.7.3",
- "serde",
- "sha2",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-curves 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-utilities 0.0.1",
+ "snarkvm-errors",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2395,62 +1952,25 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "sha2",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-dpc 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-parameters"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "curl",
- "hex",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-utilities 0.0.1",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-dpc",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-parameters"
 version = "0.0.4"
 dependencies = [
- "chrono",
  "curl",
  "hex",
- "parking_lot",
  "rand 0.7.3",
- "snarkos-consensus",
- "snarkos-posw",
- "snarkos-storage",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-dpc 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-marlin 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-objects 0.0.4",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-polycommit"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "derivative",
- "digest 0.8.1",
- "rand_core 0.5.1",
- "snarkvm-algorithms 0.0.1",
- "snarkvm-errors 0.0.1",
- "snarkvm-models 0.0.1",
- "snarkvm-profiler 0.0.1",
- "snarkvm-utilities 0.0.1",
+ "snarkvm-algorithms",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2463,18 +1983,13 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-profiler 0.0.4",
- "snarkvm-utilities 0.0.4",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-profiler",
+ "snarkvm-utilities",
 ]
-
-[[package]]
-name = "snarkvm-profiler"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
 
 [[package]]
 name = "snarkvm-profiler"
@@ -2494,14 +2009,14 @@ dependencies = [
  "rand 0.7.3",
  "rocksdb",
  "serde",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-objects 0.0.4",
- "snarkvm-parameters 0.0.4",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-objects",
+ "snarkvm-parameters",
  "snarkvm-testing",
- "snarkvm-utilities 0.0.4",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -2512,26 +2027,15 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rand_xorshift",
- "snarkvm-algorithms 0.0.4",
- "snarkvm-curves 0.0.4",
- "snarkvm-dpc 0.0.4",
- "snarkvm-errors 0.0.4",
- "snarkvm-models 0.0.4",
- "snarkvm-objects 0.0.4",
- "snarkvm-parameters 0.0.4",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-dpc",
+ "snarkvm-errors",
+ "snarkvm-models",
+ "snarkvm-objects",
+ "snarkvm-parameters",
  "snarkvm-storage",
- "snarkvm-utilities 0.0.4",
-]
-
-[[package]]
-name = "snarkvm-utilities"
-version = "0.0.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=81d225a#81d225aca0cdede198a1ef5b30b798b02ced13cc"
-dependencies = [
- "bincode",
- "rand 0.7.3",
- "snarkvm-derives 0.0.1",
- "snarkvm-errors 0.0.1",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2541,8 +2045,8 @@ dependencies = [
  "bincode",
  "rand 0.7.3",
  "rand_xorshift",
- "snarkvm-derives 0.0.4",
- "snarkvm-errors 0.0.4",
+ "snarkvm-derives",
+ "snarkvm-errors",
 ]
 
 [[package]]
@@ -2553,7 +2057,7 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2614,7 +2118,7 @@ dependencies = [
  "rand 0.8.3",
  "redox_syscall 0.2.4",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2633,7 +2137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2682,7 +2186,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2712,52 +2216,17 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.6.23",
- "mio-named-pipes",
- "mio-uds",
- "num_cpus",
- "pin-project-lite 0.1.11",
- "signal-hook-registry",
- "slab",
- "tokio-macros",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
- "mio 0.7.7",
+ "mio",
  "num_cpus",
- "pin-project-lite 0.2.4",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2767,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.2.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2776,12 +2245,12 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
- "tokio 1.2.0",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2806,8 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "tracing-core",
 ]
 
@@ -2921,7 +2389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -3036,12 +2504,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -3049,12 +2511,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3068,7 +2524,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3083,15 +2539,5 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,6 @@ dependencies = [
  "snarkvm-parameters 0.0.4",
  "snarkvm-storage",
  "snarkvm-utilities 0.0.4",
- "tokio 1.2.0",
 ]
 
 [[package]]
@@ -2731,7 +2730,7 @@ dependencies = [
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
- "tokio-macros 0.2.6",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -2747,12 +2746,7 @@ dependencies = [
  "memchr",
  "mio 0.7.7",
  "num_cpus",
- "once_cell",
- "parking_lot",
  "pin-project-lite 0.2.4",
- "signal-hook-registry",
- "tokio-macros 1.1.0",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2760,17 +2754,6 @@ name = "tokio-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,3 @@
-[package]
-name = "snarkvm"
-version = "0.0.4"
-authors = [ "The Aleo Team <hello@aleo.org>" ]
-description = "A decentralized virtual machine"
-homepage = "https://aleo.org"
-repository = "https://github.com/AleoHQ/snarkVM"
-keywords = [
-  "aleo",
-  "cryptography",
-  "blockchain",
-  "decentralized",
-  "zero-knowledge"
-]
-categories = [ "cryptography::cryptocurrencies", "operating-systems" ]
-include = [ "Cargo.toml", "snarkvm", "README.md", "LICENSE.md" ]
-license = "GPL-3.0"
-edition = "2018"
-
 [workspace]
 members = [
   "algorithms",
@@ -31,32 +12,11 @@ members = [
   "parameters",
   "polycommit",
   "profiler",
+  "snarkvm",
   "storage",
   "testing",
   "utilities"
 ]
-
-[[bin]]
-name = "snarkvm"
-path = "snarkvm/main.rs"
-
-[dependencies.anyhow]
-version = "1.0.38"
-
-[dependencies.colored]
-version = "2"
-
-[dependencies.self_update]
-version = "0.23"
-
-[dependencies.structopt]
-version = "0.3"
-
-[dependencies.thiserror]
-version = "1.0"
-
-[dev-dependencies.rusty-hook]
-version = "0.11.2"
 
 [profile.release]
 opt-level = 3

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -83,9 +83,6 @@ version = "0.7"
 [dev-dependencies.snarkvm-testing]
 path = "../testing"
 
-[dev-dependencies.criterion]
-version = "0.3.4"
-
 [dev-dependencies.rand_xorshift]
 version = "0.2"
 

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -33,23 +33,12 @@ optional = true
 [dependencies.hex]
 version = "0.4.2"
 
-[dependencies.jsonrpc-core]
-version = "17.0.0"
-
-[dependencies.rocksdb]
-version = "0.15.0"
-optional = true
-
 [dependencies.thiserror]
 version = "1.0"
-
-[dependencies.toml]
-version = "0.5.6"
 
 [dev-dependencies.curl]
 version = "0.4.34"
 
 [features]
-default = [ "librocksdb", "remote" ]
-librocksdb = [ "rocksdb" ]
+default = [ "remote" ]
 remote = [ "curl" ]

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -44,46 +44,11 @@ optional = true
 [dependencies.hex]
 version = "0.4.2"
 
-[dev-dependencies.snarkvm-curves]
-path = "../curves"
-
-[dev-dependencies.snarkvm-dpc]
-path = "../dpc"
-
-[dev-dependencies.snarkvm-marlin]
-path = "../marlin"
-
-[dev-dependencies.snarkvm-objects]
-path = "../objects"
-
-[dev-dependencies.snarkos-consensus]
-git = "https://github.com/AleoHQ/snarkOS.git"
-rev = "20a8495"
-version = "1.1.4"
-
-[dev-dependencies.snarkos-posw]
-git = "https://github.com/AleoHQ/snarkOS.git"
-rev = "20a8495"
-version = "1.1.4"
-features = [ "test-helpers" ]
-
-[dev-dependencies.snarkos-storage]
-git = "https://github.com/AleoHQ/snarkOS.git"
-rev = "20a8495"
-version = "1.1.4"
-
-[dev-dependencies.chrono]
-version = "0.4"
-features = [ "serde" ]
-
 [dev-dependencies.curl]
 version = "0.4.34"
 
 [dev-dependencies.hex]
 version = "0.4.2"
-
-[dev-dependencies.parking_lot]
-version = "0.11.1"
 
 [dev-dependencies.rand]
 version = "0.7"

--- a/snarkvm/Cargo.toml
+++ b/snarkvm/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "snarkvm"
+version = "0.0.4"
+authors = [ "The Aleo Team <hello@aleo.org>" ]
+description = "A decentralized virtual machine"
+homepage = "https://aleo.org"
+repository = "https://github.com/AleoHQ/snarkVM"
+keywords = [
+  "aleo",
+  "cryptography",
+  "blockchain",
+  "decentralized",
+  "zero-knowledge"
+]
+categories = [ "cryptography::cryptocurrencies", "operating-systems" ]
+include = [ "Cargo.toml", "snarkvm", "README.md", "LICENSE.md" ]
+license = "GPL-3.0"
+edition = "2018"
+
+[[bin]]
+name = "snarkvm"
+path = "main.rs"
+
+[dependencies.anyhow]
+version = "1.0.38"
+
+[dependencies.colored]
+version = "2"
+
+[dependencies.self_update]
+version = "0.23"
+
+[dependencies.structopt]
+version = "0.3"
+
+[dependencies.thiserror]
+version = "1.0"
+
+[dev-dependencies.rusty-hook]
+version = "0.11.2"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -61,7 +61,3 @@ version = "0.7.0"
 
 [dependencies.rand_xorshift]
 version = "0.2.0"
-
-[dependencies.tokio]
-version = "1.2.0"
-features = [ "full" ]


### PR DESCRIPTION
A maintenance pass pruning unused dependencies.

In addition, the workspace-level `Cargo.toml` is simplified to only contain member information and the binary dependencies were moved to a new `Cargo.toml` under `snarkvm`.

These changes will also have a positive impact on `snarkOS` compilation times.