### PR TITLE
Parallelize Merkle Tree Build & Rebuild

### DIFF
--- a/algorithms/benches/crh/bowe_pedersen.rs
+++ b/algorithms/benches/crh/bowe_pedersen.rs
@@ -63,7 +63,7 @@ criterion_group! {
 
 criterion_group! {
     name = bowe_crh_hash;
-    config = Criterion::default().sample_size(50);
+    config = Criterion::default().sample_size(5000);
     targets = bowe_pedersen_crh_hash
 }
 

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -41,10 +41,30 @@ pub struct MerkleTree<P: MerkleParameters> {
     parameters: Arc<P>,
 }
 
-impl<P: MerkleParameters> MerkleTree<P> {
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
     pub const DEPTH: u8 = P::DEPTH as u8;
 
-    pub fn new<L: ToBytes, I: ExactSizeIterator<Item = L>>(parameters: Arc<P>, leaves: I) -> Result<Self, MerkleError> {
+    fn hash_row<L: ToBytes + Send + Sync>(
+        parameters: &P,
+        leaves: &[L],
+    ) -> Result<Vec<Vec<<<P as MerkleParameters>::H as CRH>::Output>>, MerkleError> {
+        let hash_input_size_in_bytes = (P::H::INPUT_SIZE_BITS / 8) * 2;
+        cfg_chunks!(leaves, 500)
+            .map(|chunk| -> Result<Vec<_>, MerkleError> {
+                let mut buffer = vec![0u8; hash_input_size_in_bytes];
+                let mut out = Vec::with_capacity(chunk.len());
+                for leaf in chunk.into_iter() {
+                    out.push(parameters.hash_leaf(&leaf, &mut buffer)?);
+                }
+                Ok(out)
+            })
+            .collect::<Result<Vec<_>, MerkleError>>()
+    }
+
+    pub fn new<L: ToBytes + Send + Sync>(parameters: Arc<P>, leaves: &[L]) -> Result<Self, MerkleError> {
         let new_time = start_timer!(|| "MerkleTree::new");
 
         let last_level_size = leaves.len().next_power_of_two();
@@ -70,9 +90,14 @@ impl<P: MerkleParameters> MerkleTree<P> {
         // Compute and store the hash values for each leaf.
         let hash_input_size_in_bytes = (P::H::INPUT_SIZE_BITS / 8) * 2;
         let last_level_index = level_indices.pop().unwrap_or(0);
-        let mut buffer = vec![0u8; hash_input_size_in_bytes];
-        for (i, leaf) in leaves.enumerate() {
-            tree[last_level_index + i] = parameters.hash_leaf(&leaf, &mut buffer)?;
+
+        let subsections = Self::hash_row(&*parameters, leaves)?;
+
+        let mut subsection_index = 0;
+        for subsection in subsections.into_iter() {
+            tree[last_level_index + subsection_index..last_level_index + subsection_index + subsection.len()]
+                .copy_from_slice(&subsection[..]);
+            subsection_index += subsection.len();
         }
 
         // Compute the hash values for every node in the tree.
@@ -81,13 +106,19 @@ impl<P: MerkleParameters> MerkleTree<P> {
         level_indices.reverse();
         for &start_index in &level_indices {
             // Iterate over the current level.
-            for current_index in start_index..upper_bound {
-                let left_index = left_child(current_index);
-                let right_index = right_child(current_index);
+            let hashings = (start_index..upper_bound)
+                .map(|i| (&tree[left_child(i)], &tree[right_child(i)]))
+                .collect::<Vec<_>>();
 
-                // Compute Hash(left || right).
-                tree[current_index] = parameters.hash_inner_node(&tree[left_index], &tree[right_index], &mut buffer)?;
+            let hashes = Self::hash_row(&*parameters, &hashings[..])?;
+
+            let mut subsection_index = 0;
+            for subsection in hashes.into_iter() {
+                tree[start_index + subsection_index..start_index + subsection_index + subsection.len()]
+                    .copy_from_slice(&subsection[..]);
+                subsection_index += subsection.len();
             }
+
             upper_bound = start_index;
         }
 
@@ -118,10 +149,10 @@ impl<P: MerkleParameters> MerkleTree<P> {
         })
     }
 
-    pub fn rebuild<L: ToBytes, I: ExactSizeIterator<Item = L>, J: ExactSizeIterator<Item = L>>(
+    pub fn rebuild<L: ToBytes + Send + Sync, I: ExactSizeIterator<Item = L>>(
         &self,
         old_leaves: I,
-        new_leaves: J,
+        new_leaves: &[L],
     ) -> Result<Self, MerkleError> {
         let new_time = start_timer!(|| "MerkleTree::rebuild");
 
@@ -151,14 +182,16 @@ impl<P: MerkleParameters> MerkleTree<P> {
         // Compute and store the hash values for each leaf.
         let hash_input_size_in_bytes = (P::H::INPUT_SIZE_BITS / 8) * 2;
         let last_level_index = level_indices.pop().unwrap_or(0);
-        let mut buffer = vec![0u8; hash_input_size_in_bytes];
 
         // The beginning of the tree can be reconstructed from pre-existing hashed leaves.
         tree[last_level_index..][..old_leaves.len()].clone_from_slice(&self.hashed_leaves()[..old_leaves.len()]);
 
         // The new leaves require hashing.
-        for (i, leaf) in new_leaves.enumerate() {
-            tree[last_level_index + old_leaves.len() + i] = self.parameters.hash_leaf(&leaf, &mut buffer)?;
+        let subsections = Self::hash_row(&*self.parameters, new_leaves)?;
+
+        for (i, subsection) in subsections.into_iter().enumerate() {
+            tree[last_level_index + old_leaves.len() + i..last_level_index + old_leaves.len() + i + subsection.len()]
+                .copy_from_slice(&subsection[..]);
         }
 
         // Compute the hash values for every node in the tree.

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -52,7 +52,7 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
         leaves: &[L],
     ) -> Result<Vec<Vec<<<P as MerkleParameters>::H as CRH>::Output>>, MerkleError> {
         let hash_input_size_in_bytes = (P::H::INPUT_SIZE_BITS / 8) * 2;
-        cfg_chunks!(leaves, 500)
+        cfg_chunks!(leaves, 500) // arbitrary, experimentally derived
             .map(|chunk| -> Result<Vec<_>, MerkleError> {
                 let mut buffer = vec![0u8; hash_input_size_in_bytes];
                 let mut out = Vec::with_capacity(chunk.len());

--- a/algorithms/src/traits/commitment.rs
+++ b/algorithms/src/traits/commitment.rs
@@ -24,7 +24,7 @@ use rand::Rng;
 use std::{fmt::Debug, hash::Hash};
 
 pub trait CommitmentScheme: Sized + Clone + From<<Self as CommitmentScheme>::Parameters> {
-    type Output: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes;
+    type Output: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + Sync + Send;
     type Parameters: Clone + Debug + Eq + ToBytes + FromBytes;
     type Randomness: Clone + Debug + Default + Eq + UniformRand + ToBytes + FromBytes;
 

--- a/algorithms/src/traits/crh.rs
+++ b/algorithms/src/traits/crh.rs
@@ -28,7 +28,7 @@ pub trait CRHParameters: Clone + Debug + ToBytes + FromBytes + Eq {
 }
 
 pub trait CRH: Clone + From<<Self as CRH>::Parameters> {
-    type Output: Clone + Debug + Display + ToBytes + FromBytes + Eq + Hash + Default;
+    type Output: Clone + Debug + Display + ToBytes + FromBytes + Eq + Hash + Default + Send + Sync + Copy;
     type Parameters: CRHParameters;
 
     const INPUT_SIZE_BITS: usize;

--- a/algorithms/src/traits/merkle_tree.rs
+++ b/algorithms/src/traits/merkle_tree.rs
@@ -20,7 +20,7 @@ use snarkvm_utilities::bytes::ToBytes;
 use rand::Rng;
 use std::io::Cursor;
 
-pub trait MerkleParameters: Clone + Default {
+pub trait MerkleParameters: Send + Sync + Clone + Default {
     type H: CRH;
 
     const DEPTH: usize;

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -131,7 +131,7 @@ fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: Mas
     use_bad_root: bool,
 ) {
     let parameters = P::default();
-    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), leaves.iter()).unwrap();
+    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), &leaves[..]).unwrap();
     let root = tree.root();
 
     let mut cs = TestConstraintSystem::<F>::new();

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -62,7 +62,7 @@ fn generate_merkle_tree<P: MerkleParameters, F: PrimeField, HG: CRHGadget<P::H, 
     use_bad_root: bool,
 ) {
     let parameters = P::default();
-    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), leaves.iter()).unwrap();
+    let tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), &leaves[..]).unwrap();
     let root = tree.root();
     let mut satisfied = true;
     for (i, leaf) in leaves.iter().enumerate() {

--- a/objects/src/pedersen_merkle_tree.rs
+++ b/objects/src/pedersen_merkle_tree.rs
@@ -80,14 +80,14 @@ pub fn pedersen_merkle_root(hashes: &[[u8; 32]]) -> PedersenMerkleRootHash {
 
 /// Calculates the root of the Merkle tree using a Pedersen Hash instantiated with a PRNG
 pub fn pedersen_merkle_root_hash(hashes: &[[u8; 32]]) -> Fr {
-    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes.iter()).expect("could not create merkle tree");
+    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes).expect("could not create merkle tree");
     tree.root()
 }
 
 /// Calculates the root of the Merkle tree using a Pedersen Hash instantiated with a PRNG and the
 /// base layer hashes leaved
 pub fn pedersen_merkle_root_hash_with_leaves(hashes: &[[u8; 32]]) -> (Fr, Vec<Fr>) {
-    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes.iter()).expect("could not create merkle tree");
+    let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes).expect("could not create merkle tree");
     (tree.root(), tree.hashed_leaves().to_vec())
 }
 

--- a/objects/src/traits/transaction.rs
+++ b/objects/src/traits/transaction.rs
@@ -20,7 +20,7 @@ use snarkvm_utilities::bytes::{FromBytes, ToBytes};
 use std::hash::Hash;
 
 pub trait Transaction: Clone + Eq + FromBytes + ToBytes {
-    type Commitment: Clone + Eq + Hash + FromBytes + ToBytes;
+    type Commitment: Clone + Eq + Hash + FromBytes + ToBytes + Sync + Send;
     type Digest: Clone + Eq + Hash + FromBytes + ToBytes;
     type InnerSNARKID: Clone + Eq + FromBytes + ToBytes;
     type LocalDataRoot: Clone + Eq + Hash + FromBytes + ToBytes;

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -172,7 +172,7 @@ mod test {
 
         let nonce = [1; 32];
         let leaves = vec![vec![3u8; 32]; 7];
-        let tree = EdwardsMaskedMerkleTree::new(Arc::new(parameters.clone()), leaves.iter()).unwrap();
+        let tree = EdwardsMaskedMerkleTree::new(Arc::new(parameters.clone()), &leaves[..]).unwrap();
         let root = tree.root();
         let mut root_bytes = [0; 32];
         root.write(&mut root_bytes[..]).unwrap();

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -115,6 +115,14 @@ impl<const N: usize> FromBytes for [u64; N] {
     }
 }
 
+impl<L: ToBytes, R: ToBytes> ToBytes for (L, R) {
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.0.write(&mut writer)?;
+        self.1.write(&mut writer)?;
+        Ok(())
+    }
+}
+
 /// Takes as input a sequence of structs, and converts them to a series of
 /// bytes. All traits that implement `Bytes` can be automatically converted to
 /// bytes in this manner.


### PR DESCRIPTION
This PR parallelizes merkle tree build and part of rebuild (only leaf hashing).

Saw a 4x improvement in tree build speed (800ms -> 200ms locally on benchmark). Subjectively, snarkOS loads instantly and syncs quite quickly, during CPU-bound bits.

Upper tree rebuild was not parallelized because A. more complex logic and B. far less hash iterations per rebuild than fresh building.

NOTE: This is a *breaking* change! This requires a minor version update to snarkVM, not a patch.