### PR TITLE
Batch verification for Groth16 and preparation for batch verification gadgets

### DIFF
--- a/algorithms/src/snark/groth16/verifier.rs
+++ b/algorithms/src/snark/groth16/verifier.rs
@@ -19,6 +19,10 @@ use snarkvm_curves::traits::{PairingCurve, PairingEngine};
 use snarkvm_r1cs::errors::SynthesisError;
 
 use core::ops::{AddAssign, Mul, Neg};
+use rand::RngCore;
+use snarkvm_curves::{AffineCurve, ProjectiveCurve};
+use snarkvm_fields::One;
+use snarkvm_utilities::UniformRand;
 
 pub fn prepare_verifying_key<E: PairingEngine>(vk: VerifyingKey<E>) -> PreparedVerifyingKey<E> {
     let alpha_g1_beta_g2 = E::pairing(vk.alpha_g1, vk.beta_g2);
@@ -42,15 +46,15 @@ pub fn verify_proof<E: PairingEngine>(
         return Err(SynthesisError::MalformedVerifyingKey);
     }
 
-    let mut g_ic = pvk.gamma_abc_g1()[0];
+    let mut g_ic = pvk.gamma_abc_g1()[0].into_projective();
     for (i, b) in public_inputs.iter().zip(pvk.gamma_abc_g1().iter().skip(1)) {
-        g_ic.add_assign(b.mul(*i));
+        g_ic.add_assign(b.into_projective().mul(*i));
     }
 
     let qap = E::miller_loop(
         [
             (&proof.a.prepare(), &proof.b.prepare()),
-            (&g_ic.prepare(), &pvk.gamma_g2_neg_pc),
+            (&g_ic.into_affine().prepare(), &pvk.gamma_g2_neg_pc),
             (&proof.c.prepare(), &pvk.delta_g2_neg_pc),
         ]
         .iter()
@@ -60,4 +64,83 @@ pub fn verify_proof<E: PairingEngine>(
     let test = E::final_exponentiation(&qap).ok_or(SynthesisError::UnexpectedIdentity)?;
 
     Ok(test == pvk.alpha_g1_beta_g2)
+}
+
+pub fn batch_verify_proof<E: PairingEngine, R: RngCore>(
+    pvk: &PreparedVerifyingKey<E>,
+    proofs: &[Proof<E>],
+    public_inputs: &[Vec<E::Fr>],
+    mut rng: R,
+) -> Result<bool, SynthesisError> {
+    assert_eq!(proofs.len(), public_inputs.len());
+
+    let mut r_powers = Vec::with_capacity(proofs.len());
+    for _ in 0..proofs.len() {
+        let challenge: E::Fr = u128::rand(&mut rng).into();
+        r_powers.push(challenge);
+    }
+
+    let combined_inputs = {
+        let randomized_inputs = public_inputs
+            .iter()
+            .zip(&r_powers)
+            .map(|(input, r)| {
+                let mut g_ic = pvk.vk.gamma_abc_g1[0].into_projective();
+                for (i, b) in input.iter().zip(pvk.vk.gamma_abc_g1.iter().skip(1)) {
+                    g_ic += &b.into_projective().mul(*i);
+                }
+                g_ic.mul(*r)
+            })
+            .collect::<Vec<E::G1Projective>>();
+
+        let mut combined_inputs = randomized_inputs[0];
+        for randomized_input in randomized_inputs.iter().skip(1) {
+            combined_inputs += randomized_input;
+        }
+        combined_inputs
+    };
+
+    let combined_proof_a_s = proofs
+        .iter()
+        .zip(&r_powers)
+        .map(|(proof, r)| proof.a.into_projective().mul(*r))
+        .collect::<Vec<_>>();
+    let combined_proof_a_s = E::G1Projective::batch_normalization_into_affine(combined_proof_a_s);
+    let ml_inputs = proofs
+        .iter()
+        .zip(&combined_proof_a_s)
+        .map(|(proof, a)| ((*a).prepare(), proof.b.prepare()))
+        .collect::<Vec<_>>();
+    let ml_inputs_ref = ml_inputs.iter().map(|(a, b)| (a, b)).collect::<Vec<_>>();
+    let a_r_times_b = E::miller_loop(ml_inputs_ref.iter().cloned());
+
+    let combined_c_s = {
+        let randomized_cs = proofs
+            .iter()
+            .zip(&r_powers)
+            .map(|(proof, r)| proof.c.into_projective().mul(*r))
+            .collect::<Vec<E::G1Projective>>();
+
+        let mut combined_c_s = randomized_cs[0];
+        for randomized_c in randomized_cs.iter().skip(1) {
+            combined_c_s += randomized_c;
+        }
+        combined_c_s
+    };
+
+    let sum_of_rs = (&r_powers).iter().copied().sum::<E::Fr>();
+    let combined_alpha = -pvk.vk.alpha_g1.mul(sum_of_rs);
+    let qap = E::miller_loop(
+        [
+            (&combined_alpha.prepare(), &pvk.vk.beta_g2.prepare()),
+            (&combined_inputs.into_affine().prepare(), &pvk.gamma_g2_neg_pc),
+            (&combined_c_s.into_affine().prepare(), &pvk.delta_g2_neg_pc),
+        ]
+        .iter()
+        .cloned(),
+    );
+
+    let test = E::final_exponentiation(&(qap * &a_r_times_b)).ok_or(SynthesisError::UnexpectedIdentity)?;
+
+    Ok(test == E::Fqk::one())
 }

--- a/gadgets/src/algorithms/snark/gm17.rs
+++ b/gadgets/src/algorithms/snark/gm17.rs
@@ -16,23 +16,20 @@
 
 use std::{borrow::Borrow, marker::PhantomData};
 
-use snarkvm_algorithms::snark::gm17::{Proof, VerifyingKey, GM17};
+use snarkvm_algorithms::snark::gm17::{Proof, VerifyingKey, GM17, PreparedVerifyingKey};
 use snarkvm_curves::traits::{AffineCurve, PairingEngine};
 use snarkvm_fields::{Field, ToConstraintField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
 use snarkvm_utilities::bytes::FromBytes;
 
-use crate::{
-    bits::{Boolean, ToBitsBEGadget, ToBytesGadget},
-    integers::uint::UInt8,
-    traits::{
-        algorithms::SNARKVerifierGadget,
-        alloc::{AllocBytesGadget, AllocGadget},
-        curves::{GroupGadget, PairingGadget},
-        eq::EqGadget,
-        fields::FieldGadget,
-    },
-};
+use crate::{bits::{Boolean, ToBitsBEGadget, ToBytesGadget}, integers::uint::UInt8, traits::{
+    algorithms::SNARKVerifierGadget,
+    alloc::{AllocBytesGadget, AllocGadget},
+    curves::{GroupGadget, PairingGadget},
+    eq::EqGadget,
+    fields::FieldGadget,
+}, PrepareToGadget};
+use snarkvm_curves::PairingCurve;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "P::G1Gadget: Clone, P::G2Gadget: Clone"))]
@@ -54,8 +51,8 @@ pub struct GM17VerifyingKeyGadget<Pairing: PairingEngine, F: Field, P: PairingGa
     pub query: Vec<P::G1Gadget>,
 }
 
-impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> GM17VerifyingKeyGadget<Pairing, F, P> {
-    pub fn prepare<CS: ConstraintSystem<F>>(
+impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> PrepareToGadget<GM17PreparedVerifyingKeyGadget<Pairing, F, P>, F> for GM17VerifyingKeyGadget<Pairing, F, P> {
+    fn prepare<CS: ConstraintSystem<F>>(
         &self,
         mut cs: CS,
     ) -> Result<GM17PreparedVerifyingKeyGadget<Pairing, F, P>, SynthesisError> {
@@ -92,6 +89,70 @@ pub struct GM17PreparedVerifyingKeyGadget<Pairing: PairingEngine, F: Field, P: P
     pub query: Vec<P::G1Gadget>,
 }
 
+impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> AllocGadget<PreparedVerifyingKey<Pairing>, F> for GM17PreparedVerifyingKeyGadget<Pairing, F, P> {
+    #[inline]
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<PreparedVerifyingKey<Pairing>>, CS: ConstraintSystem<F>>(mut cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
+        value_gen().and_then(|pvk| {
+            let pvk = pvk.borrow().clone();
+
+            let g_alpha = P::G1Gadget::alloc(&mut cs.ns(|| "g_alpha"), || Ok(pvk.g_alpha.into_projective()))?;
+            let h_beta = P::G2Gadget::alloc(&mut cs.ns(|| "h_beta"), || Ok(pvk.h_beta.into_projective()))?;
+            let g_alpha_pc = P::G1PreparedGadget::alloc(&mut cs.ns(|| "g_alpha_pc"), || Ok(pvk.g_alpha.prepare()))?;
+            let h_beta_pc = P::G2PreparedGadget::alloc(&mut cs.ns(|| "h_beta_pc"), || Ok(pvk.h_beta.prepare()))?;
+            let g_gamma_pc = P::G1PreparedGadget::alloc(&mut cs.ns(|| "g_gamma_pc"), || Ok(pvk.g_gamma_pc.clone()))?;
+            let h_gamma_pc = P::G2PreparedGadget::alloc(&mut cs.ns(|| "h_gamma_pc"), || Ok(pvk.h_gamma_pc.clone()))?;
+            let h_pc = P::G2PreparedGadget::alloc(&mut cs.ns(||"h_pc"), || Ok(pvk.h_pc.clone()))?;
+
+            let mut query = Vec::new();
+            for (i, elem) in pvk.vk.query.iter().cloned().enumerate() {
+                query.push(P::G1Gadget::alloc(&mut cs.ns(|| format!("query {}", i)), || Ok(elem.into_projective()))?);
+            }
+
+            Ok(Self {
+                g_alpha,
+                h_beta,
+                g_alpha_pc,
+                h_beta_pc,
+                g_gamma_pc,
+                h_gamma_pc,
+                h_pc,
+                query
+            })
+        })
+    }
+
+    #[inline]
+    fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<PreparedVerifyingKey<Pairing>>, CS: ConstraintSystem<F>>(mut cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
+        value_gen().and_then(|pvk| {
+            let pvk = pvk.borrow().clone();
+
+            let g_alpha = P::G1Gadget::alloc_input(&mut cs.ns(|| "g_alpha"), || Ok(pvk.g_alpha.into_projective()))?;
+            let h_beta = P::G2Gadget::alloc_input(&mut cs.ns(|| "h_beta"), || Ok(pvk.h_beta.into_projective()))?;
+            let g_alpha_pc = P::G1PreparedGadget::alloc_input(&mut cs.ns(|| "g_alpha_pc"), || Ok(pvk.g_alpha.prepare()))?;
+            let h_beta_pc = P::G2PreparedGadget::alloc_input(&mut cs.ns(|| "h_beta_pc"), || Ok(pvk.h_beta.prepare()))?;
+            let g_gamma_pc = P::G1PreparedGadget::alloc_input(&mut cs.ns(|| "g_gamma_pc"), || Ok(pvk.g_gamma_pc.clone()))?;
+            let h_gamma_pc = P::G2PreparedGadget::alloc_input(&mut cs.ns(|| "h_gamma_pc"), || Ok(pvk.h_gamma_pc.clone()))?;
+            let h_pc = P::G2PreparedGadget::alloc_input(&mut cs.ns(||"h_pc"), || Ok(pvk.h_pc.clone()))?;
+
+            let mut query = Vec::new();
+            for (i, elem) in pvk.vk.query.iter().cloned().enumerate() {
+                query.push(P::G1Gadget::alloc_input(&mut cs.ns(|| format!("query {}", i)), || Ok(elem.into_projective()))?);
+            }
+
+            Ok(GM17PreparedVerifyingKeyGadget {
+                g_alpha,
+                h_beta,
+                g_alpha_pc,
+                h_beta_pc,
+                g_gamma_pc,
+                h_gamma_pc,
+                h_pc,
+                query
+            })
+        })
+    }
+}
+
 pub struct GM17VerifierGadget<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> {
     _pairing_engine: PhantomData<Pairing>,
     _engine: PhantomData<F>,
@@ -109,14 +170,16 @@ impl<
     type Input = Vec<Boolean>;
     type ProofGadget = GM17ProofGadget<Pairing, F, P>;
     type VerificationKeyGadget = GM17VerifyingKeyGadget<Pairing, F, P>;
+    type PreparedVerificationKeyGadget = GM17PreparedVerifyingKeyGadget<Pairing, F, P>;
 
-    fn check_verify<CS: ConstraintSystem<F>, I: Iterator<Item = Self::Input>>(
+    fn check_verify_with_processed_vk<CS: ConstraintSystem<F>, I: Iterator<Item = Self::Input>>(
         mut cs: CS,
-        vk: &Self::VerificationKeyGadget,
+        pvk: &Self::PreparedVerificationKeyGadget,
         mut public_inputs: I,
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError> {
-        let pvk = vk.prepare(&mut cs.ns(|| "Prepare vk"))?;
+        let pvk = (*pvk).clone();
+
         // e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma}) *
         // e(C, H) where psi = \sum_{i=0}^l input_i pvk.query[i]
 

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -54,7 +54,7 @@ pub struct VerifyingKeyGadget<PairingE: PairingEngine, ConstraintF: Field, P: Pa
 }
 
 impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, ConstraintF>>
-    PrepareToGadget<PreparedVerifyingKeyGadget<Pairing, ConstraintF, P>, ConstraintFF>
+    PrepareToGadget<PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>, ConstraintF>
     for VerifyingKeyGadget<PairingE, ConstraintF, P>
 {
     fn prepare<CS: ConstraintSystem<ConstraintF>>(

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -16,22 +16,18 @@
 
 use std::{borrow::Borrow, marker::PhantomData};
 
-use snarkvm_algorithms::snark::groth16::{Groth16, Proof, VerifyingKey};
+use snarkvm_algorithms::snark::groth16::{Groth16, Proof, VerifyingKey, PreparedVerifyingKey};
 use snarkvm_curves::traits::{AffineCurve, PairingEngine};
 use snarkvm_fields::{Field, ToConstraintField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
 use snarkvm_utilities::bytes::FromBytes;
 
-use crate::{
-    bits::{Boolean, ToBitsBEGadget, ToBytesGadget},
-    integers::uint::UInt8,
-    traits::{
-        algorithms::snark::SNARKVerifierGadget,
-        alloc::{AllocBytesGadget, AllocGadget},
-        curves::{GroupGadget, PairingGadget},
-        eq::EqGadget,
-    },
-};
+use crate::{bits::{Boolean, ToBitsBEGadget, ToBytesGadget}, integers::uint::UInt8, traits::{
+    algorithms::snark::SNARKVerifierGadget,
+    alloc::{AllocBytesGadget, AllocGadget},
+    curves::{GroupGadget, PairingGadget},
+    eq::EqGadget,
+}, PrepareToGadget};
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "P::G1Gadget: Clone, P::G2Gadget: Clone"))]
@@ -52,10 +48,10 @@ pub struct VerifyingKeyGadget<PairingE: PairingEngine, ConstraintF: Field, P: Pa
     pub gamma_abc_g1: Vec<P::G1Gadget>,
 }
 
-impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, ConstraintF>>
+impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, ConstraintF>> PrepareToGadget<PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>, ConstraintF> for
     VerifyingKeyGadget<PairingE, ConstraintF, P>
 {
-    pub fn prepare<CS: ConstraintSystem<ConstraintF>>(
+    fn prepare<CS: ConstraintSystem<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>, SynthesisError> {
@@ -99,6 +95,58 @@ pub struct PreparedVerifyingKeyGadget<
     pub gamma_abc_g1: Vec<P::G1Gadget>,
 }
 
+impl<PairingE, ConstraintF, P> AllocGadget<PreparedVerifyingKey<PairingE>, ConstraintF> for PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>
+where
+    PairingE: PairingEngine,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
+{
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<PreparedVerifyingKey<PairingE>>, CS: ConstraintSystem<ConstraintF>>(mut cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
+        value_gen().and_then(|pvk| {
+            let pvk = pvk.borrow().clone();
+
+            let alpha_g1_beta_g2 = P::GTGadget::alloc(&mut cs.ns(|| "alpha_g1_beta_g2"), || Ok(pvk.alpha_g1_beta_g2.clone()))?;
+            let gamma_g2_neg_pc = P::G2PreparedGadget::alloc(&mut cs.ns(||"gamma_g2_neg_pc"), || Ok(pvk.gamma_g2_neg_pc.clone()))?;
+            let delta_g2_neg_pc = P::G2PreparedGadget::alloc(&mut cs.ns(||"delta_g2_neg_pc"), || Ok(pvk.delta_g2_neg_pc.clone()))?;
+
+            let mut gamma_abc_g1 = Vec::new();
+            for (i, elem) in pvk.vk.gamma_abc_g1.iter().enumerate() {
+                gamma_abc_g1.push(P::G1Gadget::alloc(&mut cs.ns(|| format!("gamma_abc_g1 {}", i)), || Ok(elem.into_projective()))?);
+            }
+
+            Ok(Self {
+                alpha_g1_beta_g2,
+                gamma_g2_neg_pc,
+                delta_g2_neg_pc,
+                gamma_abc_g1
+            })
+        })
+    }
+
+    fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<PreparedVerifyingKey<PairingE>>, CS: ConstraintSystem<ConstraintF>>(mut cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
+        value_gen().and_then(|pvk| {
+            let pvk = pvk.borrow().clone();
+
+            let alpha_g1_beta_g2 = P::GTGadget::alloc_input(&mut cs.ns(|| "alpha_g1_beta_g2"), || Ok(pvk.alpha_g1_beta_g2.clone()))?;
+            let gamma_g2_neg_pc = P::G2PreparedGadget::alloc_input(&mut cs.ns(||"gamma_g2_neg_pc"), || Ok(pvk.gamma_g2_neg_pc.clone()))?;
+            let delta_g2_neg_pc = P::G2PreparedGadget::alloc_input(&mut cs.ns(||"delta_g2_neg_pc"), || Ok(pvk.delta_g2_neg_pc.clone()))?;
+
+            let mut gamma_abc_g1 = Vec::new();
+            for (i, elem) in pvk.vk.gamma_abc_g1.iter().enumerate() {
+                gamma_abc_g1.push(P::G1Gadget::alloc_input(&mut cs.ns(|| format!("gamma_abc_g1 {}", i)), || Ok(elem.into_projective()))?);
+            }
+
+            Ok(Self {
+                alpha_g1_beta_g2,
+                gamma_g2_neg_pc,
+                delta_g2_neg_pc,
+                gamma_abc_g1
+            })
+        })
+    }
+}
+
+
 pub struct Groth16VerifierGadget<PairingE, ConstraintF, P>
 where
     PairingE: PairingEngine,
@@ -122,21 +170,20 @@ where
     type Input = Vec<Boolean>;
     type ProofGadget = ProofGadget<PairingE, ConstraintF, P>;
     type VerificationKeyGadget = VerifyingKeyGadget<PairingE, ConstraintF, P>;
+    type PreparedVerificationKeyGadget = PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>;
 
-    fn check_verify<CS: ConstraintSystem<ConstraintF>, I: Iterator<Item = Self::Input>>(
+    fn check_verify_with_processed_vk<CS: ConstraintSystem<ConstraintF>, I: Iterator<Item = Self::Input>>(
         mut cs: CS,
-        vk: &Self::VerificationKeyGadget,
+        pvk: &Self::PreparedVerificationKeyGadget,
         mut public_inputs: I,
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError> {
-        let pvk = vk.prepare(&mut cs.ns(|| "Prepare vk"))?;
-
         let PreparedVerifyingKeyGadget {
             alpha_g1_beta_g2,
             gamma_g2_neg_pc,
             delta_g2_neg_pc,
             mut gamma_abc_g1,
-        } = pvk;
+        } = pvk.clone();
 
         let mut gamma_abc_g1_iter = gamma_abc_g1.iter_mut();
 

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -31,6 +31,7 @@ use crate::{
         curves::{GroupGadget, PairingGadget},
         eq::EqGadget,
     },
+    PrepareToGadget,
 };
 
 #[derive(Derivative)]
@@ -53,7 +54,8 @@ pub struct VerifyingKeyGadget<PairingE: PairingEngine, ConstraintF: Field, P: Pa
 }
 
 impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, ConstraintF>>
-    VerifyingKeyGadget<PairingE, ConstraintF, P>
+    PrepareToGadget<PreparedVerifyingKeyGadget<Pairing, ConstraintF, P>, ConstraintFF>
+    for VerifyingKeyGadget<PairingE, ConstraintF, P>
 {
     fn prepare<CS: ConstraintSystem<ConstraintF>>(
         &self,

--- a/gadgets/src/curves/templates/bls12/g1.rs
+++ b/gadgets/src/curves/templates/bls12/g1.rs
@@ -16,13 +16,24 @@
 
 use std::fmt::Debug;
 
-use snarkvm_curves::{templates::bls12::{Bls12Parameters, G1Prepared}, traits::ProjectiveCurve, AffineCurve};
+use snarkvm_curves::{
+    templates::bls12::{Bls12Parameters, G1Prepared},
+    traits::ProjectiveCurve,
+    AffineCurve,
+};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
 
-use crate::{bits::{Boolean, ToBytesGadget}, curves::templates::bls12::AffineGadget, fields::FpGadget, integers::uint::UInt8, traits::{
-    curves::GroupGadget,
-    eq::{ConditionalEqGadget, EqGadget},
-}, AllocGadget};
+use crate::{
+    bits::{Boolean, ToBytesGadget},
+    curves::templates::bls12::AffineGadget,
+    fields::FpGadget,
+    integers::uint::UInt8,
+    traits::{
+        curves::GroupGadget,
+        eq::{ConditionalEqGadget, EqGadget},
+    },
+    AllocGadget,
+};
 use std::borrow::Borrow;
 
 pub type G1Gadget<P> = AffineGadget<
@@ -79,20 +90,34 @@ impl<P: Bls12Parameters> ConditionalEqGadget<<P as Bls12Parameters>::Fp> for G1P
 }
 
 impl<P: Bls12Parameters> AllocGadget<G1Prepared<P>, <P as Bls12Parameters>::Fp> for G1PreparedGadget<P> {
-    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<G1Prepared<P>>, CS: ConstraintSystem<<P as Bls12Parameters>::Fp>>(cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
-        value_gen().and_then(| elem | {
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<G1Prepared<P>>,
+        CS: ConstraintSystem<<P as Bls12Parameters>::Fp>,
+    >(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        value_gen().and_then(|elem| {
             let elem = elem.borrow();
             Ok(Self {
-                0: G1Gadget::<P>::alloc(cs, || Ok(elem.0.into_projective()))?
+                0: G1Gadget::<P>::alloc(cs, || Ok(elem.0.into_projective()))?,
             })
         })
     }
 
-    fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<G1Prepared<P>>, CS: ConstraintSystem<<P as Bls12Parameters>::Fp>>(cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
-        value_gen().and_then(| elem | {
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<G1Prepared<P>>,
+        CS: ConstraintSystem<<P as Bls12Parameters>::Fp>,
+    >(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        value_gen().and_then(|elem| {
             let elem = elem.borrow();
             Ok(Self {
-                0: G1Gadget::<P>::alloc_input(cs, || Ok(elem.0.into_projective()))?
+                0: G1Gadget::<P>::alloc_input(cs, || Ok(elem.0.into_projective()))?,
             })
         })
     }

--- a/gadgets/src/curves/templates/bls12/g1.rs
+++ b/gadgets/src/curves/templates/bls12/g1.rs
@@ -16,22 +16,14 @@
 
 use std::fmt::Debug;
 
-use snarkvm_curves::{
-    templates::bls12::{Bls12Parameters, G1Prepared},
-    traits::ProjectiveCurve,
-};
+use snarkvm_curves::{templates::bls12::{Bls12Parameters, G1Prepared}, traits::ProjectiveCurve, AffineCurve};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
 
-use crate::{
-    bits::{Boolean, ToBytesGadget},
-    curves::templates::bls12::AffineGadget,
-    fields::FpGadget,
-    integers::uint::UInt8,
-    traits::{
-        curves::GroupGadget,
-        eq::{ConditionalEqGadget, EqGadget},
-    },
-};
+use crate::{bits::{Boolean, ToBytesGadget}, curves::templates::bls12::AffineGadget, fields::FpGadget, integers::uint::UInt8, traits::{
+    curves::GroupGadget,
+    eq::{ConditionalEqGadget, EqGadget},
+}, AllocGadget};
+use std::borrow::Borrow;
 
 pub type G1Gadget<P> = AffineGadget<
     <P as Bls12Parameters>::G1Parameters,
@@ -83,5 +75,25 @@ impl<P: Bls12Parameters> ConditionalEqGadget<<P as Bls12Parameters>::Fp> for G1P
 
     fn cost() -> usize {
         2 * <FpGadget<<P as Bls12Parameters>::Fp> as ConditionalEqGadget<<P as Bls12Parameters>::Fp>>::cost()
+    }
+}
+
+impl<P: Bls12Parameters> AllocGadget<G1Prepared<P>, <P as Bls12Parameters>::Fp> for G1PreparedGadget<P> {
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<G1Prepared<P>>, CS: ConstraintSystem<<P as Bls12Parameters>::Fp>>(cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
+        value_gen().and_then(| elem | {
+            let elem = elem.borrow();
+            Ok(Self {
+                0: G1Gadget::<P>::alloc(cs, || Ok(elem.0.into_projective()))?
+            })
+        })
+    }
+
+    fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<G1Prepared<P>>, CS: ConstraintSystem<<P as Bls12Parameters>::Fp>>(cs: CS, value_gen: Fn) -> Result<Self, SynthesisError> {
+        value_gen().and_then(| elem | {
+            let elem = elem.borrow();
+            Ok(Self {
+                0: G1Gadget::<P>::alloc_input(cs, || Ok(elem.0.into_projective()))?
+            })
+        })
     }
 }

--- a/gadgets/src/traits/algorithms/snark.rs
+++ b/gadgets/src/traits/algorithms/snark.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 pub enum RandProvider<F: Field> {
-    PowerSeries(F)
+    PowerSeries(F),
 }
 
 impl<F: Field> RandProvider<F> {
@@ -49,87 +49,21 @@ impl<F: Field> RandProvider<F> {
     }
 }
 
-pub trait PrepareToGadget<T, F: Field> : Sized {
-    fn prepare<CS: ConstraintSystem<F>>(&self, cs : CS) -> Result<T, SynthesisError>;
+pub trait PrepareToGadget<T, F: Field>: Sized {
+    fn prepare<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<T, SynthesisError>;
 }
 
 pub trait SNARKVerifierGadget<N: SNARK, F: Field> {
-    type PreparedVerificationKeyGadget: AllocGadget<N::PreparedVerifyingKey, F>;
-    type VerificationKeyGadget: AllocGadget<N::VerifyingKey, F> + AllocBytesGadget<Vec<u8>, F> + ToBytesGadget<F> + PrepareToGadget<Self::PreparedVerificationKeyGadget, F>;
+    type VerificationKeyGadget: AllocGadget<N::VerifyingKey, F> + AllocBytesGadget<Vec<u8>, F> + ToBytesGadget<F>;
     type ProofGadget: AllocGadget<N::Proof, F> + AllocBytesGadget<Vec<u8>, F>;
     type Input: ToBitsBEGadget<F> + Clone + ?Sized;
 
-    fn check_verify_with_processed_vk<CS: ConstraintSystem<F>, I: Iterator<Item = Self::Input>>(
+    fn check_verify<'a, CS: ConstraintSystem<F>, I: Iterator<Item = Self::Input>>(
         cs: CS,
-        processed_verification_key: &Self::PreparedVerificationKeyGadget,
+        verification_key: &Self::VerificationKeyGadget,
         input: I,
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError>;
-
-    fn check_verify<'a, CS: ConstraintSystem<F>, I: Iterator<Item = Self::Input>>(
-        mut cs: CS,
-        verification_key: &Self::VerificationKeyGadget,
-        input: I,
-        proof: &Self::ProofGadget,
-    ) -> Result<(), SynthesisError> {
-        let processed_verification_key = verification_key.prepare(&mut cs.ns(||"prepare the verification key"))?;
-        Self::check_verify_with_processed_vk(&mut cs.ns(|| "verify with the processed key"), &processed_verification_key, input, proof)
-    }
-
-    fn batch_check_verify_same_processed_vk<'a, CS: ConstraintSystem<F>>(
-        mut cs: CS,
-        processed_verification_key: &Self::PreparedVerificationKeyGadget,
-        inputs: &[Vec<Self::Input>],
-        proofs: &[Self::ProofGadget],
-        _rand: &RandProvider<F>,
-    ) -> Result<(), SynthesisError> {
-        assert_eq!(inputs.len(), proofs.len());
-        for (i, (input, proof)) in inputs.iter().zip(proofs.iter()).enumerate() {
-            Self::check_verify_with_processed_vk(&mut cs.ns(|| format!("verify proof {}", i)), processed_verification_key, (*input).iter().cloned(), proof)?;
-        }
-        Ok(())
-    }
-
-    fn batch_check_verify_same_vk<'a, CS: ConstraintSystem<F>>(
-        mut cs: CS,
-        verification_key: &Self::VerificationKeyGadget,
-        inputs: &[Vec<Self::Input>],
-        proofs: &[Self::ProofGadget],
-        rand: &RandProvider<F>,
-    ) -> Result<(), SynthesisError> {
-        let processed_verification_key = verification_key.prepare(&mut cs.ns(||"prepare the verification key"))?;
-        Self::batch_check_verify_same_processed_vk(&mut cs.ns(|| "verify with the processed key"), &processed_verification_key, inputs, proofs, rand)
-    }
-
-    fn batch_check_verify_different_processed_vk<'a, CS: ConstraintSystem<F>>(
-        mut cs: CS,
-        processed_verification_keys: &[Self::PreparedVerificationKeyGadget],
-        inputs: &[Vec<Self::Input>],
-        proofs: &[Self::ProofGadget],
-        _rand: &RandProvider<F>,
-    ) -> Result<(), SynthesisError> {
-        assert_eq!(processed_verification_keys.len(), inputs.len());
-        assert_eq!(inputs.len(), proofs.len());
-        for (i, ((processed_verification_key, input), proof)) in processed_verification_keys.iter().zip(inputs.iter()).zip(proofs.iter()).enumerate() {
-            Self::check_verify_with_processed_vk(&mut cs.ns(|| format!("verify proof {}", i)), processed_verification_key, (*input).iter().cloned(), proof)?;
-        }
-        Ok(())
-    }
-
-    fn batch_check_verify_different_vk<'a, CS: ConstraintSystem<F>>(
-        mut cs: CS,
-        verification_keys: &[Self::VerificationKeyGadget],
-        inputs: &[Vec<Self::Input>],
-        proofs: &[Self::ProofGadget],
-        _rand: &RandProvider<F>,
-    ) -> Result<(), SynthesisError> {
-        assert_eq!(verification_keys.len(), inputs.len());
-        assert_eq!(inputs.len(), proofs.len());
-        for (i, ((verification_key, input), proof)) in verification_keys.iter().zip(inputs.iter()).zip(proofs.iter()).enumerate() {
-            Self::check_verify(&mut cs.ns(|| format!("verify proof {}", i)), verification_key, (*input).iter().cloned(), proof)?;
-        }
-        Ok(())
-    }
 }
 
 // TODO (raychu86): Unify with the `SNARK` trait. Currently the `SNARKGadget` is only used for `marlin`.

--- a/gadgets/src/traits/curves/pairing.rs
+++ b/gadgets/src/traits/curves/pairing.rs
@@ -28,7 +28,7 @@ use crate::{
 pub trait PairingGadget<Pairing: PairingEngine, F: Field> {
     type G1Gadget: GroupGadget<Pairing::G1Projective, F>;
     type G2Gadget: GroupGadget<Pairing::G2Projective, F>;
-    type G1PreparedGadget: ToBytesGadget<F> + Clone + Debug;
+    type G1PreparedGadget: ToBytesGadget<F> + AllocGadget<<Pairing::G1Affine as PairingCurve>::Prepared, F> + Clone + Debug;
     type G2PreparedGadget: ToBytesGadget<F>
         + AllocGadget<<Pairing::G2Affine as PairingCurve>::Prepared, F>
         + Clone

--- a/gadgets/src/traits/curves/pairing.rs
+++ b/gadgets/src/traits/curves/pairing.rs
@@ -28,7 +28,10 @@ use crate::{
 pub trait PairingGadget<Pairing: PairingEngine, F: Field> {
     type G1Gadget: GroupGadget<Pairing::G1Projective, F>;
     type G2Gadget: GroupGadget<Pairing::G2Projective, F>;
-    type G1PreparedGadget: ToBytesGadget<F> + AllocGadget<<Pairing::G1Affine as PairingCurve>::Prepared, F> + Clone + Debug;
+    type G1PreparedGadget: ToBytesGadget<F>
+        + AllocGadget<<Pairing::G1Affine as PairingCurve>::Prepared, F>
+        + Clone
+        + Debug;
     type G2PreparedGadget: ToBytesGadget<F>
         + AllocGadget<<Pairing::G2Affine as PairingCurve>::Prepared, F>
         + Clone


### PR DESCRIPTION
## Motivation

This PR adds the Groth16's batch verification algorithm as Pratyush mentioned in the `eng-snarkos` [sic] channel on June 29th, as well as some housekeeping changes planned for the future.

Since the writing platform is different (arkworks-rs vs zexe), some tuning has been done. The code tries to use the projective coordinates as much as possible, for efficiency.

In the future, we may run batch verification in the constraint worlds, which I hit some blockers and would need more discussion (e.g., generating the randomness), and it will affect the current Marlin implementation, which will conflict with `testnet2-dpc`, so I will continue with them later.

## Test Plan

It passes all the tests in snarkVM.
