### PR TITLE
Use the Div trait to implement div for unsigned integers

### DIFF
--- a/gadgets/benches/integer_arithmetic.rs
+++ b/gadgets/benches/integer_arithmetic.rs
@@ -16,6 +16,7 @@
 
 use snarkvm_gadgets::traits::utilities::{
     alloc::AllocGadget,
+    arithmetic::*,
     uint::{UInt, UInt128, UInt16, UInt32, UInt64, UInt8},
 };
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};

--- a/gadgets/src/errors/mod.rs
+++ b/gadgets/src/errors/mod.rs
@@ -16,3 +16,6 @@
 
 pub mod signed_integer;
 pub use self::signed_integer::*;
+
+pub mod unsigned_integer;
+pub use self::unsigned_integer::*;

--- a/gadgets/src/errors/unsigned_integer.rs
+++ b/gadgets/src/errors/unsigned_integer.rs
@@ -14,17 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use]
-mod macros;
+use snarkvm_r1cs::errors::SynthesisError;
 
-pub mod arithmetic;
-pub use arithmetic::*;
+#[derive(Debug, Error)]
+pub enum UnsignedIntegerError {
+    #[error("Integer overflow")]
+    Overflow,
 
-pub mod unsigned_integer;
-pub use unsigned_integer::*;
+    #[error("Division by zero")]
+    DivisionByZero,
 
-pub mod uint128;
-pub use uint128::*;
-
-#[cfg(test)]
-mod tests;
+    #[error("{}", _0)]
+    SynthesisError(#[from] SynthesisError),
+}

--- a/gadgets/src/traits/utilities/uint/arithmetic/div.rs
+++ b/gadgets/src/traits/utilities/uint/arithmetic/div.rs
@@ -1,0 +1,155 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::errors::UnsignedIntegerError;
+
+use crate::utilities::{
+    alloc::AllocGadget,
+    arithmetic::Div,
+    boolean::{AllocatedBit, Boolean},
+    select::CondSelectGadget,
+    uint::*,
+    SynthesisError,
+};
+use snarkvm_fields::PrimeField;
+use snarkvm_r1cs::ConstraintSystem;
+
+/// Perform long division of two `UInt` objects.
+/// Reference: https://en.wikipedia.org/wiki/Division_algorithm
+macro_rules! div_int_impl {
+    ($($gadget:ident),*) => ($(
+        impl<F: PrimeField> Div<F> for $gadget {
+            type ErrorType = UnsignedIntegerError;
+
+            fn div<CS: ConstraintSystem<F>>(
+                &self,
+                mut cs: CS,
+                other: &Self,
+            ) -> Result<Self, Self::ErrorType> {
+                // pseudocode:
+                //
+                // if D = 0 then error(DivisionByZeroException) end
+                // Q := 0                  -- Initialize quotient and remainder to zero
+                // R := 0
+                // for i := n − 1 .. 0 do  -- Where n is number of bits in N
+                //   R := R << 1           -- Left-shift R by 1 bit
+                //   R(0) := N(i)          -- Set the least-significant bit of R equal to bit i of the numerator
+                //   if R ≥ D then
+                //     R := R − D
+                //     Q(i) := 1
+                //   end
+                // end
+
+                if other.eq(&Self::constant(0 as <$gadget as UInt>::IntegerType)) {
+                    return Err(SynthesisError::DivisionByZero.into());
+                }
+
+                let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+
+                let allocated_true = Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "true"), || Ok(true)).unwrap());
+                let true_bit = Boolean::conditionally_select(
+                    &mut cs.ns(|| "constant_or_allocated_true"),
+                    &is_constant,
+                    &Boolean::constant(true),
+                    &allocated_true,
+                )?;
+
+                let allocated_one = Self::alloc(&mut cs.ns(|| "one"), || Ok(1 as <$gadget as UInt>::IntegerType))?;
+                let one = Self::conditionally_select(
+                    &mut cs.ns(|| "constant_or_allocated_1"),
+                    &is_constant,
+                    &Self::constant(1 as <$gadget as UInt>::IntegerType),
+                    &allocated_one,
+                )?;
+
+                let allocated_zero = Self::alloc(&mut cs.ns(|| "zero"), || Ok(0 as <$gadget as UInt>::IntegerType))?;
+                let zero = Self::conditionally_select(
+                    &mut cs.ns(|| "constant_or_allocated_0"),
+                    &is_constant,
+                    &Self::constant(0 as <$gadget as UInt>::IntegerType),
+                    &allocated_zero,
+                )?;
+
+                let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0 as <$gadget as UInt>::IntegerType)));
+                let mut quotient = zero.clone();
+                let mut remainder = zero.clone();
+
+                for (i, bit) in self.bits.iter().rev().enumerate() {
+                    // Left shift remainder by 1
+                    remainder = Self::addmany(&mut cs.ns(|| format!("shift_left_{}", i)), &[
+                        remainder.clone(),
+                        remainder.clone(),
+                    ])?;
+
+                    // Set the least-significant bit of remainder to bit i of the numerator
+                    let bit_is_true = Boolean::constant(bit.eq(&Boolean::constant(true)));
+                    let new_remainder = Self::addmany(&mut cs.ns(|| format!("set_remainder_bit_{}", i)), &[
+                        remainder.clone(),
+                        one.clone(),
+                    ])?;
+
+                    remainder = Self::conditionally_select(
+                        &mut cs.ns(|| format!("increment_or_remainder_{}", i)),
+                        &bit_is_true,
+                        &new_remainder,
+                        &remainder,
+                    )?;
+
+                    // Greater than or equal to:
+                    //   R >= D
+                    //   (R == D) || (R > D)
+                    //   (R == D) || ((R !=D) && ((R - D) != 0))
+                    //
+                    //  (R > D)                     checks subtraction overflow before evaluation
+                    //  (R != D) && ((R - D) != 0)  instead evaluate subtraction and check for overflow after
+
+                    let no_remainder = Boolean::constant(remainder.eq(&other));
+                    let subtraction = remainder.sub_unsafe(&mut cs.ns(|| format!("subtract_divisor_{}", i)), &other)?;
+                    let sub_is_zero = Boolean::constant(subtraction.eq(&Self::constant(0 as <$gadget as UInt>::IntegerType)));
+                    let cond1 = Boolean::and(
+                        &mut cs.ns(|| format!("cond_1_{}", i)),
+                        &no_remainder.not(),
+                        &sub_is_zero.not(),
+                    )?;
+                    let cond2 = Boolean::or(&mut cs.ns(|| format!("cond_2_{}", i)), &no_remainder, &cond1)?;
+
+                    remainder = Self::conditionally_select(
+                        &mut cs.ns(|| format!("subtract_or_same_{}", i)),
+                        &cond2,
+                        &subtraction,
+                        &remainder,
+                    )?;
+
+                    let index = <$gadget as UInt>::SIZE - 1 - i as usize;
+                    let bit_value = (1 as <$gadget as UInt>::IntegerType) << (index as <$gadget as UInt>::IntegerType);
+                    let mut new_quotient = quotient.clone();
+                    new_quotient.bits[index] = true_bit;
+                    new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
+
+                    quotient = Self::conditionally_select(
+                        &mut cs.ns(|| format!("set_bit_or_same_{}", i)),
+                        &cond2,
+                        &new_quotient,
+                        &quotient,
+                    )?;
+                }
+                Self::conditionally_select(&mut cs.ns(|| "self_or_quotient"), &self_is_zero, self, &quotient).map_err(UnsignedIntegerError::SynthesisError)
+            }
+        }
+    )*)
+}
+
+div_int_impl!(UInt8, UInt16, UInt32, UInt64, UInt128);

--- a/gadgets/src/traits/utilities/uint/arithmetic/mod.rs
+++ b/gadgets/src/traits/utilities/uint/arithmetic/mod.rs
@@ -14,17 +14,5 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use]
-mod macros;
-
-pub mod arithmetic;
-pub use arithmetic::*;
-
-pub mod unsigned_integer;
-pub use unsigned_integer::*;
-
-pub mod uint128;
-pub use uint128::*;
-
-#[cfg(test)]
-mod tests;
+pub mod div;
+pub use self::div::*;

--- a/gadgets/src/traits/utilities/uint/macros.rs
+++ b/gadgets/src/traits/utilities/uint/macros.rs
@@ -279,6 +279,10 @@ macro_rules! uint_impl {
         uint_impl_common!($name, $_type, $size);
 
         impl UInt for $name {
+            type IntegerType = $_type;
+
+            const SIZE: usize = $size;
+
             fn negate(&self) -> Self {
                 Self {
                     bits: self.bits.clone(),
@@ -647,121 +651,6 @@ macro_rules! uint_impl {
                     .collect::<Vec<Self>>();
 
                 Self::addmany(&mut cs.ns(|| format!("partial_products")), &partial_products)
-            }
-
-            fn div<F: PrimeField, CS: ConstraintSystem<F>>(
-                &self,
-                mut cs: CS,
-                other: &Self,
-            ) -> Result<Self, SynthesisError> {
-                // pseudocode:
-                //
-                // if D = 0 then error(DivisionByZeroException) end
-                // Q := 0                  -- Initialize quotient and remainder to zero
-                // R := 0
-                // for i := n − 1 .. 0 do  -- Where n is number of bits in N
-                //   R := R << 1           -- Left-shift R by 1 bit
-                //   R(0) := N(i)          -- Set the least-significant bit of R equal to bit i of the numerator
-                //   if R ≥ D then
-                //     R := R − D
-                //     Q(i) := 1
-                //   end
-                // end
-
-                if other.eq(&Self::constant(0 as $_type)) {
-                    return Err(SynthesisError::DivisionByZero);
-                }
-
-                let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
-
-                let allocated_true = Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "true"), || Ok(true)).unwrap());
-                let true_bit = Boolean::conditionally_select(
-                    &mut cs.ns(|| "constant_or_allocated_true"),
-                    &is_constant,
-                    &Boolean::constant(true),
-                    &allocated_true,
-                )?;
-
-                let allocated_one = Self::alloc(&mut cs.ns(|| "one"), || Ok(1 as $_type))?;
-                let one = Self::conditionally_select(
-                    &mut cs.ns(|| format!("constant_or_allocated_1u{}", $size)),
-                    &is_constant,
-                    &Self::constant(1 as $_type),
-                    &allocated_one,
-                )?;
-
-                let allocated_zero = Self::alloc(&mut cs.ns(|| "zero"), || Ok(0 as $_type))?;
-                let zero = Self::conditionally_select(
-                    &mut cs.ns(|| format!("constant_or_allocated_0u{}", $size)),
-                    &is_constant,
-                    &Self::constant(0 as $_type),
-                    &allocated_zero,
-                )?;
-
-                let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0 as $_type)));
-                let mut quotient = zero.clone();
-                let mut remainder = zero.clone();
-
-                for (i, bit) in self.bits.iter().rev().enumerate() {
-                    // Left shift remainder by 1
-                    remainder = Self::addmany(&mut cs.ns(|| format!("shift_left_{}", i)), &[
-                        remainder.clone(),
-                        remainder.clone(),
-                    ])?;
-
-                    // Set the least-significant bit of remainder to bit i of the numerator
-                    let bit_is_true = Boolean::constant(bit.eq(&Boolean::constant(true)));
-                    let new_remainder = Self::addmany(&mut cs.ns(|| format!("set_remainder_bit_{}", i)), &[
-                        remainder.clone(),
-                        one.clone(),
-                    ])?;
-
-                    remainder = Self::conditionally_select(
-                        &mut cs.ns(|| format!("increment_or_remainder_{}", i)),
-                        &bit_is_true,
-                        &new_remainder,
-                        &remainder,
-                    )?;
-
-                    // Greater than or equal to:
-                    //   R >= D
-                    //   (R == D) || (R > D)
-                    //   (R == D) || ((R !=D) && ((R - D) != 0))
-                    //
-                    //  (R > D)                     checks subtraction overflow before evaluation
-                    //  (R != D) && ((R - D) != 0)  instead evaluate subtraction and check for overflow after
-
-                    let no_remainder = Boolean::constant(remainder.eq(&other));
-                    let subtraction = remainder.sub_unsafe(&mut cs.ns(|| format!("subtract_divisor_{}", i)), &other)?;
-                    let sub_is_zero = Boolean::constant(subtraction.eq(&Self::constant(0 as $_type)));
-                    let cond1 = Boolean::and(
-                        &mut cs.ns(|| format!("cond_1_{}", i)),
-                        &no_remainder.not(),
-                        &sub_is_zero.not(),
-                    )?;
-                    let cond2 = Boolean::or(&mut cs.ns(|| format!("cond_2_{}", i)), &no_remainder, &cond1)?;
-
-                    remainder = Self::conditionally_select(
-                        &mut cs.ns(|| format!("subtract_or_same_{}", i)),
-                        &cond2,
-                        &subtraction,
-                        &remainder,
-                    )?;
-
-                    let index = $size - 1 - i as usize;
-                    let bit_value = (1 as $_type) << (index as $_type);
-                    let mut new_quotient = quotient.clone();
-                    new_quotient.bits[index] = true_bit;
-                    new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
-
-                    quotient = Self::conditionally_select(
-                        &mut cs.ns(|| format!("set_bit_or_same_{}", i)),
-                        &cond2,
-                        &new_quotient,
-                        &quotient,
-                    )?;
-                }
-                Self::conditionally_select(&mut cs.ns(|| "self_or_quotient"), &self_is_zero, self, &quotient)
             }
 
             fn pow<F: Field + PrimeField, CS: ConstraintSystem<F>>(

--- a/gadgets/src/traits/utilities/uint/tests/uint128.rs
+++ b/gadgets/src/traits/utilities/uint/tests/uint128.rs
@@ -16,6 +16,7 @@
 
 use crate::utilities::{
     alloc::AllocGadget,
+    arithmetic::*,
     boolean::Boolean,
     uint::{UInt, UInt128},
 };

--- a/gadgets/src/traits/utilities/uint/tests/uint16.rs
+++ b/gadgets/src/traits/utilities/uint/tests/uint16.rs
@@ -16,6 +16,7 @@
 
 use crate::utilities::{
     alloc::AllocGadget,
+    arithmetic::*,
     boolean::Boolean,
     uint::{UInt, UInt16},
 };

--- a/gadgets/src/traits/utilities/uint/tests/uint32.rs
+++ b/gadgets/src/traits/utilities/uint/tests/uint32.rs
@@ -16,6 +16,7 @@
 
 use crate::utilities::{
     alloc::AllocGadget,
+    arithmetic::*,
     boolean::Boolean,
     uint::{UInt, UInt32},
 };

--- a/gadgets/src/traits/utilities/uint/tests/uint64.rs
+++ b/gadgets/src/traits/utilities/uint/tests/uint64.rs
@@ -16,6 +16,7 @@
 
 use crate::utilities::{
     alloc::AllocGadget,
+    arithmetic::*,
     boolean::Boolean,
     uint::{UInt, UInt64},
 };

--- a/gadgets/src/traits/utilities/uint/tests/uint8.rs
+++ b/gadgets/src/traits/utilities/uint/tests/uint8.rs
@@ -16,6 +16,7 @@
 
 use crate::utilities::{
     alloc::AllocGadget,
+    arithmetic::*,
     boolean::Boolean,
     uint::{UInt, UInt8},
 };

--- a/gadgets/src/traits/utilities/uint/unsigned_integer.rs
+++ b/gadgets/src/traits/utilities/uint/unsigned_integer.rs
@@ -39,6 +39,9 @@ uint_impl!(UInt32, u32, 32);
 uint_impl!(UInt64, u64, 64);
 
 pub trait UInt: Debug + Clone + PartialOrd + Eq + PartialEq {
+    type IntegerType;
+    const SIZE: usize;
+
     /// Returns the inverse `UInt`
     fn negate(&self) -> Self;
 
@@ -83,10 +86,6 @@ pub trait UInt: Debug + Clone + PartialOrd + Eq + PartialEq {
     /// Perform Bitwise multiplication of two `UInt` objects.
     /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
     fn mul<F: PrimeField, CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, SynthesisError>;
-
-    /// Perform long division of two `UInt` objects.
-    /// Reference: https://en.wikipedia.org/wiki/Division_algorithm
-    fn div<F: PrimeField, CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, SynthesisError>;
 
     /// Bitwise exponentiation of two `UInt64` objects.
     /// Reference: /snarkVM/models/src/curves/field.rs


### PR DESCRIPTION
This PR is a partial implementation of what was suggested in https://github.com/AleoHQ/snarkVM/pull/103#issuecomment-797469730: it re-implements `div` for unsigned integers in terms of the `Div` trait.

If desirable, I can extend this solution to other arithmetic operations on unsigned integers.

cc @collinc97