### PR TITLE
Fix the Marlin verifier gadget with more than one input

### DIFF
--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -45,6 +45,7 @@ use crate::{
     PoseidonSponge,
     PoseidonSpongeVar,
 };
+use snarkvm_algorithms::fft::EvaluationDomain;
 
 /// The Marlin verification gadget.
 pub struct MarlinVerificationGadget<
@@ -136,6 +137,17 @@ where
         let mut fs_rng = prepared_verifying_key.fs_rng.clone();
 
         eprintln!("before AHP: constraints: {}", cs.num_constraints());
+
+        let public_input = {
+            let domain_x = EvaluationDomain::<TargetField>::new(public_input.len() + 1).unwrap();
+
+            let mut new_input = public_input.to_vec();
+            new_input.resize(
+                core::cmp::max(public_input.len(), domain_x.size() - 1),
+                NonNativeFieldVar::<TargetField, BaseField>::Constant(TargetField::zero()),
+            );
+            new_input
+        };
 
         fs_rng.absorb_nonnative_field_elements(
             cs.ns(|| "initial_absorb_nonnative_field_elements"),

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -521,13 +521,12 @@ where
                 println!("Size of evaluation domain x: {}", domain_x.size());
             }
 
-            let mut unpadded_input = public_input.to_vec();
-            unpadded_input.resize(
+            let mut new_input = public_input.to_vec();
+            new_input.resize(
                 core::cmp::max(public_input.len(), domain_x.size() - 1),
                 TargetField::zero(),
             );
-
-            unpadded_input
+            new_input
         };
 
         if cfg!(debug_assertions) {


### PR DESCRIPTION
## Motivation

Per Slack channel communication with @raychu86, the Marlin verifier gadget fails when there are two inputs, as evidenced by the two failing tests in our [bug/marlin-verification-inputs](https://github.com/AleoHQ/snarkVM/commit/aa7acdd2ad6e1f9d6a734e3e291c2ebe1a8b2006) branch.

An investigation shows that the problem comes from here:

When input has 2 elements [a, b], Marlin pads it to 4 [1, a, b, 0].
- The prover/verifier in the non-constraint world: push [1, a, b, 0] to the sponge
- The verifier gadget in the constraint world: push [1, a, b] to the sponge (ignoring the zero-padding), so there is inconsistency

Therefore, since the sponge is different, all the challenges are different, and the verifier gadget rejects the proof.

## Test Plan

After the changes, the code passes the two tests in the `bug/marlin-verification-inputs` branch. In addition, it passes all the existing 38 tests in the `marlin` subdirectory.

## Related PRs

N/A