### PR TITLE
Fix leo#738

### DIFF
--- a/gadgets/src/traits/utilities/arithmetic/mul.rs
+++ b/gadgets/src/traits/utilities/arithmetic/mul.rs
@@ -25,4 +25,6 @@ where
     type ErrorType;
 
     fn mul<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
+
+    fn wrapping_mul<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/gadgets/src/traits/utilities/int/arithmetic/mul.rs
+++ b/gadgets/src/traits/utilities/int/arithmetic/mul.rs
@@ -206,6 +206,159 @@ macro_rules! mul_int_impl {
                     value: modular_value,
                 })
             }
+
+            fn wrapping_mul<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Self, Self::ErrorType> {
+                // the pseudocode is the same as with Mul::mul, just without the early return on overflow
+
+                // Conditionally select constant result
+                let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+                let allocated_false = Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "false"), || Ok(false)).unwrap());
+                let false_bit = Boolean::conditionally_select(
+                    &mut cs.ns(|| "constant_or_allocated_false"),
+                    &is_constant,
+                    &Boolean::constant(false),
+                    &allocated_false,
+                )?;
+
+                // Sign extend to double precision
+                let size = <$gadget as Int>::SIZE * 2;
+
+                let a = Boolean::sign_extend(&self.bits, size);
+                let b = Boolean::sign_extend(&other.bits, size);
+
+                let mut bits = vec![false_bit; size];
+
+                // Compute double and add algorithm
+                let mut to_add = Vec::new();
+                let mut a_shifted = Vec::new();
+                for (i, b_bit) in b.iter().enumerate() {
+                    // double
+                    a_shifted.extend(iter::repeat(false_bit).take(i));
+                    a_shifted.extend(a.iter());
+                    a_shifted.truncate(size);
+
+                    // conditionally add
+                    to_add.reserve(a_shifted.len());
+                    for (j, a_bit) in a_shifted.iter().enumerate() {
+                        let selected_bit = Boolean::conditionally_select(
+                            &mut cs.ns(|| format!("select product bit {} {}", i, j)),
+                            b_bit,
+                            a_bit,
+                            &false_bit,
+                        )?;
+
+                        to_add.push(selected_bit);
+                    }
+
+                    bits = bits.add_bits(
+                        &mut cs.ns(|| format!("add bit {}", i)),
+                        &to_add
+                    )?;
+                    let _carry = bits.pop();
+                    to_add.clear();
+                    a_shifted.clear();
+                }
+                drop(to_add);
+                drop(a_shifted);
+
+                // Compute the maximum value of the sum
+                let max_bits = <$gadget as Int>::SIZE;
+
+                // Truncate the bits to the size of the integer
+                bits.truncate(max_bits);
+
+                // Make some arbitrary bounds for ourselves to avoid overflows
+                // in the scalar field
+                assert!(F::Parameters::MODULUS_BITS >= max_bits as u32);
+
+                // Accumulate the value
+                let result_value = match (self.value, other.value) {
+                    (Some(a), Some(b)) => {
+                        Some(a.wrapping_mul(b))
+                    },
+                    _ => {
+                        // If any of the operands have unknown value, we won't
+                        // know the value of the result
+                        None
+                    }
+                };
+
+                // This is a linear combination that we will enforce to be zero
+                let mut lc = LinearCombination::zero();
+
+                let mut all_constants = true;
+
+                // Iterate over each bit_gadget of result and add each bit to
+                // the linear combination
+                let mut coeff = F::one();
+                for bit in bits {
+                    match bit {
+                        Boolean::Is(ref bit) => {
+                            all_constants = false;
+
+                            // Add the coeff * bit_gadget
+                            lc += (coeff, bit.get_variable());
+                        }
+                        Boolean::Not(ref bit) => {
+                            all_constants = false;
+
+                            // Add coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc + (coeff, CS::one()) - (coeff, bit.get_variable());
+                        }
+                        Boolean::Constant(bit) => {
+                            if bit {
+                                lc += (coeff, CS::one());
+                            }
+                        }
+                    }
+
+                    coeff.double_in_place();
+                }
+
+                // The value of the actual result is modulo 2 ^ $size
+                let modular_value = result_value.map(|v| v as <$gadget as Int>::IntegerType);
+
+                if all_constants && modular_value.is_some() {
+                    // We can just return a constant, rather than
+                    // unpacking the result into allocated bits.
+
+                    return Ok(Self::constant(modular_value.unwrap()));
+                }
+
+                // Storage area for the resulting bits
+                let mut result_bits = Vec::with_capacity(max_bits);
+
+                // Allocate each bit_gadget of the result
+                let mut coeff = F::one();
+                for i in 0..max_bits {
+                    // get bit value
+                    let mask = 1 << i as <$gadget as Int>::IntegerType;
+
+                    // Allocate the bit_gadget
+                    let b = AllocatedBit::alloc(cs.ns(|| format!("result bit_gadget {}", i)), || {
+                        result_value.map(|v| (v & mask) == mask).get()
+                    })?;
+
+                    // Subtract this bit_gadget from the linear combination to ensure that the sums
+                    // balance out
+                    lc = lc - (coeff, b.get_variable());
+
+                    result_bits.push(b.into());
+
+                    coeff.double_in_place();
+                }
+
+                // Enforce that the linear combination equals zero
+                cs.enforce(|| "modular multiplication", |lc| lc, |lc| lc, |_| lc);
+
+                // Discard carry bits we don't care about
+                result_bits.truncate(<$gadget as Int>::SIZE);
+
+                Ok(Self {
+                    bits: result_bits,
+                    value: modular_value,
+                })
+            }
         }
     )*)
 }

--- a/gadgets/src/traits/utilities/int/arithmetic/pow.rs
+++ b/gadgets/src/traits/utilities/int/arithmetic/pow.rs
@@ -57,10 +57,10 @@ macro_rules! pow_int_impl {
                 )?;
 
                 for (i, bit) in other.bits.iter().rev().enumerate() {
-                    result = result.mul(cs.ns(|| format!("square_{}", i)), &result).unwrap();
+                    result = result.mul(cs.ns(|| format!("square_{}", i)), &result)?;
 
                     let mul_by_self = result
-                        .mul(cs.ns(|| format!("multiply_by_self_{}", i)), &self);
+                        .wrapping_mul(cs.ns(|| format!("multiply_by_self_{}", i)), &self);
 
                     result = Self::conditionally_select(
                         &mut cs.ns(|| format!("mul_by_self_or_result_{}", i)),

--- a/gadgets/src/traits/utilities/int/tests/int16.rs
+++ b/gadgets/src/traits/utilities/int/tests/int16.rs
@@ -360,7 +360,7 @@ fn test_int16_pow_constants() {
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: i16 = rng.gen_range(-16..16);
+        let a: i16 = rng.gen_range(-180..180);
         let b: i16 = rng.gen_range(-4..4);
 
         let expected = match a.checked_pow(b as u32) {

--- a/gadgets/src/traits/utilities/int/tests/int32.rs
+++ b/gadgets/src/traits/utilities/int/tests/int32.rs
@@ -353,16 +353,15 @@ fn test_int32_div() {
     }
 }
 
-#[ignore]
 #[test]
 fn test_int32_pow_constants() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    for _ in 0..3 {
+    for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: i32 = rng.gen_range(-16..16);
-        let b: i32 = rng.gen_range(-8..8);
+        let a: i32 = rng.gen_range(-46340..46340);
+        let b: i32 = rng.gen_range(-4..4);
 
         let expected = match a.checked_pow(b as u32) {
             Some(valid) => valid,
@@ -380,16 +379,15 @@ fn test_int32_pow_constants() {
     }
 }
 
-#[ignore]
 #[test]
 fn test_int32_pow() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    for _ in 0..3 {
+    for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: i32 = rng.gen_range(-16..16);
-        let b: i32 = rng.gen_range(-8..8);
+        let a: i32 = rng.gen_range(-46340..46340);
+        let b: i32 = rng.gen_range(-4..4);
 
         let expected = match a.checked_pow(b as u32) {
             Some(valid) => valid,

--- a/gadgets/src/traits/utilities/int/tests/int64.rs
+++ b/gadgets/src/traits/utilities/int/tests/int64.rs
@@ -360,66 +360,74 @@ fn test_int64_div() {
     }
 }
 
-#[ignore]
 #[test]
 fn test_int64_pow_constants() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    let mut cs = TestConstraintSystem::<Fr>::new();
+    for _ in 0..5 {
+        let mut cs = TestConstraintSystem::<Fr>::new();
 
-    let a: i64 = rng.gen_range(-16..16);
-    let b: i64 = rng.gen_range(-12..12);
+        let a: i64 = rng.gen_range(-3037000499..3037000499);
+        let b: i64 = rng.gen_range(-3..3);
 
-    let expected = a.checked_pow(b as u32).unwrap();
+        let expected = match a.checked_pow(b as u32) {
+            Some(valid) => valid,
+            None => continue,
+        };
 
-    let a_bit = Int64::constant(a);
-    let b_bit = Int64::constant(b);
+        let a_bit = Int64::constant(a);
+        let b_bit = Int64::constant(b);
 
-    let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+        let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
 
-    assert!(r.value == Some(expected));
+        assert!(r.value == Some(expected));
 
-    check_all_constant_bits(expected, r);
+        check_all_constant_bits(expected, r);
+    }
 }
 
-#[ignore]
 #[test]
 fn test_int64_pow() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    let mut cs = TestConstraintSystem::<Fr>::new();
+    for _ in 0..5 {
+        let mut cs = TestConstraintSystem::<Fr>::new();
 
-    let a: i64 = rng.gen_range(-16..16);
-    let b: i64 = rng.gen_range(-12..12);
+        let a: i64 = rng.gen_range(-3037000499..3037000499);
+        let b: i64 = rng.gen_range(-3..3);
 
-    let expected = a.checked_pow(b as u32).unwrap();
+        let expected = match a.checked_pow(b as u32) {
+            Some(valid) => valid,
+            None => continue,
+        };
 
-    let a_bit = Int64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
-    let b_bit = Int64::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap();
+        let a_bit = Int64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+        let b_bit = Int64::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap();
 
-    let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+        let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
 
-    assert!(cs.is_satisfied());
+        assert!(cs.is_satisfied());
 
-    assert!(r.value == Some(expected));
+        assert!(r.value == Some(expected));
 
-    check_all_allocated_bits(expected, r);
+        check_all_allocated_bits(expected, r);
 
-    // Flip a bit_gadget and see if the exponentiation constraint still works
-    if cs
-        .get("exponentiation/multiply_by_self_0/result bit_gadget 0/boolean")
-        .is_zero()
-    {
-        cs.set(
-            "exponentiation/multiply_by_self_0/result bit_gadget 0/boolean",
-            Fr::one(),
-        );
-    } else {
-        cs.set(
-            "exponentiation/multiply_by_self_0/result bit_gadget 0/boolean",
-            Fr::zero(),
-        );
+        // Flip a bit_gadget and see if the exponentiation constraint still works
+        if cs
+            .get("exponentiation/multiply_by_self_0/result bit_gadget 0/boolean")
+            .is_zero()
+        {
+            cs.set(
+                "exponentiation/multiply_by_self_0/result bit_gadget 0/boolean",
+                Fr::one(),
+            );
+        } else {
+            cs.set(
+                "exponentiation/multiply_by_self_0/result bit_gadget 0/boolean",
+                Fr::zero(),
+            );
+        }
+
+        assert!(!cs.is_satisfied());
     }
-
-    assert!(!cs.is_satisfied());
 }

--- a/gadgets/src/traits/utilities/int/tests/int8.rs
+++ b/gadgets/src/traits/utilities/int/tests/int8.rs
@@ -351,10 +351,10 @@ fn test_int8_div() {
 fn test_int8_pow_constants() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    for _ in 0..100 {
+    for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: i8 = rng.gen_range(-4..4);
+        let a: i8 = rng.gen_range(-12..12);
         let b: i8 = rng.gen_range(-4..4);
 
         let expected = match a.checked_pow(b as u32) {
@@ -380,7 +380,7 @@ fn test_int8_pow() {
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: i8 = rng.gen_range(-4..4);
+        let a: i8 = rng.gen_range(-12..12);
         let b: i8 = rng.gen_range(-4..4);
 
         let expected = match a.checked_pow(b as u32) {


### PR DESCRIPTION
As discussed in https://github.com/AleoHQ/leo/pull/762 and outlined in https://github.com/AleoHQ/leo/issues/763, leo will be removing its `gadgets` and intstead use the ones in snarkVM; therefore, this PR replaces the one filed in leo, and adjusts the `pow` operation for signed integers to internally use a new `Mul::wrapping_mul` method in an intermediate operation that should be allowed to overflow.

In addition, the signed `pow` tests are adjusted and extended so that the bug can actually be triggered (which does happen without https://github.com/AleoHQ/snarkVM/pull/103/commits/556073c21da6afe7e97eb5a60e94227e5309dbf6). Some of them are also un-ignored.

Supersedes https://github.com/AleoHQ/leo/pull/762.
Fixes https://github.com/AleoHQ/leo/issues/738.