### PR TITLE
clippy: fix --all-features lints

### DIFF
--- a/curves/src/lib.rs
+++ b/curves/src/lib.rs
@@ -16,6 +16,7 @@
 
 // Compilation
 #![allow(clippy::module_inception)]
+#![cfg_attr(test, allow(deprecated))]
 #![deny(unused_import_braces, unused_qualifications, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_qualifications, variant_size_differences, stable_features, unreachable_pub)]
 #![deny(non_shorthand_field_patterns, unused_attributes, unused_extern_crates)]

--- a/curves/src/sw6/g1.rs
+++ b/curves/src/sw6/g1.rs
@@ -32,7 +32,7 @@ impl PairingCurve for G1Affine {
     type Prepared = Self;
 
     fn prepare(&self) -> Self::Prepared {
-        self.clone()
+        *self
     }
 
     fn pairing_with(&self, other: &Self::PairWith) -> Self::PairingResult {

--- a/curves/src/sw6/g2.rs
+++ b/curves/src/sw6/g2.rs
@@ -32,7 +32,7 @@ impl PairingCurve for G2Affine {
     type Prepared = Self;
 
     fn prepare(&self) -> Self::Prepared {
-        self.clone()
+        *self
     }
 
     fn pairing_with(&self, other: &Self::PairWith) -> Self::PairingResult {

--- a/curves/src/sw6/parameters.rs
+++ b/curves/src/sw6/parameters.rs
@@ -70,6 +70,7 @@ impl SW6 {
         SW6::final_exponentiation(&SW6::ate_miller_loop(p, q))
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn ate_miller_loop(p: &G1Affine, q: &G2Affine) -> Fq6 {
         let px = p.x;
         let py = p.y;
@@ -133,7 +134,7 @@ impl SW6 {
 
                 rx = gamma.square() - &old_rx - &qx;
                 ry = gamma * &(old_rx - &rx) - &old_ry;
-                f = f * &ell_rq_at_p;
+                f *= &ell_rq_at_p;
             }
         }
         f
@@ -150,19 +151,19 @@ impl SW6 {
         // (q^3-1)*(q+1)
 
         // elt_q3 = elt^(q^3)
-        let mut elt_q3 = elt.clone();
+        let mut elt_q3 = *elt;
         elt_q3.frobenius_map(3);
         // elt_q3_over_elt = elt^(q^3-1)
-        let elt_q3_over_elt = elt_q3 * &elt_inv;
+        let elt_q3_over_elt = elt_q3 * elt_inv;
         // alpha = elt^((q^3-1) * q)
-        let mut alpha = elt_q3_over_elt.clone();
+        let mut alpha = elt_q3_over_elt;
         alpha.frobenius_map(1);
         // beta = elt^((q^3-1)*(q+1)
         alpha * &elt_q3_over_elt
     }
 
     fn final_exponentiation_last(elt: &Fq6, elt_inv: &Fq6) -> Fq6 {
-        let mut elt_q = elt.clone();
+        let mut elt_q = *elt;
         elt_q.frobenius_map(1);
 
         let w1_part = elt_q.cyclotomic_exp(&FINAL_EXPONENT_LAST_CHUNK_W1);

--- a/curves/src/sw6/tests.rs
+++ b/curves/src/sw6/tests.rs
@@ -26,8 +26,6 @@ use snarkvm_fields::{
     PrimeField,
 };
 
-use rand;
-
 #[test]
 fn test_sw6_fr() {
     let a: Fr = rand::random();

--- a/gadgets/src/traits/utilities/boolean.rs
+++ b/gadgets/src/traits/utilities/boolean.rs
@@ -646,7 +646,7 @@ impl Boolean {
     }
 
     pub fn enforce_smaller_or_equal_than_le<F: Field, CS: ConstraintSystem<F>>(
-        mut cs: CS,
+        cs: CS,
         bits: &[Self],
         element: impl AsRef<[u64]>,
     ) -> Result<Vec<Self>, SynthesisError> {
@@ -656,7 +656,7 @@ impl Boolean {
         Self::enforce_smaller_or_equal_than_be(cs, &bits_be, element)
     }
 
-    pub fn enforce_smaller_or_equal_than_be<'a, F: Field, CS: ConstraintSystem<F>>(
+    pub fn enforce_smaller_or_equal_than_be<F: Field, CS: ConstraintSystem<F>>(
         mut cs: CS,
         bits: &[Self],
         element: impl AsRef<[u64]>,


### PR DESCRIPTION
There are some clippy lints that are reported by GitHub Actions under PRs; they seem to be ones that the `--all-features` option (in addition to the usual `cargo clippy --workspace --all-targets`) can detect.