### PR TITLE
clippy: a few 1.50 lints more

### DIFF
--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -278,7 +278,7 @@ pub fn test_with_metrics(_: proc_macro::TokenStream, item: proc_macro::TokenStre
                 })
                 .into()
             }
-            let name = crate_name("snarkos-metrics").unwrap_or("crate".to_string());
+            let name = crate_name("snarkos-metrics").unwrap_or_else(|_| "crate".to_string());
             let crate_name = Ident::new(&name, Span::call_site());
             generate_test_function(function, crate_name)
         }

--- a/gadgets/src/traits/utilities/boolean.rs
+++ b/gadgets/src/traits/utilities/boolean.rs
@@ -645,7 +645,7 @@ impl Boolean {
         }
     }
 
-    pub fn enforce_smaller_or_equal_than_le<'a, F: Field, CS: ConstraintSystem<F>>(
+    pub fn enforce_smaller_or_equal_than_le<F: Field, CS: ConstraintSystem<F>>(
         mut cs: CS,
         bits: &[Self],
         element: impl AsRef<[u64]>,
@@ -682,13 +682,13 @@ impl Boolean {
         {
             if b {
                 // This is part of a run of ones.
-                current_run.push(a.clone());
+                current_run.push(*a);
             } else {
                 if !current_run.is_empty() {
                     // This is the start of a run of zeros, but we need
                     // to k-ary AND against `last_run` first.
 
-                    current_run.push(last_run.clone());
+                    current_run.push(last_run);
                     last_run = Self::kary_and(cs.ns(|| format!("kary_and_{}", i)), &current_run)?;
                     current_run.truncate(0);
                 }
@@ -699,10 +699,7 @@ impl Boolean {
                 // If `last_run` is false, `a` can be true or false.
                 //
                 // Ergo, at least one of `last_run` and `a` must be false.
-                Self::enforce_kary_nand(cs.ns(|| format!("enforce_kary_and_{}", i)), &[
-                    last_run.clone(),
-                    a.clone(),
-                ])?;
+                Self::enforce_kary_nand(cs.ns(|| format!("enforce_kary_and_{}", i)), &[last_run, *a])?;
             }
         }
         assert!(bits_iter.next().is_none());

--- a/nonnative/tests/arithmetic_tests.rs
+++ b/nonnative/tests/arithmetic_tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_curves::{bls12_377::Bls12_377, bw6_761::BW6_761, traits::PairingEngine};
+use snarkvm_curves::{bls12_377::Bls12_377, traits::PairingEngine};
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     traits::fields::FieldGadget,
@@ -41,7 +41,7 @@ fn allocation_test<TargetField: PrimeField, BaseField: PrimeField, CS: Constrain
     rng: &mut R,
 ) {
     let a_native = TargetField::rand(rng);
-    let a = NonNativeFieldVar::<TargetField, BaseField>::alloc(cs.ns(|| "alloc_a"), || Ok(a_native.clone())).unwrap();
+    let a = NonNativeFieldVar::<TargetField, BaseField>::alloc(cs.ns(|| "alloc_a"), || Ok(a_native)).unwrap();
 
     let a_actual = a.value().unwrap();
     let a_expected = a_native;
@@ -209,10 +209,10 @@ fn distribution_law_test<
     let b_native = TargetField::rand(rng);
     let c_native = TargetField::rand(rng);
 
-    let a_plus_b_native = a_native.clone() + &b_native;
-    let a_times_c_native = a_native.clone() * &c_native;
-    let b_times_c_native = b_native.clone() * &c_native;
-    let a_plus_b_times_c_native = a_plus_b_native.clone() * &c_native;
+    let a_plus_b_native = a_native + &b_native;
+    let a_times_c_native = a_native * &c_native;
+    let b_times_c_native = b_native * &c_native;
+    let a_plus_b_times_c_native = a_plus_b_native * &c_native;
     let a_times_c_plus_b_times_c_native = a_times_c_native + &b_times_c_native;
 
     assert!(

--- a/objects/src/traits/storage.rs
+++ b/objects/src/traits/storage.rs
@@ -32,6 +32,7 @@ where
     fn get(&self, col: u32, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError>;
 
     /// Returns all the keys and values belonging to the given column.
+    #[allow(clippy::type_complexity)]
     fn get_col(&self, col: u32) -> Result<Vec<(Box<[u8]>, Box<[u8]>)>, StorageError>;
 
     /// Returns all the keys belonging to the given column.

--- a/posw/benches/posw.rs
+++ b/posw/benches/posw.rs
@@ -25,6 +25,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
+#[allow(deprecated)]
 fn gm17_posw(c: &mut Criterion) {
     let mut group = c.benchmark_group("Proof of Succinct Work: GM17");
     group.sample_size(10);

--- a/posw/src/lib.rs
+++ b/posw/src/lib.rs
@@ -95,6 +95,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_posw_gm17() {
         let rng = &mut XorShiftRng::seed_from_u64(1234567);
 


### PR DESCRIPTION
It seems that a few lints slipped through the cracks with the last pass; this time the `cargo clippy --workspace --all-targets` run was performed after `cargo clean`.