### PR TITLE
1.50 clippy lints

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -638,14 +638,14 @@ mod tests {
             let domain_size = 1 << domain_dimension;
             let domain = EvaluationDomain::<Fr>::new(domain_size).unwrap();
             let all_domain_elements: Vec<Fr> = domain.elements().collect();
-            for i in 0..domain_size {
-                let lagrange_coefficients = domain.evaluate_all_lagrange_coefficients(all_domain_elements[i]);
-                for j in 0..domain_size {
+            for (i, domain_element) in all_domain_elements.iter().enumerate().take(domain_size) {
+                let lagrange_coefficients = domain.evaluate_all_lagrange_coefficients(*domain_element);
+                for (j, lagrange_coefficient) in lagrange_coefficients.iter().enumerate().take(domain_size) {
                     // Lagrange coefficient for the evaluation point, which should be 1
                     if i == j {
-                        assert_eq!(lagrange_coefficients[j], Fr::one());
+                        assert_eq!(*lagrange_coefficient, Fr::one());
                     } else {
-                        assert_eq!(lagrange_coefficients[j], Fr::zero());
+                        assert_eq!(*lagrange_coefficient, Fr::zero());
                     }
                 }
             }

--- a/algorithms/src/fft/tests.rs
+++ b/algorithms/src/fft/tests.rs
@@ -69,7 +69,7 @@ fn parallel_fft_consistency() {
         serial_radix2_fft(a, omega.inverse().unwrap(), log_n);
         let domain_size_inv = E::Fr::from(a.len() as u64).inverse().unwrap();
         for coeff in a.iter_mut() {
-            *coeff *= &E::Fr::from(domain_size_inv);
+            *coeff *= &domain_size_inv;
         }
     }
 

--- a/curves/benches/bls12_377/pairing.rs
+++ b/curves/benches/bls12_377/pairing.rs
@@ -14,83 +14,81 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod pairing {
-    use snarkvm_curves::{
-        bls12_377::{Bls12_377, Bls12_377Parameters, Fq12, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2},
-        templates::bls12::{G1Prepared, G2Prepared},
-        traits::{PairingCurve, PairingEngine},
-    };
-    use snarkvm_utilities::rand::UniformRand;
+use snarkvm_curves::{
+    bls12_377::{Bls12_377, Bls12_377Parameters, Fq12, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2},
+    templates::bls12::{G1Prepared, G2Prepared},
+    traits::{PairingCurve, PairingEngine},
+};
+use snarkvm_utilities::rand::UniformRand;
 
-    use criterion::Criterion;
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
+use criterion::Criterion;
+use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
 
-    use std::iter;
+use std::iter;
 
-    pub fn bench_pairing_miller_loop(c: &mut Criterion) {
-        const SAMPLES: usize = 1000;
+pub fn bench_pairing_miller_loop(c: &mut Criterion) {
+    const SAMPLES: usize = 1000;
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-        let v: Vec<(G1Prepared<Bls12_377Parameters>, G2Prepared<Bls12_377Parameters>)> = (0..SAMPLES)
-            .map(|_| {
-                (
-                    G1Affine::from(G1::rand(&mut rng)).prepare(),
-                    G2Affine::from(G2::rand(&mut rng)).prepare(),
-                )
-            })
-            .collect();
+    let v: Vec<(G1Prepared<Bls12_377Parameters>, G2Prepared<Bls12_377Parameters>)> = (0..SAMPLES)
+        .map(|_| {
+            (
+                G1Affine::from(G1::rand(&mut rng)).prepare(),
+                G2Affine::from(G2::rand(&mut rng)).prepare(),
+            )
+        })
+        .collect();
 
-        let mut count = 0;
-        c.bench_function("bls12_377: pairing_miller_loop", |c| {
-            c.iter(|| {
-                let tmp = Bls12_377::miller_loop(iter::once((&v[count].0, &v[count].1)));
-                count = (count + 1) % SAMPLES;
-                tmp
-            })
-        });
-    }
+    let mut count = 0;
+    c.bench_function("bls12_377: pairing_miller_loop", |c| {
+        c.iter(|| {
+            let tmp = Bls12_377::miller_loop(iter::once((&v[count].0, &v[count].1)));
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
+    });
+}
 
-    pub fn bench_pairing_final_exponentiation(c: &mut Criterion) {
-        const SAMPLES: usize = 1000;
+pub fn bench_pairing_final_exponentiation(c: &mut Criterion) {
+    const SAMPLES: usize = 1000;
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-        let v: Vec<Fq12> = (0..SAMPLES)
-            .map(|_| {
-                (
-                    G1Affine::from(G1::rand(&mut rng)).prepare(),
-                    G2Affine::from(G2::rand(&mut rng)).prepare(),
-                )
-            })
-            .map(|(ref p, ref q)| Bls12_377::miller_loop([(p, q)].iter().copied()))
-            .collect();
+    let v: Vec<Fq12> = (0..SAMPLES)
+        .map(|_| {
+            (
+                G1Affine::from(G1::rand(&mut rng)).prepare(),
+                G2Affine::from(G2::rand(&mut rng)).prepare(),
+            )
+        })
+        .map(|(ref p, ref q)| Bls12_377::miller_loop([(p, q)].iter().copied()))
+        .collect();
 
-        let mut count = 0;
-        c.bench_function("bls12_377: pairing_final_exponentiation", |c| {
-            c.iter(|| {
-                let tmp = Bls12_377::final_exponentiation(&v[count]);
-                count = (count + 1) % SAMPLES;
-                tmp
-            })
-        });
-    }
+    let mut count = 0;
+    c.bench_function("bls12_377: pairing_final_exponentiation", |c| {
+        c.iter(|| {
+            let tmp = Bls12_377::final_exponentiation(&v[count]);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
+    });
+}
 
-    pub fn bench_pairing_full(c: &mut Criterion) {
-        const SAMPLES: usize = 1000;
+pub fn bench_pairing_full(c: &mut Criterion) {
+    const SAMPLES: usize = 1000;
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-        let v: Vec<(G1, G2)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G2::rand(&mut rng))).collect();
+    let v: Vec<(G1, G2)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G2::rand(&mut rng))).collect();
 
-        let mut count = 0;
-        c.bench_function("bls12_377: pairing_full", |c| {
-            c.iter(|| {
-                let tmp = Bls12_377::pairing(v[count].0, v[count].1);
-                count = (count + 1) % SAMPLES;
-                tmp
-            })
-        });
-    }
+    let mut count = 0;
+    c.bench_function("bls12_377: pairing_full", |c| {
+        c.iter(|| {
+            let tmp = Bls12_377::pairing(v[count].0, v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
+    });
 }

--- a/curves/benches/bw6_761/pairing.rs
+++ b/curves/benches/bw6_761/pairing.rs
@@ -14,83 +14,81 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod pairing {
-    use snarkvm_curves::{
-        bw6_761::{BW6_761Parameters, Fq6, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2, BW6_761},
-        templates::bw6::{G1Prepared, G2Prepared},
-        traits::{PairingCurve, PairingEngine},
-    };
-    use snarkvm_utilities::rand::UniformRand;
+use snarkvm_curves::{
+    bw6_761::{BW6_761Parameters, Fq6, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2, BW6_761},
+    templates::bw6::{G1Prepared, G2Prepared},
+    traits::{PairingCurve, PairingEngine},
+};
+use snarkvm_utilities::rand::UniformRand;
 
-    use criterion::Criterion;
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
+use criterion::Criterion;
+use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
 
-    use std::iter;
+use std::iter;
 
-    pub fn bench_pairing_miller_loop(c: &mut Criterion) {
-        const SAMPLES: usize = 1000;
+pub fn bench_pairing_miller_loop(c: &mut Criterion) {
+    const SAMPLES: usize = 1000;
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-        let v: Vec<(G1Prepared<BW6_761Parameters>, G2Prepared<BW6_761Parameters>)> = (0..SAMPLES)
-            .map(|_| {
-                (
-                    G1Affine::from(G1::rand(&mut rng)).prepare(),
-                    G2Affine::from(G2::rand(&mut rng)).prepare(),
-                )
-            })
-            .collect();
+    let v: Vec<(G1Prepared<BW6_761Parameters>, G2Prepared<BW6_761Parameters>)> = (0..SAMPLES)
+        .map(|_| {
+            (
+                G1Affine::from(G1::rand(&mut rng)).prepare(),
+                G2Affine::from(G2::rand(&mut rng)).prepare(),
+            )
+        })
+        .collect();
 
-        let mut count = 0;
-        c.bench_function("bw6_761: pairing_miller_loop", |c| {
-            c.iter(|| {
-                let tmp = BW6_761::miller_loop(iter::once((&v[count].0, &v[count].1)));
-                count = (count + 1) % SAMPLES;
-                tmp
-            })
-        });
-    }
+    let mut count = 0;
+    c.bench_function("bw6_761: pairing_miller_loop", |c| {
+        c.iter(|| {
+            let tmp = BW6_761::miller_loop(iter::once((&v[count].0, &v[count].1)));
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
+    });
+}
 
-    pub fn bench_pairing_final_exponentiation(c: &mut Criterion) {
-        const SAMPLES: usize = 1000;
+pub fn bench_pairing_final_exponentiation(c: &mut Criterion) {
+    const SAMPLES: usize = 1000;
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-        let v: Vec<Fq6> = (0..SAMPLES)
-            .map(|_| {
-                (
-                    G1Affine::from(G1::rand(&mut rng)).prepare(),
-                    G2Affine::from(G2::rand(&mut rng)).prepare(),
-                )
-            })
-            .map(|(ref p, ref q)| BW6_761::miller_loop([(p, q)].iter().copied()))
-            .collect();
+    let v: Vec<Fq6> = (0..SAMPLES)
+        .map(|_| {
+            (
+                G1Affine::from(G1::rand(&mut rng)).prepare(),
+                G2Affine::from(G2::rand(&mut rng)).prepare(),
+            )
+        })
+        .map(|(ref p, ref q)| BW6_761::miller_loop([(p, q)].iter().copied()))
+        .collect();
 
-        let mut count = 0;
-        c.bench_function("bw6_761: pairing_final_exponentiation", |c| {
-            c.iter(|| {
-                let tmp = BW6_761::final_exponentiation(&v[count]);
-                count = (count + 1) % SAMPLES;
-                tmp
-            })
-        });
-    }
+    let mut count = 0;
+    c.bench_function("bw6_761: pairing_final_exponentiation", |c| {
+        c.iter(|| {
+            let tmp = BW6_761::final_exponentiation(&v[count]);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
+    });
+}
 
-    pub fn bench_pairing_full(c: &mut Criterion) {
-        const SAMPLES: usize = 1000;
+pub fn bench_pairing_full(c: &mut Criterion) {
+    const SAMPLES: usize = 1000;
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-        let v: Vec<(G1, G2)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G2::rand(&mut rng))).collect();
+    let v: Vec<(G1, G2)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G2::rand(&mut rng))).collect();
 
-        let mut count = 0;
-        c.bench_function("bw6_761: pairing_full", |c| {
-            c.iter(|| {
-                let tmp = BW6_761::pairing(v[count].0, v[count].1);
-                count = (count + 1) % SAMPLES;
-                tmp
-            })
-        });
-    }
+    let mut count = 0;
+    c.bench_function("bw6_761: pairing_full", |c| {
+        c.iter(|| {
+            let tmp = BW6_761::pairing(v[count].0, v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
+    });
 }

--- a/curves/benches/curves.rs
+++ b/curves/benches/curves.rs
@@ -94,9 +94,9 @@ criterion_group!(
 
 criterion_group!(
     bls12_377_pairing,
-    bls12_377::pairing::pairing::bench_pairing_miller_loop,
-    bls12_377::pairing::pairing::bench_pairing_final_exponentiation,
-    bls12_377::pairing::pairing::bench_pairing_full,
+    bls12_377::pairing::bench_pairing_miller_loop,
+    bls12_377::pairing::bench_pairing_final_exponentiation,
+    bls12_377::pairing::bench_pairing_full,
 );
 
 criterion_group!(
@@ -174,9 +174,9 @@ criterion_group!(
 
 criterion_group!(
     bw6_761_pairing,
-    bw6_761::pairing::pairing::bench_pairing_miller_loop,
-    bw6_761::pairing::pairing::bench_pairing_final_exponentiation,
-    bw6_761::pairing::pairing::bench_pairing_full,
+    bw6_761::pairing::bench_pairing_miller_loop,
+    bw6_761::pairing::bench_pairing_final_exponentiation,
+    bw6_761::pairing::bench_pairing_full,
 );
 
 criterion_main!(

--- a/curves/src/traits/pairing_engine.rs
+++ b/curves/src/traits/pairing_engine.rs
@@ -177,6 +177,7 @@ pub trait ProjectiveCurve:
 
     /// Converts this element into its affine representation.
     #[must_use]
+    #[allow(clippy::wrong_self_convention)]
     fn into_affine(&self) -> Self::Affine;
 
     /// Recommends a wNAF window table size given a scalar. Always returns a
@@ -193,6 +194,7 @@ pub trait ProjectiveCurve:
 
 /// Affine representation of an elliptic curve point guaranteed to be
 /// in the correct prime order subgroup.
+#[allow(clippy::wrong_self_convention)]
 pub trait AffineCurve:
     Eq
     + Sized

--- a/dpc/src/base_dpc/tests.rs
+++ b/dpc/src/base_dpc/tests.rs
@@ -123,12 +123,12 @@ fn test_transaction_kernel_serialization() {
     let new_values = vec![10; NUM_OUTPUT_RECORDS];
     let new_payloads = vec![RecordPayload::default(); NUM_OUTPUT_RECORDS];
     let new_birth_program_ids = vec![noop_program_id.clone(); NUM_OUTPUT_RECORDS];
-    let new_death_program_ids = vec![noop_program_id.clone(); NUM_OUTPUT_RECORDS];
+    let new_death_program_ids = vec![noop_program_id; NUM_OUTPUT_RECORDS];
     let memo = [0u8; 32];
 
     // Generate transaction kernel
     let transaction_kernel = <InstantiatedDPC as DPCScheme<L>>::execute_offline(
-        system_parameters.clone(),
+        system_parameters,
         old_records,
         old_account_private_keys,
         new_record_owners,

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -39,5 +39,6 @@ pub trait Program: Clone {
     fn evaluate(&self, primary: &Self::PublicInput, witness: &Self::PrivateWitness) -> bool;
 
     /// Returns the program identity
+    #[allow(clippy::wrong_self_convention)]
     fn into_compact_repr(&self) -> Vec<u8>;
 }

--- a/fields/src/primefield.rs
+++ b/fields/src/primefield.rs
@@ -20,6 +20,7 @@ use snarkvm_utilities::biginteger::BigInteger;
 use std::str::FromStr;
 
 /// The interface for a prime field.
+#[allow(clippy::wrong_self_convention)]
 pub trait PrimeField: Field + FromStr {
     type Parameters: FpParameters<BigInteger = Self::BigInteger>;
     type BigInteger: BigInteger;

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -207,7 +207,7 @@ where
             let delta_g2 = P::G2Gadget::alloc(cs.ns(|| "delta_g2"), || Ok(delta_g2.into_projective()))?;
 
             let gamma_abc_g1 = gamma_abc_g1
-                .into_iter()
+                .iter()
                 .enumerate()
                 .map(|(i, gamma_abc_i)| {
                     P::G1Gadget::alloc(cs.ns(|| format!("gamma_abc_{}", i)), || {
@@ -245,7 +245,7 @@ where
             let delta_g2 = P::G2Gadget::alloc_input(cs.ns(|| "delta_g2"), || Ok(delta_g2.into_projective()))?;
 
             let gamma_abc_g1 = gamma_abc_g1
-                .into_iter()
+                .iter()
                 .enumerate()
                 .map(|(i, gamma_abc_i)| {
                     P::G1Gadget::alloc_input(cs.ns(|| format!("gamma_abc_{}", i)), || {

--- a/gadgets/src/fields/fp.rs
+++ b/gadgets/src/fields/fp.rs
@@ -76,7 +76,7 @@ impl<F: PrimeField> From<AllocatedFp<F>> for FpGadget<F> {
 impl<F: PrimeField> AllocatedFp<F> {
     /// Constructs `Self` from a `Boolean`: if `other` is false, this outputs
     /// `zero`, else it outputs `one`.
-    pub fn from_boolean<CS: ConstraintSystem<F>>(mut cs: CS, other: Boolean) -> Result<Self, SynthesisError> {
+    pub fn from_boolean<CS: ConstraintSystem<F>>(cs: CS, other: Boolean) -> Result<Self, SynthesisError> {
         let value = F::from(other.get_value().get()? as u128);
 
         Self::alloc(cs, || Ok(value))
@@ -204,6 +204,7 @@ impl<F: PrimeField> AllocatedFp<F> {
     }
 
     #[inline]
+    #[allow(dead_code)]
     fn add_constant_in_place<CS: ConstraintSystem<F>>(
         &mut self,
         _cs: CS,
@@ -265,6 +266,7 @@ impl<F: PrimeField> AllocatedFp<F> {
         Ok(self.clone())
     }
 
+    #[allow(dead_code)]
     fn frobenius_map_in_place<CS: ConstraintSystem<F>>(
         &mut self,
         _: CS,
@@ -298,10 +300,12 @@ impl<F: PrimeField> AllocatedFp<F> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     fn cost_of_mul() -> usize {
         1
     }
 
+    #[allow(dead_code)]
     fn cost_of_inv() -> usize {
         1
     }
@@ -588,7 +592,7 @@ impl<F: PrimeField> Clone for AllocatedFp<F> {
 
 impl<F: PrimeField> AllocGadget<F, F> for AllocatedFp<F> {
     #[inline]
-    fn alloc_constant<FN, T, CS: ConstraintSystem<F>>(mut cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
+    fn alloc_constant<FN, T, CS: ConstraintSystem<F>>(cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<F>,
@@ -657,7 +661,7 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
     #[inline]
     fn get_variable(&self) -> <Self as FieldGadget<F, F>>::Variable {
         match self {
-            FpGadget::Constant(v) => unimplemented!(),
+            FpGadget::Constant(_v) => unimplemented!(),
             FpGadget::Variable(v) => v.variable.clone(),
         }
     }
@@ -704,7 +708,7 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
     }
 
     #[inline]
-    fn add<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError> {
+    fn add<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, SynthesisError> {
         match (self, other) {
             (Self::Constant(c1), Self::Constant(c2)) => Ok(Self::Constant(*c1 + &*c2)),
             (Self::Constant(c), Self::Variable(v)) | (Self::Variable(v), Self::Constant(c)) => {
@@ -813,7 +817,7 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
     }
 
     #[inline]
-    fn inverse<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Self, SynthesisError> {
+    fn inverse<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Self, SynthesisError> {
         match self {
             Self::Constant(f) => f.inverse().get().map(Self::Constant),
             Self::Variable(v) => v.inverse(cs).map(Self::Variable),
@@ -952,14 +956,14 @@ impl<F: PrimeField> NEqGadget<F> for FpGadget<F> {
 impl<F: PrimeField> ToBitsGadget<F> for FpGadget<F> {
     /// Outputs the binary representation of the value in `self` in *big-endian*
     /// form.
-    fn to_bits<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
+    fn to_bits<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         match self {
             Self::Constant(_) => self.to_bits_strict(cs),
             Self::Variable(v) => v.to_bits(cs),
         }
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
+    fn to_bits_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         use snarkvm_utilities::bititerator::BitIteratorLE;
         match self {
             Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
@@ -972,14 +976,14 @@ impl<F: PrimeField> ToBitsGadget<F> for FpGadget<F> {
 }
 
 impl<F: PrimeField> ToBytesGadget<F> for FpGadget<F> {
-    fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         match self {
             Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes![c].unwrap())),
             Self::Variable(v) => v.to_bytes(cs),
         }
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         match self {
             Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes![c].unwrap())),
             Self::Variable(v) => v.to_bytes_strict(cs),
@@ -1001,7 +1005,7 @@ impl<F: PrimeField> CondSelectGadget<F> for FpGadget<F> {
             _ => {
                 match (first, second) {
                     (Self::Constant(t), Self::Constant(f)) => {
-                        let is = AllocatedFp::from_boolean(cs.ns(|| "from_bool_is"), cond.clone())?;
+                        let is = AllocatedFp::from_boolean(cs.ns(|| "from_bool_is"), *cond)?;
                         let not = AllocatedFp::from_boolean(cs.ns(|| "from_bool_not"), cond.not())?;
                         // cond * t + (1 - cond) * f
                         let not_f = &not.mul_by_constant(cs.ns(|| "mul_by_f"), &*f)?;
@@ -1038,7 +1042,7 @@ impl<F: PrimeField> TwoBitLookupGadget<F> for FpGadget<F> {
     type TableConstant = F;
 
     fn two_bit_lookup<CS: ConstraintSystem<F>>(
-        mut cs: CS,
+        cs: CS,
         b: &[Boolean],
         c: &[Self::TableConstant],
     ) -> Result<Self, SynthesisError> {
@@ -1078,7 +1082,7 @@ impl<F: PrimeField> ThreeBitCondNegLookupGadget<F> for FpGadget<F> {
     type TableConstant = F;
 
     fn three_bit_cond_neg_lookup<CS: ConstraintSystem<F>>(
-        mut cs: CS,
+        cs: CS,
         b: &[Boolean],
         b0b1: &Boolean,
         c: &[Self::TableConstant],

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -23,6 +23,7 @@
 //! is the same as the number of constraints (i.e., where the constraint
 //! matrices are square). Furthermore, Marlin only supports instances where the
 //! public inputs are of size one less than a power of 2 (i.e., 2^n - 1).
+#![allow(clippy::module_inception)]
 #![deny(unused_import_braces, unused_qualifications, trivial_casts)]
 #![deny(trivial_numeric_casts, private_in_public)]
 #![deny(stable_features, unreachable_pub, non_shorthand_field_patterns)]

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -459,10 +459,7 @@ mod tests {
     impl<E: PairingEngine> KZG10<E> {
         /// Specializes the public parameters for a given maximum degree `d` for polynomials
         /// `d` should be less that `pp.max_degree()`.
-        pub(crate) fn trim(
-            pp: &UniversalParams<E>,
-            mut supported_degree: usize,
-        ) -> Result<(Powers<E>, VerifierKey<E>), Error> {
+        pub(crate) fn trim(pp: &UniversalParams<E>, mut supported_degree: usize) -> (Powers<E>, VerifierKey<E>) {
             if supported_degree == 1 {
                 supported_degree += 1;
             }
@@ -481,7 +478,7 @@ mod tests {
                 prepared_h: pp.prepared_h.clone(),
                 prepared_beta_h: pp.prepared_beta_h.clone(),
             };
-            Ok((powers, vk))
+            (powers, vk)
         }
     }
 
@@ -501,7 +498,7 @@ mod tests {
 
         let degree = 4;
         let pp = KZG_Bls12_377::setup(degree, false, rng).unwrap();
-        let (powers, _) = KZG_Bls12_377::trim(&pp, degree).unwrap();
+        let (powers, _) = KZG_Bls12_377::trim(&pp, degree);
 
         let hiding_bound = None;
         let (comm, _) = KZG10::commit(&powers, &p, hiding_bound, Some(rng)).unwrap();
@@ -520,7 +517,7 @@ mod tests {
                 degree = usize::rand(rng) % 20;
             }
             let pp = KZG10::<E>::setup(degree, false, rng)?;
-            let (ck, vk) = KZG10::trim(&pp, degree)?;
+            let (ck, vk) = KZG10::trim(&pp, degree);
             let p = Polynomial::rand(degree, rng);
             let hiding_bound = Some(1);
             let (comm, rand) = KZG10::<E>::commit(&ck, &p, hiding_bound, Some(rng))?;
@@ -543,7 +540,7 @@ mod tests {
         for _ in 0..100 {
             let degree = 50;
             let pp = KZG10::<E>::setup(degree, false, rng)?;
-            let (ck, vk) = KZG10::trim(&pp, 2)?;
+            let (ck, vk) = KZG10::trim(&pp, 2);
             let p = Polynomial::rand(1, rng);
             let hiding_bound = Some(1);
             let (comm, rand) = KZG10::<E>::commit(&ck, &p, hiding_bound, Some(rng))?;
@@ -569,7 +566,7 @@ mod tests {
                 degree = usize::rand(rng) % 20;
             }
             let pp = KZG10::<E>::setup(degree, false, rng)?;
-            let (ck, vk) = KZG10::trim(&pp, degree)?;
+            let (ck, vk) = KZG10::trim(&pp, degree);
             let mut comms = Vec::new();
             let mut values = Vec::new();
             let mut points = Vec::new();

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -403,11 +403,11 @@ impl<E: PairingEngine> KZG10<E> {
         }
     }
 
-    pub(crate) fn check_degrees_and_bounds<'a>(
+    pub(crate) fn check_degrees_and_bounds(
         supported_degree: usize,
         max_degree: usize,
         enforced_degree_bounds: Option<&[usize]>,
-        p: &'a LabeledPolynomial<E::Fr>,
+        p: &LabeledPolynomial<E::Fr>,
     ) -> Result<(), Error> {
         if let Some(bound) = p.degree_bound() {
             let enforced_degree_bounds = enforced_degree_bounds.ok_or(Error::UnsupportedDegreeBound(bound))?;

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -646,10 +646,7 @@ pub mod tests {
             }
             let supported_hiding_bound = polynomials
                 .iter()
-                .map(|p| match p.hiding_bound() {
-                    Some(b) => b,
-                    None => 0,
-                })
+                .map(|p| p.hiding_bound().unwrap_or(0))
                 .max()
                 .unwrap_or(0);
             println!("supported degree: {:?}", supported_degree);
@@ -769,10 +766,7 @@ pub mod tests {
             }
             let supported_hiding_bound = polynomials
                 .iter()
-                .map(|p| match p.hiding_bound() {
-                    Some(b) => b,
-                    None => 0,
-                })
+                .map(|p| p.hiding_bound().unwrap_or(0))
                 .max()
                 .unwrap_or(0);
             println!("supported degree: {:?}", supported_degree);

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -41,7 +41,7 @@ use snarkvm_utilities::{
     serialize::*,
 };
 
-use core::{fmt::Debug, iter::FromIterator};
+use core::fmt::Debug;
 use rand_core::RngCore;
 
 #[cfg(not(feature = "std"))]
@@ -413,10 +413,10 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
             evaluations: evals,
         } = proof;
 
-        let lc_s = BTreeMap::from_iter(linear_combinations.into_iter().map(|lc| (lc.label(), lc)));
+        let lc_s: BTreeMap<_, _> = linear_combinations.into_iter().map(|lc| (lc.label(), lc)).collect();
 
         let poly_query_set = lc_query_set_to_poly_query_set(lc_s.values().copied(), eqn_query_set);
-        let poly_evals = Evaluations::from_iter(poly_query_set.iter().cloned().zip(evals.clone().unwrap()));
+        let poly_evals: Evaluations<_> = poly_query_set.iter().cloned().zip(evals.clone().unwrap()).collect();
 
         for &(ref lc_label, point) in eqn_query_set {
             if let Some(lc) = lc_s.get(lc_label) {
@@ -468,7 +468,7 @@ pub fn evaluate_query_set<'a, F: Field>(
     polys: impl IntoIterator<Item = &'a LabeledPolynomial<F>>,
     query_set: &QuerySet<'a, F>,
 ) -> Evaluations<'a, F> {
-    let polys = BTreeMap::from_iter(polys.into_iter().map(|p| (p.label(), p)));
+    let polys: BTreeMap<_, _> = polys.into_iter().map(|p| (p.label(), p)).collect();
     let mut evaluations = Evaluations::new();
     for (label, point) in query_set {
         let poly = polys.get(label).expect("polynomial in evaluated lc is not found");
@@ -484,7 +484,7 @@ fn lc_query_set_to_poly_query_set<'a, F: 'a + Field>(
 ) -> QuerySet<'a, F> {
     let mut poly_query_set = QuerySet::new();
     let lc_s = linear_combinations.into_iter().map(|lc| (lc.label(), lc));
-    let linear_combinations = BTreeMap::from_iter(lc_s);
+    let linear_combinations: BTreeMap<_, _> = lc_s.collect();
     for (lc_label, point) in query_set {
         if let Some(lc) = linear_combinations.get(lc_label) {
             for (_, poly_label) in lc.iter().filter(|(_, l)| !l.is_one()) {

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -230,7 +230,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
                     (None, None)
                 } else {
                     let mut sorted_enforced_degree_bounds = enforced_degree_bounds.clone();
-                    sorted_enforced_degree_bounds.sort();
+                    sorted_enforced_degree_bounds.sort_unstable();
 
                     let lowest_shifted_power =
                         max_degree - sorted_enforced_degree_bounds.last().ok_or(Error::EmptyDegreeBounds)?;

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -123,7 +123,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
 
                 let mut cm_and_indices = vec![];
 
-                for (commitment_key, index_value) in storage.get_iter(COL_COMMITMENT)? {
+                for (commitment_key, index_value) in storage.get_iter(COL_COMMITMENT) {
                     let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
                     let index = bytes_to_u32(index_value.to_vec()) as usize;
 

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -60,7 +60,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     /// Get the set of past ledger digests
     pub fn past_digests(&self) -> Result<HashSet<Vec<u8>>, StorageError> {
         let mut digests = HashSet::new();
-        for (key, _value) in self.storage.get_iter(COL_DIGEST)? {
+        for (key, _value) in self.storage.get_iter(COL_DIGEST) {
             digests.insert(key.to_vec());
         }
 
@@ -114,7 +114,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         // TODO (raychu86) make this more efficient
         let mut cm_and_indices = additional_cms;
 
-        for (commitment_key, index_value) in self.storage.get_iter(COL_COMMITMENT)? {
+        for (commitment_key, index_value) in self.storage.get_iter(COL_COMMITMENT) {
             let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
             let index = bytes_to_u32(index_value.to_vec()) as usize;
 

--- a/storage/src/objects/records.rs
+++ b/storage/src/objects/records.rs
@@ -30,7 +30,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     pub fn get_record_commitments(&self, limit: Option<usize>) -> Result<Vec<Vec<u8>>, StorageError> {
         let mut record_commitments = vec![];
 
-        for (commitment_key, _record) in self.storage.get_iter(COL_RECORDS)? {
+        for (commitment_key, _record) in self.storage.get_iter(COL_RECORDS) {
             if let Some(limit) = limit {
                 if record_commitments.len() >= limit {
                     break;

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -103,8 +103,8 @@ impl Storage {
 
     /// Returns the iterator from a given col.
     /// If the given key does not exist, returns [StorageError](snarkvm_errors::storage::StorageError).
-    pub(crate) fn get_iter(&self, col: u32) -> Result<DBIterator, StorageError> {
-        Ok(self.db.iterator_cf(self.get_cf_ref(col), IteratorMode::Start))
+    pub(crate) fn get_iter(&self, col: u32) -> DBIterator {
+        self.db.iterator_cf(self.get_cf_ref(col), IteratorMode::Start)
     }
 
     /// Returns `Ok(())` after executing a database transaction


### PR DESCRIPTION
These changes make `cargo clippy --workspace --all-targets` with Rust 1.50 green.