### PR TITLE
Make snarkos-toolkit WASM tests compile

### DIFF
--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -119,7 +119,6 @@ wasm = [
   "full",
   "snarkvm-algorithms/wasm",
   "snarkvm-gadgets/full",
-  "snarkvm-parameters/remote"
 ]
 print-trace = [ "snarkvm-profiler/print-trace" ]
 full = [ "testnet1" ]

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -143,7 +143,7 @@ macro_rules! impl_params_remote {
 
             #[cfg(not(any(test, feature = "remote")))]
             pub fn load_remote() -> Result<Vec<u8>, crate::errors::ParameterError> {
-                Err(ParameterError::RemoteFetchDisabled)
+                Err(crate::errors::ParameterError::RemoteFetchDisabled)
             }
 
             fn versioned_filename() -> String {


### PR DESCRIPTION
While `snarkos-toolkit` tests pass, the WASM ones failed; I think I've found the last missing bit - with these changes and snarkOS having its snarkVM dependencies changed to local paths, `cargo test --target wasm32-unknown-unknown --no-run` in `snarkos-toolkit` compiles for me.