### PR TITLE
Optimize Bowe Hopwood Pedersen Hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,8 +596,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1807,6 +1809,7 @@ name = "snarkvm-wasm"
 version = "0.3.1"
 dependencies = [
  "derivative",
+ "getrandom",
  "rand",
  "rand_xorshift",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +505,12 @@ name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
+
+[[package]]
+name = "funty"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futures-channel"
@@ -1155,6 +1173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1541,7 @@ dependencies = [
 name = "snarkvm-algorithms"
 version = "0.3.1"
 dependencies = [
+ "bitvec",
  "blake2",
  "criterion",
  "csv",
@@ -1852,6 +1877,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2266,4 +2297,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
 ]

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -28,6 +28,11 @@ path = "benches/crh/pedersen.rs"
 harness = false
 
 [[bench]]
+name = "crh-bowe-pedersen"
+path = "benches/crh/bowe_pedersen.rs"
+harness = false
+
+[[bench]]
 name = "fft"
 path = "benches/fft/fft.rs"
 harness = false
@@ -91,7 +96,6 @@ version = "0.10.0"
 
 [dependencies.rand]
 version = "0.8"
-default-features = false
 
 [dependencies.rand_chacha]
 version = "0.3"
@@ -109,6 +113,9 @@ version = "1.6"
 
 [dependencies.thiserror]
 version = "1.0"
+
+[dependencies.bitvec]
+version = "0.22"
 
 [dev-dependencies.criterion]
 version = "0.3.4"

--- a/algorithms/benches/crh/bowe_pedersen.rs
+++ b/algorithms/benches/crh/bowe_pedersen.rs
@@ -18,7 +18,7 @@
 extern crate criterion;
 
 use snarkvm_algorithms::{
-    crh::pedersen::{PedersenCRH, PedersenSize},
+    crh::{pedersen::PedersenSize, BoweHopwoodPedersenCRH},
     traits::CRH,
 };
 use snarkvm_curves::edwards_bls12::EdwardsProjective;
@@ -37,34 +37,34 @@ impl PedersenSize for CRHSize {
     const WINDOW_SIZE: usize = 32;
 }
 
-fn pedersen_crh_setup(c: &mut Criterion) {
+fn bowe_pedersen_crh_setup(c: &mut Criterion) {
     let rng = &mut thread_rng();
 
-    c.bench_function("Pedersen Commitment Setup", move |b| {
-        b.iter(|| <PedersenCRH<EdwardsProjective, CRHSize> as CRH>::setup(rng))
+    c.bench_function("Bowe Pedersen Commitment Setup", move |b| {
+        b.iter(|| <BoweHopwoodPedersenCRH<EdwardsProjective, CRHSize> as CRH>::setup(rng))
     });
 }
 
-fn pedersen_crh_hash(c: &mut Criterion) {
+fn bowe_pedersen_crh_hash(c: &mut Criterion) {
     let rng = &mut thread_rng();
-    let parameters = <PedersenCRH<EdwardsProjective, CRHSize> as CRH>::setup(rng);
+    let parameters = <BoweHopwoodPedersenCRH<EdwardsProjective, CRHSize> as CRH>::setup(rng);
     let input = vec![127u8; 32];
 
-    c.bench_function("Pedersen Commitment Evaluation", move |b| {
-        b.iter(|| <PedersenCRH<EdwardsProjective, CRHSize> as CRH>::hash(&parameters, &input).unwrap())
+    c.bench_function("Bowe Pedersen Commitment Evaluation", move |b| {
+        b.iter(|| <BoweHopwoodPedersenCRH<EdwardsProjective, CRHSize> as CRH>::hash(&parameters, &input).unwrap())
     });
 }
 
 criterion_group! {
-    name = crh_setup;
+    name = bowe_crh_setup;
     config = Criterion::default().sample_size(50);
-    targets = pedersen_crh_setup
+    targets = bowe_pedersen_crh_setup
 }
 
 criterion_group! {
-    name = crh_hash;
+    name = bowe_crh_hash;
     config = Criterion::default().sample_size(50);
-    targets = pedersen_crh_hash
+    targets = bowe_pedersen_crh_hash
 }
 
-criterion_main!(crh_setup, crh_hash);
+criterion_main!(bowe_crh_setup, bowe_crh_hash);

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -135,7 +135,12 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
             S::NUM_WINDOWS,
             BOWE_HOPWOOD_CHUNK_SIZE,
         );
+        assert_eq!(self.parameters.len(), S::NUM_WINDOWS);
         for bases in self.parameters.bases.iter() {
+            assert_eq!(bases.len(), S::WINDOW_SIZE);
+        }
+        assert_eq!(self.bowe_hopwood_parameters.base_lookup.len(), S::NUM_WINDOWS);
+        for bases in self.bowe_hopwood_parameters.base_lookup.iter() {
             assert_eq!(bases.len(), S::WINDOW_SIZE);
         }
         assert_eq!(BOWE_HOPWOOD_CHUNK_SIZE, 3);

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -22,11 +22,11 @@ use crate::{
     errors::CRHError,
     traits::CRH,
 };
-use bitvec::{order::Lsb0, view::BitView};
 use snarkvm_curves::Group;
 use snarkvm_fields::{ConstraintFieldError, Field, PrimeField, ToConstraintField};
 use snarkvm_utilities::biginteger::biginteger::BigInteger;
 
+use bitvec::{order::Lsb0, view::BitView};
 use rand::Rng;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -29,6 +29,10 @@ use snarkvm_utilities::biginteger::biginteger::BigInteger;
 use bitvec::{order::Lsb0, view::BitView};
 use rand::Rng;
 
+// we cant use these in array sizes since they are from a trait (and cant be refered to at const time)
+const MAX_WINDOW_SIZE: usize = 256;
+const MAX_NUM_WINDOWS: usize = 296;
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BoweHopwoodPedersenCRH<G: Group, S: PedersenSize> {
     pub parameters: PedersenCRHParameters<G, S>,
@@ -110,12 +114,11 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
                 S::NUM_WINDOWS,
             ));
         }
-        // we cant use these in array sizes since they are from a trait (and cant be refered to at const time)
-        assert!(S::WINDOW_SIZE <= 256);
-        assert!(S::NUM_WINDOWS <= 296);
+        assert!(S::WINDOW_SIZE <= MAX_WINDOW_SIZE);
+        assert!(S::NUM_WINDOWS <= MAX_NUM_WINDOWS);
 
         // overzealous but stack allocation
-        let mut buffer = [0u8; 296 * 256 / 8 + BOWE_HOPWOOD_CHUNK_SIZE + 1];
+        let mut buffer = [0u8; MAX_WINDOW_SIZE * MAX_NUM_WINDOWS / 8 + BOWE_HOPWOOD_CHUNK_SIZE + 1];
         buffer[..input.len()].copy_from_slice(input);
         let buf_slice = (&buffer[..]).view_bits::<Lsb0>();
 

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -135,7 +135,7 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
             S::NUM_WINDOWS,
             BOWE_HOPWOOD_CHUNK_SIZE,
         );
-        assert_eq!(self.parameters.len(), S::NUM_WINDOWS);
+        assert_eq!(self.parameters.bases.len(), S::NUM_WINDOWS);
         for bases in self.parameters.bases.iter() {
             assert_eq!(bases.len(), S::WINDOW_SIZE);
         }

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -112,10 +112,10 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
         }
         // we cant use these in array sizes since they are from a trait (and cant be refered to at const time)
         assert!(S::WINDOW_SIZE <= 256);
-        assert!(S::NUM_WINDOWS <= 256);
+        assert!(S::NUM_WINDOWS <= 296);
 
         // overzealous but stack allocation
-        let mut buffer = [0u8; 256 * 256 / 8 + BOWE_HOPWOOD_CHUNK_SIZE + 1];
+        let mut buffer = [0u8; 296 * 256 / 8 + BOWE_HOPWOOD_CHUNK_SIZE + 1];
         buffer[..input.len()].copy_from_slice(input);
         let buf_slice = (&buffer[..]).view_bits::<Lsb0>();
 

--- a/algorithms/src/crh/bowe_hopwood_pedersen_parameters.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen_parameters.rs
@@ -1,0 +1,59 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkvm_curves::Group;
+
+use super::{PedersenCRHParameters, PedersenSize};
+
+pub const BOWE_HOPWOOD_CHUNK_SIZE: usize = 3;
+pub const BOWE_HOPWOOD_LOOKUP_SIZE: usize = 2usize.pow(BOWE_HOPWOOD_CHUNK_SIZE as u32);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BoweHopwoodPedersenCRHParameters<G: Group> {
+    pub base_lookup: Vec<Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>>,
+}
+
+impl<G: Group> BoweHopwoodPedersenCRHParameters<G> {
+    pub fn setup<S: PedersenSize>(input: &PedersenCRHParameters<G, S>) -> Self {
+        Self {
+            base_lookup: input
+                .bases
+                .iter()
+                .map(|x| {
+                    x.iter()
+                        .map(|g| {
+                            let mut out = [G::zero(); BOWE_HOPWOOD_LOOKUP_SIZE];
+                            for i in 0..BOWE_HOPWOOD_LOOKUP_SIZE {
+                                let mut encoded = *g;
+                                if (i & 0x01) != 0 {
+                                    encoded += g;
+                                }
+                                if (i & 0x02) != 0 {
+                                    encoded += &g.double();
+                                }
+                                if (i & 0x04) != 0 {
+                                    encoded = encoded.neg();
+                                }
+                                out[i] = encoded;
+                            }
+                            out
+                        })
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+}

--- a/algorithms/src/crh/mod.rs
+++ b/algorithms/src/crh/mod.rs
@@ -20,6 +20,9 @@ pub use bowe_hopwood_pedersen::*;
 pub mod bowe_hopwood_pedersen_compressed;
 pub use bowe_hopwood_pedersen_compressed::*;
 
+pub mod bowe_hopwood_pedersen_parameters;
+pub use bowe_hopwood_pedersen_parameters::*;
+
 pub mod pedersen;
 pub use pedersen::*;
 

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -173,7 +173,7 @@ mod pedersen_crh_on_affine {
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct Size;
     impl PedersenSize for Size {
-        const NUM_WINDOWS: usize = 512;
+        const NUM_WINDOWS: usize = 256;
         const WINDOW_SIZE: usize = 4;
     }
 
@@ -216,7 +216,7 @@ mod pedersen_crh_on_projective {
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct Size;
     impl PedersenSize for Size {
-        const NUM_WINDOWS: usize = 512;
+        const NUM_WINDOWS: usize = 256;
         const WINDOW_SIZE: usize = 4;
     }
 
@@ -263,7 +263,7 @@ mod pedersen_compressed_crh_on_projective {
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct Size;
     impl PedersenSize for Size {
-        const NUM_WINDOWS: usize = 512;
+        const NUM_WINDOWS: usize = 256;
         const WINDOW_SIZE: usize = 4;
     }
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -81,6 +81,10 @@ features = [ "derive" ]
 version = "0.2"
 features = [ "serde-serialize" ]
 
+[dependencies.getrandom]
+version = "0.2"
+features = ["js"]
+
 [dev-dependencies.wasm-bindgen-test]
 version = "0.3.24"
 


### PR DESCRIPTION
## Motivation

Optimize Bowe Hopwood Pedersen hashing function

## Approaches taken
* Removed use of concurrency since it was hurting (bad use case)
* Removed 2 heap allocations (now zero)
* Enforced single copy of input only
* Created lookup table for bit lookups

## Approaches possible going forward
* Use a larger (I think most optimally 24-bit lookup table) so we can do less/no bit arithmetic
  * Note that since we usually do 8 windows, that would take 128 MB of static/on-load-init memory which is kinda big and probably costly to make at runtime. Definitely costly to store in memory.
* Create a specialized variant that requires input to be prepadded for zero-copy

Note that shrinking the stack buffer isn't listed since this aught not to be an expensive allocation (its not heap, just zeroing), and actual testing yielded nothing of significance.

## Effects
* Hash speed is about 70% faster in benchmarks matching merkle tree configuration
  * Should snarkOS improve load times by ~70%
  * Should improve block sync time by ~70%
