### PR TITLE
Make rebuild return a new MerkleTree for better synchronization logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snarkvm"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm"
-version = "0.2.2"
+version = "0.3.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/algorithms/src/merkle_tree/merkle_path.rs
+++ b/algorithms/src/merkle_tree/merkle_path.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
+
 use crate::{
     errors::MerkleError,
     traits::{MerkleParameters, CRH},
@@ -26,7 +28,7 @@ pub type MerkleTreeDigest<P> = <<P as MerkleParameters>::H as CRH>::Output;
 /// Our path `is_left_child()` if the boolean in `path` is true.
 #[derive(Clone, Debug)]
 pub struct MerklePath<P: MerkleParameters> {
-    pub parameters: P,
+    pub parameters: Arc<P>,
     pub path: Vec<(MerkleTreeDigest<P>, MerkleTreeDigest<P>)>,
 }
 
@@ -77,7 +79,7 @@ impl<P: MerkleParameters> Default for MerklePath<P> {
             path.push((MerkleTreeDigest::<P>::default(), MerkleTreeDigest::<P>::default()));
         }
         Self {
-            parameters: P::default(),
+            parameters: Arc::new(P::default()),
             path,
         }
     }

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -20,6 +20,7 @@ use crate::{
     traits::{MerkleParameters, CRH},
 };
 use snarkvm_utilities::ToBytes;
+use std::sync::Arc;
 
 #[derive(Default)]
 pub struct MerkleTree<P: MerkleParameters> {
@@ -37,13 +38,13 @@ pub struct MerkleTree<P: MerkleParameters> {
     padding_tree: Vec<(MerkleTreeDigest<P>, MerkleTreeDigest<P>)>,
 
     /// The Merkle tree parameters (e.g. the hash function).
-    parameters: P,
+    parameters: Arc<P>,
 }
 
 impl<P: MerkleParameters> MerkleTree<P> {
     pub const DEPTH: u8 = P::DEPTH as u8;
 
-    pub fn new<L: ToBytes, I: ExactSizeIterator<Item = L>>(parameters: P, leaves: I) -> Result<Self, MerkleError> {
+    pub fn new<L: ToBytes, I: ExactSizeIterator<Item = L>>(parameters: Arc<P>, leaves: I) -> Result<Self, MerkleError> {
         let new_time = start_timer!(|| "MerkleTree::new");
 
         let last_level_size = leaves.len().next_power_of_two();

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
+
 use crate::{
     crh::{PedersenCRH, PedersenCompressedCRH, PedersenSize},
     define_merkle_tree_parameters,
@@ -27,7 +29,7 @@ fn generate_merkle_tree<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(
     leaves: &[L],
     parameters: &P,
 ) -> MerkleTree<P> {
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
+    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), leaves.iter()).unwrap();
     for (i, leaf) in leaves.iter().enumerate() {
         let proof = tree.generate_proof(i, &leaf).unwrap();
         assert_eq!(P::DEPTH, proof.path.len());
@@ -38,7 +40,7 @@ fn generate_merkle_tree<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(
 
 /// Generates a valid Merkle tree and verifies the Merkle path witness for each leaf does not verify to an invalid root hash.
 fn bad_merkle_tree_verify<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(leaves: &[L], parameters: &P) {
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
+    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), leaves.iter()).unwrap();
     for (i, leaf) in leaves.iter().enumerate() {
         let proof = tree.generate_proof(i, &leaf).unwrap();
         assert!(proof.verify(&<P::H as CRH>::Output::default(), &leaf).unwrap());

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit.rs
@@ -30,13 +30,14 @@ use snarkvm_algorithms::{
 };
 use snarkvm_objects::AleoAmount;
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
+use std::sync::Arc;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: BaseDPCComponents"))]
 pub struct InnerCircuit<C: BaseDPCComponents> {
     // Parameters
     system_parameters: SystemParameters<C>,
-    ledger_parameters: C::MerkleParameters,
+    ledger_parameters: Arc<C::MerkleParameters>,
 
     ledger_digest: MerkleTreeDigest<C::MerkleParameters>,
 
@@ -71,7 +72,7 @@ pub struct InnerCircuit<C: BaseDPCComponents> {
 }
 
 impl<C: BaseDPCComponents> InnerCircuit<C> {
-    pub fn blank(system_parameters: &SystemParameters<C>, ledger_parameters: &C::MerkleParameters) -> Self {
+    pub fn blank(system_parameters: &SystemParameters<C>, ledger_parameters: &Arc<C::MerkleParameters>) -> Self {
         let num_input_records = C::NUM_INPUT_RECORDS;
         let num_output_records = C::NUM_OUTPUT_RECORDS;
         let digest = MerkleTreeDigest::<C::MerkleParameters>::default();
@@ -147,7 +148,7 @@ impl<C: BaseDPCComponents> InnerCircuit<C> {
     pub fn new(
         // Parameters
         system_parameters: SystemParameters<C>,
-        ledger_parameters: C::MerkleParameters,
+        ledger_parameters: Arc<C::MerkleParameters>,
 
         // Digest
         ledger_digest: MerkleTreeDigest<C::MerkleParameters>,

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit_verifier_input.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit_verifier_input.rs
@@ -21,6 +21,7 @@ use snarkvm_algorithms::{
 };
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
 use snarkvm_objects::AleoAmount;
+use std::sync::Arc;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: BaseDPCComponents"))]
@@ -29,7 +30,7 @@ pub struct InnerCircuitVerifierInput<C: BaseDPCComponents> {
     pub system_parameters: SystemParameters<C>,
 
     // Ledger parameters and digest
-    pub ledger_parameters: C::MerkleParameters,
+    pub ledger_parameters: Arc<C::MerkleParameters>,
     pub ledger_digest: MerkleTreeDigest<C::MerkleParameters>,
 
     // Input record serial numbers

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -54,6 +54,7 @@ use rand::Rng;
 use std::{
     io::{Read, Result as IoResult, Write},
     marker::PhantomData,
+    sync::Arc,
 };
 
 pub mod inner_circuit;
@@ -581,7 +582,7 @@ where
     type TransactionKernel = TransactionKernel<Components>;
 
     fn setup<R: Rng>(
-        ledger_parameters: &Components::MerkleParameters,
+        ledger_parameters: &Arc<Components::MerkleParameters>,
         rng: &mut R,
     ) -> anyhow::Result<Self::NetworkParameters> {
         let setup_time = start_timer!(|| "BaseDPC::setup");

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit.rs
@@ -27,6 +27,7 @@ use snarkvm_algorithms::{
 use snarkvm_fields::ToConstraintField;
 use snarkvm_objects::AleoAmount;
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
+use std::sync::Arc;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: BaseDPCComponents"))]
@@ -34,7 +35,7 @@ pub struct OuterCircuit<C: BaseDPCComponents> {
     system_parameters: SystemParameters<C>,
 
     // Inner snark verifier public inputs
-    ledger_parameters: C::MerkleParameters,
+    ledger_parameters: Arc<C::MerkleParameters>,
     ledger_digest: MerkleTreeDigest<C::MerkleParameters>,
     old_serial_numbers: Vec<<C::AccountSignature as SignatureScheme>::PublicKey>,
     new_commitments: Vec<<C::RecordCommitment as CommitmentScheme>::Output>,
@@ -60,7 +61,7 @@ pub struct OuterCircuit<C: BaseDPCComponents> {
 impl<C: BaseDPCComponents> OuterCircuit<C> {
     pub fn blank(
         system_parameters: SystemParameters<C>,
-        ledger_parameters: C::MerkleParameters,
+        ledger_parameters: Arc<C::MerkleParameters>,
         inner_snark_vk: <C::InnerSNARK as SNARK>::VerificationParameters,
         inner_snark_proof: <C::InnerSNARK as SNARK>::Proof,
         program_snark_vk_and_proof: PrivateProgramInput,
@@ -112,7 +113,7 @@ impl<C: BaseDPCComponents> OuterCircuit<C> {
         system_parameters: SystemParameters<C>,
 
         // Inner SNARK public inputs
-        ledger_parameters: C::MerkleParameters,
+        ledger_parameters: Arc<C::MerkleParameters>,
         ledger_digest: MerkleTreeDigest<C::MerkleParameters>,
         old_serial_numbers: Vec<<C::AccountSignature as SignatureScheme>::PublicKey>,
         new_commitments: Vec<<C::RecordCommitment as CommitmentScheme>::Output>,

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -18,6 +18,7 @@ use crate::traits::{AccountScheme, Record};
 use snarkvm_objects::traits::{LedgerScheme, Transaction};
 
 use rand::Rng;
+use std::sync::Arc;
 
 pub trait DPCScheme<L: LedgerScheme> {
     type Account: AccountScheme;
@@ -31,7 +32,10 @@ pub trait DPCScheme<L: LedgerScheme> {
     type TransactionKernel;
 
     /// Returns public parameters for the DPC.
-    fn setup<R: Rng>(ledger_parameters: &L::MerkleParameters, rng: &mut R) -> anyhow::Result<Self::NetworkParameters>;
+    fn setup<R: Rng>(
+        ledger_parameters: &Arc<L::MerkleParameters>,
+        rng: &mut R,
+    ) -> anyhow::Result<Self::NetworkParameters>;
 
     /// Returns an account, given the system parameters, metadata, and an RNG.
     fn create_account<R: Rng>(parameters: &Self::SystemParameters, rng: &mut R) -> anyhow::Result<Self::Account>;

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
+
 use crate::{
     algorithms::{
         crh::{BoweHopwoodPedersenCompressedCRHGadget, PedersenCRHGadget, PedersenCompressedCRHGadget},
@@ -60,7 +62,7 @@ fn generate_merkle_tree<P: MerkleParameters, F: PrimeField, HG: CRHGadget<P::H, 
     use_bad_root: bool,
 ) {
     let parameters = P::default();
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
+    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), leaves.iter()).unwrap();
     let root = tree.root();
     let mut satisfied = true;
     for (i, leaf) in leaves.iter().enumerate() {
@@ -129,7 +131,7 @@ fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: Mas
     use_bad_root: bool,
 ) {
     let parameters = P::default();
-    let tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter()).unwrap();
+    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), leaves.iter()).unwrap();
     let root = tree.root();
 
     let mut cs = TestConstraintSystem::<F>::new();

--- a/objects/src/pedersen_merkle_tree.rs
+++ b/objects/src/pedersen_merkle_tree.rs
@@ -20,10 +20,13 @@ use snarkvm_utilities::{bytes::ToBytes, to_bytes};
 
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::fmt::{
-    Display,
-    Formatter,
-    {self},
+use std::{
+    fmt::{
+        Display,
+        Formatter,
+        {self},
+    },
+    sync::Arc,
 };
 
 // Do not leak the type
@@ -50,7 +53,8 @@ define_masked_merkle_tree_parameters!(MaskedMerkleTreeParameters, MerkleTreeCRH,
 pub type EdwardsMaskedMerkleTree = MerkleTree<MaskedMerkleTreeParameters>;
 
 /// Lazily evaluated parameters for the Masked Merkle tree
-pub static PARAMS: Lazy<MaskedMerkleTreeParameters> = Lazy::new(|| MaskedMerkleTreeParameters::setup(&mut prng()));
+pub static PARAMS: Lazy<Arc<MaskedMerkleTreeParameters>> =
+    Lazy::new(|| Arc::new(MaskedMerkleTreeParameters::setup(&mut prng())));
 
 /// A Pedersen Merkle Root Hash
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/objects/src/traits/ledger.rs
+++ b/objects/src/traits/ledger.rs
@@ -16,7 +16,7 @@
 
 use crate::traits::{BlockScheme, Transaction};
 
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 #[allow(clippy::len_without_is_empty)]
 pub trait LedgerScheme: Sized {
@@ -29,14 +29,17 @@ pub trait LedgerScheme: Sized {
     type Transaction: Transaction;
 
     /// Instantiates a new ledger with a genesis block.
-    fn new(path: Option<&Path>, parameters: Self::MerkleParameters, genesis_block: Self::Block)
-    -> anyhow::Result<Self>;
+    fn new(
+        path: Option<&Path>,
+        parameters: Arc<Self::MerkleParameters>,
+        genesis_block: Self::Block,
+    ) -> anyhow::Result<Self>;
 
     /// Returns the number of blocks including the genesis block
     fn len(&self) -> usize;
 
     /// Return the parameters used to construct the ledger Merkle tree.
-    fn parameters(&self) -> &Self::MerkleParameters;
+    fn parameters(&self) -> &Arc<Self::MerkleParameters>;
 
     /// Return a digest of the latest ledger Merkle tree.
     fn digest(&self) -> Option<Self::MerkleTreeDigest>;
@@ -60,7 +63,7 @@ pub trait LedgerScheme: Sized {
     /// Returns true if the given Merkle path is a valid witness for
     /// the given ledger digest and commitment.
     fn verify_cm(
-        parameters: &Self::MerkleParameters,
+        parameters: &Arc<Self::MerkleParameters>,
         digest: &Self::MerkleTreeDigest,
         cm: &Self::Commitment,
         witness: &Self::MerklePath,

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -34,7 +34,7 @@ use snarkvm_utilities::{
 };
 
 use rand::thread_rng;
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 mod utils;
 use utils::store;
@@ -45,7 +45,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     // TODO (howardwu): Resolve this inconsistency on import structure with a new model once MerkleParameters are refactored.
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
         From::from(FromBytes::read(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
-    let ledger_merkle_tree_parameters = From::from(merkle_tree_hash_parameters);
+    let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
     let system_parameters = SystemParameters::<C>::load()?;
     let inner_snark_parameters = C::InnerSNARK::setup(

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -41,7 +41,7 @@ use snarkvm_utilities::{
 };
 
 use rand::thread_rng;
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 mod utils;
 use utils::store;
@@ -52,7 +52,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
         From::from(FromBytes::read(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
-    let ledger_merkle_tree_parameters = From::from(merkle_tree_hash_parameters);
+    let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
     let inner_snark_pk: <C::InnerSNARK as SNARK>::ProvingParameters =
         <C::InnerSNARK as SNARK>::ProvingParameters::read(InnerSNARKPKParameters::load_bytes()?.as_slice())?;


### PR DESCRIPTION
This will allow us to go lock free for MerkleTree storage for what appears to be very low cost.

This PR also includes `Arc` wrapping for parameters to avoid cloning cost.

This PR includes a version bump for `v0.3.0`. Semver minor bump due to API change in rebuild. It's particularly necessary since previous callers will not get a compiler error for input types, but the return type has changed from nothing to a new struct.

No change in performance observed from this change. See graphs:
Before:
![image](https://user-images.githubusercontent.com/8600837/117194829-6883c600-ad99-11eb-8e14-916ed18227e4.png)
After:
![image](https://user-images.githubusercontent.com/8600837/117194857-75081e80-ad99-11eb-82fc-64a4d690c1d2.png)

Using 100 block test chain.