### PR TITLE
fix: avoid a stack overflow in the Display impl for SynthesisError

### DIFF
--- a/r1cs/src/errors/synthesis.rs
+++ b/r1cs/src/errors/synthesis.rs
@@ -67,7 +67,7 @@ impl fmt::Display for SynthesisError {
             write!(f, "I/O error: ")?;
             e.fmt(f)
         } else {
-            write!(f, "{}", self)
+            write!(f, "{:?}", self)
         }
     }
 }


### PR DESCRIPTION
The current `Display` impl for `SynthesisError` causes a stack overflow whenever the `else` branch is entered, due to using `{}` (which calls the `Display` impl for `SynthesisError`) within `write!`.

Fixes https://github.com/AleoHQ/leo/issues/666.