### PR TITLE
Deduplicate common uint methods

### DIFF
--- a/gadgets/src/traits/utilities/uint/arithmetic/mod.rs
+++ b/gadgets/src/traits/utilities/uint/arithmetic/mod.rs
@@ -20,6 +20,9 @@ pub use self::add::*;
 pub mod div;
 pub use self::div::*;
 
+pub mod mul;
+pub use self::mul::*;
+
 pub mod pow;
 pub use self::pow::*;
 

--- a/gadgets/src/traits/utilities/uint/arithmetic/mul.rs
+++ b/gadgets/src/traits/utilities/uint/arithmetic/mul.rs
@@ -1,0 +1,98 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::errors::UnsignedIntegerError;
+
+use crate::utilities::{
+    alloc::AllocGadget,
+    arithmetic::Mul,
+    boolean::Boolean,
+    integer::Integer,
+    select::CondSelectGadget,
+    uint::*,
+};
+use snarkvm_fields::PrimeField;
+use snarkvm_r1cs::ConstraintSystem;
+
+/// Bitwise multiplication of two `UInt` objects.
+/// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
+macro_rules! mul_int_impl {
+    ($($gadget:ident),*) => ($(
+        impl<F: PrimeField> Mul<F> for $gadget {
+            type ErrorType = UnsignedIntegerError;
+
+            fn mul<CS: ConstraintSystem<F>>(
+                &self,
+                mut cs: CS,
+                other: &Self,
+            ) -> Result<Self, Self::ErrorType> {
+                // pseudocode:
+                //
+                // res = 0;
+                // shifted_self = self;
+                // for bit in other.bits {
+                //   if bit {
+                //     res += shifted_self;
+                //   }
+                //   shifted_self = shifted_self << 1;
+                // }
+                // return res
+
+                let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+                let constant_result = Self::constant(0 as <Self as Integer>::IntegerType);
+                let allocated_result = Self::alloc(&mut cs.ns(|| format!("allocated_0u{}", <Self as Integer>::SIZE)), || Ok(0 as <Self as Integer>::IntegerType))?;
+                let zero_result = Self::conditionally_select(
+                    &mut cs.ns(|| "constant_or_allocated"),
+                    &is_constant,
+                    &constant_result,
+                    &allocated_result,
+                )?;
+
+                let mut left_shift = self.clone();
+
+                let partial_products = other
+                    .bits
+                    .iter()
+                    .enumerate()
+                    .map(|(i, bit)| {
+                        let current_left_shift = left_shift.clone();
+                        left_shift = Self::addmany(&mut cs.ns(|| format!("shift_left_{}", i)), &[
+                            left_shift.clone(),
+                            left_shift.clone(),
+                        ])
+                        .unwrap();
+
+                        Self::conditionally_select(
+                            &mut cs.ns(|| format!("calculate_product_{}", i)),
+                            &bit,
+                            &current_left_shift,
+                            &zero_result,
+                        )
+                        .unwrap()
+                    })
+                    .collect::<Vec<Self>>();
+
+                Self::addmany(&mut cs.ns(|| "partial_products"), &partial_products).map_err(|e| e.into())
+            }
+
+            fn mul_unsafe<CS: ConstraintSystem<F>>(&self, _cs: CS, _other: &Self) -> Result<Self, Self::ErrorType> {
+                unimplemented!()
+            }
+        }
+    )*)
+}
+
+mul_int_impl!(UInt8, UInt16, UInt32, UInt64, UInt128);

--- a/gadgets/src/traits/utilities/uint/arithmetic/pow.rs
+++ b/gadgets/src/traits/utilities/uint/arithmetic/pow.rs
@@ -18,7 +18,7 @@ use crate::errors::UnsignedIntegerError;
 
 use crate::utilities::{
     alloc::AllocGadget,
-    arithmetic::Pow,
+    arithmetic::{Mul, Pow},
     boolean::Boolean,
     integer::Integer,
     select::CondSelectGadget,

--- a/gadgets/src/traits/utilities/uint/uint128.rs
+++ b/gadgets/src/traits/utilities/uint/uint128.rs
@@ -18,7 +18,7 @@ use crate::{
     uint_impl_common,
     utilities::{
         alloc::AllocGadget,
-        arithmetic::Pow,
+        arithmetic::{Mul, Pow},
         boolean::{AllocatedBit, Boolean},
         eq::{ConditionalEqGadget, EqGadget},
         integer::Integer,
@@ -174,63 +174,6 @@ impl UInt for UInt128 {
             negated: false,
             value: modular_value,
         })
-    }
-
-    /// Bitwise multiplication of two `UInt128` objects.
-    /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
-    fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
-        &self,
-        mut cs: CS,
-        other: &Self,
-    ) -> Result<Self, UnsignedIntegerError> {
-        // pseudocode:
-        //
-        // res = 0;
-        // shifted_self = self;
-        // for bit in other.bits {
-        //   if bit {
-        //     res += shifted_self;
-        //   }
-        //   shifted_self = shifted_self << 1;
-        // }
-        // return res
-
-        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
-        let constant_result = Self::constant(0u128);
-        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_0u128"), || Ok(0u128))?;
-        let zero_result = Self::conditionally_select(
-            &mut cs.ns(|| "constant_or_allocated"),
-            &is_constant,
-            &constant_result,
-            &allocated_result,
-        )?;
-
-        let mut left_shift = self.clone();
-
-        let partial_products = other
-            .bits
-            .iter()
-            .enumerate()
-            .map(|(i, bit)| {
-                let current_left_shift = left_shift.clone();
-                left_shift = Self::addmany(&mut cs.ns(|| format!("shift_left_{}", i)), &[
-                    left_shift.clone(),
-                    left_shift.clone(),
-                ])
-                .unwrap();
-
-                Self::conditionally_select(
-                    &mut cs.ns(|| format!("calculate_product_{}", i)),
-                    &bit,
-                    &current_left_shift,
-                    &zero_result,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<Self>>();
-
-        Self::addmany(&mut cs.ns(|| "partial_products"), &partial_products)
-            .map_err(UnsignedIntegerError::SynthesisError)
     }
 }
 

--- a/gadgets/src/traits/utilities/uint/uint128.rs
+++ b/gadgets/src/traits/utilities/uint/uint128.rs
@@ -39,33 +39,7 @@ use snarkvm_utilities::{
 uint_impl_common!(UInt128, u128, 128);
 
 impl UInt for UInt128 {
-    /// Returns the inverse UInt128
-    fn negate(&self) -> Self {
-        Self {
-            bits: self.bits.clone(),
-            negated: true,
-            value: self.value,
-        }
-    }
-
-    fn rotr(&self, by: usize) -> Self {
-        let by = by % 128;
-
-        let new_bits = self
-            .bits
-            .iter()
-            .skip(by)
-            .chain(self.bits.iter())
-            .take(128)
-            .cloned()
-            .collect();
-
-        Self {
-            bits: new_bits,
-            negated: false,
-            value: self.value.map(|v| v.rotate_right(by as u32) as u128),
-        }
-    }
+    uint_trait_common!(self);
 
     /// Perform modular addition of several `UInt128` objects.
     fn addmany<F: PrimeField, CS: ConstraintSystem<F>>(mut cs: CS, operands: &[Self]) -> Result<Self, SynthesisError> {

--- a/gadgets/src/traits/utilities/uint/unsigned_integer.rs
+++ b/gadgets/src/traits/utilities/uint/unsigned_integer.rs
@@ -25,7 +25,6 @@ use crate::{
         ToBitsBEGadget,
         ToBytesGadget,
     },
-    UnsignedIntegerError,
 };
 use snarkvm_fields::{Field, FieldParameters, PrimeField, ToConstraintField};
 use snarkvm_r1cs::{errors::SynthesisError, Assignment, ConstraintSystem, LinearCombination};
@@ -47,10 +46,6 @@ pub trait UInt: Integer {
 
     /// Perform modular addition of several `UInt` objects.
     fn addmany<F: PrimeField, CS: ConstraintSystem<F>>(cs: CS, operands: &[Self]) -> Result<Self, SynthesisError>;
-
-    /// Perform Bitwise multiplication of two `UInt` objects.
-    /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
-    fn mul<F: PrimeField, CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, UnsignedIntegerError>;
 }
 
 // These methods are used throughout snarkvm-gadgets exclusively by UInt8


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkVM/pull/121, the last 2 commits are new.

This PR deduplicates some common unsigned integer code by introducing the following changes:
- use a macro to implement `UInt::{negate, rotr}` for all unsigned integers
- implement the `Mul` trait for all unsigned integers