### PR TITLE
Fix the compilation error in the latest feat/testnet2-dpc

### DIFF
--- a/marlin/src/constraints/snark.rs
+++ b/marlin/src/constraints/snark.rs
@@ -700,7 +700,7 @@ pub mod multiple_input_tests {
 
     pub struct VerifierCircuit<
         F: PrimeField,
-        ConstraintF: PrimeField,
+        ConstraintF: PrimeField + PoseidonMDSField,
         PC: PolynomialCommitment<F>,
         FS: FiatShamirRng<F, ConstraintF>,
         MM: MarlinMode,
@@ -725,7 +725,7 @@ pub mod multiple_input_tests {
 
     impl<
         F: PrimeField,
-        ConstraintF: PrimeField,
+        ConstraintF: PrimeField + PoseidonMDSField,
         PC: PolynomialCommitment<F>,
         FS: FiatShamirRng<F, ConstraintF>,
         MM: MarlinMode,


### PR DESCRIPTION
## Motivation

It appears that the new Poseidon infrastructure causes a compilation error in the feat/testnet2-dpc branch. This PR fixes it. 

## Test Plan

Passes the test in snarkvm-marlin. Based on CircleCI, this is where it fails.

## Related PRs

#220 

@howardwu 