### PR TITLE
Speed up merkle tree growth

### DIFF
--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -30,7 +30,7 @@ pub struct MerkleTree<P: MerkleParameters> {
     tree: Vec<MerkleTreeDigest<P>>,
 
     /// The hash of each non-empty leaf in the Merkle tree.
-    hashed_leaves: Vec<MerkleTreeDigest<P>>,
+    hashed_leaves: Vec<MerkleTreeDigest<P>>, // TODO(ljedrz): this can be procured without allocations
 
     /// For each level after a full tree has been built from the leaves,
     /// keeps both the roots the siblings that are used to get to the desired depth.
@@ -118,14 +118,122 @@ impl<P: MerkleParameters> MerkleTree<P> {
         })
     }
 
+    pub fn rebuild<L: ToBytes, I: ExactSizeIterator<Item = L>, J: ExactSizeIterator<Item = L>>(
+        &mut self,
+        old_leaves: I,
+        new_leaves: J,
+    ) -> Result<(), MerkleError> {
+        let new_time = start_timer!(|| "MerkleTree::rebuild");
+
+        let last_level_size = (old_leaves.len() + new_leaves.len()).next_power_of_two();
+        let tree_size = 2 * last_level_size - 1;
+        let tree_depth = tree_depth(tree_size);
+
+        if tree_depth > Self::DEPTH as usize {
+            return Err(MerkleError::InvalidTreeDepth(tree_depth, Self::DEPTH as usize));
+        }
+
+        // Initialize the Merkle tree.
+        let empty_hash = self.parameters.hash_empty()?;
+        let mut tree = vec![empty_hash.clone(); tree_size];
+
+        // Compute the starting index (on the left) for each level of the tree.
+        let mut index = 0;
+        let mut level_indices = Vec::with_capacity(tree_depth);
+        for _ in 0..=tree_depth {
+            level_indices.push(index);
+            index = left_child(index);
+        }
+
+        // Track the indices of newly added leaves.
+        let new_indices = (old_leaves.len()..old_leaves.len() + new_leaves.len()).collect::<Vec<_>>();
+
+        // Compute and store the hash values for each leaf.
+        let hash_input_size_in_bytes = (P::H::INPUT_SIZE_BITS / 8) * 2;
+        let last_level_index = level_indices.pop().unwrap_or(0);
+        let mut buffer = vec![0u8; hash_input_size_in_bytes];
+
+        // The beginning of the tree can be reconstructed from pre-existing hashed leaves.
+        tree[last_level_index..][..old_leaves.len()].clone_from_slice(&self.hashed_leaves[..old_leaves.len()]);
+
+        // The new leaves require hashing.
+        for (i, leaf) in new_leaves.enumerate() {
+            tree[last_level_index + old_leaves.len() + i] = self.parameters.hash_leaf(&leaf, &mut buffer)?;
+        }
+
+        // Compute the hash values for every node in the tree.
+        let mut upper_bound = last_level_index;
+        let mut buffer = vec![0u8; hash_input_size_in_bytes];
+        level_indices.reverse();
+        for &start_index in &level_indices {
+            // Iterate over the current level.
+            for current_index in start_index..upper_bound {
+                let left_index = left_child(current_index);
+                let right_index = right_child(current_index);
+
+                // Hash only the tree paths that are altered by the addition of new leaves or are brand new.
+                if new_indices.contains(&current_index)
+                    || self.tree.get(left_index) != tree.get(left_index)
+                    || self.tree.get(right_index) != tree.get(right_index)
+                    || new_indices
+                        .iter()
+                        .any(|&idx| Ancestors(idx).into_iter().find(|&i| i == current_index).is_some())
+                {
+                    // Compute Hash(left || right).
+                    tree[current_index] =
+                        self.parameters
+                            .hash_inner_node(&tree[left_index], &tree[right_index], &mut buffer)?;
+                } else {
+                    tree[current_index] = self.tree[current_index].clone();
+                }
+            }
+            upper_bound = start_index;
+        }
+
+        // Finished computing actual tree.
+        // Now, we compute the dummy nodes until we hit our DEPTH goal.
+        let mut current_depth = tree_depth;
+        let mut padding_tree = Vec::with_capacity((Self::DEPTH as usize).saturating_sub(current_depth + 1));
+        let mut current_hash = tree[0].clone();
+        while current_depth < Self::DEPTH as usize {
+            current_hash = self
+                .parameters
+                .hash_inner_node(&current_hash, &empty_hash, &mut buffer)?;
+
+            // do not pad at the top-level of the tree
+            if current_depth < Self::DEPTH as usize - 1 {
+                padding_tree.push((current_hash.clone(), empty_hash.clone()));
+            }
+            current_depth += 1;
+        }
+        let root_hash = current_hash;
+
+        end_timer!(new_time);
+
+        let hashed_leaves = tree[last_level_index..].to_vec();
+
+        // update the values at the very end so the original tree is not altered in case of failure
+        self.root = Some(root_hash);
+        self.tree = tree;
+        self.hashed_leaves = hashed_leaves;
+        self.padding_tree = padding_tree;
+
+        Ok(())
+    }
+
     #[inline]
     pub fn root(&self) -> <P::H as CRH>::Output {
         self.root.clone().unwrap()
     }
 
     #[inline]
-    pub fn hashed_leaves(&self) -> Vec<<P::H as CRH>::Output> {
-        self.hashed_leaves.clone()
+    pub fn tree(&self) -> &[<P::H as CRH>::Output] {
+        &self.tree
+    }
+
+    #[inline]
+    pub fn hashed_leaves(&self) -> &[<P::H as CRH>::Output] {
+        &self.hashed_leaves
     }
 
     pub fn generate_proof<L: ToBytes>(&self, index: usize, leaf: &L) -> Result<MerklePath<P>, MerkleError> {

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -241,3 +241,18 @@ fn parent(index: usize) -> Option<usize> {
 fn convert_index_to_last_level(index: usize, tree_depth: usize) -> usize {
     index + (1 << tree_depth) - 1
 }
+
+pub struct Ancestors(usize);
+
+impl Iterator for Ancestors {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        if let Some(parent) = parent(self.0) {
+            self.0 = parent;
+            Some(parent)
+        } else {
+            None
+        }
+    }
+}

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -43,7 +43,7 @@ pub struct MerkleTree<P: MerkleParameters> {
 impl<P: MerkleParameters> MerkleTree<P> {
     pub const DEPTH: u8 = P::DEPTH as u8;
 
-    pub fn new<L: ToBytes>(parameters: P, leaves: &[L]) -> Result<Self, MerkleError> {
+    pub fn new<L: ToBytes, I: ExactSizeIterator<Item = L>>(parameters: P, leaves: I) -> Result<Self, MerkleError> {
         let new_time = start_timer!(|| "MerkleTree::new");
 
         let last_level_size = leaves.len().next_power_of_two();
@@ -70,8 +70,8 @@ impl<P: MerkleParameters> MerkleTree<P> {
         let hash_input_size_in_bytes = (P::H::INPUT_SIZE_BITS / 8) * 2;
         let last_level_index = level_indices.pop().unwrap_or(0);
         let mut buffer = vec![0u8; hash_input_size_in_bytes];
-        for (i, leaf) in leaves.iter().enumerate() {
-            tree[last_level_index + i] = parameters.hash_leaf(leaf, &mut buffer)?;
+        for (i, leaf) in leaves.enumerate() {
+            tree[last_level_index + i] = parameters.hash_leaf(&leaf, &mut buffer)?;
         }
 
         // Compute the hash values for every node in the tree.

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -27,7 +27,7 @@ fn generate_merkle_tree<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(
     leaves: &[L],
     parameters: &P,
 ) -> MerkleTree<P> {
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves).unwrap();
+    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
     for (i, leaf) in leaves.iter().enumerate() {
         let proof = tree.generate_proof(i, &leaf).unwrap();
         assert_eq!(P::DEPTH, proof.path.len());
@@ -38,7 +38,7 @@ fn generate_merkle_tree<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(
 
 /// Generates a valid Merkle tree and verifies the Merkle path witness for each leaf does not verify to an invalid root hash.
 fn bad_merkle_tree_verify<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(leaves: &[L], parameters: &P) {
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves).unwrap();
+    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
     for (i, leaf) in leaves.iter().enumerate() {
         let proof = tree.generate_proof(i, &leaf).unwrap();
         assert!(proof.verify(&<P::H as CRH>::Output::default(), &leaf).unwrap());

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -60,7 +60,7 @@ fn generate_merkle_tree<P: MerkleParameters, F: PrimeField, HG: CRHGadget<P::H, 
     use_bad_root: bool,
 ) {
     let parameters = P::default();
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves).unwrap();
+    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
     let root = tree.root();
     let mut satisfied = true;
     for (i, leaf) in leaves.iter().enumerate() {
@@ -129,7 +129,7 @@ fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: Mas
     use_bad_root: bool,
 ) {
     let parameters = P::default();
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves).unwrap();
+    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
     let root = tree.root();
 
     let mut cs = TestConstraintSystem::<F>::new();

--- a/objects/src/pedersen_merkle_tree.rs
+++ b/objects/src/pedersen_merkle_tree.rs
@@ -76,14 +76,14 @@ pub fn pedersen_merkle_root(hashes: &[[u8; 32]]) -> PedersenMerkleRootHash {
 
 /// Calculates the root of the Merkle tree using a Pedersen Hash instantiated with a PRNG
 pub fn pedersen_merkle_root_hash(hashes: &[[u8; 32]]) -> Fr {
-    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes).expect("could not create merkle tree");
+    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes.iter()).expect("could not create merkle tree");
     tree.root()
 }
 
 /// Calculates the root of the Merkle tree using a Pedersen Hash instantiated with a PRNG and the
 /// base layer hashes leaved
 pub fn pedersen_merkle_root_hash_with_leaves(hashes: &[[u8; 32]]) -> (Fr, Vec<Fr>) {
-    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes).expect("could not create merkle tree");
+    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes.iter()).expect("could not create merkle tree");
     (tree.root(), tree.hashed_leaves())
 }
 

--- a/objects/src/pedersen_merkle_tree.rs
+++ b/objects/src/pedersen_merkle_tree.rs
@@ -84,7 +84,7 @@ pub fn pedersen_merkle_root_hash(hashes: &[[u8; 32]]) -> Fr {
 /// base layer hashes leaved
 pub fn pedersen_merkle_root_hash_with_leaves(hashes: &[[u8; 32]]) -> (Fr, Vec<Fr>) {
     let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes.iter()).expect("could not create merkle tree");
-    (tree.root(), tree.hashed_leaves())
+    (tree.root(), tree.hashed_leaves().to_vec())
 }
 
 impl From<Fr> for PedersenMerkleRootHash {

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -182,7 +182,7 @@ mod test {
         h.update(root_bytes.as_ref());
         let mask = h.finalize().to_vec();
 
-        let snark_leaves = tree.hashed_leaves().into_iter().map(Some).collect();
+        let snark_leaves = tree.hashed_leaves().to_vec().into_iter().map(Some).collect();
         let proof = create_random_proof(
             &POSWCircuit::<_, EdwardsMaskedMerkleParameters, HashGadget, TestPOSWCircuitParameters> {
                 leaves: snark_leaves,

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -172,7 +172,7 @@ mod test {
 
         let nonce = [1; 32];
         let leaves = vec![vec![3u8; 32]; 7];
-        let tree = EdwardsMaskedMerkleTree::new(parameters.clone(), &leaves).unwrap();
+        let tree = EdwardsMaskedMerkleTree::new(parameters.clone(), leaves.iter()).unwrap();
         let root = tree.root();
         let mut root_bytes = [0; 32];
         root.write(&mut root_bytes[..]).unwrap();

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -132,9 +132,9 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
                 }
 
                 cm_and_indices.sort_by(|&(_, i), &(_, j)| i.cmp(&j));
-                let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm).collect::<Vec<_>>();
+                let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm);
 
-                let merkle_tree = MerkleTree::new(ledger_parameters.clone(), &commitments)?;
+                let merkle_tree = MerkleTree::new(ledger_parameters.clone(), commitments)?;
 
                 Ok(Self {
                     latest_block_height: RwLock::new(bytes_to_u32(val)),

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -122,9 +122,9 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         }
 
         cm_and_indices.sort_by(|&(_, i), &(_, j)| i.cmp(&j));
-        let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm).collect::<Vec<_>>();
+        let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm);
 
-        Ok(MerkleTree::new(self.ledger_parameters.clone(), &commitments)?)
+        Ok(MerkleTree::new(self.ledger_parameters.clone(), commitments)?)
     }
 
     /// Rebuild the stored merkle tree with the current stored commitments

--- a/storage/src/objects/ledger_scheme.rs
+++ b/storage/src/objects/ledger_scheme.rs
@@ -58,8 +58,8 @@ impl<T: Transaction, P: LoadableMerkleParameters> LedgerScheme for Ledger<T, P> 
             }
         }
 
-        let leaves: Vec<[u8; 32]> = vec![];
-        let empty_cm_merkle_tree = MerkleTree::<Self::MerkleParameters>::new(parameters.clone(), &leaves)?;
+        let leaves: &[[u8; 32]] = &[];
+        let empty_cm_merkle_tree = MerkleTree::<Self::MerkleParameters>::new(parameters.clone(), leaves.iter())?;
 
         let ledger_storage = Self {
             latest_block_height: RwLock::new(0),


### PR DESCRIPTION
This PR dramatically reduces the time needed to grow the `MerkleTree` object, allowing block syncing in snarkOS to happen in a reasonable time frame. Only when the new leaves share nearly no ancestors a large portion of the tree needs to be rebuilt, otherwise a lot of the pre-exsting hashes can be reused.

The results of this change were validated by using both `MerkleTree::{new, rebuild}` when synchronizing blocks and comparing the trees; no issues were found for the first few thousand blocks taken from the testnet. snarkOS tests also pass with `MerkleTree::rebuild` implicitly being used in tests (when blocks are committed).

In addition, memory use in `MerkleTree::new` is reduced by using an `ExactSizeIterator` instead of a slice for the `leaves` argument.

A snarkOS-side PR will follow once a new version of snarkVM is released.

Fixes https://github.com/AleoHQ/snarkOS/issues/459.

A comparison of the currently used `MerkleTree::new` with the new `MerkleTree::rebuild`:
![merkle_tree_comparison](https://user-images.githubusercontent.com/3750347/113029713-0aa60200-918d-11eb-938e-22540b877ad5.png)
