### PR TITLE
Introduce FiatShamir and Poseidon randomness gadgets to marlin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "snarkvm-algorithms",
  "snarkvm-curves",
  "snarkvm-fields",
+ "snarkvm-nonnative",
  "snarkvm-polycommit",
  "snarkvm-profiler",
  "snarkvm-r1cs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "snarkvm-algorithms",
  "snarkvm-curves",
  "snarkvm-fields",
+ "snarkvm-gadgets",
  "snarkvm-nonnative",
  "snarkvm-polycommit",
  "snarkvm-profiler",

--- a/gadgets/src/traits/fields/field.rs
+++ b/gadgets/src/traits/fields/field.rs
@@ -192,7 +192,7 @@ pub trait FieldGadget<NativeF: Field, F: Field>:
         for (index, i) in BitIteratorBE::new_without_leading_zeros(exp).enumerate() {
             res.square_in_place(cs.ns(|| format!("square_in_place_{}", index)))?;
             if i {
-                res.mul_in_place(cs.ns(|| format!("square_in_place_{}", index)), self)?;
+                res.mul_in_place(cs.ns(|| format!("mul_in_place_{}", index)), self)?;
             }
         }
         Ok(res)

--- a/gadgets/src/traits/fields/field.rs
+++ b/gadgets/src/traits/fields/field.rs
@@ -24,6 +24,7 @@ use crate::utilities::{
 };
 use snarkvm_fields::Field;
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
+use snarkvm_utilities::bititerator::BitIteratorBE;
 
 use std::fmt::Debug;
 
@@ -176,6 +177,23 @@ pub trait FieldGadget<NativeF: Field, F: Field>:
             res = res.square(cs.ns(|| format!("Double {}", i)))?;
             let tmp = res.mul(cs.ns(|| format!("Add {}-th base power", i)), self)?;
             res = Self::conditionally_select(cs.ns(|| format!("Conditional Select {}", i)), bit, &tmp, &res)?;
+        }
+        Ok(res)
+    }
+
+    /// Computes `self^S`, where S is interpreted as an little-endian
+    /// u64-decomposition of an integer.
+    fn pow_by_constant<CS: ConstraintSystem<F>, S: AsRef<[u64]>>(
+        &self,
+        mut cs: CS,
+        exp: S,
+    ) -> Result<Self, SynthesisError> {
+        let mut res = Self::one(cs.ns(|| "one"))?;
+        for (index, i) in BitIteratorBE::new_without_leading_zeros(exp).enumerate() {
+            res.square_in_place(cs.ns(|| format!("square_in_place_{}", index)))?;
+            if i {
+                res.mul_in_place(cs.ns(|| format!("square_in_place_{}", index)), self)?;
+            }
         }
         Ok(res)
     }

--- a/gadgets/src/traits/utilities/uint/macros.rs
+++ b/gadgets/src/traits/utilities/uint/macros.rs
@@ -57,6 +57,8 @@ macro_rules! alloc_int_fn_impl {
 macro_rules! alloc_int_impl {
     ($name: ident, $_type: ty, $size: expr) => {
         impl<F: Field> AllocGadget<$_type, F> for $name {
+            alloc_int_fn_impl!($name, $_type, $size, alloc_constant);
+
             alloc_int_fn_impl!($name, $_type, $size, alloc);
 
             alloc_int_fn_impl!($name, $_type, $size, alloc_input);

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -72,6 +72,10 @@ features = [ "use_core" ]
 [dependencies.digest]
 version = "0.9"
 
+[dependencies.rand]
+version = "0.8"
+default-features = false
+
 [dependencies.rand_chacha]
 version = "0.3"
 default-features = false
@@ -83,10 +87,6 @@ features = ["getrandom"]
 [dependencies.rayon]
 version = "1"
 optional = true
-
-[dev-dependencies.rand]
-version = "0.8"
-default-features = false
 
 [dev-dependencies.criterion]
 version = "0.3.4"

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -41,6 +41,10 @@ version = "0.2.0"
 path = "../fields"
 version = "0.2.0"
 
+[dependencies.snarkvm-gadgets]
+path = "../gadgets"
+version = "0.2.0"
+
 [dependencies.snarkvm-nonnative]
 path = "../nonnative"
 version = "0.2.0"

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -78,6 +78,7 @@ default-features = false
 
 [dependencies.rand_core]
 version = "0.6"
+features = ["getrandom"]
 
 [dependencies.rayon]
 version = "1"

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -41,6 +41,10 @@ version = "0.2.0"
 path = "../fields"
 version = "0.2.0"
 
+[dependencies.snarkvm-nonnative]
+path = "../nonnative"
+version = "0.2.0"
+
 [dependencies.snarkvm-polycommit]
 path = "../polycommit"
 version = "0.2.0"

--- a/marlin/src/fiat_shamir/constraints.rs
+++ b/marlin/src/fiat_shamir/constraints.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-#![allow(unused_imports)]
-
 use crate::{
     fiat_shamir::{AlgebraicSponge, FiatShamirAlgebraicSpongeRng, FiatShamirRng},
     overhead,
@@ -38,7 +36,7 @@ use snarkvm_nonnative::{
     NonNativeFieldVar,
 };
 use snarkvm_r1cs::{ConstraintSystem, ConstraintVariable, LinearCombination, SynthesisError};
-use std::{marker::PhantomData, ops::Sub};
+use std::marker::PhantomData;
 
 /// Vars for a RNG for use in a Fiat-Shamir transform.
 pub trait FiatShamirRngVar<F: PrimeField, CF: PrimeField, PFS: FiatShamirRng<F, CF>>: Clone {

--- a/marlin/src/fiat_shamir/constraints.rs
+++ b/marlin/src/fiat_shamir/constraints.rs
@@ -468,7 +468,7 @@ impl<F: PrimeField, CF: PrimeField, PS: AlgebraicSponge<CF>, S: AlgebraicSpongeV
             cs.enforce(|| format!("enforce_constraint_{}", i), |lc| lc, |lc| lc, |_| lc);
         }
 
-        self.s.absorb(cs.ns(|| "abosorb"), &gadgets)
+        self.s.absorb(cs.ns(|| "absorb"), &gadgets)
     }
 
     fn squeeze_native_field_elements<CS: ConstraintSystem<CF>>(

--- a/marlin/src/fiat_shamir/constraints.rs
+++ b/marlin/src/fiat_shamir/constraints.rs
@@ -1,0 +1,476 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+// use crate::fiat_shamir::{AlgebraicSponge, FiatShamirAlgebraicSpongeRng, FiatShamirRng};
+// use crate::{overhead, Vec};
+// use ark_ff::PrimeField;
+// use ark_nonnative_field::params::{get_params, OptimizationType};
+// use ark_nonnative_field::{AllocatedNonNativeFieldVar, NonNativeFieldVar};
+// use ark_r1cs_std::{
+//     alloc::AllocVar,
+//     bits::{uint8::UInt8, ToBitsGadget},
+//     boolean::Boolean,
+//     fields::fp::AllocatedFp,
+//     fields::fp::FpVar,
+//     R1CSVar,
+// };
+// use ark_relations::lc;
+// use ark_relations::r1cs::{
+//     ConstraintSystemRef, LinearCombination, OptimizationGoal, SynthesisError,
+// };
+// use core::marker::PhantomData;
+//
+// /// Vars for a RNG for use in a Fiat-Shamir transform.
+// pub trait FiatShamirRngVar<F: PrimeField, CF: PrimeField, PFS: FiatShamirRng<F, CF>>:
+//     Clone
+// {
+//     /// Create a new RNG.
+//     fn new(cs: ConstraintSystemRef<CF>) -> Self;
+//
+//     // Instantiate from a plaintext fs_rng.
+//     fn constant(cs: ConstraintSystemRef<CF>, pfs: &PFS) -> Self;
+//
+//     /// Take in field elements.
+//     fn absorb_nonnative_field_elements(
+//         &mut self,
+//         elems: &[NonNativeFieldVar<F, CF>],
+//         ty: OptimizationType,
+//     ) -> Result<(), SynthesisError>;
+//
+//     /// Take in field elements.
+//     fn absorb_native_field_elements(&mut self, elems: &[FpVar<CF>]) -> Result<(), SynthesisError>;
+//
+//     /// Take in bytes.
+//     fn absorb_bytes(&mut self, elems: &[UInt8<CF>]) -> Result<(), SynthesisError>;
+//
+//     /// Output field elements.
+//     fn squeeze_native_field_elements(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<Vec<FpVar<CF>>, SynthesisError>;
+//
+//     /// Output field elements.
+//     fn squeeze_field_elements(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError>;
+//
+//     /// Output field elements and the corresponding bits (this can reduce repeated computation).
+//     #[allow(clippy::type_complexity)]
+//     fn squeeze_field_elements_and_bits(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError>;
+//
+//     /// Output field elements with only 128 bits.
+//     fn squeeze_128_bits_field_elements(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError>;
+//
+//     /// Output field elements with only 128 bits, and the corresponding bits (this can reduce
+//     /// repeated computation).
+//     #[allow(clippy::type_complexity)]
+//     fn squeeze_128_bits_field_elements_and_bits(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError>;
+// }
+//
+// /// Trait for an algebraic sponge such as Poseidon.
+// pub trait AlgebraicSpongeVar<CF: PrimeField, PS: AlgebraicSponge<CF>>: Clone {
+//     /// Create the new sponge.
+//     fn new(cs: ConstraintSystemRef<CF>) -> Self;
+//
+//     /// Instantiate from a plaintext sponge.
+//     fn constant(cs: ConstraintSystemRef<CF>, ps: &PS) -> Self;
+//
+//     /// Obtain the constraint system.
+//     fn cs(&self) -> ConstraintSystemRef<CF>;
+//
+//     /// Take in field elements.
+//     fn absorb(&mut self, elems: &[FpVar<CF>]) -> Result<(), SynthesisError>;
+//
+//     /// Output field elements.
+//     fn squeeze(&mut self, num: usize) -> Result<Vec<FpVar<CF>>, SynthesisError>;
+// }
+//
+// /// Building the Fiat-Shamir sponge's gadget from any algebraic sponge's gadget.
+// #[derive(Clone)]
+// pub struct FiatShamirAlgebraicSpongeRngVar<
+//     F: PrimeField,
+//     CF: PrimeField,
+//     PS: AlgebraicSponge<CF>,
+//     S: AlgebraicSpongeVar<CF, PS>,
+// > {
+//     pub cs: ConstraintSystemRef<CF>,
+//     pub s: S,
+//     #[doc(hidden)]
+//     f_phantom: PhantomData<F>,
+//     cf_phantom: PhantomData<CF>,
+//     ps_phantom: PhantomData<PS>,
+// }
+//
+// impl<F: PrimeField, CF: PrimeField, PS: AlgebraicSponge<CF>, S: AlgebraicSpongeVar<CF, PS>>
+//     FiatShamirAlgebraicSpongeRngVar<F, CF, PS, S>
+// {
+//     /// Compress every two elements if possible. Provides a vector of (limb, num_of_additions),
+//     /// both of which are CF.
+//     #[tracing::instrument(target = "r1cs")]
+//     pub fn compress_gadgets(
+//         src_limbs: &[(FpVar<CF>, CF)],
+//         ty: OptimizationType,
+//     ) -> Result<Vec<FpVar<CF>>, SynthesisError> {
+//         let capacity = CF::size_in_bits() - 1;
+//         let mut dest_limbs = Vec::<FpVar<CF>>::new();
+//
+//         if src_limbs.is_empty() {
+//             return Ok(vec![]);
+//         }
+//
+//         let params = get_params(F::size_in_bits(), CF::size_in_bits(), ty);
+//
+//         let adjustment_factor_lookup_table = {
+//             let mut table = Vec::<CF>::new();
+//
+//             let mut cur = CF::one();
+//             for _ in 1..=capacity {
+//                 table.push(cur);
+//                 cur.double_in_place();
+//             }
+//
+//             table
+//         };
+//
+//         let mut i: usize = 0;
+//         let src_len = src_limbs.len();
+//         while i < src_len {
+//             let first = &src_limbs[i];
+//             let second = if i + 1 < src_len {
+//                 Some(&src_limbs[i + 1])
+//             } else {
+//                 None
+//             };
+//
+//             let first_max_bits_per_limb = params.bits_per_limb + overhead!(first.1 + &CF::one());
+//             let second_max_bits_per_limb = if second.is_some() {
+//                 params.bits_per_limb + overhead!(second.unwrap().1 + &CF::one())
+//             } else {
+//                 0
+//             };
+//
+//             if second.is_some() && first_max_bits_per_limb + second_max_bits_per_limb <= capacity {
+//                 let adjustment_factor = &adjustment_factor_lookup_table[second_max_bits_per_limb];
+//
+//                 dest_limbs.push(&first.0 * *adjustment_factor + &second.unwrap().0);
+//                 i += 2;
+//             } else {
+//                 dest_limbs.push(first.0.clone());
+//                 i += 1;
+//             }
+//         }
+//
+//         Ok(dest_limbs)
+//     }
+//
+//     /// Push gadgets to sponge.
+//     #[tracing::instrument(target = "r1cs", skip(sponge))]
+//     pub fn push_gadgets_to_sponge(
+//         sponge: &mut S,
+//         src: &[NonNativeFieldVar<F, CF>],
+//         ty: OptimizationType,
+//     ) -> Result<(), SynthesisError> {
+//         let mut src_limbs: Vec<(FpVar<CF>, CF)> = Vec::new();
+//
+//         for elem in src.iter() {
+//             match elem {
+//                 NonNativeFieldVar::Constant(c) => {
+//                     let v = AllocatedNonNativeFieldVar::<F, CF>::new_constant(sponge.cs(), c)?;
+//
+//                     for limb in v.limbs.iter() {
+//                         let num_of_additions_over_normal_form =
+//                             if v.num_of_additions_over_normal_form == CF::zero() {
+//                                 CF::one()
+//                             } else {
+//                                 v.num_of_additions_over_normal_form
+//                             };
+//                         src_limbs.push((limb.clone(), num_of_additions_over_normal_form));
+//                     }
+//                 }
+//                 NonNativeFieldVar::Var(v) => {
+//                     for limb in v.limbs.iter() {
+//                         let num_of_additions_over_normal_form =
+//                             if v.num_of_additions_over_normal_form == CF::zero() {
+//                                 CF::one()
+//                             } else {
+//                                 v.num_of_additions_over_normal_form
+//                             };
+//                         src_limbs.push((limb.clone(), num_of_additions_over_normal_form));
+//                     }
+//                 }
+//             }
+//         }
+//
+//         let dest_limbs = Self::compress_gadgets(&src_limbs, ty)?;
+//         sponge.absorb(&dest_limbs)?;
+//         Ok(())
+//     }
+//
+//     /// Obtain random bits from hashchain gadget. (Not guaranteed to be uniformly distributed,
+//     /// should only be used in certain situations.)
+//     #[tracing::instrument(target = "r1cs", skip(sponge))]
+//     pub fn get_booleans_from_sponge(
+//         sponge: &mut S,
+//         num_bits: usize,
+//     ) -> Result<Vec<Boolean<CF>>, SynthesisError> {
+//         let bits_per_element = CF::size_in_bits() - 1;
+//         let num_elements = (num_bits + bits_per_element - 1) / bits_per_element;
+//
+//         let src_elements = sponge.squeeze(num_elements)?;
+//         let mut dest_bits = Vec::<Boolean<CF>>::new();
+//
+//         for elem in src_elements.iter() {
+//             let elem_bits = elem.to_bits_be()?;
+//             dest_bits.extend_from_slice(&elem_bits[1..]); // discard the highest bit
+//         }
+//
+//         Ok(dest_bits)
+//     }
+//
+//     /// Obtain random elements from hashchain gadget. (Not guaranteed to be uniformly distributed,
+//     /// should only be used in certain situations.)
+//     #[tracing::instrument(target = "r1cs", skip(sponge))]
+//     pub fn get_gadgets_from_sponge(
+//         sponge: &mut S,
+//         num_elements: usize,
+//         outputs_short_elements: bool,
+//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError> {
+//         let (dest_gadgets, _) =
+//             Self::get_gadgets_and_bits_from_sponge(sponge, num_elements, outputs_short_elements)?;
+//
+//         Ok(dest_gadgets)
+//     }
+//
+//     /// Obtain random elements, and the corresponding bits, from hashchain gadget. (Not guaranteed
+//     /// to be uniformly distributed, should only be used in certain situations.)
+//     #[tracing::instrument(target = "r1cs", skip(sponge))]
+//     #[allow(clippy::type_complexity)]
+//     pub fn get_gadgets_and_bits_from_sponge(
+//         sponge: &mut S,
+//         num_elements: usize,
+//         outputs_short_elements: bool,
+//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError> {
+//         let cs = sponge.cs();
+//
+//         let optimization_type = match cs.optimization_goal() {
+//             OptimizationGoal::None => OptimizationType::Constraints,
+//             OptimizationGoal::Constraints => OptimizationType::Constraints,
+//             OptimizationGoal::Weight => OptimizationType::Weight,
+//         };
+//
+//         let params = get_params(F::size_in_bits(), CF::size_in_bits(), optimization_type);
+//
+//         let num_bits_per_nonnative = if outputs_short_elements {
+//             128
+//         } else {
+//             F::size_in_bits() - 1 // also omit the highest bit
+//         };
+//         let bits = Self::get_booleans_from_sponge(sponge, num_bits_per_nonnative * num_elements)?;
+//
+//         let mut lookup_table = Vec::<Vec<CF>>::new();
+//         let mut cur = F::one();
+//         for _ in 0..num_bits_per_nonnative {
+//             let repr = AllocatedNonNativeFieldVar::<F, CF>::get_limbs_representations(
+//                 &cur,
+//                 optimization_type,
+//             )?;
+//             lookup_table.push(repr);
+//             cur.double_in_place();
+//         }
+//
+//         let mut dest_gadgets = Vec::<NonNativeFieldVar<F, CF>>::new();
+//         let mut dest_bits = Vec::<Vec<Boolean<CF>>>::new();
+//         bits.chunks_exact(num_bits_per_nonnative)
+//             .for_each(|per_nonnative_bits| {
+//                 let mut val = vec![CF::zero(); params.num_limbs];
+//                 let mut lc = vec![LinearCombination::<CF>::zero(); params.num_limbs];
+//
+//                 let mut per_nonnative_bits_le = per_nonnative_bits.to_vec();
+//                 per_nonnative_bits_le.reverse();
+//
+//                 dest_bits.push(per_nonnative_bits_le.clone());
+//
+//                 for (j, bit) in per_nonnative_bits_le.iter().enumerate() {
+//                     if bit.value().unwrap_or_default() {
+//                         for (k, val) in val.iter_mut().enumerate().take(params.num_limbs) {
+//                             *val += &lookup_table[j][k];
+//                         }
+//                     }
+//
+//                     #[allow(clippy::needless_range_loop)]
+//                     for k in 0..params.num_limbs {
+//                         lc[k] = &lc[k] + bit.lc() * lookup_table[j][k];
+//                     }
+//                 }
+//
+//                 let mut limbs = Vec::new();
+//                 for k in 0..params.num_limbs {
+//                     let gadget =
+//                         AllocatedFp::new_witness(ark_relations::ns!(cs, "alloc"), || Ok(val[k]))
+//                             .unwrap();
+//                     lc[k] = lc[k].clone() - (CF::one(), gadget.variable);
+//                     cs.enforce_constraint(lc!(), lc!(), lc[k].clone()).unwrap();
+//                     limbs.push(FpVar::<CF>::from(gadget));
+//                 }
+//
+//                 dest_gadgets.push(NonNativeFieldVar::<F, CF>::Var(
+//                     AllocatedNonNativeFieldVar::<F, CF> {
+//                         cs: cs.clone(),
+//                         limbs,
+//                         num_of_additions_over_normal_form: CF::zero(),
+//                         is_in_the_normal_form: true,
+//                         target_phantom: Default::default(),
+//                     },
+//                 ));
+//             });
+//
+//         Ok((dest_gadgets, dest_bits))
+//     }
+// }
+//
+// impl<F: PrimeField, CF: PrimeField, PS: AlgebraicSponge<CF>, S: AlgebraicSpongeVar<CF, PS>>
+//     FiatShamirRngVar<F, CF, FiatShamirAlgebraicSpongeRng<F, CF, PS>>
+//     for FiatShamirAlgebraicSpongeRngVar<F, CF, PS, S>
+// {
+//     fn new(cs: ConstraintSystemRef<CF>) -> Self {
+//         Self {
+//             cs: cs.clone(),
+//             s: S::new(cs),
+//             f_phantom: PhantomData,
+//             cf_phantom: PhantomData,
+//             ps_phantom: PhantomData,
+//         }
+//     }
+//
+//     fn constant(
+//         cs: ConstraintSystemRef<CF>,
+//         pfs: &FiatShamirAlgebraicSpongeRng<F, CF, PS>,
+//     ) -> Self {
+//         Self {
+//             cs: cs.clone(),
+//             s: S::constant(cs, &pfs.s.clone()),
+//             f_phantom: PhantomData,
+//             cf_phantom: PhantomData,
+//             ps_phantom: PhantomData,
+//         }
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn absorb_nonnative_field_elements(
+//         &mut self,
+//         elems: &[NonNativeFieldVar<F, CF>],
+//         ty: OptimizationType,
+//     ) -> Result<(), SynthesisError> {
+//         Self::push_gadgets_to_sponge(&mut self.s, &elems.to_vec(), ty)
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn absorb_native_field_elements(&mut self, elems: &[FpVar<CF>]) -> Result<(), SynthesisError> {
+//         self.s.absorb(elems)?;
+//         Ok(())
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn absorb_bytes(&mut self, elems: &[UInt8<CF>]) -> Result<(), SynthesisError> {
+//         let capacity = CF::size_in_bits() - 1;
+//         let mut bits = Vec::<Boolean<CF>>::new();
+//         for elem in elems.iter() {
+//             let mut bits_le = elem.to_bits_le()?; // UInt8's to_bits is le, which is an exception in Zexe.
+//             bits_le.reverse();
+//             bits.extend_from_slice(&bits_le);
+//         }
+//
+//         let mut adjustment_factors = Vec::<CF>::new();
+//         let mut cur = CF::one();
+//         for _ in 0..capacity {
+//             adjustment_factors.push(cur);
+//             cur.double_in_place();
+//         }
+//
+//         let mut gadgets = Vec::<FpVar<CF>>::new();
+//         for elem_bits in bits.chunks(capacity) {
+//             let mut elem = CF::zero();
+//             let mut lc = LinearCombination::zero();
+//             for (bit, adjustment_factor) in elem_bits.iter().rev().zip(adjustment_factors.iter()) {
+//                 if bit.value().unwrap_or_default() {
+//                     elem += adjustment_factor;
+//                 }
+//                 lc = &lc + bit.lc() * *adjustment_factor;
+//             }
+//
+//             let gadget =
+//                 AllocatedFp::new_witness(ark_relations::ns!(self.cs, "gadget"), || Ok(elem))?;
+//             lc = lc.clone() - (CF::one(), gadget.variable);
+//
+//             gadgets.push(FpVar::from(gadget));
+//             self.cs.enforce_constraint(lc!(), lc!(), lc)?;
+//         }
+//
+//         self.s.absorb(&gadgets)
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn squeeze_native_field_elements(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<Vec<FpVar<CF>>, SynthesisError> {
+//         self.s.squeeze(num)
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn squeeze_field_elements(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError> {
+//         Self::get_gadgets_from_sponge(&mut self.s, num, false)
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     #[allow(clippy::type_complexity)]
+//     fn squeeze_field_elements_and_bits(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError> {
+//         Self::get_gadgets_and_bits_from_sponge(&mut self.s, num, false)
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn squeeze_128_bits_field_elements(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError> {
+//         Self::get_gadgets_from_sponge(&mut self.s, num, true)
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     #[allow(clippy::type_complexity)]
+//     fn squeeze_128_bits_field_elements_and_bits(
+//         &mut self,
+//         num: usize,
+//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError> {
+//         Self::get_gadgets_and_bits_from_sponge(&mut self.s, num, true)
+//     }
+// }

--- a/marlin/src/fiat_shamir/constraints.rs
+++ b/marlin/src/fiat_shamir/constraints.rs
@@ -14,343 +14,334 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-// use crate::fiat_shamir::{AlgebraicSponge, FiatShamirAlgebraicSpongeRng, FiatShamirRng};
-// use crate::{overhead, Vec};
-// use ark_ff::PrimeField;
-// use ark_nonnative_field::params::{get_params, OptimizationType};
-// use ark_nonnative_field::{AllocatedNonNativeFieldVar, NonNativeFieldVar};
-// use ark_r1cs_std::{
-//     alloc::AllocVar,
-//     bits::{uint8::UInt8, ToBitsGadget},
-//     boolean::Boolean,
-//     fields::fp::AllocatedFp,
-//     fields::fp::FpVar,
-//     R1CSVar,
-// };
-// use ark_relations::lc;
-// use ark_relations::r1cs::{
-//     ConstraintSystemRef, LinearCombination, OptimizationGoal, SynthesisError,
-// };
-// use core::marker::PhantomData;
-//
-// /// Vars for a RNG for use in a Fiat-Shamir transform.
-// pub trait FiatShamirRngVar<F: PrimeField, CF: PrimeField, PFS: FiatShamirRng<F, CF>>:
-//     Clone
-// {
-//     /// Create a new RNG.
-//     fn new(cs: ConstraintSystemRef<CF>) -> Self;
-//
-//     // Instantiate from a plaintext fs_rng.
-//     fn constant(cs: ConstraintSystemRef<CF>, pfs: &PFS) -> Self;
-//
-//     /// Take in field elements.
-//     fn absorb_nonnative_field_elements(
-//         &mut self,
-//         elems: &[NonNativeFieldVar<F, CF>],
-//         ty: OptimizationType,
-//     ) -> Result<(), SynthesisError>;
-//
-//     /// Take in field elements.
-//     fn absorb_native_field_elements(&mut self, elems: &[FpVar<CF>]) -> Result<(), SynthesisError>;
-//
-//     /// Take in bytes.
-//     fn absorb_bytes(&mut self, elems: &[UInt8<CF>]) -> Result<(), SynthesisError>;
-//
-//     /// Output field elements.
-//     fn squeeze_native_field_elements(
-//         &mut self,
-//         num: usize,
-//     ) -> Result<Vec<FpVar<CF>>, SynthesisError>;
-//
-//     /// Output field elements.
-//     fn squeeze_field_elements(
-//         &mut self,
-//         num: usize,
-//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError>;
-//
-//     /// Output field elements and the corresponding bits (this can reduce repeated computation).
-//     #[allow(clippy::type_complexity)]
-//     fn squeeze_field_elements_and_bits(
-//         &mut self,
-//         num: usize,
-//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError>;
-//
-//     /// Output field elements with only 128 bits.
-//     fn squeeze_128_bits_field_elements(
-//         &mut self,
-//         num: usize,
-//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError>;
-//
-//     /// Output field elements with only 128 bits, and the corresponding bits (this can reduce
-//     /// repeated computation).
-//     #[allow(clippy::type_complexity)]
-//     fn squeeze_128_bits_field_elements_and_bits(
-//         &mut self,
-//         num: usize,
-//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError>;
-// }
-//
-// /// Trait for an algebraic sponge such as Poseidon.
-// pub trait AlgebraicSpongeVar<CF: PrimeField, PS: AlgebraicSponge<CF>>: Clone {
-//     /// Create the new sponge.
-//     fn new(cs: ConstraintSystemRef<CF>) -> Self;
-//
-//     /// Instantiate from a plaintext sponge.
-//     fn constant(cs: ConstraintSystemRef<CF>, ps: &PS) -> Self;
-//
-//     /// Obtain the constraint system.
-//     fn cs(&self) -> ConstraintSystemRef<CF>;
-//
-//     /// Take in field elements.
-//     fn absorb(&mut self, elems: &[FpVar<CF>]) -> Result<(), SynthesisError>;
-//
-//     /// Output field elements.
-//     fn squeeze(&mut self, num: usize) -> Result<Vec<FpVar<CF>>, SynthesisError>;
-// }
-//
-// /// Building the Fiat-Shamir sponge's gadget from any algebraic sponge's gadget.
-// #[derive(Clone)]
-// pub struct FiatShamirAlgebraicSpongeRngVar<
-//     F: PrimeField,
-//     CF: PrimeField,
-//     PS: AlgebraicSponge<CF>,
-//     S: AlgebraicSpongeVar<CF, PS>,
-// > {
-//     pub cs: ConstraintSystemRef<CF>,
-//     pub s: S,
-//     #[doc(hidden)]
-//     f_phantom: PhantomData<F>,
-//     cf_phantom: PhantomData<CF>,
-//     ps_phantom: PhantomData<PS>,
-// }
-//
-// impl<F: PrimeField, CF: PrimeField, PS: AlgebraicSponge<CF>, S: AlgebraicSpongeVar<CF, PS>>
-//     FiatShamirAlgebraicSpongeRngVar<F, CF, PS, S>
-// {
-//     /// Compress every two elements if possible. Provides a vector of (limb, num_of_additions),
-//     /// both of which are CF.
-//     #[tracing::instrument(target = "r1cs")]
-//     pub fn compress_gadgets(
-//         src_limbs: &[(FpVar<CF>, CF)],
-//         ty: OptimizationType,
-//     ) -> Result<Vec<FpVar<CF>>, SynthesisError> {
-//         let capacity = CF::size_in_bits() - 1;
-//         let mut dest_limbs = Vec::<FpVar<CF>>::new();
-//
-//         if src_limbs.is_empty() {
-//             return Ok(vec![]);
-//         }
-//
-//         let params = get_params(F::size_in_bits(), CF::size_in_bits(), ty);
-//
-//         let adjustment_factor_lookup_table = {
-//             let mut table = Vec::<CF>::new();
-//
-//             let mut cur = CF::one();
-//             for _ in 1..=capacity {
-//                 table.push(cur);
-//                 cur.double_in_place();
-//             }
-//
-//             table
-//         };
-//
-//         let mut i: usize = 0;
-//         let src_len = src_limbs.len();
-//         while i < src_len {
-//             let first = &src_limbs[i];
-//             let second = if i + 1 < src_len {
-//                 Some(&src_limbs[i + 1])
-//             } else {
-//                 None
-//             };
-//
-//             let first_max_bits_per_limb = params.bits_per_limb + overhead!(first.1 + &CF::one());
-//             let second_max_bits_per_limb = if second.is_some() {
-//                 params.bits_per_limb + overhead!(second.unwrap().1 + &CF::one())
-//             } else {
-//                 0
-//             };
-//
-//             if second.is_some() && first_max_bits_per_limb + second_max_bits_per_limb <= capacity {
-//                 let adjustment_factor = &adjustment_factor_lookup_table[second_max_bits_per_limb];
-//
-//                 dest_limbs.push(&first.0 * *adjustment_factor + &second.unwrap().0);
-//                 i += 2;
-//             } else {
-//                 dest_limbs.push(first.0.clone());
-//                 i += 1;
-//             }
-//         }
-//
-//         Ok(dest_limbs)
-//     }
-//
-//     /// Push gadgets to sponge.
-//     #[tracing::instrument(target = "r1cs", skip(sponge))]
-//     pub fn push_gadgets_to_sponge(
-//         sponge: &mut S,
-//         src: &[NonNativeFieldVar<F, CF>],
-//         ty: OptimizationType,
-//     ) -> Result<(), SynthesisError> {
-//         let mut src_limbs: Vec<(FpVar<CF>, CF)> = Vec::new();
-//
-//         for elem in src.iter() {
-//             match elem {
-//                 NonNativeFieldVar::Constant(c) => {
-//                     let v = AllocatedNonNativeFieldVar::<F, CF>::new_constant(sponge.cs(), c)?;
-//
-//                     for limb in v.limbs.iter() {
-//                         let num_of_additions_over_normal_form =
-//                             if v.num_of_additions_over_normal_form == CF::zero() {
-//                                 CF::one()
-//                             } else {
-//                                 v.num_of_additions_over_normal_form
-//                             };
-//                         src_limbs.push((limb.clone(), num_of_additions_over_normal_form));
-//                     }
-//                 }
-//                 NonNativeFieldVar::Var(v) => {
-//                     for limb in v.limbs.iter() {
-//                         let num_of_additions_over_normal_form =
-//                             if v.num_of_additions_over_normal_form == CF::zero() {
-//                                 CF::one()
-//                             } else {
-//                                 v.num_of_additions_over_normal_form
-//                             };
-//                         src_limbs.push((limb.clone(), num_of_additions_over_normal_form));
-//                     }
-//                 }
-//             }
-//         }
-//
-//         let dest_limbs = Self::compress_gadgets(&src_limbs, ty)?;
-//         sponge.absorb(&dest_limbs)?;
-//         Ok(())
-//     }
-//
-//     /// Obtain random bits from hashchain gadget. (Not guaranteed to be uniformly distributed,
-//     /// should only be used in certain situations.)
-//     #[tracing::instrument(target = "r1cs", skip(sponge))]
-//     pub fn get_booleans_from_sponge(
-//         sponge: &mut S,
-//         num_bits: usize,
-//     ) -> Result<Vec<Boolean<CF>>, SynthesisError> {
-//         let bits_per_element = CF::size_in_bits() - 1;
-//         let num_elements = (num_bits + bits_per_element - 1) / bits_per_element;
-//
-//         let src_elements = sponge.squeeze(num_elements)?;
-//         let mut dest_bits = Vec::<Boolean<CF>>::new();
-//
-//         for elem in src_elements.iter() {
-//             let elem_bits = elem.to_bits_be()?;
-//             dest_bits.extend_from_slice(&elem_bits[1..]); // discard the highest bit
-//         }
-//
-//         Ok(dest_bits)
-//     }
-//
-//     /// Obtain random elements from hashchain gadget. (Not guaranteed to be uniformly distributed,
-//     /// should only be used in certain situations.)
-//     #[tracing::instrument(target = "r1cs", skip(sponge))]
-//     pub fn get_gadgets_from_sponge(
-//         sponge: &mut S,
-//         num_elements: usize,
-//         outputs_short_elements: bool,
-//     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError> {
-//         let (dest_gadgets, _) =
-//             Self::get_gadgets_and_bits_from_sponge(sponge, num_elements, outputs_short_elements)?;
-//
-//         Ok(dest_gadgets)
-//     }
-//
-//     /// Obtain random elements, and the corresponding bits, from hashchain gadget. (Not guaranteed
-//     /// to be uniformly distributed, should only be used in certain situations.)
-//     #[tracing::instrument(target = "r1cs", skip(sponge))]
-//     #[allow(clippy::type_complexity)]
-//     pub fn get_gadgets_and_bits_from_sponge(
-//         sponge: &mut S,
-//         num_elements: usize,
-//         outputs_short_elements: bool,
-//     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError> {
-//         let cs = sponge.cs();
-//
-//         let optimization_type = match cs.optimization_goal() {
-//             OptimizationGoal::None => OptimizationType::Constraints,
-//             OptimizationGoal::Constraints => OptimizationType::Constraints,
-//             OptimizationGoal::Weight => OptimizationType::Weight,
-//         };
-//
-//         let params = get_params(F::size_in_bits(), CF::size_in_bits(), optimization_type);
-//
-//         let num_bits_per_nonnative = if outputs_short_elements {
-//             128
-//         } else {
-//             F::size_in_bits() - 1 // also omit the highest bit
-//         };
-//         let bits = Self::get_booleans_from_sponge(sponge, num_bits_per_nonnative * num_elements)?;
-//
-//         let mut lookup_table = Vec::<Vec<CF>>::new();
-//         let mut cur = F::one();
-//         for _ in 0..num_bits_per_nonnative {
-//             let repr = AllocatedNonNativeFieldVar::<F, CF>::get_limbs_representations(
-//                 &cur,
-//                 optimization_type,
-//             )?;
-//             lookup_table.push(repr);
-//             cur.double_in_place();
-//         }
-//
-//         let mut dest_gadgets = Vec::<NonNativeFieldVar<F, CF>>::new();
-//         let mut dest_bits = Vec::<Vec<Boolean<CF>>>::new();
-//         bits.chunks_exact(num_bits_per_nonnative)
-//             .for_each(|per_nonnative_bits| {
-//                 let mut val = vec![CF::zero(); params.num_limbs];
-//                 let mut lc = vec![LinearCombination::<CF>::zero(); params.num_limbs];
-//
-//                 let mut per_nonnative_bits_le = per_nonnative_bits.to_vec();
-//                 per_nonnative_bits_le.reverse();
-//
-//                 dest_bits.push(per_nonnative_bits_le.clone());
-//
-//                 for (j, bit) in per_nonnative_bits_le.iter().enumerate() {
-//                     if bit.value().unwrap_or_default() {
-//                         for (k, val) in val.iter_mut().enumerate().take(params.num_limbs) {
-//                             *val += &lookup_table[j][k];
-//                         }
-//                     }
-//
-//                     #[allow(clippy::needless_range_loop)]
-//                     for k in 0..params.num_limbs {
-//                         lc[k] = &lc[k] + bit.lc() * lookup_table[j][k];
-//                     }
-//                 }
-//
-//                 let mut limbs = Vec::new();
-//                 for k in 0..params.num_limbs {
-//                     let gadget =
-//                         AllocatedFp::new_witness(ark_relations::ns!(cs, "alloc"), || Ok(val[k]))
-//                             .unwrap();
-//                     lc[k] = lc[k].clone() - (CF::one(), gadget.variable);
-//                     cs.enforce_constraint(lc!(), lc!(), lc[k].clone()).unwrap();
-//                     limbs.push(FpVar::<CF>::from(gadget));
-//                 }
-//
-//                 dest_gadgets.push(NonNativeFieldVar::<F, CF>::Var(
-//                     AllocatedNonNativeFieldVar::<F, CF> {
-//                         cs: cs.clone(),
-//                         limbs,
-//                         num_of_additions_over_normal_form: CF::zero(),
-//                         is_in_the_normal_form: true,
-//                         target_phantom: Default::default(),
-//                     },
-//                 ));
-//             });
-//
-//         Ok((dest_gadgets, dest_bits))
-//     }
-// }
-//
+#![allow(unused_imports)]
+
+use crate::{
+    fiat_shamir::{AlgebraicSponge, FiatShamirAlgebraicSpongeRng, FiatShamirRng},
+    overhead,
+};
+
+use snarkvm_fields::PrimeField;
+use snarkvm_gadgets::{
+    fields::{AllocatedFp, FpGadget},
+    traits::fields::FieldGadget,
+    utilities::{alloc::AllocGadget, boolean::Boolean, uint::UInt8, ToBitsGadget},
+};
+use snarkvm_nonnative::{
+    params::{get_params, OptimizationType},
+    AllocatedNonNativeFieldVar,
+    NonNativeFieldVar,
+};
+use snarkvm_r1cs::{ConstraintSystem, LinearCombination, SynthesisError};
+use std::marker::PhantomData;
+
+/// Vars for a RNG for use in a Fiat-Shamir transform.
+pub trait FiatShamirRngVar<F: PrimeField, CF: PrimeField, PFS: FiatShamirRng<F, CF>>: Clone {
+    /// Create a new RNG.
+    fn new<CS: ConstraintSystem<CF>>(cs: CS) -> Self;
+
+    /// Instantiate from a plaintext fs_rng.
+    fn constant<CS: ConstraintSystem<CF>>(cs: CS, pfs: &PFS) -> Self;
+
+    /// Take in field elements.
+    fn absorb_nonnative_field_elements(
+        &mut self,
+        elems: &[NonNativeFieldVar<F, CF>],
+        ty: OptimizationType,
+    ) -> Result<(), SynthesisError>;
+
+    /// Take in field elements.
+    fn absorb_native_field_elements(&mut self, elems: &[FpGadget<CF>]) -> Result<(), SynthesisError>;
+
+    /// Take in bytes.
+    fn absorb_bytes(&mut self, elems: &[UInt8]) -> Result<(), SynthesisError>;
+
+    /// Output field elements.
+    fn squeeze_native_field_elements(&mut self, num: usize) -> Result<Vec<FpGadget<CF>>, SynthesisError>;
+
+    /// Output field elements.
+    fn squeeze_field_elements(&mut self, num: usize) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError>;
+
+    /// Output field elements and the corresponding bits (this can reduce repeated computation).
+    #[allow(clippy::type_complexity)]
+    fn squeeze_field_elements_and_bits(
+        &mut self,
+        num: usize,
+    ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean>>), SynthesisError>;
+
+    /// Output field elements with only 128 bits.
+    fn squeeze_128_bits_field_elements(&mut self, num: usize) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError>;
+
+    /// Output field elements with only 128 bits, and the corresponding bits (this can reduce
+    /// repeated computation).
+    #[allow(clippy::type_complexity)]
+    fn squeeze_128_bits_field_elements_and_bits(
+        &mut self,
+        num: usize,
+    ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean>>), SynthesisError>;
+}
+
+/// Trait for an algebraic sponge such as Poseidon.
+pub trait AlgebraicSpongeVar<CF: PrimeField, PS: AlgebraicSponge<CF>>: Clone {
+    /// Create the new sponge.
+    fn new<CS: ConstraintSystem<CF>>(cs: CS) -> Self;
+
+    /// Instantiate from a plaintext sponge.
+    fn constant<CS: ConstraintSystem<CF>>(cs: CS, ps: &PS) -> Self;
+
+    /// Take in field elements.
+    fn absorb(&mut self, elems: &[FpGadget<CF>]) -> Result<(), SynthesisError>;
+
+    /// Output field elements.
+    fn squeeze(&mut self, num: usize) -> Result<Vec<FpGadget<CF>>, SynthesisError>;
+}
+
+/// Building the Fiat-Shamir sponge's gadget from any algebraic sponge's gadget.
+#[derive(Clone)]
+pub struct FiatShamirAlgebraicSpongeRngVar<
+    F: PrimeField,
+    CF: PrimeField,
+    PS: AlgebraicSponge<CF>,
+    S: AlgebraicSpongeVar<CF, PS>,
+> {
+    /// Algebraic sponge gadget.
+    pub s: S,
+    #[doc(hidden)]
+    f_phantom: PhantomData<F>,
+    cf_phantom: PhantomData<CF>,
+    ps_phantom: PhantomData<PS>,
+}
+
+impl<F: PrimeField, CF: PrimeField, PS: AlgebraicSponge<CF>, S: AlgebraicSpongeVar<CF, PS>>
+    FiatShamirAlgebraicSpongeRngVar<F, CF, PS, S>
+{
+    /// Compress every two elements if possible. Provides a vector of (limb, num_of_additions),
+    /// both of which are CF.
+    pub fn compress_gadgets<CS: ConstraintSystem<CF>>(
+        mut cs: CS,
+        src_limbs: &[(FpGadget<CF>, CF)],
+        ty: OptimizationType,
+    ) -> Result<Vec<FpGadget<CF>>, SynthesisError> {
+        let capacity = CF::size_in_bits() - 1;
+        let mut dest_limbs = Vec::<FpGadget<CF>>::new();
+
+        if src_limbs.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let params = get_params(F::size_in_bits(), CF::size_in_bits(), ty);
+
+        let adjustment_factor_lookup_table = {
+            let mut table = Vec::<CF>::new();
+
+            let mut cur = CF::one();
+            for _ in 1..=capacity {
+                table.push(cur);
+                cur.double_in_place();
+            }
+
+            table
+        };
+
+        let mut i: usize = 0;
+        let src_len = src_limbs.len();
+        while i < src_len {
+            let first = &src_limbs[i];
+            let second = if i + 1 < src_len { Some(&src_limbs[i + 1]) } else { None };
+
+            let first_max_bits_per_limb = params.bits_per_limb + overhead!(first.1 + &CF::one());
+            let second_max_bits_per_limb = if second.is_some() {
+                params.bits_per_limb + overhead!(second.unwrap().1 + &CF::one())
+            } else {
+                0
+            };
+
+            if second.is_some() && first_max_bits_per_limb + second_max_bits_per_limb <= capacity {
+                let adjustment_factor = &adjustment_factor_lookup_table[second_max_bits_per_limb];
+
+                let mut value = first.0.mul_by_constant(
+                    cs.ns(|| format!("first_mul_by_constant_adjustment_factor_{}", i)),
+                    adjustment_factor,
+                )?;
+
+                value = value.add(cs.ns(|| format!("value_add_second_{}", i)), &second.unwrap().0)?;
+
+                dest_limbs.push(value);
+                i += 2;
+            } else {
+                dest_limbs.push(first.0.clone());
+                i += 1;
+            }
+        }
+
+        Ok(dest_limbs)
+    }
+
+    //     /// Push gadgets to sponge.
+    //     #[tracing::instrument(target = "r1cs", skip(sponge))]
+    //     pub fn push_gadgets_to_sponge(
+    //         sponge: &mut S,
+    //         src: &[NonNativeFieldVar<F, CF>],
+    //         ty: OptimizationType,
+    //     ) -> Result<(), SynthesisError> {
+    //         let mut src_limbs: Vec<(FpVar<CF>, CF)> = Vec::new();
+    //
+    //         for elem in src.iter() {
+    //             match elem {
+    //                 NonNativeFieldVar::Constant(c) => {
+    //                     let v = AllocatedNonNativeFieldVar::<F, CF>::new_constant(sponge.cs(), c)?;
+    //
+    //                     for limb in v.limbs.iter() {
+    //                         let num_of_additions_over_normal_form =
+    //                             if v.num_of_additions_over_normal_form == CF::zero() {
+    //                                 CF::one()
+    //                             } else {
+    //                                 v.num_of_additions_over_normal_form
+    //                             };
+    //                         src_limbs.push((limb.clone(), num_of_additions_over_normal_form));
+    //                     }
+    //                 }
+    //                 NonNativeFieldVar::Var(v) => {
+    //                     for limb in v.limbs.iter() {
+    //                         let num_of_additions_over_normal_form =
+    //                             if v.num_of_additions_over_normal_form == CF::zero() {
+    //                                 CF::one()
+    //                             } else {
+    //                                 v.num_of_additions_over_normal_form
+    //                             };
+    //                         src_limbs.push((limb.clone(), num_of_additions_over_normal_form));
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //
+    //         let dest_limbs = Self::compress_gadgets(&src_limbs, ty)?;
+    //         sponge.absorb(&dest_limbs)?;
+    //         Ok(())
+    //     }
+    //
+    //     /// Obtain random bits from hashchain gadget. (Not guaranteed to be uniformly distributed,
+    //     /// should only be used in certain situations.)
+    //     #[tracing::instrument(target = "r1cs", skip(sponge))]
+    //     pub fn get_booleans_from_sponge(
+    //         sponge: &mut S,
+    //         num_bits: usize,
+    //     ) -> Result<Vec<Boolean<CF>>, SynthesisError> {
+    //         let bits_per_element = CF::size_in_bits() - 1;
+    //         let num_elements = (num_bits + bits_per_element - 1) / bits_per_element;
+    //
+    //         let src_elements = sponge.squeeze(num_elements)?;
+    //         let mut dest_bits = Vec::<Boolean<CF>>::new();
+    //
+    //         for elem in src_elements.iter() {
+    //             let elem_bits = elem.to_bits_be()?;
+    //             dest_bits.extend_from_slice(&elem_bits[1..]); // discard the highest bit
+    //         }
+    //
+    //         Ok(dest_bits)
+    //     }
+    //
+    //     /// Obtain random elements from hashchain gadget. (Not guaranteed to be uniformly distributed,
+    //     /// should only be used in certain situations.)
+    //     #[tracing::instrument(target = "r1cs", skip(sponge))]
+    //     pub fn get_gadgets_from_sponge(
+    //         sponge: &mut S,
+    //         num_elements: usize,
+    //         outputs_short_elements: bool,
+    //     ) -> Result<Vec<NonNativeFieldVar<F, CF>>, SynthesisError> {
+    //         let (dest_gadgets, _) =
+    //             Self::get_gadgets_and_bits_from_sponge(sponge, num_elements, outputs_short_elements)?;
+    //
+    //         Ok(dest_gadgets)
+    //     }
+    //
+    //     /// Obtain random elements, and the corresponding bits, from hashchain gadget. (Not guaranteed
+    //     /// to be uniformly distributed, should only be used in certain situations.)
+    //     #[tracing::instrument(target = "r1cs", skip(sponge))]
+    //     #[allow(clippy::type_complexity)]
+    //     pub fn get_gadgets_and_bits_from_sponge(
+    //         sponge: &mut S,
+    //         num_elements: usize,
+    //         outputs_short_elements: bool,
+    //     ) -> Result<(Vec<NonNativeFieldVar<F, CF>>, Vec<Vec<Boolean<CF>>>), SynthesisError> {
+    //         let cs = sponge.cs();
+    //
+    //         let optimization_type = match cs.optimization_goal() {
+    //             OptimizationGoal::None => OptimizationType::Constraints,
+    //             OptimizationGoal::Constraints => OptimizationType::Constraints,
+    //             OptimizationGoal::Weight => OptimizationType::Weight,
+    //         };
+    //
+    //         let params = get_params(F::size_in_bits(), CF::size_in_bits(), optimization_type);
+    //
+    //         let num_bits_per_nonnative = if outputs_short_elements {
+    //             128
+    //         } else {
+    //             F::size_in_bits() - 1 // also omit the highest bit
+    //         };
+    //         let bits = Self::get_booleans_from_sponge(sponge, num_bits_per_nonnative * num_elements)?;
+    //
+    //         let mut lookup_table = Vec::<Vec<CF>>::new();
+    //         let mut cur = F::one();
+    //         for _ in 0..num_bits_per_nonnative {
+    //             let repr = AllocatedNonNativeFieldVar::<F, CF>::get_limbs_representations(
+    //                 &cur,
+    //                 optimization_type,
+    //             )?;
+    //             lookup_table.push(repr);
+    //             cur.double_in_place();
+    //         }
+    //
+    //         let mut dest_gadgets = Vec::<NonNativeFieldVar<F, CF>>::new();
+    //         let mut dest_bits = Vec::<Vec<Boolean<CF>>>::new();
+    //         bits.chunks_exact(num_bits_per_nonnative)
+    //             .for_each(|per_nonnative_bits| {
+    //                 let mut val = vec![CF::zero(); params.num_limbs];
+    //                 let mut lc = vec![LinearCombination::<CF>::zero(); params.num_limbs];
+    //
+    //                 let mut per_nonnative_bits_le = per_nonnative_bits.to_vec();
+    //                 per_nonnative_bits_le.reverse();
+    //
+    //                 dest_bits.push(per_nonnative_bits_le.clone());
+    //
+    //                 for (j, bit) in per_nonnative_bits_le.iter().enumerate() {
+    //                     if bit.value().unwrap_or_default() {
+    //                         for (k, val) in val.iter_mut().enumerate().take(params.num_limbs) {
+    //                             *val += &lookup_table[j][k];
+    //                         }
+    //                     }
+    //
+    //                     #[allow(clippy::needless_range_loop)]
+    //                     for k in 0..params.num_limbs {
+    //                         lc[k] = &lc[k] + bit.lc() * lookup_table[j][k];
+    //                     }
+    //                 }
+    //
+    //                 let mut limbs = Vec::new();
+    //                 for k in 0..params.num_limbs {
+    //                     let gadget =
+    //                         AllocatedFp::new_witness(ark_relations::ns!(cs, "alloc"), || Ok(val[k]))
+    //                             .unwrap();
+    //                     lc[k] = lc[k].clone() - (CF::one(), gadget.variable);
+    //                     cs.enforce_constraint(lc!(), lc!(), lc[k].clone()).unwrap();
+    //                     limbs.push(FpVar::<CF>::from(gadget));
+    //                 }
+    //
+    //                 dest_gadgets.push(NonNativeFieldVar::<F, CF>::Var(
+    //                     AllocatedNonNativeFieldVar::<F, CF> {
+    //                         cs: cs.clone(),
+    //                         limbs,
+    //                         num_of_additions_over_normal_form: CF::zero(),
+    //                         is_in_the_normal_form: true,
+    //                         target_phantom: Default::default(),
+    //                     },
+    //                 ));
+    //             });
+    //
+    //         Ok((dest_gadgets, dest_bits))
+    //     }
+}
+
 // impl<F: PrimeField, CF: PrimeField, PS: AlgebraicSponge<CF>, S: AlgebraicSpongeVar<CF, PS>>
 //     FiatShamirRngVar<F, CF, FiatShamirAlgebraicSpongeRng<F, CF, PS>>
 //     for FiatShamirAlgebraicSpongeRngVar<F, CF, PS, S>

--- a/marlin/src/fiat_shamir/mod.rs
+++ b/marlin/src/fiat_shamir/mod.rs
@@ -96,7 +96,9 @@ pub trait AlgebraicSponge<CF: PrimeField>: Clone {
 /// use a ChaCha stream cipher to generate the actual pseudorandom bits
 /// use a digest funcion to do absorbing
 pub struct FiatShamirChaChaRng<F: PrimeField, CF: PrimeField, D: Digest> {
+    /// ChachaRng.
     pub r: ChaChaRng,
+    /// Seed used for randomness.
     pub seed: Vec<u8>,
     #[doc(hidden)]
     field: PhantomData<F>,
@@ -200,6 +202,7 @@ impl<F: PrimeField, CF: PrimeField, D: Digest> FiatShamirRng<F, CF> for FiatSham
 
 /// rng from any algebraic sponge
 pub struct FiatShamirAlgebraicSpongeRng<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> {
+    /// Algebraic Sponge.
     pub s: S,
     #[doc(hidden)]
     f_phantom: PhantomData<F>,
@@ -385,7 +388,7 @@ impl<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> RngCore for FiatSham
         });
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ark_std::rand::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
         assert!(
             CF::size_in_bits() > 128,
             "The native field of the algebraic sponge is too small."
@@ -436,7 +439,7 @@ impl<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> FiatShamirRng<F, CF>
         }
         let elements = bits
             .chunks(capacity)
-            .map(|bits| CF::from_repr(CF::BigInt::from_bits_be(bits)).unwrap())
+            .map(|bits| CF::from_repr(CF::BigInteger::from_bits_be(bits.to_vec())).unwrap())
             .collect::<Vec<CF>>();
 
         self.s.absorb(&elements);

--- a/marlin/src/fiat_shamir/mod.rs
+++ b/marlin/src/fiat_shamir/mod.rs
@@ -1,0 +1,456 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkvm_fields::{traits::ToConstraintField, FpParameters, PrimeField};
+use snarkvm_nonnative::{
+    params::{get_params, OptimizationType},
+    AllocatedNonNativeFieldVar,
+};
+use snarkvm_utilities::BigInteger;
+
+use digest::Digest;
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
+use std::marker::PhantomData;
+
+/// The constraints for Fiat-Shamir
+pub mod constraints;
+/// The Poseidon sponge
+pub mod poseidon;
+
+/// a macro for computing ceil(log2(x))+1 for a field element x
+#[doc(hidden)]
+#[macro_export]
+macro_rules! overhead {
+    ($x:expr) => {{
+        use snarkvm_utilities::BigInteger;
+        let num = $x;
+        let num_bits = num.into_repr().to_bits_be();
+        let mut skipped_bits = 0;
+        for b in num_bits.iter() {
+            if *b == false {
+                skipped_bits += 1;
+            } else {
+                break;
+            }
+        }
+
+        let mut is_power_of_2 = true;
+        for b in num_bits.iter().skip(skipped_bits + 1) {
+            if *b == true {
+                is_power_of_2 = false;
+            }
+        }
+
+        if is_power_of_2 {
+            num_bits.len() - skipped_bits
+        } else {
+            num_bits.len() - skipped_bits + 1
+        }
+    }};
+}
+
+/// the trait for Fiat-Shamir RNG
+pub trait FiatShamirRng<F: PrimeField, CF: PrimeField>: RngCore {
+    /// initialize the RNG
+    fn new() -> Self;
+
+    /// take in field elements
+    fn absorb_nonnative_field_elements(&mut self, elems: &[F], ty: OptimizationType);
+    /// take in field elements
+    fn absorb_native_field_elements<T: ToConstraintField<CF>>(&mut self, elems: &[T]);
+    /// take in bytes
+    fn absorb_bytes(&mut self, elems: &[u8]);
+
+    /// take out field elements
+    fn squeeze_nonnative_field_elements(&mut self, num: usize, ty: OptimizationType) -> Vec<F>;
+    /// take in field elements
+    fn squeeze_native_field_elements(&mut self, num: usize) -> Vec<CF>;
+    /// take out field elements of 128 bits
+    fn squeeze_128_bits_nonnative_field_elements(&mut self, num: usize) -> Vec<F>;
+}
+
+/// the trait for algebraic sponge
+pub trait AlgebraicSponge<CF: PrimeField>: Clone {
+    /// initialize the sponge
+    fn new() -> Self;
+    /// take in field elements
+    fn absorb(&mut self, elems: &[CF]);
+    /// take out field elements
+    fn squeeze(&mut self, num: usize) -> Vec<CF>;
+}
+
+/// use a ChaCha stream cipher to generate the actual pseudorandom bits
+/// use a digest funcion to do absorbing
+pub struct FiatShamirChaChaRng<F: PrimeField, CF: PrimeField, D: Digest> {
+    pub r: ChaChaRng,
+    pub seed: Vec<u8>,
+    #[doc(hidden)]
+    field: PhantomData<F>,
+    representation_field: PhantomData<CF>,
+    digest: PhantomData<D>,
+}
+
+impl<F: PrimeField, CF: PrimeField, D: Digest> RngCore for FiatShamirChaChaRng<F, CF, D> {
+    fn next_u32(&mut self) -> u32 {
+        self.r.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.r.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.r.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.r.try_fill_bytes(dest)
+    }
+}
+
+impl<F: PrimeField, CF: PrimeField, D: Digest> FiatShamirRng<F, CF> for FiatShamirChaChaRng<F, CF, D> {
+    fn new() -> Self {
+        let seed = [0; 32];
+        let r = ChaChaRng::from_seed(seed);
+        Self {
+            r,
+            seed: seed.to_vec(),
+            field: PhantomData,
+            representation_field: PhantomData,
+            digest: PhantomData,
+        }
+    }
+
+    fn absorb_nonnative_field_elements(&mut self, elems: &[F], _: OptimizationType) {
+        let mut bytes = Vec::new();
+        for elem in elems {
+            elem.write(&mut bytes).expect("failed to convert to bytes");
+        }
+        self.absorb_bytes(&bytes);
+    }
+
+    fn absorb_native_field_elements<T: ToConstraintField<CF>>(&mut self, src: &[T]) {
+        let mut elems = Vec::<CF>::new();
+        for elem in src.iter() {
+            elems.append(&mut elem.to_field_elements().unwrap());
+        }
+
+        let mut bytes = Vec::new();
+        for elem in elems.iter() {
+            elem.write(&mut bytes).expect("failed to convert to bytes");
+        }
+        self.absorb_bytes(&bytes);
+    }
+
+    fn absorb_bytes(&mut self, elems: &[u8]) {
+        let mut bytes = elems.to_vec();
+        bytes.extend_from_slice(&self.seed);
+
+        let new_seed = D::digest(&bytes);
+        self.seed = (*new_seed.as_slice()).to_vec();
+
+        let mut seed = [0u8; 32];
+        for (i, byte) in self.seed.as_slice().iter().enumerate() {
+            seed[i] = *byte;
+        }
+
+        self.r = ChaChaRng::from_seed(seed);
+    }
+
+    fn squeeze_nonnative_field_elements(&mut self, num: usize, _: OptimizationType) -> Vec<F> {
+        let mut res = Vec::<F>::new();
+        for _ in 0..num {
+            res.push(F::rand(&mut self.r));
+        }
+        res
+    }
+
+    fn squeeze_native_field_elements(&mut self, num: usize) -> Vec<CF> {
+        let mut res = Vec::<CF>::new();
+        for _ in 0..num {
+            res.push(CF::rand(&mut self.r));
+        }
+        res
+    }
+
+    fn squeeze_128_bits_nonnative_field_elements(&mut self, num: usize) -> Vec<F> {
+        let mut res = Vec::<F>::new();
+        for _ in 0..num {
+            let mut x = [0u8; 16];
+            self.r.fill_bytes(&mut x);
+            res.push(F::from_random_bytes(&x).unwrap());
+        }
+        res
+    }
+}
+
+/// rng from any algebraic sponge
+pub struct FiatShamirAlgebraicSpongeRng<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> {
+    pub s: S,
+    #[doc(hidden)]
+    f_phantom: PhantomData<F>,
+    cf_phantom: PhantomData<CF>,
+}
+
+impl<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> FiatShamirAlgebraicSpongeRng<F, CF, S> {
+    /// compress every two elements if possible. Provides a vector of (limb, num_of_additions), both of which are P::BaseField.
+    pub fn compress_elements(src_limbs: &[(CF, CF)], ty: OptimizationType) -> Vec<CF> {
+        let capacity = CF::size_in_bits() - 1;
+        let mut dest_limbs = Vec::<CF>::new();
+
+        let params = get_params(F::size_in_bits(), CF::size_in_bits(), ty);
+
+        let adjustment_factor_lookup_table = {
+            let mut table = Vec::<CF>::new();
+
+            let mut cur = CF::one();
+            for _ in 1..=capacity {
+                table.push(cur);
+                cur.double_in_place();
+            }
+
+            table
+        };
+
+        let mut i = 0;
+        let src_len = src_limbs.len();
+        while i < src_len {
+            let first = &src_limbs[i];
+            let second = if i + 1 < src_len { Some(&src_limbs[i + 1]) } else { None };
+
+            let first_max_bits_per_limb = params.bits_per_limb + overhead!(first.1 + &CF::one());
+            let second_max_bits_per_limb = if let Some(second) = second {
+                params.bits_per_limb + overhead!(second.1 + &CF::one())
+            } else {
+                0
+            };
+
+            if let Some(second) = second {
+                if first_max_bits_per_limb + second_max_bits_per_limb <= capacity {
+                    let adjustment_factor = &adjustment_factor_lookup_table[second_max_bits_per_limb];
+
+                    dest_limbs.push(first.0 * adjustment_factor + &second.0);
+                    i += 2;
+                } else {
+                    dest_limbs.push(first.0);
+                    i += 1;
+                }
+            } else {
+                dest_limbs.push(first.0);
+                i += 1;
+            }
+        }
+
+        dest_limbs
+    }
+
+    /// push elements to sponge, treated in the non-native field representations.
+    pub fn push_elements_to_sponge(sponge: &mut S, src: &[F], ty: OptimizationType) {
+        let mut src_limbs = Vec::<(CF, CF)>::new();
+
+        for elem in src.iter() {
+            let limbs = AllocatedNonNativeFieldVar::<F, CF>::get_limbs_representations(elem, ty).unwrap();
+            for limb in limbs.iter() {
+                src_limbs.push((*limb, CF::one()));
+                // specifically set to one, since most gadgets in the constraint world would not have zero noise (due to the relatively weak normal form testing in `alloc`)
+            }
+        }
+
+        let dest_limbs = Self::compress_elements(&src_limbs, ty);
+        sponge.absorb(&dest_limbs);
+    }
+
+    /// obtain random bits from hashchain.
+    /// not guaranteed to be uniformly distributed, should only be used in certain situations.
+    pub fn get_bits_from_sponge(sponge: &mut S, num_bits: usize) -> Vec<bool> {
+        let bits_per_element = CF::size_in_bits() - 1;
+        let num_elements = (num_bits + bits_per_element - 1) / bits_per_element;
+
+        let src_elements = sponge.squeeze(num_elements);
+        let mut dest_bits = Vec::<bool>::new();
+
+        let skip = (CF::Parameters::REPR_SHAVE_BITS + 1) as usize;
+        for elem in src_elements.iter() {
+            // discard the highest bit
+            let elem_bits = elem.into_repr().to_bits_be();
+            dest_bits.extend_from_slice(&elem_bits[skip..]);
+        }
+
+        dest_bits
+    }
+
+    /// obtain random elements from hashchain.
+    /// not guaranteed to be uniformly distributed, should only be used in certain situations.
+    pub fn get_elements_from_sponge(sponge: &mut S, num_elements: usize, outputs_short_elements: bool) -> Vec<F> {
+        let num_bits_per_nonnative = if outputs_short_elements {
+            128
+        } else {
+            F::size_in_bits() - 1 // also omit the highest bit
+        };
+        let bits = Self::get_bits_from_sponge(sponge, num_bits_per_nonnative * num_elements);
+
+        let mut lookup_table = Vec::<F>::new();
+        let mut cur = F::one();
+        for _ in 0..num_bits_per_nonnative {
+            lookup_table.push(cur);
+            cur.double_in_place();
+        }
+
+        let mut dest_elements = Vec::<F>::new();
+        bits.chunks_exact(num_bits_per_nonnative)
+            .for_each(|per_nonnative_bits| {
+                // technically, this can be done via BigInteger::from_bits; here, we use this method for consistency with the gadget counterpart
+                let mut res = F::zero();
+
+                for (i, bit) in per_nonnative_bits.iter().rev().enumerate() {
+                    if *bit {
+                        res += &lookup_table[i];
+                    }
+                }
+
+                dest_elements.push(res);
+            });
+
+        dest_elements
+    }
+}
+
+impl<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> RngCore for FiatShamirAlgebraicSpongeRng<F, CF, S> {
+    fn next_u32(&mut self) -> u32 {
+        assert!(
+            CF::size_in_bits() > 128,
+            "The native field of the algebraic sponge is too small."
+        );
+
+        let mut dest = [0u8; 4];
+        self.fill_bytes(&mut dest);
+
+        u32::from_be_bytes(dest)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        assert!(
+            CF::size_in_bits() > 128,
+            "The native field of the algebraic sponge is too small."
+        );
+
+        let mut dest = [0u8; 8];
+        self.fill_bytes(&mut dest);
+
+        u64::from_be_bytes(dest)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        assert!(
+            CF::size_in_bits() > 128,
+            "The native field of the algebraic sponge is too small."
+        );
+
+        let capacity = CF::size_in_bits() - 128;
+        let len = dest.len() * 8;
+
+        let num_of_elements = (capacity + len - 1) / len;
+        let elements = self.s.squeeze(num_of_elements);
+
+        let mut bits = Vec::<bool>::new();
+        for elem in elements.iter() {
+            let mut elem_bits = elem.into_repr().to_bits_be();
+            elem_bits.reverse();
+            bits.extend_from_slice(&elem_bits[0..capacity]);
+        }
+
+        bits.truncate(len);
+        bits.chunks_exact(8).enumerate().for_each(|(i, bits_per_byte)| {
+            let mut byte = 0;
+            for (j, bit) in bits_per_byte.iter().enumerate() {
+                if *bit {
+                    byte += 1 << j;
+                }
+            }
+            dest[i] = byte;
+        });
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ark_std::rand::Error> {
+        assert!(
+            CF::size_in_bits() > 128,
+            "The native field of the algebraic sponge is too small."
+        );
+
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> FiatShamirRng<F, CF>
+    for FiatShamirAlgebraicSpongeRng<F, CF, S>
+{
+    fn new() -> Self {
+        Self {
+            s: S::new(),
+            f_phantom: PhantomData,
+            cf_phantom: PhantomData,
+        }
+    }
+
+    fn absorb_nonnative_field_elements(&mut self, elems: &[F], ty: OptimizationType) {
+        Self::push_elements_to_sponge(&mut self.s, elems, ty);
+    }
+
+    fn absorb_native_field_elements<T: ToConstraintField<CF>>(&mut self, src: &[T]) {
+        let mut elems = Vec::<CF>::new();
+        for elem in src.iter() {
+            elems.append(&mut elem.to_field_elements().unwrap());
+        }
+        self.s.absorb(&elems);
+    }
+
+    fn absorb_bytes(&mut self, elems: &[u8]) {
+        let capacity = CF::size_in_bits() - 1;
+        let mut bits = Vec::<bool>::new();
+        for elem in elems.iter() {
+            bits.append(&mut vec![
+                elem & 128 != 0,
+                elem & 64 != 0,
+                elem & 32 != 0,
+                elem & 16 != 0,
+                elem & 8 != 0,
+                elem & 4 != 0,
+                elem & 2 != 0,
+                elem & 1 != 0,
+            ]);
+        }
+        let elements = bits
+            .chunks(capacity)
+            .map(|bits| CF::from_repr(CF::BigInt::from_bits_be(bits)).unwrap())
+            .collect::<Vec<CF>>();
+
+        self.s.absorb(&elements);
+    }
+
+    fn squeeze_nonnative_field_elements(&mut self, num: usize, _: OptimizationType) -> Vec<F> {
+        Self::get_elements_from_sponge(&mut self.s, num, false)
+    }
+
+    fn squeeze_native_field_elements(&mut self, num: usize) -> Vec<CF> {
+        self.s.squeeze(num)
+    }
+
+    fn squeeze_128_bits_nonnative_field_elements(&mut self, num: usize) -> Vec<F> {
+        Self::get_elements_from_sponge(&mut self.s, num, true)
+    }
+}

--- a/marlin/src/fiat_shamir/mod.rs
+++ b/marlin/src/fiat_shamir/mod.rs
@@ -202,7 +202,7 @@ impl<F: PrimeField, CF: PrimeField, D: Digest> FiatShamirRng<F, CF> for FiatSham
 
 /// rng from any algebraic sponge
 pub struct FiatShamirAlgebraicSpongeRng<F: PrimeField, CF: PrimeField, S: AlgebraicSponge<CF>> {
-    /// Algebraic Sponge.
+    /// Algebraic sponge.
     pub s: S,
     #[doc(hidden)]
     f_phantom: PhantomData<F>,

--- a/marlin/src/fiat_shamir/poseidon/constraints.rs
+++ b/marlin/src/fiat_shamir/poseidon/constraints.rs
@@ -14,179 +14,181 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-// /*
-//  * credit:
-//  *      This implementation of Poseidon is entirely from Fractal's implementation
-//  *      ([COS20]: https://eprint.iacr.org/2019/1076)
-//  *      with small syntax changes.
-//  */
-//
-// use crate::fiat_shamir::constraints::AlgebraicSpongeVar;
-// use crate::fiat_shamir::poseidon::{PoseidonSponge, PoseidonSpongeState};
-// use crate::Vec;
-// use ark_ff::PrimeField;
-// use ark_r1cs_std::fields::fp::FpVar;
-// use ark_r1cs_std::prelude::*;
-// use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-// use ark_std::rand::SeedableRng;
-//
-// #[derive(Clone)]
-// /// the gadget for Poseidon sponge
-// pub struct PoseidonSpongeVar<F: PrimeField> {
-//     /// constraint system
-//     pub cs: ConstraintSystemRef<F>,
-//     /// number of rounds in a full-round operation
-//     pub full_rounds: u32,
-//     /// number of rounds in a partial-round operation
-//     pub partial_rounds: u32,
-//     /// Exponent used in S-boxes
-//     pub alpha: u64,
-//     /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
-//     /// They are indexed by ark[round_num][state_element_index]
-//     pub ark: Vec<Vec<F>>,
-//     /// Maximally Distance Separating Matrix.
-//     pub mds: Vec<Vec<F>>,
-//
-//     /// the sponge's state
-//     pub state: Vec<FpVar<F>>,
-//     /// the rate
-//     pub rate: usize,
-//     /// the capacity
-//     pub capacity: usize,
-//     /// the mode
-//     mode: PoseidonSpongeState,
-// }
-//
-// impl<F: PrimeField> PoseidonSpongeVar<F> {
-//     #[tracing::instrument(target = "r1cs", skip(self))]
-//     fn apply_s_box(
-//         &self,
-//         state: &mut [FpVar<F>],
-//         is_full_round: bool,
-//     ) -> Result<(), SynthesisError> {
-//         // Full rounds apply the S Box (x^alpha) to every element of state
-//         if is_full_round {
-//             for state_item in state.iter_mut() {
-//                 *state_item = state_item.pow_by_constant(&[self.alpha])?;
-//             }
-//         }
-//         // Partial rounds apply the S Box (x^alpha) to just the final element of state
-//         else {
-//             state[state.len() - 1] = state[state.len() - 1].pow_by_constant(&[self.alpha])?;
-//         }
-//
-//         Ok(())
-//     }
-//
-//     #[tracing::instrument(target = "r1cs", skip(self))]
-//     fn apply_ark(&self, state: &mut [FpVar<F>], round_number: usize) -> Result<(), SynthesisError> {
-//         for (i, state_elem) in state.iter_mut().enumerate() {
-//             *state_elem += self.ark[round_number][i];
-//         }
-//         Ok(())
-//     }
-//
-//     #[tracing::instrument(target = "r1cs", skip(self))]
-//     fn apply_mds(&self, state: &mut [FpVar<F>]) -> Result<(), SynthesisError> {
-//         let mut new_state = Vec::new();
-//         let zero = FpVar::<F>::zero();
-//         for i in 0..state.len() {
-//             let mut cur = zero.clone();
-//             for (j, state_elem) in state.iter().enumerate() {
-//                 let term = state_elem * self.mds[i][j];
-//                 cur += &term;
-//             }
-//             new_state.push(cur);
-//         }
-//         state.clone_from_slice(&new_state[..state.len()]);
-//         Ok(())
-//     }
-//
-//     #[tracing::instrument(target = "r1cs", skip(self))]
-//     fn permute(&mut self) -> Result<(), SynthesisError> {
-//         let full_rounds_over_2 = self.full_rounds / 2;
-//         let mut state = self.state.clone();
-//         for i in 0..full_rounds_over_2 {
-//             self.apply_ark(&mut state, i as usize)?;
-//             self.apply_s_box(&mut state, true)?;
-//             self.apply_mds(&mut state)?;
-//         }
-//         for i in full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds) {
-//             self.apply_ark(&mut state, i as usize)?;
-//             self.apply_s_box(&mut state, false)?;
-//             self.apply_mds(&mut state)?;
-//         }
-//
-//         for i in
-//             (full_rounds_over_2 + self.partial_rounds)..(self.partial_rounds + self.full_rounds)
-//         {
-//             self.apply_ark(&mut state, i as usize)?;
-//             self.apply_s_box(&mut state, true)?;
-//             self.apply_mds(&mut state)?;
-//         }
-//
-//         self.state = state;
-//         Ok(())
-//     }
-//
-//     #[tracing::instrument(target = "r1cs", skip(self))]
-//     fn absorb_internal(
-//         &mut self,
-//         rate_start_index: usize,
-//         elements: &[FpVar<F>],
-//     ) -> Result<(), SynthesisError> {
-//         // if we can finish in this call
-//         if rate_start_index + elements.len() <= self.rate {
-//             for (i, element) in elements.iter().enumerate() {
-//                 self.state[i + rate_start_index] += element;
-//             }
-//             self.mode = PoseidonSpongeState::Absorbing {
-//                 next_absorb_index: rate_start_index + elements.len(),
-//             };
-//
-//             return Ok(());
-//         }
-//         // otherwise absorb (rate - rate_start_index) elements
-//         let num_elements_absorbed = self.rate - rate_start_index;
-//         for (i, element) in elements.iter().enumerate().take(num_elements_absorbed) {
-//             self.state[i + rate_start_index] += element;
-//         }
-//         self.permute()?;
-//         // Tail recurse, with the input elements being truncated by num elements absorbed
-//         self.absorb_internal(0, &elements[num_elements_absorbed..])
-//     }
-//
-//     // Squeeze |output| many elements. This does not end in a squeeze
-//     #[tracing::instrument(target = "r1cs", skip(self))]
-//     fn squeeze_internal(
-//         &mut self,
-//         rate_start_index: usize,
-//         output: &mut [FpVar<F>],
-//     ) -> Result<(), SynthesisError> {
-//         // if we can finish in this call
-//         if rate_start_index + output.len() <= self.rate {
-//             output
-//                 .clone_from_slice(&self.state[rate_start_index..(output.len() + rate_start_index)]);
-//             self.mode = PoseidonSpongeState::Squeezing {
-//                 next_squeeze_index: rate_start_index + output.len(),
-//             };
-//             return Ok(());
-//         }
-//         // otherwise squeeze (rate - rate_start_index) elements
-//         let num_elements_squeezed = self.rate - rate_start_index;
-//         output[..num_elements_squeezed].clone_from_slice(
-//             &self.state[rate_start_index..(num_elements_squeezed + rate_start_index)],
-//         );
-//
-//         // Unless we are done with squeezing in this call, permute.
-//         if output.len() != self.rate {
-//             self.permute()?;
-//         }
-//         // Tail recurse, with the correct change to indices in output happening due to changing the slice
-//         self.squeeze_internal(0, &mut output[num_elements_squeezed..])
-//     }
-// }
-//
+/*
+ * credit:
+ *      This implementation of Poseidon is entirely from Fractal's implementation
+ *      ([COS20]: https://eprint.iacr.org/2019/1076)
+ *      with small syntax changes.
+ */
+
+#![allow(unused_imports)]
+
+use crate::fiat_shamir::{
+    constraints::AlgebraicSpongeVar,
+    poseidon::{PoseidonSponge, PoseidonSpongeState},
+};
+
+use snarkvm_fields::PrimeField;
+use snarkvm_gadgets::{fields::FpGadget, traits::fields::FieldGadget};
+use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
+
+use rand::SeedableRng;
+
+#[derive(Clone)]
+/// the gadget for Poseidon sponge
+pub struct PoseidonSpongeVar<F: PrimeField> {
+    /// number of rounds in a full-round operation
+    pub full_rounds: u32,
+    /// number of rounds in a partial-round operation
+    pub partial_rounds: u32,
+    /// Exponent used in S-boxes
+    pub alpha: u64,
+    /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
+    /// They are indexed by ark[round_num][state_element_index]
+    pub ark: Vec<Vec<F>>,
+    /// Maximally Distance Separating Matrix.
+    pub mds: Vec<Vec<F>>,
+
+    /// the sponge's state
+    pub state: Vec<FpGadget<F>>,
+    /// the rate
+    pub rate: usize,
+    /// the capacity
+    pub capacity: usize,
+    /// the mode
+    mode: PoseidonSpongeState,
+}
+
+impl<F: PrimeField> PoseidonSpongeVar<F> {
+    fn apply_s_box<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        state: &mut [FpGadget<F>],
+        is_full_round: bool,
+    ) -> Result<(), SynthesisError> {
+        // Full rounds apply the S Box (x^alpha) to every element of state
+        if is_full_round {
+            for (i, state_item) in state.iter_mut().enumerate() {
+                *state_item = state_item.pow_by_constant(cs.ns(|| format!("pow_by_constant_{}", i)), &[self.alpha])?;
+            }
+        }
+        // Partial rounds apply the S Box (x^alpha) to just the final element of state
+        else {
+            state[state.len() - 1] =
+                state[state.len() - 1].pow_by_constant(cs.ns(|| "pow_by_constant"), &[self.alpha])?;
+        }
+
+        Ok(())
+    }
+
+    fn apply_ark<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        state: &mut [FpGadget<F>],
+        round_number: usize,
+    ) -> Result<(), SynthesisError> {
+        for (i, state_elem) in state.iter_mut().enumerate() {
+            *state_elem = state_elem.add_constant(cs.ns(|| format!("add_{}", i)), &self.ark[round_number][i])?;
+        }
+        Ok(())
+    }
+
+    fn apply_mds<CS: ConstraintSystem<F>>(&self, mut cs: CS, state: &mut [FpGadget<F>]) -> Result<(), SynthesisError> {
+        let mut new_state = Vec::new();
+        let zero = FpGadget::<F>::zero(cs.ns(|| "zero"))?;
+        for i in 0..state.len() {
+            let mut cur = zero.clone();
+            for (j, state_elem) in state.iter().enumerate() {
+                let term = state_elem
+                    .mul_by_constant(cs.ns(|| format!("state_elem_times_mds_{}_{}", i, j)), &self.mds[i][j])?;
+                cur = cur.add(cs.ns(|| format!("cur_add_term_{}_{}", i, j)), &term)?;
+            }
+            new_state.push(cur);
+        }
+        state.clone_from_slice(&new_state[..state.len()]);
+        Ok(())
+    }
+
+    fn permute<CS: ConstraintSystem<F>>(&mut self, mut cs: CS) -> Result<(), SynthesisError> {
+        let full_rounds_over_2 = self.full_rounds / 2;
+        let mut state = self.state.clone();
+        for i in 0..full_rounds_over_2 {
+            self.apply_ark(cs.ns(|| format!("first_apply_ark_{}", i)), &mut state, i as usize)?;
+            self.apply_s_box(cs.ns(|| format!("first_apply_s_box_{}", i)), &mut state, true)?;
+            self.apply_mds(cs.ns(|| format!("first_apply_mds_{}", i)), &mut state)?;
+        }
+        for i in full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds) {
+            self.apply_ark(cs.ns(|| format!("second_apply_ark_{}", i)), &mut state, i as usize)?;
+            self.apply_s_box(cs.ns(|| format!("second_apply_s_box_{}", i)), &mut state, false)?;
+            self.apply_mds(cs.ns(|| format!("second_apply_mds_{}", i)), &mut state)?;
+        }
+
+        for i in (full_rounds_over_2 + self.partial_rounds)..(self.partial_rounds + self.full_rounds) {
+            self.apply_ark(cs.ns(|| format!("third_apply_ark_{}", i)), &mut state, i as usize)?;
+            self.apply_s_box(cs.ns(|| format!("third_apply_s_box_{}", i)), &mut state, true)?;
+            self.apply_mds(cs.ns(|| format!("third_apply_mds_{}", i)), &mut state)?;
+        }
+
+        self.state = state;
+        Ok(())
+    }
+
+    fn absorb_internal<CS: ConstraintSystem<F>>(
+        &mut self,
+        mut cs: CS,
+        rate_start_index: usize,
+        elements: &[FpGadget<F>],
+    ) -> Result<(), SynthesisError> {
+        // if we can finish in this call
+        if rate_start_index + elements.len() <= self.rate {
+            for (i, element) in elements.iter().enumerate() {
+                self.state[i + rate_start_index].add_in_place(cs.ns(|| format!("first_add_element_{}", i)), element)?;
+            }
+            self.mode = PoseidonSpongeState::Absorbing {
+                next_absorb_index: rate_start_index + elements.len(),
+            };
+
+            return Ok(());
+        }
+        // otherwise absorb (rate - rate_start_index) elements
+        let num_elements_absorbed = self.rate - rate_start_index;
+        for (i, element) in elements.iter().enumerate().take(num_elements_absorbed) {
+            self.state[i + rate_start_index].add_in_place(cs.ns(|| format!("second_add_element_{}", i)), element)?;
+        }
+        self.permute(cs.ns(|| "permute"))?;
+        // Tail recurse, with the input elements being truncated by num elements absorbed
+        self.absorb_internal(cs.ns(|| "absorb_internal"), 0, &elements[num_elements_absorbed..])
+    }
+
+    // Squeeze |output| many elements. This does not end in a squeeze
+    fn squeeze_internal<CS: ConstraintSystem<F>>(
+        &mut self,
+        mut cs: CS,
+        rate_start_index: usize,
+        output: &mut [FpGadget<F>],
+    ) -> Result<(), SynthesisError> {
+        // if we can finish in this call
+        if rate_start_index + output.len() <= self.rate {
+            output.clone_from_slice(&self.state[rate_start_index..(output.len() + rate_start_index)]);
+            self.mode = PoseidonSpongeState::Squeezing {
+                next_squeeze_index: rate_start_index + output.len(),
+            };
+            return Ok(());
+        }
+        // otherwise squeeze (rate - rate_start_index) elements
+        let num_elements_squeezed = self.rate - rate_start_index;
+        output[..num_elements_squeezed]
+            .clone_from_slice(&self.state[rate_start_index..(num_elements_squeezed + rate_start_index)]);
+
+        // Unless we are done with squeezing in this call, permute.
+        if output.len() != self.rate {
+            self.permute(cs.ns(|| "permute"))?;
+        }
+        // Tail recurse, with the correct change to indices in output happening due to changing the slice
+        self.squeeze_internal(cs.ns(|| "squeeze_internal"), 0, &mut output[num_elements_squeezed..])
+    }
+}
+
 // impl<F: PrimeField> AlgebraicSpongeVar<F, PoseidonSponge<F>> for PoseidonSpongeVar<F> {
 //     fn new(cs: ConstraintSystemRef<F>) -> Self {
 //         // Requires F to be Alt_Bn128Fr

--- a/marlin/src/fiat_shamir/poseidon/constraints.rs
+++ b/marlin/src/fiat_shamir/poseidon/constraints.rs
@@ -21,8 +21,6 @@
  *      with small syntax changes.
  */
 
-#![allow(unused_imports)]
-
 use crate::fiat_shamir::{
     constraints::AlgebraicSpongeVar,
     poseidon::{PoseidonSponge, PoseidonSpongeState},

--- a/marlin/src/fiat_shamir/poseidon/constraints.rs
+++ b/marlin/src/fiat_shamir/poseidon/constraints.rs
@@ -1,0 +1,314 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+// /*
+//  * credit:
+//  *      This implementation of Poseidon is entirely from Fractal's implementation
+//  *      ([COS20]: https://eprint.iacr.org/2019/1076)
+//  *      with small syntax changes.
+//  */
+//
+// use crate::fiat_shamir::constraints::AlgebraicSpongeVar;
+// use crate::fiat_shamir::poseidon::{PoseidonSponge, PoseidonSpongeState};
+// use crate::Vec;
+// use ark_ff::PrimeField;
+// use ark_r1cs_std::fields::fp::FpVar;
+// use ark_r1cs_std::prelude::*;
+// use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
+// use ark_std::rand::SeedableRng;
+//
+// #[derive(Clone)]
+// /// the gadget for Poseidon sponge
+// pub struct PoseidonSpongeVar<F: PrimeField> {
+//     /// constraint system
+//     pub cs: ConstraintSystemRef<F>,
+//     /// number of rounds in a full-round operation
+//     pub full_rounds: u32,
+//     /// number of rounds in a partial-round operation
+//     pub partial_rounds: u32,
+//     /// Exponent used in S-boxes
+//     pub alpha: u64,
+//     /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
+//     /// They are indexed by ark[round_num][state_element_index]
+//     pub ark: Vec<Vec<F>>,
+//     /// Maximally Distance Separating Matrix.
+//     pub mds: Vec<Vec<F>>,
+//
+//     /// the sponge's state
+//     pub state: Vec<FpVar<F>>,
+//     /// the rate
+//     pub rate: usize,
+//     /// the capacity
+//     pub capacity: usize,
+//     /// the mode
+//     mode: PoseidonSpongeState,
+// }
+//
+// impl<F: PrimeField> PoseidonSpongeVar<F> {
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn apply_s_box(
+//         &self,
+//         state: &mut [FpVar<F>],
+//         is_full_round: bool,
+//     ) -> Result<(), SynthesisError> {
+//         // Full rounds apply the S Box (x^alpha) to every element of state
+//         if is_full_round {
+//             for state_item in state.iter_mut() {
+//                 *state_item = state_item.pow_by_constant(&[self.alpha])?;
+//             }
+//         }
+//         // Partial rounds apply the S Box (x^alpha) to just the final element of state
+//         else {
+//             state[state.len() - 1] = state[state.len() - 1].pow_by_constant(&[self.alpha])?;
+//         }
+//
+//         Ok(())
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn apply_ark(&self, state: &mut [FpVar<F>], round_number: usize) -> Result<(), SynthesisError> {
+//         for (i, state_elem) in state.iter_mut().enumerate() {
+//             *state_elem += self.ark[round_number][i];
+//         }
+//         Ok(())
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn apply_mds(&self, state: &mut [FpVar<F>]) -> Result<(), SynthesisError> {
+//         let mut new_state = Vec::new();
+//         let zero = FpVar::<F>::zero();
+//         for i in 0..state.len() {
+//             let mut cur = zero.clone();
+//             for (j, state_elem) in state.iter().enumerate() {
+//                 let term = state_elem * self.mds[i][j];
+//                 cur += &term;
+//             }
+//             new_state.push(cur);
+//         }
+//         state.clone_from_slice(&new_state[..state.len()]);
+//         Ok(())
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn permute(&mut self) -> Result<(), SynthesisError> {
+//         let full_rounds_over_2 = self.full_rounds / 2;
+//         let mut state = self.state.clone();
+//         for i in 0..full_rounds_over_2 {
+//             self.apply_ark(&mut state, i as usize)?;
+//             self.apply_s_box(&mut state, true)?;
+//             self.apply_mds(&mut state)?;
+//         }
+//         for i in full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds) {
+//             self.apply_ark(&mut state, i as usize)?;
+//             self.apply_s_box(&mut state, false)?;
+//             self.apply_mds(&mut state)?;
+//         }
+//
+//         for i in
+//             (full_rounds_over_2 + self.partial_rounds)..(self.partial_rounds + self.full_rounds)
+//         {
+//             self.apply_ark(&mut state, i as usize)?;
+//             self.apply_s_box(&mut state, true)?;
+//             self.apply_mds(&mut state)?;
+//         }
+//
+//         self.state = state;
+//         Ok(())
+//     }
+//
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn absorb_internal(
+//         &mut self,
+//         rate_start_index: usize,
+//         elements: &[FpVar<F>],
+//     ) -> Result<(), SynthesisError> {
+//         // if we can finish in this call
+//         if rate_start_index + elements.len() <= self.rate {
+//             for (i, element) in elements.iter().enumerate() {
+//                 self.state[i + rate_start_index] += element;
+//             }
+//             self.mode = PoseidonSpongeState::Absorbing {
+//                 next_absorb_index: rate_start_index + elements.len(),
+//             };
+//
+//             return Ok(());
+//         }
+//         // otherwise absorb (rate - rate_start_index) elements
+//         let num_elements_absorbed = self.rate - rate_start_index;
+//         for (i, element) in elements.iter().enumerate().take(num_elements_absorbed) {
+//             self.state[i + rate_start_index] += element;
+//         }
+//         self.permute()?;
+//         // Tail recurse, with the input elements being truncated by num elements absorbed
+//         self.absorb_internal(0, &elements[num_elements_absorbed..])
+//     }
+//
+//     // Squeeze |output| many elements. This does not end in a squeeze
+//     #[tracing::instrument(target = "r1cs", skip(self))]
+//     fn squeeze_internal(
+//         &mut self,
+//         rate_start_index: usize,
+//         output: &mut [FpVar<F>],
+//     ) -> Result<(), SynthesisError> {
+//         // if we can finish in this call
+//         if rate_start_index + output.len() <= self.rate {
+//             output
+//                 .clone_from_slice(&self.state[rate_start_index..(output.len() + rate_start_index)]);
+//             self.mode = PoseidonSpongeState::Squeezing {
+//                 next_squeeze_index: rate_start_index + output.len(),
+//             };
+//             return Ok(());
+//         }
+//         // otherwise squeeze (rate - rate_start_index) elements
+//         let num_elements_squeezed = self.rate - rate_start_index;
+//         output[..num_elements_squeezed].clone_from_slice(
+//             &self.state[rate_start_index..(num_elements_squeezed + rate_start_index)],
+//         );
+//
+//         // Unless we are done with squeezing in this call, permute.
+//         if output.len() != self.rate {
+//             self.permute()?;
+//         }
+//         // Tail recurse, with the correct change to indices in output happening due to changing the slice
+//         self.squeeze_internal(0, &mut output[num_elements_squeezed..])
+//     }
+// }
+//
+// impl<F: PrimeField> AlgebraicSpongeVar<F, PoseidonSponge<F>> for PoseidonSpongeVar<F> {
+//     fn new(cs: ConstraintSystemRef<F>) -> Self {
+//         // Requires F to be Alt_Bn128Fr
+//         let full_rounds = 8;
+//         let partial_rounds = 31;
+//         let alpha = 17;
+//
+//         let mds = vec![
+//             vec![F::one(), F::zero(), F::one()],
+//             vec![F::one(), F::one(), F::zero()],
+//             vec![F::zero(), F::one(), F::one()],
+//         ];
+//
+//         let mut ark = Vec::new();
+//         let mut ark_rng = rand_chacha::ChaChaRng::seed_from_u64(123456789u64);
+//
+//         for _ in 0..(full_rounds + partial_rounds) {
+//             let mut res = Vec::new();
+//
+//             for _ in 0..3 {
+//                 res.push(F::rand(&mut ark_rng));
+//             }
+//             ark.push(res);
+//         }
+//
+//         let rate = 2;
+//         let capacity = 1;
+//         let zero = FpVar::<F>::zero();
+//         let state = vec![zero; rate + capacity];
+//         let mode = PoseidonSpongeState::Absorbing {
+//             next_absorb_index: 0,
+//         };
+//
+//         Self {
+//             cs,
+//             full_rounds,
+//             partial_rounds,
+//             alpha,
+//             ark,
+//             mds,
+//
+//             state,
+//             rate,
+//             capacity,
+//             mode,
+//         }
+//     }
+//
+//     fn constant(cs: ConstraintSystemRef<F>, pfs: &PoseidonSponge<F>) -> Self {
+//         let mut state_gadgets = Vec::new();
+//
+//         for state_elem in pfs.state.iter() {
+//             state_gadgets.push(
+//                 FpVar::<F>::new_constant(ark_relations::ns!(cs, "alloc_elems"), *state_elem)
+//                     .unwrap(),
+//             );
+//         }
+//
+//         Self {
+//             cs,
+//             full_rounds: pfs.full_rounds,
+//             partial_rounds: pfs.partial_rounds,
+//             alpha: pfs.alpha,
+//             ark: pfs.ark.clone(),
+//             mds: pfs.mds.clone(),
+//
+//             state: state_gadgets,
+//             rate: pfs.rate,
+//             capacity: pfs.capacity,
+//             mode: pfs.mode.clone(),
+//         }
+//     }
+//
+//     fn cs(&self) -> ConstraintSystemRef<F> {
+//         self.cs.clone()
+//     }
+//
+//     fn absorb(&mut self, elems: &[FpVar<F>]) -> Result<(), SynthesisError> {
+//         if elems.is_empty() {
+//             return Ok(());
+//         }
+//
+//         match self.mode {
+//             PoseidonSpongeState::Absorbing { next_absorb_index } => {
+//                 let mut absorb_index = next_absorb_index;
+//                 if absorb_index == self.rate {
+//                     self.permute()?;
+//                     absorb_index = 0;
+//                 }
+//                 self.absorb_internal(absorb_index, elems)?;
+//             }
+//             PoseidonSpongeState::Squeezing {
+//                 next_squeeze_index: _,
+//             } => {
+//                 self.permute()?;
+//                 self.absorb_internal(0, elems)?;
+//             }
+//         };
+//
+//         Ok(())
+//     }
+//
+//     fn squeeze(&mut self, num: usize) -> Result<Vec<FpVar<F>>, SynthesisError> {
+//         let zero = FpVar::zero();
+//         let mut squeezed_elems = vec![zero; num];
+//         match self.mode {
+//             PoseidonSpongeState::Absorbing {
+//                 next_absorb_index: _,
+//             } => {
+//                 self.permute()?;
+//                 self.squeeze_internal(0, &mut squeezed_elems)?;
+//             }
+//             PoseidonSpongeState::Squeezing { next_squeeze_index } => {
+//                 let mut squeeze_index = next_squeeze_index;
+//                 if squeeze_index == self.rate {
+//                     self.permute()?;
+//                     squeeze_index = 0;
+//                 }
+//                 self.squeeze_internal(squeeze_index, &mut squeezed_elems)?;
+//             }
+//         };
+//
+//         Ok(squeezed_elems)
+//     }
+// }

--- a/marlin/src/fiat_shamir/poseidon/mod.rs
+++ b/marlin/src/fiat_shamir/poseidon/mod.rs
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-// /*
-//  * credit:
-//  *      This implementation of Poseidon is entirely from Fractal's implementation
-//  *      ([COS20]: https://eprint.iacr.org/2019/1076)
-//  *      with small syntax changes.
-//  */
-//
+/*
+ * credit:
+ *      This implementation of Poseidon is entirely from Fractal's implementation
+ *      ([COS20]: https://eprint.iacr.org/2019/1076)
+ *      with small syntax changes.
+ */
+
 use crate::fiat_shamir::AlgebraicSponge;
 use snarkvm_fields::PrimeField;
 
@@ -36,9 +36,9 @@ enum PoseidonSpongeState {
 }
 
 #[derive(Clone)]
-/// the sponge for Poseidon
+/// The sponge for Poseidon
 pub struct PoseidonSponge<F: PrimeField> {
-    /// number of rounds in a full-round operation
+    /// Number of rounds in a full-round operation
     pub full_rounds: u32,
     /// number of rounds in a partial-round operation
     pub partial_rounds: u32,
@@ -50,13 +50,13 @@ pub struct PoseidonSponge<F: PrimeField> {
     /// Maximally Distance Separating Matrix.
     pub mds: Vec<Vec<F>>,
 
-    /// the sponge's state
+    /// The sponge's state
     pub state: Vec<F>,
-    /// the rate
+    /// The rate
     pub rate: usize,
-    /// the capacity
+    /// The capacity
     pub capacity: usize,
-    /// the mode
+    /// The mode
     mode: PoseidonSpongeState,
 }
 

--- a/marlin/src/fiat_shamir/poseidon/mod.rs
+++ b/marlin/src/fiat_shamir/poseidon/mod.rs
@@ -22,6 +22,7 @@
  */
 
 use crate::fiat_shamir::AlgebraicSponge;
+
 use snarkvm_fields::PrimeField;
 
 use rand::SeedableRng;

--- a/marlin/src/fiat_shamir/poseidon/mod.rs
+++ b/marlin/src/fiat_shamir/poseidon/mod.rs
@@ -1,0 +1,259 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+// /*
+//  * credit:
+//  *      This implementation of Poseidon is entirely from Fractal's implementation
+//  *      ([COS20]: https://eprint.iacr.org/2019/1076)
+//  *      with small syntax changes.
+//  */
+//
+// use crate::fiat_shamir::AlgebraicSponge;
+// use crate::Vec;
+// use ark_ff::PrimeField;
+// use ark_std::rand::SeedableRng;
+//
+// /// constraints for Poseidon
+// pub mod constraints;
+//
+// #[derive(Clone)]
+// enum PoseidonSpongeState {
+//     Absorbing { next_absorb_index: usize },
+//     Squeezing { next_squeeze_index: usize },
+// }
+//
+// #[derive(Clone)]
+// /// the sponge for Poseidon
+// pub struct PoseidonSponge<F: PrimeField> {
+//     /// number of rounds in a full-round operation
+//     pub full_rounds: u32,
+//     /// number of rounds in a partial-round operation
+//     pub partial_rounds: u32,
+//     /// Exponent used in S-boxes
+//     pub alpha: u64,
+//     /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
+//     /// They are indexed by ark[round_num][state_element_index]
+//     pub ark: Vec<Vec<F>>,
+//     /// Maximally Distance Separating Matrix.
+//     pub mds: Vec<Vec<F>>,
+//
+//     /// the sponge's state
+//     pub state: Vec<F>,
+//     /// the rate
+//     pub rate: usize,
+//     /// the capacity
+//     pub capacity: usize,
+//     /// the mode
+//     mode: PoseidonSpongeState,
+// }
+//
+// impl<F: PrimeField> PoseidonSponge<F> {
+//     fn apply_s_box(&self, state: &mut [F], is_full_round: bool) {
+//         // Full rounds apply the S Box (x^alpha) to every element of state
+//         if is_full_round {
+//             for elem in state {
+//                 *elem = elem.pow(&[self.alpha]);
+//             }
+//         }
+//         // Partial rounds apply the S Box (x^alpha) to just the final element of state
+//         else {
+//             state[state.len() - 1] = state[state.len() - 1].pow(&[self.alpha]);
+//         }
+//     }
+//
+//     fn apply_ark(&self, state: &mut [F], round_number: usize) {
+//         for (i, state_elem) in state.iter_mut().enumerate() {
+//             state_elem.add_assign(&self.ark[round_number][i]);
+//         }
+//     }
+//
+//     fn apply_mds(&self, state: &mut [F]) {
+//         let mut new_state = Vec::new();
+//         for i in 0..state.len() {
+//             let mut cur = F::zero();
+//             for (j, state_elem) in state.iter().enumerate() {
+//                 let term = state_elem.mul(&self.mds[i][j]);
+//                 cur.add_assign(&term);
+//             }
+//             new_state.push(cur);
+//         }
+//         state.clone_from_slice(&new_state[..state.len()])
+//     }
+//
+//     fn permute(&mut self) {
+//         let full_rounds_over_2 = self.full_rounds / 2;
+//         let mut state = self.state.clone();
+//         for i in 0..full_rounds_over_2 {
+//             self.apply_ark(&mut state, i as usize);
+//             self.apply_s_box(&mut state, true);
+//             self.apply_mds(&mut state);
+//         }
+//
+//         for i in full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds) {
+//             self.apply_ark(&mut state, i as usize);
+//             self.apply_s_box(&mut state, false);
+//             self.apply_mds(&mut state);
+//         }
+//
+//         for i in
+//             (full_rounds_over_2 + self.partial_rounds)..(self.partial_rounds + self.full_rounds)
+//         {
+//             self.apply_ark(&mut state, i as usize);
+//             self.apply_s_box(&mut state, true);
+//             self.apply_mds(&mut state);
+//         }
+//         self.state = state;
+//     }
+//
+//     // Absorbs everything in elements, this does not end in an absorbtion.
+//     fn absorb_internal(&mut self, rate_start_index: usize, elements: &[F]) {
+//         // if we can finish in this call
+//         if rate_start_index + elements.len() <= self.rate {
+//             for (i, element) in elements.iter().enumerate() {
+//                 self.state[i + rate_start_index] += element;
+//             }
+//             self.mode = PoseidonSpongeState::Absorbing {
+//                 next_absorb_index: rate_start_index + elements.len(),
+//             };
+//
+//             return;
+//         }
+//         // otherwise absorb (rate - rate_start_index) elements
+//         let num_elements_absorbed = self.rate - rate_start_index;
+//         for (i, element) in elements.iter().enumerate().take(num_elements_absorbed) {
+//             self.state[i + rate_start_index] += element;
+//         }
+//         self.permute();
+//         // Tail recurse, with the input elements being truncated by num elements absorbed
+//         self.absorb_internal(0, &elements[num_elements_absorbed..]);
+//     }
+//
+//     // Squeeze |output| many elements. This does not end in a squeeze
+//     fn squeeze_internal(&mut self, rate_start_index: usize, output: &mut [F]) {
+//         // if we can finish in this call
+//         if rate_start_index + output.len() <= self.rate {
+//             output
+//                 .clone_from_slice(&self.state[rate_start_index..(output.len() + rate_start_index)]);
+//             self.mode = PoseidonSpongeState::Squeezing {
+//                 next_squeeze_index: rate_start_index + output.len(),
+//             };
+//             return;
+//         }
+//         // otherwise squeeze (rate - rate_start_index) elements
+//         let num_elements_squeezed = self.rate - rate_start_index;
+//         output[..num_elements_squeezed].clone_from_slice(
+//             &self.state[rate_start_index..(num_elements_squeezed + rate_start_index)],
+//         );
+//
+//         // Unless we are done with squeezing in this call, permute.
+//         if output.len() != self.rate {
+//             self.permute();
+//         }
+//         // Tail recurse, with the correct change to indices in output happening due to changing the slice
+//         self.squeeze_internal(0, &mut output[num_elements_squeezed..]);
+//     }
+// }
+//
+// impl<F: PrimeField> AlgebraicSponge<F> for PoseidonSponge<F> {
+//     fn new() -> Self {
+//         // Requires F to be Alt_Bn128Fr
+//         let full_rounds = 8;
+//         let partial_rounds = 31;
+//         let alpha = 17;
+//
+//         let mds = vec![
+//             vec![F::one(), F::zero(), F::one()],
+//             vec![F::one(), F::one(), F::zero()],
+//             vec![F::zero(), F::one(), F::one()],
+//         ];
+//
+//         let mut ark = Vec::new();
+//         let mut ark_rng = rand_chacha::ChaChaRng::seed_from_u64(123456789u64);
+//
+//         for _ in 0..(full_rounds + partial_rounds) {
+//             let mut res = Vec::new();
+//
+//             for _ in 0..3 {
+//                 res.push(F::rand(&mut ark_rng));
+//             }
+//             ark.push(res);
+//         }
+//
+//         let rate = 2;
+//         let capacity = 1;
+//         let state = vec![F::zero(); rate + capacity];
+//         let mode = PoseidonSpongeState::Absorbing {
+//             next_absorb_index: 0,
+//         };
+//
+//         PoseidonSponge {
+//             full_rounds,
+//             partial_rounds,
+//             alpha,
+//             ark,
+//             mds,
+//
+//             state,
+//             rate,
+//             capacity,
+//             mode,
+//         }
+//     }
+//
+//     fn absorb(&mut self, elems: &[F]) {
+//         if elems.is_empty() {
+//             return;
+//         }
+//
+//         match self.mode {
+//             PoseidonSpongeState::Absorbing { next_absorb_index } => {
+//                 let mut absorb_index = next_absorb_index;
+//                 if absorb_index == self.rate {
+//                     self.permute();
+//                     absorb_index = 0;
+//                 }
+//                 self.absorb_internal(absorb_index, elems);
+//             }
+//             PoseidonSpongeState::Squeezing {
+//                 next_squeeze_index: _,
+//             } => {
+//                 self.permute();
+//                 self.absorb_internal(0, elems);
+//             }
+//         };
+//     }
+//
+//     fn squeeze(&mut self, num: usize) -> Vec<F> {
+//         let mut squeezed_elems = vec![F::zero(); num];
+//         match self.mode {
+//             PoseidonSpongeState::Absorbing {
+//                 next_absorb_index: _,
+//             } => {
+//                 self.permute();
+//                 self.squeeze_internal(0, &mut squeezed_elems);
+//             }
+//             PoseidonSpongeState::Squeezing { next_squeeze_index } => {
+//                 let mut squeeze_index = next_squeeze_index;
+//                 if squeeze_index == self.rate {
+//                     self.permute();
+//                     squeeze_index = 0;
+//                 }
+//                 self.squeeze_internal(squeeze_index, &mut squeezed_elems);
+//             }
+//         };
+//         squeezed_elems
+//     }
+// }

--- a/marlin/src/fiat_shamir/poseidon/mod.rs
+++ b/marlin/src/fiat_shamir/poseidon/mod.rs
@@ -21,239 +21,229 @@
 //  *      with small syntax changes.
 //  */
 //
-// use crate::fiat_shamir::AlgebraicSponge;
-// use crate::Vec;
-// use ark_ff::PrimeField;
-// use ark_std::rand::SeedableRng;
-//
-// /// constraints for Poseidon
-// pub mod constraints;
-//
-// #[derive(Clone)]
-// enum PoseidonSpongeState {
-//     Absorbing { next_absorb_index: usize },
-//     Squeezing { next_squeeze_index: usize },
-// }
-//
-// #[derive(Clone)]
-// /// the sponge for Poseidon
-// pub struct PoseidonSponge<F: PrimeField> {
-//     /// number of rounds in a full-round operation
-//     pub full_rounds: u32,
-//     /// number of rounds in a partial-round operation
-//     pub partial_rounds: u32,
-//     /// Exponent used in S-boxes
-//     pub alpha: u64,
-//     /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
-//     /// They are indexed by ark[round_num][state_element_index]
-//     pub ark: Vec<Vec<F>>,
-//     /// Maximally Distance Separating Matrix.
-//     pub mds: Vec<Vec<F>>,
-//
-//     /// the sponge's state
-//     pub state: Vec<F>,
-//     /// the rate
-//     pub rate: usize,
-//     /// the capacity
-//     pub capacity: usize,
-//     /// the mode
-//     mode: PoseidonSpongeState,
-// }
-//
-// impl<F: PrimeField> PoseidonSponge<F> {
-//     fn apply_s_box(&self, state: &mut [F], is_full_round: bool) {
-//         // Full rounds apply the S Box (x^alpha) to every element of state
-//         if is_full_round {
-//             for elem in state {
-//                 *elem = elem.pow(&[self.alpha]);
-//             }
-//         }
-//         // Partial rounds apply the S Box (x^alpha) to just the final element of state
-//         else {
-//             state[state.len() - 1] = state[state.len() - 1].pow(&[self.alpha]);
-//         }
-//     }
-//
-//     fn apply_ark(&self, state: &mut [F], round_number: usize) {
-//         for (i, state_elem) in state.iter_mut().enumerate() {
-//             state_elem.add_assign(&self.ark[round_number][i]);
-//         }
-//     }
-//
-//     fn apply_mds(&self, state: &mut [F]) {
-//         let mut new_state = Vec::new();
-//         for i in 0..state.len() {
-//             let mut cur = F::zero();
-//             for (j, state_elem) in state.iter().enumerate() {
-//                 let term = state_elem.mul(&self.mds[i][j]);
-//                 cur.add_assign(&term);
-//             }
-//             new_state.push(cur);
-//         }
-//         state.clone_from_slice(&new_state[..state.len()])
-//     }
-//
-//     fn permute(&mut self) {
-//         let full_rounds_over_2 = self.full_rounds / 2;
-//         let mut state = self.state.clone();
-//         for i in 0..full_rounds_over_2 {
-//             self.apply_ark(&mut state, i as usize);
-//             self.apply_s_box(&mut state, true);
-//             self.apply_mds(&mut state);
-//         }
-//
-//         for i in full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds) {
-//             self.apply_ark(&mut state, i as usize);
-//             self.apply_s_box(&mut state, false);
-//             self.apply_mds(&mut state);
-//         }
-//
-//         for i in
-//             (full_rounds_over_2 + self.partial_rounds)..(self.partial_rounds + self.full_rounds)
-//         {
-//             self.apply_ark(&mut state, i as usize);
-//             self.apply_s_box(&mut state, true);
-//             self.apply_mds(&mut state);
-//         }
-//         self.state = state;
-//     }
-//
-//     // Absorbs everything in elements, this does not end in an absorbtion.
-//     fn absorb_internal(&mut self, rate_start_index: usize, elements: &[F]) {
-//         // if we can finish in this call
-//         if rate_start_index + elements.len() <= self.rate {
-//             for (i, element) in elements.iter().enumerate() {
-//                 self.state[i + rate_start_index] += element;
-//             }
-//             self.mode = PoseidonSpongeState::Absorbing {
-//                 next_absorb_index: rate_start_index + elements.len(),
-//             };
-//
-//             return;
-//         }
-//         // otherwise absorb (rate - rate_start_index) elements
-//         let num_elements_absorbed = self.rate - rate_start_index;
-//         for (i, element) in elements.iter().enumerate().take(num_elements_absorbed) {
-//             self.state[i + rate_start_index] += element;
-//         }
-//         self.permute();
-//         // Tail recurse, with the input elements being truncated by num elements absorbed
-//         self.absorb_internal(0, &elements[num_elements_absorbed..]);
-//     }
-//
-//     // Squeeze |output| many elements. This does not end in a squeeze
-//     fn squeeze_internal(&mut self, rate_start_index: usize, output: &mut [F]) {
-//         // if we can finish in this call
-//         if rate_start_index + output.len() <= self.rate {
-//             output
-//                 .clone_from_slice(&self.state[rate_start_index..(output.len() + rate_start_index)]);
-//             self.mode = PoseidonSpongeState::Squeezing {
-//                 next_squeeze_index: rate_start_index + output.len(),
-//             };
-//             return;
-//         }
-//         // otherwise squeeze (rate - rate_start_index) elements
-//         let num_elements_squeezed = self.rate - rate_start_index;
-//         output[..num_elements_squeezed].clone_from_slice(
-//             &self.state[rate_start_index..(num_elements_squeezed + rate_start_index)],
-//         );
-//
-//         // Unless we are done with squeezing in this call, permute.
-//         if output.len() != self.rate {
-//             self.permute();
-//         }
-//         // Tail recurse, with the correct change to indices in output happening due to changing the slice
-//         self.squeeze_internal(0, &mut output[num_elements_squeezed..]);
-//     }
-// }
-//
-// impl<F: PrimeField> AlgebraicSponge<F> for PoseidonSponge<F> {
-//     fn new() -> Self {
-//         // Requires F to be Alt_Bn128Fr
-//         let full_rounds = 8;
-//         let partial_rounds = 31;
-//         let alpha = 17;
-//
-//         let mds = vec![
-//             vec![F::one(), F::zero(), F::one()],
-//             vec![F::one(), F::one(), F::zero()],
-//             vec![F::zero(), F::one(), F::one()],
-//         ];
-//
-//         let mut ark = Vec::new();
-//         let mut ark_rng = rand_chacha::ChaChaRng::seed_from_u64(123456789u64);
-//
-//         for _ in 0..(full_rounds + partial_rounds) {
-//             let mut res = Vec::new();
-//
-//             for _ in 0..3 {
-//                 res.push(F::rand(&mut ark_rng));
-//             }
-//             ark.push(res);
-//         }
-//
-//         let rate = 2;
-//         let capacity = 1;
-//         let state = vec![F::zero(); rate + capacity];
-//         let mode = PoseidonSpongeState::Absorbing {
-//             next_absorb_index: 0,
-//         };
-//
-//         PoseidonSponge {
-//             full_rounds,
-//             partial_rounds,
-//             alpha,
-//             ark,
-//             mds,
-//
-//             state,
-//             rate,
-//             capacity,
-//             mode,
-//         }
-//     }
-//
-//     fn absorb(&mut self, elems: &[F]) {
-//         if elems.is_empty() {
-//             return;
-//         }
-//
-//         match self.mode {
-//             PoseidonSpongeState::Absorbing { next_absorb_index } => {
-//                 let mut absorb_index = next_absorb_index;
-//                 if absorb_index == self.rate {
-//                     self.permute();
-//                     absorb_index = 0;
-//                 }
-//                 self.absorb_internal(absorb_index, elems);
-//             }
-//             PoseidonSpongeState::Squeezing {
-//                 next_squeeze_index: _,
-//             } => {
-//                 self.permute();
-//                 self.absorb_internal(0, elems);
-//             }
-//         };
-//     }
-//
-//     fn squeeze(&mut self, num: usize) -> Vec<F> {
-//         let mut squeezed_elems = vec![F::zero(); num];
-//         match self.mode {
-//             PoseidonSpongeState::Absorbing {
-//                 next_absorb_index: _,
-//             } => {
-//                 self.permute();
-//                 self.squeeze_internal(0, &mut squeezed_elems);
-//             }
-//             PoseidonSpongeState::Squeezing { next_squeeze_index } => {
-//                 let mut squeeze_index = next_squeeze_index;
-//                 if squeeze_index == self.rate {
-//                     self.permute();
-//                     squeeze_index = 0;
-//                 }
-//                 self.squeeze_internal(squeeze_index, &mut squeezed_elems);
-//             }
-//         };
-//         squeezed_elems
-//     }
-// }
+use crate::fiat_shamir::AlgebraicSponge;
+use snarkvm_fields::PrimeField;
+
+use rand::SeedableRng;
+
+/// constraints for Poseidon
+pub mod constraints;
+
+#[derive(Clone)]
+enum PoseidonSpongeState {
+    Absorbing { next_absorb_index: usize },
+    Squeezing { next_squeeze_index: usize },
+}
+
+#[derive(Clone)]
+/// the sponge for Poseidon
+pub struct PoseidonSponge<F: PrimeField> {
+    /// number of rounds in a full-round operation
+    pub full_rounds: u32,
+    /// number of rounds in a partial-round operation
+    pub partial_rounds: u32,
+    /// Exponent used in S-boxes
+    pub alpha: u64,
+    /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
+    /// They are indexed by ark[round_num][state_element_index]
+    pub ark: Vec<Vec<F>>,
+    /// Maximally Distance Separating Matrix.
+    pub mds: Vec<Vec<F>>,
+
+    /// the sponge's state
+    pub state: Vec<F>,
+    /// the rate
+    pub rate: usize,
+    /// the capacity
+    pub capacity: usize,
+    /// the mode
+    mode: PoseidonSpongeState,
+}
+
+impl<F: PrimeField> PoseidonSponge<F> {
+    fn apply_s_box(&self, state: &mut [F], is_full_round: bool) {
+        // Full rounds apply the S Box (x^alpha) to every element of state
+        if is_full_round {
+            for elem in state {
+                *elem = elem.pow(&[self.alpha]);
+            }
+        }
+        // Partial rounds apply the S Box (x^alpha) to just the final element of state
+        else {
+            state[state.len() - 1] = state[state.len() - 1].pow(&[self.alpha]);
+        }
+    }
+
+    fn apply_ark(&self, state: &mut [F], round_number: usize) {
+        for (i, state_elem) in state.iter_mut().enumerate() {
+            state_elem.add_assign(&self.ark[round_number][i]);
+        }
+    }
+
+    fn apply_mds(&self, state: &mut [F]) {
+        let mut new_state = Vec::new();
+        for i in 0..state.len() {
+            let mut cur = F::zero();
+            for (j, state_elem) in state.iter().enumerate() {
+                let term = state_elem.mul(&self.mds[i][j]);
+                cur.add_assign(&term);
+            }
+            new_state.push(cur);
+        }
+        state.clone_from_slice(&new_state[..state.len()])
+    }
+
+    fn permute(&mut self) {
+        let full_rounds_over_2 = self.full_rounds / 2;
+        let mut state = self.state.clone();
+        for i in 0..full_rounds_over_2 {
+            self.apply_ark(&mut state, i as usize);
+            self.apply_s_box(&mut state, true);
+            self.apply_mds(&mut state);
+        }
+
+        for i in full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds) {
+            self.apply_ark(&mut state, i as usize);
+            self.apply_s_box(&mut state, false);
+            self.apply_mds(&mut state);
+        }
+
+        for i in (full_rounds_over_2 + self.partial_rounds)..(self.partial_rounds + self.full_rounds) {
+            self.apply_ark(&mut state, i as usize);
+            self.apply_s_box(&mut state, true);
+            self.apply_mds(&mut state);
+        }
+        self.state = state;
+    }
+
+    // Absorbs everything in elements, this does not end in an absorbtion.
+    fn absorb_internal(&mut self, rate_start_index: usize, elements: &[F]) {
+        // if we can finish in this call
+        if rate_start_index + elements.len() <= self.rate {
+            for (i, element) in elements.iter().enumerate() {
+                self.state[i + rate_start_index] += element;
+            }
+            self.mode = PoseidonSpongeState::Absorbing {
+                next_absorb_index: rate_start_index + elements.len(),
+            };
+
+            return;
+        }
+        // otherwise absorb (rate - rate_start_index) elements
+        let num_elements_absorbed = self.rate - rate_start_index;
+        for (i, element) in elements.iter().enumerate().take(num_elements_absorbed) {
+            self.state[i + rate_start_index] += element;
+        }
+        self.permute();
+        // Tail recurse, with the input elements being truncated by num elements absorbed
+        self.absorb_internal(0, &elements[num_elements_absorbed..]);
+    }
+
+    // Squeeze |output| many elements. This does not end in a squeeze
+    fn squeeze_internal(&mut self, rate_start_index: usize, output: &mut [F]) {
+        // if we can finish in this call
+        if rate_start_index + output.len() <= self.rate {
+            output.clone_from_slice(&self.state[rate_start_index..(output.len() + rate_start_index)]);
+            self.mode = PoseidonSpongeState::Squeezing {
+                next_squeeze_index: rate_start_index + output.len(),
+            };
+            return;
+        }
+        // otherwise squeeze (rate - rate_start_index) elements
+        let num_elements_squeezed = self.rate - rate_start_index;
+        output[..num_elements_squeezed]
+            .clone_from_slice(&self.state[rate_start_index..(num_elements_squeezed + rate_start_index)]);
+
+        // Unless we are done with squeezing in this call, permute.
+        if output.len() != self.rate {
+            self.permute();
+        }
+        // Tail recurse, with the correct change to indices in output happening due to changing the slice
+        self.squeeze_internal(0, &mut output[num_elements_squeezed..]);
+    }
+}
+
+impl<F: PrimeField> AlgebraicSponge<F> for PoseidonSponge<F> {
+    fn new() -> Self {
+        // Requires F to be Alt_Bn128Fr
+        let full_rounds = 8;
+        let partial_rounds = 31;
+        let alpha = 17;
+
+        let mds = vec![
+            vec![F::one(), F::zero(), F::one()],
+            vec![F::one(), F::one(), F::zero()],
+            vec![F::zero(), F::one(), F::one()],
+        ];
+
+        let mut ark = Vec::new();
+        let mut ark_rng = rand_chacha::ChaChaRng::seed_from_u64(123456789u64);
+
+        for _ in 0..(full_rounds + partial_rounds) {
+            let mut res = Vec::new();
+
+            for _ in 0..3 {
+                res.push(F::rand(&mut ark_rng));
+            }
+            ark.push(res);
+        }
+
+        let rate = 2;
+        let capacity = 1;
+        let state = vec![F::zero(); rate + capacity];
+        let mode = PoseidonSpongeState::Absorbing { next_absorb_index: 0 };
+
+        PoseidonSponge {
+            full_rounds,
+            partial_rounds,
+            alpha,
+            ark,
+            mds,
+
+            state,
+            rate,
+            capacity,
+            mode,
+        }
+    }
+
+    fn absorb(&mut self, elems: &[F]) {
+        if elems.is_empty() {
+            return;
+        }
+
+        match self.mode {
+            PoseidonSpongeState::Absorbing { next_absorb_index } => {
+                let mut absorb_index = next_absorb_index;
+                if absorb_index == self.rate {
+                    self.permute();
+                    absorb_index = 0;
+                }
+                self.absorb_internal(absorb_index, elems);
+            }
+            PoseidonSpongeState::Squeezing { next_squeeze_index: _ } => {
+                self.permute();
+                self.absorb_internal(0, elems);
+            }
+        };
+    }
+
+    fn squeeze(&mut self, num: usize) -> Vec<F> {
+        let mut squeezed_elems = vec![F::zero(); num];
+        match self.mode {
+            PoseidonSpongeState::Absorbing { next_absorb_index: _ } => {
+                self.permute();
+                self.squeeze_internal(0, &mut squeezed_elems);
+            }
+            PoseidonSpongeState::Squeezing { next_squeeze_index } => {
+                let mut squeeze_index = next_squeeze_index;
+                if squeeze_index == self.rate {
+                    self.permute();
+                    squeeze_index = 0;
+                }
+                self.squeeze_internal(squeeze_index, &mut squeezed_elems);
+            }
+        };
+        squeezed_elems
+    }
+}

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -75,3 +75,8 @@ pub use parameters::*;
 /// Implements the snarkVM-compatible Marlin SNARK interface.
 pub mod snark;
 pub use snark::*;
+
+// Implements a Fiat-Shamir based Rng that allows one to incrementally update
+// the seed based on new messages in the proof transcript.
+// pub mod fiat_shamir;
+// use crate::fiat_shamir::FiatShamirRng;

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -76,7 +76,7 @@ pub use parameters::*;
 pub mod snark;
 pub use snark::*;
 
-// Implements a Fiat-Shamir based Rng that allows one to incrementally update
-// the seed based on new messages in the proof transcript.
-// pub mod fiat_shamir;
+/// Implements a Fiat-Shamir based Rng that allows one to incrementally update
+/// the seed based on new messages in the proof transcript.
+pub mod fiat_shamir;
 // use crate::fiat_shamir::FiatShamirRng;

--- a/marlin/tests/fiat_shamir.rs
+++ b/marlin/tests/fiat_shamir.rs
@@ -1,0 +1,185 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+// use ark_mnt4_298::{Fq, Fr};
+
+use snarkvm_curves::bls12_377::{Fq, Fr};
+use snarkvm_fields::PrimeField;
+use snarkvm_gadgets::utilities::{alloc::AllocGadget, uint::UInt8};
+use snarkvm_marlin::fiat_shamir::{
+    constraints::{FiatShamirAlgebraicSpongeRngVar, FiatShamirRngVar},
+    poseidon::{constraints::PoseidonSpongeVar, PoseidonSponge},
+    FiatShamirAlgebraicSpongeRng,
+    FiatShamirChaChaRng,
+    FiatShamirRng,
+};
+use snarkvm_nonnative::{params::OptimizationType, NonNativeFieldVar};
+use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
+use snarkvm_utilities::UniformRand;
+
+use blake2::Blake2s;
+use rand::SeedableRng;
+
+const NUM_ABSORBED_RAND_FIELD_ELEMS: usize = 10;
+const NUM_ABSORBED_RAND_BYTE_ELEMS: usize = 10;
+const SIZE_ABSORBED_BYTE_ELEM: usize = 64;
+
+const NUM_SQUEEZED_FIELD_ELEMS: usize = 10;
+const NUM_SQUEEZED_SHORT_FIELD_ELEMS: usize = 10;
+
+#[test]
+fn test_chacharng() {
+    let rng = &mut rand_chacha::ChaChaRng::seed_from_u64(123456789u64);
+
+    let mut absorbed_rand_field_elems = Vec::new();
+    for _ in 0..NUM_ABSORBED_RAND_FIELD_ELEMS {
+        absorbed_rand_field_elems.push(Fr::rand(rng));
+    }
+
+    let mut absorbed_rand_byte_elems = Vec::<Vec<u8>>::new();
+    for _ in 0..NUM_ABSORBED_RAND_BYTE_ELEMS {
+        absorbed_rand_byte_elems.push((0..SIZE_ABSORBED_BYTE_ELEM).map(|_| u8::rand(rng)).collect());
+    }
+
+    let mut fs_rng = FiatShamirChaChaRng::<Fr, Fq, Blake2s>::new();
+    fs_rng.absorb_nonnative_field_elements(&absorbed_rand_field_elems, OptimizationType::Weight);
+    for absorbed_rand_byte_elem in absorbed_rand_byte_elems {
+        fs_rng.absorb_bytes(&absorbed_rand_byte_elem);
+    }
+
+    let _squeezed_fields_elems =
+        fs_rng.squeeze_nonnative_field_elements(NUM_SQUEEZED_FIELD_ELEMS, OptimizationType::Weight);
+    let _squeezed_short_fields_elems = fs_rng.squeeze_128_bits_nonnative_field_elements(NUM_SQUEEZED_SHORT_FIELD_ELEMS);
+}
+
+#[test]
+fn test_poseidon() {
+    let rng = &mut rand_chacha::ChaChaRng::seed_from_u64(123456789u64);
+
+    let mut absorbed_rand_field_elems = Vec::new();
+    for _ in 0..NUM_ABSORBED_RAND_FIELD_ELEMS {
+        absorbed_rand_field_elems.push(Fr::rand(rng));
+    }
+
+    let mut absorbed_rand_byte_elems = Vec::<Vec<u8>>::new();
+    for _ in 0..NUM_ABSORBED_RAND_BYTE_ELEMS {
+        absorbed_rand_byte_elems.push((0..SIZE_ABSORBED_BYTE_ELEM).map(|_| u8::rand(rng)).collect());
+    }
+
+    // fs_rng in the plaintext world
+    let mut fs_rng = FiatShamirAlgebraicSpongeRng::<Fr, Fq, PoseidonSponge<Fq>>::new();
+
+    fs_rng.absorb_nonnative_field_elements(&absorbed_rand_field_elems, OptimizationType::Constraints);
+
+    for absorbed_rand_byte_elem in &absorbed_rand_byte_elems {
+        fs_rng.absorb_bytes(absorbed_rand_byte_elem);
+    }
+
+    let squeezed_fields_elems =
+        fs_rng.squeeze_nonnative_field_elements(NUM_SQUEEZED_FIELD_ELEMS, OptimizationType::Constraints);
+    let squeezed_short_fields_elems = fs_rng.squeeze_128_bits_nonnative_field_elements(NUM_SQUEEZED_SHORT_FIELD_ELEMS);
+
+    // fs_rng in the constraint world
+    let mut cs = TestConstraintSystem::<Fq>::new();
+    // let cs_sys = ConstraintSystem::<Fq>::new();
+    // let cs = ConstraintSystemRef::new(cs_sys);
+    // cs.set_optimization_goal(OptimizationGoal::Weight);
+
+    let mut fs_rng_gadget =
+        FiatShamirAlgebraicSpongeRngVar::<Fr, Fq, PoseidonSponge<Fq>, PoseidonSpongeVar<Fq>>::new(cs.ns(|| "new"));
+
+    let mut absorbed_rand_field_elems_gadgets = Vec::new();
+    for (i, absorbed_rand_field_elem) in absorbed_rand_field_elems.iter().enumerate() {
+        absorbed_rand_field_elems_gadgets.push(
+            NonNativeFieldVar::<Fr, Fq>::alloc_constant(cs.ns(|| format!("alloc_elem_{}", i)), || {
+                Ok(absorbed_rand_field_elem)
+            })
+            .unwrap(),
+        );
+    }
+    fs_rng_gadget
+        .absorb_nonnative_field_elements(
+            cs.ns(|| "absorb_nonnative_field_elements"),
+            &absorbed_rand_field_elems_gadgets,
+            OptimizationType::Constraints,
+        )
+        .unwrap();
+
+    let mut absorbed_rand_byte_elems_gadgets = Vec::<Vec<UInt8>>::new();
+    for (i, absorbed_rand_byte_elem) in absorbed_rand_byte_elems.iter().enumerate() {
+        let mut byte_gadget = Vec::<UInt8>::new();
+        for (j, byte) in absorbed_rand_byte_elem.iter().enumerate() {
+            byte_gadget.push(UInt8::alloc(cs.ns(|| format!("alloc_byte_{}_{}", i, j)), || Ok(byte)).unwrap());
+        }
+        absorbed_rand_byte_elems_gadgets.push(byte_gadget);
+    }
+    for (i, absorbed_rand_byte_elems_gadget) in absorbed_rand_byte_elems_gadgets.iter().enumerate() {
+        fs_rng_gadget
+            .absorb_bytes(cs.ns(|| format!("absorb_bytes{}", i)), absorbed_rand_byte_elems_gadget)
+            .unwrap();
+    }
+
+    let squeezed_fields_elems_gadgets = fs_rng_gadget
+        .squeeze_field_elements(cs.ns(|| "squeeze_field_elements"), NUM_SQUEEZED_FIELD_ELEMS)
+        .unwrap();
+
+    let squeezed_short_fields_elems_gadgets = fs_rng_gadget
+        .squeeze_128_bits_field_elements(
+            cs.ns(|| "squeeze_128_bits_field_elements"),
+            NUM_SQUEEZED_SHORT_FIELD_ELEMS,
+        )
+        .unwrap();
+
+    // compare elems
+    for (i, (left, right)) in squeezed_fields_elems
+        .iter()
+        .zip(squeezed_fields_elems_gadgets.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            left.into_repr(),
+            right.value().unwrap().into_repr(),
+            "{}: left = {:?}, right = {:?}",
+            i,
+            left.into_repr(),
+            right.value().unwrap().into_repr()
+        );
+    }
+
+    // compare short elems
+    for (i, (left, right)) in squeezed_short_fields_elems
+        .iter()
+        .zip(squeezed_short_fields_elems_gadgets.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            left.into_repr(),
+            right.value().unwrap().into_repr(),
+            "{}: left = {:?}, right = {:?}",
+            i,
+            left.into_repr(),
+            right.value().unwrap().into_repr()
+        );
+    }
+
+    if !cs.is_satisfied() {
+        println!("\n=========================================================");
+        println!("\nUnsatisfied constraints:");
+        println!("\n{:?}", cs.which_is_unsatisfied().unwrap());
+        println!("\n=========================================================");
+    }
+    assert!(cs.is_satisfied());
+}

--- a/nonnative/src/allocated_nonnative_field_var.rs
+++ b/nonnative/src/allocated_nonnative_field_var.rs
@@ -821,9 +821,9 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocGadget<TargetField, Ba
         let elem_representations = Self::get_limbs_representations(&elem, optimization_type)?;
         let mut limbs = Vec::new();
 
-        for limb in elem_representations.iter() {
+        for (i, limb) in elem_representations.iter().enumerate() {
             limbs.push(FpGadget::<BaseField>::alloc_constant(
-                cs.ns(|| "alloc_constant"),
+                cs.ns(|| format!("alloc_constant_{}", i)),
                 || Ok(limb),
             )?);
         }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds the Fiat Shamir and Poseidon randomness gadgets to the `marlin` module.

## Test Plan

Tests have been added to `/tests/fiat_shamir.rs`

## Related PRs

This PR is built on the `nonnative` changes made in #78 .