### PR TITLE
Align the Integer gadget with leo's IntegerTrait

### DIFF
--- a/gadgets/src/traits/utilities/int/int_impl.rs
+++ b/gadgets/src/traits/utilities/int/int_impl.rs
@@ -112,6 +112,14 @@ macro_rules! int_impl {
                     bits,
                 }
             }
+
+            fn get_value(&self) -> Option<String> {
+                self.value.map(|num| num.to_string())
+            }
+
+            fn get_bits(&self) -> Vec<Boolean> {
+                self.bits.clone()
+            }
         }
     };
 }

--- a/gadgets/src/traits/utilities/int/int_impl.rs
+++ b/gadgets/src/traits/utilities/int/int_impl.rs
@@ -116,10 +116,6 @@ macro_rules! int_impl {
             fn get_value(&self) -> Option<String> {
                 self.value.map(|num| num.to_string())
             }
-
-            fn get_bits(&self) -> Vec<Boolean> {
-                self.bits.clone()
-            }
         }
     };
 }

--- a/gadgets/src/traits/utilities/integer.rs
+++ b/gadgets/src/traits/utilities/integer.rs
@@ -45,6 +45,4 @@ pub trait Integer: Debug + Clone {
     fn from_bits_le(bits: &[Boolean]) -> Self;
 
     fn get_value(&self) -> Option<String>;
-
-    fn get_bits(&self) -> Vec<Boolean>;
 }

--- a/gadgets/src/traits/utilities/integer.rs
+++ b/gadgets/src/traits/utilities/integer.rs
@@ -43,4 +43,8 @@ pub trait Integer: Debug + Clone {
     fn to_bits_le(&self) -> Vec<Boolean>;
 
     fn from_bits_le(bits: &[Boolean]) -> Self;
+
+    fn get_value(&self) -> Option<String>;
+
+    fn get_bits(&self) -> Vec<Boolean>;
 }

--- a/gadgets/src/traits/utilities/uint/arithmetic/add.rs
+++ b/gadgets/src/traits/utilities/uint/arithmetic/add.rs
@@ -14,22 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::utilities::{arithmetic::Add, uint::*};
+use crate::{
+    utilities::{arithmetic::Add, uint::*},
+    UnsignedIntegerError,
+};
 use snarkvm_fields::{Field, PrimeField};
-use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
+use snarkvm_r1cs::ConstraintSystem;
 
 // Implement unsigned integers
 macro_rules! add_uint_impl {
     ($($gadget: ident),*) => ($(
         impl<F: Field + PrimeField> Add<F> for $gadget {
-            type ErrorType = SynthesisError;
+            type ErrorType = UnsignedIntegerError;
 
             fn add<CS: ConstraintSystem<F>>(
                 &self,
                 cs: CS,
                 other: &Self
             ) -> Result<Self, Self::ErrorType> {
-                <$gadget as UInt>::addmany(cs, &[self.clone(), other.clone()])
+                <$gadget as UInt>::addmany(cs, &[self.clone(), other.clone()]).map_err(Self::ErrorType::SynthesisError)
             }
         }
     )*)

--- a/gadgets/src/traits/utilities/uint/macros.rs
+++ b/gadgets/src/traits/utilities/uint/macros.rs
@@ -224,6 +224,14 @@ macro_rules! uint_impl_common {
                     bits,
                 }
             }
+
+            fn get_value(&self) -> Option<String> {
+                self.value.map(|num| num.to_string())
+            }
+
+            fn get_bits(&self) -> Vec<Boolean> {
+                self.bits.clone()
+            }
         }
 
         cond_select_int_impl!($name, $_type, $size);

--- a/gadgets/src/traits/utilities/uint/macros.rs
+++ b/gadgets/src/traits/utilities/uint/macros.rs
@@ -404,7 +404,7 @@ macro_rules! uint_impl {
                 &self,
                 mut cs: CS,
                 other: &Self,
-            ) -> Result<Self, SynthesisError> {
+            ) -> Result<Self, UnsignedIntegerError> {
                 // pseudocode:
                 //
                 // res = 0;
@@ -455,6 +455,7 @@ macro_rules! uint_impl {
                     .collect::<Vec<Self>>();
 
                 Self::addmany(&mut cs.ns(|| format!("partial_products")), &partial_products)
+                    .map_err(UnsignedIntegerError::SynthesisError)
             }
         }
     };

--- a/gadgets/src/traits/utilities/uint/macros.rs
+++ b/gadgets/src/traits/utilities/uint/macros.rs
@@ -228,10 +228,6 @@ macro_rules! uint_impl_common {
             fn get_value(&self) -> Option<String> {
                 self.value.map(|num| num.to_string())
             }
-
-            fn get_bits(&self) -> Vec<Boolean> {
-                self.bits.clone()
-            }
         }
 
         cond_select_int_impl!($name, $_type, $size);

--- a/gadgets/src/traits/utilities/uint/uint128.rs
+++ b/gadgets/src/traits/utilities/uint/uint128.rs
@@ -204,7 +204,11 @@ impl UInt for UInt128 {
 
     /// Bitwise multiplication of two `UInt128` objects.
     /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
-    fn mul<F: PrimeField, CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError> {
+    fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, UnsignedIntegerError> {
         // pseudocode:
         //
         // res = 0;
@@ -252,6 +256,7 @@ impl UInt for UInt128 {
             .collect::<Vec<Self>>();
 
         Self::addmany(&mut cs.ns(|| "partial_products"), &partial_products)
+            .map_err(UnsignedIntegerError::SynthesisError)
     }
 }
 

--- a/gadgets/src/traits/utilities/uint/unsigned_integer.rs
+++ b/gadgets/src/traits/utilities/uint/unsigned_integer.rs
@@ -25,6 +25,7 @@ use crate::{
         ToBitsBEGadget,
         ToBytesGadget,
     },
+    UnsignedIntegerError,
 };
 use snarkvm_fields::{Field, FieldParameters, PrimeField, ToConstraintField};
 use snarkvm_r1cs::{errors::SynthesisError, Assignment, ConstraintSystem, LinearCombination};
@@ -49,7 +50,7 @@ pub trait UInt: Integer {
 
     /// Perform Bitwise multiplication of two `UInt` objects.
     /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
-    fn mul<F: PrimeField, CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, SynthesisError>;
+    fn mul<F: PrimeField, CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, UnsignedIntegerError>;
 }
 
 // These methods are used throughout snarkvm-gadgets exclusively by UInt8


### PR DESCRIPTION
This PR makes it possible to remove Leo's `IntegerTrait` by extending `Integer` with `get_bits` and `get_value` methods, and also adjusts the unsigned integer error types so they are all aligned. The Leo-side counterpart to this PR is https://github.com/AleoHQ/leo/pull/796.