### PR TITLE
Fix 1.51 clippy lints

### DIFF
--- a/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
@@ -510,12 +510,12 @@ where
                     let given_account_view_key = AccountEncryptionGadget::PrivateKeyGadget::alloc(
                         &mut account_cs.ns(|| "Allocate account view key"),
                         || {
-                            Ok(account_private_key
+                            account_private_key
                                 .to_decryption_key(
                                     &system_parameters.account_signature,
                                     &system_parameters.account_commitment,
                                 )
-                                .map_err(|_| SynthesisError::AssignmentMissing)?)
+                                .map_err(|_| SynthesisError::AssignmentMissing)
                         },
                     )?;
 

--- a/dpc/src/base_dpc/record/record_serializer.rs
+++ b/dpc/src/base_dpc/record/record_serializer.rs
@@ -152,8 +152,8 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
 
         // Process birth_program_id and death_program_id. (Assumption 2 and 3 applies)
 
-        let birth_program_id_biginteger = Self::OuterField::read(&birth_program_id[..])?.into_repr();
-        let death_program_id_biginteger = Self::OuterField::read(&death_program_id[..])?.into_repr();
+        let birth_program_id_biginteger = Self::OuterField::read(birth_program_id)?.into_repr();
+        let death_program_id_biginteger = Self::OuterField::read(death_program_id)?.into_repr();
 
         let mut birth_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);
         let mut death_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);

--- a/gadgets/src/algorithms/crh/pedersen.rs
+++ b/gadgets/src/algorithms/crh/pedersen.rs
@@ -89,11 +89,7 @@ impl<F: Field, G: Group, GG: GroupGadget<G, F>, S: PedersenSize> CRHGadget<Peder
         // Pad the input if it is not the correct length.
         let input_in_bits = pad_input_and_bitify::<S>(input);
 
-        Ok(GG::multi_scalar_multiplication(
-            cs,
-            &parameters.parameters.bases,
-            input_in_bits.chunks(S::WINDOW_SIZE),
-        )?)
+        GG::multi_scalar_multiplication(cs, &parameters.parameters.bases, input_in_bits.chunks(S::WINDOW_SIZE))
     }
 }
 

--- a/gadgets/src/algorithms/encoding/elligator2.rs
+++ b/gadgets/src/algorithms/encoding/elligator2.rs
@@ -68,20 +68,20 @@ impl<P: MontgomeryModelParameters, F: PrimeField> AllocGadget<<P as ModelParamet
 
 impl<P: MontgomeryModelParameters, F: PrimeField> ToBitsBEGadget<F> for Elligator2FieldGadget<P, F> {
     fn to_bits_be<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
-        Ok(self.0.to_bits_be(cs)?)
+        self.0.to_bits_be(cs)
     }
 
     fn to_bits_be_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
-        Ok(self.0.to_bits_be_strict(cs)?)
+        self.0.to_bits_be_strict(cs)
     }
 }
 
 impl<P: MontgomeryModelParameters, F: PrimeField> ToBytesGadget<F> for Elligator2FieldGadget<P, F> {
     fn to_bytes<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        Ok(self.0.to_bytes(cs)?)
+        self.0.to_bytes(cs)
     }
 
     fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        Ok(self.0.to_bytes_strict(cs)?)
+        self.0.to_bytes_strict(cs)
     }
 }

--- a/gadgets/src/algorithms/prf/blake2s.rs
+++ b/gadgets/src/algorithms/prf/blake2s.rs
@@ -324,15 +324,16 @@ pub fn blake2s_gadget<F: PrimeField, CS: ConstraintSystem<F>>(
 ) -> Result<Vec<UInt32>, SynthesisError> {
     assert!(input.len() % 8 == 0);
 
-    let mut h = Vec::with_capacity(8);
-    h.push(UInt32::constant(0x6A09E667 ^ 0x01010000 ^ 32));
-    h.push(UInt32::constant(0xBB67AE85));
-    h.push(UInt32::constant(0x3C6EF372));
-    h.push(UInt32::constant(0xA54FF53A));
-    h.push(UInt32::constant(0x510E527F));
-    h.push(UInt32::constant(0x9B05688C));
-    h.push(UInt32::constant(0x1F83D9AB));
-    h.push(UInt32::constant(0x5BE0CD19));
+    let mut h = vec![
+        UInt32::constant(0x6A09E667 ^ 0x01010000 ^ 32),
+        UInt32::constant(0xBB67AE85),
+        UInt32::constant(0x3C6EF372),
+        UInt32::constant(0xA54FF53A),
+        UInt32::constant(0x510E527F),
+        UInt32::constant(0x9B05688C),
+        UInt32::constant(0x1F83D9AB),
+        UInt32::constant(0x5BE0CD19),
+    ];
 
     let mut blocks: Vec<Vec<UInt32>> = Vec::with_capacity(input.len() / 512);
 

--- a/gadgets/src/traits/utilities/boolean.rs
+++ b/gadgets/src/traits/utilities/boolean.rs
@@ -656,7 +656,7 @@ impl Boolean {
         Self::enforce_smaller_or_equal_than_be(cs, &bits_be, element)
     }
 
-    pub fn enforce_smaller_or_equal_than_be<'a, F: Field, CS: ConstraintSystem<F>>(
+    pub fn enforce_smaller_or_equal_than_be<F: Field, CS: ConstraintSystem<F>>(
         mut cs: CS,
         bits: &[Self],
         element: impl AsRef<[u64]>,

--- a/nonnative/src/allocated_nonnative_field_mul_result_var.rs
+++ b/nonnative/src/allocated_nonnative_field_mul_result_var.rs
@@ -197,8 +197,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocatedNonNativeFieldMulR
             target_phantom: PhantomData,
         };
 
-        let r_gadget =
-            AllocatedNonNativeFieldVar::<TargetField, BaseField>::alloc(cs.ns(|| "r"), || Ok(self.value()?))?;
+        let r_gadget = AllocatedNonNativeFieldVar::<TargetField, BaseField>::alloc(cs.ns(|| "r"), || self.value())?;
 
         let params = get_params(
             TargetField::size_in_bits(),

--- a/nonnative/src/allocated_nonnative_field_var.rs
+++ b/nonnative/src/allocated_nonnative_field_var.rs
@@ -232,7 +232,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocatedNonNativeFieldVar<
             .muln((surfeit + (TargetField::size_in_bits() - params.bits_per_limb * (params.num_limbs - 1))) as u32);
         let pad_top_limb = BaseField::from_repr(pad_top_limb_repr).unwrap();
 
-        let mut pad_limbs = Vec::new();
+        let mut pad_limbs = Vec::with_capacity(self.limbs.len());
         pad_limbs.push(pad_top_limb);
         for _ in 0..self.limbs.len() - 1 {
             pad_limbs.push(pad_non_top_limb);


### PR DESCRIPTION
This PR is the result of a `cargo clippy --workspace --all-targets` pass, omitting `clippy::upper_case_acronyms` (there are plenty of them and it's a question of whether the names should change or if they should be ignored) and the `storage` crate, which should soon be removable.