### PR TITLE
Use the Xor trait for AllocatedBit and Boolean

### DIFF
--- a/gadgets/src/traits/utilities/bits/adder.rs
+++ b/gadgets/src/traits/utilities/bits/adder.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::utilities::boolean::Boolean;
+use crate::utilities::{bits::Xor, boolean::Boolean};
 use snarkvm_fields::Field;
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
 
@@ -42,8 +42,8 @@ impl<'a, F: Field> FullAdder<'a, F> for Boolean {
         b: &'a Self,
         carry: &'a Self,
     ) -> Result<(Self, Self), SynthesisError> {
-        let a_x_b = Boolean::xor(cs.ns(|| "a XOR b"), a, b)?;
-        let sum = Boolean::xor(cs.ns(|| "adder sum"), &a_x_b, carry)?;
+        let a_x_b = a.xor(cs.ns(|| "a XOR b"), b)?;
+        let sum = a_x_b.xor(cs.ns(|| "adder sum"), carry)?;
 
         let c1 = Boolean::and(cs.ns(|| "a AND b"), a, b)?;
         let c2 = Boolean::and(cs.ns(|| "carry AND (a XOR b)"), carry, &a_x_b)?;

--- a/gadgets/src/traits/utilities/int/relational/cmp.rs
+++ b/gadgets/src/traits/utilities/int/relational/cmp.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::utilities::{
-    bits::{ComparatorGadget, EvaluateLtGadget},
+    bits::{ComparatorGadget, EvaluateLtGadget, Xor},
     boolean::Boolean,
     int::*,
     select::CondSelectGadget,
@@ -57,7 +57,7 @@ macro_rules! cmp_gadget_impl {
                     };
 
                     // a == b = !(a ^ b)
-                    let not_equal = Boolean::xor(cs.ns(|| format!("a XOR b [{}]", i)), a, b)?;
+                    let not_equal = a.xor(cs.ns(|| format!("a XOR b [{}]", i)), b)?;
                     let equal = not_equal.not();
 
                     // evaluate a <= b

--- a/gadgets/src/traits/utilities/uint/bits/xor.rs
+++ b/gadgets/src/traits/utilities/uint/bits/xor.rs
@@ -17,7 +17,7 @@
 use snarkvm_fields::PrimeField;
 use snarkvm_r1cs::ConstraintSystem;
 
-use crate::utilities::{bits::Xor, uint::*, Boolean, SynthesisError};
+use crate::utilities::{bits::Xor, uint::*, SynthesisError};
 
 macro_rules! uint_xor_impl {
     ($($gadget: ident),*) => ($(
@@ -33,7 +33,7 @@ macro_rules! uint_xor_impl {
                     .iter()
                     .zip(other.bits.iter())
                     .enumerate()
-                    .map(|(i, (a, b))| Boolean::xor(cs.ns(|| format!("xor of bit_gadget {}", i)), a, b))
+                    .map(|(i, (a, b))| a.xor(cs.ns(|| format!("xor of bit_gadget {}", i)), b))
                     .collect::<Result<_, _>>()?;
 
                 Ok(Self {

--- a/gadgets/src/traits/utilities/uint/relational/cmp.rs
+++ b/gadgets/src/traits/utilities/uint/relational/cmp.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::utilities::{
-    bits::{ComparatorGadget, EvaluateLtGadget},
+    bits::{ComparatorGadget, EvaluateLtGadget, Xor},
     boolean::Boolean,
     select::CondSelectGadget,
     uint::{UInt128, UInt16, UInt32, UInt64, UInt8},
@@ -46,7 +46,7 @@ macro_rules! uint_cmp_impl {
                     let less = Boolean::and(cs.ns(|| format!("not a and b [{}]", i)), &a.not(), b)?;
 
                     // a == b = !(a ^ b)
-                    let not_equal = Boolean::xor(cs.ns(|| format!("a XOR b [{}]", i)), a, b)?;
+                    let not_equal = a.xor(cs.ns(|| format!("a XOR b [{}]", i)), b)?;
                     let equal = not_equal.not();
 
                     // evaluate a <= b


### PR DESCRIPTION
Utilizing common traits as much as possible is preferable in terms of keeping the APIs aligned and cargo docs being able to provide more references to trait implementors.