### PR TITLE
Enable default features in gadgets' rand dep to fix the benches

### DIFF
--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -67,7 +67,6 @@ version = "0.3"
 
 [dev-dependencies.rand]
 version = "0.8"
-default-features = false
 
 [dev-dependencies.rand_xorshift]
 version = "0.3"


### PR DESCRIPTION
Those features are already used within the crate, so it doesn't impact the size of the lockfile. It's only a `dev-dependency`, too.