### PR TITLE
Fix Marlin gadget's risky verifying key preparation

### DIFF
--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -117,6 +117,7 @@ where
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
+    PC::Commitment: ToConstraintField<BaseField>,
     PCG::VerifierKeyVar: ToConstraintFieldGadget<BaseField>,
     PCG::CommitmentVar: ToConstraintFieldGadget<BaseField>,
 {

--- a/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
@@ -31,6 +31,8 @@ pub struct CircuitVerifyingKeyVar<
     PC: PolynomialCommitment<TargetField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
 > {
+    /// The original key
+    pub origin_verifier_key: CircuitVerifyingKey<TargetField, PC>,
     /// The size of domain h
     pub domain_h_size: u64,
     /// The size of domain k
@@ -54,6 +56,7 @@ impl<
 {
     fn clone(&self) -> Self {
         Self {
+            origin_verifier_key: self.origin_verifier_key.clone(),
             domain_h_size: self.domain_h_size,
             domain_k_size: self.domain_k_size,
             domain_h_size_gadget: self.domain_h_size_gadget.clone(),
@@ -117,6 +120,7 @@ impl<
         })?;
 
         Ok(CircuitVerifyingKeyVar {
+            origin_verifier_key: (*ivk).clone(),
             domain_h_size: domain_h.size() as u64,
             domain_k_size: domain_k.size() as u64,
             domain_h_size_gadget,
@@ -158,6 +162,7 @@ impl<
         })?;
 
         Ok(CircuitVerifyingKeyVar {
+            origin_verifier_key: (*ivk).clone(),
             domain_h_size: domain_h.size() as u64,
             domain_k_size: domain_k.size() as u64,
             domain_h_size_gadget,
@@ -199,6 +204,7 @@ impl<
         })?;
 
         Ok(CircuitVerifyingKeyVar {
+            origin_verifier_key: (*ivk).clone(),
             domain_h_size: domain_h.size() as u64,
             domain_k_size: domain_k.size() as u64,
             domain_h_size_gadget,

--- a/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
@@ -24,11 +24,11 @@ use snarkvm_gadgets::{
     integers::uint::UInt8,
     traits::{
         alloc::{AllocBytesGadget, AllocGadget},
-        fields::{FieldGadget, ToConstraintFieldGadget},
+        fields::ToConstraintFieldGadget,
     },
 };
 use snarkvm_polycommit::{PCCheckVar, PrepareGadget};
-use snarkvm_r1cs::{ConstraintSystem, SynthesisError, TestConstraintSystem};
+use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use crate::{
@@ -118,8 +118,7 @@ where
             vk.origin_verifier_key
                 .circuit_commitments
                 .iter()
-                .enumerate()
-                .for_each(|(i, index_comm)| {
+                .for_each(|index_comm| {
                     vk_elems.append(&mut index_comm.to_field_elements().unwrap());
                 });
             vk_hash_rng.absorb_native_field_elements(&vk_elems);

--- a/polycommit/src/marlin_pc/gadgets/verifier_key/prepared_verifier_key.rs
+++ b/polycommit/src/marlin_pc/gadgets/verifier_key/prepared_verifier_key.rs
@@ -259,7 +259,7 @@ where
                     )?);
                 }
 
-                let d_gadget = FpGadget::<<BaseCurve as PairingEngine>::Fr>::alloc(
+                let d_gadget = FpGadget::<<BaseCurve as PairingEngine>::Fr>::alloc_constant(
                     cs.ns(|| format!("alloc_constant_d_{}", i)),
                     || Ok(<<BaseCurve as PairingEngine>::Fr as From<u128>>::from(*d as u128)),
                 )?;


### PR DESCRIPTION
## Motivation

First thanks to @raychu86 for discovering this issue. This PR is made to the `bug/marlin-verification-inputs` branch, as there is more to do before merging to `master`.

When Marlin’s constraint gadget prepares the key, it uses a trick to compute a hash of `CommitmentVar<F>` in the native world; this trick breaks the wall between the constraint world and the native world.

This trick is used at that time because arkworks-rs did not have `ToConstraintField` widely implemented in the native world. So, that was the only way to do `to_constraint_elements`. Soon after that arkworks-rs has a wide implementation of `ToConstraintField` for all SW and TE curve points and snarkVM, but we haven't updated these implementations.

This trick would work fine unless the R1CS has another optimization… Recall that for efficiency, `Setup` does not store any values for efficiency; therefore, when key preparation breaks the wall, it sees all zeros in `Setup`, but meaningful real values in `Prove`.

Therefore, `Setup` believes that the `vk` has a very different hash, though `Prove` disagrees. 

The Marlin’s constraint gadget has a few other places also breaking this wall, which is left as a to-do for cleanup.

## Test is still failing

This is due to the same reason, but in the poly-commit, and requires a big-picture change. See https://github.com/AleoHQ/snarkVM/issues/210 for more discussion.
