### PR TITLE
Update rand to 0.8, blake2 and digest to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,24 +642,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1354,37 +1343,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.15",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.1",
- "rand_hc 0.3.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1394,16 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.15",
+ "rand_core",
 ]
 
 [[package]]
@@ -1412,16 +1369,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "getrandom 0.2.2",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1430,16 +1378,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1809,8 +1757,8 @@ dependencies = [
  "derivative",
  "digest 0.8.1",
  "itertools 0.10.0",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "rayon",
  "sha2",
@@ -1828,7 +1776,7 @@ version = "0.0.4"
 dependencies = [
  "criterion",
  "derivative",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "rustc_version 0.3.3",
  "serde",
@@ -1857,7 +1805,7 @@ dependencies = [
  "derivative",
  "hex",
  "itertools 0.10.0",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "snarkvm-algorithms",
  "snarkvm-curves",
@@ -1891,7 +1839,7 @@ dependencies = [
  "derivative",
  "digest 0.8.1",
  "itertools 0.10.0",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "snarkvm-algorithms",
  "snarkvm-curves",
@@ -1907,8 +1855,8 @@ dependencies = [
  "blake2",
  "derivative",
  "digest 0.8.1",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
  "rayon",
  "snarkvm-algorithms",
  "snarkvm-curves",
@@ -1931,7 +1879,7 @@ dependencies = [
  "fxhash",
  "indexmap",
  "itertools 0.10.0",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "serde",
  "snarkvm-errors",
@@ -1949,7 +1897,7 @@ dependencies = [
  "derivative",
  "hex",
  "once_cell",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2",
  "snarkvm-algorithms",
@@ -1966,7 +1914,7 @@ version = "0.0.4"
 dependencies = [
  "curl",
  "hex",
- "rand 0.7.3",
+ "rand",
  "snarkvm-algorithms",
  "snarkvm-errors",
  "snarkvm-models",
@@ -1980,8 +1928,8 @@ dependencies = [
  "blake2",
  "derivative",
  "digest 0.8.1",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand",
+ "rand_core",
  "rayon",
  "snarkvm-algorithms",
  "snarkvm-curves",
@@ -2006,7 +1954,7 @@ dependencies = [
  "bincode",
  "hex",
  "parking_lot",
- "rand 0.7.3",
+ "rand",
  "rocksdb",
  "serde",
  "snarkvm-algorithms",
@@ -2025,7 +1973,7 @@ name = "snarkvm-testing"
 version = "0.0.4"
 dependencies = [
  "once_cell",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "snarkvm-algorithms",
  "snarkvm-curves",
@@ -2043,7 +1991,7 @@ name = "snarkvm-utilities"
 version = "0.0.4"
 dependencies = [
  "bincode",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "snarkvm-derives",
  "snarkvm-errors",
@@ -2115,7 +2063,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand",
  "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi",
@@ -2185,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
  "winapi",
 ]
 
@@ -2402,12 +2350,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
 
 [[package]]
 name = "byte-tools"
@@ -146,9 +146,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "core-foundation"
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.39+curl-7.74.0"
+version = "0.4.40+curl-7.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874"
+checksum = "2ffafc1c35958318bd7fdd0582995ce4c72f4f461a8e70499ccee83a619fd562"
 dependencies = [
  "cc",
  "libc",
@@ -485,9 +485,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.26"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -896,9 +896,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libloading"
@@ -945,11 +945,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1334,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
@@ -2119,29 +2119,28 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi",
  "winapi",
 ]
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
 dependencies = [
  "serde",
  "serde_json",
@@ -2218,9 +2217,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2275,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
@@ -2353,15 +2352,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2371,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2386,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
+checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2398,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2408,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2421,15 +2420,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "web-sys"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,14 +101,13 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
+checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
- "byte-tools",
  "crypto-mac",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -117,7 +116,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -137,12 +136,6 @@ name = "bumpalo"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -382,11 +375,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array",
  "subtle",
 ]
 
@@ -455,20 +448,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -610,15 +594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -1091,12 +1066,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -1713,8 +1682,8 @@ dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1755,7 +1724,7 @@ dependencies = [
  "criterion",
  "csv",
  "derivative",
- "digest 0.8.1",
+ "digest",
  "itertools 0.10.0",
  "rand",
  "rand_chacha",
@@ -1837,7 +1806,7 @@ version = "0.0.4"
 dependencies = [
  "blake2",
  "derivative",
- "digest 0.8.1",
+ "digest",
  "itertools 0.10.0",
  "rand",
  "rand_xorshift",
@@ -1854,7 +1823,7 @@ version = "0.0.4"
 dependencies = [
  "blake2",
  "derivative",
- "digest 0.8.1",
+ "digest",
  "rand_chacha",
  "rand_core",
  "rayon",
@@ -1927,7 +1896,7 @@ version = "0.0.4"
 dependencies = [
  "blake2",
  "derivative",
- "digest 0.8.1",
+ "digest",
  "rand",
  "rand_core",
  "rayon",
@@ -2040,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "1.0.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -59,10 +59,10 @@ version = "0.8.1"
 version = "0.10.0"
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 
 [dependencies.rand_chacha]
-version = "0.2.2"
+version = "0.3"
 
 [dependencies.rayon]
 version = "1"
@@ -83,7 +83,7 @@ version = "0.3.4"
 version = "1"
 
 [dev-dependencies.rand_xorshift]
-version = "0.2"
+version = "0.3"
 
 [features]
 default = [

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -47,13 +47,13 @@ version = "0.0.4"
 default-features = false
 
 [dependencies.blake2]
-version = "0.8.1"
+version = "0.9"
 
 [dependencies.derivative]
 version = "2"
 
 [dependencies.digest]
-version = "0.8.1"
+version = "0.9"
 
 [dependencies.itertools]
 version = "0.10.0"

--- a/algorithms/src/commitment/blake2s.rs
+++ b/algorithms/src/commitment/blake2s.rs
@@ -35,11 +35,11 @@ impl CommitmentScheme for Blake2sCommitment {
 
     fn commit(&self, input: &[u8], randomness: &Self::Randomness) -> Result<Self::Output, CommitmentError> {
         let mut h = blake2s::new();
-        h.input(input);
-        h.input(randomness.as_ref());
+        h.update(input);
+        h.update(randomness.as_ref());
 
         let mut result = [0u8; 32];
-        result.copy_from_slice(&h.result());
+        result.copy_from_slice(&h.finalize());
         Ok(result)
     }
 

--- a/algorithms/src/prf/blake2s.rs
+++ b/algorithms/src/prf/blake2s.rs
@@ -31,11 +31,11 @@ impl PRF for Blake2s {
     fn evaluate(seed: &Self::Seed, input: &Self::Input) -> Result<Self::Output, PRFError> {
         let eval_time = start_timer!(|| "Blake2s::Eval");
         let mut h = blake2s::new();
-        h.input(seed.as_ref());
-        h.input(input.as_ref());
+        h.update(seed.as_ref());
+        h.update(input.as_ref());
 
         let mut result = [0u8; 32];
-        result.copy_from_slice(&h.result());
+        result.copy_from_slice(&h.finalize());
         end_timer!(eval_time);
         Ok(result)
     }

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -35,7 +35,7 @@ version = "0.0.4"
 version = "2"
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 
 [dependencies.serde]
 version = "1.0.123"
@@ -43,7 +43,7 @@ default-features = false
 features = [ "derive" ]
 
 [dependencies.rand_xorshift]
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [features]

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -78,13 +78,13 @@ version = "0.4.2"
 version = "0.10.0"
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 
 [dev-dependencies.snarkvm-testing]
 path = "../testing"
 
 [dev-dependencies.rand_xorshift]
-version = "0.2"
+version = "0.3"
 
 [features]
 default = [

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -66,7 +66,7 @@ default-features = false
 version = "1.0.38"
 
 [dependencies.blake2]
-version = "0.8.1"
+version = "0.9"
 
 [dependencies.derivative]
 version = "2"

--- a/dpc/src/base_dpc/transaction.rs
+++ b/dpc/src/base_dpc/transaction.rs
@@ -144,10 +144,10 @@ impl<C: BaseDPCComponents> Transaction for DPCTransaction<C> {
         pre_image_bytes.extend(self.memorandum());
 
         let mut h = b2s::new();
-        h.input(&pre_image_bytes);
+        h.update(&pre_image_bytes);
 
         let mut result = [0u8; 32];
-        result.copy_from_slice(&h.result());
+        result.copy_from_slice(&h.finalize());
         Ok(result)
     }
 

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -46,13 +46,13 @@ default-features = false
 version = "2"
 
 [dependencies.digest]
-version = "0.8.1"
+version = "0.9"
 
 [dependencies.itertools]
 version = "0.10.0"
 
 [dev-dependencies.blake2]
-version = "0.8.1"
+version = "0.9"
 
 [dev-dependencies.rand]
 version = "0.8"

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -55,10 +55,10 @@ version = "0.10.0"
 version = "0.8.1"
 
 [dev-dependencies.rand]
-version = "0.7"
+version = "0.8"
 
 [dev-dependencies.rand_xorshift]
-version = "0.2"
+version = "0.3"
 
 [features]
 default = [

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -148,9 +148,9 @@ fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: Mas
     root.write(&mut root_bytes[..]).unwrap();
 
     let mut h = Blake2s::new();
-    h.input(nonce.as_ref());
-    h.input(&root_bytes);
-    let mask = h.result().to_vec();
+    h.update(nonce.as_ref());
+    h.update(&root_bytes);
+    let mask = h.finalize().to_vec();
     let mask_bytes = UInt8::alloc_vec(cs.ns(|| "mask"), &mask).unwrap();
 
     let crh_parameters = <HG as CRHGadget<_, _>>::ParametersGadget::alloc(&mut cs.ns(|| "new_parameters"), || {

--- a/gadgets/src/algorithms/prf/tests.rs
+++ b/gadgets/src/algorithms/prf/tests.rs
@@ -32,7 +32,7 @@ use snarkvm_models::{
 };
 
 use blake2::VarBlake2s;
-use digest::{Input, VariableOutput};
+use digest::{Update, VariableOutput};
 use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
@@ -116,10 +116,10 @@ fn test_blake2s() {
 
         let data: Vec<u8> = (0..input_len).map(|_| rng.gen()).collect();
 
-        h.input(&data);
+        h.update(&data);
 
         let mut hash_result = Vec::new();
-        h.variable_result(|output| hash_result.extend_from_slice(output));
+        h.finalize_variable(|output| hash_result.extend_from_slice(output));
 
         let mut cs = TestConstraintSystem::<Fr>::new();
 

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -56,7 +56,7 @@ path = "../utilities"
 version = "0.0.4"
 
 [dependencies.blake2]
-version = "0.8"
+version = "0.9"
 default-features = false
 
 [dependencies.derivative]
@@ -64,7 +64,7 @@ version = "2"
 features = [ "use_core" ]
 
 [dependencies.digest]
-version = "0.8"
+version = "0.9"
 
 [dependencies.rand_chacha]
 version = "0.3"

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -67,11 +67,11 @@ features = [ "use_core" ]
 version = "0.8"
 
 [dependencies.rand_chacha]
-version = "0.2.1"
+version = "0.3"
 default-features = false
 
 [dependencies.rand_core]
-version = "0.5"
+version = "0.6"
 
 [dependencies.rayon]
 version = "1"

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -49,11 +49,11 @@ version = "1.6.0"
 version = "0.10.0"
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 default-features = false
 
 [dependencies.rand_xorshift]
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.serde]

--- a/models/benches/integer_arithmetic.rs
+++ b/models/benches/integer_arithmetic.rs
@@ -92,8 +92,8 @@ macro_rules! create_sub_bench {
     ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
         fn $bench_name(c: &mut Criterion) {
             fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
-                let a: $std_type = rng.gen_range(<$std_type>::max_value() / 2, <$std_type>::max_value());
-                let b: $std_type = rng.gen_range(0, <$std_type>::max_value() / 2);
+                let a: $std_type = rng.gen_range(<$std_type>::max_value() / 2..<$std_type>::max_value());
+                let b: $std_type = rng.gen_range(0..<$std_type>::max_value() / 2);
 
                 let bench_run_id: u64 = rng.gen();
 
@@ -120,8 +120,8 @@ macro_rules! create_sub_const_bench {
     ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
         fn $bench_name(c: &mut Criterion) {
             fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
-                let a: $std_type = rng.gen_range(<$std_type>::max_value() / 2, <$std_type>::max_value());
-                let b: $std_type = rng.gen_range(0, <$std_type>::max_value() / 2);
+                let a: $std_type = rng.gen_range(<$std_type>::max_value() / 2..<$std_type>::max_value());
+                let b: $std_type = rng.gen_range(0..<$std_type>::max_value() / 2);
 
                 let bench_run_id: u64 = rng.gen();
 
@@ -205,7 +205,7 @@ macro_rules! create_div_bench {
         fn $bench_name(c: &mut Criterion) {
             fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
                 let a: $std_type = rng.gen();
-                let b: $std_type = rng.gen_range(1, <$std_type>::max_value());
+                let b: $std_type = rng.gen_range(1..<$std_type>::max_value());
 
                 let bench_run_id: u64 = rng.gen();
 
@@ -233,7 +233,7 @@ macro_rules! create_div_const_bench {
         fn $bench_name(c: &mut Criterion) {
             fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
                 let a: $std_type = rng.gen();
-                let b: $std_type = rng.gen_range(1, <$std_type>::max_value());
+                let b: $std_type = rng.gen_range(1..<$std_type>::max_value());
 
                 let bench_run_id: u64 = rng.gen();
 
@@ -260,8 +260,8 @@ macro_rules! create_pow_bench {
     ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
         fn $bench_name(c: &mut Criterion) {
             fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
-                let a: $std_type = rng.gen_range(0, <$std_type>::from(u8::max_value()));
-                let b: $std_type = rng.gen_range(0, 4);
+                let a: $std_type = rng.gen_range(0..<$std_type>::from(u8::max_value()));
+                let b: $std_type = rng.gen_range(0..4);
 
                 let bench_run_id: u64 = rng.gen();
 
@@ -288,8 +288,8 @@ macro_rules! create_pow_const_bench {
     ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
         fn $bench_name(c: &mut Criterion) {
             fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
-                let a: $std_type = rng.gen_range(0, <$std_type>::from(u8::max_value()));
-                let b: $std_type = rng.gen_range(0, 4);
+                let a: $std_type = rng.gen_range(0..<$std_type>::from(u8::max_value()));
+                let b: $std_type = rng.gen_range(0..4);
 
                 let bench_run_id: u64 = rng.gen();
 

--- a/models/src/gadgets/utilities/uint/tests/uint128.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint128.rs
@@ -227,8 +227,8 @@ fn test_uint128_sub_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u128 = rng.gen_range(u128::max_value() / 2u128, u128::max_value());
-        let b: u128 = rng.gen_range(0u128, u128::max_value() / 2u128);
+        let a: u128 = rng.gen_range(u128::max_value() / 2u128..u128::max_value());
+        let b: u128 = rng.gen_range(0u128..u128::max_value() / 2u128);
 
         let a_bit = UInt128::constant(a);
         let b_bit = UInt128::constant(b);
@@ -250,8 +250,8 @@ fn test_uint128_sub() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u128 = rng.gen_range(u128::max_value() / 2u128, u128::max_value());
-        let b: u128 = rng.gen_range(0u128, u128::max_value() / 2u128);
+        let a: u128 = rng.gen_range(u128::max_value() / 2u128..u128::max_value());
+        let b: u128 = rng.gen_range(0u128..u128::max_value() / 2u128);
 
         let expected = a.wrapping_sub(b);
 
@@ -418,8 +418,8 @@ fn test_uint128_pow_constants() {
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u128 = rng.gen_range(0, u128::from(u32::max_value()));
-        let b: u128 = rng.gen_range(0, 4);
+        let a: u128 = rng.gen_range(0..u128::from(u32::max_value()));
+        let b: u128 = rng.gen_range(0..4);
 
         let a_bit = UInt128::constant(a);
         let b_bit = UInt128::constant(b);
@@ -441,8 +441,8 @@ fn test_uint128_pow() {
 
     let mut cs = TestConstraintSystem::<Fr>::new();
 
-    let a: u128 = rng.gen_range(0, u128::from(u32::max_value()));
-    let b: u128 = rng.gen_range(0, 4);
+    let a: u128 = rng.gen_range(0..u128::from(u32::max_value()));
+    let b: u128 = rng.gen_range(0..4);
 
     let expected = a.wrapping_pow(b.try_into().unwrap());
 

--- a/models/src/gadgets/utilities/uint/tests/uint16.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint16.rs
@@ -232,8 +232,8 @@ fn test_uint16_sub_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u16 = rng.gen_range(u16::max_value() / 2u16, u16::max_value());
-        let b: u16 = rng.gen_range(0u16, u16::max_value() / 2u16);
+        let a: u16 = rng.gen_range(u16::max_value() / 2u16..u16::max_value());
+        let b: u16 = rng.gen_range(0u16..u16::max_value() / 2u16);
 
         let a_bit = UInt16::constant(a);
         let b_bit = UInt16::constant(b);
@@ -255,8 +255,8 @@ fn test_uint16_sub() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u16 = rng.gen_range(u16::max_value() / 2u16, u16::max_value());
-        let b: u16 = rng.gen_range(0u16, u16::max_value() / 2u16);
+        let a: u16 = rng.gen_range(u16::max_value() / 2u16..u16::max_value());
+        let b: u16 = rng.gen_range(0u16..u16::max_value() / 2u16);
 
         let expected = a.wrapping_sub(b);
 
@@ -293,8 +293,8 @@ fn test_uint16_mul_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u16 = rng.gen_range(0, u16::max_value());
-        let b: u16 = rng.gen_range(0, u16::max_value());
+        let a: u16 = rng.gen_range(0..u16::max_value());
+        let b: u16 = rng.gen_range(0..u16::max_value());
 
         let a_bit = UInt16::constant(a);
         let b_bit = UInt16::constant(b);
@@ -316,8 +316,8 @@ fn test_uint16_mul() {
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u16 = rng.gen_range(0, u16::max_value());
-        let b: u16 = rng.gen_range(0, u16::max_value());
+        let a: u16 = rng.gen_range(0..u16::max_value());
+        let b: u16 = rng.gen_range(0..u16::max_value());
 
         let expected = a.wrapping_mul(b);
 
@@ -361,7 +361,7 @@ fn test_uint16_div_constants() {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
         let a: u16 = rng.gen();
-        let b: u16 = rng.gen_range(0u16, u16::max_value());
+        let b: u16 = rng.gen_range(0u16..u16::max_value());
 
         let a_bit = UInt16::constant(a);
         let b_bit = UInt16::constant(b);
@@ -384,7 +384,7 @@ fn test_uint16_div() {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
         let a: u16 = rng.gen();
-        let b: u16 = rng.gen_range(0u16, u16::max_value());
+        let b: u16 = rng.gen_range(0u16..u16::max_value());
 
         let expected = a.wrapping_div(b);
 
@@ -447,8 +447,8 @@ fn test_uint16_pow() {
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u16 = rng.gen_range(0, u16::from(u8::max_value()));
-        let b: u16 = rng.gen_range(0, 4);
+        let a: u16 = rng.gen_range(0..u16::from(u8::max_value()));
+        let b: u16 = rng.gen_range(0..4);
 
         let expected = a.wrapping_pow(b.into());
 

--- a/models/src/gadgets/utilities/uint/tests/uint32.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint32.rs
@@ -232,8 +232,8 @@ fn test_uint32_sub_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u32 = rng.gen_range(u32::max_value() / 2u32, u32::max_value());
-        let b: u32 = rng.gen_range(0u32, u32::max_value() / 2u32);
+        let a: u32 = rng.gen_range(u32::max_value() / 2u32..u32::max_value());
+        let b: u32 = rng.gen_range(0u32..u32::max_value() / 2u32);
 
         let a_bit = UInt32::constant(a);
         let b_bit = UInt32::constant(b);
@@ -255,8 +255,8 @@ fn test_uint32_sub() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u32 = rng.gen_range(u32::max_value() / 2u32, u32::max_value());
-        let b: u32 = rng.gen_range(0u32, u32::max_value() / 2u32);
+        let a: u32 = rng.gen_range(u32::max_value() / 2u32..u32::max_value());
+        let b: u32 = rng.gen_range(0u32..u32::max_value() / 2u32);
 
         let expected = a.wrapping_sub(b);
 
@@ -424,8 +424,8 @@ fn test_uint32_pow_constants() {
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u32 = rng.gen_range(0, u32::from(u8::max_value()));
-        let b: u32 = rng.gen_range(0, 4);
+        let a: u32 = rng.gen_range(0..u32::from(u8::max_value()));
+        let b: u32 = rng.gen_range(0..4);
 
         let a_bit = UInt32::constant(a);
         let b_bit = UInt32::constant(b);
@@ -447,8 +447,8 @@ fn test_uint32_pow() {
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u32 = rng.gen_range(0, u32::from(u8::max_value()));
-        let b: u32 = rng.gen_range(0, 4);
+        let a: u32 = rng.gen_range(0..u32::from(u8::max_value()));
+        let b: u32 = rng.gen_range(0..4);
 
         let expected = a.wrapping_pow(b);
 

--- a/models/src/gadgets/utilities/uint/tests/uint64.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint64.rs
@@ -233,8 +233,8 @@ fn test_uint64_sub_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u64 = rng.gen_range(u64::max_value() / 2u64, u64::max_value());
-        let b: u64 = rng.gen_range(0u64, u64::max_value() / 2u64);
+        let a: u64 = rng.gen_range(u64::max_value() / 2u64..u64::max_value());
+        let b: u64 = rng.gen_range(0u64..u64::max_value() / 2u64);
 
         let a_bit = UInt64::constant(a);
         let b_bit = UInt64::constant(b);
@@ -256,8 +256,8 @@ fn test_uint64_sub() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u64 = rng.gen_range(u64::max_value() / 2u64, u64::max_value());
-        let b: u64 = rng.gen_range(0u64, u64::max_value() / 2u64);
+        let a: u64 = rng.gen_range(u64::max_value() / 2u64..u64::max_value());
+        let b: u64 = rng.gen_range(0u64..u64::max_value() / 2u64);
 
         let expected = a.wrapping_sub(b);
 
@@ -425,8 +425,8 @@ fn test_uint64_pow_constants() {
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u64 = rng.gen_range(0, u64::from(u16::max_value()));
-        let b: u64 = rng.gen_range(0, 4);
+        let a: u64 = rng.gen_range(0..u64::from(u16::max_value()));
+        let b: u64 = rng.gen_range(0..4);
 
         let a_bit = UInt64::constant(a);
         let b_bit = UInt64::constant(b);
@@ -448,8 +448,8 @@ fn test_uint64_pow() {
     for _ in 0..4 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u64 = rng.gen_range(0, u64::from(u16::max_value()));
-        let b: u64 = rng.gen_range(0, 4);
+        let a: u64 = rng.gen_range(0..u64::from(u16::max_value()));
+        let b: u64 = rng.gen_range(0..4);
 
         let expected = a.wrapping_pow(b.try_into().unwrap());
 

--- a/models/src/gadgets/utilities/uint/tests/uint8.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint8.rs
@@ -256,8 +256,8 @@ fn test_uint8_sub_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u8 = rng.gen_range(u8::max_value() / 2u8, u8::max_value());
-        let b: u8 = rng.gen_range(0u8, u8::max_value() / 2u8);
+        let a: u8 = rng.gen_range(u8::max_value() / 2u8..u8::max_value());
+        let b: u8 = rng.gen_range(0u8..u8::max_value() / 2u8);
 
         let a_bit = UInt8::constant(a);
         let b_bit = UInt8::constant(b);
@@ -279,8 +279,8 @@ fn test_uint8_sub() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u8 = rng.gen_range(u8::max_value() / 2u8, u8::max_value());
-        let b: u8 = rng.gen_range(0u8, u8::max_value() / 2u8);
+        let a: u8 = rng.gen_range(u8::max_value() / 2u8..u8::max_value());
+        let b: u8 = rng.gen_range(0u8..u8::max_value() / 2u8);
 
         let expected = a.wrapping_sub(b);
 
@@ -317,8 +317,8 @@ fn test_uint8_mul_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u8 = rng.gen_range(0, u8::max_value());
-        let b: u8 = rng.gen_range(0, u8::max_value());
+        let a: u8 = rng.gen_range(0..u8::max_value());
+        let b: u8 = rng.gen_range(0..u8::max_value());
 
         let a_bit = UInt8::constant(a);
         let b_bit = UInt8::constant(b);
@@ -340,8 +340,8 @@ fn test_uint8_mul() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: u8 = rng.gen_range(0, u8::max_value());
-        let b: u8 = rng.gen_range(0, u8::max_value());
+        let a: u8 = rng.gen_range(0..u8::max_value());
+        let b: u8 = rng.gen_range(0..u8::max_value());
 
         let expected = a.wrapping_mul(b);
 
@@ -385,7 +385,7 @@ fn test_uint8_div_constants() {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
         let a: u8 = rng.gen();
-        let b: u8 = rng.gen_range(1, u8::max_value());
+        let b: u8 = rng.gen_range(1..u8::max_value());
 
         let a_bit = UInt8::constant(a);
         let b_bit = UInt8::constant(b);
@@ -408,7 +408,7 @@ fn test_uint8_div() {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
         let a: u8 = rng.gen();
-        let b: u8 = rng.gen_range(1, u8::max_value());
+        let b: u8 = rng.gen_range(1..u8::max_value());
 
         let expected = a.wrapping_div(b);
 

--- a/objects/Cargo.toml
+++ b/objects/Cargo.toml
@@ -62,7 +62,7 @@ version = "0.4.2"
 version = "1.5.2"
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 
 [dependencies.serde]
 version = "1.0"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -51,7 +51,7 @@ version = "0.4.34"
 version = "0.4.2"
 
 [dev-dependencies.rand]
-version = "0.7"
+version = "0.8"
 
 [features]
 default = [

--- a/polycommit/Cargo.toml
+++ b/polycommit/Cargo.toml
@@ -56,7 +56,7 @@ version = "2"
 features = [ "use_core" ]
 
 [dependencies.digest]
-version = "0.8"
+version = "0.9"
 
 [dependencies.rand_core]
 version = "0.6"
@@ -70,7 +70,7 @@ optional = true
 path = "../curves"
 
 [dev-dependencies.blake2]
-version = "0.8"
+version = "0.9"
 default-features = false
 
 [dev-dependencies.rand]

--- a/polycommit/Cargo.toml
+++ b/polycommit/Cargo.toml
@@ -59,7 +59,7 @@ features = [ "use_core" ]
 version = "0.8"
 
 [dependencies.rand_core]
-version = "0.5"
+version = "0.6"
 default-features = false
 
 [dependencies.rayon]
@@ -74,7 +74,7 @@ version = "0.8"
 default-features = false
 
 [dev-dependencies.rand]
-version = "0.7"
+version = "0.8"
 default-features = false
 
 [features]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -54,7 +54,7 @@ version = "0.4.2"
 version = "0.11.1"
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 
 [dependencies.rocksdb]
 version = "0.15.0"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -57,7 +57,7 @@ version = "0.0.4"
 version = "1.5.2"
 
 [dependencies.rand]
-version = "0.7.0"
+version = "0.8"
 
 [dependencies.rand_xorshift]
-version = "0.2.0"
+version = "0.3"

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -31,11 +31,11 @@ default-features = false
 version = "1.3.1"
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 default-features = false
 
 [dev-dependencies.rand_xorshift]
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [features]


### PR DESCRIPTION
This update will also allow for the same to be done for `snarkos`.

`cargo update` was also run to auto-update some other dependencies.

Obviates https://github.com/AleoHQ/snarkVM/pull/39, https://github.com/AleoHQ/snarkVM/pull/18, https://github.com/AleoHQ/snarkVM/pull/10, https://github.com/AleoHQ/snarkVM/pull/3, https://github.com/AleoHQ/snarkVM/pull/19, and https://github.com/AleoHQ/snarkVM/pull/40.