### PR TITLE
Signature scheme cleanup and add flexibility to signature verification gadget

### DIFF
--- a/algorithms/src/signature/group.rs
+++ b/algorithms/src/signature/group.rs
@@ -51,10 +51,12 @@ impl<G: Group + ProjectiveCurve + CanonicalSerialize, SG: Group + CanonicalDeser
         let parameters = SchnorrParameters {
             generator_powers,
             salt: parameters.salt,
-            _hash: PhantomData,
         };
 
-        Self { parameters }
+        Self {
+            parameters,
+            _hash: PhantomData,
+        }
     }
 }
 

--- a/algorithms/src/signature/schnorr_parameters.rs
+++ b/algorithms/src/signature/schnorr_parameters.rs
@@ -18,27 +18,22 @@ use snarkvm_curves::traits::Group;
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
 use snarkvm_utilities::bytes::{FromBytes, ToBytes};
 
-use digest::Digest;
 use rand::Rng;
-use std::{
-    io::{Read, Result as IoResult, Write},
-    marker::PhantomData,
-};
+use std::io::{Read, Result as IoResult, Write};
 
 #[derive(Derivative)]
 #[derivative(
-    Clone(bound = "G: Group, D: Digest"),
-    Debug(bound = "G: Group, D: Digest"),
-    PartialEq(bound = "G: Group, D: Digest"),
-    Eq(bound = "G: Group, D: Digest")
+    Clone(bound = "G: Group"),
+    Debug(bound = "G: Group"),
+    PartialEq(bound = "G: Group"),
+    Eq(bound = "G: Group")
 )]
-pub struct SchnorrParameters<G: Group, D: Digest> {
+pub struct SchnorrParameters<G: Group> {
     pub generator_powers: Vec<G>,
     pub salt: [u8; 32],
-    pub _hash: PhantomData<D>,
 }
 
-impl<G: Group, D: Digest> SchnorrParameters<G, D> {
+impl<G: Group> SchnorrParameters<G> {
     pub fn setup<R: Rng>(rng: &mut R, private_key_size_in_bits: usize) -> Self {
         // Round to the closest multiple of 64 to factor bit and byte encoding differences.
         assert!(private_key_size_in_bits < usize::MAX - 63);
@@ -46,7 +41,6 @@ impl<G: Group, D: Digest> SchnorrParameters<G, D> {
         Self {
             generator_powers: Self::generator(num_powers, rng),
             salt: rng.gen(),
-            _hash: PhantomData,
         }
     }
 
@@ -61,7 +55,7 @@ impl<G: Group, D: Digest> SchnorrParameters<G, D> {
     }
 }
 
-impl<G: Group, D: Digest> ToBytes for SchnorrParameters<G, D> {
+impl<G: Group> ToBytes for SchnorrParameters<G> {
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
         (self.generator_powers.len() as u32).write(&mut writer)?;
         for g in &self.generator_powers {
@@ -71,7 +65,7 @@ impl<G: Group, D: Digest> ToBytes for SchnorrParameters<G, D> {
     }
 }
 
-impl<G: Group, D: Digest> FromBytes for SchnorrParameters<G, D> {
+impl<G: Group> FromBytes for SchnorrParameters<G> {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
         let generator_powers_length: u32 = FromBytes::read(&mut reader)?;
@@ -83,15 +77,11 @@ impl<G: Group, D: Digest> FromBytes for SchnorrParameters<G, D> {
 
         let salt: [u8; 32] = FromBytes::read(&mut reader)?;
 
-        Ok(Self {
-            generator_powers,
-            salt,
-            _hash: PhantomData,
-        })
+        Ok(Self { generator_powers, salt })
     }
 }
 
-impl<F: Field, G: Group + ToConstraintField<F>, D: Digest> ToConstraintField<F> for SchnorrParameters<G, D> {
+impl<F: Field, G: Group + ToConstraintField<F>> ToConstraintField<F> for SchnorrParameters<G> {
     #[inline]
     fn to_field_elements(&self) -> Result<Vec<F>, ConstraintFieldError> {
         Ok(Vec::new())

--- a/gadgets/src/algorithms/signature/group.rs
+++ b/gadgets/src/algorithms/signature/group.rs
@@ -1,0 +1,243 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    algorithms::signature::schnorr::*,
+    bits::{Boolean, ToBytesGadget},
+    integers::uint::UInt8,
+    traits::{
+        algorithms::SignaturePublicKeyRandomizationGadget,
+        alloc::AllocGadget,
+        curves::GroupGadget,
+        eq::EqGadget,
+        integers::Integer,
+    },
+    FieldGadget,
+    PRFGadget,
+};
+use snarkvm_algorithms::prf::Blake2s;
+use snarkvm_curves::traits::Group;
+use snarkvm_fields::{Field, PrimeField};
+use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
+use snarkvm_utilities::serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+use digest::Digest;
+use itertools::Itertools;
+use snarkvm_algorithms::encryption::{GroupEncryption, GroupEncryptionParameters, GroupEncryptionPublicKey};
+use snarkvm_curves::ProjectiveCurve;
+use std::{borrow::Borrow, marker::PhantomData};
+
+#[derive(Clone)]
+pub struct GroupEncryptionParametersGadget<G: Group, F: Field> {
+    pub parameters: GroupEncryptionParameters<G>,
+    _engine: PhantomData<*const F>,
+}
+
+impl<G: Group, F: Field> AllocGadget<GroupEncryptionParameters<G>, F> for GroupEncryptionParametersGadget<G, F> {
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<GroupEncryptionParameters<G>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let value = value_gen()?;
+        let parameters = value.borrow().clone();
+        Ok(Self {
+            parameters,
+            _engine: PhantomData,
+        })
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<GroupEncryptionParameters<G>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let value = value_gen()?;
+        let parameters = value.borrow().clone();
+        Ok(Self {
+            parameters,
+            _engine: PhantomData,
+        })
+    }
+}
+
+impl<G: Group + ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize, F: Field, GG: GroupGadget<G, F>>
+    AllocGadget<GroupEncryptionPublicKey<G>, F> for SchnorrPublicKeyGadget<G, F, GG>
+{
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<GroupEncryptionPublicKey<G>>,
+        CS: ConstraintSystem<F>,
+    >(
+        cs: CS,
+        f: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            public_key: GG::alloc_checked(cs, || f().map(|pk| pk.borrow().0))?,
+            _engine: PhantomData,
+            _group: PhantomData,
+        })
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<GroupEncryptionPublicKey<G>>,
+        CS: ConstraintSystem<F>,
+    >(
+        cs: CS,
+        f: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            public_key: GG::alloc_input(cs, || f().map(|pk| pk.borrow().0))?,
+            _engine: PhantomData,
+            _group: PhantomData,
+        })
+    }
+}
+
+// TODO (raychu86): Make this implementation generic for both GroupEncryption and Schnorr Signature.
+impl<
+    G: Group + CanonicalSerialize + CanonicalDeserialize + ProjectiveCurve,
+    GG: GroupGadget<G, F>,
+    FG: FieldGadget<F, F>,
+    D: Digest + Send + Sync,
+    F: PrimeField,
+> SignaturePublicKeyRandomizationGadget<GroupEncryption<G, G, D>, F>
+    for SchnorrPublicKeyRandomizationGadget<G, F, GG, FG>
+{
+    type ParametersGadget = GroupEncryptionParametersGadget<G, F>;
+    type PublicKeyGadget = SchnorrPublicKeyGadget<G, F, GG>;
+    type SignatureGadget = SchnorrSignatureGadget<G, F, FG>;
+
+    fn check_randomization_gadget<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        parameters: &Self::ParametersGadget,
+        public_key: &Self::PublicKeyGadget,
+        randomness: &[UInt8],
+    ) -> Result<Self::PublicKeyGadget, SynthesisError> {
+        let randomness = randomness.iter().flat_map(|b| b.to_bits_le()).collect::<Vec<_>>();
+        let mut rand_pk = public_key.public_key.clone();
+        rand_pk.scalar_multiplication(
+            cs.ns(|| "check_randomization_gadget"),
+            randomness.iter().zip_eq(&parameters.parameters.generator_powers),
+        )?;
+
+        Ok(SchnorrPublicKeyGadget {
+            public_key: rand_pk,
+            _group: PhantomData,
+            _engine: PhantomData,
+        })
+    }
+
+    // TODO (raychu86): Make the blake2s usage generic for all PRFs.
+    fn verify<CS: ConstraintSystem<F>, PG: PRFGadget<Blake2s, F>>(
+        mut cs: CS,
+        parameters: &Self::ParametersGadget,
+        public_key: &Self::PublicKeyGadget,
+        message: &[UInt8],
+        signature: &Self::SignatureGadget,
+    ) -> Result<Boolean, SynthesisError> {
+        let zero_group_gadget = GG::zero(cs.ns(|| "zero"))?;
+
+        let prover_response_bytes = signature
+            .prover_response
+            .to_bytes(cs.ns(|| "prover_response_to_bytes"))?;
+
+        let prover_response_bits = prover_response_bytes
+            .iter()
+            .flat_map(|byte| byte.to_bits_le())
+            .collect::<Vec<_>>();
+        let verifier_challenge_bits = signature
+            .verifier_challenge
+            .to_bits_le(cs.ns(|| "verifier_challenge_to_bits"))?;
+
+        let mut claimed_prover_commitment = GG::zero(cs.ns(|| "zero_claimed_prover_commitment"))?;
+        for (i, (bit, base_power)) in prover_response_bits
+            .iter()
+            .zip_eq(&parameters.parameters.generator_powers)
+            .enumerate()
+        {
+            let added =
+                claimed_prover_commitment.add_constant(cs.ns(|| format!("add_base_power_{}", i)), base_power)?;
+
+            claimed_prover_commitment = GG::conditionally_select(
+                cs.ns(|| format!("cond_select_{}", i)),
+                &bit,
+                &added,
+                &claimed_prover_commitment,
+            )?;
+        }
+
+        let public_key_times_verifier_challenge = public_key.public_key.mul_bits(
+            cs.ns(|| "record_view_key"),
+            &zero_group_gadget,
+            verifier_challenge_bits.into_iter(),
+        )?;
+
+        claimed_prover_commitment = claimed_prover_commitment.add(
+            cs.ns(|| "claimed_prover_commitment_plus_public_key_times_verifier_challenge"),
+            &public_key_times_verifier_challenge,
+        )?;
+
+        let salt_bytes = UInt8::alloc_vec(cs.ns(|| "alloc_salt"), &parameters.parameters.salt)?;
+        let claimed_prover_commitment_bytes =
+            claimed_prover_commitment.to_bytes(cs.ns(|| "claimed_prover_commitment_to_bytes"))?;
+
+        // Construct the hash
+
+        let mut hash_input = Vec::new();
+        hash_input.extend_from_slice(&claimed_prover_commitment_bytes);
+        hash_input.extend_from_slice(&message);
+
+        let hash = PG::check_evaluation_gadget(cs.ns(|| "schnorr_hash"), &salt_bytes, &hash_input)?;
+
+        // Check that the hash bytes are equivalent to the Field gadget.
+
+        let hash_bytes = hash.to_bytes(cs.ns(|| "hash_to_bytes"))?;
+        let verifier_challenge_bytes = signature
+            .verifier_challenge
+            .to_bytes(cs.ns(|| "verifier_challenge_to_bytes"))?;
+
+        let total_bits = <G as Group>::ScalarField::size_in_bits();
+        let mut expected_bits = Vec::with_capacity(total_bits);
+        let mut found_bits = Vec::with_capacity(total_bits);
+
+        // Check all the bits up to the bit size of the Field gadget.
+        for (i, (expected_byte, found_byte)) in verifier_challenge_bytes.iter().zip_eq(&hash_bytes).enumerate() {
+            for (j, (expected_bit, found_bit)) in expected_byte
+                .to_bits_le()
+                .iter()
+                .zip_eq(found_byte.to_bits_le())
+                .enumerate()
+            {
+                if (i * 8 + j) < total_bits {
+                    expected_bits.push(expected_bit.clone());
+                    found_bits.push(found_bit.clone());
+                }
+            }
+        }
+
+        let result = expected_bits.is_eq(cs.ns(|| "is_eq"), &found_bits)?;
+
+        return Ok(result);
+    }
+}

--- a/gadgets/src/algorithms/signature/group.rs
+++ b/gadgets/src/algorithms/signature/group.rs
@@ -296,11 +296,13 @@ impl<G: Group, SG: Group, F: Field, FG: FieldGadget<F, F>> ToBytesGadget<F>
 
 pub struct GroupEncryptionPublicKeyRandomizationGadget<
     G: Group,
+    SG: Group,
     F: PrimeField,
     GG: GroupGadget<G, F>,
     FG: FieldGadget<F, F>,
 > {
     pub(crate) _group: PhantomData<*const G>,
+    pub(crate) _signature_group: PhantomData<*const SG>,
     pub(crate) _group_gadget: PhantomData<*const GG>,
     pub(crate) _field_gadget: PhantomData<*const FG>,
     pub(crate) _engine: PhantomData<*const F>,
@@ -314,7 +316,7 @@ impl<
     D: Digest + Send + Sync,
     F: PrimeField,
 > SignaturePublicKeyRandomizationGadget<GroupEncryption<G, SG, D>, F>
-    for GroupEncryptionPublicKeyRandomizationGadget<G, F, GG, FG>
+    for GroupEncryptionPublicKeyRandomizationGadget<G, SG, F, GG, FG>
 {
     type ParametersGadget = GroupEncryptionParametersGadget<G, F>;
     type PublicKeyGadget = GroupEncryptionPublicKeyGadget<G, F, GG>;

--- a/gadgets/src/algorithms/signature/mod.rs
+++ b/gadgets/src/algorithms/signature/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod group;
+pub use group::*;
+
 pub mod schnorr;
 pub use schnorr::*;
 

--- a/gadgets/src/algorithms/signature/schnorr.rs
+++ b/gadgets/src/algorithms/signature/schnorr.rs
@@ -46,13 +46,13 @@ use itertools::Itertools;
 use std::{borrow::Borrow, marker::PhantomData};
 
 #[derive(Clone)]
-pub struct SchnorrParametersGadget<G: Group, F: Field, D: Digest> {
-    parameters: SchnorrParameters<G, D>,
-    _engine: PhantomData<*const F>,
+pub struct SchnorrParametersGadget<G: Group, F: Field> {
+    pub(crate) parameters: SchnorrParameters<G>,
+    pub(crate) _engine: PhantomData<*const F>,
 }
 
-impl<G: Group, F: Field, D: Digest> AllocGadget<SchnorrParameters<G, D>, F> for SchnorrParametersGadget<G, F, D> {
-    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<SchnorrParameters<G, D>>, CS: ConstraintSystem<F>>(
+impl<G: Group, F: Field> AllocGadget<SchnorrParameters<G>, F> for SchnorrParametersGadget<G, F> {
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<SchnorrParameters<G>>, CS: ConstraintSystem<F>>(
         _cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
@@ -66,7 +66,7 @@ impl<G: Group, F: Field, D: Digest> AllocGadget<SchnorrParameters<G, D>, F> for 
 
     fn alloc_input<
         Fn: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<SchnorrParameters<G, D>>,
+        T: Borrow<SchnorrParameters<G>>,
         CS: ConstraintSystem<F>,
     >(
         _cs: CS,
@@ -83,9 +83,9 @@ impl<G: Group, F: Field, D: Digest> AllocGadget<SchnorrParameters<G, D>, F> for 
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchnorrPublicKeyGadget<G: Group, F: Field, GG: GroupGadget<G, F>> {
-    public_key: GG,
-    _group: PhantomData<G>,
-    _engine: PhantomData<F>,
+    pub(crate) public_key: GG,
+    pub(crate) _group: PhantomData<G>,
+    pub(crate) _engine: PhantomData<F>,
 }
 
 impl<G: Group + CanonicalSerialize + CanonicalDeserialize, F: Field, GG: GroupGadget<G, F>>
@@ -153,10 +153,10 @@ impl<G: Group, F: Field, GG: GroupGadget<G, F>> ToBytesGadget<F> for SchnorrPubl
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchnorrSignatureGadget<G: Group, F: Field, FG: FieldGadget<F, F>> {
-    prover_response: FG,
-    verifier_challenge: FG,
-    _field: PhantomData<*const F>,
-    _group: PhantomData<*const G>,
+    pub(crate) prover_response: FG,
+    pub(crate) verifier_challenge: FG,
+    pub(crate) _field: PhantomData<*const F>,
+    pub(crate) _group: PhantomData<*const G>,
 }
 
 impl<G: Group, F: Field, FG: FieldGadget<F, F>> AllocGadget<SchnorrSignature<G>, F>
@@ -275,10 +275,10 @@ impl<G: Group, F: Field, FG: FieldGadget<F, F>> ToBytesGadget<F> for SchnorrSign
 }
 
 pub struct SchnorrPublicKeyRandomizationGadget<G: Group, F: PrimeField, GG: GroupGadget<G, F>, FG: FieldGadget<F, F>> {
-    _group: PhantomData<*const G>,
-    _group_gadget: PhantomData<*const GG>,
-    _field_gadget: PhantomData<*const FG>,
-    _engine: PhantomData<*const F>,
+    pub(crate) _group: PhantomData<*const G>,
+    pub(crate) _group_gadget: PhantomData<*const GG>,
+    pub(crate) _field_gadget: PhantomData<*const FG>,
+    pub(crate) _engine: PhantomData<*const F>,
 }
 
 impl<
@@ -289,7 +289,7 @@ impl<
     F: PrimeField,
 > SignaturePublicKeyRandomizationGadget<Schnorr<G, D>, F> for SchnorrPublicKeyRandomizationGadget<G, F, GG, FG>
 {
-    type ParametersGadget = SchnorrParametersGadget<G, F, D>;
+    type ParametersGadget = SchnorrParametersGadget<G, F>;
     type PublicKeyGadget = SchnorrPublicKeyGadget<G, F, GG>;
     type SignatureGadget = SchnorrSignatureGadget<G, F, FG>;
 

--- a/gadgets/src/algorithms/signature/tests.rs
+++ b/gadgets/src/algorithms/signature/tests.rs
@@ -75,11 +75,11 @@ fn test_schnorr_signature_randomize_public_key_gadget() {
 
     // Circuit Schnorr randomized public key (candidate)
 
-    let candidate_parameters_gadget = SchnorrParametersGadget::<EdwardsAffine, Fr, Blake2s>::alloc_input(
-        &mut cs.ns(|| "candidate_parameters"),
-        || Ok(schnorr_signature.parameters()),
-    )
-    .unwrap();
+    let candidate_parameters_gadget =
+        SchnorrParametersGadget::<EdwardsAffine, Fr>::alloc_input(&mut cs.ns(|| "candidate_parameters"), || {
+            Ok(schnorr_signature.parameters())
+        })
+        .unwrap();
 
     let candidate_public_key_gadget = SchnorrPublicKeyGadget::<EdwardsAffine, Fr, EdwardsBls12Gadget>::alloc(
         &mut cs.ns(|| "candidate_public_key"),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes unnecessary trait requirements like `digest` from Schnorr parameters and Schnorr verification gadgets. 

Additionally, more support has been added to the Signature verification gadget in order to support the signature scheme used in the Account model (GroupEncryption), which is a wrapper around the Schnorr signature implementation.
