### PR TITLE
Groth16 constraint system improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "csv",
  "derivative",
  "digest",
+ "indexmap",
  "itertools 0.10.0",
  "rand",
  "rand_chacha",

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -86,6 +86,9 @@ version = "2"
 [dependencies.digest]
 version = "0.9"
 
+[dependencies.indexmap]
+version = "1.6"
+
 [dependencies.itertools]
 version = "0.10.0"
 

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -424,15 +424,30 @@ impl<E: PairingEngine> From<VerifyingKey<E>> for PreparedVerifyingKey<E> {
     }
 }
 
-fn push_constraints<F: Field>(l: LinearCombination<F>, constraints: &mut Vec<Vec<(F, Index)>>) {
+pub struct ConstraintSet<E: PairingEngine> {
+    pub at: Vec<(E::Fr, Index)>,
+    pub bt: Vec<(E::Fr, Index)>,
+    pub ct: Vec<(E::Fr, Index)>,
+}
+
+impl<E: PairingEngine> Default for ConstraintSet<E> {
+    fn default() -> Self {
+        ConstraintSet {
+            at: Default::default(),
+            bt: Default::default(),
+            ct: Default::default(),
+        }
+    }
+}
+
+fn push_constraints<F: Field>(l: LinearCombination<F>, constraint: &mut Vec<(F, Index)>) {
     let vars_and_coeffs = l.as_ref();
-    let mut vec = Vec::with_capacity(vars_and_coeffs.len());
+    constraint.reserve(vars_and_coeffs.len());
 
     for (var, coeff) in vars_and_coeffs {
         match var.get_unchecked() {
-            Index::Public(i) => vec.push((*coeff, Index::Public(i))),
-            Index::Private(i) => vec.push((*coeff, Index::Private(i))),
+            Index::Public(i) => constraint.push((*coeff, Index::Public(i))),
+            Index::Private(i) => constraint.push((*coeff, Index::Private(i))),
         }
     }
-    constraints.push(vec);
 }


### PR DESCRIPTION
This PR consists of a set of following changes:
- introduce a helper `ConstraintSet` object that simplifies constraint handling (like in https://github.com/AleoHQ/leo/pull/759)
- improve the performance of `groth16::evaluate_constraint` by not allocating a vector of all variables
- consume `KeypairAssembly` in `R1CStoQAP::instance_map_with_evaluation` to reclaim memory faster
- intern fields in `KeypairAssembly` and `ProvingAssignment` (a fair decrease in memory use; improves issues like https://github.com/AleoHQ/leo/issues/608)