### PR TITLE
Fix Sonic test compilation in Marlin

### DIFF
--- a/marlin/src/marlin/tests.rs
+++ b/marlin/src/marlin/tests.rs
@@ -63,8 +63,7 @@ mod marlin {
         marlin::{MarlinSNARK, MarlinTestnet1Mode},
     };
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
-    use snarkvm_polycommit::marlin_pc::MarlinKZG10;
-    // use snarkvm_polycommit::{marlin_pc::MarlinKZG10, sonic_pc::SonicKZG10};
+    use snarkvm_polycommit::{marlin_pc::MarlinKZG10, sonic_pc::SonicKZG10};
     use snarkvm_utilities::rand::{test_rng, UniformRand};
 
     use blake2::Blake2s;
@@ -73,8 +72,8 @@ mod marlin {
     type MultiPC = MarlinKZG10<Bls12_377>;
     type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode>;
 
-    // type MultiPCSonic = SonicKZG10<Bls12_377>;
-    // type MarlinSonicInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode>;
+    type MultiPCSonic = SonicKZG10<Bls12_377>;
+    type MarlinSonicInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode>;
 
     macro_rules! impl_marlin_test {
         ($test_struct: ident, $marlin_inst: tt) => {
@@ -115,7 +114,7 @@ mod marlin {
     }
 
     impl_marlin_test!(MarlinPCTest, MarlinInst);
-    // impl_marlin_test!(SonicPCTest, MarlinSonicInst);
+    impl_marlin_test!(SonicPCTest, MarlinSonicInst);
 
     #[test]
     fn prove_and_verify_with_tall_matrix_big() {
@@ -123,7 +122,7 @@ mod marlin {
         let num_variables = 25;
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
-        // SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -132,7 +131,7 @@ mod marlin {
         let num_variables = 25;
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
-        // SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -141,7 +140,7 @@ mod marlin {
         let num_variables = 100;
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
-        // SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -150,7 +149,7 @@ mod marlin {
         let num_variables = 26;
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
-        // SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -159,6 +158,6 @@ mod marlin {
         let num_variables = 25;
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
-        // SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCTest::test_circuit(num_constraints, num_variables);
     }
 }

--- a/polycommit/src/sonic_pc/data_structures.rs
+++ b/polycommit/src/sonic_pc/data_structures.rs
@@ -171,7 +171,21 @@ where
     E::G2Affine: ToConstraintField<E::Fq>,
 {
     fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
-        unimplemented!()
+        let mut res = Vec::new();
+        res.extend_from_slice(&self.g.to_field_elements()?);
+        res.extend_from_slice(&self.gamma_g.to_field_elements()?);
+        res.extend_from_slice(&self.h.to_field_elements()?);
+        res.extend_from_slice(&self.beta_h.to_field_elements()?);
+
+        if let Some(degree_bounds_and_prepared_neg_powers_of_h) = &self.degree_bounds_and_prepared_neg_powers_of_h {
+            for (d, _prepared_neg_powers_of_h) in degree_bounds_and_prepared_neg_powers_of_h.iter() {
+                let d_elem: E::Fq = (*d as u64).into();
+
+                res.push(d_elem);
+            }
+        }
+
+        Ok(res)
     }
 }
 

--- a/polycommit/src/sonic_pc/data_structures.rs
+++ b/polycommit/src/sonic_pc/data_structures.rs
@@ -16,6 +16,7 @@
 
 use crate::{impl_bytes, kzg10, BTreeMap, PCCommitterKey, PCVerifierKey, Vec};
 use snarkvm_curves::traits::{PairingCurve, PairingEngine};
+use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
 use snarkvm_utilities::{
     bytes::{FromBytes, ToBytes},
     error,
@@ -161,6 +162,16 @@ impl<E: PairingEngine> PCVerifierKey for VerifierKey<E> {
 
     fn supported_degree(&self) -> usize {
         self.supported_degree
+    }
+}
+
+impl<E: PairingEngine> ToConstraintField<E::Fq> for VerifierKey<E>
+where
+    E::G1Affine: ToConstraintField<E::Fq>,
+    E::G2Affine: ToConstraintField<E::Fq>,
+{
+    fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes the Sonic tests in the new Marlin model by implementing the ToContraintField for the Sonic `VeriiferKey`.
