### PR TITLE
Snark verification gadget constraint size tests and Marlin benchmarks

### DIFF
--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -622,4 +622,100 @@ mod test {
             assert!(cs.is_satisfied());
         }
     }
+
+    #[test]
+    fn groth16_verifier_num_constraints_test() {
+        let num_inputs = 100;
+        let num_constraints = num_inputs;
+        let rng = &mut test_rng();
+        let mut inputs: Vec<Option<Fr>> = Vec::with_capacity(num_inputs);
+        for _ in 0..num_inputs {
+            inputs.push(Some(rng.gen()));
+        }
+        let params = {
+            let c = Bench::<Fr> {
+                inputs: vec![None; num_inputs],
+                num_constraints,
+            };
+
+            generate_random_parameters(&c, rng).unwrap()
+        };
+
+        {
+            let proof = {
+                // Create an instance of our circuit (with the
+                // witness)
+                let c = Bench {
+                    inputs: inputs.clone(),
+                    num_constraints,
+                };
+                // Create a groth16 proof with our parameters.
+                create_random_proof(&c, &params, rng).unwrap()
+            };
+
+            // assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
+            let mut cs = TestConstraintSystem::<Fq>::new();
+
+            let inputs = inputs.into_iter().map(|input| input.unwrap());
+            let mut input_gadgets = Vec::new();
+
+            {
+                let mut cs = cs.ns(|| "Allocate Input");
+                for (i, input) in inputs.enumerate() {
+                    let mut input_bits = BitIteratorBE::new(input.into_repr()).collect::<Vec<_>>();
+                    // Input must be in little-endian, but BitIterator outputs in big-endian.
+                    input_bits.reverse();
+
+                    let input_bits =
+                        Vec::<Boolean>::alloc_input(cs.ns(|| format!("Input {}", i)), || Ok(input_bits)).unwrap();
+                    input_gadgets.push(input_bits);
+                }
+            }
+
+            let input_gadget_constraints = cs.num_constraints();
+
+            let vk_gadget = TestVkGadget::alloc_input(cs.ns(|| "Vk"), || Ok(&params.vk)).unwrap();
+
+            let vk_gadget_constraints = cs.num_constraints() - input_gadget_constraints;
+
+            let proof_gadget = TestProofGadget::alloc(cs.ns(|| "Proof"), || Ok(proof.clone())).unwrap();
+
+            let proof_gadget_constraints = cs.num_constraints() - vk_gadget_constraints;
+
+            <TestVerifierGadget as SNARKVerifierGadget<TestProofSystem, Fq>>::check_verify(
+                cs.ns(|| "Verify"),
+                &vk_gadget,
+                input_gadgets.iter(),
+                &proof_gadget,
+            )
+            .unwrap();
+
+            let verifier_gadget_constraints = cs.num_constraints() - proof_gadget_constraints;
+
+            if !cs.is_satisfied() {
+                println!("=========================================================");
+                println!("Unsatisfied constraints:");
+                println!("{:?}", cs.which_is_unsatisfied().unwrap());
+                println!("=========================================================");
+            }
+
+            // cs.print_named_objects();
+            assert!(cs.is_satisfied());
+
+            println!("input_gadget_constraints : {:?}", input_gadget_constraints);
+            println!("vk_gadget_constraints : {:?}", vk_gadget_constraints);
+            println!("proof_gadget_constraints : {:?}", proof_gadget_constraints);
+            println!("verifier_gadget_constraints : {:?}", verifier_gadget_constraints);
+
+            const INPUT_GADGET_CONSTRAINTS: usize = 25600;
+            const VK_GADGET_CONSTRAINTS: usize = 105;
+            const PROOF_GADGET_CONSTRAINTS: usize = 30199;
+            const VERIFIER_GADGET_CONSTRAINTS: usize = 316635;
+
+            assert_eq!(input_gadget_constraints, INPUT_GADGET_CONSTRAINTS);
+            assert_eq!(vk_gadget_constraints, VK_GADGET_CONSTRAINTS);
+            assert_eq!(proof_gadget_constraints, PROOF_GADGET_CONSTRAINTS);
+            assert_eq!(verifier_gadget_constraints, VERIFIER_GADGET_CONSTRAINTS);
+        }
+    }
 }

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -81,7 +81,6 @@ version = "0.11.2"
 
 [dependencies.rand]
 version = "0.8"
-default-features = false
 
 [dependencies.rand_chacha]
 version = "0.3"

--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -389,8 +389,6 @@ mod test {
         .enforce_equal(cs.ns(|| "enforce_equal"), &Boolean::Constant(true))
         .unwrap();
 
-        println!("after Marlin, num_of_constraints = {}", cs.num_constraints());
-
         assert!(
             cs.is_satisfied(),
             "Constraints not satisfied: {}",

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -501,14 +501,6 @@ where
         proof.print_size_info();
         end_timer!(prover_time);
 
-        println!("Number of proof commitments: {}", proof.commitments.len());
-        println!("Number of proof evaluations: {}", proof.evaluations.len());
-        println!("Number of proof messages: {}", proof.prover_messages.len());
-        println!(
-            "Number of proof batch evaluations: {}",
-            proof.clone().pc_proof.proof.into().len()
-        );
-
         Ok(proof)
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR implements additional tests for the snark verification gadgets (groth16, gm17, and marlin) that enforce the fixed size of the gadgets. This will allow us to determine if any underlying components are needlessly changed in future iterations. 

Additionally, new benchmarks for Marlin have been added (universal setup, circuit specific setup, verification, and verification gadget).