### PR TITLE
Add additional FS RNG tests

### DIFF
--- a/nonnative/src/allocated_nonnative_field_var.rs
+++ b/nonnative/src/allocated_nonnative_field_var.rs
@@ -862,9 +862,9 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocGadget<TargetField, Ba
         let elem_representations = Self::get_limbs_representations(&elem, optimization_type)?;
         let mut limbs = Vec::new();
 
-        for limb in elem_representations.iter() {
+        for (i, limb) in elem_representations.iter().enumerate() {
             limbs.push(FpGadget::<BaseField>::alloc_constant(
-                cs.ns(|| "alloc_constant"),
+                cs.ns(|| format!("alloc_constant_limb_{}", i)),
                 || Ok(limb),
             )?);
         }

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -834,15 +834,7 @@ pub mod tests {
                 &rands,
                 Some(rng),
             )?;
-            let result = PC::batch_check(
-                &vk,
-                comms.into_iter(),
-                &query_set,
-                &values,
-                &proof,
-                opening_challenge,
-                rng,
-            )?;
+            let result = PC::batch_check(&vk, &comms, &query_set, &values, &proof, opening_challenge, rng)?;
             assert!(result, "proof was incorrect, Query set: {:#?}", query_set);
         }
         Ok(())
@@ -940,15 +932,7 @@ pub mod tests {
                 &rands,
                 Some(rng),
             )?;
-            let result = PC::batch_check(
-                &vk,
-                comms.into_iter(),
-                &query_set,
-                &values,
-                &proof,
-                opening_challenge,
-                rng,
-            )?;
+            let result = PC::batch_check(&vk, &comms, &query_set, &values, &proof, opening_challenge, rng)?;
             if !result {
                 println!(
                     "Failed with {} polynomials, num_points_in_query_set: {:?}",
@@ -1098,7 +1082,7 @@ pub mod tests {
             let result = PC::check_combinations(
                 &vk,
                 &linear_combinations,
-                comms.into_iter(),
+                &comms,
                 &query_set,
                 &values,
                 &proof,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds two additional tests from the the reference implementation - a native chacha rng test and a poseidon sponge gadget test.