### PR TITLE
Fix LinearCombination build-time nondeterminism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snarkvm"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm"
-version = "0.3.2"
+version = "0.3.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm"
-version = "0.3.1"
+version = "0.3.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/r1cs/src/linear_combination.rs
+++ b/r1cs/src/linear_combination.rs
@@ -91,7 +91,11 @@ impl<F: Field> LinearCombination<F> {
                     found_index += 1;
                 }
             }
-            Err(found_index)
+            if self.0.get(found_index).map(|x| &x.0 == search_var).unwrap_or_default() {
+                Ok(found_index)
+            } else {
+                Err(found_index)
+            }
         } else {
             self.0.binary_search_by_key(search_var, |&(cur_var, _)| cur_var)
         }
@@ -477,5 +481,22 @@ impl<'a, F: Field> Sub<(F, LinearCombination<F>)> for LinearCombination<F> {
 
     fn sub(self, (coeff, other): (F, LinearCombination<F>)) -> LinearCombination<F> {
         self + (-coeff, other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Index;
+
+    use super::*;
+    use snarkvm_curves::bls12_377::Fr;
+
+    #[test]
+    fn linear_combination_append() {
+        let mut combo = LinearCombination::<Fr>::zero();
+        for i in 0..100u64 {
+            combo += (i.into(), Variable::new_unchecked(Index::Public(0)));
+        }
+        assert_eq!(combo.0.len(), 1);
     }
 }


### PR DESCRIPTION
This PR fixes build-time nondeterminism in `UInt::addmany` through `LinearCombination::add_assign`. Issue was noticed during upgrade from rust 1.51.0 -> 1.52.0, where

[rust 18e44a1b](https://github.com/rust-lang/rust/commit/18e44a1be4d8aecf41d0b904d63f6c72f51d6b0d)
[rust 7d078cfb9](https://github.com/rust-lang/rust/commit/7d078cfb94fa75e5dee699535f3f9781d3a1d47d)

changed internals of `binary_search_by` leading to a change in emitted R1CS. `binary_search_by` doesn't guarantee stability if the items being sorted are not unique, and the excess appending of duplicates this PR fixes removes the issue encountered from changing internals of rust.

*warning* This PR will change emitted R1CS from that of rust `1.51.0, `1.52.0`, and all other versions of rust.