### PR TITLE
Fix signed integer subtraction involving iX::MIN

### DIFF
--- a/gadgets/src/traits/utilities/int/tests/int128.rs
+++ b/gadgets/src/traits/utilities/int/tests/int128.rs
@@ -156,10 +156,6 @@ fn test_int128_sub_constants() {
         let a: i128 = rng.gen();
         let b: i128 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,
@@ -187,10 +183,6 @@ fn test_int128_sub() {
         let a: i128 = rng.gen();
         let b: i128 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,

--- a/gadgets/src/traits/utilities/int/tests/int16.rs
+++ b/gadgets/src/traits/utilities/int/tests/int16.rs
@@ -156,10 +156,6 @@ fn test_int16_sub_constants() {
         let a: i16 = rng.gen();
         let b: i16 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,
@@ -187,10 +183,6 @@ fn test_int16_sub() {
         let a: i16 = rng.gen();
         let b: i16 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,

--- a/gadgets/src/traits/utilities/int/tests/int32.rs
+++ b/gadgets/src/traits/utilities/int/tests/int32.rs
@@ -156,10 +156,6 @@ fn test_int32_sub_constants() {
         let a: i32 = rng.gen();
         let b: i32 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,
@@ -187,10 +183,6 @@ fn test_int32_sub() {
         let a: i32 = rng.gen();
         let b: i32 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,

--- a/gadgets/src/traits/utilities/int/tests/int64.rs
+++ b/gadgets/src/traits/utilities/int/tests/int64.rs
@@ -163,10 +163,6 @@ fn test_int64_sub_constants() {
         let a: i64 = rng.gen();
         let b: i64 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,
@@ -194,10 +190,6 @@ fn test_int64_sub() {
         let a: i64 = rng.gen();
         let b: i64 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -9223372036854775808
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,

--- a/gadgets/src/traits/utilities/int/tests/int8.rs
+++ b/gadgets/src/traits/utilities/int/tests/int8.rs
@@ -156,10 +156,6 @@ fn test_int8_sub_constants() {
         let a: i8 = rng.gen();
         let b: i8 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,
@@ -187,10 +183,6 @@ fn test_int8_sub() {
         let a: i8 = rng.gen();
         let b: i8 = rng.gen();
 
-        if b.checked_neg().is_none() {
-            // negate with overflows will fail: -128
-            continue;
-        }
         let expected = match a.checked_sub(b) {
             // subtract with overflow will fail: -0
             Some(valid) => valid,


### PR DESCRIPTION
The current state of affairs is that subtraction with `iX::MIN` as the second operand results in an overflow, as signed integer subtraction is implemented using the following algorithm: `a - b = a + (-b)` and if the value of `b` is the minimum boundary of that type, the negation results in an overflow. This is special-cased in tests, which skip operations where `b.checked_neg().is_none()`.

A possible solution is to adjust the subtraction algorithm for `b == iX::MIN` to the following: `a - b = -(-a + b)`, and to handle the one operation where it doesn't work, i.e. when both `a` and `b` are equal to `iX::MIN` by just returning `0`.

Fixes https://github.com/AleoHQ/leo/issues/800.