### PR TITLE
Fix the Marlin verifier

### DIFF
--- a/marlin/src/ahp/ahp.rs
+++ b/marlin/src/ahp/ahp.rs
@@ -291,6 +291,8 @@ pub trait EvaluationsProvider<F: Field> {
 impl<'a, F: Field> EvaluationsProvider<F> for snarkvm_polycommit::Evaluations<'a, F> {
     fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F, AHPError> {
         let key = (lc.label.clone(), point);
+        println!("{:?}", self.keys());
+        println!("{:?}", key);
         self.get(&key)
             .copied()
             .ok_or_else(|| AHPError::MissingEval(lc.label.clone()))

--- a/marlin/src/ahp/ahp.rs
+++ b/marlin/src/ahp/ahp.rs
@@ -291,8 +291,6 @@ pub trait EvaluationsProvider<F: Field> {
 impl<'a, F: Field> EvaluationsProvider<F> for snarkvm_polycommit::Evaluations<'a, F> {
     fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F, AHPError> {
         let key = (lc.label.clone(), point);
-        println!("{:?}", self.keys());
-        println!("{:?}", key);
         self.get(&key)
             .copied()
             .ok_or_else(|| AHPError::MissingEval(lc.label.clone()))

--- a/marlin/src/ahp/verifier/verifier.rs
+++ b/marlin/src/ahp/verifier/verifier.rs
@@ -139,10 +139,10 @@ impl<TargetField: PrimeField> AHPForR1CS<TargetField> {
         //  LinearCombination::new("z_b", vec![(F::one(), z_b)])
         //  LinearCombination::new("g_1", vec![(F::one(), g_1)], rhs::new(g_1_at_beta))
         //  LinearCombination::new("t", vec![(F::one(), t)])
-        query_set.insert(("g_1".into(), beta));
-        query_set.insert(("z_b".into(), beta));
-        query_set.insert(("t".into(), beta));
-        query_set.insert(("outer_sumcheck".into(), beta));
+        query_set.insert(("g_1".into(), ("beta".into(), beta)));
+        query_set.insert(("z_b".into(), ("beta".into(), beta)));
+        query_set.insert(("t".into(), ("beta".into(), beta)));
+        query_set.insert(("outer_sumcheck".into(), ("beta".into(), beta)));
 
         // For the second linear combination
         // Inner sumcheck test:
@@ -202,16 +202,16 @@ impl<TargetField: PrimeField> AHPForR1CS<TargetField> {
         // // This LC is the only one that is evaluated:
         // let inner_sumcheck = a_poly_lc - (b_lc * (gamma * &g_2_at_gamma + &(t_at_beta / &k_size))) - h_lc
         // main_lc.set_label("inner_sumcheck");
-        query_set.insert(("g_2".into(), gamma));
-        query_set.insert(("a_denom".into(), gamma));
-        query_set.insert(("b_denom".into(), gamma));
-        query_set.insert(("c_denom".into(), gamma));
-        query_set.insert(("inner_sumcheck".into(), gamma));
+        query_set.insert(("g_2".into(), ("gamma".into(), gamma)));
+        query_set.insert(("a_denom".into(), ("gamma".into(), gamma)));
+        query_set.insert(("b_denom".into(), ("gamma".into(), gamma)));
+        query_set.insert(("c_denom".into(), ("gamma".into(), gamma)));
+        query_set.insert(("inner_sumcheck".into(), ("gamma".into(), gamma)));
 
         if with_vanishing {
-            query_set.insert(("vanishing_poly_h_alpha".into(), alpha));
-            query_set.insert(("vanishing_poly_h_beta".into(), beta));
-            query_set.insert(("vanishing_poly_k_gamma".into(), gamma));
+            query_set.insert(("vanishing_poly_h_alpha".into(), ("alpha".into(), alpha)));
+            query_set.insert(("vanishing_poly_h_beta".into(), ("beta".into(), beta)));
+            query_set.insert(("vanishing_poly_k_gamma".into(), ("gamma".into(), gamma)));
         }
 
         (query_set, state)

--- a/marlin/src/constraints/ahp.rs
+++ b/marlin/src/constraints/ahp.rs
@@ -1786,11 +1786,11 @@ mod test {
 
         let mut evaluation_labels = Vec::<(String, Fr)>::new();
 
-        for q in query_set.iter().cloned() {
-            if AHPForR1CSNative::<Fr>::LC_WITH_ZERO_EVAL.contains(&q.0.as_ref()) {
-                evaluations.insert(q, Fr::zero());
+        for (label, (_point_name, q)) in query_set.iter().cloned() {
+            if AHPForR1CSNative::<Fr>::LC_WITH_ZERO_EVAL.contains(&label.as_ref()) {
+                evaluations.insert((label, q), Fr::zero());
             } else {
-                evaluation_labels.push(q);
+                evaluation_labels.push((label, q));
             }
         }
         evaluation_labels.sort_by(|a, b| a.0.cmp(&b.0));
@@ -2087,11 +2087,11 @@ mod test {
 
         let mut evaluation_labels = Vec::<(String, Fr)>::new();
 
-        for q in query_set.iter().cloned() {
-            if AHPForR1CSNative::<Fr>::LC_WITH_ZERO_EVAL.contains(&q.0.as_ref()) {
-                evaluations.insert(q, Fr::zero());
+        for (label, (_point_name, q)) in query_set.iter().cloned() {
+            if AHPForR1CSNative::<Fr>::LC_WITH_ZERO_EVAL.contains(&label.as_ref()) {
+                evaluations.insert((label, q), Fr::zero());
             } else {
-                evaluation_labels.push(q);
+                evaluation_labels.push((label, q));
             }
         }
         evaluation_labels.sort_by(|a, b| a.0.cmp(&b.0));
@@ -2160,11 +2160,13 @@ mod test {
         let mut sorted_query_set_gadgets: Vec<_> = query_set_gadgets.0.iter().collect();
         sorted_query_set_gadgets.sort_by(|a, b| a.0.cmp(&b.0));
 
-        for (i, (query_native, query_gadget)) in query_set_native.iter().zip(sorted_query_set_gadgets).enumerate() {
-            assert_eq!(query_native.0, query_gadget.0);
+        for (i, ((label, (_query_point_name, query_native)), query_gadget)) in
+            query_set_native.iter().zip(sorted_query_set_gadgets).enumerate()
+        {
+            assert_eq!(label.clone(), query_gadget.0);
 
             let expected_query =
-                NonNativeFieldVar::alloc(cs.ns(|| format!("alloc_query{}", i)), || Ok(query_native.1)).unwrap();
+                NonNativeFieldVar::alloc(cs.ns(|| format!("alloc_query{}", i)), || Ok(query_native)).unwrap();
 
             expected_query
                 .enforce_equal(cs.ns(|| format!("enforce_eq_query_{}", i)), &query_gadget.1.value)

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -439,7 +439,7 @@ where
 
         let eval_time = start_timer!(|| "Evaluating linear combinations over query set");
         let mut evaluations_unsorted = Vec::new();
-        for (label, point) in &query_set {
+        for (label, (_point_name, point)) in &query_set {
             let lc = lc_s
                 .iter()
                 .find(|lc| &lc.label == label)
@@ -645,11 +645,11 @@ where
 
         let mut evaluation_labels = Vec::<(String, TargetField)>::new();
 
-        for q in query_set.iter().cloned() {
-            if AHPForR1CS::<TargetField>::LC_WITH_ZERO_EVAL.contains(&q.0.as_ref()) {
-                evaluations.insert(q, TargetField::zero());
+        for (label, (_point_name, q)) in query_set.iter().cloned() {
+            if AHPForR1CS::<TargetField>::LC_WITH_ZERO_EVAL.contains(&label.as_ref()) {
+                evaluations.insert((label, q), TargetField::zero());
             } else {
-                evaluation_labels.push(q);
+                evaluation_labels.push((label, q));
             }
         }
         evaluation_labels.sort_by(|a, b| a.0.cmp(&b.0));

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -120,13 +120,13 @@ pub mod sonic_pc;
 /// pair, where `label` is the label of a polynomial in `p`, and `query` is the field element
 /// that `p[label]` is to be queried at.
 ///
-/// Added the third field: the point name
+/// Added the third field: the point name.
 pub type QuerySet<'a, T> = BTreeSet<(String, (String, T))>;
 
 /// `Evaluations` is the result of querying a set of labeled polynomials or equations
 /// `p` at a `QuerySet` `Q`. It maps each element of `Q` to the resulting evaluation.
 /// That is, if `(label, query)` is an element of `Q`, then `evaluation.get((label, query))`
-/// should equal `p[label].evaluate(query)`
+/// should equal `p[label].evaluate(query)`.
 pub type Evaluations<'a, F> = BTreeMap<(String, F), F>;
 
 /// A proof of satisfaction of linear combinations.

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -119,12 +119,14 @@ pub mod sonic_pc;
 /// `p` that have previously been committed to. Each element of a `QuerySet` is a `(label, query)`
 /// pair, where `label` is the label of a polynomial in `p`, and `query` is the field element
 /// that `p[label]` is to be queried at.
-pub type QuerySet<'a, F> = BTreeSet<(String, F)>;
+///
+/// Added the third field: the point name
+pub type QuerySet<'a, T> = BTreeSet<(String, (String, T))>;
 
 /// `Evaluations` is the result of querying a set of labeled polynomials or equations
 /// `p` at a `QuerySet` `Q`. It maps each element of `Q` to the resulting evaluation.
 /// That is, if `(label, query)` is an element of `Q`, then `evaluation.get((label, query))`
-/// should equal `p[label].evaluate(query)`.
+/// should equal `p[label].evaluate(query)`
 pub type Evaluations<'a, F> = BTreeMap<(String, F), F>;
 
 /// A proof of satisfaction of linear combinations.
@@ -256,13 +258,15 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
 
         let mut query_to_labels_map = BTreeMap::new();
 
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
 
         let mut proofs = Vec::with_capacity(query_to_labels_map.len());
-        for (query, labels) in query_to_labels_map.into_iter() {
+        for (_point_name, (query, labels)) in query_to_labels_map.into_iter() {
             let mut query_polys = Vec::with_capacity(labels.len());
             let mut query_rands = Vec::with_capacity(labels.len());
             let mut query_comms = Vec::with_capacity(labels.len());
@@ -327,9 +331,11 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
     {
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
 
         // Implicit assumption: proofs are order in same manner as queries in
@@ -338,7 +344,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
         assert_eq!(proofs.len(), query_to_labels_map.len());
 
         let mut result = true;
-        for ((query, labels), proof) in query_to_labels_map.into_iter().zip(proofs) {
+        for ((_point_name, (query, labels)), proof) in query_to_labels_map.into_iter().zip(proofs) {
             let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::with_capacity(labels.len());
             let mut values = Vec::with_capacity(labels.len());
             for label in labels.into_iter() {
@@ -424,9 +430,14 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
         let lc_s: BTreeMap<_, _> = linear_combinations.into_iter().map(|lc| (lc.label(), lc)).collect();
 
         let poly_query_set = lc_query_set_to_poly_query_set(lc_s.values().copied(), eqn_query_set);
-        let poly_evals: Evaluations<_> = poly_query_set.iter().cloned().zip(evals.clone().unwrap()).collect();
+        let poly_evals: Evaluations<_> = poly_query_set
+            .iter()
+            .map(|(_, point)| point)
+            .cloned()
+            .zip(evals.clone().unwrap())
+            .collect();
 
-        for &(ref lc_label, point) in eqn_query_set {
+        for &(ref lc_label, (_, point)) in eqn_query_set {
             if let Some(lc) = lc_s.get(lc_label) {
                 let claimed_rhs = *eqn_evaluations
                     .get(&(lc_label.clone(), point))
@@ -508,7 +519,7 @@ pub fn evaluate_query_set<'a, F: Field>(
 ) -> Evaluations<'a, F> {
     let polys: BTreeMap<_, _> = polys.into_iter().map(|p| (p.label(), p)).collect();
     let mut evaluations = Evaluations::new();
-    for (label, point) in query_set {
+    for (label, (_point_name, point)) in query_set {
         let poly = polys.get(label).expect("polynomial in evaluated lc is not found");
         let eval = poly.evaluate(*point);
         evaluations.insert((label.clone(), *point), eval);
@@ -523,11 +534,11 @@ fn lc_query_set_to_poly_query_set<'a, F: 'a + Field>(
     let mut poly_query_set = QuerySet::new();
     let lc_s = linear_combinations.into_iter().map(|lc| (lc.label(), lc));
     let linear_combinations: BTreeMap<_, _> = lc_s.collect();
-    for (lc_label, point) in query_set {
+    for (lc_label, (point_name, point)) in query_set {
         if let Some(lc) = linear_combinations.get(lc_label) {
             for (_, poly_label) in lc.iter().filter(|(_, l)| !l.is_one()) {
                 if let LCTerm::PolyLabel(l) = poly_label {
-                    poly_query_set.insert((l.into(), *point));
+                    poly_query_set.insert((l.into(), (point_name.clone(), *point)));
                 }
             }
         }
@@ -603,7 +614,7 @@ pub mod tests {
             let mut values = Evaluations::new();
             let point = F::rand(rng);
             for (i, label) in labels.iter().enumerate() {
-                query_set.insert((label.clone(), point));
+                query_set.insert((label.clone(), ("rand".into(), point)));
                 let value = polynomials[i].evaluate(point);
                 values.insert((label.clone(), point), value);
             }
@@ -699,10 +710,10 @@ pub mod tests {
             let mut query_set = QuerySet::new();
             let mut values = Evaluations::new();
             // let mut point = F::one();
-            for _ in 0..num_points_in_query_set {
+            for point_id in 0..num_points_in_query_set {
                 let point = F::rand(rng);
                 for (i, label) in labels.iter().enumerate() {
-                    query_set.insert((label.clone(), point));
+                    query_set.insert((label.clone(), (format!("rand_{}", point_id), point)));
                     let value = polynomials[i].evaluate(point);
                     values.insert((label.clone(), point), value);
                 }
@@ -857,7 +868,7 @@ pub mod tests {
                     if !lc.is_empty() {
                         linear_combinations.push(lc);
                         // Insert query
-                        query_set.insert((label.clone(), point));
+                        query_set.insert((label.clone(), (format!("rand_{}", i), point)));
                     }
                 }
             }

--- a/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
+++ b/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
@@ -141,7 +141,7 @@ where
         > = lc_info.iter().map(|c| (c.0.clone(), c.clone())).collect();
 
         let mut query_to_labels_map: BTreeMap<
-            <TargetCurve as PairingEngine>::Fr,
+            String,
             (
                 NonNativeFieldVar<<TargetCurve as PairingEngine>::Fr, <BaseCurve as PairingEngine>::Fr>,
                 BTreeSet<&String>,
@@ -152,18 +152,9 @@ where
         let mut sorted_query_set_gadgets: Vec<_> = query_set.0.iter().collect();
         sorted_query_set_gadgets.sort_by(|a, b| a.0.cmp(&b.0));
 
-        for (i, (label, point)) in sorted_query_set_gadgets.iter().enumerate() {
-            //TODO (raychu86): Changed entry `point.name` to `point.value` to preserve the same ordering,
-            // as the native implementation
-
-            // TODO (raychu86): Workaround for `AssignmentMissing` error in setup
-            let entry = match point.value.value() {
-                Ok(val) => val,
-                Err(_) => <TargetCurve as PairingEngine>::Fr::from(i as u128),
-            };
-
+        for (label, point) in sorted_query_set_gadgets.iter() {
             let labels = query_to_labels_map
-                .entry(entry)
+                .entry(point.name.clone())
                 .or_insert((point.value.clone(), BTreeSet::new()));
             labels.1.insert(label);
         }

--- a/polycommit/src/marlin_pc/gadgets/proof/batch_lc_proof.rs
+++ b/polycommit/src/marlin_pc/gadgets/proof/batch_lc_proof.rs
@@ -245,7 +245,7 @@ mod tests {
         let mut lc = LinearCombination::empty(label.clone());
         lc.push((Fr::one(), label.to_string().into()));
         lc_s.push(lc);
-        query_set.insert((label, random_point.clone()));
+        query_set.insert((label, ("rand".into(), random_point.clone())));
 
         let challenge = Fr::rand(rng);
 

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -369,16 +369,18 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label().to_owned(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
 
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
         assert_eq!(proof.len(), query_to_labels_map.len());
 
         let mut combined_comms = Vec::with_capacity(query_to_labels_map.len());
         let mut combined_queries = Vec::with_capacity(query_to_labels_map.len());
         let mut combined_evals = Vec::with_capacity(query_to_labels_map.len());
-        for (query, labels) in query_to_labels_map.into_iter() {
+        for (_point_name, (query, labels)) in query_to_labels_map.into_iter() {
             let lc_time = start_timer!(|| format!("Randomly combining {} commitments", labels.len()));
             let mut comms_to_combine = Vec::with_capacity(labels.len());
             let mut values_to_combine = Vec::with_capacity(labels.len());
@@ -876,13 +878,15 @@ impl<E: PairingEngine> MarlinKZG10<E> {
 
         let mut query_to_labels_map = BTreeMap::new();
 
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
 
         let mut proofs = Vec::new();
-        for (query, labels) in query_to_labels_map.into_iter() {
+        for (_point_name, (query, labels)) in query_to_labels_map.into_iter() {
             let mut query_polys: Vec<&'a LabeledPolynomial<_>> = Vec::new();
             let mut query_rands: Vec<&'a <Self as PolynomialCommitment<E::Fr>>::Randomness> = Vec::new();
             let mut query_comms: Vec<&'a LabeledCommitment<<Self as PolynomialCommitment<E::Fr>>::Commitment>> =
@@ -1031,15 +1035,17 @@ impl<E: PairingEngine> MarlinKZG10<E> {
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
 
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
 
         let mut combined_comms = Vec::new();
         let mut combined_queries = Vec::new();
         let mut combined_evals = Vec::new();
-        for (point, labels) in query_to_labels_map.into_iter() {
+        for (_point_name, (point, labels)) in query_to_labels_map.into_iter() {
             let lc_time = start_timer!(|| format!("Randomly combining {} commitments", labels.len()));
             let mut comms_to_combine: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values_to_combine = Vec::new();

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -335,9 +335,11 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label().to_owned(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
 
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
 
         assert_eq!(proof.len(), query_to_labels_map.len());
@@ -348,7 +350,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
         let mut combined_witness: E::G1Projective = E::G1Projective::zero();
         let mut combined_adjusted_witness: E::G1Projective = E::G1Projective::zero();
 
-        for ((query, labels), p) in query_to_labels_map.into_iter().zip(proof) {
+        for ((_query_name, (query, labels)), p) in query_to_labels_map.into_iter().zip(proof) {
             let mut comms_to_combine: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values_to_combine = Vec::new();
             for label in labels.into_iter() {
@@ -606,11 +608,12 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
         let poly_query_set = lc_query_set_to_poly_query_set(lc_s.values().copied(), eqn_query_set);
         let poly_evals: Evaluations<_> = poly_query_set
             .iter()
+            .map(|(_, point)| point)
             .cloned()
             .zip(evaluations.clone().unwrap())
             .collect();
 
-        for &(ref lc_label, ref point) in eqn_query_set {
+        for &(ref lc_label, (_, ref point)) in eqn_query_set {
             if let Some(lc) = lc_s.get(lc_label) {
                 let claimed_rhs =
                     *eqn_evaluations
@@ -729,13 +732,15 @@ impl<E: PairingEngine> SonicKZG10<E> {
 
         let mut query_to_labels_map = BTreeMap::new();
 
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
 
         let mut proofs = Vec::new();
-        for (query, labels) in query_to_labels_map.into_iter() {
+        for (_query_name, (query, labels)) in query_to_labels_map.into_iter() {
             let mut query_polys: Vec<&'a LabeledPolynomial<_>> = Vec::new();
             let mut query_rands: Vec<&'a <Self as PolynomialCommitment<E::Fr>>::Randomness> = Vec::new();
             let mut query_comms: Vec<&'a LabeledCommitment<<Self as PolynomialCommitment<E::Fr>>::Commitment>> =
@@ -821,9 +826,11 @@ impl<E: PairingEngine> SonicKZG10<E> {
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label(), c)).collect();
 
         let mut query_to_labels_map = BTreeMap::new();
-        for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
-            labels.insert(label);
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map
+                .entry(point_name)
+                .or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
         }
 
         // Implicit assumption: proofs are order in same manner as queries in
@@ -832,7 +839,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
         assert_eq!(proofs.len(), query_to_labels_map.len());
 
         let mut result = true;
-        for ((point, labels), proof) in query_to_labels_map.into_iter().zip(proofs) {
+        for ((_point_name, (point, labels)), proof) in query_to_labels_map.into_iter().zip(proofs) {
             let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values = Vec::new();
             for label in labels {


### PR DESCRIPTION
## Motivation

This PR fixes the Marlin verifier. I will push the `bug/marlin-verification-inputs` first. Then, I will push to `feat/testnet2-dpc` in a separate PR, given that there are conflicts that GitHub cannot automatically merge, 

The fix consists of two parts:

- In the Marlin verifier gadgets, sort the points by names instead of values. 
- In the Marlin prover, outputs the proofs' evaluations in the order of point names rather than point values.

## Test Plan

The tests in poly-commit and marlin all pass. 

## Related PRs

This closes #210.
