### PR TITLE
Upgrade bits and bytes

### DIFF
--- a/.integration/src/ledger.rs
+++ b/.integration/src/ledger.rs
@@ -82,7 +82,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
     /// Get the list of transaction ids given a block hash.
     pub fn get_block_transactions(&self, block_hash: &BlockHeaderHash) -> Result<Transactions<T>, StorageError> {
         match self.storage.get(COL_BLOCK_TRANSACTIONS, &block_hash.0)? {
-            Some(encoded_block_transactions) => Ok(Transactions::read(&encoded_block_transactions[..])?),
+            Some(encoded_block_transactions) => Ok(Transactions::read_le(&encoded_block_transactions[..])?),
             None => Err(StorageError::MissingBlockTransactions(block_hash.to_string())),
         }
     }
@@ -123,7 +123,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
     /// Get a block header given the block hash.
     pub fn get_block_header(&self, block_hash: &BlockHeaderHash) -> Result<BlockHeader, StorageError> {
         match self.storage.get(COL_BLOCK_HEADER, &block_hash.0)? {
-            Some(block_header_bytes) => Ok(BlockHeader::read(&block_header_bytes[..])?),
+            Some(block_header_bytes) => Ok(BlockHeader::read_le(&block_header_bytes[..])?),
             None => Err(StorageError::MissingBlockHeader(block_hash.to_string())),
         }
     }
@@ -213,7 +213,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
 
         let mut old_cm_and_indices = vec![];
         for (commitment_key, index_value) in self.storage.get_col(COL_COMMITMENT)? {
-            let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
+            let commitment: T::Commitment = FromBytes::read_le(&commitment_key[..])?;
             let index = bytes_to_u32(&index_value) as usize;
 
             old_cm_and_indices.push((commitment, index));
@@ -289,7 +289,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> LedgerScheme
 
     /// Return a digest of the latest ledger Merkle tree.
     fn digest(&self) -> Option<Self::MerkleTreeDigest> {
-        let digest: Self::MerkleTreeDigest = FromBytes::read(&self.current_digest().unwrap()[..]).unwrap();
+        let digest: Self::MerkleTreeDigest = FromBytes::read_le(&self.current_digest().unwrap()[..]).unwrap();
         Some(digest)
     }
 

--- a/.integration/src/ledger.rs
+++ b/.integration/src/ledger.rs
@@ -17,11 +17,7 @@
 use crate::*;
 use snarkvm_algorithms::{merkle_tree::*, traits::LoadableMerkleParameters};
 use snarkvm_dpc::prelude::*;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    has_duplicates,
-    to_bytes,
-};
+use snarkvm_utilities::{has_duplicates, to_bytes, FromBytes, ToBytes};
 
 use parking_lot::RwLock;
 use std::{

--- a/.integration/src/lib.rs
+++ b/.integration/src/lib.rs
@@ -66,9 +66,9 @@ pub struct TransactionLocation {
 
 impl ToBytes for TransactionLocation {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.index.write(&mut writer)?;
-        self.block_hash.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.index.write_le(&mut writer)?;
+        self.block_hash.write_le(&mut writer)
     }
 }
 

--- a/.integration/src/lib.rs
+++ b/.integration/src/lib.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::io::{Read, Result as IoResult, Write};
 

--- a/.integration/src/lib.rs
+++ b/.integration/src/lib.rs
@@ -74,9 +74,9 @@ impl ToBytes for TransactionLocation {
 
 impl FromBytes for TransactionLocation {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let index: u32 = FromBytes::read(&mut reader)?;
-        let block_hash: [u8; 32] = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let index: u32 = FromBytes::read_le(&mut reader)?;
+        let block_hash: [u8; 32] = FromBytes::read_le(&mut reader)?;
 
         Ok(Self { index, block_hash })
     }

--- a/.integration/src/storage.rs
+++ b/.integration/src/storage.rs
@@ -122,7 +122,7 @@ impl ToBytes for TestTx {
 
 impl FromBytes for TestTx {
     #[inline]
-    fn read<R: Read>(mut _reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut _reader: R) -> IoResult<Self> {
         Ok(Self)
     }
 }

--- a/.integration/src/storage.rs
+++ b/.integration/src/storage.rs
@@ -115,7 +115,7 @@ impl TransactionScheme for TestTx {
 
 impl ToBytes for TestTx {
     #[inline]
-    fn write<W: Write>(&self, mut _writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut _writer: W) -> IoResult<()> {
         Ok(())
     }
 }

--- a/.integration/src/testnet1.rs
+++ b/.integration/src/testnet1.rs
@@ -18,7 +18,7 @@ use crate::Ledger;
 use snarkvm_algorithms::{MerkleParameters, CRH};
 use snarkvm_dpc::{testnet1::instantiated::*, Account, DPCScheme, Storage};
 use snarkvm_parameters::{LedgerMerkleTreeParameters, Parameter};
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use rand::{CryptoRng, Rng};
 use std::sync::Arc;

--- a/.integration/src/testnet1.rs
+++ b/.integration/src/testnet1.rs
@@ -31,7 +31,7 @@ pub fn setup_or_load_parameters<R: Rng + CryptoRng, S: Storage>(
 ) -> (Arc<CommitmentMerkleParameters>, Testnet1DPC) {
     // TODO (howardwu): Resolve this inconsistency on import structure with a new model once MerkleParameters are refactored.
     let crh_parameters =
-        <MerkleTreeCRH as CRH>::Parameters::read(&LedgerMerkleTreeParameters::load_bytes().unwrap()[..])
+        <MerkleTreeCRH as CRH>::Parameters::read_le(&LedgerMerkleTreeParameters::load_bytes().unwrap()[..])
             .expect("read bytes as hash for MerkleParameters in ledger");
     let merkle_tree_hash_parameters = <CommitmentMerkleParameters as MerkleParameters>::H::from(crh_parameters);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));

--- a/.integration/src/testnet2.rs
+++ b/.integration/src/testnet2.rs
@@ -18,7 +18,7 @@ use crate::Ledger;
 use snarkvm_algorithms::{MerkleParameters, CRH};
 use snarkvm_dpc::{testnet2::instantiated::*, Account, DPCScheme, Storage};
 use snarkvm_parameters::{LedgerMerkleTreeParameters, Parameter};
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use rand::{CryptoRng, Rng};
 use std::sync::Arc;

--- a/.integration/src/testnet2.rs
+++ b/.integration/src/testnet2.rs
@@ -31,7 +31,7 @@ pub fn setup_or_load_parameters<R: Rng + CryptoRng, S: Storage>(
 ) -> (Arc<CommitmentMerkleParameters>, Testnet2DPC) {
     // TODO (howardwu): Resolve this inconsistency on import structure with a new model once MerkleParameters are refactored.
     let crh_parameters =
-        <MerkleTreeCRH as CRH>::Parameters::read(&LedgerMerkleTreeParameters::load_bytes().unwrap()[..])
+        <MerkleTreeCRH as CRH>::Parameters::read_le(&LedgerMerkleTreeParameters::load_bytes().unwrap()[..])
             .expect("read bytes as hash for MerkleParameters in ledger");
     let merkle_tree_hash_parameters = <CommitmentMerkleParameters as MerkleParameters>::H::from(crh_parameters);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -185,7 +185,7 @@ fn dpc_testnet1_integration_test() {
 
     // Check that the transaction is serialized and deserialized correctly
     let transaction_bytes = to_bytes![transaction].unwrap();
-    let recovered_transaction = Testnet1Transaction::read(&transaction_bytes[..]).unwrap();
+    let recovered_transaction = Testnet1Transaction::read_le(&transaction_bytes[..]).unwrap();
     assert_eq!(transaction, recovered_transaction);
 
     // Check that new_records can be decrypted from the transaction.
@@ -334,7 +334,7 @@ fn test_transaction_kernel_serialization() {
     let transaction_kernel_bytes = to_bytes![&transaction_kernel].unwrap();
 
     let recovered_transaction_kernel: <Testnet1DPC as DPCScheme<L>>::TransactionKernel =
-        FromBytes::read(&transaction_kernel_bytes[..]).unwrap();
+        FromBytes::read_le(&transaction_kernel_bytes[..]).unwrap();
 
     assert_eq!(transaction_kernel, recovered_transaction_kernel);
 }

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -36,10 +36,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_integration::{ledger::*, memdb::MemDb, storage::*, testnet1::*};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use itertools::Itertools;
 use rand::SeedableRng;

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -36,7 +36,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_integration::{ledger::*, memdb::MemDb, storage::*, testnet1::*};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use itertools::Itertools;
 use rand::SeedableRng;
@@ -56,10 +56,10 @@ fn testnet1_inner_circuit_id() -> anyhow::Result<Vec<u8>> {
 
     let inner_circuit_id = <<Components as DPCComponents>::InnerCircuitIDCRH as CRH>::hash(
         &dpc.system_parameters.inner_circuit_id_crh,
-        &to_bytes![inner_snark_vk]?,
+        &to_bytes_le![inner_snark_vk]?,
     )?;
 
-    Ok(to_bytes![inner_circuit_id]?)
+    Ok(to_bytes_le![inner_circuit_id]?)
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn dpc_testnet1_integration_test() {
         let (sn, _) = old_record
             .to_serial_number(&dpc.system_parameters.account_signature, &old_private_keys[i])
             .unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes![sn].unwrap());
+        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
 
         old_records.push(old_record);
     }
@@ -184,7 +184,7 @@ fn dpc_testnet1_integration_test() {
         .unwrap();
 
     // Check that the transaction is serialized and deserialized correctly
-    let transaction_bytes = to_bytes![transaction].unwrap();
+    let transaction_bytes = to_bytes_le![transaction].unwrap();
     let recovered_transaction = Testnet1Transaction::read_le(&transaction_bytes[..]).unwrap();
     assert_eq!(transaction, recovered_transaction);
 
@@ -290,7 +290,7 @@ fn test_transaction_kernel_serialization() {
         let (sn, _) = old_record
             .to_serial_number(&system_parameters.account_signature, &old_private_keys[i])
             .unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes![sn].unwrap());
+        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
 
         old_records.push(old_record);
     }
@@ -331,7 +331,7 @@ fn test_transaction_kernel_serialization() {
     .unwrap();
 
     // Serialize the transaction kernel
-    let transaction_kernel_bytes = to_bytes![&transaction_kernel].unwrap();
+    let transaction_kernel_bytes = to_bytes_le![&transaction_kernel].unwrap();
 
     let recovered_transaction_kernel: <Testnet1DPC as DPCScheme<L>>::TransactionKernel =
         FromBytes::read_le(&transaction_kernel_bytes[..]).unwrap();
@@ -415,7 +415,7 @@ fn test_testnet1_dpc_execute_constraints() {
         let (sn, _) = old_record
             .to_serial_number(signature_parameters, &old_private_keys[i])
             .unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes![sn].unwrap());
+        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
 
         old_records.push(old_record);
     }
@@ -593,7 +593,7 @@ fn test_testnet1_dpc_execute_constraints() {
 
     let inner_snark_id = <Components as DPCComponents>::InnerCircuitIDCRH::hash(
         &system_parameters.inner_circuit_id_crh,
-        &to_bytes![inner_snark_vk].unwrap(),
+        &to_bytes_le![inner_snark_vk].unwrap(),
     )
     .unwrap();
 

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -186,7 +186,7 @@ fn dpc_testnet2_integration_test() {
 
     // Check that the transaction is serialized and deserialized correctly
     let transaction_bytes = to_bytes![transaction].unwrap();
-    let recovered_transaction = Testnet2Transaction::read(&transaction_bytes[..]).unwrap();
+    let recovered_transaction = Testnet2Transaction::read_le(&transaction_bytes[..]).unwrap();
     assert_eq!(transaction, recovered_transaction);
 
     // Check that new_records can be decrypted from the transaction
@@ -334,7 +334,7 @@ fn test_testnet_2_transaction_kernel_serialization() {
     // Serialize the transaction kernel
     let transaction_kernel_bytes = to_bytes![&transaction_kernel].unwrap();
     let recovered_transaction_kernel: <Testnet2DPC as DPCScheme<L>>::TransactionKernel =
-        FromBytes::read(&transaction_kernel_bytes[..]).unwrap();
+        FromBytes::read_le(&transaction_kernel_bytes[..]).unwrap();
     assert_eq!(transaction_kernel, recovered_transaction_kernel);
 }
 

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -36,10 +36,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_integration::{ledger::*, memdb::MemDb, storage::*, testnet2::*};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use itertools::Itertools;
 use rand::SeedableRng;

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -36,7 +36,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_integration::{ledger::*, memdb::MemDb, storage::*, testnet2::*};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use itertools::Itertools;
 use rand::SeedableRng;
@@ -56,10 +56,10 @@ fn testnet2_inner_circuit_id() -> anyhow::Result<Vec<u8>> {
 
     let inner_circuit_id = <<Components as DPCComponents>::InnerCircuitIDCRH as CRH>::hash(
         &dpc.system_parameters.inner_circuit_id_crh,
-        &to_bytes![inner_snark_vk]?,
+        &to_bytes_le![inner_snark_vk]?,
     )?;
 
-    Ok(to_bytes![inner_circuit_id]?)
+    Ok(to_bytes_le![inner_circuit_id]?)
 }
 
 /// TODO (howardwu): Update this to the correct inner circuit ID when the final parameters are set.
@@ -130,7 +130,7 @@ fn dpc_testnet2_integration_test() {
         let (sn, _) = old_record
             .to_serial_number(&dpc.system_parameters.account_signature, &old_private_keys[i])
             .unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes![sn].unwrap());
+        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
 
         old_records.push(old_record);
     }
@@ -185,7 +185,7 @@ fn dpc_testnet2_integration_test() {
         .unwrap();
 
     // Check that the transaction is serialized and deserialized correctly
-    let transaction_bytes = to_bytes![transaction].unwrap();
+    let transaction_bytes = to_bytes_le![transaction].unwrap();
     let recovered_transaction = Testnet2Transaction::read_le(&transaction_bytes[..]).unwrap();
     assert_eq!(transaction, recovered_transaction);
 
@@ -291,7 +291,7 @@ fn test_testnet_2_transaction_kernel_serialization() {
         let (sn, _) = old_record
             .to_serial_number(&system_parameters.account_signature, &old_private_keys[i])
             .unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes![sn].unwrap());
+        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
 
         old_records.push(old_record);
     }
@@ -332,7 +332,7 @@ fn test_testnet_2_transaction_kernel_serialization() {
     .unwrap();
 
     // Serialize the transaction kernel
-    let transaction_kernel_bytes = to_bytes![&transaction_kernel].unwrap();
+    let transaction_kernel_bytes = to_bytes_le![&transaction_kernel].unwrap();
     let recovered_transaction_kernel: <Testnet2DPC as DPCScheme<L>>::TransactionKernel =
         FromBytes::read_le(&transaction_kernel_bytes[..]).unwrap();
     assert_eq!(transaction_kernel, recovered_transaction_kernel);
@@ -414,7 +414,7 @@ fn test_testnet2_dpc_execute_constraints() {
         let (sn, _) = old_record
             .to_serial_number(signature_parameters, &old_private_keys[i])
             .unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes![sn].unwrap());
+        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
 
         old_records.push(old_record);
     }
@@ -596,7 +596,7 @@ fn test_testnet2_dpc_execute_constraints() {
 
     let inner_snark_id = <Components as DPCComponents>::InnerCircuitIDCRH::hash(
         &system_parameters.inner_circuit_id_crh,
-        &to_bytes![inner_snark_vk].unwrap(),
+        &to_bytes_le![inner_snark_vk].unwrap(),
     )
     .unwrap();
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
 name = "snarkvm-algorithms"
 version = "0.7.2"
 dependencies = [
+ "anyhow",
  "bitvec",
  "blake2",
  "criterion",
@@ -1673,6 +1674,7 @@ dependencies = [
 name = "snarkvm-fields"
 version = "0.7.2"
 dependencies = [
+ "anyhow",
  "bincode",
  "derivative",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,7 @@ dependencies = [
 name = "snarkvm-utilities"
 version = "0.7.2"
 dependencies = [
+ "anyhow",
  "bincode",
  "num-bigint",
  "rand",

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -86,6 +86,9 @@ path = "../utilities"
 version = "0.7.2"
 default-features = false
 
+[dependencies.anyhow]
+version = "1.0"
+
 [dependencies.blake2]
 version = "0.9"
 optional = true

--- a/algorithms/src/commitment/pedersen_parameters.rs
+++ b/algorithms/src/commitment/pedersen_parameters.rs
@@ -72,21 +72,21 @@ impl<F: Field, G: Group + ToConstraintField<F>, const NUM_WINDOWS: usize, const 
 impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> ToBytes
     for PedersenCommitmentParameters<G, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        (self.bases.len() as u32).write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        (self.bases.len() as u32).write_le(&mut writer)?;
         for base in &self.bases {
-            (base.len() as u32).write(&mut writer)?;
+            (base.len() as u32).write_le(&mut writer)?;
             for g in base {
-                g.write(&mut writer)?;
+                g.write_le(&mut writer)?;
             }
         }
 
-        (self.random_base.len() as u32).write(&mut writer)?;
+        (self.random_base.len() as u32).write_le(&mut writer)?;
         for g in &self.random_base {
-            g.write(&mut writer)?;
+            g.write_le(&mut writer)?;
         }
 
-        self.crh.parameters().write(&mut writer)?;
+        self.crh.parameters().write_le(&mut writer)?;
 
         Ok(())
     }

--- a/algorithms/src/commitment/pedersen_parameters.rs
+++ b/algorithms/src/commitment/pedersen_parameters.rs
@@ -96,31 +96,31 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> FromBytes
     for PedersenCommitmentParameters<G, NUM_WINDOWS, WINDOW_SIZE>
 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let num_bases: u32 = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let num_bases: u32 = FromBytes::read_le(&mut reader)?;
         let mut bases = Vec::with_capacity(num_bases as usize);
 
         for _ in 0..num_bases {
-            let base_len: u32 = FromBytes::read(&mut reader)?;
+            let base_len: u32 = FromBytes::read_le(&mut reader)?;
             let mut base = Vec::with_capacity(base_len as usize);
 
             for _ in 0..base_len {
-                let g: G = FromBytes::read(&mut reader)?;
+                let g: G = FromBytes::read_le(&mut reader)?;
                 base.push(g);
             }
             bases.push(base);
         }
 
-        let random_base_len: u32 = FromBytes::read(&mut reader)?;
+        let random_base_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut random_base = Vec::with_capacity(random_base_len as usize);
 
         for _ in 0..random_base_len {
-            let g: G = FromBytes::read(&mut reader)?;
+            let g: G = FromBytes::read_le(&mut reader)?;
             random_base.push(g);
         }
 
         let crh_parameters: <PedersenCRH<G, NUM_WINDOWS, WINDOW_SIZE> as CRH>::Parameters =
-            FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
         let crh = PedersenCRH::<G, NUM_WINDOWS, WINDOW_SIZE>::from(crh_parameters);
 
         Ok(Self {

--- a/algorithms/src/commitment/pedersen_parameters.rs
+++ b/algorithms/src/commitment/pedersen_parameters.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use snarkvm_curves::traits::Group;
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::Rng;
 use std::io::{Read, Result as IoResult, Write};

--- a/algorithms/src/commitment/tests.rs
+++ b/algorithms/src/commitment/tests.rs
@@ -19,7 +19,7 @@ use crate::{
     traits::CommitmentScheme,
 };
 use snarkvm_curves::edwards_bls12::EdwardsProjective;
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
@@ -31,7 +31,7 @@ fn commitment_parameters_serialization<C: CommitmentScheme>() {
     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
     let commitment = C::setup(rng);
 
-    let commitment_parameters_bytes = to_bytes![commitment.parameters()].unwrap();
+    let commitment_parameters_bytes = commitment.parameters().to_bytes_le().unwrap();
 
     let recovered_commitment_parameters =
         <C as CommitmentScheme>::Parameters::read_le(&commitment_parameters_bytes[..]).unwrap();

--- a/algorithms/src/commitment/tests.rs
+++ b/algorithms/src/commitment/tests.rs
@@ -34,7 +34,7 @@ fn commitment_parameters_serialization<C: CommitmentScheme>() {
     let commitment_parameters_bytes = to_bytes![commitment.parameters()].unwrap();
 
     let recovered_commitment_parameters =
-        <C as CommitmentScheme>::Parameters::read(&commitment_parameters_bytes[..]).unwrap();
+        <C as CommitmentScheme>::Parameters::read_le(&commitment_parameters_bytes[..]).unwrap();
 
     assert_eq!(commitment.parameters(), &recovered_commitment_parameters);
 }

--- a/algorithms/src/commitment/tests.rs
+++ b/algorithms/src/commitment/tests.rs
@@ -19,10 +19,7 @@ use crate::{
     traits::CommitmentScheme,
 };
 use snarkvm_curves::edwards_bls12::EdwardsProjective;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;

--- a/algorithms/src/commitment_tree/commitment_path.rs
+++ b/algorithms/src/commitment_tree/commitment_path.rs
@@ -18,7 +18,7 @@ use crate::{
     errors::MerkleError,
     traits::{CommitmentScheme, CRH},
 };
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 use std::io::{Read, Result as IoResult, Write};
 
 #[derive(Derivative)]
@@ -64,7 +64,7 @@ impl<C: CommitmentScheme, H: CRH> CommitmentMerklePath<C, H> {
 
 /// Returns the output hash, given a left and right hash value.
 fn hash_inner_node<H: CRH, L: ToBytes>(crh: &H, left: &L, right: &L) -> Result<<H as CRH>::Output, MerkleError> {
-    let input = to_bytes![left, right]?;
+    let input = to_bytes_le![left, right]?;
     Ok(crh.hash(&input)?)
 }
 

--- a/algorithms/src/commitment_tree/commitment_path.rs
+++ b/algorithms/src/commitment_tree/commitment_path.rs
@@ -80,9 +80,9 @@ impl<C: CommitmentScheme, H: CRH> ToBytes for CommitmentMerklePath<C, H> {
 
 impl<C: CommitmentScheme, H: CRH> FromBytes for CommitmentMerklePath<C, H> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let leaves = (C::Output::read(&mut reader)?, C::Output::read(&mut reader)?);
-        let inner_hashes = (H::Output::read(&mut reader)?, H::Output::read(&mut reader)?);
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let leaves = (C::Output::read_le(&mut reader)?, C::Output::read_le(&mut reader)?);
+        let inner_hashes = (H::Output::read_le(&mut reader)?, H::Output::read_le(&mut reader)?);
 
         Ok(Self { leaves, inner_hashes })
     }

--- a/algorithms/src/commitment_tree/commitment_path.rs
+++ b/algorithms/src/commitment_tree/commitment_path.rs
@@ -70,11 +70,11 @@ fn hash_inner_node<H: CRH, L: ToBytes>(crh: &H, left: &L, right: &L) -> Result<<
 
 impl<C: CommitmentScheme, H: CRH> ToBytes for CommitmentMerklePath<C, H> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.leaves.0.write(&mut writer)?;
-        self.leaves.1.write(&mut writer)?;
-        self.inner_hashes.0.write(&mut writer)?;
-        self.inner_hashes.1.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.leaves.0.write_le(&mut writer)?;
+        self.leaves.1.write_le(&mut writer)?;
+        self.inner_hashes.0.write_le(&mut writer)?;
+        self.inner_hashes.1.write_le(&mut writer)
     }
 }
 

--- a/algorithms/src/commitment_tree/commitment_tree.rs
+++ b/algorithms/src/commitment_tree/commitment_tree.rs
@@ -104,16 +104,16 @@ impl<C: CommitmentScheme, H: CRH> CommitmentMerkleTree<C, H> {
     }
 
     pub fn from_bytes<R: Read>(mut reader: R, parameters: H) -> IoResult<Self> {
-        let root = <H as CRH>::Output::read(&mut reader)?;
+        let root = <H as CRH>::Output::read_le(&mut reader)?;
 
-        let left_inner_hash = <H as CRH>::Output::read(&mut reader)?;
-        let right_inner_hash = <H as CRH>::Output::read(&mut reader)?;
+        let left_inner_hash = <H as CRH>::Output::read_le(&mut reader)?;
+        let right_inner_hash = <H as CRH>::Output::read_le(&mut reader)?;
 
         let inner_hashes = (left_inner_hash, right_inner_hash);
 
         let mut leaves = vec![];
         for _ in 0..4 {
-            let leaf = <C as CommitmentScheme>::Output::read(&mut reader)?;
+            let leaf = <C as CommitmentScheme>::Output::read_le(&mut reader)?;
             leaves.push(leaf);
         }
 

--- a/algorithms/src/commitment_tree/commitment_tree.rs
+++ b/algorithms/src/commitment_tree/commitment_tree.rs
@@ -137,12 +137,12 @@ impl<C: CommitmentScheme, H: CRH> CommitmentMerkleTree<C, H> {
 
 impl<C: CommitmentScheme, H: CRH> ToBytes for CommitmentMerkleTree<C, H> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.root.write(&mut writer)?;
-        self.inner_hashes.0.write(&mut writer)?;
-        self.inner_hashes.1.write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.root.write_le(&mut writer)?;
+        self.inner_hashes.0.write_le(&mut writer)?;
+        self.inner_hashes.1.write_le(&mut writer)?;
         for leaf in &self.leaves {
-            leaf.write(&mut writer)?;
+            leaf.write_le(&mut writer)?;
         }
 
         Ok(())

--- a/algorithms/src/commitment_tree/commitment_tree.rs
+++ b/algorithms/src/commitment_tree/commitment_tree.rs
@@ -19,7 +19,7 @@ use crate::{
     errors::MerkleError,
     traits::{CommitmentScheme, CRH},
 };
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use std::io::{Read, Result as IoResult, Write};
 
@@ -48,13 +48,13 @@ pub struct CommitmentMerkleTree<C: CommitmentScheme, H: CRH> {
 impl<C: CommitmentScheme, H: CRH> CommitmentMerkleTree<C, H> {
     /// Construct a new commitment Merkle tree.
     pub fn new(parameters: H, leaves: &[<C as CommitmentScheme>::Output; 4]) -> Result<Self, MerkleError> {
-        let input_1 = to_bytes![leaves[0], leaves[1]]?;
+        let input_1 = to_bytes_le![leaves[0], leaves[1]]?;
         let inner_hash1 = H::hash(&parameters, &input_1)?;
 
-        let input_2 = to_bytes![leaves[2], leaves[3]]?;
+        let input_2 = to_bytes_le![leaves[2], leaves[3]]?;
         let inner_hash2 = H::hash(&parameters, &input_2)?;
 
-        let root = H::hash(&parameters, &to_bytes![inner_hash1, inner_hash2]?)?;
+        let root = H::hash(&parameters, &to_bytes_le![inner_hash1, inner_hash2]?)?;
 
         Ok(Self {
             root,

--- a/algorithms/src/commitment_tree/tests.rs
+++ b/algorithms/src/commitment_tree/tests.rs
@@ -21,7 +21,7 @@ use crate::{
     traits::{CommitmentScheme, CRH},
 };
 use snarkvm_curves::edwards_bls12::EdwardsProjective as EdwardsBls;
-use snarkvm_utilities::{rand::UniformRand, to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBytes};
 
 use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
@@ -95,7 +95,7 @@ fn test_serialize_commitment_merkle_tree() {
 
     let merkle_tree = generate_merkle_tree(&commitment, &crh, rng);
 
-    let merkle_tree_bytes = to_bytes![merkle_tree].unwrap();
+    let merkle_tree_bytes = merkle_tree.to_bytes_le().unwrap();
     let recovered_merkle_tree = CommitmentMerkleTree::<C, H>::from_bytes(&merkle_tree_bytes[..], crh).unwrap();
 
     assert!(merkle_tree == recovered_merkle_tree);
@@ -113,7 +113,7 @@ fn test_serialize_commitment_path() {
     for leaf in merkle_tree.leaves().iter() {
         let proof = merkle_tree.generate_proof(&leaf).unwrap();
 
-        let proof_bytes = to_bytes![proof].unwrap();
+        let proof_bytes = proof.to_bytes_le().unwrap();
         let recovered_proof = CM::read_le(&proof_bytes[..]).unwrap();
 
         assert!(proof == recovered_proof);

--- a/algorithms/src/commitment_tree/tests.rs
+++ b/algorithms/src/commitment_tree/tests.rs
@@ -114,7 +114,7 @@ fn test_serialize_commitment_path() {
         let proof = merkle_tree.generate_proof(&leaf).unwrap();
 
         let proof_bytes = to_bytes![proof].unwrap();
-        let recovered_proof = CM::read(&proof_bytes[..]).unwrap();
+        let recovered_proof = CM::read_le(&proof_bytes[..]).unwrap();
 
         assert!(proof == recovered_proof);
 

--- a/algorithms/src/commitment_tree/tests.rs
+++ b/algorithms/src/commitment_tree/tests.rs
@@ -21,11 +21,7 @@ use crate::{
     traits::{CommitmentScheme, CRH},
 };
 use snarkvm_curves::edwards_bls12::EdwardsProjective as EdwardsBls;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    to_bytes,
-};
+use snarkvm_utilities::{rand::UniformRand, to_bytes, FromBytes, ToBytes};
 
 use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;

--- a/algorithms/src/crh/pedersen_parameters.rs
+++ b/algorithms/src/crh/pedersen_parameters.rs
@@ -75,16 +75,16 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> FromBytes
     for PedersenCRHParameters<G, NUM_WINDOWS, WINDOW_SIZE>
 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let num_bases: u32 = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let num_bases: u32 = FromBytes::read_le(&mut reader)?;
         let mut bases = Vec::with_capacity(num_bases as usize);
 
         for _ in 0..num_bases {
-            let base_len: u32 = FromBytes::read(&mut reader)?;
+            let base_len: u32 = FromBytes::read_le(&mut reader)?;
             let mut base = Vec::with_capacity(base_len as usize);
 
             for _ in 0..base_len {
-                let g: G = FromBytes::read(&mut reader)?;
+                let g: G = FromBytes::read_le(&mut reader)?;
                 base.push(g);
             }
             bases.push(base);

--- a/algorithms/src/crh/pedersen_parameters.rs
+++ b/algorithms/src/crh/pedersen_parameters.rs
@@ -59,12 +59,12 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> PedersenCRHPa
 impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> ToBytes
     for PedersenCRHParameters<G, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        (self.bases.len() as u32).write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        (self.bases.len() as u32).write_le(&mut writer)?;
         for base in &self.bases {
-            (base.len() as u32).write(&mut writer)?;
+            (base.len() as u32).write_le(&mut writer)?;
             for g in base {
-                g.write(&mut writer)?;
+                g.write_le(&mut writer)?;
             }
         }
         Ok(())

--- a/algorithms/src/crh/pedersen_parameters.rs
+++ b/algorithms/src/crh/pedersen_parameters.rs
@@ -17,7 +17,7 @@
 use crate::traits::crh::CRHParameters;
 use snarkvm_curves::Group;
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::Rng;
 use std::{

--- a/algorithms/src/crh/tests.rs
+++ b/algorithms/src/crh/tests.rs
@@ -19,10 +19,7 @@ use crate::{
     traits::CRH,
 };
 use snarkvm_curves::edwards_bls12::EdwardsProjective;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;

--- a/algorithms/src/crh/tests.rs
+++ b/algorithms/src/crh/tests.rs
@@ -37,7 +37,7 @@ fn crh_parameters_serialization<C: CRH>() {
     let crh_parameters = crh.parameters();
 
     let crh_parameters_bytes = to_bytes![crh_parameters].unwrap();
-    let recovered_crh_parameters: <C as CRH>::Parameters = FromBytes::read(&crh_parameters_bytes[..]).unwrap();
+    let recovered_crh_parameters: <C as CRH>::Parameters = FromBytes::read_le(&crh_parameters_bytes[..]).unwrap();
 
     assert_eq!(crh_parameters, &recovered_crh_parameters);
 }

--- a/algorithms/src/crh/tests.rs
+++ b/algorithms/src/crh/tests.rs
@@ -19,7 +19,7 @@ use crate::{
     traits::CRH,
 };
 use snarkvm_curves::edwards_bls12::EdwardsProjective;
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
@@ -36,7 +36,7 @@ fn crh_parameters_serialization<C: CRH>() {
     let crh = C::setup(rng);
     let crh_parameters = crh.parameters();
 
-    let crh_parameters_bytes = to_bytes![crh_parameters].unwrap();
+    let crh_parameters_bytes = crh_parameters.to_bytes_le().unwrap();
     let recovered_crh_parameters: <C as CRH>::Parameters = FromBytes::read_le(&crh_parameters_bytes[..]).unwrap();
 
     assert_eq!(crh_parameters, &recovered_crh_parameters);

--- a/algorithms/src/encoding/elligator2.rs
+++ b/algorithms/src/encoding/elligator2.rs
@@ -22,7 +22,7 @@ use snarkvm_curves::traits::{
     TwistedEdwardsParameters,
 };
 use snarkvm_fields::{Field, LegendreSymbol, One, SquareRootField, Zero};
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use std::{cmp, marker::PhantomData, ops::Neg};
 
@@ -152,7 +152,7 @@ impl<P: MontgomeryParameters + TwistedEdwardsParameters, G: Group + ProjectiveCu
         };
 
         Ok((
-            <G as ProjectiveCurve>::Affine::read_le(&to_bytes![x, y]?[..])?,
+            <G as ProjectiveCurve>::Affine::read_le(&to_bytes_le![x, y]?[..])?,
             sign_high,
         ))
     }
@@ -167,8 +167,8 @@ impl<P: MontgomeryParameters + TwistedEdwardsParameters, G: Group + ProjectiveCu
             return Err(EncodingError::InputMustBeNonzero);
         }
 
-        let x = P::BaseField::read_le(&to_bytes![group_element.to_x_coordinate()]?[..])?;
-        let y = P::BaseField::read_le(&to_bytes![group_element.to_y_coordinate()]?[..])?;
+        let x = P::BaseField::read_le(&to_bytes_le![group_element.to_x_coordinate()]?[..])?;
+        let y = P::BaseField::read_le(&to_bytes_le![group_element.to_y_coordinate()]?[..])?;
 
         // Compute the parameters for the alternate Montgomery form: v^2 == u^3 + A * u^2 + B * u.
         let (a, b) = {

--- a/algorithms/src/encoding/elligator2.rs
+++ b/algorithms/src/encoding/elligator2.rs
@@ -151,7 +151,10 @@ impl<P: MontgomeryParameters + TwistedEdwardsParameters, G: Group + ProjectiveCu
             (x, y)
         };
 
-        Ok((<G as ProjectiveCurve>::Affine::read(&to_bytes![x, y]?[..])?, sign_high))
+        Ok((
+            <G as ProjectiveCurve>::Affine::read_le(&to_bytes![x, y]?[..])?,
+            sign_high,
+        ))
     }
 
     #[allow(clippy::many_single_char_names)]
@@ -164,8 +167,8 @@ impl<P: MontgomeryParameters + TwistedEdwardsParameters, G: Group + ProjectiveCu
             return Err(EncodingError::InputMustBeNonzero);
         }
 
-        let x = P::BaseField::read(&to_bytes![group_element.to_x_coordinate()]?[..])?;
-        let y = P::BaseField::read(&to_bytes![group_element.to_y_coordinate()]?[..])?;
+        let x = P::BaseField::read_le(&to_bytes![group_element.to_x_coordinate()]?[..])?;
+        let y = P::BaseField::read_le(&to_bytes![group_element.to_y_coordinate()]?[..])?;
 
         // Compute the parameters for the alternate Montgomery form: v^2 == u^3 + A * u^2 + B * u.
         let (a, b) = {

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -22,7 +22,6 @@ use snarkvm_utilities::{
     from_bytes_le_to_bits_le,
     rand::UniformRand,
     serialize::*,
-    to_bytes,
     FromBytes,
     ToBytes,
 };
@@ -134,7 +133,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
 
         let mut public_key = G::zero();
         for (bit, base_power) in
-            from_bytes_le_to_bits_le(&to_bytes![private_key]?).zip_eq(&self.parameters.generator_powers)
+            from_bytes_le_to_bits_le(&private_key.to_bytes_le()?).zip_eq(&self.parameters.generator_powers)
         {
             if bit {
                 public_key += base_power;
@@ -158,7 +157,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
 
             let affine = public_key.0.mul(y).into_affine();
             debug_assert!(affine.is_in_correct_subgroup_assuming_on_curve());
-            z_bytes = to_bytes![affine.to_x_coordinate()]?;
+            z_bytes = affine.to_x_coordinate().to_bytes_le()?;
         }
 
         Ok(y)
@@ -174,7 +173,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
 
         let affine = record_view_key.into_affine();
         debug_assert!(affine.is_in_correct_subgroup_assuming_on_curve());
-        let z_bytes = to_bytes![affine.to_x_coordinate()]?;
+        let z_bytes = affine.to_x_coordinate().to_bytes_le()?;
 
         let z = Self::Randomness::read_le(&z_bytes[..])?;
 
@@ -205,7 +204,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
 
         let mut c_0 = G::zero();
         for (bit, base_power) in
-            from_bytes_le_to_bits_le(&to_bytes![randomness]?).zip_eq(&self.parameters.generator_powers)
+            from_bytes_le_to_bits_le(&randomness.to_bytes_le()?).zip_eq(&self.parameters.generator_powers)
         {
             if bit {
                 c_0 += base_power;
@@ -244,7 +243,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
 
         let affine = record_view_key.into_affine();
         debug_assert!(affine.is_in_correct_subgroup_assuming_on_curve());
-        let z_bytes = to_bytes![affine.to_x_coordinate()]?;
+        let z_bytes = affine.to_x_coordinate().to_bytes_le()?;
 
         let z = Self::Randomness::read_le(&z_bytes[..])?;
 

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -49,10 +49,10 @@ pub struct GroupEncryptionPublicKey<G: Group + ProjectiveCurve + CanonicalSerial
 impl<G: Group + ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize> ToBytes for GroupEncryptionPublicKey<G> {
     /// Writes the x-coordinate of the encryption public key.
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         let affine = self.0.into_affine();
         let x_coordinate = affine.to_x_coordinate();
-        x_coordinate.write(&mut writer)
+        x_coordinate.write_le(&mut writer)
     }
 }
 

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -59,8 +59,8 @@ impl<G: Group + ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize> ToB
 impl<G: Group + ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize> FromBytes for GroupEncryptionPublicKey<G> {
     /// Reads the x-coordinate of the encryption public key.
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let x_coordinate = <G::Affine as AffineCurve>::BaseField::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let x_coordinate = <G::Affine as AffineCurve>::BaseField::read_le(&mut reader)?;
 
         if let Some(element) = <G as ProjectiveCurve>::Affine::from_x_coordinate(x_coordinate, true) {
             if element.is_in_correct_subgroup_assuming_on_curve() {
@@ -153,7 +153,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
         let mut y = Self::Randomness::zero();
         let mut z_bytes = vec![];
 
-        while Self::Randomness::read(&z_bytes[..]).is_err() {
+        while Self::Randomness::read_le(&z_bytes[..]).is_err() {
             y = Self::Randomness::rand(rng);
 
             let affine = public_key.0.mul(y).into_affine();
@@ -176,7 +176,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
         debug_assert!(affine.is_in_correct_subgroup_assuming_on_curve());
         let z_bytes = to_bytes![affine.to_x_coordinate()]?;
 
-        let z = Self::Randomness::read(&z_bytes[..])?;
+        let z = Self::Randomness::read_le(&z_bytes[..])?;
 
         let one = Self::Randomness::one();
         let mut i = Self::Randomness::one();
@@ -246,7 +246,7 @@ impl<G: Group + ProjectiveCurve, SG: Group + CanonicalSerialize + CanonicalDeser
         debug_assert!(affine.is_in_correct_subgroup_assuming_on_curve());
         let z_bytes = to_bytes![affine.to_x_coordinate()]?;
 
-        let z = Self::Randomness::read(&z_bytes[..])?;
+        let z = Self::Randomness::read_le(&z_bytes[..])?;
 
         let one = Self::Randomness::one();
         let mut plaintext = Vec::with_capacity(ciphertext.len().saturating_sub(1));

--- a/algorithms/src/encryption/group_parameters.rs
+++ b/algorithms/src/encryption/group_parameters.rs
@@ -56,12 +56,12 @@ impl<G: Group> GroupEncryptionParameters<G> {
 }
 
 impl<G: Group> ToBytes for GroupEncryptionParameters<G> {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        (self.generator_powers.len() as u32).write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        (self.generator_powers.len() as u32).write_le(&mut writer)?;
         for g in &self.generator_powers {
-            g.write(&mut writer)?;
+            g.write_le(&mut writer)?;
         }
-        self.salt.write(&mut writer)
+        self.salt.write_le(&mut writer)
     }
 }
 

--- a/algorithms/src/encryption/group_parameters.rs
+++ b/algorithms/src/encryption/group_parameters.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_curves::traits::Group;
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::Rng;
 use std::io::{Read, Result as IoResult, Write};

--- a/algorithms/src/encryption/group_parameters.rs
+++ b/algorithms/src/encryption/group_parameters.rs
@@ -67,15 +67,15 @@ impl<G: Group> ToBytes for GroupEncryptionParameters<G> {
 
 impl<G: Group> FromBytes for GroupEncryptionParameters<G> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let generator_powers_length: u32 = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let generator_powers_length: u32 = FromBytes::read_le(&mut reader)?;
         let mut generator_powers = Vec::with_capacity(generator_powers_length as usize);
         for _ in 0..generator_powers_length {
-            let g: G = FromBytes::read(&mut reader)?;
+            let g: G = FromBytes::read_le(&mut reader)?;
             generator_powers.push(g);
         }
 
-        let salt: [u8; 32] = FromBytes::read(&mut reader)?;
+        let salt: [u8; 32] = FromBytes::read_le(&mut reader)?;
 
         Ok(Self { generator_powers, salt })
     }

--- a/algorithms/src/encryption/tests.rs
+++ b/algorithms/src/encryption/tests.rs
@@ -19,7 +19,7 @@ use snarkvm_curves::{
     edwards_bls12::{EdwardsAffine, EdwardsProjective},
     traits::{Group, ProjectiveCurve},
 };
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use blake2::Blake2s;
 use rand::{Rng, SeedableRng};
@@ -61,7 +61,7 @@ fn encryption_public_key_serialization() {
         let private_key = encryption_scheme.generate_private_key(rng);
         let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
 
-        let public_key_bytes = to_bytes![public_key].unwrap();
+        let public_key_bytes = to_bytes_le![public_key].unwrap();
         let recovered_public_key =
             <TestEncryptionScheme as EncryptionScheme>::PublicKey::read_le(&public_key_bytes[..]).unwrap();
 

--- a/algorithms/src/encryption/tests.rs
+++ b/algorithms/src/encryption/tests.rs
@@ -63,7 +63,7 @@ fn encryption_public_key_serialization() {
 
         let public_key_bytes = to_bytes![public_key].unwrap();
         let recovered_public_key =
-            <TestEncryptionScheme as EncryptionScheme>::PublicKey::read(&public_key_bytes[..]).unwrap();
+            <TestEncryptionScheme as EncryptionScheme>::PublicKey::read_le(&public_key_bytes[..]).unwrap();
 
         assert_eq!(public_key, recovered_public_key);
     }

--- a/algorithms/src/errors/commitment.rs
+++ b/algorithms/src/errors/commitment.rs
@@ -18,6 +18,9 @@ use std::io::{Error, ErrorKind};
 
 #[derive(Debug, Error)]
 pub enum CommitmentError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/algorithms/src/errors/crh.rs
+++ b/algorithms/src/errors/crh.rs
@@ -18,6 +18,9 @@ use std::io::{Error, ErrorKind};
 
 #[derive(Debug, Error)]
 pub enum CRHError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/algorithms/src/errors/encoding.rs
+++ b/algorithms/src/errors/encoding.rs
@@ -18,6 +18,9 @@ use std::io::{Error, ErrorKind};
 
 #[derive(Debug, Error)]
 pub enum EncodingError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/algorithms/src/errors/encryption.rs
+++ b/algorithms/src/errors/encryption.rs
@@ -16,6 +16,9 @@
 
 #[derive(Debug, Error)]
 pub enum EncryptionError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/algorithms/src/errors/merkle.rs
+++ b/algorithms/src/errors/merkle.rs
@@ -16,6 +16,9 @@
 
 #[derive(Debug, Error)]
 pub enum MerkleError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/algorithms/src/errors/prf.rs
+++ b/algorithms/src/errors/prf.rs
@@ -16,6 +16,9 @@
 
 #[derive(Debug, Error)]
 pub enum PRFError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/algorithms/src/errors/signature.rs
+++ b/algorithms/src/errors/signature.rs
@@ -18,6 +18,9 @@ use std::io::{Error, ErrorKind};
 
 #[derive(Debug, Error)]
 pub enum SignatureError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/algorithms/src/errors/snark.rs
+++ b/algorithms/src/errors/snark.rs
@@ -20,6 +20,9 @@ use snarkvm_r1cs::SynthesisError;
 #[derive(Debug, Error)]
 pub enum SNARKError {
     #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
+    #[error("{}", _0)]
     ConstraintFieldError(ConstraintFieldError),
 
     #[error("{}: {}", _0, _1)]

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -22,7 +22,7 @@ use crate::{
     merkle_tree::MerkleTree,
     traits::{crh::CRH, merkle_tree::LoadableMerkleParameters},
 };
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 /// Generates a valid Merkle tree and verifies the Merkle path witness for each leaf.
 fn generate_merkle_tree<P: LoadableMerkleParameters, L: ToBytes + Send + Sync + Clone + Eq>(
@@ -111,11 +111,11 @@ fn run_merkle_tree_matches_hashing_test<P: LoadableMerkleParameters>() {
     let leaf4 = pedersen.hash(&leaves[3]).unwrap();
 
     // depth 1
-    let left = pedersen.hash(&to_bytes![leaf1, leaf2].unwrap()).unwrap();
-    let right = pedersen.hash(&to_bytes![leaf3, leaf4].unwrap()).unwrap();
+    let left = pedersen.hash(&to_bytes_le![leaf1, leaf2].unwrap()).unwrap();
+    let right = pedersen.hash(&to_bytes_le![leaf3, leaf4].unwrap()).unwrap();
 
     // depth 0
-    let expected_root = pedersen.hash(&to_bytes![left, right].unwrap()).unwrap();
+    let expected_root = pedersen.hash(&to_bytes_le![left, right].unwrap()).unwrap();
 
     println!(
         "merkle_root == expected_root\n\t{} == {}",
@@ -149,16 +149,16 @@ fn run_padded_merkle_tree_matches_hashing_test<P: LoadableMerkleParameters>() {
     let leaf4 = pedersen.hash(&leaves[3]).unwrap();
 
     // depth 2
-    let left = pedersen.hash(&to_bytes![leaf1, leaf2].unwrap()).unwrap();
-    let right = pedersen.hash(&to_bytes![leaf3, leaf4].unwrap()).unwrap();
+    let left = pedersen.hash(&to_bytes_le![leaf1, leaf2].unwrap()).unwrap();
+    let right = pedersen.hash(&to_bytes_le![leaf3, leaf4].unwrap()).unwrap();
 
     // depth 1
-    let penultimate_left = pedersen.hash(&to_bytes![left, right].unwrap()).unwrap();
+    let penultimate_left = pedersen.hash(&to_bytes_le![left, right].unwrap()).unwrap();
     let penultimate_right = parameters.hash_empty().unwrap();
 
     // depth 0
     let expected_root = pedersen
-        .hash(&to_bytes![penultimate_left, penultimate_right].unwrap())
+        .hash(&to_bytes_le![penultimate_left, penultimate_right].unwrap())
         .unwrap();
 
     println!(

--- a/algorithms/src/msm/fixed_base.rs
+++ b/algorithms/src/msm/fixed_base.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_curves::traits::ProjectiveCurve;
 use snarkvm_fields::{FieldParameters, PrimeField};
-use snarkvm_utilities::biginteger::BigInteger;
+use snarkvm_utilities::ToBits;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/algorithms/src/signature/group.rs
+++ b/algorithms/src/signature/group.rs
@@ -100,7 +100,7 @@ where
         rng: &mut R,
     ) -> Result<Self::Signature, SignatureError> {
         let schnorr_signature: Schnorr<SG, D> = self.parameters.clone().into();
-        let private_key = <SG as Group>::ScalarField::read(&to_bytes![private_key]?[..])?;
+        let private_key = <SG as Group>::ScalarField::read_le(&to_bytes![private_key]?[..])?;
 
         Ok(schnorr_signature.sign(&private_key, message, rng)?)
     }

--- a/algorithms/src/signature/group.rs
+++ b/algorithms/src/signature/group.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use snarkvm_curves::traits::{Group, ProjectiveCurve};
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{serialize::*, to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{serialize::*, to_bytes_le, FromBytes, ToBytes};
 
 use digest::Digest;
 use rand::Rng;
@@ -100,7 +100,7 @@ where
         rng: &mut R,
     ) -> Result<Self::Signature, SignatureError> {
         let schnorr_signature: Schnorr<SG, D> = self.parameters.clone().into();
-        let private_key = <SG as Group>::ScalarField::read_le(&to_bytes![private_key]?[..])?;
+        let private_key = <SG as Group>::ScalarField::read_le(&to_bytes_le![private_key]?[..])?;
 
         Ok(schnorr_signature.sign(&private_key, message, rng)?)
     }

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -48,9 +48,9 @@ pub struct SchnorrSignature<G: Group> {
 
 impl<G: Group> ToBytes for SchnorrSignature<G> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.prover_response.write(&mut writer)?;
-        self.verifier_challenge.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.prover_response.write_le(&mut writer)?;
+        self.verifier_challenge.write_le(&mut writer)
     }
 }
 
@@ -81,8 +81,8 @@ pub struct SchnorrPublicKey<G: Group + CanonicalSerialize + CanonicalDeserialize
 
 impl<G: Group + CanonicalSerialize + CanonicalDeserialize> ToBytes for SchnorrPublicKey<G> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.0.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.0.write_le(&mut writer)
     }
 }
 

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -56,9 +56,9 @@ impl<G: Group> ToBytes for SchnorrSignature<G> {
 
 impl<G: Group> FromBytes for SchnorrSignature<G> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let prover_response = <G as Group>::ScalarField::read(&mut reader)?;
-        let verifier_challenge = <G as Group>::ScalarField::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let prover_response = <G as Group>::ScalarField::read_le(&mut reader)?;
+        let verifier_challenge = <G as Group>::ScalarField::read_le(&mut reader)?;
 
         Ok(Self {
             prover_response,
@@ -88,8 +88,8 @@ impl<G: Group + CanonicalSerialize + CanonicalDeserialize> ToBytes for SchnorrPu
 
 impl<G: Group + CanonicalSerialize + CanonicalDeserialize> FromBytes for SchnorrPublicKey<G> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        Ok(Self(G::read(&mut reader)?))
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self(G::read_le(&mut reader)?))
     }
 }
 

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -22,7 +22,7 @@ use snarkvm_utilities::{
     errors::SerializationError,
     rand::UniformRand,
     serialize::*,
-    to_bytes,
+    to_bytes_le,
 };
 
 use digest::Digest;
@@ -147,7 +147,7 @@ where
 
         let mut public_key = G::zero();
         for (bit, base_power) in
-            from_bytes_le_to_bits_le(&to_bytes![private_key]?).zip_eq(&self.parameters.generator_powers)
+            from_bytes_le_to_bits_le(&to_bytes_le![private_key]?).zip_eq(&self.parameters.generator_powers)
         {
             if bit {
                 public_key += base_power;
@@ -173,7 +173,7 @@ where
             // This is the prover's first msg in the Sigma protocol.
             let mut prover_commitment = G::zero();
             for (bit, base_power) in
-                from_bytes_le_to_bits_le(&to_bytes![random_scalar]?).zip_eq(&self.parameters.generator_powers)
+                from_bytes_le_to_bits_le(&to_bytes_le![random_scalar]?).zip_eq(&self.parameters.generator_powers)
             {
                 if bit {
                     prover_commitment += base_power;
@@ -183,7 +183,7 @@ where
             // Hash everything to get verifier challenge.
             let mut hash_input = Vec::new();
             hash_input.extend_from_slice(&self.parameters.salt);
-            hash_input.extend_from_slice(&to_bytes![prover_commitment]?);
+            hash_input.extend_from_slice(&to_bytes_le![prover_commitment]?);
             hash_input.extend_from_slice(message);
 
             // Compute the supposed verifier response: e := H(salt || r || msg);
@@ -218,7 +218,7 @@ where
 
         let mut claimed_prover_commitment = G::zero();
         for (bit, base_power) in
-            from_bytes_le_to_bits_le(&to_bytes![prover_response]?).zip_eq(&self.parameters.generator_powers)
+            from_bytes_le_to_bits_le(&to_bytes_le![prover_response]?).zip_eq(&self.parameters.generator_powers)
         {
             if bit {
                 claimed_prover_commitment += base_power;
@@ -230,7 +230,7 @@ where
 
         let mut hash_input = Vec::new();
         hash_input.extend_from_slice(&self.parameters.salt);
-        hash_input.extend_from_slice(&to_bytes![claimed_prover_commitment]?);
+        hash_input.extend_from_slice(&to_bytes_le![claimed_prover_commitment]?);
         hash_input.extend_from_slice(&message);
 
         let obtained_verifier_challenge = if let Some(obtained_verifier_challenge) =
@@ -255,7 +255,7 @@ where
 
         let mut encoded = G::zero();
         for (bit, base_power) in
-            from_bytes_le_to_bits_le(&to_bytes![randomness]?).zip_eq(&self.parameters.generator_powers)
+            from_bytes_le_to_bits_le(&to_bytes_le![randomness]?).zip_eq(&self.parameters.generator_powers)
         {
             if bit {
                 encoded += base_power;

--- a/algorithms/src/signature/schnorr_parameters.rs
+++ b/algorithms/src/signature/schnorr_parameters.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_curves::traits::Group;
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use digest::Digest;
 use rand::Rng;

--- a/algorithms/src/signature/schnorr_parameters.rs
+++ b/algorithms/src/signature/schnorr_parameters.rs
@@ -62,12 +62,12 @@ impl<G: Group, D: Digest> SchnorrParameters<G, D> {
 }
 
 impl<G: Group, D: Digest> ToBytes for SchnorrParameters<G, D> {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        (self.generator_powers.len() as u32).write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        (self.generator_powers.len() as u32).write_le(&mut writer)?;
         for g in &self.generator_powers {
-            g.write(&mut writer)?;
+            g.write_le(&mut writer)?;
         }
-        self.salt.write(&mut writer)
+        self.salt.write_le(&mut writer)
     }
 }
 

--- a/algorithms/src/signature/schnorr_parameters.rs
+++ b/algorithms/src/signature/schnorr_parameters.rs
@@ -73,15 +73,15 @@ impl<G: Group, D: Digest> ToBytes for SchnorrParameters<G, D> {
 
 impl<G: Group, D: Digest> FromBytes for SchnorrParameters<G, D> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let generator_powers_length: u32 = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let generator_powers_length: u32 = FromBytes::read_le(&mut reader)?;
         let mut generator_powers = Vec::with_capacity(generator_powers_length as usize);
         for _ in 0..generator_powers_length {
-            let g: G = FromBytes::read(&mut reader)?;
+            let g: G = FromBytes::read_le(&mut reader)?;
             generator_powers.push(g);
         }
 
-        let salt: [u8; 32] = FromBytes::read(&mut reader)?;
+        let salt: [u8; 32] = FromBytes::read_le(&mut reader)?;
 
         Ok(Self {
             generator_powers,

--- a/algorithms/src/signature/tests.rs
+++ b/algorithms/src/signature/tests.rs
@@ -20,11 +20,7 @@ use snarkvm_curves::{
     edwards_bw6::EdwardsAffine as Edwards,
     traits::Group,
 };
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    to_bytes,
-};
+use snarkvm_utilities::{rand::UniformRand, to_bytes, FromBytes, ToBytes};
 
 use blake2::Blake2s;
 use rand::SeedableRng;

--- a/algorithms/src/signature/tests.rs
+++ b/algorithms/src/signature/tests.rs
@@ -20,7 +20,7 @@ use snarkvm_curves::{
     edwards_bw6::EdwardsAffine as Edwards,
     traits::Group,
 };
-use snarkvm_utilities::{rand::UniformRand, to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{rand::UniformRand, to_bytes_le, FromBytes, ToBytes};
 
 use blake2::Blake2s;
 use rand::SeedableRng;
@@ -70,7 +70,7 @@ fn signature_scheme_parameter_serialization<S: SignatureScheme>() {
     let signature_scheme = S::setup(rng).unwrap();
     let signature_scheme_parameters = signature_scheme.parameters();
 
-    let signature_scheme_parameters_bytes = to_bytes![signature_scheme_parameters].unwrap();
+    let signature_scheme_parameters_bytes = to_bytes_le![signature_scheme_parameters].unwrap();
     let recovered_signature_scheme_parameters: <S as SignatureScheme>::Parameters =
         FromBytes::read_le(&signature_scheme_parameters_bytes[..]).unwrap();
 
@@ -83,7 +83,7 @@ fn schnorr_signature_test() {
     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
     sign_and_verify::<TestSignature>(message.as_bytes());
     failed_verification::<TestSignature>(message.as_bytes(), b"Bad message");
-    let random_scalar = to_bytes!(<Edwards as Group>::ScalarField::rand(rng)).unwrap();
+    let random_scalar = to_bytes_le!(<Edwards as Group>::ScalarField::rand(rng)).unwrap();
     randomize_and_verify::<TestSignature>(message.as_bytes(), &random_scalar.as_slice());
 }
 

--- a/algorithms/src/signature/tests.rs
+++ b/algorithms/src/signature/tests.rs
@@ -72,7 +72,7 @@ fn signature_scheme_parameter_serialization<S: SignatureScheme>() {
 
     let signature_scheme_parameters_bytes = to_bytes![signature_scheme_parameters].unwrap();
     let recovered_signature_scheme_parameters: <S as SignatureScheme>::Parameters =
-        FromBytes::read(&signature_scheme_parameters_bytes[..]).unwrap();
+        FromBytes::read_le(&signature_scheme_parameters_bytes[..]).unwrap();
 
     assert_eq!(signature_scheme_parameters, &recovered_signature_scheme_parameters);
 }

--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -72,7 +72,7 @@ impl<E: PairingEngine> ToBytes for Proof<E> {
 
 impl<E: PairingEngine> FromBytes for Proof<E> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         Self::read(&mut reader)
     }
 }
@@ -118,9 +118,9 @@ impl<E: PairingEngine> Proof<E> {
 
     /// Deserialize the proof from uncompressed bytes.
     pub fn read_uncompressed<R: Read>(mut reader: R) -> IoResult<Self> {
-        let a: E::G1Affine = FromBytes::read(&mut reader)?;
-        let b: E::G2Affine = FromBytes::read(&mut reader)?;
-        let c: E::G1Affine = FromBytes::read(&mut reader)?;
+        let a: E::G1Affine = FromBytes::read_le(&mut reader)?;
+        let b: E::G2Affine = FromBytes::read_le(&mut reader)?;
+        let c: E::G1Affine = FromBytes::read_le(&mut reader)?;
 
         Ok(Self {
             a,
@@ -198,7 +198,7 @@ impl<E: PairingEngine> ToBytes for VerifyingKey<E> {
 
 impl<E: PairingEngine> FromBytes for VerifyingKey<E> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         Self::read(&mut reader)
     }
 }
@@ -230,16 +230,16 @@ impl<E: PairingEngine> PartialEq for VerifyingKey<E> {
 impl<E: PairingEngine> VerifyingKey<E> {
     /// Deserialize the verifying key from bytes.
     pub fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let h_g2: E::G2Affine = FromBytes::read(&mut reader)?;
-        let g_alpha_g1: E::G1Affine = FromBytes::read(&mut reader)?;
-        let h_beta_g2: E::G2Affine = FromBytes::read(&mut reader)?;
-        let g_gamma_g1: E::G1Affine = FromBytes::read(&mut reader)?;
-        let h_gamma_g2: E::G2Affine = FromBytes::read(&mut reader)?;
+        let h_g2: E::G2Affine = FromBytes::read_le(&mut reader)?;
+        let g_alpha_g1: E::G1Affine = FromBytes::read_le(&mut reader)?;
+        let h_beta_g2: E::G2Affine = FromBytes::read_le(&mut reader)?;
+        let g_gamma_g1: E::G1Affine = FromBytes::read_le(&mut reader)?;
+        let h_gamma_g2: E::G2Affine = FromBytes::read_le(&mut reader)?;
 
-        let query_len: u32 = FromBytes::read(&mut reader)?;
+        let query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut query: Vec<E::G1Affine> = Vec::with_capacity(query_len as usize);
         for _ in 0..query_len {
-            let query_element: E::G1Affine = FromBytes::read(&mut reader)?;
+            let query_element: E::G1Affine = FromBytes::read_le(&mut reader)?;
             query.push(query_element);
         }
 
@@ -328,7 +328,7 @@ impl<E: PairingEngine> ToBytes for ProvingKey<E> {
 
 impl<E: PairingEngine> FromBytes for ProvingKey<E> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         Self::read(&mut reader, false)
     }
 }
@@ -349,7 +349,7 @@ impl<E: PairingEngine> ProvingKey<E> {
     /// Deserialize the public parameters from bytes.
     pub fn read<R: Read>(mut reader: R, checked: bool) -> IoResult<Self> {
         let read_g1_affine = |mut reader: &mut R| -> IoResult<E::G1Affine> {
-            let g1_affine: E::G1Affine = FromBytes::read(&mut reader)?;
+            let g1_affine: E::G1Affine = FromBytes::read_le(&mut reader)?;
 
             if checked && !g1_affine.is_in_correct_subgroup_assuming_on_curve() {
                 return Err(io::Error::new(
@@ -362,7 +362,7 @@ impl<E: PairingEngine> ProvingKey<E> {
         };
 
         let read_g2_affine = |mut reader: &mut R| -> IoResult<E::G2Affine> {
-            let g2_affine: E::G2Affine = FromBytes::read(&mut reader)?;
+            let g2_affine: E::G2Affine = FromBytes::read_le(&mut reader)?;
 
             if checked && !g2_affine.is_in_correct_subgroup_assuming_on_curve() {
                 return Err(io::Error::new(
@@ -376,36 +376,36 @@ impl<E: PairingEngine> ProvingKey<E> {
 
         let vk = VerifyingKey::<E>::read(&mut reader)?;
 
-        let a_query_len: u32 = FromBytes::read(&mut reader)?;
+        let a_query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut a_query = Vec::with_capacity(a_query_len as usize);
         for _ in 0..a_query_len {
             a_query.push(read_g1_affine(&mut reader)?);
         }
 
-        let b_query_len: u32 = FromBytes::read(&mut reader)?;
+        let b_query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut b_query = Vec::with_capacity(b_query_len as usize);
         for _ in 0..b_query_len {
             b_query.push(read_g2_affine(&mut reader)?);
         }
 
-        let c_query_1_len: u32 = FromBytes::read(&mut reader)?;
+        let c_query_1_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut c_query_1 = Vec::with_capacity(c_query_1_len as usize);
         for _ in 0..c_query_1_len {
             c_query_1.push(read_g1_affine(&mut reader)?);
         }
 
-        let c_query_2_len: u32 = FromBytes::read(&mut reader)?;
+        let c_query_2_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut c_query_2 = Vec::with_capacity(c_query_2_len as usize);
         for _ in 0..c_query_2_len {
             c_query_2.push(read_g1_affine(&mut reader)?);
         }
 
-        let g_gamma_z: E::G1Affine = FromBytes::read(&mut reader)?;
-        let h_gamma_z: E::G2Affine = FromBytes::read(&mut reader)?;
-        let g_ab_gamma_z: E::G1Affine = FromBytes::read(&mut reader)?;
-        let g_gamma2_z2: E::G1Affine = FromBytes::read(&mut reader)?;
+        let g_gamma_z: E::G1Affine = FromBytes::read_le(&mut reader)?;
+        let h_gamma_z: E::G2Affine = FromBytes::read_le(&mut reader)?;
+        let g_ab_gamma_z: E::G1Affine = FromBytes::read_le(&mut reader)?;
+        let g_gamma2_z2: E::G1Affine = FromBytes::read_le(&mut reader)?;
 
-        let g_gamma2_z_t_len: u32 = FromBytes::read(&mut reader)?;
+        let g_gamma2_z_t_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut g_gamma2_z_t = Vec::with_capacity(g_gamma2_z_t_len as usize);
         for _ in 0..g_gamma2_z_t_len {
             g_gamma2_z_t.push(read_g1_affine(&mut reader)?);

--- a/algorithms/src/snark/gm17/tests.rs
+++ b/algorithms/src/snark/gm17/tests.rs
@@ -187,7 +187,7 @@ mod serialization {
         );
         assert!(Proof::<Bls12_377>::read_uncompressed(&compressed_serialization[..]).is_err());
 
-        let recovered_proof: Proof<Bls12_377> = FromBytes::read(&compressed_serialization[..]).unwrap();
+        let recovered_proof: Proof<Bls12_377> = FromBytes::read_le(&compressed_serialization[..]).unwrap();
         assert_eq!(recovered_proof.compressed, true);
     }
 
@@ -212,7 +212,7 @@ mod serialization {
         );
         assert!(Proof::<Bls12_377>::read_compressed(&uncompressed_serialization[..]).is_err());
 
-        let recovered_proof: Proof<Bls12_377> = FromBytes::read(&uncompressed_serialization[..]).unwrap();
+        let recovered_proof: Proof<Bls12_377> = FromBytes::read_le(&uncompressed_serialization[..]).unwrap();
         assert_eq!(recovered_proof.compressed, false);
     }
 
@@ -227,8 +227,8 @@ mod serialization {
         let parameter_bytes = to_bytes![&parameters].unwrap();
         let vk_bytes = to_bytes![&vk].unwrap();
 
-        let recovered_parameters: ProvingKey<Bls12_377> = FromBytes::read(&parameter_bytes[..]).unwrap();
-        let recovered_vk: VerifyingKey<Bls12_377> = FromBytes::read(&vk_bytes[..]).unwrap();
+        let recovered_parameters: ProvingKey<Bls12_377> = FromBytes::read_le(&parameter_bytes[..]).unwrap();
+        let recovered_vk: VerifyingKey<Bls12_377> = FromBytes::read_le(&vk_bytes[..]).unwrap();
 
         assert_eq!(parameters, recovered_parameters);
         assert_eq!(vk, recovered_vk);

--- a/algorithms/src/snark/gm17/tests.rs
+++ b/algorithms/src/snark/gm17/tests.rs
@@ -162,11 +162,7 @@ mod serialization {
     use crate::snark::gm17::{create_random_proof, generate_random_parameters, Proof, ProvingKey, VerifyingKey};
 
     use snarkvm_curves::bls12_377::{Bls12_377, Fr};
-    use snarkvm_utilities::{
-        bytes::{FromBytes, ToBytes},
-        rand::UniformRand,
-        to_bytes,
-    };
+    use snarkvm_utilities::{rand::UniformRand, to_bytes, FromBytes, ToBytes};
 
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;

--- a/algorithms/src/snark/gm17/tests.rs
+++ b/algorithms/src/snark/gm17/tests.rs
@@ -162,7 +162,7 @@ mod serialization {
     use crate::snark::gm17::{create_random_proof, generate_random_parameters, Proof, ProvingKey, VerifyingKey};
 
     use snarkvm_curves::bls12_377::{Bls12_377, Fr};
-    use snarkvm_utilities::{rand::UniformRand, to_bytes, FromBytes, ToBytes};
+    use snarkvm_utilities::{rand::UniformRand, to_bytes_le, FromBytes, ToBytes};
 
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
@@ -224,8 +224,8 @@ mod serialization {
             generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
         let vk = parameters.vk.clone();
 
-        let parameter_bytes = to_bytes![&parameters].unwrap();
-        let vk_bytes = to_bytes![&vk].unwrap();
+        let parameter_bytes = to_bytes_le![&parameters].unwrap();
+        let vk_bytes = to_bytes_le![&vk].unwrap();
 
         let recovered_parameters: ProvingKey<Bls12_377> = FromBytes::read_le(&parameter_bytes[..]).unwrap();
         let recovered_vk: VerifyingKey<Bls12_377> = FromBytes::read_le(&vk_bytes[..]).unwrap();

--- a/algorithms/src/snark/gm17/tests.rs
+++ b/algorithms/src/snark/gm17/tests.rs
@@ -179,7 +179,7 @@ mod serialization {
 
         let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
 
-        let compressed_serialization = to_bytes![proof].unwrap();
+        let compressed_serialization = proof.to_bytes_le().unwrap();
 
         assert_eq!(
             Proof::<Bls12_377>::compressed_proof_size().unwrap(),

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -74,7 +74,7 @@ impl<E: PairingEngine> ToBytes for Proof<E> {
 
 impl<E: PairingEngine> FromBytes for Proof<E> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         Self::read(&mut reader)
     }
 }
@@ -120,9 +120,9 @@ impl<E: PairingEngine> Proof<E> {
 
     /// Deserialize the proof from uncompressed bytes.
     pub fn read_uncompressed<R: Read>(mut reader: R) -> IoResult<Self> {
-        let a: E::G1Affine = FromBytes::read(&mut reader)?;
-        let b: E::G2Affine = FromBytes::read(&mut reader)?;
-        let c: E::G1Affine = FromBytes::read(&mut reader)?;
+        let a: E::G1Affine = FromBytes::read_le(&mut reader)?;
+        let b: E::G2Affine = FromBytes::read_le(&mut reader)?;
+        let c: E::G1Affine = FromBytes::read_le(&mut reader)?;
 
         Ok(Self {
             a,
@@ -198,7 +198,7 @@ impl<E: PairingEngine> ToBytes for VerifyingKey<E> {
 
 impl<E: PairingEngine> FromBytes for VerifyingKey<E> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         Self::read(&mut reader)
     }
 }
@@ -230,15 +230,15 @@ impl<E: PairingEngine> Default for VerifyingKey<E> {
 impl<E: PairingEngine> VerifyingKey<E> {
     /// Deserialize the verification key from bytes.
     pub fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let alpha_g1: E::G1Affine = FromBytes::read(&mut reader)?;
-        let beta_g2: E::G2Affine = FromBytes::read(&mut reader)?;
-        let gamma_g2: E::G2Affine = FromBytes::read(&mut reader)?;
-        let delta_g2: E::G2Affine = FromBytes::read(&mut reader)?;
+        let alpha_g1: E::G1Affine = FromBytes::read_le(&mut reader)?;
+        let beta_g2: E::G2Affine = FromBytes::read_le(&mut reader)?;
+        let gamma_g2: E::G2Affine = FromBytes::read_le(&mut reader)?;
+        let delta_g2: E::G2Affine = FromBytes::read_le(&mut reader)?;
 
-        let gamma_abc_g1_len: u32 = FromBytes::read(&mut reader)?;
+        let gamma_abc_g1_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut gamma_abc_g1: Vec<E::G1Affine> = Vec::with_capacity(gamma_abc_g1_len as usize);
         for _ in 0..gamma_abc_g1_len {
-            let gamma_abc_g1_element: E::G1Affine = FromBytes::read(&mut reader)?;
+            let gamma_abc_g1_element: E::G1Affine = FromBytes::read_le(&mut reader)?;
             gamma_abc_g1.push(gamma_abc_g1_element);
         }
 
@@ -305,7 +305,7 @@ impl<E: PairingEngine> ToBytes for ProvingKey<E> {
 
 impl<E: PairingEngine> FromBytes for ProvingKey<E> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         Self::read(&mut reader, false)
     }
 }
@@ -314,7 +314,7 @@ impl<E: PairingEngine> ProvingKey<E> {
     /// Deserialize the public parameters from bytes.
     pub fn read<R: Read>(mut reader: R, checked: bool) -> IoResult<Self> {
         let read_g1_affine = |mut reader: &mut R| -> IoResult<E::G1Affine> {
-            let g1_affine: E::G1Affine = FromBytes::read(&mut reader)?;
+            let g1_affine: E::G1Affine = FromBytes::read_le(&mut reader)?;
 
             if checked && !g1_affine.is_in_correct_subgroup_assuming_on_curve() {
                 return Err(io::Error::new(
@@ -327,7 +327,7 @@ impl<E: PairingEngine> ProvingKey<E> {
         };
 
         let read_g2_affine = |mut reader: &mut R| -> IoResult<E::G2Affine> {
-            let g2_affine: E::G2Affine = FromBytes::read(&mut reader)?;
+            let g2_affine: E::G2Affine = FromBytes::read_le(&mut reader)?;
 
             if checked && !g2_affine.is_in_correct_subgroup_assuming_on_curve() {
                 return Err(io::Error::new(
@@ -341,35 +341,35 @@ impl<E: PairingEngine> ProvingKey<E> {
 
         let vk = VerifyingKey::<E>::read(&mut reader)?;
 
-        let beta_g1: E::G1Affine = FromBytes::read(&mut reader)?;
+        let beta_g1: E::G1Affine = FromBytes::read_le(&mut reader)?;
 
-        let delta_g1: E::G1Affine = FromBytes::read(&mut reader)?;
+        let delta_g1: E::G1Affine = FromBytes::read_le(&mut reader)?;
 
-        let a_query_len: u32 = FromBytes::read(&mut reader)?;
+        let a_query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut a_query = Vec::with_capacity(a_query_len as usize);
         for _ in 0..a_query_len {
             a_query.push(read_g1_affine(&mut reader)?);
         }
 
-        let b_g1_query_len: u32 = FromBytes::read(&mut reader)?;
+        let b_g1_query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut b_g1_query = Vec::with_capacity(b_g1_query_len as usize);
         for _ in 0..b_g1_query_len {
             b_g1_query.push(read_g1_affine(&mut reader)?);
         }
 
-        let b_g2_query_len: u32 = FromBytes::read(&mut reader)?;
+        let b_g2_query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut b_g2_query = Vec::with_capacity(b_g2_query_len as usize);
         for _ in 0..b_g2_query_len {
             b_g2_query.push(read_g2_affine(&mut reader)?);
         }
 
-        let h_query_len: u32 = FromBytes::read(&mut reader)?;
+        let h_query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut h_query = Vec::with_capacity(h_query_len as usize);
         for _ in 0..h_query_len {
             h_query.push(read_g1_affine(&mut reader)?);
         }
 
-        let l_query_len: u32 = FromBytes::read(&mut reader)?;
+        let l_query_len: u32 = FromBytes::read_le(&mut reader)?;
         let mut l_query = Vec::with_capacity(l_query_len as usize);
         for _ in 0..l_query_len {
             l_query.push(read_g1_affine(&mut reader)?);

--- a/algorithms/src/snark/groth16/tests.rs
+++ b/algorithms/src/snark/groth16/tests.rs
@@ -134,7 +134,7 @@ mod serialization {
         );
         assert!(Proof::<Bls12_377>::read_uncompressed(&compressed_serialization[..]).is_err());
 
-        let recovered_proof: Proof<Bls12_377> = FromBytes::read(&compressed_serialization[..]).unwrap();
+        let recovered_proof: Proof<Bls12_377> = FromBytes::read_le(&compressed_serialization[..]).unwrap();
         assert_eq!(recovered_proof.compressed, true);
     }
 
@@ -159,7 +159,7 @@ mod serialization {
         );
         assert!(Proof::<Bls12_377>::read_compressed(&uncompressed_serialization[..]).is_err());
 
-        let recovered_proof: Proof<Bls12_377> = FromBytes::read(&uncompressed_serialization[..]).unwrap();
+        let recovered_proof: Proof<Bls12_377> = FromBytes::read_le(&uncompressed_serialization[..]).unwrap();
         assert_eq!(recovered_proof.compressed, false);
     }
 }

--- a/algorithms/src/snark/groth16/tests.rs
+++ b/algorithms/src/snark/groth16/tests.rs
@@ -108,9 +108,10 @@ mod serialization {
     use crate::snark::groth16::{create_random_proof, generate_random_parameters, Proof};
     use snarkvm_curves::bls12_377::{Bls12_377, Fr};
     use snarkvm_utilities::{
-        bytes::{FromBytes, ToBytes},
         rand::{test_rng, UniformRand},
         to_bytes,
+        FromBytes,
+        ToBytes,
     };
 
     #[test]

--- a/algorithms/src/snark/groth16/tests.rs
+++ b/algorithms/src/snark/groth16/tests.rs
@@ -109,7 +109,6 @@ mod serialization {
     use snarkvm_curves::bls12_377::{Bls12_377, Fr};
     use snarkvm_utilities::{
         rand::{test_rng, UniformRand},
-        to_bytes,
         FromBytes,
         ToBytes,
     };
@@ -126,7 +125,7 @@ mod serialization {
 
         let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
 
-        let compressed_serialization = to_bytes![proof].unwrap();
+        let compressed_serialization = proof.to_bytes_le().unwrap();
 
         assert_eq!(
             Proof::<Bls12_377>::compressed_proof_size().unwrap(),

--- a/algorithms/src/traits/commitment.rs
+++ b/algorithms/src/traits/commitment.rs
@@ -15,10 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::errors::CommitmentError;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-};
+use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBytes};
 
 use rand::Rng;
 use std::{fmt::Debug, hash::Hash};

--- a/algorithms/src/traits/crh.rs
+++ b/algorithms/src/traits/crh.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::errors::CRHError;
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::Rng;
 use std::{

--- a/algorithms/src/traits/encryption.rs
+++ b/algorithms/src/traits/encryption.rs
@@ -15,10 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{errors::EncryptionError, traits::SignatureScheme};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-};
+use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBytes};
 
 use rand::Rng;
 use std::{fmt::Debug, hash::Hash};

--- a/algorithms/src/traits/merkle_tree.rs
+++ b/algorithms/src/traits/merkle_tree.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{errors::MerkleError, CRH};
-use snarkvm_utilities::bytes::ToBytes;
+use snarkvm_utilities::ToBytes;
 
 use rand::Rng;
 use std::io::Cursor;

--- a/algorithms/src/traits/merkle_tree.rs
+++ b/algorithms/src/traits/merkle_tree.rs
@@ -37,7 +37,7 @@ pub trait MerkleParameters: Send + Sync + Clone + Default {
     /// Returns the hash of a given leaf.
     fn hash_leaf<L: ToBytes>(&self, leaf: &L, buffer: &mut [u8]) -> Result<<Self::H as CRH>::Output, MerkleError> {
         let mut writer = Cursor::new(buffer);
-        leaf.write(&mut writer)?;
+        leaf.write_le(&mut writer)?;
 
         let buffer = writer.into_inner();
         Ok(self.crh().hash(&buffer[..(Self::H::INPUT_SIZE_BITS / 8)])?)
@@ -53,10 +53,10 @@ pub trait MerkleParameters: Send + Sync + Clone + Default {
         let mut writer = Cursor::new(buffer);
 
         // Construct left input.
-        left.write(&mut writer)?;
+        left.write_le(&mut writer)?;
 
         // Construct right input.
-        right.write(&mut writer)?;
+        right.write_le(&mut writer)?;
 
         let buffer = writer.into_inner();
         Ok(self.crh().hash(&buffer[..(<Self::H as CRH>::INPUT_SIZE_BITS / 8)])?)

--- a/algorithms/src/traits/prf.rs
+++ b/algorithms/src/traits/prf.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::errors::PRFError;
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::{fmt::Debug, hash::Hash};
 

--- a/algorithms/src/traits/signature.rs
+++ b/algorithms/src/traits/signature.rs
@@ -16,8 +16,9 @@
 
 use crate::errors::SignatureError;
 use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
     serialize::{CanonicalDeserialize, CanonicalSerialize},
+    FromBytes,
+    ToBytes,
 };
 
 use rand::Rng;

--- a/algorithms/src/traits/snark.rs
+++ b/algorithms/src/traits/snark.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::errors::SNARKError;
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::Rng;
 use std::fmt::Debug;

--- a/algorithms/tests/snark/mimc.rs
+++ b/algorithms/tests/snark/mimc.rs
@@ -216,7 +216,7 @@ fn test_mimc_groth_16() {
             let proof = create_random_proof(&c, &params, rng).unwrap();
             assert!(verify_proof(&pvk, &proof, &[image]).unwrap());
 
-            // proof.write(&mut proof_vec).unwrap();
+            // proof.write_le(&mut proof_vec).unwrap();
         }
 
         total_proving += start.elapsed();
@@ -303,7 +303,7 @@ fn test_mimc_groth_maller_17() {
             let proof = create_random_proof(&c, &params, rng).unwrap();
             assert!(verify_proof(&pvk, &proof, &[image]).unwrap());
 
-            // proof.write(&mut proof_vec).unwrap();
+            // proof.write_le(&mut proof_vec).unwrap();
         }
 
         total_proving += start.elapsed();

--- a/curves/src/edwards_bls12/tests.rs
+++ b/curves/src/edwards_bls12/tests.rs
@@ -35,7 +35,7 @@ use snarkvm_fields::{
     SquareRootField,
     Zero,
 };
-use snarkvm_utilities::{rand::UniformRand, to_bytes, ToBytes};
+use snarkvm_utilities::{rand::UniformRand, to_bytes_le, ToBytes};
 
 use rand::thread_rng;
 
@@ -190,7 +190,7 @@ fn test_isomorphism() {
 
     // Map it to its corresponding Fq element.
     let fq_element = {
-        let output = Fq::from_random_bytes(&to_bytes![fr_element].unwrap());
+        let output = Fq::from_random_bytes(&to_bytes_le![fr_element].unwrap());
         assert!(output.is_some());
         output.unwrap()
     };
@@ -410,7 +410,7 @@ fn test_isomorphism() {
     };
 
     let fr_element_reconstructed = {
-        let output = Fr::from_random_bytes(&to_bytes![fq_element_reconstructed].unwrap());
+        let output = Fr::from_random_bytes(&to_bytes_le![fq_element_reconstructed].unwrap());
         assert!(output.is_some());
         output.unwrap()
     };

--- a/curves/src/templates/bls12/g1.rs
+++ b/curves/src/templates/bls12/g1.rs
@@ -55,7 +55,7 @@ impl<P: Bls12Parameters> Default for G1Prepared<P> {
 }
 
 impl<P: Bls12Parameters> ToBytes for G1Prepared<P> {
-    fn write<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.0.write(writer)
+    fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
+        self.0.write_le(writer)
     }
 }

--- a/curves/src/templates/bls12/g1.rs
+++ b/curves/src/templates/bls12/g1.rs
@@ -22,7 +22,7 @@ use crate::{
     traits::pairing_engine::AffineCurve,
 };
 use snarkvm_fields::Zero;
-use snarkvm_utilities::{bytes::ToBytes, errors::SerializationError, serialize::*};
+use snarkvm_utilities::{errors::SerializationError, serialize::*, ToBytes};
 
 use std::io::{Result as IoResult, Write};
 

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -63,13 +63,13 @@ impl<P: Bls12Parameters> Default for G2Prepared<P> {
 }
 
 impl<P: Bls12Parameters> ToBytes for G2Prepared<P> {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         for coeff in &self.ell_coeffs {
-            coeff.0.write(&mut writer)?;
-            coeff.1.write(&mut writer)?;
-            coeff.2.write(&mut writer)?;
+            coeff.0.write_le(&mut writer)?;
+            coeff.1.write_le(&mut writer)?;
+            coeff.2.write_le(&mut writer)?;
         }
-        self.infinity.write(writer)
+        self.infinity.write_le(writer)
     }
 }
 

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -22,7 +22,7 @@ use crate::{
     traits::{AffineCurve, ShortWeierstrassParameters},
 };
 use snarkvm_fields::{Field, Fp2, One, Zero};
-use snarkvm_utilities::{bititerator::BitIteratorBE, bytes::ToBytes, errors::SerializationError, serialize::*};
+use snarkvm_utilities::{bititerator::BitIteratorBE, errors::SerializationError, serialize::*, ToBytes};
 
 use std::io::{Result as IoResult, Write};
 

--- a/curves/src/templates/bw6/g1.rs
+++ b/curves/src/templates/bw6/g1.rs
@@ -22,7 +22,7 @@ use crate::{
     traits::pairing_engine::AffineCurve,
 };
 use snarkvm_fields::Zero;
-use snarkvm_utilities::{bytes::ToBytes, errors::SerializationError, serialize::*};
+use snarkvm_utilities::{errors::SerializationError, serialize::*, ToBytes};
 
 use std::io::{Result as IoResult, Write};
 

--- a/curves/src/templates/bw6/g1.rs
+++ b/curves/src/templates/bw6/g1.rs
@@ -57,7 +57,7 @@ impl<P: BW6Parameters> Default for G1Prepared<P> {
 }
 
 impl<P: BW6Parameters> ToBytes for G1Prepared<P> {
-    fn write<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.0.write(writer)
+    fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
+        self.0.write_le(writer)
     }
 }

--- a/curves/src/templates/bw6/g2.rs
+++ b/curves/src/templates/bw6/g2.rs
@@ -66,18 +66,18 @@ impl<P: BW6Parameters> Default for G2Prepared<P> {
 }
 
 impl<P: BW6Parameters> ToBytes for G2Prepared<P> {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         for coeff_1 in &self.ell_coeffs_1 {
-            coeff_1.0.write(&mut writer)?;
-            coeff_1.1.write(&mut writer)?;
-            coeff_1.2.write(&mut writer)?;
+            coeff_1.0.write_le(&mut writer)?;
+            coeff_1.1.write_le(&mut writer)?;
+            coeff_1.2.write_le(&mut writer)?;
         }
         for coeff_2 in &self.ell_coeffs_2 {
-            coeff_2.0.write(&mut writer)?;
-            coeff_2.1.write(&mut writer)?;
-            coeff_2.2.write(&mut writer)?;
+            coeff_2.0.write_le(&mut writer)?;
+            coeff_2.1.write_le(&mut writer)?;
+            coeff_2.2.write_le(&mut writer)?;
         }
-        self.infinity.write(writer)
+        self.infinity.write_le(writer)
     }
 }
 

--- a/curves/src/templates/bw6/g2.rs
+++ b/curves/src/templates/bw6/g2.rs
@@ -22,7 +22,7 @@ use crate::{
     traits::{AffineCurve, ShortWeierstrassParameters},
 };
 use snarkvm_fields::{Field, One, Zero};
-use snarkvm_utilities::{bititerator::BitIteratorBE, bytes::ToBytes, errors::SerializationError, serialize::*};
+use snarkvm_utilities::{bititerator::BitIteratorBE, errors::SerializationError, serialize::*, ToBytes};
 
 use std::{
     io::{Result as IoResult, Write},

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -272,10 +272,10 @@ impl<P: Parameters> ToBytes for Affine<P> {
 
 impl<P: Parameters> FromBytes for Affine<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let x = P::BaseField::read(&mut reader)?;
-        let y = P::BaseField::read(&mut reader)?;
-        let infinity = bool::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let x = P::BaseField::read_le(&mut reader)?;
+        let y = P::BaseField::read_le(&mut reader)?;
+        let infinity = bool::read_le(&mut reader)?;
 
         if infinity != x.is_zero() && y.is_one() {
             return Err(Error::new(ErrorKind::InvalidData, "Infinity flag is not valid"));

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -20,12 +20,7 @@ use crate::{
     traits::{AffineCurve, Group, ProjectiveCurve, ShortWeierstrassParameters as Parameters},
 };
 use snarkvm_fields::{impl_add_sub_from_field_ref, Field, One, PrimeField, SquareRootField, Zero};
-use snarkvm_utilities::{
-    bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -268,10 +268,10 @@ impl<P: Parameters> MulAssign<P::ScalarField> for Affine<P> {
 
 impl<P: Parameters> ToBytes for Affine<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.x.write(&mut writer)?;
-        self.y.write(&mut writer)?;
-        self.infinity.write(writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.x.write_le(&mut writer)?;
+        self.y.write_le(&mut writer)?;
+        self.infinity.write_le(writer)
     }
 }
 

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -19,12 +19,7 @@ use crate::{
     traits::{AffineCurve, Group, ProjectiveCurve, ShortWeierstrassParameters as Parameters},
 };
 use snarkvm_fields::{impl_add_sub_from_field_ref, Field, One, PrimeField, Zero};
-use snarkvm_utilities::{
-    bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -98,10 +98,10 @@ impl<P: Parameters> Distribution<Projective<P>> for Standard {
 
 impl<P: Parameters> ToBytes for Projective<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.x.write(&mut writer)?;
-        self.y.write(&mut writer)?;
-        self.z.write(writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.x.write_le(&mut writer)?;
+        self.y.write_le(&mut writer)?;
+        self.z.write_le(writer)
     }
 }
 

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -102,10 +102,10 @@ impl<P: Parameters> ToBytes for Projective<P> {
 
 impl<P: Parameters> FromBytes for Projective<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let x = P::BaseField::read(&mut reader)?;
-        let y = P::BaseField::read(&mut reader)?;
-        let z = P::BaseField::read(reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let x = P::BaseField::read_le(&mut reader)?;
+        let y = P::BaseField::read_le(&mut reader)?;
+        let z = P::BaseField::read_le(reader)?;
         Ok(Self::new(x, y, z))
     }
 }

--- a/curves/src/templates/short_weierstrass_projective/affine.rs
+++ b/curves/src/templates/short_weierstrass_projective/affine.rs
@@ -258,10 +258,10 @@ impl<P: Parameters> ToBytes for Affine<P> {
 
 impl<P: Parameters> FromBytes for Affine<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let x = P::BaseField::read(&mut reader)?;
-        let y = P::BaseField::read(&mut reader)?;
-        let infinity = bool::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let x = P::BaseField::read_le(&mut reader)?;
+        let y = P::BaseField::read_le(&mut reader)?;
+        let infinity = bool::read_le(&mut reader)?;
 
         if infinity != x.is_zero() && y.is_one() {
             return Err(Error::new(ErrorKind::InvalidData, "Infinity flag is not valid"));

--- a/curves/src/templates/short_weierstrass_projective/affine.rs
+++ b/curves/src/templates/short_weierstrass_projective/affine.rs
@@ -20,12 +20,7 @@ use crate::{
     traits::{AffineCurve, Group, ProjectiveCurve, ShortWeierstrassParameters as Parameters},
 };
 use snarkvm_fields::{impl_add_sub_from_field_ref, Field, One, PrimeField, SquareRootField, Zero};
-use snarkvm_utilities::{
-    bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/curves/src/templates/short_weierstrass_projective/affine.rs
+++ b/curves/src/templates/short_weierstrass_projective/affine.rs
@@ -254,10 +254,10 @@ impl<P: Parameters> MulAssign<P::ScalarField> for Affine<P> {
 
 impl<P: Parameters> ToBytes for Affine<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.x.write(&mut writer)?;
-        self.y.write(&mut writer)?;
-        self.infinity.write(writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.x.write_le(&mut writer)?;
+        self.y.write_le(&mut writer)?;
+        self.infinity.write_le(writer)
     }
 }
 

--- a/curves/src/templates/short_weierstrass_projective/projective.rs
+++ b/curves/src/templates/short_weierstrass_projective/projective.rs
@@ -19,12 +19,7 @@ use crate::{
     traits::{AffineCurve, Group, ProjectiveCurve, ShortWeierstrassParameters as Parameters},
 };
 use snarkvm_fields::{impl_add_sub_from_field_ref, Field, One, PrimeField, Zero};
-use snarkvm_utilities::{
-    bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/curves/src/templates/short_weierstrass_projective/projective.rs
+++ b/curves/src/templates/short_weierstrass_projective/projective.rs
@@ -93,10 +93,10 @@ impl<P: Parameters> Distribution<Projective<P>> for Standard {
 
 impl<P: Parameters> ToBytes for Projective<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.x.write(&mut writer)?;
-        self.y.write(&mut writer)?;
-        self.z.write(writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.x.write_le(&mut writer)?;
+        self.y.write_le(&mut writer)?;
+        self.z.write_le(writer)
     }
 }
 

--- a/curves/src/templates/short_weierstrass_projective/projective.rs
+++ b/curves/src/templates/short_weierstrass_projective/projective.rs
@@ -97,10 +97,10 @@ impl<P: Parameters> ToBytes for Projective<P> {
 
 impl<P: Parameters> FromBytes for Projective<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let x = P::BaseField::read(&mut reader)?;
-        let y = P::BaseField::read(&mut reader)?;
-        let z = P::BaseField::read(reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let x = P::BaseField::read_le(&mut reader)?;
+        let y = P::BaseField::read_le(&mut reader)?;
+        let z = P::BaseField::read_le(reader)?;
         Ok(Self::new(x, y, z))
     }
 }

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -305,9 +305,9 @@ impl<P: Parameters> ToBytes for Affine<P> {
 
 impl<P: Parameters> FromBytes for Affine<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let x = P::BaseField::read(&mut reader)?;
-        let y = P::BaseField::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let x = P::BaseField::read_le(&mut reader)?;
+        let y = P::BaseField::read_le(&mut reader)?;
         Ok(Self::new(x, y))
     }
 }

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -302,9 +302,9 @@ impl<P: Parameters> MulAssign<P::ScalarField> for Affine<P> {
 
 impl<P: Parameters> ToBytes for Affine<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.x.write(&mut writer)?;
-        self.y.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.x.write_le(&mut writer)?;
+        self.y.write_le(&mut writer)
     }
 }
 

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -20,12 +20,7 @@ use crate::{
     traits::{AffineCurve, Group, MontgomeryParameters, ProjectiveCurve, TwistedEdwardsParameters as Parameters},
 };
 use snarkvm_fields::{impl_add_sub_from_field_ref, Field, One, PrimeField, SquareRootField, Zero};
-use snarkvm_utilities::{
-    bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/curves/src/templates/twisted_edwards_extended/projective.rs
+++ b/curves/src/templates/twisted_edwards_extended/projective.rs
@@ -94,11 +94,11 @@ impl<P: Parameters> Distribution<Projective<P>> for Standard {
 
 impl<P: Parameters> ToBytes for Projective<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.x.write(&mut writer)?;
-        self.y.write(&mut writer)?;
-        self.t.write(&mut writer)?;
-        self.z.write(writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.x.write_le(&mut writer)?;
+        self.y.write_le(&mut writer)?;
+        self.t.write_le(&mut writer)?;
+        self.z.write_le(writer)
     }
 }
 

--- a/curves/src/templates/twisted_edwards_extended/projective.rs
+++ b/curves/src/templates/twisted_edwards_extended/projective.rs
@@ -19,12 +19,7 @@ use crate::{
     traits::{AffineCurve, Group, ProjectiveCurve, TwistedEdwardsParameters as Parameters},
 };
 use snarkvm_fields::{impl_add_sub_from_field_ref, Field, One, PrimeField, Zero};
-use snarkvm_utilities::{
-    bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/curves/src/templates/twisted_edwards_extended/projective.rs
+++ b/curves/src/templates/twisted_edwards_extended/projective.rs
@@ -99,11 +99,11 @@ impl<P: Parameters> ToBytes for Projective<P> {
 
 impl<P: Parameters> FromBytes for Projective<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let x = P::BaseField::read(&mut reader)?;
-        let y = P::BaseField::read(&mut reader)?;
-        let t = P::BaseField::read(&mut reader)?;
-        let z = P::BaseField::read(reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let x = P::BaseField::read_le(&mut reader)?;
+        let y = P::BaseField::read_le(&mut reader)?;
+        let t = P::BaseField::read_le(&mut reader)?;
+        let z = P::BaseField::read_le(reader)?;
         Ok(Self::new(x, y, t, z))
     }
 }

--- a/curves/src/templates/twisted_edwards_extended/tests.rs
+++ b/curves/src/templates/twisted_edwards_extended/tests.rs
@@ -17,11 +17,11 @@
 use super::{Affine, Projective};
 
 use snarkvm_utilities::{
-    bytes::ToBytes,
     io::Cursor,
     rand::UniformRand,
     serialize::{CanonicalDeserialize, CanonicalSerialize},
     to_bytes,
+    ToBytes,
 };
 
 use crate::traits::{

--- a/curves/src/templates/twisted_edwards_extended/tests.rs
+++ b/curves/src/templates/twisted_edwards_extended/tests.rs
@@ -20,7 +20,7 @@ use snarkvm_utilities::{
     io::Cursor,
     rand::UniformRand,
     serialize::{CanonicalDeserialize, CanonicalSerialize},
-    to_bytes,
+    to_bytes_le,
     ToBytes,
 };
 
@@ -146,7 +146,7 @@ where
 
     for _ in 0..ITERATIONS {
         let biginteger = <<Affine<P> as AffineCurve>::BaseField as PrimeField>::BigInteger::rand(&mut rng);
-        let mut bytes = to_bytes![biginteger].unwrap();
+        let mut bytes = to_bytes_le![biginteger].unwrap();
         let mut g = Affine::<P>::from_random_bytes(&bytes);
         while g.is_none() {
             bytes.iter_mut().for_each(|i| *i = i.wrapping_sub(1));

--- a/curves/src/traits/group.rs
+++ b/curves/src/traits/group.rs
@@ -15,10 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkvm_fields::{PrimeField, SquareRootField};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    rand::UniformRand,
-};
+use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBytes};
 
 use std::{
     fmt::{Debug, Display},

--- a/curves/src/traits/pairing_engine.rs
+++ b/curves/src/traits/pairing_engine.rs
@@ -16,7 +16,7 @@
 
 use crate::traits::Group;
 use snarkvm_fields::{Field, PrimeField, SquareRootField};
-use snarkvm_utilities::{biginteger::BigInteger, bytes::ToBytes, serialize::*, BitIteratorBE};
+use snarkvm_utilities::{biginteger::BigInteger, serialize::*, BitIteratorBE, ToBytes};
 
 use std::{fmt::Debug, iter};
 

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -90,8 +90,8 @@ impl<C: DPCComponents> ToBytes for Address<C> {
 impl<C: DPCComponents> FromBytes for Address<C> {
     /// Reads in an account address buffer.
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let encryption_key: <C::AccountEncryption as EncryptionScheme>::PublicKey = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let encryption_key: <C::AccountEncryption as EncryptionScheme>::PublicKey = FromBytes::read_le(&mut reader)?;
 
         Ok(Self { encryption_key })
     }
@@ -117,7 +117,7 @@ impl<C: DPCComponents> FromStr for Address<C> {
         }
 
         let buffer = Vec::from_base32(&data)?;
-        Ok(Self::read(&buffer[..])?)
+        Ok(Self::read_le(&buffer[..])?)
     }
 }
 

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -82,8 +82,8 @@ impl<C: DPCComponents> Address<C> {
 }
 
 impl<C: DPCComponents> ToBytes for Address<C> {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.encryption_key.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.encryption_key.write_le(&mut writer)
     }
 }
 
@@ -126,7 +126,7 @@ impl<C: DPCComponents> fmt::Display for Address<C> {
         // Write the encryption key to a buffer.
         let mut address = [0u8; 32];
         self.encryption_key
-            .write(&mut address[0..32])
+            .write_le(&mut address[0..32])
             .expect("address formatting failed");
 
         bech32::encode(

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -19,7 +19,7 @@ use snarkvm_algorithms::{
     prf::Blake2s,
     traits::{CommitmentScheme, EncryptionScheme, SignatureScheme, PRF},
 };
-use snarkvm_utilities::{from_bytes_le_to_bits_le, to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{from_bytes_le_to_bits_le, to_bytes_le, FromBytes, ToBytes};
 
 use base58::{FromBase58, ToBase58};
 use rand::{CryptoRng, Rng};
@@ -135,7 +135,7 @@ impl<C: DPCComponents> PrivateKey<C> {
         commitment_parameters: &C::AccountCommitment,
     ) -> Result<<C::AccountEncryption as EncryptionScheme>::PrivateKey, AccountError> {
         let commitment = self.commit(signature_parameters, commitment_parameters)?;
-        let decryption_key_bytes = to_bytes![commitment]?;
+        let decryption_key_bytes = to_bytes_le![commitment]?;
 
         // This operation implicitly enforces that the unused MSB bits
         // for the scalar field representation are correctly set to 0.
@@ -226,7 +226,7 @@ impl<C: DPCComponents> PrivateKey<C> {
     ) -> Result<<C::AccountCommitment as CommitmentScheme>::Output, AccountError> {
         // Construct the commitment input for the account address.
         let pk_sig = self.pk_sig(signature_parameters)?;
-        let commit_input = to_bytes![pk_sig, self.sk_prf]?;
+        let commit_input = to_bytes_le![pk_sig, self.sk_prf]?;
 
         Ok(C::AccountCommitment::commit(
             commitment_parameters,

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -79,11 +79,11 @@ impl<C: DPCComponents> PrivateKey<C> {
     ) -> Result<Self, AccountError> {
         // Generate the SIG key pair.
         let sk_sig_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?;
-        let sk_sig = <C::AccountSignature as SignatureScheme>::PrivateKey::read(&sk_sig_bytes[..])?;
+        let sk_sig = <C::AccountSignature as SignatureScheme>::PrivateKey::read_le(&sk_sig_bytes[..])?;
 
         // Generate the PRF secret key.
         let sk_prf_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_PRF)?;
-        let sk_prf = <C::PRF as PRF>::Seed::read(&sk_prf_bytes[..])?;
+        let sk_prf = <C::PRF as PRF>::Seed::read_le(&sk_prf_bytes[..])?;
 
         let mut r_pk_counter = Self::INITIAL_R_PK_COUNTER;
         loop {
@@ -141,7 +141,7 @@ impl<C: DPCComponents> PrivateKey<C> {
         // for the scalar field representation are correctly set to 0.
         let decryption_key = match self.is_dummy {
             true => <C::AccountEncryption as EncryptionScheme>::PrivateKey::default(),
-            false => <C::AccountEncryption as EncryptionScheme>::PrivateKey::read(&decryption_key_bytes[..])?,
+            false => <C::AccountEncryption as EncryptionScheme>::PrivateKey::read_le(&decryption_key_bytes[..])?,
         };
 
         // This operation explicitly enforces that the unused MSB bits
@@ -184,11 +184,11 @@ impl<C: DPCComponents> PrivateKey<C> {
     fn from_seed_and_counter_unsafe(seed: &[u8; 32], r_pk_counter: u16) -> Result<Self, AccountError> {
         // Generate the SIG key pair.
         let sk_sig_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?;
-        let sk_sig = <C::AccountSignature as SignatureScheme>::PrivateKey::read(&sk_sig_bytes[..])?;
+        let sk_sig = <C::AccountSignature as SignatureScheme>::PrivateKey::read_le(&sk_sig_bytes[..])?;
 
         // Generate the PRF secret key.
         let sk_prf_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_PRF)?;
-        let sk_prf = <C::PRF as PRF>::Seed::read(&sk_prf_bytes[..])?;
+        let sk_prf = <C::PRF as PRF>::Seed::read_le(&sk_prf_bytes[..])?;
 
         // Generate the randomness rpk for the commitment scheme.
         let r_pk = Self::derive_r_pk(seed, r_pk_counter)?;
@@ -213,7 +213,7 @@ impl<C: DPCComponents> PrivateKey<C> {
 
         // Generate the randomness rpk for the commitment scheme.
         let r_pk_bytes = Blake2s::evaluate(seed, &r_pk_input)?;
-        let r_pk = <C::AccountCommitment as CommitmentScheme>::Randomness::read(&r_pk_bytes[..])?;
+        let r_pk = <C::AccountCommitment as CommitmentScheme>::Randomness::read_le(&r_pk_bytes[..])?;
 
         Ok(r_pk)
     }
@@ -251,8 +251,8 @@ impl<C: DPCComponents> FromStr for PrivateKey<C> {
         }
 
         let mut reader = &data[9..];
-        let counter_bytes: [u8; 2] = FromBytes::read(&mut reader)?;
-        let seed: [u8; 32] = FromBytes::read(&mut reader)?;
+        let counter_bytes: [u8; 2] = FromBytes::read_le(&mut reader)?;
+        let seed: [u8; 32] = FromBytes::read_le(&mut reader)?;
 
         Self::from_seed_and_counter_unsafe(&seed, u16::from_le_bytes(counter_bytes))
     }

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -267,7 +267,7 @@ impl<C: DPCComponents> fmt::Display for PrivateKey<C> {
         private_key[9..11].copy_from_slice(&self.r_pk_counter.to_le_bytes());
 
         self.seed
-            .write(&mut private_key[11..43])
+            .write_le(&mut private_key[11..43])
             .expect("seed formatting failed");
 
         write!(f, "{}", private_key.to_base58())

--- a/dpc/src/account/view_key.rs
+++ b/dpc/src/account/view_key.rs
@@ -61,8 +61,8 @@ impl<C: DPCComponents> ViewKey<C> {
 }
 
 impl<C: DPCComponents> ToBytes for ViewKey<C> {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.decryption_key.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.decryption_key.write_le(&mut writer)
     }
 }
 
@@ -103,7 +103,7 @@ impl<C: DPCComponents> fmt::Display for ViewKey<C> {
         view_key[0..7].copy_from_slice(&account_format::VIEW_KEY_PREFIX);
 
         self.decryption_key
-            .write(&mut view_key[7..39])
+            .write_le(&mut view_key[7..39])
             .expect("decryption_key formatting failed");
 
         write!(f, "{}", view_key.to_base58())

--- a/dpc/src/account/view_key.rs
+++ b/dpc/src/account/view_key.rs
@@ -68,9 +68,9 @@ impl<C: DPCComponents> ToBytes for ViewKey<C> {
 
 impl<C: DPCComponents> FromBytes for ViewKey<C> {
     /// Reads in an account view key buffer.
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         Ok(Self {
-            decryption_key: <C::AccountEncryption as EncryptionScheme>::PrivateKey::read(&mut reader)?,
+            decryption_key: <C::AccountEncryption as EncryptionScheme>::PrivateKey::read_le(&mut reader)?,
         })
     }
 }
@@ -92,7 +92,7 @@ impl<C: DPCComponents> FromStr for ViewKey<C> {
         let mut reader = &data[7..];
 
         Ok(Self {
-            decryption_key: FromBytes::read(&mut reader)?,
+            decryption_key: FromBytes::read_le(&mut reader)?,
         })
     }
 }

--- a/dpc/src/block/amount.rs
+++ b/dpc/src/block/amount.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::{
     fmt,

--- a/dpc/src/block/amount.rs
+++ b/dpc/src/block/amount.rs
@@ -117,8 +117,8 @@ impl ToBytes for AleoAmount {
 
 impl FromBytes for AleoAmount {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let amount: i64 = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let amount: i64 = FromBytes::read_le(&mut reader)?;
 
         Ok(Self(amount))
     }

--- a/dpc/src/block/amount.rs
+++ b/dpc/src/block/amount.rs
@@ -110,8 +110,8 @@ impl AleoAmount {
 }
 
 impl ToBytes for AleoAmount {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.0.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.0.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -57,9 +57,9 @@ impl<T: TransactionScheme> ToBytes for Block<T> {
 
 impl<T: TransactionScheme> FromBytes for Block<T> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let header: BlockHeader = FromBytes::read(&mut reader)?;
-        let transactions: Transactions<T> = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let header: BlockHeader = FromBytes::read_le(&mut reader)?;
+        let transactions: Transactions<T> = FromBytes::read_le(&mut reader)?;
 
         Ok(Self { header, transactions })
     }
@@ -86,7 +86,7 @@ impl<T: TransactionScheme> Block<T> {
         header_array.copy_from_slice(&header_bytes[0..HEADER_SIZE]);
         let header = BlockHeader::deserialize(&header_array);
 
-        let transactions: Transactions<T> = FromBytes::read(transactions_bytes)?;
+        let transactions: Transactions<T> = FromBytes::read_le(transactions_bytes)?;
 
         Ok(Block { header, transactions })
     }

--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -53,9 +53,9 @@ impl<T: TransactionScheme> BlockScheme for Block<T> {
 
 impl<T: TransactionScheme> ToBytes for Block<T> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.header.write(&mut writer)?;
-        self.transactions.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.header.write_le(&mut writer)?;
+        self.transactions.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -20,11 +20,7 @@ use crate::{
     BlockHeader,
     Transactions,
 };
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-    variable_length_integer::variable_length_integer,
-};
+use snarkvm_utilities::{to_bytes, variable_length_integer::variable_length_integer, FromBytes, ToBytes};
 
 use std::io::{Read, Result as IoResult, Write};
 

--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -20,7 +20,7 @@ use crate::{
     BlockHeader,
     Transactions,
 };
-use snarkvm_utilities::{to_bytes, variable_length_integer::variable_length_integer, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, variable_length_integer::variable_length_integer, FromBytes, ToBytes};
 
 use std::io::{Read, Result as IoResult, Write};
 
@@ -72,7 +72,7 @@ impl<T: TransactionScheme> Block<T> {
         serialization.extend(&variable_length_integer(self.transactions.len() as u64));
 
         for transaction in self.transactions.iter() {
-            serialization.extend(to_bytes![transaction]?)
+            serialization.extend(to_bytes_le![transaction]?)
         }
 
         Ok(serialization)

--- a/dpc/src/block/block_header.rs
+++ b/dpc/src/block/block_header.rs
@@ -16,7 +16,7 @@
 
 use crate::{BlockHeaderHash, MerkleRootHash, PedersenMerkleRootHash, ProofOfSuccinctWork};
 use snarkvm_algorithms::crh::{double_sha256, sha256d_to_u64};
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use serde::{Deserialize, Serialize};
 use std::{

--- a/dpc/src/block/block_header.rs
+++ b/dpc/src/block/block_header.rs
@@ -175,14 +175,14 @@ impl ToBytes for BlockHeader {
 
 impl FromBytes for BlockHeader {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let previous_block_hash = <[u8; 32]>::read(&mut reader)?;
-        let merkle_root_hash = <[u8; 32]>::read(&mut reader)?;
-        let pedersen_merkle_root_hash = <[u8; 32]>::read(&mut reader)?;
-        let proof = ProofOfSuccinctWork::read(&mut reader)?;
-        let time = <[u8; 8]>::read(&mut reader)?;
-        let difficulty_target = <[u8; 8]>::read(&mut reader)?;
-        let nonce = <[u8; 4]>::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let previous_block_hash = <[u8; 32]>::read_le(&mut reader)?;
+        let merkle_root_hash = <[u8; 32]>::read_le(&mut reader)?;
+        let pedersen_merkle_root_hash = <[u8; 32]>::read_le(&mut reader)?;
+        let proof = ProofOfSuccinctWork::read_le(&mut reader)?;
+        let time = <[u8; 8]>::read_le(&mut reader)?;
+        let difficulty_target = <[u8; 8]>::read_le(&mut reader)?;
+        let nonce = <[u8; 4]>::read_le(&mut reader)?;
 
         Ok(Self {
             previous_block_hash: BlockHeaderHash(previous_block_hash),
@@ -219,7 +219,7 @@ mod tests {
 
         let mut serialized2 = vec![];
         block_header.write_le(&mut serialized2).unwrap();
-        let de = BlockHeader::read(&serialized2[..]).unwrap();
+        let de = BlockHeader::read_le(&serialized2[..]).unwrap();
 
         assert_eq!(&serialized1[..], &serialized2[..]);
         assert_eq!(&serialized1[..], &bincode::serialize(&block_header).unwrap()[..]);

--- a/dpc/src/block/block_header.rs
+++ b/dpc/src/block/block_header.rs
@@ -162,14 +162,14 @@ impl BlockHeader {
 
 impl ToBytes for BlockHeader {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.previous_block_hash.0.write(&mut writer)?;
-        self.merkle_root_hash.0.write(&mut writer)?;
-        self.pedersen_merkle_root_hash.0.write(&mut writer)?;
-        self.proof.write(&mut writer)?;
-        self.time.to_le_bytes().write(&mut writer)?;
-        self.difficulty_target.to_le_bytes().write(&mut writer)?;
-        self.nonce.to_le_bytes().write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.previous_block_hash.0.write_le(&mut writer)?;
+        self.merkle_root_hash.0.write_le(&mut writer)?;
+        self.pedersen_merkle_root_hash.0.write_le(&mut writer)?;
+        self.proof.write_le(&mut writer)?;
+        self.time.to_le_bytes().write_le(&mut writer)?;
+        self.difficulty_target.to_le_bytes().write_le(&mut writer)?;
+        self.nonce.to_le_bytes().write_le(&mut writer)
     }
 }
 
@@ -218,7 +218,7 @@ mod tests {
         let result = BlockHeader::deserialize(&serialized1);
 
         let mut serialized2 = vec![];
-        block_header.write(&mut serialized2).unwrap();
+        block_header.write_le(&mut serialized2).unwrap();
         let de = BlockHeader::read(&serialized2[..]).unwrap();
 
         assert_eq!(&serialized1[..], &serialized2[..]);

--- a/dpc/src/block/network.rs
+++ b/dpc/src/block/network.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::{
     fmt,

--- a/dpc/src/block/network.rs
+++ b/dpc/src/block/network.rs
@@ -54,8 +54,8 @@ impl Network {
 
 impl ToBytes for Network {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.id().write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.id().write_le(&mut writer)
     }
 }
 

--- a/dpc/src/block/network.rs
+++ b/dpc/src/block/network.rs
@@ -61,8 +61,8 @@ impl ToBytes for Network {
 
 impl FromBytes for Network {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let network_id: u8 = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let network_id: u8 = FromBytes::read_le(&mut reader)?;
         Ok(Self::from_id(network_id))
     }
 }

--- a/dpc/src/block/pedersen_merkle_tree.rs
+++ b/dpc/src/block/pedersen_merkle_tree.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{crh::PedersenCompressedCRH, define_masked_merkle_tree_parameters, merkle_tree::prng};
 use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective as EdwardsBls};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,7 @@ pub fn pedersen_merkle_root_hash_with_leaves(hashes: &[[u8; 32]]) -> (Fr, Vec<Fr
 
 impl From<Fr> for PedersenMerkleRootHash {
     fn from(src: Fr) -> PedersenMerkleRootHash {
-        let root_bytes = to_bytes![src].expect("could not convert merkle root to bytes");
+        let root_bytes = to_bytes_le![src].expect("could not convert merkle root to bytes");
         let mut pedersen_merkle_root_bytes = [0u8; 32];
         pedersen_merkle_root_bytes[..].copy_from_slice(&root_bytes);
         PedersenMerkleRootHash(pedersen_merkle_root_bytes)

--- a/dpc/src/block/pedersen_merkle_tree.rs
+++ b/dpc/src/block/pedersen_merkle_tree.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{crh::PedersenCompressedCRH, define_masked_merkle_tree_parameters, merkle_tree::prng};
 use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective as EdwardsBls};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};

--- a/dpc/src/block/posw.rs
+++ b/dpc/src/block/posw.rs
@@ -119,7 +119,7 @@ impl ToBytes for ProofOfSuccinctWork {
 
 impl FromBytes for ProofOfSuccinctWork {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut proof = [0; PROOF_SIZE];
         reader.read_exact(&mut proof)?;
         Ok(ProofOfSuccinctWork(proof))

--- a/dpc/src/block/posw.rs
+++ b/dpc/src/block/posw.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use serde::{
     de::{Error as DeserializeError, SeqAccess, Visitor},

--- a/dpc/src/block/posw.rs
+++ b/dpc/src/block/posw.rs
@@ -112,8 +112,8 @@ impl Serialize for ProofOfSuccinctWork {
 
 impl ToBytes for ProofOfSuccinctWork {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        (&self.0[..]).write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        (&self.0[..]).write_le(&mut writer)
     }
 }
 

--- a/dpc/src/block/transactions.rs
+++ b/dpc/src/block/transactions.rs
@@ -132,11 +132,11 @@ impl<T: TransactionScheme> ToBytes for Transactions<T> {
 
 impl<T: TransactionScheme> FromBytes for Transactions<T> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let num_transactions = read_variable_length_integer(&mut reader)?;
         let mut transactions = Vec::with_capacity(num_transactions);
         for _ in 0..num_transactions {
-            let transaction: T = FromBytes::read(&mut reader)?;
+            let transaction: T = FromBytes::read_le(&mut reader)?;
             transactions.push(transaction);
         }
 

--- a/dpc/src/block/transactions.rs
+++ b/dpc/src/block/transactions.rs
@@ -17,7 +17,7 @@
 use crate::{traits::TransactionScheme, TransactionError};
 use snarkvm_utilities::{
     has_duplicates,
-    to_bytes,
+    to_bytes_le,
     variable_length_integer::{read_variable_length_integer, variable_length_integer},
     FromBytes,
     ToBytes,
@@ -56,7 +56,7 @@ impl<T: TransactionScheme> Transactions<T> {
     pub fn serialize(&self) -> Result<Vec<Vec<u8>>, TransactionError> {
         self.0
             .iter()
-            .map(|transaction| -> Result<Vec<u8>, TransactionError> { Ok(to_bytes![transaction]?) })
+            .map(|transaction| -> Result<Vec<u8>, TransactionError> { Ok(to_bytes_le![transaction]?) })
             .collect::<Result<Vec<Vec<u8>>, TransactionError>>()
     }
 
@@ -64,7 +64,7 @@ impl<T: TransactionScheme> Transactions<T> {
     pub fn serialize_as_str(&self) -> Result<Vec<String>, TransactionError> {
         self.0
             .iter()
-            .map(|transaction| -> Result<String, TransactionError> { Ok(hex::encode(to_bytes![transaction]?)) })
+            .map(|transaction| -> Result<String, TransactionError> { Ok(hex::encode(to_bytes_le![transaction]?)) })
             .collect::<Result<Vec<String>, TransactionError>>()
     }
 

--- a/dpc/src/block/transactions.rs
+++ b/dpc/src/block/transactions.rs
@@ -118,11 +118,11 @@ impl<T: TransactionScheme> Transactions<T> {
 
 impl<T: TransactionScheme> ToBytes for Transactions<T> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        variable_length_integer(self.0.len() as u64).write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        variable_length_integer(self.0.len() as u64).write_le(&mut writer)?;
 
         for transaction in &self.0 {
-            transaction.write(&mut writer)?;
+            transaction.write_le(&mut writer)?;
         }
 
         Ok(())

--- a/dpc/src/block/transactions.rs
+++ b/dpc/src/block/transactions.rs
@@ -16,10 +16,11 @@
 
 use crate::{traits::TransactionScheme, TransactionError};
 use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
     has_duplicates,
     to_bytes,
     variable_length_integer::{read_variable_length_integer, variable_length_integer},
+    FromBytes,
+    ToBytes,
 };
 
 use std::{

--- a/dpc/src/errors/dpc.rs
+++ b/dpc/src/errors/dpc.rs
@@ -33,6 +33,9 @@ pub enum DPCError {
     AccountError(#[from] AccountError),
 
     #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
+    #[error("{}", _0)]
     CommitmentError(#[from] CommitmentError),
 
     #[error("{}", _0)]

--- a/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
@@ -47,7 +47,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{from_bits_le_to_bytes_le, to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{from_bits_le_to_bytes_le, to_bytes_le, FromBytes, ToBytes};
 
 #[allow(clippy::too_many_arguments)]
 pub fn execute_inner_circuit<C: Testnet1Components, CS: ConstraintSystem<C::InnerScalarField>>(
@@ -332,7 +332,7 @@ where
         )
     };
 
-    let zero_value = UInt8::alloc_vec(&mut cs.ns(|| "Declare record zero value"), &to_bytes![0u64]?)?;
+    let zero_value = UInt8::alloc_vec(&mut cs.ns(|| "Declare record zero value"), &to_bytes_le![0u64]?)?;
 
     let digest_gadget = <C::MerkleHashGadget as CRHGadget<_, _>>::OutputGadget::alloc_input(
         &mut cs.ns(|| "Declare ledger digest"),
@@ -385,7 +385,7 @@ where
 
             let given_is_dummy = Boolean::alloc(&mut declare_cs.ns(|| "given_is_dummy"), || Ok(record.is_dummy()))?;
 
-            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes![record.value()]?)?;
+            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes_le![record.value()]?)?;
 
             let given_payload = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes())?;
 
@@ -689,7 +689,7 @@ where
 
             let given_is_dummy = Boolean::alloc(&mut declare_cs.ns(|| "given_is_dummy"), || Ok(record.is_dummy()))?;
 
-            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes![record.value()]?)?;
+            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes_le![record.value()]?)?;
 
             let given_payload = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes())?;
 
@@ -821,10 +821,10 @@ where
             let serial_number_nonce_bits = serial_number_nonce_bytes
                 .to_bits_le(&mut encryption_cs.ns(|| "Convert serial_number_nonce_bytes to bits"))?;
 
-            let commitment_randomness_bytes =
-                UInt8::alloc_vec(encryption_cs.ns(|| "Allocate commitment randomness bytes"), &to_bytes![
-                    record.commitment_randomness()
-                ]?)?;
+            let commitment_randomness_bytes = UInt8::alloc_vec(
+                encryption_cs.ns(|| "Allocate commitment randomness bytes"),
+                &to_bytes_le![record.commitment_randomness()]?,
+            )?;
 
             let commitment_randomness_bits = commitment_randomness_bytes
                 .to_bits_le(&mut encryption_cs.ns(|| "Convert commitment_randomness_bytes to bits"))?;
@@ -1041,9 +1041,9 @@ where
             let mut encryption_plaintext = Vec::with_capacity(record_group_encoding.len());
 
             for (i, (x, y)) in record_group_encoding.iter().enumerate() {
-                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read_le(&to_bytes![x, y]?[..])?;
+                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read_le(&to_bytes_le![x, y]?[..])?;
                 encryption_plaintext.push(<C::AccountEncryption as EncryptionScheme>::Text::read_le(
-                    &to_bytes![affine.into_projective()]?[..],
+                    &to_bytes_le![affine.into_projective()]?[..],
                 )?);
 
                 let y_gadget = Elligator2FieldGadget::<C::EncryptionParameters, C::InnerScalarField>::alloc(
@@ -1063,10 +1063,10 @@ where
             let u = <C::EncryptionParameters as TwistedEdwardsParameters>::COEFF_D;
             let ua = a.mul(&u);
 
-            let a = C::InnerScalarField::read_le(&to_bytes![a]?[..])?;
-            let b = C::InnerScalarField::read_le(&to_bytes![coeff_b]?[..])?;
-            let u = C::InnerScalarField::read_le(&to_bytes![u]?[..])?;
-            let ua = C::InnerScalarField::read_le(&to_bytes![ua]?[..])?;
+            let a = C::InnerScalarField::read_le(&to_bytes_le![a]?[..])?;
+            let b = C::InnerScalarField::read_le(&to_bytes_le![coeff_b]?[..])?;
+            let u = C::InnerScalarField::read_le(&to_bytes_le![u]?[..])?;
+            let ua = C::InnerScalarField::read_le(&to_bytes_le![ua]?[..])?;
 
             let fp_zero = FpGadget::zero(encryption_cs.ns(|| "fpg zero"))?;
 

--- a/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
@@ -1041,8 +1041,8 @@ where
             let mut encryption_plaintext = Vec::with_capacity(record_group_encoding.len());
 
             for (i, (x, y)) in record_group_encoding.iter().enumerate() {
-                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read(&to_bytes![x, y]?[..])?;
-                encryption_plaintext.push(<C::AccountEncryption as EncryptionScheme>::Text::read(
+                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read_le(&to_bytes![x, y]?[..])?;
+                encryption_plaintext.push(<C::AccountEncryption as EncryptionScheme>::Text::read_le(
                     &to_bytes![affine.into_projective()]?[..],
                 )?);
 
@@ -1063,10 +1063,10 @@ where
             let u = <C::EncryptionParameters as TwistedEdwardsParameters>::COEFF_D;
             let ua = a.mul(&u);
 
-            let a = C::InnerScalarField::read(&to_bytes![a]?[..])?;
-            let b = C::InnerScalarField::read(&to_bytes![coeff_b]?[..])?;
-            let u = C::InnerScalarField::read(&to_bytes![u]?[..])?;
-            let ua = C::InnerScalarField::read(&to_bytes![ua]?[..])?;
+            let a = C::InnerScalarField::read_le(&to_bytes![a]?[..])?;
+            let b = C::InnerScalarField::read_le(&to_bytes![coeff_b]?[..])?;
+            let u = C::InnerScalarField::read_le(&to_bytes![u]?[..])?;
+            let ua = C::InnerScalarField::read_le(&to_bytes![ua]?[..])?;
 
             let fp_zero = FpGadget::zero(encryption_cs.ns(|| "fpg zero"))?;
 

--- a/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
@@ -47,11 +47,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    from_bits_le_to_bytes_le,
-    to_bytes,
-};
+use snarkvm_utilities::{from_bits_le_to_bytes_le, to_bytes, FromBytes, ToBytes};
 
 #[allow(clippy::too_many_arguments)]
 pub fn execute_inner_circuit<C: Testnet1Components, CS: ConstraintSystem<C::InnerScalarField>>(

--- a/dpc/src/testnet1/mod.rs
+++ b/dpc/src/testnet1/mod.rs
@@ -190,12 +190,12 @@ where
         let inner_snark_parameters = {
             let inner_snark_pk = match verify_only {
                 true => None,
-                false => Some(<C::InnerSNARK as SNARK>::ProvingKey::read(
+                false => Some(<C::InnerSNARK as SNARK>::ProvingKey::read_le(
                     InnerSNARKPKParameters::load_bytes()?.as_slice(),
                 )?),
             };
             let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey =
-                <C::InnerSNARK as SNARK>::VerifyingKey::read(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
+                <C::InnerSNARK as SNARK>::VerifyingKey::read_le(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
 
             (inner_snark_pk, inner_snark_vk.into())
         };
@@ -203,12 +203,12 @@ where
         let outer_snark_parameters = {
             let outer_snark_pk = match verify_only {
                 true => None,
-                false => Some(<C::OuterSNARK as SNARK>::ProvingKey::read(
+                false => Some(<C::OuterSNARK as SNARK>::ProvingKey::read_le(
                     OuterSNARKPKParameters::load_bytes()?.as_slice(),
                 )?),
             };
             let outer_snark_vk: <C::OuterSNARK as SNARK>::VerifyingKey =
-                <C::OuterSNARK as SNARK>::VerifyingKey::read(OuterSNARKVKParameters::load_bytes()?.as_slice())?;
+                <C::OuterSNARK as SNARK>::VerifyingKey::read_le(OuterSNARKVKParameters::load_bytes()?.as_slice())?;
 
             (outer_snark_pk, outer_snark_vk.into())
         };

--- a/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
@@ -36,7 +36,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 fn field_element_to_bytes<C: Testnet1Components, CS: ConstraintSystem<C::OuterScalarField>>(
     cs: &mut CS,

--- a/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
@@ -36,7 +36,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 fn field_element_to_bytes<C: Testnet1Components, CS: ConstraintSystem<C::OuterScalarField>>(
     cs: &mut CS,
@@ -46,14 +46,14 @@ fn field_element_to_bytes<C: Testnet1Components, CS: ConstraintSystem<C::OuterSc
     if field_elements.len() <= 1 {
         Ok(vec![UInt8::alloc_input_vec_le(
             cs.ns(|| format!("Allocate {}", name)),
-            &to_bytes![field_elements].map_err(|_| SynthesisError::AssignmentMissing)?,
+            &to_bytes_le![field_elements].map_err(|_| SynthesisError::AssignmentMissing)?,
         )?])
     } else {
         let mut fe_bytes = Vec::with_capacity(field_elements.len());
         for (index, field_element) in field_elements.iter().enumerate() {
             fe_bytes.push(UInt8::alloc_input_vec_le(
                 cs.ns(|| format!("Allocate {} - index {} ", name, index)),
-                &to_bytes![field_element].map_err(|_| SynthesisError::AssignmentMissing)?,
+                &to_bytes_le![field_element].map_err(|_| SynthesisError::AssignmentMissing)?,
             )?);
         }
         Ok(fe_bytes)

--- a/dpc/src/testnet1/outer_circuit/outer_circuit_verifier_input.rs
+++ b/dpc/src/testnet1/outer_circuit/outer_circuit_verifier_input.rs
@@ -20,7 +20,7 @@ use snarkvm_algorithms::{
     traits::{CommitmentScheme, EncryptionScheme, MerkleParameters, SignatureScheme, CRH},
 };
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Testnet1Components"))]
@@ -95,7 +95,7 @@ where
         let inner_snark_field_elements = &self.inner_snark_verifier_input.to_field_elements()?;
 
         for inner_snark_fe in inner_snark_field_elements {
-            let inner_snark_fe_bytes = to_bytes![inner_snark_fe]?;
+            let inner_snark_fe_bytes = to_bytes_le![inner_snark_fe]?;
             v.extend_from_slice(&ToConstraintField::<C::OuterScalarField>::to_field_elements(
                 inner_snark_fe_bytes.as_slice(),
             )?);

--- a/dpc/src/testnet1/outer_circuit/outer_circuit_verifier_input.rs
+++ b/dpc/src/testnet1/outer_circuit/outer_circuit_verifier_input.rs
@@ -20,7 +20,7 @@ use snarkvm_algorithms::{
     traits::{CommitmentScheme, EncryptionScheme, MerkleParameters, SignatureScheme, CRH},
 };
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Testnet1Components"))]

--- a/dpc/src/testnet1/parameters.rs
+++ b/dpc/src/testnet1/parameters.rs
@@ -17,7 +17,7 @@
 use crate::{testnet1::Testnet1Components, DPCError};
 use snarkvm_algorithms::prelude::*;
 use snarkvm_parameters::prelude::*;
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use rand::{CryptoRng, Rng};
 use std::io::Result as IoResult;

--- a/dpc/src/testnet1/parameters.rs
+++ b/dpc/src/testnet1/parameters.rs
@@ -101,29 +101,33 @@ impl<C: Testnet1Components> SystemParameters<C> {
 
     /// TODO (howardwu): Inspect what is going on with program_verification_key_commitment.
     pub fn load() -> IoResult<Self> {
-        let account_commitment: C::AccountCommitment =
-            From::from(FromBytes::read(AccountCommitmentParameters::load_bytes()?.as_slice())?);
+        let account_commitment: C::AccountCommitment = From::from(FromBytes::read_le(
+            AccountCommitmentParameters::load_bytes()?.as_slice(),
+        )?);
         let account_encryption_parameters: <C::AccountEncryption as EncryptionScheme>::Parameters =
-            FromBytes::read(AccountEncryptionParameters::load_bytes()?.as_slice())?;
+            FromBytes::read_le(AccountEncryptionParameters::load_bytes()?.as_slice())?;
         let account_encryption: C::AccountEncryption = From::from(account_encryption_parameters);
-        let account_signature: C::AccountSignature =
-            From::from(FromBytes::read(AccountSignatureParameters::load_bytes()?.as_slice())?);
-        let encrypted_record_crh: C::EncryptedRecordCRH =
-            From::from(FromBytes::read(EncryptedRecordCRHParameters::load_bytes()?.as_slice())?);
+        let account_signature: C::AccountSignature = From::from(FromBytes::read_le(
+            AccountSignatureParameters::load_bytes()?.as_slice(),
+        )?);
+        let encrypted_record_crh: C::EncryptedRecordCRH = From::from(FromBytes::read_le(
+            EncryptedRecordCRHParameters::load_bytes()?.as_slice(),
+        )?);
         let inner_circuit_id_crh: C::InnerCircuitIDCRH =
-            From::from(FromBytes::read(InnerCircuitIDCRH::load_bytes()?.as_slice())?);
+            From::from(FromBytes::read_le(InnerCircuitIDCRH::load_bytes()?.as_slice())?);
         let local_data_crh: C::LocalDataCRH =
-            From::from(FromBytes::read(LocalDataCRHParameters::load_bytes()?.as_slice())?);
-        let local_data_commitment: C::LocalDataCommitment = From::from(FromBytes::read(
+            From::from(FromBytes::read_le(LocalDataCRHParameters::load_bytes()?.as_slice())?);
+        let local_data_commitment: C::LocalDataCommitment = From::from(FromBytes::read_le(
             LocalDataCommitmentParameters::load_bytes()?.as_slice(),
         )?);
         let program_verification_key_commitment: C::ProgramVerificationKeyCommitment =
-            From::from(FromBytes::read(&[][..])?);
+            From::from(FromBytes::read_le(&[][..])?);
         let program_verification_key_crh: C::ProgramVerificationKeyCRH =
-            From::from(FromBytes::read(ProgramVKCRHParameters::load_bytes()?.as_slice())?);
-        let record_commitment: C::RecordCommitment =
-            From::from(FromBytes::read(RecordCommitmentParameters::load_bytes()?.as_slice())?);
-        let serial_number_nonce: C::SerialNumberNonceCRH = From::from(FromBytes::read(
+            From::from(FromBytes::read_le(ProgramVKCRHParameters::load_bytes()?.as_slice())?);
+        let record_commitment: C::RecordCommitment = From::from(FromBytes::read_le(
+            RecordCommitmentParameters::load_bytes()?.as_slice(),
+        )?);
+        let serial_number_nonce: C::SerialNumberNonceCRH = From::from(FromBytes::read_le(
             SerialNumberNonceCRHParameters::load_bytes()?.as_slice(),
         )?);
 

--- a/dpc/src/testnet1/program/noop_program.rs
+++ b/dpc/src/testnet1/program/noop_program.rs
@@ -26,7 +26,7 @@ use snarkvm_parameters::{
     testnet1::{NoopProgramSNARKPKParameters, NoopProgramSNARKVKParameters},
     Parameter,
 };
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use rand::{CryptoRng, Rng};
 
@@ -67,9 +67,9 @@ impl<C: Testnet1Components> ProgramScheme for NoopProgram<C> {
         let verifying_key = prepared_verifying_key.into();
 
         // Compute the program ID.
-        let id = to_bytes![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
+        let id = to_bytes_le![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
             program_verifying_key_crh,
-            &to_bytes![verifying_key]?
+            &to_bytes_le![verifying_key]?
         )?]?;
 
         Ok(Self {
@@ -93,9 +93,9 @@ impl<C: Testnet1Components> ProgramScheme for NoopProgram<C> {
         )?;
 
         // Compute the program ID.
-        let program_id = to_bytes![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
+        let program_id = to_bytes_le![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
             program_verifying_key_crh,
-            &to_bytes![verifying_key]?
+            &to_bytes_le![verifying_key]?
         )?]?;
 
         Ok(Self {
@@ -146,8 +146,8 @@ impl<C: Testnet1Components> ProgramScheme for NoopProgram<C> {
         }
 
         Ok(Self::Execution {
-            verifying_key: to_bytes![self.verifying_key]?,
-            proof: to_bytes![proof]?,
+            verifying_key: to_bytes_le![self.verifying_key]?,
+            proof: to_bytes_le![proof]?,
         })
     }
 
@@ -159,8 +159,8 @@ impl<C: Testnet1Components> ProgramScheme for NoopProgram<C> {
         )?;
 
         Ok(Self::Execution {
-            verifying_key: to_bytes![self.verifying_key]?,
-            proof: to_bytes![proof]?,
+            verifying_key: to_bytes_le![self.verifying_key]?,
+            proof: to_bytes_le![proof]?,
         })
     }
 

--- a/dpc/src/testnet1/program/noop_program.rs
+++ b/dpc/src/testnet1/program/noop_program.rs
@@ -87,9 +87,10 @@ impl<C: Testnet1Components> ProgramScheme for NoopProgram<C> {
         program_verifying_key_crh: &Self::ProgramVerifyingKeyCRH,
     ) -> Result<Self, ProgramError> {
         let proving_key: <Self::ProofSystem as SNARK>::ProvingKey =
-            FromBytes::read(NoopProgramSNARKPKParameters::load_bytes()?.as_slice())?;
-        let verifying_key =
-            <Self::ProofSystem as SNARK>::VerifyingKey::read(NoopProgramSNARKVKParameters::load_bytes()?.as_slice())?;
+            FromBytes::read_le(NoopProgramSNARKPKParameters::load_bytes()?.as_slice())?;
+        let verifying_key = <Self::ProofSystem as SNARK>::VerifyingKey::read_le(
+            NoopProgramSNARKVKParameters::load_bytes()?.as_slice(),
+        )?;
 
         // Compute the program ID.
         let program_id = to_bytes![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(

--- a/dpc/src/testnet1/record/encoded.rs
+++ b/dpc/src/testnet1/record/encoded.rs
@@ -40,7 +40,7 @@ pub fn encode_to_group<P: MontgomeryParameters + TwistedEdwardsParameters, G: Gr
         bytes.push(0)
     }
 
-    let input = P::BaseField::read(&bytes[..])?;
+    let input = P::BaseField::read_le(&bytes[..])?;
     let (output, fq_high) = Elligator2::<P, G>::encode(&input)?;
     Ok((output, fq_high))
 }
@@ -169,8 +169,8 @@ impl<C: Testnet1Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
 
         // Process birth_program_id and death_program_id. (Assumption 2 and 3 applies)
 
-        let birth_program_id_biginteger = Self::OuterField::read(birth_program_id)?.into_repr();
-        let death_program_id_biginteger = Self::OuterField::read(death_program_id)?.into_repr();
+        let birth_program_id_biginteger = Self::OuterField::read_le(birth_program_id)?.into_repr();
+        let death_program_id_biginteger = Self::OuterField::read_le(death_program_id)?.into_repr();
 
         let mut birth_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);
         let mut death_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);
@@ -305,7 +305,7 @@ impl<C: Testnet1Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
 
         let (serial_number_nonce, _) = &(self.encoded_elements[0], fq_high_bits[0]);
         let serial_number_nonce_bytes = to_bytes![serial_number_nonce.into_affine().to_x_coordinate()]?;
-        let serial_number_nonce = <C::SerialNumberNonceCRH as CRH>::Output::read(&serial_number_nonce_bytes[..])?;
+        let serial_number_nonce = <C::SerialNumberNonceCRH as CRH>::Output::read_le(&serial_number_nonce_bytes[..])?;
 
         // Deserialize commitment randomness
 
@@ -317,7 +317,7 @@ impl<C: Testnet1Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         let commitment_randomness_bits = &from_bytes_le_to_bits_le(&commitment_randomness_bytes)
             .take(Self::DATA_ELEMENT_BITSIZE)
             .collect::<Vec<_>>();
-        let commitment_randomness = <C::RecordCommitment as CommitmentScheme>::Randomness::read(
+        let commitment_randomness = <C::RecordCommitment as CommitmentScheme>::Randomness::read_le(
             &from_bits_le_to_bytes_le(commitment_randomness_bits)[..],
         )?;
 
@@ -360,7 +360,7 @@ impl<C: Testnet1Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         let value_start = self.encoded_elements.len();
         let value_end = value_start + (std::mem::size_of_val(&<Self::Record as RecordScheme>::Value::default()) * 8);
         let value: <Self::Record as RecordScheme>::Value =
-            FromBytes::read(&from_bits_le_to_bytes_le(&final_element_bits[value_start..value_end])[..])?;
+            FromBytes::read_le(&from_bits_le_to_bytes_le(&final_element_bits[value_start..value_end])[..])?;
 
         // Deserialize payload
 
@@ -374,7 +374,7 @@ impl<C: Testnet1Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         }
         payload_bits.extend_from_slice(&final_element_bits[value_end..]);
 
-        let payload = Payload::read(&from_bits_le_to_bytes_le(&payload_bits)[..])?;
+        let payload = Payload::read_le(&from_bits_le_to_bytes_le(&payload_bits)[..])?;
 
         Ok(DecodedRecord {
             value,

--- a/dpc/src/testnet1/record/encrypted.rs
+++ b/dpc/src/testnet1/record/encrypted.rs
@@ -35,7 +35,7 @@ use snarkvm_fields::One;
 use snarkvm_utilities::{
     from_bits_le_to_bytes_le,
     from_bytes_le_to_bits_le,
-    to_bytes,
+    to_bytes_le,
     variable_length_integer::*,
     FromBytes,
     ToBytes,
@@ -127,8 +127,9 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
         for element in encoded_record.encoded_elements.iter() {
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
-            let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
+            let plaintext_element = <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(
+                &to_bytes_le![element]?[..],
+            )?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -167,7 +168,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
 
         let mut plaintext = Vec::with_capacity(plaintext_elements.len());
         for element in plaintext_elements {
-            let plaintext_element = <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![element]?[..])?;
+            let plaintext_element = <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes_le![element]?[..])?;
 
             plaintext.push(plaintext_element);
         }
@@ -205,7 +206,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
 
         // Calculate record commitment
 
-        let commitment_input = to_bytes![
+        let commitment_input = to_bytes_le![
             owner,
             is_dummy,
             value,
@@ -245,7 +246,8 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes_le![ciphertext_element]?[..])?
+                    .into_affine();
             let ciphertext_x_coordinate = ciphertext_element_affine.to_x_coordinate();
 
             // Fetch the ciphertext selector bit
@@ -268,7 +270,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
 
         Ok(system_parameters
             .encrypted_record_crh
-            .hash(&to_bytes![ciphertext_affine_x, selector_bytes]?)?)
+            .hash(&to_bytes_le![ciphertext_affine_x, selector_bytes]?)?)
     }
 
     /// Returns the intermediate components of the encryption algorithm that the inner SNARK
@@ -324,7 +326,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
                 // Serial number nonce
                 let record_field_element =
                     <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
-                        &to_bytes![element]?[..],
+                        &to_bytes_le![element]?[..],
                     )?;
                 record_field_elements.push(record_field_element);
             } else {
@@ -340,17 +342,18 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
             // Fetch the x and y coordinates of the serialized group elements
             // These values will be used in the inner circuit to validate the Elligator2 encoding
             let x = <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
-                &to_bytes![element_affine.to_x_coordinate()]?[..],
+                &to_bytes_le![element_affine.to_x_coordinate()]?[..],
             )?;
             let y = <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
-                &to_bytes![element_affine.to_y_coordinate()]?[..],
+                &to_bytes_le![element_affine.to_y_coordinate()]?[..],
             )?;
             record_group_encoding.push((x, y));
 
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
-            let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
+            let plaintext_element = <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(
+                &to_bytes_le![element]?[..],
+            )?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -374,7 +377,8 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
         for ciphertext_element in encrypted_record.iter() {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes_le![ciphertext_element]?[..])?
+                    .into_affine();
 
             // Fetch the ciphertext selector bit
             let selector =
@@ -409,7 +413,8 @@ impl<C: Testnet1Components> ToBytes for EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext representation to the affine x-coordinate and the selector bit
             let ciphertext_element_affine =
-                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes_le![ciphertext_element]?[..])?
+                    .into_affine();
 
             let x_coordinate = ciphertext_element_affine.to_x_coordinate();
             x_coordinate.write_le(&mut writer)?;
@@ -470,7 +475,7 @@ impl<C: Testnet1Components> FromBytes for EncryptedRecord<C> {
                 };
 
             let ciphertext_element: <C::AccountEncryption as EncryptionScheme>::Text =
-                FromBytes::read_le(&to_bytes![ciphertext_element_affine.into_projective()]?[..])?;
+                FromBytes::read_le(&to_bytes_le![ciphertext_element_affine.into_projective()]?[..])?;
 
             ciphertext.push(ciphertext_element);
         }

--- a/dpc/src/testnet1/record/encrypted.rs
+++ b/dpc/src/testnet1/record/encrypted.rs
@@ -128,7 +128,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
             let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read(&to_bytes![element]?[..])?;
+                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -167,7 +167,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
 
         let mut plaintext = Vec::with_capacity(plaintext_elements.len());
         for element in plaintext_elements {
-            let plaintext_element = <C as Testnet1Components>::EncryptionGroup::read(&to_bytes![element]?[..])?;
+            let plaintext_element = <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![element]?[..])?;
 
             plaintext.push(plaintext_element);
         }
@@ -245,7 +245,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet1Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
             let ciphertext_x_coordinate = ciphertext_element_affine.to_x_coordinate();
 
             // Fetch the ciphertext selector bit
@@ -323,7 +323,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
             if i == 0 {
                 // Serial number nonce
                 let record_field_element =
-                    <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read(
+                    <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
                         &to_bytes![element]?[..],
                     )?;
                 record_field_elements.push(record_field_element);
@@ -339,10 +339,10 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
 
             // Fetch the x and y coordinates of the serialized group elements
             // These values will be used in the inner circuit to validate the Elligator2 encoding
-            let x = <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read(
+            let x = <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
                 &to_bytes![element_affine.to_x_coordinate()]?[..],
             )?;
-            let y = <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read(
+            let y = <<C as Testnet1Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
                 &to_bytes![element_affine.to_y_coordinate()]?[..],
             )?;
             record_group_encoding.push((x, y));
@@ -350,7 +350,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
             let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read(&to_bytes![element]?[..])?;
+                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -374,7 +374,7 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
         for ciphertext_element in encrypted_record.iter() {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet1Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
 
             // Fetch the ciphertext selector bit
             let selector =
@@ -409,7 +409,7 @@ impl<C: Testnet1Components> ToBytes for EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext representation to the affine x-coordinate and the selector bit
             let ciphertext_element_affine =
-                <C as Testnet1Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet1Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
 
             let x_coordinate = ciphertext_element_affine.to_x_coordinate();
             x_coordinate.write_le(&mut writer)?;
@@ -438,13 +438,13 @@ impl<C: Testnet1Components> ToBytes for EncryptedRecord<C> {
 
 impl<C: Testnet1Components> FromBytes for EncryptedRecord<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the ciphertext x coordinates
         let num_ciphertext_elements = read_variable_length_integer(&mut reader)?;
         let mut ciphertext_x_coordinates = Vec::with_capacity(num_ciphertext_elements);
         for _ in 0..num_ciphertext_elements {
             let ciphertext_element_x_coordinate: <<<C as Testnet1Components>::EncryptionGroup as ProjectiveCurve>::Affine as AffineCurve>::BaseField =
-                FromBytes::read(&mut reader)?;
+                FromBytes::read_le(&mut reader)?;
             ciphertext_x_coordinates.push(ciphertext_element_x_coordinate);
         }
 
@@ -470,7 +470,7 @@ impl<C: Testnet1Components> FromBytes for EncryptedRecord<C> {
                 };
 
             let ciphertext_element: <C::AccountEncryption as EncryptionScheme>::Text =
-                FromBytes::read(&to_bytes![ciphertext_element_affine.into_projective()]?[..])?;
+                FromBytes::read_le(&to_bytes![ciphertext_element_affine.into_projective()]?[..])?;
 
             ciphertext.push(ciphertext_element);
         }

--- a/dpc/src/testnet1/record/encrypted.rs
+++ b/dpc/src/testnet1/record/encrypted.rs
@@ -401,18 +401,18 @@ impl<C: Testnet1Components> EncryptedRecord<C> {
 
 impl<C: Testnet1Components> ToBytes for EncryptedRecord<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         let mut ciphertext_selectors = Vec::with_capacity(self.encrypted_elements.len() + 1);
 
         // Write the encrypted record
-        variable_length_integer(self.encrypted_elements.len() as u64).write(&mut writer)?;
+        variable_length_integer(self.encrypted_elements.len() as u64).write_le(&mut writer)?;
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext representation to the affine x-coordinate and the selector bit
             let ciphertext_element_affine =
                 <C as Testnet1Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
 
             let x_coordinate = ciphertext_element_affine.to_x_coordinate();
-            x_coordinate.write(&mut writer)?;
+            x_coordinate.write_le(&mut writer)?;
 
             let selector =
                 match <<C as Testnet1Components>::EncryptionGroup as ProjectiveCurve>::Affine::from_x_coordinate(
@@ -430,7 +430,7 @@ impl<C: Testnet1Components> ToBytes for EncryptedRecord<C> {
 
         // Write the ciphertext and fq_high selector bits
         let selector_bytes = from_bits_le_to_bytes_le(&ciphertext_selectors);
-        selector_bytes.write(&mut writer)?;
+        selector_bytes.write_le(&mut writer)?;
 
         Ok(())
     }

--- a/dpc/src/testnet1/record/payload.rs
+++ b/dpc/src/testnet1/record/payload.rs
@@ -49,7 +49,7 @@ impl ToBytes for Payload {
 
 impl FromBytes for Payload {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        Ok(Self(FromBytes::read(&mut reader)?))
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self(FromBytes::read_le(&mut reader)?))
     }
 }

--- a/dpc/src/testnet1/record/payload.rs
+++ b/dpc/src/testnet1/record/payload.rs
@@ -42,8 +42,8 @@ impl Payload {
 
 impl ToBytes for Payload {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.0.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.0.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/testnet1/record/payload.rs
+++ b/dpc/src/testnet1/record/payload.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::io::{Read, Result as IoResult, Write};
 

--- a/dpc/src/testnet1/record/record.rs
+++ b/dpc/src/testnet1/record/record.rs
@@ -22,12 +22,7 @@ use crate::{
     RecordError,
 };
 use snarkvm_algorithms::traits::{CommitmentScheme, SignatureScheme, CRH, PRF};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-    variable_length_integer::*,
-    UniformRand,
-};
+use snarkvm_utilities::{to_bytes, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
 
 use rand::{CryptoRng, Rng};
 use std::{

--- a/dpc/src/testnet1/record/record.rs
+++ b/dpc/src/testnet1/record/record.rs
@@ -193,8 +193,8 @@ impl<C: Testnet1Components> Record<C> {
         // }
 
         // Compute the serial number.
-        let seed = FromBytes::read(to_bytes!(&private_key.sk_prf)?.as_slice())?;
-        let input = FromBytes::read(to_bytes!(self.serial_number_nonce)?.as_slice())?;
+        let seed = FromBytes::read_le(to_bytes!(&private_key.sk_prf)?.as_slice())?;
+        let input = FromBytes::read_le(to_bytes!(self.serial_number_nonce)?.as_slice())?;
         let randomizer = to_bytes![C::PRF::evaluate(&seed, &input)?]?;
         let serial_number = C::AccountSignature::randomize_public_key(
             &signature_parameters,
@@ -279,17 +279,17 @@ impl<C: Testnet1Components> ToBytes for Record<C> {
 
 impl<C: Testnet1Components> FromBytes for Record<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let owner: Address<C> = FromBytes::read(&mut reader)?;
-        let is_dummy: bool = FromBytes::read(&mut reader)?;
-        let value: u64 = FromBytes::read(&mut reader)?;
-        let payload: Payload = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let owner: Address<C> = FromBytes::read_le(&mut reader)?;
+        let is_dummy: bool = FromBytes::read_le(&mut reader)?;
+        let value: u64 = FromBytes::read_le(&mut reader)?;
+        let payload: Payload = FromBytes::read_le(&mut reader)?;
 
         let birth_program_id_size: usize = read_variable_length_integer(&mut reader)?;
 
         let mut birth_program_id = Vec::with_capacity(birth_program_id_size);
         for _ in 0..birth_program_id_size {
-            let byte: u8 = FromBytes::read(&mut reader)?;
+            let byte: u8 = FromBytes::read_le(&mut reader)?;
             birth_program_id.push(byte);
         }
 
@@ -297,14 +297,14 @@ impl<C: Testnet1Components> FromBytes for Record<C> {
 
         let mut death_program_id = Vec::with_capacity(death_program_id_size);
         for _ in 0..death_program_id_size {
-            let byte: u8 = FromBytes::read(&mut reader)?;
+            let byte: u8 = FromBytes::read_le(&mut reader)?;
             death_program_id.push(byte);
         }
 
-        let serial_number_nonce: <C::SerialNumberNonceCRH as CRH>::Output = FromBytes::read(&mut reader)?;
-        let commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read(&mut reader)?;
+        let serial_number_nonce: <C::SerialNumberNonceCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
+        let commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read_le(&mut reader)?;
         let commitment_randomness: <C::RecordCommitment as CommitmentScheme>::Randomness =
-            FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
 
         Ok(Self {
             owner,
@@ -327,7 +327,7 @@ impl<C: Testnet1Components> FromStr for Record<C> {
     type Err = RecordError;
 
     fn from_str(record: &str) -> Result<Self, Self::Err> {
-        Ok(Self::read(&hex::decode(record)?[..])?)
+        Ok(Self::read_le(&hex::decode(record)?[..])?)
     }
 }
 

--- a/dpc/src/testnet1/record/record.rs
+++ b/dpc/src/testnet1/record/record.rs
@@ -264,21 +264,21 @@ impl<C: Testnet1Components> RecordScheme for Record<C> {
 
 impl<C: Testnet1Components> ToBytes for Record<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.owner.write(&mut writer)?;
-        self.is_dummy.write(&mut writer)?;
-        self.value.write(&mut writer)?;
-        self.payload.write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.owner.write_le(&mut writer)?;
+        self.is_dummy.write_le(&mut writer)?;
+        self.value.write_le(&mut writer)?;
+        self.payload.write_le(&mut writer)?;
 
-        variable_length_integer(self.birth_program_id.len() as u64).write(&mut writer)?;
-        self.birth_program_id.write(&mut writer)?;
+        variable_length_integer(self.birth_program_id.len() as u64).write_le(&mut writer)?;
+        self.birth_program_id.write_le(&mut writer)?;
 
-        variable_length_integer(self.death_program_id.len() as u64).write(&mut writer)?;
-        self.death_program_id.write(&mut writer)?;
+        variable_length_integer(self.death_program_id.len() as u64).write_le(&mut writer)?;
+        self.death_program_id.write_le(&mut writer)?;
 
-        self.serial_number_nonce.write(&mut writer)?;
-        self.commitment.write(&mut writer)?;
-        self.commitment_randomness.write(&mut writer)
+        self.serial_number_nonce.write_le(&mut writer)?;
+        self.commitment.write_le(&mut writer)?;
+        self.commitment_randomness.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/testnet1/transaction/kernel.rs
+++ b/dpc/src/testnet1/transaction/kernel.rs
@@ -19,7 +19,7 @@ use crate::{
     testnet1::{EncryptedRecord, LocalData, Record, SystemParameters, Testnet1Components, Transaction},
 };
 use snarkvm_algorithms::{commitment_tree::CommitmentMerkleTree, prelude::*};
-use snarkvm_utilities::{to_bytes, variable_length_integer::*, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes};
 
 use std::{
     fmt,
@@ -276,7 +276,7 @@ impl<C: Testnet1Components> fmt::Display for TransactionKernel<C> {
         write!(
             f,
             "{}",
-            hex::encode(to_bytes![self].expect("couldn't serialize to bytes"))
+            hex::encode(to_bytes_le![self].expect("couldn't serialize to bytes"))
         )
     }
 }

--- a/dpc/src/testnet1/transaction/kernel.rs
+++ b/dpc/src/testnet1/transaction/kernel.rs
@@ -146,20 +146,21 @@ impl<C: Testnet1Components> ToBytes for TransactionKernel<C> {
 
 impl<C: Testnet1Components> FromBytes for TransactionKernel<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let system_parameters = SystemParameters::<C>::load().expect("Could not load system parameters");
 
         // Read old record components
 
         let mut old_records = vec![];
         for _ in 0..C::NUM_INPUT_RECORDS {
-            let old_record: Record<C> = FromBytes::read(&mut reader)?;
+            let old_record: Record<C> = FromBytes::read_le(&mut reader)?;
             old_records.push(old_record);
         }
 
         let mut old_serial_numbers = vec![];
         for _ in 0..C::NUM_INPUT_RECORDS {
-            let old_serial_number: <C::AccountSignature as SignatureScheme>::PublicKey = FromBytes::read(&mut reader)?;
+            let old_serial_number: <C::AccountSignature as SignatureScheme>::PublicKey =
+                FromBytes::read_le(&mut reader)?;
             old_serial_numbers.push(old_serial_number);
         }
 
@@ -168,7 +169,7 @@ impl<C: Testnet1Components> FromBytes for TransactionKernel<C> {
             let num_bytes = read_variable_length_integer(&mut reader)?;
             let mut randomizer = vec![];
             for _ in 0..num_bytes {
-                let byte: u8 = FromBytes::read(&mut reader)?;
+                let byte: u8 = FromBytes::read_le(&mut reader)?;
                 randomizer.push(byte);
             }
 
@@ -179,47 +180,47 @@ impl<C: Testnet1Components> FromBytes for TransactionKernel<C> {
 
         let mut new_records = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let new_record: Record<C> = FromBytes::read(&mut reader)?;
+            let new_record: Record<C> = FromBytes::read_le(&mut reader)?;
             new_records.push(new_record);
         }
 
         let mut new_sn_nonce_randomness = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let randomness: [u8; 32] = FromBytes::read(&mut reader)?;
+            let randomness: [u8; 32] = FromBytes::read_le(&mut reader)?;
             new_sn_nonce_randomness.push(randomness);
         }
 
         let mut new_commitments = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read(&mut reader)?;
+            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read_le(&mut reader)?;
             new_commitments.push(new_commitment);
         }
 
         let mut new_records_encryption_randomness = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
             let encryption_randomness: <C::AccountEncryption as EncryptionScheme>::Randomness =
-                FromBytes::read(&mut reader)?;
+                FromBytes::read_le(&mut reader)?;
             new_records_encryption_randomness.push(encryption_randomness);
         }
 
         let mut new_encrypted_records = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let encrypted_record: EncryptedRecord<C> = FromBytes::read(&mut reader)?;
+            let encrypted_record: EncryptedRecord<C> = FromBytes::read_le(&mut reader)?;
             new_encrypted_records.push(encrypted_record);
         }
 
         let mut new_encrypted_record_hashes = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let encrypted_record_hash: <C::EncryptedRecordCRH as CRH>::Output = FromBytes::read(&mut reader)?;
+            let encrypted_record_hash: <C::EncryptedRecordCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
             new_encrypted_record_hashes.push(encrypted_record_hash);
         }
 
         // Read transaction components
 
         let program_commitment: <C::ProgramVerificationKeyCommitment as CommitmentScheme>::Output =
-            FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
         let program_randomness: <C::ProgramVerificationKeyCommitment as CommitmentScheme>::Randomness =
-            FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
 
         let local_data_merkle_tree = CommitmentMerkleTree::<C::LocalDataCommitment, C::LocalDataCRH>::from_bytes(
             &mut reader,
@@ -230,13 +231,13 @@ impl<C: Testnet1Components> FromBytes for TransactionKernel<C> {
         let mut local_data_commitment_randomizers = vec![];
         for _ in 0..4 {
             let local_data_commitment_randomizer: <C::LocalDataCommitment as CommitmentScheme>::Randomness =
-                FromBytes::read(&mut reader)?;
+                FromBytes::read_le(&mut reader)?;
             local_data_commitment_randomizers.push(local_data_commitment_randomizer);
         }
 
-        let value_balance: AleoAmount = FromBytes::read(&mut reader)?;
-        let memorandum: <Transaction<C> as TransactionScheme>::Memorandum = FromBytes::read(&mut reader)?;
-        let network_id: u8 = FromBytes::read(&mut reader)?;
+        let value_balance: AleoAmount = FromBytes::read_le(&mut reader)?;
+        let memorandum: <Transaction<C> as TransactionScheme>::Memorandum = FromBytes::read_le(&mut reader)?;
+        let network_id: u8 = FromBytes::read_le(&mut reader)?;
 
         Ok(Self {
             old_records,
@@ -266,7 +267,7 @@ impl<C: Testnet1Components> FromStr for TransactionKernel<C> {
     type Err = TransactionError;
 
     fn from_str(kernel: &str) -> Result<Self, Self::Err> {
-        Ok(Self::read(&hex::decode(kernel)?[..])?)
+        Ok(Self::read_le(&hex::decode(kernel)?[..])?)
     }
 }
 

--- a/dpc/src/testnet1/transaction/kernel.rs
+++ b/dpc/src/testnet1/transaction/kernel.rs
@@ -85,62 +85,62 @@ impl<C: Testnet1Components> TransactionKernel<C> {
 
 impl<C: Testnet1Components> ToBytes for TransactionKernel<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write old record components
 
         for old_record in &self.old_records {
-            old_record.write(&mut writer)?;
+            old_record.write_le(&mut writer)?;
         }
 
         for old_serial_number in &self.old_serial_numbers {
-            old_serial_number.write(&mut writer)?;
+            old_serial_number.write_le(&mut writer)?;
         }
 
         for old_randomizer in &self.old_randomizers {
-            variable_length_integer(old_randomizer.len() as u64).write(&mut writer)?;
-            old_randomizer.write(&mut writer)?;
+            variable_length_integer(old_randomizer.len() as u64).write_le(&mut writer)?;
+            old_randomizer.write_le(&mut writer)?;
         }
 
         // Write new record components
 
         for new_record in &self.new_records {
-            new_record.write(&mut writer)?;
+            new_record.write_le(&mut writer)?;
         }
 
         for new_sn_nonce_randomness in &self.new_sn_nonce_randomness {
-            new_sn_nonce_randomness.write(&mut writer)?;
+            new_sn_nonce_randomness.write_le(&mut writer)?;
         }
 
         for new_commitment in &self.new_commitments {
-            new_commitment.write(&mut writer)?;
+            new_commitment.write_le(&mut writer)?;
         }
 
         for new_records_encryption_randomness in &self.new_records_encryption_randomness {
-            new_records_encryption_randomness.write(&mut writer)?;
+            new_records_encryption_randomness.write_le(&mut writer)?;
         }
 
         for new_encrypted_record in &self.new_encrypted_records {
-            new_encrypted_record.write(&mut writer)?;
+            new_encrypted_record.write_le(&mut writer)?;
         }
 
         for new_encrypted_record_hash in &self.new_encrypted_record_hashes {
-            new_encrypted_record_hash.write(&mut writer)?;
+            new_encrypted_record_hash.write_le(&mut writer)?;
         }
 
         // Write transaction components
 
-        self.program_commitment.write(&mut writer)?;
-        self.program_randomness.write(&mut writer)?;
+        self.program_commitment.write_le(&mut writer)?;
+        self.program_randomness.write_le(&mut writer)?;
 
-        self.local_data_merkle_tree.write(&mut writer)?;
+        self.local_data_merkle_tree.write_le(&mut writer)?;
 
         for local_data_commitment_randomizer in &self.local_data_commitment_randomizers {
-            local_data_commitment_randomizer.write(&mut writer)?;
+            local_data_commitment_randomizer.write_le(&mut writer)?;
         }
 
-        self.value_balance.write(&mut writer)?;
-        self.memorandum.write(&mut writer)?;
-        self.network_id.write(&mut writer)
+        self.value_balance.write_le(&mut writer)?;
+        self.memorandum.write_le(&mut writer)?;
+        self.network_id.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/testnet1/transaction/transaction.rs
+++ b/dpc/src/testnet1/transaction/transaction.rs
@@ -26,9 +26,10 @@ use snarkvm_algorithms::{
     traits::{CommitmentScheme, SignatureScheme, CRH, SNARK},
 };
 use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
     serialize::{CanonicalDeserialize, CanonicalSerialize},
     to_bytes,
+    FromBytes,
+    ToBytes,
 };
 
 use blake2::{digest::Digest, Blake2s as b2s};

--- a/dpc/src/testnet1/transaction/transaction.rs
+++ b/dpc/src/testnet1/transaction/transaction.rs
@@ -27,7 +27,7 @@ use snarkvm_algorithms::{
 };
 use snarkvm_utilities::{
     serialize::{CanonicalDeserialize, CanonicalSerialize},
-    to_bytes,
+    to_bytes_le,
     FromBytes,
     ToBytes,
 };
@@ -143,11 +143,11 @@ impl<C: Testnet1Components> TransactionScheme for Transaction<C> {
         let mut pre_image_bytes: Vec<u8> = vec![];
 
         for serial_number in self.old_serial_numbers() {
-            pre_image_bytes.extend(&to_bytes![serial_number]?);
+            pre_image_bytes.extend(&to_bytes_le![serial_number]?);
         }
 
         for commitment in self.new_commitments() {
-            pre_image_bytes.extend(&to_bytes![commitment]?);
+            pre_image_bytes.extend(&to_bytes_le![commitment]?);
         }
 
         pre_image_bytes.extend(self.memorandum());
@@ -205,7 +205,7 @@ impl<C: Testnet1Components> TransactionScheme for Transaction<C> {
     }
 
     fn size(&self) -> usize {
-        let transaction_bytes = to_bytes![self].unwrap();
+        let transaction_bytes = to_bytes_le![self].unwrap();
         transaction_bytes.len()
     }
 }

--- a/dpc/src/testnet1/transaction/transaction.rs
+++ b/dpc/src/testnet1/transaction/transaction.rs
@@ -211,32 +211,32 @@ impl<C: Testnet1Components> TransactionScheme for Transaction<C> {
 
 impl<C: Testnet1Components> ToBytes for Transaction<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         for old_serial_number in &self.old_serial_numbers {
             CanonicalSerialize::serialize(old_serial_number, &mut writer).unwrap();
         }
 
         for new_commitment in &self.new_commitments {
-            new_commitment.write(&mut writer)?;
+            new_commitment.write_le(&mut writer)?;
         }
 
-        self.memorandum.write(&mut writer)?;
+        self.memorandum.write_le(&mut writer)?;
 
-        self.ledger_digest.write(&mut writer)?;
-        self.inner_circuit_id.write(&mut writer)?;
-        self.transaction_proof.write(&mut writer)?;
-        self.program_commitment.write(&mut writer)?;
-        self.local_data_root.write(&mut writer)?;
+        self.ledger_digest.write_le(&mut writer)?;
+        self.inner_circuit_id.write_le(&mut writer)?;
+        self.transaction_proof.write_le(&mut writer)?;
+        self.program_commitment.write_le(&mut writer)?;
+        self.local_data_root.write_le(&mut writer)?;
 
-        self.value_balance.write(&mut writer)?;
-        self.network.write(&mut writer)?;
+        self.value_balance.write_le(&mut writer)?;
+        self.network.write_le(&mut writer)?;
 
         for signature in &self.signatures {
-            signature.write(&mut writer)?;
+            signature.write_le(&mut writer)?;
         }
 
         for encrypted_record in &self.encrypted_records {
-            encrypted_record.write(&mut writer)?;
+            encrypted_record.write_le(&mut writer)?;
         }
 
         Ok(())

--- a/dpc/src/testnet1/transaction/transaction.rs
+++ b/dpc/src/testnet1/transaction/transaction.rs
@@ -246,7 +246,7 @@ impl<C: Testnet1Components> ToBytes for Transaction<C> {
 
 impl<C: Testnet1Components> FromBytes for Transaction<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the old serial numbers
         let num_old_serial_numbers = C::NUM_INPUT_RECORDS;
         let mut old_serial_numbers = Vec::with_capacity(num_old_serial_numbers);
@@ -261,27 +261,27 @@ impl<C: Testnet1Components> FromBytes for Transaction<C> {
         let num_new_commitments = C::NUM_OUTPUT_RECORDS;
         let mut new_commitments = Vec::with_capacity(num_new_commitments);
         for _ in 0..num_new_commitments {
-            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read(&mut reader)?;
+            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read_le(&mut reader)?;
             new_commitments.push(new_commitment);
         }
 
-        let memorandum: [u8; 32] = FromBytes::read(&mut reader)?;
+        let memorandum: [u8; 32] = FromBytes::read_le(&mut reader)?;
 
-        let ledger_digest: MerkleTreeDigest<C::MerkleParameters> = FromBytes::read(&mut reader)?;
-        let inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output = FromBytes::read(&mut reader)?;
-        let transaction_proof: <C::OuterSNARK as SNARK>::Proof = FromBytes::read(&mut reader)?;
+        let ledger_digest: MerkleTreeDigest<C::MerkleParameters> = FromBytes::read_le(&mut reader)?;
+        let inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
+        let transaction_proof: <C::OuterSNARK as SNARK>::Proof = FromBytes::read_le(&mut reader)?;
         let program_commitment: <C::ProgramVerificationKeyCommitment as CommitmentScheme>::Output =
-            FromBytes::read(&mut reader)?;
-        let local_data_root: <C::LocalDataCRH as CRH>::Output = FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
+        let local_data_root: <C::LocalDataCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
 
-        let value_balance: AleoAmount = FromBytes::read(&mut reader)?;
-        let network: Network = FromBytes::read(&mut reader)?;
+        let value_balance: AleoAmount = FromBytes::read_le(&mut reader)?;
+        let network: Network = FromBytes::read_le(&mut reader)?;
 
         // Read the signatures
         let num_signatures = C::NUM_INPUT_RECORDS;
         let mut signatures = Vec::with_capacity(num_signatures);
         for _ in 0..num_signatures {
-            let signature: <C::AccountSignature as SignatureScheme>::Signature = FromBytes::read(&mut reader)?;
+            let signature: <C::AccountSignature as SignatureScheme>::Signature = FromBytes::read_le(&mut reader)?;
             signatures.push(signature);
         }
 
@@ -289,7 +289,7 @@ impl<C: Testnet1Components> FromBytes for Transaction<C> {
         let num_encrypted_records = C::NUM_OUTPUT_RECORDS;
         let mut encrypted_records = Vec::with_capacity(num_encrypted_records);
         for _ in 0..num_encrypted_records {
-            let encrypted_record: EncryptedRecord<C> = FromBytes::read(&mut reader)?;
+            let encrypted_record: EncryptedRecord<C> = FromBytes::read_le(&mut reader)?;
 
             encrypted_records.push(encrypted_record);
         }

--- a/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
@@ -47,11 +47,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    from_bits_le_to_bytes_le,
-    to_bytes,
-};
+use snarkvm_utilities::{from_bits_le_to_bytes_le, to_bytes, FromBytes, ToBytes};
 
 #[allow(clippy::too_many_arguments)]
 pub fn execute_inner_circuit<C: Testnet2Components, CS: ConstraintSystem<C::InnerScalarField>>(

--- a/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
@@ -1041,8 +1041,8 @@ where
             let mut encryption_plaintext = Vec::with_capacity(record_group_encoding.len());
 
             for (i, (x, y)) in record_group_encoding.iter().enumerate() {
-                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read(&to_bytes![x, y]?[..])?;
-                encryption_plaintext.push(<C::AccountEncryption as EncryptionScheme>::Text::read(
+                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read_le(&to_bytes![x, y]?[..])?;
+                encryption_plaintext.push(<C::AccountEncryption as EncryptionScheme>::Text::read_le(
                     &to_bytes![affine.into_projective()]?[..],
                 )?);
 
@@ -1063,10 +1063,10 @@ where
             let u = <C::EncryptionParameters as TwistedEdwardsParameters>::COEFF_D;
             let ua = a.mul(&u);
 
-            let a = C::InnerScalarField::read(&to_bytes![a]?[..])?;
-            let b = C::InnerScalarField::read(&to_bytes![coeff_b]?[..])?;
-            let u = C::InnerScalarField::read(&to_bytes![u]?[..])?;
-            let ua = C::InnerScalarField::read(&to_bytes![ua]?[..])?;
+            let a = C::InnerScalarField::read_le(&to_bytes![a]?[..])?;
+            let b = C::InnerScalarField::read_le(&to_bytes![coeff_b]?[..])?;
+            let u = C::InnerScalarField::read_le(&to_bytes![u]?[..])?;
+            let ua = C::InnerScalarField::read_le(&to_bytes![ua]?[..])?;
 
             let fp_zero = FpGadget::zero(encryption_cs.ns(|| "fpg zero"))?;
 

--- a/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
@@ -47,7 +47,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{from_bits_le_to_bytes_le, to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{from_bits_le_to_bytes_le, to_bytes_le, FromBytes, ToBytes};
 
 #[allow(clippy::too_many_arguments)]
 pub fn execute_inner_circuit<C: Testnet2Components, CS: ConstraintSystem<C::InnerScalarField>>(
@@ -332,7 +332,7 @@ where
         )
     };
 
-    let zero_value = UInt8::alloc_vec(&mut cs.ns(|| "Declare record zero value"), &to_bytes![0u64]?)?;
+    let zero_value = UInt8::alloc_vec(&mut cs.ns(|| "Declare record zero value"), &to_bytes_le![0u64]?)?;
 
     let digest_gadget = <C::MerkleHashGadget as CRHGadget<_, _>>::OutputGadget::alloc_input(
         &mut cs.ns(|| "Declare ledger digest"),
@@ -385,7 +385,7 @@ where
 
             let given_is_dummy = Boolean::alloc(&mut declare_cs.ns(|| "given_is_dummy"), || Ok(record.is_dummy()))?;
 
-            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes![record.value()]?)?;
+            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes_le![record.value()]?)?;
 
             let given_payload = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes())?;
 
@@ -689,7 +689,7 @@ where
 
             let given_is_dummy = Boolean::alloc(&mut declare_cs.ns(|| "given_is_dummy"), || Ok(record.is_dummy()))?;
 
-            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes![record.value()]?)?;
+            let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &to_bytes_le![record.value()]?)?;
 
             let given_payload = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes())?;
 
@@ -821,10 +821,10 @@ where
             let serial_number_nonce_bits = serial_number_nonce_bytes
                 .to_bits_le(&mut encryption_cs.ns(|| "Convert serial_number_nonce_bytes to bits"))?;
 
-            let commitment_randomness_bytes =
-                UInt8::alloc_vec(encryption_cs.ns(|| "Allocate commitment randomness bytes"), &to_bytes![
-                    record.commitment_randomness()
-                ]?)?;
+            let commitment_randomness_bytes = UInt8::alloc_vec(
+                encryption_cs.ns(|| "Allocate commitment randomness bytes"),
+                &to_bytes_le![record.commitment_randomness()]?,
+            )?;
 
             let commitment_randomness_bits = commitment_randomness_bytes
                 .to_bits_le(&mut encryption_cs.ns(|| "Convert commitment_randomness_bytes to bits"))?;
@@ -1041,9 +1041,9 @@ where
             let mut encryption_plaintext = Vec::with_capacity(record_group_encoding.len());
 
             for (i, (x, y)) in record_group_encoding.iter().enumerate() {
-                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read_le(&to_bytes![x, y]?[..])?;
+                let affine = <C::EncryptionGroup as ProjectiveCurve>::Affine::read_le(&to_bytes_le![x, y]?[..])?;
                 encryption_plaintext.push(<C::AccountEncryption as EncryptionScheme>::Text::read_le(
-                    &to_bytes![affine.into_projective()]?[..],
+                    &to_bytes_le![affine.into_projective()]?[..],
                 )?);
 
                 let y_gadget = Elligator2FieldGadget::<C::EncryptionParameters, C::InnerScalarField>::alloc(
@@ -1063,10 +1063,10 @@ where
             let u = <C::EncryptionParameters as TwistedEdwardsParameters>::COEFF_D;
             let ua = a.mul(&u);
 
-            let a = C::InnerScalarField::read_le(&to_bytes![a]?[..])?;
-            let b = C::InnerScalarField::read_le(&to_bytes![coeff_b]?[..])?;
-            let u = C::InnerScalarField::read_le(&to_bytes![u]?[..])?;
-            let ua = C::InnerScalarField::read_le(&to_bytes![ua]?[..])?;
+            let a = C::InnerScalarField::read_le(&to_bytes_le![a]?[..])?;
+            let b = C::InnerScalarField::read_le(&to_bytes_le![coeff_b]?[..])?;
+            let u = C::InnerScalarField::read_le(&to_bytes_le![u]?[..])?;
+            let ua = C::InnerScalarField::read_le(&to_bytes_le![ua]?[..])?;
 
             let fp_zero = FpGadget::zero(encryption_cs.ns(|| "fpg zero"))?;
 

--- a/dpc/src/testnet2/mod.rs
+++ b/dpc/src/testnet2/mod.rs
@@ -290,7 +290,7 @@ where
 
             let (sn, randomizer) =
                 record.to_serial_number(&self.system_parameters.account_signature, &old_private_keys[i])?;
-            joint_serial_numbers.extend_from_slice(&to_bytes![sn]?);
+            joint_serial_numbers.extend_from_slice(&sn.to_bytes_le()?);
             old_serial_numbers.push(sn);
             old_randomizers.push(randomizer);
             old_death_program_ids.push(record.death_program_id().to_vec());
@@ -594,10 +594,10 @@ where
 
         let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey = self.inner_snark_parameters.1.clone().into();
 
-        let inner_circuit_id =
-            <C::InnerCircuitIDCRH as CRH>::hash(&self.system_parameters.inner_circuit_id_crh, &to_bytes![
-                inner_snark_vk
-            ]?)?;
+        let inner_circuit_id = <C::InnerCircuitIDCRH as CRH>::hash(
+            &self.system_parameters.inner_circuit_id_crh,
+            &inner_snark_vk.to_bytes_le()?,
+        )?;
 
         let transaction_proof = {
             let circuit = OuterCircuit::new(

--- a/dpc/src/testnet2/mod.rs
+++ b/dpc/src/testnet2/mod.rs
@@ -217,12 +217,12 @@ where
         let inner_snark_parameters = {
             let inner_snark_pk = match verify_only {
                 true => None,
-                false => Some(<C::InnerSNARK as SNARK>::ProvingKey::read(
+                false => Some(<C::InnerSNARK as SNARK>::ProvingKey::read_le(
                     InnerSNARKPKParameters::load_bytes()?.as_slice(),
                 )?),
             };
             let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey =
-                <C::InnerSNARK as SNARK>::VerifyingKey::read(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
+                <C::InnerSNARK as SNARK>::VerifyingKey::read_le(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
 
             (inner_snark_pk, inner_snark_vk.into())
         };
@@ -230,12 +230,12 @@ where
         let outer_snark_parameters = {
             let outer_snark_pk = match verify_only {
                 true => None,
-                false => Some(<C::OuterSNARK as SNARK>::ProvingKey::read(
+                false => Some(<C::OuterSNARK as SNARK>::ProvingKey::read_le(
                     OuterSNARKPKParameters::load_bytes()?.as_slice(),
                 )?),
             };
             let outer_snark_vk: <C::OuterSNARK as SNARK>::VerifyingKey =
-                <C::OuterSNARK as SNARK>::VerifyingKey::read(OuterSNARKVKParameters::load_bytes()?.as_slice())?;
+                <C::OuterSNARK as SNARK>::VerifyingKey::read_le(OuterSNARKVKParameters::load_bytes()?.as_slice())?;
 
             (outer_snark_pk, outer_snark_vk.into())
         };

--- a/dpc/src/testnet2/mod.rs
+++ b/dpc/src/testnet2/mod.rs
@@ -41,7 +41,7 @@ use snarkvm_marlin::{
 };
 use snarkvm_parameters::{prelude::*, testnet2::*};
 use snarkvm_polycommit::PolynomialCommitment;
-use snarkvm_utilities::{has_duplicates, rand::UniformRand, to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{has_duplicates, rand::UniformRand, to_bytes_le, FromBytes, ToBytes};
 
 use itertools::Itertools;
 use rand::{CryptoRng, Rng};
@@ -331,7 +331,7 @@ where
         let mut local_data_commitment_randomizers = Vec::with_capacity(C::NUM_INPUT_RECORDS);
         let mut old_record_commitments = Vec::with_capacity(C::NUM_INPUT_RECORDS);
         for i in 0..C::NUM_INPUT_RECORDS {
-            let input_bytes = to_bytes![
+            let input_bytes = to_bytes_le![
                 old_serial_numbers[i],
                 &old_records[i].commitment(),
                 memorandum,
@@ -351,7 +351,7 @@ where
 
         let mut new_record_commitments = Vec::with_capacity(C::NUM_OUTPUT_RECORDS);
         for record in new_records.iter().take(C::NUM_OUTPUT_RECORDS) {
-            let input_bytes = to_bytes![record.commitment(), memorandum, C::NETWORK_ID]?;
+            let input_bytes = to_bytes_le![record.commitment(), memorandum, C::NETWORK_ID]?;
 
             let commitment_randomness = <C::LocalDataCommitment as CommitmentScheme>::Randomness::rand(rng);
             let commitment = C::LocalDataCommitment::commit(
@@ -490,7 +490,7 @@ where
         // TODO (raychu86): Remove ledger_digest from signature and move the schnorr signing into `execute_offline_phase`
         let signature_time = start_timer!(|| "Sign and randomize transaction contents");
 
-        let signature_message = to_bytes![
+        let signature_message = to_bytes_le![
             network_id,
             ledger_digest,
             old_serial_numbers,
@@ -714,7 +714,7 @@ where
             return false;
         }
 
-        let signature_message = match to_bytes![
+        let signature_message = match to_bytes_le![
             transaction.network_id(),
             transaction.ledger_digest(),
             transaction.old_serial_numbers(),
@@ -785,7 +785,7 @@ where
         let inner_snark_vk: <<C as Testnet2Components>::InnerSNARK as SNARK>::VerifyingKey =
             self.inner_snark_parameters.1.clone().into();
 
-        let inner_snark_vk_bytes = match to_bytes![inner_snark_vk] {
+        let inner_snark_vk_bytes = match to_bytes_le![inner_snark_vk] {
             Ok(bytes) => bytes,
             _ => {
                 eprintln!("Unable to convert inner snark vk into bytes.");

--- a/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
@@ -36,7 +36,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 fn field_element_to_bytes<C: Testnet2Components, CS: ConstraintSystem<C::OuterScalarField>>(
     cs: &mut CS,
@@ -46,14 +46,18 @@ fn field_element_to_bytes<C: Testnet2Components, CS: ConstraintSystem<C::OuterSc
     if field_elements.len() <= 1 {
         Ok(vec![UInt8::alloc_input_vec_le(
             cs.ns(|| format!("Allocate {}", name)),
-            &to_bytes![field_elements].map_err(|_| SynthesisError::AssignmentMissing)?,
+            &field_elements
+                .to_bytes_le()
+                .map_err(|_| SynthesisError::AssignmentMissing)?,
         )?])
     } else {
         let mut fe_bytes = Vec::with_capacity(field_elements.len());
         for (index, field_element) in field_elements.iter().enumerate() {
             fe_bytes.push(UInt8::alloc_input_vec_le(
                 cs.ns(|| format!("Allocate {} - index {} ", name, index)),
-                &to_bytes![field_element].map_err(|_| SynthesisError::AssignmentMissing)?,
+                &field_element
+                    .to_bytes_le()
+                    .map_err(|_| SynthesisError::AssignmentMissing)?,
             )?);
         }
         Ok(fe_bytes)

--- a/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
@@ -36,7 +36,7 @@ use snarkvm_gadgets::{
     },
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 fn field_element_to_bytes<C: Testnet2Components, CS: ConstraintSystem<C::OuterScalarField>>(
     cs: &mut CS,

--- a/dpc/src/testnet2/outer_circuit/outer_circuit_verifier_input.rs
+++ b/dpc/src/testnet2/outer_circuit/outer_circuit_verifier_input.rs
@@ -20,7 +20,7 @@ use snarkvm_algorithms::{
     traits::{CommitmentScheme, EncryptionScheme, MerkleParameters, SignatureScheme, CRH},
 };
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Testnet2Components"))]
@@ -97,9 +97,8 @@ where
         let inner_snark_field_elements = &self.inner_snark_verifier_input.to_field_elements()?;
 
         for inner_snark_fe in inner_snark_field_elements {
-            let inner_snark_fe_bytes = to_bytes![inner_snark_fe]?;
             v.extend_from_slice(&ToConstraintField::<C::OuterScalarField>::to_field_elements(
-                inner_snark_fe_bytes.as_slice(),
+                inner_snark_fe.to_bytes_le()?.as_slice(),
             )?);
         }
 

--- a/dpc/src/testnet2/outer_circuit/outer_circuit_verifier_input.rs
+++ b/dpc/src/testnet2/outer_circuit/outer_circuit_verifier_input.rs
@@ -20,7 +20,7 @@ use snarkvm_algorithms::{
     traits::{CommitmentScheme, EncryptionScheme, MerkleParameters, SignatureScheme, CRH},
 };
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Testnet2Components"))]

--- a/dpc/src/testnet2/parameters.rs
+++ b/dpc/src/testnet2/parameters.rs
@@ -104,30 +104,34 @@ impl<C: Testnet2Components> SystemParameters<C> {
 
     /// TODO (howardwu): Inspect what is going on with program_verification_key_commitment.
     pub fn load() -> IoResult<Self> {
-        let account_commitment: C::AccountCommitment =
-            From::from(FromBytes::read(AccountCommitmentParameters::load_bytes()?.as_slice())?);
+        let account_commitment: C::AccountCommitment = From::from(FromBytes::read_le(
+            AccountCommitmentParameters::load_bytes()?.as_slice(),
+        )?);
         let account_encryption_parameters: <C::AccountEncryption as EncryptionScheme>::Parameters =
-            FromBytes::read(AccountEncryptionParameters::load_bytes()?.as_slice())?;
+            FromBytes::read_le(AccountEncryptionParameters::load_bytes()?.as_slice())?;
         let account_encryption: C::AccountEncryption = From::from(account_encryption_parameters);
-        let account_signature: C::AccountSignature =
-            From::from(FromBytes::read(AccountSignatureParameters::load_bytes()?.as_slice())?);
-        let encrypted_record_crh: C::EncryptedRecordCRH =
-            From::from(FromBytes::read(EncryptedRecordCRHParameters::load_bytes()?.as_slice())?);
+        let account_signature: C::AccountSignature = From::from(FromBytes::read_le(
+            AccountSignatureParameters::load_bytes()?.as_slice(),
+        )?);
+        let encrypted_record_crh: C::EncryptedRecordCRH = From::from(FromBytes::read_le(
+            EncryptedRecordCRHParameters::load_bytes()?.as_slice(),
+        )?);
         let inner_circuit_id_crh: C::InnerCircuitIDCRH =
-            From::from(FromBytes::read(InnerCircuitIDCRH::load_bytes()?.as_slice())?);
+            From::from(FromBytes::read_le(InnerCircuitIDCRH::load_bytes()?.as_slice())?);
         let local_data_crh: C::LocalDataCRH =
-            From::from(FromBytes::read(LocalDataCRHParameters::load_bytes()?.as_slice())?);
-        let local_data_commitment: C::LocalDataCommitment = From::from(FromBytes::read(
+            From::from(FromBytes::read_le(LocalDataCRHParameters::load_bytes()?.as_slice())?);
+        let local_data_commitment: C::LocalDataCommitment = From::from(FromBytes::read_le(
             LocalDataCommitmentParameters::load_bytes()?.as_slice(),
         )?);
         let program_verification_key_commitment: C::ProgramVerificationKeyCommitment =
-            From::from(FromBytes::read(&[][..])?);
-        let program_verification_key_crh: C::ProgramVerificationKeyCRH = From::from(FromBytes::read(
+            From::from(FromBytes::read_le(&[][..])?);
+        let program_verification_key_crh: C::ProgramVerificationKeyCRH = From::from(FromBytes::read_le(
             Testnet2ProgramVKCRHParameters::load_bytes()?.as_slice(),
         )?);
-        let record_commitment: C::RecordCommitment =
-            From::from(FromBytes::read(RecordCommitmentParameters::load_bytes()?.as_slice())?);
-        let serial_number_nonce: C::SerialNumberNonceCRH = From::from(FromBytes::read(
+        let record_commitment: C::RecordCommitment = From::from(FromBytes::read_le(
+            RecordCommitmentParameters::load_bytes()?.as_slice(),
+        )?);
+        let serial_number_nonce: C::SerialNumberNonceCRH = From::from(FromBytes::read_le(
             SerialNumberNonceCRHParameters::load_bytes()?.as_slice(),
         )?);
 
@@ -182,7 +186,7 @@ where
 
 impl<C: Testnet2Components> ProgramSNARKUniversalSRS<C> {
     pub fn load() -> IoResult<Self> {
-        Ok(Self(From::from(FromBytes::read(
+        Ok(Self(From::from(FromBytes::read_le(
             UniversalSRSParameters::load_bytes()?.as_slice(),
         )?)))
     }

--- a/dpc/src/testnet2/parameters.rs
+++ b/dpc/src/testnet2/parameters.rs
@@ -20,7 +20,7 @@ use snarkvm_fields::ToConstraintField;
 use snarkvm_marlin::marlin::{MarlinSNARK, UniversalSRS};
 use snarkvm_parameters::{prelude::*, testnet2::*};
 use snarkvm_polycommit::PolynomialCommitment;
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use rand::{CryptoRng, Rng};
 use std::io::Result as IoResult;

--- a/dpc/src/testnet2/program/noop_program.rs
+++ b/dpc/src/testnet2/program/noop_program.rs
@@ -27,7 +27,7 @@ use snarkvm_parameters::{
     testnet2::{NoopProgramSNARKPKParameters, NoopProgramSNARKVKParameters},
     Parameter,
 };
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use rand::{CryptoRng, Rng};
 
@@ -73,9 +73,9 @@ impl<C: Testnet2Components> ProgramScheme for NoopProgram<C> {
         let verifying_key: Self::VerifyingKey = prepared_verifying_key.into();
 
         // Compute the program ID.
-        let id = to_bytes![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
+        let id = to_bytes_le![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
             program_verifying_key_crh,
-            &to_bytes![verifying_key]?
+            &to_bytes_le![verifying_key]?
         )?]?;
 
         Ok(Self {
@@ -99,9 +99,9 @@ impl<C: Testnet2Components> ProgramScheme for NoopProgram<C> {
         )?;
 
         // Compute the program ID.
-        let program_id = to_bytes![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
+        let program_id = to_bytes_le![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(
             program_verifying_key_crh,
-            &to_bytes![verifying_key]?
+            &to_bytes_le![verifying_key]?
         )?]?;
 
         Ok(Self {
@@ -152,8 +152,8 @@ impl<C: Testnet2Components> ProgramScheme for NoopProgram<C> {
         }
 
         Ok(Self::Execution {
-            verifying_key: to_bytes![self.verifying_key]?,
-            proof: to_bytes![proof]?,
+            verifying_key: to_bytes_le![self.verifying_key]?,
+            proof: to_bytes_le![proof]?,
         })
     }
 
@@ -165,8 +165,8 @@ impl<C: Testnet2Components> ProgramScheme for NoopProgram<C> {
         )?;
 
         Ok(Self::Execution {
-            verifying_key: to_bytes![self.verifying_key]?,
-            proof: to_bytes![proof]?,
+            verifying_key: to_bytes_le![self.verifying_key]?,
+            proof: to_bytes_le![proof]?,
         })
     }
 

--- a/dpc/src/testnet2/program/noop_program.rs
+++ b/dpc/src/testnet2/program/noop_program.rs
@@ -93,9 +93,10 @@ impl<C: Testnet2Components> ProgramScheme for NoopProgram<C> {
         program_verifying_key_crh: &Self::ProgramVerifyingKeyCRH,
     ) -> Result<Self, ProgramError> {
         let proving_key: <Self::ProofSystem as SNARK>::ProvingKey =
-            FromBytes::read(NoopProgramSNARKPKParameters::load_bytes()?.as_slice())?;
-        let verifying_key =
-            <Self::ProofSystem as SNARK>::VerifyingKey::read(NoopProgramSNARKVKParameters::load_bytes()?.as_slice())?;
+            FromBytes::read_le(NoopProgramSNARKPKParameters::load_bytes()?.as_slice())?;
+        let verifying_key = <Self::ProofSystem as SNARK>::VerifyingKey::read_le(
+            NoopProgramSNARKVKParameters::load_bytes()?.as_slice(),
+        )?;
 
         // Compute the program ID.
         let program_id = to_bytes![<C as DPCComponents>::ProgramVerificationKeyCRH::hash(

--- a/dpc/src/testnet2/record/encoded.rs
+++ b/dpc/src/testnet2/record/encoded.rs
@@ -40,7 +40,7 @@ pub fn encode_to_group<P: MontgomeryParameters + TwistedEdwardsParameters, G: Gr
         bytes.push(0)
     }
 
-    let input = P::BaseField::read(&bytes[..])?;
+    let input = P::BaseField::read_le(&bytes[..])?;
     let (output, fq_high) = Elligator2::<P, G>::encode(&input)?;
     Ok((output, fq_high))
 }
@@ -170,8 +170,8 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
 
         // Process birth_program_id and death_program_id. (Assumption 2 and 3 applies)
 
-        let birth_program_id_biginteger = Self::OuterField::read(birth_program_id)?.into_repr();
-        let death_program_id_biginteger = Self::OuterField::read(death_program_id)?.into_repr();
+        let birth_program_id_biginteger = Self::OuterField::read_le(birth_program_id)?.into_repr();
+        let death_program_id_biginteger = Self::OuterField::read_le(death_program_id)?.into_repr();
 
         let mut birth_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);
         let mut death_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);
@@ -305,7 +305,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
 
         let (serial_number_nonce, _) = &(self.encoded_elements[0], fq_high_bits[0]);
         let serial_number_nonce_bytes = to_bytes![serial_number_nonce.into_affine().to_x_coordinate()]?;
-        let serial_number_nonce = <C::SerialNumberNonceCRH as CRH>::Output::read(&serial_number_nonce_bytes[..])?;
+        let serial_number_nonce = <C::SerialNumberNonceCRH as CRH>::Output::read_le(&serial_number_nonce_bytes[..])?;
 
         // Deserialize commitment randomness
 
@@ -317,7 +317,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         let commitment_randomness_bits = &from_bytes_le_to_bits_le(&commitment_randomness_bytes)
             .take(Self::DATA_ELEMENT_BITSIZE)
             .collect::<Vec<_>>();
-        let commitment_randomness = <C::RecordCommitment as CommitmentScheme>::Randomness::read(
+        let commitment_randomness = <C::RecordCommitment as CommitmentScheme>::Randomness::read_le(
             &from_bits_le_to_bytes_le(commitment_randomness_bits)[..],
         )?;
 
@@ -360,7 +360,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         let value_start = self.encoded_elements.len();
         let value_end = value_start + (std::mem::size_of_val(&<Self::Record as RecordScheme>::Value::default()) * 8);
         let value: <Self::Record as RecordScheme>::Value =
-            FromBytes::read(&from_bits_le_to_bytes_le(&final_element_bits[value_start..value_end])[..])?;
+            FromBytes::read_le(&from_bits_le_to_bytes_le(&final_element_bits[value_start..value_end])[..])?;
 
         // Deserialize payload
 
@@ -374,7 +374,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         }
         payload_bits.extend_from_slice(&final_element_bits[value_end..]);
 
-        let payload = Payload::read(&from_bits_le_to_bytes_le(&payload_bits)[..])?;
+        let payload = Payload::read_le(&from_bits_le_to_bytes_le(&payload_bits)[..])?;
 
         Ok(DecodedRecord {
             value,

--- a/dpc/src/testnet2/record/encoded.rs
+++ b/dpc/src/testnet2/record/encoded.rs
@@ -25,7 +25,14 @@ use snarkvm_algorithms::{
 };
 use snarkvm_curves::traits::{AffineCurve, Group, MontgomeryParameters, ProjectiveCurve, TwistedEdwardsParameters};
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{from_bits_le_to_bytes_le, from_bytes_le_to_bits_le, to_bytes, BigInteger, FromBytes, ToBytes};
+use snarkvm_utilities::{
+    from_bits_le_to_bytes_le,
+    from_bytes_le_to_bits_le,
+    to_bytes_le,
+    BigInteger,
+    FromBytes,
+    ToBytes,
+};
 
 use itertools::Itertools;
 use std::marker::PhantomData;
@@ -51,7 +58,7 @@ pub fn decode_from_group<P: MontgomeryParameters + TwistedEdwardsParameters, G: 
     fq_high: bool,
 ) -> Result<Vec<u8>, DPCError> {
     let output = Elligator2::<P, G>::decode(&affine, fq_high)?;
-    Ok(to_bytes![output]?)
+    Ok(to_bytes_le![output]?)
 }
 
 pub struct DecodedRecord<C: Testnet2Components> {
@@ -128,7 +135,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         // This element needs to be represented in the constraint field; its bits and the number of elements
         // are calculated early, so that the storage vectors can be pre-allocated.
         let payload = record.payload();
-        let payload_bytes = to_bytes![payload]?;
+        let payload_bytes = to_bytes_le![payload]?;
         let payload_bits_count = payload_bytes.len() * 8;
         let payload_bits = from_bytes_le_to_bits_le(&payload_bytes);
         let num_payload_elements = payload_bits_count / Self::PAYLOAD_ELEMENT_BITSIZE;
@@ -142,7 +149,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
 
         let serial_number_nonce = record.serial_number_nonce();
         let serial_number_nonce_encoded =
-            <Self::Group as ProjectiveCurve>::Affine::from_random_bytes(&to_bytes![serial_number_nonce]?.to_vec())
+            <Self::Group as ProjectiveCurve>::Affine::from_random_bytes(&to_bytes_le![serial_number_nonce]?.to_vec())
                 .unwrap();
 
         data_elements.push(serial_number_nonce_encoded);
@@ -161,7 +168,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         // Process commitment_randomness. (Assumption 1 applies)
 
         let (encoded_commitment_randomness, sign_high) =
-            encode_to_group::<Self::Parameters, Self::Group>(&to_bytes![commitment_randomness]?[..])?;
+            encode_to_group::<Self::Parameters, Self::Group>(&to_bytes_le![commitment_randomness]?[..])?;
         data_elements.push(encoded_commitment_randomness);
         data_high_bits.push(sign_high);
 
@@ -266,7 +273,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         );
 
         // Append the value bits and create the final base element.
-        let value_bits = from_bytes_le_to_bits_le(&to_bytes![value]?).collect();
+        let value_bits = from_bytes_le_to_bits_le(&to_bytes_le![value]?).collect();
 
         // (Assumption 4)
         let final_element = [vec![true], data_high_bits, value_bits, payload_field_bits].concat();
@@ -304,7 +311,7 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
         // Deserialize serial number nonce
 
         let (serial_number_nonce, _) = &(self.encoded_elements[0], fq_high_bits[0]);
-        let serial_number_nonce_bytes = to_bytes![serial_number_nonce.into_affine().to_x_coordinate()]?;
+        let serial_number_nonce_bytes = to_bytes_le![serial_number_nonce.into_affine().to_x_coordinate()]?;
         let serial_number_nonce = <C::SerialNumberNonceCRH as CRH>::Output::read_le(&serial_number_nonce_bytes[..])?;
 
         // Deserialize commitment randomness

--- a/dpc/src/testnet2/record/encrypted.rs
+++ b/dpc/src/testnet2/record/encrypted.rs
@@ -35,7 +35,7 @@ use snarkvm_fields::One;
 use snarkvm_utilities::{
     from_bits_le_to_bytes_le,
     from_bytes_le_to_bits_le,
-    to_bytes,
+    to_bytes_le,
     variable_length_integer::*,
     FromBytes,
     ToBytes,
@@ -127,8 +127,9 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
         for element in encoded_record.encoded_elements.iter() {
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
-            let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
+            let plaintext_element = <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(
+                &to_bytes_le![element]?[..],
+            )?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -167,7 +168,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
 
         let mut plaintext = Vec::with_capacity(plaintext_elements.len());
         for element in plaintext_elements {
-            let plaintext_element = <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![element]?[..])?;
+            let plaintext_element = <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes_le![element]?[..])?;
 
             plaintext.push(plaintext_element);
         }
@@ -205,7 +206,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
 
         // Calculate record commitment
 
-        let commitment_input = to_bytes![
+        let commitment_input = to_bytes_le![
             owner,
             is_dummy,
             value,
@@ -245,7 +246,8 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes_le![ciphertext_element]?[..])?
+                    .into_affine();
             let ciphertext_x_coordinate = ciphertext_element_affine.to_x_coordinate();
 
             // Fetch the ciphertext selector bit
@@ -268,7 +270,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
 
         Ok(system_parameters
             .encrypted_record_crh
-            .hash(&to_bytes![ciphertext_affine_x, selector_bytes]?)?)
+            .hash(&to_bytes_le![ciphertext_affine_x, selector_bytes]?)?)
     }
 
     /// Returns the intermediate components of the encryption algorithm that the inner SNARK
@@ -324,7 +326,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
                 // Serial number nonce
                 let record_field_element =
                     <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
-                        &to_bytes![element]?[..],
+                        &to_bytes_le![element]?[..],
                     )?;
                 record_field_elements.push(record_field_element);
             } else {
@@ -340,17 +342,18 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
             // Fetch the x and y coordinates of the serialized group elements
             // These values will be used in the inner circuit to validate the Elligator2 encoding
             let x = <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
-                &to_bytes![element_affine.to_x_coordinate()]?[..],
+                &to_bytes_le![element_affine.to_x_coordinate()]?[..],
             )?;
             let y = <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
-                &to_bytes![element_affine.to_y_coordinate()]?[..],
+                &to_bytes_le![element_affine.to_y_coordinate()]?[..],
             )?;
             record_group_encoding.push((x, y));
 
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
-            let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
+            let plaintext_element = <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(
+                &to_bytes_le![element]?[..],
+            )?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -374,7 +377,8 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
         for ciphertext_element in encrypted_record.iter() {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes_le![ciphertext_element]?[..])?
+                    .into_affine();
 
             // Fetch the ciphertext selector bit
             let selector =
@@ -409,7 +413,8 @@ impl<C: Testnet2Components> ToBytes for EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext representation to the affine x-coordinate and the selector bit
             let ciphertext_element_affine =
-                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes_le![ciphertext_element]?[..])?
+                    .into_affine();
 
             let x_coordinate = ciphertext_element_affine.to_x_coordinate();
             x_coordinate.write_le(&mut writer)?;
@@ -470,7 +475,7 @@ impl<C: Testnet2Components> FromBytes for EncryptedRecord<C> {
                 };
 
             let ciphertext_element: <C::AccountEncryption as EncryptionScheme>::Text =
-                FromBytes::read_le(&to_bytes![ciphertext_element_affine.into_projective()]?[..])?;
+                FromBytes::read_le(&to_bytes_le![ciphertext_element_affine.into_projective()]?[..])?;
 
             ciphertext.push(ciphertext_element);
         }

--- a/dpc/src/testnet2/record/encrypted.rs
+++ b/dpc/src/testnet2/record/encrypted.rs
@@ -128,7 +128,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
             let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read(&to_bytes![element]?[..])?;
+                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -167,7 +167,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
 
         let mut plaintext = Vec::with_capacity(plaintext_elements.len());
         for element in plaintext_elements {
-            let plaintext_element = <C as Testnet2Components>::EncryptionGroup::read(&to_bytes![element]?[..])?;
+            let plaintext_element = <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![element]?[..])?;
 
             plaintext.push(plaintext_element);
         }
@@ -245,7 +245,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet2Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
             let ciphertext_x_coordinate = ciphertext_element_affine.to_x_coordinate();
 
             // Fetch the ciphertext selector bit
@@ -323,7 +323,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
             if i == 0 {
                 // Serial number nonce
                 let record_field_element =
-                    <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read(
+                    <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
                         &to_bytes![element]?[..],
                     )?;
                 record_field_elements.push(record_field_element);
@@ -339,10 +339,10 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
 
             // Fetch the x and y coordinates of the serialized group elements
             // These values will be used in the inner circuit to validate the Elligator2 encoding
-            let x = <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read(
+            let x = <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
                 &to_bytes![element_affine.to_x_coordinate()]?[..],
             )?;
-            let y = <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read(
+            let y = <<C as Testnet2Components>::EncryptionParameters as ModelParameters>::BaseField::read_le(
                 &to_bytes![element_affine.to_y_coordinate()]?[..],
             )?;
             record_group_encoding.push((x, y));
@@ -350,7 +350,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
             let plaintext_element =
-                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read(&to_bytes![element]?[..])?;
+                <<C as DPCComponents>::AccountEncryption as EncryptionScheme>::Text::read_le(&to_bytes![element]?[..])?;
             record_plaintexts.push(plaintext_element);
         }
 
@@ -374,7 +374,7 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
         for ciphertext_element in encrypted_record.iter() {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
-                <C as Testnet2Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
 
             // Fetch the ciphertext selector bit
             let selector =
@@ -409,7 +409,7 @@ impl<C: Testnet2Components> ToBytes for EncryptedRecord<C> {
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext representation to the affine x-coordinate and the selector bit
             let ciphertext_element_affine =
-                <C as Testnet2Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
+                <C as Testnet2Components>::EncryptionGroup::read_le(&to_bytes![ciphertext_element]?[..])?.into_affine();
 
             let x_coordinate = ciphertext_element_affine.to_x_coordinate();
             x_coordinate.write_le(&mut writer)?;
@@ -438,13 +438,13 @@ impl<C: Testnet2Components> ToBytes for EncryptedRecord<C> {
 
 impl<C: Testnet2Components> FromBytes for EncryptedRecord<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the ciphertext x coordinates
         let num_ciphertext_elements = read_variable_length_integer(&mut reader)?;
         let mut ciphertext_x_coordinates = Vec::with_capacity(num_ciphertext_elements);
         for _ in 0..num_ciphertext_elements {
             let ciphertext_element_x_coordinate: <<<C as Testnet2Components>::EncryptionGroup as ProjectiveCurve>::Affine as AffineCurve>::BaseField =
-                FromBytes::read(&mut reader)?;
+                FromBytes::read_le(&mut reader)?;
             ciphertext_x_coordinates.push(ciphertext_element_x_coordinate);
         }
 
@@ -470,7 +470,7 @@ impl<C: Testnet2Components> FromBytes for EncryptedRecord<C> {
                 };
 
             let ciphertext_element: <C::AccountEncryption as EncryptionScheme>::Text =
-                FromBytes::read(&to_bytes![ciphertext_element_affine.into_projective()]?[..])?;
+                FromBytes::read_le(&to_bytes![ciphertext_element_affine.into_projective()]?[..])?;
 
             ciphertext.push(ciphertext_element);
         }

--- a/dpc/src/testnet2/record/encrypted.rs
+++ b/dpc/src/testnet2/record/encrypted.rs
@@ -401,18 +401,18 @@ impl<C: Testnet2Components> EncryptedRecord<C> {
 
 impl<C: Testnet2Components> ToBytes for EncryptedRecord<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         let mut ciphertext_selectors = Vec::with_capacity(self.encrypted_elements.len() + 1);
 
         // Write the encrypted record
-        variable_length_integer(self.encrypted_elements.len() as u64).write(&mut writer)?;
+        variable_length_integer(self.encrypted_elements.len() as u64).write_le(&mut writer)?;
         for ciphertext_element in &self.encrypted_elements {
             // Compress the ciphertext representation to the affine x-coordinate and the selector bit
             let ciphertext_element_affine =
                 <C as Testnet2Components>::EncryptionGroup::read(&to_bytes![ciphertext_element]?[..])?.into_affine();
 
             let x_coordinate = ciphertext_element_affine.to_x_coordinate();
-            x_coordinate.write(&mut writer)?;
+            x_coordinate.write_le(&mut writer)?;
 
             let selector =
                 match <<C as Testnet2Components>::EncryptionGroup as ProjectiveCurve>::Affine::from_x_coordinate(
@@ -430,7 +430,7 @@ impl<C: Testnet2Components> ToBytes for EncryptedRecord<C> {
 
         // Write the ciphertext and fq_high selector bits
         let selector_bytes = from_bits_le_to_bytes_le(&ciphertext_selectors);
-        selector_bytes.write(&mut writer)?;
+        selector_bytes.write_le(&mut writer)?;
 
         Ok(())
     }

--- a/dpc/src/testnet2/record/payload.rs
+++ b/dpc/src/testnet2/record/payload.rs
@@ -49,7 +49,7 @@ impl ToBytes for Payload {
 
 impl FromBytes for Payload {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        Ok(Self(FromBytes::read(&mut reader)?))
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self(FromBytes::read_le(&mut reader)?))
     }
 }

--- a/dpc/src/testnet2/record/payload.rs
+++ b/dpc/src/testnet2/record/payload.rs
@@ -42,8 +42,8 @@ impl Payload {
 
 impl ToBytes for Payload {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.0.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.0.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/testnet2/record/payload.rs
+++ b/dpc/src/testnet2/record/payload.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::io::{Read, Result as IoResult, Write};
 

--- a/dpc/src/testnet2/record/record.rs
+++ b/dpc/src/testnet2/record/record.rs
@@ -22,12 +22,7 @@ use crate::{
     RecordError,
 };
 use snarkvm_algorithms::traits::{CommitmentScheme, SignatureScheme, CRH, PRF};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-    variable_length_integer::*,
-    UniformRand,
-};
+use snarkvm_utilities::{to_bytes, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
 
 use rand::{CryptoRng, Rng};
 use std::{

--- a/dpc/src/testnet2/record/record.rs
+++ b/dpc/src/testnet2/record/record.rs
@@ -62,7 +62,7 @@ pub struct Record<C: Testnet2Components> {
 }
 
 fn default_program_id<C: CRH>() -> Vec<u8> {
-    to_bytes![C::Output::default()].unwrap()
+    C::Output::default().to_bytes_le().unwrap()
 }
 
 impl<C: Testnet2Components> Record<C> {

--- a/dpc/src/testnet2/record/record.rs
+++ b/dpc/src/testnet2/record/record.rs
@@ -22,7 +22,7 @@ use crate::{
     RecordError,
 };
 use snarkvm_algorithms::traits::{CommitmentScheme, SignatureScheme, CRH, PRF};
-use snarkvm_utilities::{to_bytes, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
+use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
 
 use rand::{CryptoRng, Rng};
 use std::{
@@ -85,7 +85,7 @@ impl<C: Testnet2Components> Record<C> {
         // Sample randomness sn_randomness for the CRH input.
         let sn_randomness: [u8; 32] = rng.gen();
 
-        let crh_input = to_bytes![position, sn_randomness, joint_serial_numbers]?;
+        let crh_input = to_bytes_le![position, sn_randomness, joint_serial_numbers]?;
         let serial_number_nonce = C::SerialNumberNonceCRH::hash(&serial_number_nonce_parameters, &crh_input)?;
 
         let mut record = Self::new(
@@ -123,7 +123,7 @@ impl<C: Testnet2Components> Record<C> {
         let commitment_randomness = <C::RecordCommitment as CommitmentScheme>::Randomness::rand(rng);
 
         // Total = 32 + 1 + 8 + 32 + 48 + 48 + 32 = 201 bytes
-        let commitment_input = to_bytes![
+        let commitment_input = to_bytes_le![
             owner,               // 256 bits = 32 bytes
             is_dummy,            // 1 bit = 1 byte
             value,               // 64 bits = 8 bytes
@@ -193,9 +193,9 @@ impl<C: Testnet2Components> Record<C> {
         // }
 
         // Compute the serial number.
-        let seed = FromBytes::read_le(to_bytes!(&private_key.sk_prf)?.as_slice())?;
-        let input = FromBytes::read_le(to_bytes!(self.serial_number_nonce)?.as_slice())?;
-        let randomizer = to_bytes![C::PRF::evaluate(&seed, &input)?]?;
+        let seed = FromBytes::read_le(to_bytes_le!(&private_key.sk_prf)?.as_slice())?;
+        let input = FromBytes::read_le(to_bytes_le!(self.serial_number_nonce)?.as_slice())?;
+        let randomizer = to_bytes_le![C::PRF::evaluate(&seed, &input)?]?;
         let serial_number = C::AccountSignature::randomize_public_key(
             &signature_parameters,
             &private_key.pk_sig(&signature_parameters)?,
@@ -336,7 +336,7 @@ impl<C: Testnet2Components> fmt::Display for Record<C> {
         write!(
             f,
             "{}",
-            hex::encode(to_bytes![self].expect("serialization to bytes failed"))
+            hex::encode(to_bytes_le![self].expect("serialization to bytes failed"))
         )
     }
 }

--- a/dpc/src/testnet2/record/record.rs
+++ b/dpc/src/testnet2/record/record.rs
@@ -264,21 +264,21 @@ impl<C: Testnet2Components> RecordScheme for Record<C> {
 
 impl<C: Testnet2Components> ToBytes for Record<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.owner.write(&mut writer)?;
-        self.is_dummy.write(&mut writer)?;
-        self.value.write(&mut writer)?;
-        self.payload.write(&mut writer)?;
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.owner.write_le(&mut writer)?;
+        self.is_dummy.write_le(&mut writer)?;
+        self.value.write_le(&mut writer)?;
+        self.payload.write_le(&mut writer)?;
 
-        variable_length_integer(self.birth_program_id.len() as u64).write(&mut writer)?;
-        self.birth_program_id.write(&mut writer)?;
+        variable_length_integer(self.birth_program_id.len() as u64).write_le(&mut writer)?;
+        self.birth_program_id.write_le(&mut writer)?;
 
-        variable_length_integer(self.death_program_id.len() as u64).write(&mut writer)?;
-        self.death_program_id.write(&mut writer)?;
+        variable_length_integer(self.death_program_id.len() as u64).write_le(&mut writer)?;
+        self.death_program_id.write_le(&mut writer)?;
 
-        self.serial_number_nonce.write(&mut writer)?;
-        self.commitment.write(&mut writer)?;
-        self.commitment_randomness.write(&mut writer)
+        self.serial_number_nonce.write_le(&mut writer)?;
+        self.commitment.write_le(&mut writer)?;
+        self.commitment_randomness.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/testnet2/record/record.rs
+++ b/dpc/src/testnet2/record/record.rs
@@ -193,8 +193,8 @@ impl<C: Testnet2Components> Record<C> {
         // }
 
         // Compute the serial number.
-        let seed = FromBytes::read(to_bytes!(&private_key.sk_prf)?.as_slice())?;
-        let input = FromBytes::read(to_bytes!(self.serial_number_nonce)?.as_slice())?;
+        let seed = FromBytes::read_le(to_bytes!(&private_key.sk_prf)?.as_slice())?;
+        let input = FromBytes::read_le(to_bytes!(self.serial_number_nonce)?.as_slice())?;
         let randomizer = to_bytes![C::PRF::evaluate(&seed, &input)?]?;
         let serial_number = C::AccountSignature::randomize_public_key(
             &signature_parameters,
@@ -279,17 +279,17 @@ impl<C: Testnet2Components> ToBytes for Record<C> {
 
 impl<C: Testnet2Components> FromBytes for Record<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let owner: Address<C> = FromBytes::read(&mut reader)?;
-        let is_dummy: bool = FromBytes::read(&mut reader)?;
-        let value: u64 = FromBytes::read(&mut reader)?;
-        let payload: Payload = FromBytes::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let owner: Address<C> = FromBytes::read_le(&mut reader)?;
+        let is_dummy: bool = FromBytes::read_le(&mut reader)?;
+        let value: u64 = FromBytes::read_le(&mut reader)?;
+        let payload: Payload = FromBytes::read_le(&mut reader)?;
 
         let birth_program_id_size: usize = read_variable_length_integer(&mut reader)?;
 
         let mut birth_program_id = Vec::with_capacity(birth_program_id_size);
         for _ in 0..birth_program_id_size {
-            let byte: u8 = FromBytes::read(&mut reader)?;
+            let byte: u8 = FromBytes::read_le(&mut reader)?;
             birth_program_id.push(byte);
         }
 
@@ -297,14 +297,14 @@ impl<C: Testnet2Components> FromBytes for Record<C> {
 
         let mut death_program_id = Vec::with_capacity(death_program_id_size);
         for _ in 0..death_program_id_size {
-            let byte: u8 = FromBytes::read(&mut reader)?;
+            let byte: u8 = FromBytes::read_le(&mut reader)?;
             death_program_id.push(byte);
         }
 
-        let serial_number_nonce: <C::SerialNumberNonceCRH as CRH>::Output = FromBytes::read(&mut reader)?;
-        let commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read(&mut reader)?;
+        let serial_number_nonce: <C::SerialNumberNonceCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
+        let commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read_le(&mut reader)?;
         let commitment_randomness: <C::RecordCommitment as CommitmentScheme>::Randomness =
-            FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
 
         Ok(Self {
             owner,
@@ -327,7 +327,7 @@ impl<C: Testnet2Components> FromStr for Record<C> {
     type Err = RecordError;
 
     fn from_str(record: &str) -> Result<Self, Self::Err> {
-        Ok(Self::read(&hex::decode(record)?[..])?)
+        Ok(Self::read_le(&hex::decode(record)?[..])?)
     }
 }
 

--- a/dpc/src/testnet2/transaction/kernel.rs
+++ b/dpc/src/testnet2/transaction/kernel.rs
@@ -19,7 +19,7 @@ use crate::{
     testnet2::{EncryptedRecord, LocalData, Record, SystemParameters, Testnet2Components, Transaction},
 };
 use snarkvm_algorithms::{commitment_tree::CommitmentMerkleTree, prelude::*};
-use snarkvm_utilities::{to_bytes, variable_length_integer::*, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes};
 
 use std::{
     fmt,
@@ -276,7 +276,7 @@ impl<C: Testnet2Components> fmt::Display for TransactionKernel<C> {
         write!(
             f,
             "{}",
-            hex::encode(to_bytes![self].expect("couldn't serialize to bytes"))
+            hex::encode(to_bytes_le![self].expect("couldn't serialize to bytes"))
         )
     }
 }

--- a/dpc/src/testnet2/transaction/kernel.rs
+++ b/dpc/src/testnet2/transaction/kernel.rs
@@ -85,62 +85,62 @@ impl<C: Testnet2Components> TransactionKernel<C> {
 
 impl<C: Testnet2Components> ToBytes for TransactionKernel<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write old record components
 
         for old_record in &self.old_records {
-            old_record.write(&mut writer)?;
+            old_record.write_le(&mut writer)?;
         }
 
         for old_serial_number in &self.old_serial_numbers {
-            old_serial_number.write(&mut writer)?;
+            old_serial_number.write_le(&mut writer)?;
         }
 
         for old_randomizer in &self.old_randomizers {
-            variable_length_integer(old_randomizer.len() as u64).write(&mut writer)?;
-            old_randomizer.write(&mut writer)?;
+            variable_length_integer(old_randomizer.len() as u64).write_le(&mut writer)?;
+            old_randomizer.write_le(&mut writer)?;
         }
 
         // Write new record components
 
         for new_record in &self.new_records {
-            new_record.write(&mut writer)?;
+            new_record.write_le(&mut writer)?;
         }
 
         for new_sn_nonce_randomness in &self.new_sn_nonce_randomness {
-            new_sn_nonce_randomness.write(&mut writer)?;
+            new_sn_nonce_randomness.write_le(&mut writer)?;
         }
 
         for new_commitment in &self.new_commitments {
-            new_commitment.write(&mut writer)?;
+            new_commitment.write_le(&mut writer)?;
         }
 
         for new_records_encryption_randomness in &self.new_records_encryption_randomness {
-            new_records_encryption_randomness.write(&mut writer)?;
+            new_records_encryption_randomness.write_le(&mut writer)?;
         }
 
         for new_encrypted_record in &self.new_encrypted_records {
-            new_encrypted_record.write(&mut writer)?;
+            new_encrypted_record.write_le(&mut writer)?;
         }
 
         for new_encrypted_record_hash in &self.new_encrypted_record_hashes {
-            new_encrypted_record_hash.write(&mut writer)?;
+            new_encrypted_record_hash.write_le(&mut writer)?;
         }
 
         // Write transaction components
 
-        self.program_commitment.write(&mut writer)?;
-        self.program_randomness.write(&mut writer)?;
+        self.program_commitment.write_le(&mut writer)?;
+        self.program_randomness.write_le(&mut writer)?;
 
-        self.local_data_merkle_tree.write(&mut writer)?;
+        self.local_data_merkle_tree.write_le(&mut writer)?;
 
         for local_data_commitment_randomizer in &self.local_data_commitment_randomizers {
-            local_data_commitment_randomizer.write(&mut writer)?;
+            local_data_commitment_randomizer.write_le(&mut writer)?;
         }
 
-        self.value_balance.write(&mut writer)?;
-        self.memorandum.write(&mut writer)?;
-        self.network_id.write(&mut writer)
+        self.value_balance.write_le(&mut writer)?;
+        self.memorandum.write_le(&mut writer)?;
+        self.network_id.write_le(&mut writer)
     }
 }
 

--- a/dpc/src/testnet2/transaction/kernel.rs
+++ b/dpc/src/testnet2/transaction/kernel.rs
@@ -146,20 +146,21 @@ impl<C: Testnet2Components> ToBytes for TransactionKernel<C> {
 
 impl<C: Testnet2Components> FromBytes for TransactionKernel<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let system_parameters = SystemParameters::<C>::load().expect("Could not load system parameters");
 
         // Read old record components
 
         let mut old_records = vec![];
         for _ in 0..C::NUM_INPUT_RECORDS {
-            let old_record: Record<C> = FromBytes::read(&mut reader)?;
+            let old_record: Record<C> = FromBytes::read_le(&mut reader)?;
             old_records.push(old_record);
         }
 
         let mut old_serial_numbers = vec![];
         for _ in 0..C::NUM_INPUT_RECORDS {
-            let old_serial_number: <C::AccountSignature as SignatureScheme>::PublicKey = FromBytes::read(&mut reader)?;
+            let old_serial_number: <C::AccountSignature as SignatureScheme>::PublicKey =
+                FromBytes::read_le(&mut reader)?;
             old_serial_numbers.push(old_serial_number);
         }
 
@@ -168,7 +169,7 @@ impl<C: Testnet2Components> FromBytes for TransactionKernel<C> {
             let num_bytes = read_variable_length_integer(&mut reader)?;
             let mut randomizer = vec![];
             for _ in 0..num_bytes {
-                let byte: u8 = FromBytes::read(&mut reader)?;
+                let byte: u8 = FromBytes::read_le(&mut reader)?;
                 randomizer.push(byte);
             }
 
@@ -179,47 +180,47 @@ impl<C: Testnet2Components> FromBytes for TransactionKernel<C> {
 
         let mut new_records = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let new_record: Record<C> = FromBytes::read(&mut reader)?;
+            let new_record: Record<C> = FromBytes::read_le(&mut reader)?;
             new_records.push(new_record);
         }
 
         let mut new_sn_nonce_randomness = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let randomness: [u8; 32] = FromBytes::read(&mut reader)?;
+            let randomness: [u8; 32] = FromBytes::read_le(&mut reader)?;
             new_sn_nonce_randomness.push(randomness);
         }
 
         let mut new_commitments = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read(&mut reader)?;
+            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read_le(&mut reader)?;
             new_commitments.push(new_commitment);
         }
 
         let mut new_records_encryption_randomness = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
             let encryption_randomness: <C::AccountEncryption as EncryptionScheme>::Randomness =
-                FromBytes::read(&mut reader)?;
+                FromBytes::read_le(&mut reader)?;
             new_records_encryption_randomness.push(encryption_randomness);
         }
 
         let mut new_encrypted_records = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let encrypted_record: EncryptedRecord<C> = FromBytes::read(&mut reader)?;
+            let encrypted_record: EncryptedRecord<C> = FromBytes::read_le(&mut reader)?;
             new_encrypted_records.push(encrypted_record);
         }
 
         let mut new_encrypted_record_hashes = vec![];
         for _ in 0..C::NUM_OUTPUT_RECORDS {
-            let encrypted_record_hash: <C::EncryptedRecordCRH as CRH>::Output = FromBytes::read(&mut reader)?;
+            let encrypted_record_hash: <C::EncryptedRecordCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
             new_encrypted_record_hashes.push(encrypted_record_hash);
         }
 
         // Read transaction components
 
         let program_commitment: <C::ProgramVerificationKeyCommitment as CommitmentScheme>::Output =
-            FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
         let program_randomness: <C::ProgramVerificationKeyCommitment as CommitmentScheme>::Randomness =
-            FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
 
         let local_data_merkle_tree = CommitmentMerkleTree::<C::LocalDataCommitment, C::LocalDataCRH>::from_bytes(
             &mut reader,
@@ -230,13 +231,13 @@ impl<C: Testnet2Components> FromBytes for TransactionKernel<C> {
         let mut local_data_commitment_randomizers = vec![];
         for _ in 0..4 {
             let local_data_commitment_randomizer: <C::LocalDataCommitment as CommitmentScheme>::Randomness =
-                FromBytes::read(&mut reader)?;
+                FromBytes::read_le(&mut reader)?;
             local_data_commitment_randomizers.push(local_data_commitment_randomizer);
         }
 
-        let value_balance: AleoAmount = FromBytes::read(&mut reader)?;
-        let memorandum: <Transaction<C> as TransactionScheme>::Memorandum = FromBytes::read(&mut reader)?;
-        let network_id: u8 = FromBytes::read(&mut reader)?;
+        let value_balance: AleoAmount = FromBytes::read_le(&mut reader)?;
+        let memorandum: <Transaction<C> as TransactionScheme>::Memorandum = FromBytes::read_le(&mut reader)?;
+        let network_id: u8 = FromBytes::read_le(&mut reader)?;
 
         Ok(Self {
             old_records,
@@ -266,7 +267,7 @@ impl<C: Testnet2Components> FromStr for TransactionKernel<C> {
     type Err = DPCError;
 
     fn from_str(kernel: &str) -> Result<Self, Self::Err> {
-        Ok(Self::read(&hex::decode(kernel)?[..])?)
+        Ok(Self::read_le(&hex::decode(kernel)?[..])?)
     }
 }
 

--- a/dpc/src/testnet2/transaction/transaction.rs
+++ b/dpc/src/testnet2/transaction/transaction.rs
@@ -26,9 +26,10 @@ use snarkvm_algorithms::{
     traits::{CommitmentScheme, SignatureScheme, CRH, SNARK},
 };
 use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
     serialize::{CanonicalDeserialize, CanonicalSerialize},
     to_bytes,
+    FromBytes,
+    ToBytes,
 };
 
 use blake2::{digest::Digest, Blake2s as b2s};

--- a/dpc/src/testnet2/transaction/transaction.rs
+++ b/dpc/src/testnet2/transaction/transaction.rs
@@ -211,32 +211,32 @@ impl<C: Testnet2Components> TransactionScheme for Transaction<C> {
 
 impl<C: Testnet2Components> ToBytes for Transaction<C> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         for old_serial_number in &self.old_serial_numbers {
             CanonicalSerialize::serialize(old_serial_number, &mut writer).unwrap();
         }
 
         for new_commitment in &self.new_commitments {
-            new_commitment.write(&mut writer)?;
+            new_commitment.write_le(&mut writer)?;
         }
 
-        self.memorandum.write(&mut writer)?;
+        self.memorandum.write_le(&mut writer)?;
 
-        self.ledger_digest.write(&mut writer)?;
-        self.inner_circuit_id.write(&mut writer)?;
-        self.transaction_proof.write(&mut writer)?;
-        self.program_commitment.write(&mut writer)?;
-        self.local_data_root.write(&mut writer)?;
+        self.ledger_digest.write_le(&mut writer)?;
+        self.inner_circuit_id.write_le(&mut writer)?;
+        self.transaction_proof.write_le(&mut writer)?;
+        self.program_commitment.write_le(&mut writer)?;
+        self.local_data_root.write_le(&mut writer)?;
 
-        self.value_balance.write(&mut writer)?;
-        self.network.write(&mut writer)?;
+        self.value_balance.write_le(&mut writer)?;
+        self.network.write_le(&mut writer)?;
 
         for signature in &self.signatures {
-            signature.write(&mut writer)?;
+            signature.write_le(&mut writer)?;
         }
 
         for encrypted_record in &self.encrypted_records {
-            encrypted_record.write(&mut writer)?;
+            encrypted_record.write_le(&mut writer)?;
         }
 
         Ok(())

--- a/dpc/src/testnet2/transaction/transaction.rs
+++ b/dpc/src/testnet2/transaction/transaction.rs
@@ -27,7 +27,7 @@ use snarkvm_algorithms::{
 };
 use snarkvm_utilities::{
     serialize::{CanonicalDeserialize, CanonicalSerialize},
-    to_bytes,
+    to_bytes_le,
     FromBytes,
     ToBytes,
 };
@@ -143,11 +143,11 @@ impl<C: Testnet2Components> TransactionScheme for Transaction<C> {
         let mut pre_image_bytes: Vec<u8> = vec![];
 
         for serial_number in self.old_serial_numbers() {
-            pre_image_bytes.extend(&to_bytes![serial_number]?);
+            pre_image_bytes.extend(&to_bytes_le![serial_number]?);
         }
 
         for commitment in self.new_commitments() {
-            pre_image_bytes.extend(&to_bytes![commitment]?);
+            pre_image_bytes.extend(&to_bytes_le![commitment]?);
         }
 
         pre_image_bytes.extend(self.memorandum());
@@ -205,7 +205,7 @@ impl<C: Testnet2Components> TransactionScheme for Transaction<C> {
     }
 
     fn size(&self) -> usize {
-        let transaction_bytes = to_bytes![self].unwrap();
+        let transaction_bytes = to_bytes_le![self].unwrap();
         transaction_bytes.len()
     }
 }

--- a/dpc/src/testnet2/transaction/transaction.rs
+++ b/dpc/src/testnet2/transaction/transaction.rs
@@ -246,7 +246,7 @@ impl<C: Testnet2Components> ToBytes for Transaction<C> {
 
 impl<C: Testnet2Components> FromBytes for Transaction<C> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the old serial numbers
         let num_old_serial_numbers = C::NUM_INPUT_RECORDS;
         let mut old_serial_numbers = Vec::with_capacity(num_old_serial_numbers);
@@ -261,27 +261,27 @@ impl<C: Testnet2Components> FromBytes for Transaction<C> {
         let num_new_commitments = C::NUM_OUTPUT_RECORDS;
         let mut new_commitments = Vec::with_capacity(num_new_commitments);
         for _ in 0..num_new_commitments {
-            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read(&mut reader)?;
+            let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read_le(&mut reader)?;
             new_commitments.push(new_commitment);
         }
 
-        let memorandum: [u8; 32] = FromBytes::read(&mut reader)?;
+        let memorandum: [u8; 32] = FromBytes::read_le(&mut reader)?;
 
-        let ledger_digest: MerkleTreeDigest<C::MerkleParameters> = FromBytes::read(&mut reader)?;
-        let inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output = FromBytes::read(&mut reader)?;
-        let transaction_proof: <C::OuterSNARK as SNARK>::Proof = FromBytes::read(&mut reader)?;
+        let ledger_digest: MerkleTreeDigest<C::MerkleParameters> = FromBytes::read_le(&mut reader)?;
+        let inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
+        let transaction_proof: <C::OuterSNARK as SNARK>::Proof = FromBytes::read_le(&mut reader)?;
         let program_commitment: <C::ProgramVerificationKeyCommitment as CommitmentScheme>::Output =
-            FromBytes::read(&mut reader)?;
-        let local_data_root: <C::LocalDataCRH as CRH>::Output = FromBytes::read(&mut reader)?;
+            FromBytes::read_le(&mut reader)?;
+        let local_data_root: <C::LocalDataCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
 
-        let value_balance: AleoAmount = FromBytes::read(&mut reader)?;
-        let network: Network = FromBytes::read(&mut reader)?;
+        let value_balance: AleoAmount = FromBytes::read_le(&mut reader)?;
+        let network: Network = FromBytes::read_le(&mut reader)?;
 
         // Read the signatures
         let num_signatures = C::NUM_INPUT_RECORDS;
         let mut signatures = Vec::with_capacity(num_signatures);
         for _ in 0..num_signatures {
-            let signature: <C::AccountSignature as SignatureScheme>::Signature = FromBytes::read(&mut reader)?;
+            let signature: <C::AccountSignature as SignatureScheme>::Signature = FromBytes::read_le(&mut reader)?;
             signatures.push(signature);
         }
 
@@ -289,7 +289,7 @@ impl<C: Testnet2Components> FromBytes for Transaction<C> {
         let num_encrypted_records = C::NUM_OUTPUT_RECORDS;
         let mut encrypted_records = Vec::with_capacity(num_encrypted_records);
         for _ in 0..num_encrypted_records {
-            let encrypted_record: EncryptedRecord<C> = FromBytes::read(&mut reader)?;
+            let encrypted_record: EncryptedRecord<C> = FromBytes::read_le(&mut reader)?;
 
             encrypted_records.push(encrypted_record);
         }

--- a/dpc/src/traits/block.rs
+++ b/dpc/src/traits/block.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::traits::TransactionScheme;
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 pub trait BlockScheme: Clone + Eq + FromBytes + ToBytes {
     type BlockHeader: Clone + Eq + FromBytes + ToBytes;

--- a/dpc/src/traits/record.rs
+++ b/dpc/src/traits/record.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::hash::Hash;
 

--- a/dpc/src/traits/transaction.rs
+++ b/dpc/src/traits/transaction.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::errors::TransactionError;
-use snarkvm_utilities::bytes::{FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::hash::Hash;
 

--- a/fields/Cargo.toml
+++ b/fields/Cargo.toml
@@ -22,6 +22,9 @@ path = "../utilities"
 version = "0.7.2"
 default-features = false
 
+[dependencies.anyhow]
+version = "1.0"
+
 [dependencies.bincode]
 version = "1.3.3"
 

--- a/fields/src/errors/constraint_field.rs
+++ b/fields/src/errors/constraint_field.rs
@@ -16,6 +16,9 @@
 
 #[derive(Debug, Error)]
 pub enum ConstraintFieldError {
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 

--- a/fields/src/fp12_2over3over2.rs
+++ b/fields/src/fp12_2over3over2.rs
@@ -17,10 +17,11 @@
 use crate::{fp6_3over2::*, Field, Fp2, Fp2Parameters, One, Zero};
 use snarkvm_utilities::{
     bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
     errors::SerializationError,
     rand::UniformRand,
     serialize::*,
+    FromBytes,
+    ToBytes,
 };
 
 use rand::{

--- a/fields/src/fp12_2over3over2.rs
+++ b/fields/src/fp12_2over3over2.rs
@@ -481,9 +481,9 @@ impl<P: Fp12Parameters> From<u8> for Fp12<P> {
 
 impl<P: Fp12Parameters> ToBytes for Fp12<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.c0.write(&mut writer)?;
-        self.c1.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.c0.write_le(&mut writer)?;
+        self.c1.write_le(&mut writer)
     }
 }
 

--- a/fields/src/fp12_2over3over2.rs
+++ b/fields/src/fp12_2over3over2.rs
@@ -490,9 +490,9 @@ impl<P: Fp12Parameters> ToBytes for Fp12<P> {
 
 impl<P: Fp12Parameters> FromBytes for Fp12<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let c0 = Fp6::read(&mut reader)?;
-        let c1 = Fp6::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let c0 = Fp6::read_le(&mut reader)?;
+        let c1 = Fp6::read_le(&mut reader)?;
         Ok(Fp12::new(c0, c1))
     }
 }

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -293,9 +293,9 @@ impl<P: Fp2Parameters> ToBytes for Fp2<P> {
 
 impl<P: Fp2Parameters> FromBytes for Fp2<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let c0 = P::Fp::read(&mut reader)?;
-        let c1 = P::Fp::read(reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let c0 = P::Fp::read_le(&mut reader)?;
+        let c1 = P::Fp::read_le(reader)?;
         Ok(Fp2::new(c0, c1))
     }
 }

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -290,9 +290,9 @@ impl<P: Fp2Parameters> From<u8> for Fp2<P> {
 
 impl<P: Fp2Parameters> ToBytes for Fp2<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.c0.write(&mut writer)?;
-        self.c1.write(writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.c0.write_le(&mut writer)?;
+        self.c1.write_le(writer)
     }
 }
 

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -15,12 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Field, LegendreSymbol, One, PrimeField, SquareRootField, Zero};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    errors::SerializationError,
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{errors::SerializationError, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/fields/src/fp3.rs
+++ b/fields/src/fp3.rs
@@ -339,10 +339,10 @@ impl<P: Fp3Parameters> ToBytes for Fp3<P> {
 
 impl<P: Fp3Parameters> FromBytes for Fp3<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let c0 = P::Fp::read(&mut reader)?;
-        let c1 = P::Fp::read(&mut reader)?;
-        let c2 = P::Fp::read(reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let c0 = P::Fp::read_le(&mut reader)?;
+        let c1 = P::Fp::read_le(&mut reader)?;
+        let c2 = P::Fp::read_le(reader)?;
         Ok(Fp3::new(c0, c1, c2))
     }
 }

--- a/fields/src/fp3.rs
+++ b/fields/src/fp3.rs
@@ -15,12 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Field, LegendreSymbol, One, PrimeField, SquareRootField, Zero};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    errors::SerializationError,
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{errors::SerializationError, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/fields/src/fp3.rs
+++ b/fields/src/fp3.rs
@@ -335,10 +335,10 @@ impl<P: Fp3Parameters> From<u8> for Fp3<P> {
 
 impl<P: Fp3Parameters> ToBytes for Fp3<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.c0.write(&mut writer)?;
-        self.c1.write(&mut writer)?;
-        self.c2.write(writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.c0.write_le(&mut writer)?;
+        self.c1.write_le(&mut writer)?;
+        self.c2.write_le(writer)
     }
 }
 

--- a/fields/src/fp6_2over3.rs
+++ b/fields/src/fp6_2over3.rs
@@ -353,9 +353,9 @@ impl<P: Fp6Parameters> ToBytes for Fp6<P> {
 
 impl<P: Fp6Parameters> FromBytes for Fp6<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let c0 = Fp3::read(&mut reader)?;
-        let c1 = Fp3::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let c0 = Fp3::read_le(&mut reader)?;
+        let c1 = Fp3::read_le(&mut reader)?;
         Ok(Fp6::new(c0, c1))
     }
 }

--- a/fields/src/fp6_2over3.rs
+++ b/fields/src/fp6_2over3.rs
@@ -344,9 +344,9 @@ impl<P: Fp6Parameters> From<u8> for Fp6<P> {
 
 impl<P: Fp6Parameters> ToBytes for Fp6<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.c0.write(&mut writer)?;
-        self.c1.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.c0.write_le(&mut writer)?;
+        self.c1.write_le(&mut writer)
     }
 }
 

--- a/fields/src/fp6_2over3.rs
+++ b/fields/src/fp6_2over3.rs
@@ -17,10 +17,11 @@
 use crate::{Field, Fp3, Fp3Parameters, One, Zero};
 use snarkvm_utilities::{
     biginteger::BigInteger,
-    bytes::{FromBytes, ToBytes},
     errors::SerializationError,
     rand::UniformRand,
     serialize::*,
+    FromBytes,
+    ToBytes,
 };
 
 use rand::{

--- a/fields/src/fp6_3over2.rs
+++ b/fields/src/fp6_3over2.rs
@@ -473,10 +473,10 @@ impl<P: Fp6Parameters> From<u8> for Fp6<P> {
 
 impl<P: Fp6Parameters> ToBytes for Fp6<P> {
     #[inline]
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.c0.write(&mut writer)?;
-        self.c1.write(&mut writer)?;
-        self.c2.write(&mut writer)
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.c0.write_le(&mut writer)?;
+        self.c1.write_le(&mut writer)?;
+        self.c2.write_le(&mut writer)
     }
 }
 

--- a/fields/src/fp6_3over2.rs
+++ b/fields/src/fp6_3over2.rs
@@ -477,10 +477,10 @@ impl<P: Fp6Parameters> ToBytes for Fp6<P> {
 
 impl<P: Fp6Parameters> FromBytes for Fp6<P> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let c0 = Fp2::read(&mut reader)?;
-        let c1 = Fp2::read(&mut reader)?;
-        let c2 = Fp2::read(&mut reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let c0 = Fp2::read_le(&mut reader)?;
+        let c1 = Fp2::read_le(&mut reader)?;
+        let c2 = Fp2::read_le(&mut reader)?;
         Ok(Fp6::new(c0, c1, c2))
     }
 }

--- a/fields/src/fp6_3over2.rs
+++ b/fields/src/fp6_3over2.rs
@@ -15,12 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Field, Fp2, Fp2Parameters, One, Zero};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    errors::SerializationError,
-    rand::UniformRand,
-    serialize::*,
-};
+use snarkvm_utilities::{errors::SerializationError, rand::UniformRand, serialize::*, FromBytes, ToBytes};
 
 use rand::{
     distributions::{Distribution, Standard},

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -399,8 +399,8 @@ impl_mul_div_from_field_ref!(Fp256, Fp256Parameters);
 
 impl<P: Fp256Parameters> ToBytes for Fp256<P> {
     #[inline]
-    fn write<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.into_repr().write(writer)
+    fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
+        self.into_repr().write_le(writer)
     }
 }
 

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -31,8 +31,9 @@ use crate::{
 };
 use snarkvm_utilities::{
     biginteger::{arithmetic as fa, BigInteger as _BigInteger, BigInteger256 as BigInteger},
-    bytes::{FromBytes, ToBytes},
     serialize::CanonicalDeserialize,
+    FromBytes,
+    ToBytes,
 };
 
 use std::{

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -407,8 +407,8 @@ impl<P: Fp256Parameters> ToBytes for Fp256<P> {
 
 impl<P: Fp256Parameters> FromBytes for Fp256<P> {
     #[inline]
-    fn read<R: Read>(reader: R) -> IoResult<Self> {
-        BigInteger::read(reader).and_then(|b| match Self::from_repr(b) {
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        BigInteger::read_le(reader).and_then(|b| match Self::from_repr(b) {
             Some(f) => Ok(f),
             None => Err(FieldError::InvalidFieldElement.into()),
         })

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -31,8 +31,9 @@ use crate::{
 };
 use snarkvm_utilities::{
     biginteger::{arithmetic as fa, BigInteger as _BigInteger, BigInteger384 as BigInteger},
-    bytes::{FromBytes, ToBytes},
     serialize::CanonicalDeserialize,
+    FromBytes,
+    ToBytes,
 };
 
 use std::{

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -482,8 +482,8 @@ impl<P: Fp384Parameters> ToBytes for Fp384<P> {
 
 impl<P: Fp384Parameters> FromBytes for Fp384<P> {
     #[inline]
-    fn read<R: Read>(reader: R) -> IoResult<Self> {
-        BigInteger::read(reader).and_then(|b| match Self::from_repr(b) {
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        BigInteger::read_le(reader).and_then(|b| match Self::from_repr(b) {
             Some(f) => Ok(f),
             None => Err(FieldError::InvalidFieldElement.into()),
         })

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -474,8 +474,8 @@ impl_mul_div_from_field_ref!(Fp384, Fp384Parameters);
 
 impl<P: Fp384Parameters> ToBytes for Fp384<P> {
     #[inline]
-    fn write<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.into_repr().write(writer)
+    fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
+        self.into_repr().write_le(writer)
     }
 }
 

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -31,8 +31,9 @@ use crate::{
 };
 use snarkvm_utilities::{
     biginteger::{arithmetic as fa, BigInteger as _BigInteger, BigInteger768 as BigInteger},
-    bytes::{FromBytes, ToBytes},
     serialize::CanonicalDeserialize,
+    FromBytes,
+    ToBytes,
 };
 
 use std::{

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -817,8 +817,8 @@ impl<P: Fp768Parameters> ToBytes for Fp768<P> {
 
 impl<P: Fp768Parameters> FromBytes for Fp768<P> {
     #[inline]
-    fn read<R: Read>(reader: R) -> IoResult<Self> {
-        BigInteger::read(reader).and_then(|b| match Self::from_repr(b) {
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        BigInteger::read_le(reader).and_then(|b| match Self::from_repr(b) {
             Some(f) => Ok(f),
             None => Err(FieldError::InvalidFieldElement.into()),
         })

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -809,8 +809,8 @@ impl_mul_div_from_field_ref!(Fp768, Fp768Parameters);
 
 impl<P: Fp768Parameters> ToBytes for Fp768<P> {
     #[inline]
-    fn write<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.into_repr().write(writer)
+    fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
+        self.into_repr().write_le(writer)
     }
 }
 

--- a/fields/src/lib.rs
+++ b/fields/src/lib.rs
@@ -61,7 +61,6 @@ pub use traits::*;
 
 use snarkvm_utilities::{
     biginteger::*,
-    bytes::{FromBytes, ToBytes},
     serialize::{
         CanonicalDeserialize,
         CanonicalDeserializeWithFlags,
@@ -69,6 +68,8 @@ use snarkvm_utilities::{
         CanonicalSerializeWithFlags,
         ConstantSerializedSize,
     },
+    FromBytes,
+    ToBytes,
 };
 
 impl_field_into_biginteger!(Fp256, BigInteger256, Fp256Parameters);

--- a/fields/src/macros.rs
+++ b/fields/src/macros.rs
@@ -167,7 +167,7 @@ macro_rules! impl_primefield_serializer {
                 }
 
                 let mut bytes = [0u8; BYTE_SIZE];
-                self.write(&mut bytes[..])?;
+                self.write_le(&mut bytes[..])?;
 
                 bytes[output_byte_size - 1] |= flags.u8_bitmask();
 

--- a/fields/src/macros.rs
+++ b/fields/src/macros.rs
@@ -217,7 +217,7 @@ macro_rules! impl_primefield_serializer {
 
                 let flags = F::from_u8_remove_flags(&mut masked_bytes[output_byte_size - 1]);
 
-                Ok((Self::read(&masked_bytes[..])?, flags))
+                Ok((Self::read_le(&masked_bytes[..])?, flags))
             }
         }
 
@@ -233,7 +233,7 @@ macro_rules! impl_primefield_serializer {
 
                 let mut masked_bytes = [0; BYTE_SIZE];
                 reader.read_exact(&mut masked_bytes[..output_byte_size])?;
-                Ok(Self::read(&masked_bytes[..])?)
+                Ok(Self::read_le(&masked_bytes[..])?)
             }
         }
 

--- a/fields/src/to_field_vec.rs
+++ b/fields/src/to_field_vec.rs
@@ -65,7 +65,7 @@ impl<F: PrimeField> ToConstraintField<F> for [u8] {
             .map(|chunk| {
                 let mut chunk = chunk.to_vec();
                 chunk.resize(max_size + 1, 0u8);
-                F::read(chunk.as_slice())
+                F::read_le(chunk.as_slice())
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(fes)

--- a/fields/src/traits/field.rs
+++ b/fields/src/traits/field.rs
@@ -17,7 +17,6 @@
 use crate::{One, Zero};
 use snarkvm_utilities::{
     bititerator::BitIteratorBE,
-    bytes::{FromBytes, ToBytes},
     rand::UniformRand,
     serialize::{
         CanonicalDeserialize,
@@ -28,6 +27,8 @@ use snarkvm_utilities::{
         EmptyFlags,
         Flags,
     },
+    FromBytes,
+    ToBytes,
 };
 
 use std::{

--- a/gadgets/src/algorithms/commitment/pedersen.rs
+++ b/gadgets/src/algorithms/commitment/pedersen.rs
@@ -23,7 +23,7 @@ use snarkvm_algorithms::commitment::{PedersenCommitment, PedersenCommitmentParam
 use snarkvm_curves::traits::{Group, ProjectiveCurve};
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use crate::{
     integers::uint::UInt8,

--- a/gadgets/src/algorithms/commitment/pedersen.rs
+++ b/gadgets/src/algorithms/commitment/pedersen.rs
@@ -23,7 +23,7 @@ use snarkvm_algorithms::commitment::{PedersenCommitment, PedersenCommitmentParam
 use snarkvm_curves::traits::{Group, ProjectiveCurve};
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use crate::{
     integers::uint::UInt8,
@@ -86,7 +86,7 @@ impl<G: Group, F: PrimeField> AllocGadget<G::ScalarField, F> for PedersenRandomn
         cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let randomness = to_bytes![value_gen()?.borrow()].unwrap();
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
         Ok(PedersenRandomnessGadget(
             UInt8::alloc_vec(cs, &randomness)?,
             PhantomData,
@@ -97,7 +97,7 @@ impl<G: Group, F: PrimeField> AllocGadget<G::ScalarField, F> for PedersenRandomn
         cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let randomness = to_bytes![value_gen()?.borrow()].unwrap();
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
         Ok(PedersenRandomnessGadget(
             UInt8::alloc_input_vec_le(cs, &randomness)?,
             PhantomData,

--- a/gadgets/src/algorithms/encoding/elligator2.rs
+++ b/gadgets/src/algorithms/encoding/elligator2.rs
@@ -44,7 +44,7 @@ impl<P: MontgomeryParameters, F: PrimeField> AllocGadget<<P as ModelParameters>:
     ) -> Result<Self, SynthesisError> {
         Ok(Elligator2FieldGadget(
             FpGadget::alloc(cs, || match value_gen() {
-                Ok(value) => Ok(F::read(&to_bytes![value.borrow()]?[..])?),
+                Ok(value) => Ok(F::read_le(&to_bytes![value.borrow()]?[..])?),
                 Err(_) => Err(SynthesisError::AssignmentMissing),
             })?,
             PhantomData,
@@ -61,7 +61,7 @@ impl<P: MontgomeryParameters, F: PrimeField> AllocGadget<<P as ModelParameters>:
     ) -> Result<Self, SynthesisError> {
         Ok(Elligator2FieldGadget(
             FpGadget::alloc_input(cs, || match value_gen() {
-                Ok(value) => Ok(F::read(&to_bytes![value.borrow()]?[..])?),
+                Ok(value) => Ok(F::read_le(&to_bytes![value.borrow()]?[..])?),
                 Err(_) => Err(SynthesisError::AssignmentMissing),
             })?,
             PhantomData,

--- a/gadgets/src/algorithms/encoding/elligator2.rs
+++ b/gadgets/src/algorithms/encoding/elligator2.rs
@@ -19,7 +19,7 @@ use std::{borrow::Borrow, marker::PhantomData};
 use snarkvm_curves::traits::{ModelParameters, MontgomeryParameters};
 use snarkvm_fields::PrimeField;
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use crate::{
     bits::{Boolean, ToBitsBEGadget, ToBytesGadget},
@@ -44,7 +44,7 @@ impl<P: MontgomeryParameters, F: PrimeField> AllocGadget<<P as ModelParameters>:
     ) -> Result<Self, SynthesisError> {
         Ok(Elligator2FieldGadget(
             FpGadget::alloc(cs, || match value_gen() {
-                Ok(value) => Ok(F::read_le(&to_bytes![value.borrow()]?[..])?),
+                Ok(value) => Ok(F::read_le(&to_bytes_le![value.borrow()]?[..])?),
                 Err(_) => Err(SynthesisError::AssignmentMissing),
             })?,
             PhantomData,
@@ -61,7 +61,7 @@ impl<P: MontgomeryParameters, F: PrimeField> AllocGadget<<P as ModelParameters>:
     ) -> Result<Self, SynthesisError> {
         Ok(Elligator2FieldGadget(
             FpGadget::alloc_input(cs, || match value_gen() {
-                Ok(value) => Ok(F::read_le(&to_bytes![value.borrow()]?[..])?),
+                Ok(value) => Ok(F::read_le(&to_bytes_le![value.borrow()]?[..])?),
                 Err(_) => Err(SynthesisError::AssignmentMissing),
             })?,
             PhantomData,

--- a/gadgets/src/algorithms/encryption/group.rs
+++ b/gadgets/src/algorithms/encryption/group.rs
@@ -23,7 +23,7 @@ use snarkvm_algorithms::encryption::{GroupEncryption, GroupEncryptionParameters,
 use snarkvm_curves::traits::{Group, ProjectiveCurve};
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{to_bytes, CanonicalDeserialize, CanonicalSerialize, ToBytes};
+use snarkvm_utilities::{to_bytes_le, CanonicalDeserialize, CanonicalSerialize, ToBytes};
 
 use crate::{
     bits::{Boolean, ToBytesGadget},
@@ -82,7 +82,7 @@ impl<G: Group, F: PrimeField> AllocGadget<G::ScalarField, F> for GroupEncryption
         cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let private_key = to_bytes![value_gen()?.borrow()].unwrap();
+        let private_key = to_bytes_le![value_gen()?.borrow()].unwrap();
         Ok(GroupEncryptionPrivateKeyGadget(
             UInt8::alloc_vec(cs, &private_key)?,
             PhantomData,
@@ -93,7 +93,7 @@ impl<G: Group, F: PrimeField> AllocGadget<G::ScalarField, F> for GroupEncryption
         cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let private_key = to_bytes![value_gen()?.borrow()].unwrap();
+        let private_key = to_bytes_le![value_gen()?.borrow()].unwrap();
         Ok(GroupEncryptionPrivateKeyGadget(
             UInt8::alloc_vec(cs, &private_key)?,
             PhantomData,
@@ -120,7 +120,7 @@ impl<G: Group, F: PrimeField> AllocGadget<G::ScalarField, F> for GroupEncryption
         cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let randomness = to_bytes![value_gen()?.borrow()].unwrap();
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
         Ok(GroupEncryptionRandomnessGadget(
             UInt8::alloc_vec(cs, &randomness)?,
             PhantomData,
@@ -131,7 +131,7 @@ impl<G: Group, F: PrimeField> AllocGadget<G::ScalarField, F> for GroupEncryption
         cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let randomness = to_bytes![value_gen()?.borrow()].unwrap();
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
         Ok(GroupEncryptionRandomnessGadget(
             UInt8::alloc_vec(cs, &randomness)?,
             PhantomData,
@@ -152,7 +152,7 @@ impl<G: Group, F: PrimeField> AllocGadget<Vec<G::ScalarField>, F> for GroupEncry
 
         let mut blinding_exponents = Vec::with_capacity(values.len());
         for (i, value) in values.into_iter().enumerate() {
-            let alloc = UInt8::alloc_vec(cs.ns(|| format!("Blinding Exponent Iteration {}", i)), &to_bytes![
+            let alloc = UInt8::alloc_vec(cs.ns(|| format!("Blinding Exponent Iteration {}", i)), &to_bytes_le![
                 value.borrow()
             ]?)?;
             blinding_exponents.push(alloc);
@@ -173,9 +173,10 @@ impl<G: Group, F: PrimeField> AllocGadget<Vec<G::ScalarField>, F> for GroupEncry
 
         let mut blinding_exponents = Vec::with_capacity(values.len());
         for (i, value) in values.into_iter().enumerate() {
-            let alloc = UInt8::alloc_input_vec_le(cs.ns(|| format!("Blinding Exponent Iteration {}", i)), &to_bytes![
-                value.borrow()
-            ]?)?;
+            let alloc =
+                UInt8::alloc_input_vec_le(cs.ns(|| format!("Blinding Exponent Iteration {}", i)), &to_bytes_le![
+                    value.borrow()
+                ]?)?;
             blinding_exponents.push(alloc);
         }
 

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -140,7 +140,7 @@ fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: Mas
 
     let nonce: [u8; 4] = rand::random();
     let mut root_bytes = [0u8; 32];
-    root.write(&mut root_bytes[..]).unwrap();
+    root.write_le(&mut root_bytes[..]).unwrap();
 
     let mut h = Blake2s::new();
     h.update(nonce.as_ref());

--- a/gadgets/src/algorithms/signature/schnorr.rs
+++ b/gadgets/src/algorithms/signature/schnorr.rs
@@ -36,7 +36,7 @@ use snarkvm_fields::{Field, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
 use snarkvm_utilities::{
     serialize::{CanonicalDeserialize, CanonicalSerialize},
-    to_bytes,
+    to_bytes_le,
     FromBytes,
     ToBytes,
 };
@@ -172,8 +172,8 @@ impl<G: Group, F: Field, FG: FieldGadget<F, F>> AllocGadget<SchnorrSignature<G>,
         // TODO (raychu86): Check that this conversion is valid.
         //  This will work for EdwardsBls Fr and Bls12_377 Fr because they are both represented with Fp256.
         // Cast <G as Group>::ScalarField as F.
-        let prover_response: F = FromBytes::read_le(&to_bytes![schnorr_output.prover_response]?[..])?;
-        let verifier_challenge: F = FromBytes::read_le(&to_bytes![schnorr_output.verifier_challenge]?[..])?;
+        let prover_response: F = FromBytes::read_le(&to_bytes_le![schnorr_output.prover_response]?[..])?;
+        let verifier_challenge: F = FromBytes::read_le(&to_bytes_le![schnorr_output.verifier_challenge]?[..])?;
 
         let prover_response = FG::alloc(cs.ns(|| "alloc_prover_response"), || Ok(&prover_response))?;
         let verifier_challenge = FG::alloc(cs.ns(|| "alloc_verifier_challenge"), || Ok(&verifier_challenge))?;
@@ -198,8 +198,8 @@ impl<G: Group, F: Field, FG: FieldGadget<F, F>> AllocGadget<SchnorrSignature<G>,
         let schnorr_output = value.borrow().clone();
 
         // Cast <G as Group>::ScalarField as F.
-        let prover_response: F = FromBytes::read_le(&to_bytes![schnorr_output.prover_response]?[..])?;
-        let verifier_challenge: F = FromBytes::read_le(&to_bytes![schnorr_output.verifier_challenge]?[..])?;
+        let prover_response: F = FromBytes::read_le(&to_bytes_le![schnorr_output.prover_response]?[..])?;
+        let verifier_challenge: F = FromBytes::read_le(&to_bytes_le![schnorr_output.verifier_challenge]?[..])?;
 
         let prover_response = FG::alloc_input(cs.ns(|| "alloc_input_prover_response"), || Ok(&prover_response))?;
         let verifier_challenge =

--- a/gadgets/src/algorithms/signature/schnorr.rs
+++ b/gadgets/src/algorithms/signature/schnorr.rs
@@ -172,8 +172,8 @@ impl<G: Group, F: Field, FG: FieldGadget<F, F>> AllocGadget<SchnorrSignature<G>,
         // TODO (raychu86): Check that this conversion is valid.
         //  This will work for EdwardsBls Fr and Bls12_377 Fr because they are both represented with Fp256.
         // Cast <G as Group>::ScalarField as F.
-        let prover_response: F = FromBytes::read(&to_bytes![schnorr_output.prover_response]?[..])?;
-        let verifier_challenge: F = FromBytes::read(&to_bytes![schnorr_output.verifier_challenge]?[..])?;
+        let prover_response: F = FromBytes::read_le(&to_bytes![schnorr_output.prover_response]?[..])?;
+        let verifier_challenge: F = FromBytes::read_le(&to_bytes![schnorr_output.verifier_challenge]?[..])?;
 
         let prover_response = FG::alloc(cs.ns(|| "alloc_prover_response"), || Ok(&prover_response))?;
         let verifier_challenge = FG::alloc(cs.ns(|| "alloc_verifier_challenge"), || Ok(&verifier_challenge))?;
@@ -198,8 +198,8 @@ impl<G: Group, F: Field, FG: FieldGadget<F, F>> AllocGadget<SchnorrSignature<G>,
         let schnorr_output = value.borrow().clone();
 
         // Cast <G as Group>::ScalarField as F.
-        let prover_response: F = FromBytes::read(&to_bytes![schnorr_output.prover_response]?[..])?;
-        let verifier_challenge: F = FromBytes::read(&to_bytes![schnorr_output.verifier_challenge]?[..])?;
+        let prover_response: F = FromBytes::read_le(&to_bytes![schnorr_output.prover_response]?[..])?;
+        let verifier_challenge: F = FromBytes::read_le(&to_bytes![schnorr_output.verifier_challenge]?[..])?;
 
         let prover_response = FG::alloc_input(cs.ns(|| "alloc_input_prover_response"), || Ok(&prover_response))?;
         let verifier_challenge =

--- a/gadgets/src/algorithms/signature/tests.rs
+++ b/gadgets/src/algorithms/signature/tests.rs
@@ -28,7 +28,7 @@ use crate::{
 use snarkvm_algorithms::{signature::Schnorr, traits::SignatureScheme};
 use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsAffine, traits::Group};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{bytes::ToBytes, rand::UniformRand, to_bytes};
+use snarkvm_utilities::{rand::UniformRand, to_bytes, ToBytes};
 
 use blake2::Blake2s;
 use rand::{thread_rng, Rng, SeedableRng};

--- a/gadgets/src/algorithms/signature/tests.rs
+++ b/gadgets/src/algorithms/signature/tests.rs
@@ -28,7 +28,7 @@ use crate::{
 use snarkvm_algorithms::{signature::Schnorr, traits::SignatureScheme};
 use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsAffine, traits::Group};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{rand::UniformRand, to_bytes, ToBytes};
+use snarkvm_utilities::{rand::UniformRand, to_bytes_le, ToBytes};
 
 use blake2::Blake2s;
 use rand::{thread_rng, Rng, SeedableRng};
@@ -60,7 +60,7 @@ fn test_schnorr_signature_randomize_public_key_gadget() {
 
     // Native Schnorr randomization
 
-    let random_scalar = to_bytes!(<EdwardsAffine as Group>::ScalarField::rand(rng)).unwrap();
+    let random_scalar = to_bytes_le!(<EdwardsAffine as Group>::ScalarField::rand(rng)).unwrap();
     let randomized_public_key = schnorr_signature
         .randomize_public_key(&public_key, &random_scalar)
         .unwrap();

--- a/gadgets/src/algorithms/snark/gm17.rs
+++ b/gadgets/src/algorithms/snark/gm17.rs
@@ -280,7 +280,7 @@ impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> AllocBytesG
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let vk: VerifyingKey<Pairing> = FromBytes::read(&vk_bytes.borrow().clone()[..])?;
+            let vk: VerifyingKey<Pairing> = FromBytes::read_le(&vk_bytes.borrow().clone()[..])?;
 
             Self::alloc(cs.ns(|| "alloc_bytes"), || Ok(vk))
         })
@@ -293,7 +293,7 @@ impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> AllocBytesG
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let vk: VerifyingKey<Pairing> = FromBytes::read(&vk_bytes.borrow().clone()[..])?;
+            let vk: VerifyingKey<Pairing> = FromBytes::read_le(&vk_bytes.borrow().clone()[..])?;
 
             Self::alloc_input(cs.ns(|| "alloc_input_bytes"), || Ok(vk))
         })
@@ -344,7 +344,7 @@ impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> AllocBytesG
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<Pairing> = FromBytes::read(&proof_bytes.borrow().clone()[..])?;
+            let proof: Proof<Pairing> = FromBytes::read_le(&proof_bytes.borrow().clone()[..])?;
 
             Self::alloc(cs.ns(|| "alloc_bytes"), || Ok(proof))
         })
@@ -357,7 +357,7 @@ impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> AllocBytesG
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<Pairing> = FromBytes::read(&proof_bytes.borrow().clone()[..])?;
+            let proof: Proof<Pairing> = FromBytes::read_le(&proof_bytes.borrow().clone()[..])?;
 
             Self::alloc_input(cs.ns(|| "alloc_input_bytes"), || Ok(proof))
         })

--- a/gadgets/src/algorithms/snark/gm17.rs
+++ b/gadgets/src/algorithms/snark/gm17.rs
@@ -20,7 +20,7 @@ use snarkvm_algorithms::snark::gm17::{Proof, VerifyingKey, GM17};
 use snarkvm_curves::traits::{AffineCurve, PairingEngine};
 use snarkvm_fields::{Field, ToConstraintField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use crate::{
     bits::{Boolean, ToBitsBEGadget, ToBytesGadget},

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -423,7 +423,7 @@ mod test {
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
     use snarkvm_fields::PrimeField;
     use snarkvm_r1cs::{ConstraintSynthesizer, ConstraintSystem, TestConstraintSystem};
-    use snarkvm_utilities::{test_rng, to_bytes, BitIteratorBE, ToBytes};
+    use snarkvm_utilities::{test_rng, to_bytes_le, BitIteratorBE, ToBytes};
 
     use crate::{bits::Boolean, curves::bls12_377::PairingGadget as Bls12_377PairingGadget};
 
@@ -596,8 +596,8 @@ mod test {
                 }
             }
 
-            let vk_bytes = to_bytes![params.vk].unwrap();
-            let proof_bytes = to_bytes![proof].unwrap();
+            let vk_bytes = to_bytes_le![params.vk].unwrap();
+            let proof_bytes = to_bytes_le![proof].unwrap();
 
             let vk_gadget = TestVkGadget::alloc_input_bytes(cs.ns(|| "Vk"), || Ok(vk_bytes)).unwrap();
             let proof_gadget = TestProofGadget::alloc_bytes(cs.ns(|| "Proof"), || Ok(proof_bytes)).unwrap();

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -274,7 +274,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let vk: VerifyingKey<PairingE> = FromBytes::read(&vk_bytes.borrow()[..])?;
+            let vk: VerifyingKey<PairingE> = FromBytes::read_le(&vk_bytes.borrow()[..])?;
 
             Self::alloc(cs.ns(|| "alloc_bytes"), || Ok(vk))
         })
@@ -290,7 +290,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let vk: VerifyingKey<PairingE> = FromBytes::read(&vk_bytes.borrow()[..])?;
+            let vk: VerifyingKey<PairingE> = FromBytes::read_le(&vk_bytes.borrow()[..])?;
 
             Self::alloc_input(cs.ns(|| "alloc_input_bytes"), || Ok(vk))
         })
@@ -349,7 +349,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<PairingE> = FromBytes::read(&proof_bytes.borrow()[..])?;
+            let proof: Proof<PairingE> = FromBytes::read_le(&proof_bytes.borrow()[..])?;
 
             Self::alloc(cs.ns(|| "alloc_bytes"), || Ok(proof))
         })
@@ -365,7 +365,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<PairingE> = FromBytes::read(&proof_bytes.borrow()[..])?;
+            let proof: Proof<PairingE> = FromBytes::read_le(&proof_bytes.borrow()[..])?;
 
             Self::alloc_input(cs.ns(|| "alloc_input_bytes"), || Ok(proof))
         })

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -20,7 +20,7 @@ use snarkvm_algorithms::snark::groth16::{Groth16, Proof, VerifyingKey};
 use snarkvm_curves::traits::{AffineCurve, PairingEngine};
 use snarkvm_fields::{Field, ToConstraintField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use crate::{
     bits::{Boolean, ToBitsBEGadget, ToBytesGadget},

--- a/gadgets/src/algorithms/snark/tests.rs
+++ b/gadgets/src/algorithms/snark/tests.rs
@@ -20,7 +20,7 @@ use snarkvm_algorithms::snark::gm17::{create_random_proof, generate_random_param
 use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{bititerator::BitIteratorBE, to_bytes, ToBytes};
+use snarkvm_utilities::{bititerator::BitIteratorBE, to_bytes_le, ToBytes};
 
 use crate::{
     algorithms::snark::*,
@@ -203,8 +203,8 @@ fn gm17_verifier_bytes_test() {
             }
         }
 
-        let vk_bytes = to_bytes![params.vk].unwrap();
-        let proof_bytes = to_bytes![proof].unwrap();
+        let vk_bytes = to_bytes_le![params.vk].unwrap();
+        let proof_bytes = to_bytes_le![proof].unwrap();
 
         let vk_gadget = TestVkGadget::alloc_input_bytes(cs.ns(|| "Vk"), || Ok(vk_bytes)).unwrap();
         let proof_gadget = TestProofGadget::alloc_bytes(cs.ns(|| "Proof"), || Ok(proof_bytes)).unwrap();

--- a/gadgets/src/bits/boolean_input.rs
+++ b/gadgets/src/bits/boolean_input.rs
@@ -18,7 +18,7 @@ use std::{borrow::Borrow, marker::PhantomData};
 
 use snarkvm_fields::{FieldParameters, PrimeField};
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
-use snarkvm_utilities::BigInteger;
+use snarkvm_utilities::{FromBits, ToBits};
 
 use crate::{
     bits::{Boolean, ToBitsLEGadget},
@@ -167,7 +167,7 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
         // Step 3: allocate the CF field elements as input
         let mut src_booleans = Vec::<Boolean>::new();
         for (i, chunk) in src_bits.chunks(capacity).enumerate() {
-            let elem = CF::from_repr(<CF as PrimeField>::BigInteger::from_bits_be(chunk.to_vec())).unwrap(); // big endian
+            let elem = CF::from_repr(<CF as PrimeField>::BigInteger::from_bits_be(chunk)).unwrap(); // big endian
 
             let elem_gadget = FpGadget::<CF>::alloc_input(cs.ns(|| format!("alloc_elem_{}", i)), || Ok(elem))?;
             let mut booleans = elem_gadget.to_bits_le(cs.ns(|| format!("elem_to_bits_{}", i)))?;

--- a/gadgets/src/bits/boolean_input.rs
+++ b/gadgets/src/bits/boolean_input.rs
@@ -262,7 +262,7 @@ mod test {
     use snarkvm_r1cs::{Fr, TestConstraintSystem};
     use snarkvm_utilities::{
         rand::{test_rng, UniformRand},
-        to_bytes,
+        to_bytes_le,
         ToBytes,
     };
 
@@ -277,7 +277,7 @@ mod test {
             vec![
                 UInt8::alloc_input_vec_le(
                     cs.ns(|| format!("Allocate field elements")),
-                    &to_bytes![field_elements].unwrap(),
+                    &to_bytes_le![field_elements].unwrap(),
                 )
                 .unwrap(),
             ]
@@ -287,7 +287,7 @@ mod test {
                 fe_bytes.push(
                     UInt8::alloc_input_vec_le(
                         cs.ns(|| format!("Allocate field elements - index {} ", index)),
-                        &to_bytes![field_element].unwrap(),
+                        &to_bytes_le![field_element].unwrap(),
                     )
                     .unwrap(),
                 );

--- a/gadgets/src/fields/fp.rs
+++ b/gadgets/src/fields/fp.rs
@@ -30,7 +30,7 @@ use snarkvm_r1cs::{
 };
 use snarkvm_utilities::{
     bititerator::{BitIteratorBE, BitIteratorLE},
-    to_bytes,
+    to_bytes_le,
     ToBytes,
 };
 
@@ -540,10 +540,13 @@ impl<F: PrimeField> ToBitsLEGadget<F> for AllocatedFp<F> {
 impl<F: PrimeField> ToBytesGadget<F> for AllocatedFp<F> {
     fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         let byte_values = match self.value {
-            Some(value) => to_bytes![&value.into_repr()]?.into_iter().map(Some).collect::<Vec<_>>(),
+            Some(value) => to_bytes_le![&value.into_repr()]?
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>(),
             None => {
                 let default = F::default();
-                let default_len = to_bytes![&default].unwrap().len();
+                let default_len = to_bytes_le![&default].unwrap().len();
                 vec![None; default_len]
             }
         };
@@ -1153,14 +1156,14 @@ impl<F: PrimeField> ToBitsLEGadget<F> for FpGadget<F> {
 impl<F: PrimeField> ToBytesGadget<F> for FpGadget<F> {
     fn to_bytes<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes![c].unwrap())),
+            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes_le![c].unwrap())),
             Self::Variable(v) => v.to_bytes(cs),
         }
     }
 
     fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes![c].unwrap())),
+            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes_le![c].unwrap())),
             Self::Variable(v) => v.to_bytes_strict(cs),
         }
     }

--- a/gadgets/src/fields/fp.rs
+++ b/gadgets/src/fields/fp.rs
@@ -30,8 +30,8 @@ use snarkvm_r1cs::{
 };
 use snarkvm_utilities::{
     bititerator::{BitIteratorBE, BitIteratorLE},
-    bytes::ToBytes,
     to_bytes,
+    ToBytes,
 };
 
 use crate::{

--- a/gadgets/src/integers/uint/macros.rs
+++ b/gadgets/src/integers/uint/macros.rs
@@ -25,7 +25,7 @@ macro_rules! to_bytes_int_impl {
 
                 let value_chunks = match self.value.map(|val| {
                     let mut bytes = [0u8; BYTES_SIZE];
-                    val.write(bytes.as_mut()).unwrap();
+                    val.write_le(bytes.as_mut()).unwrap();
                     bytes
                 }) {
                     Some(chunks) => [Some(chunks[0]), Some(chunks[1]), Some(chunks[2]), Some(chunks[3])],

--- a/gadgets/src/integers/uint/uint128.rs
+++ b/gadgets/src/integers/uint/uint128.rs
@@ -18,7 +18,7 @@ use snarkvm_fields::{Field, FieldParameters, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, Assignment, ConstraintSystem, LinearCombination};
 use snarkvm_utilities::{
     biginteger::{BigInteger, BigInteger256},
-    bytes::ToBytes,
+    ToBytes,
 };
 
 use crate::{

--- a/gadgets/src/integers/uint/uint_impl.rs
+++ b/gadgets/src/integers/uint/uint_impl.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 
 use snarkvm_fields::{Field, FieldParameters, PrimeField, ToConstraintField};
 use snarkvm_r1cs::{errors::SynthesisError, Assignment, ConstraintSystem, LinearCombination};
-use snarkvm_utilities::bytes::ToBytes;
+use snarkvm_utilities::ToBytes;
 
 use crate::{
     bits::{

--- a/gadgets/src/nonnative/allocated_nonnative_field_var.rs
+++ b/gadgets/src/nonnative/allocated_nonnative_field_var.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 use snarkvm_fields::{FieldParameters, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, Assignment, ConstraintSystem};
-use snarkvm_utilities::BigInteger;
+use snarkvm_utilities::{BigInteger, FromBits, ToBits};
 
 use crate::nonnative::{
     allocated_nonnative_field_mul_result_var::AllocatedNonNativeFieldMulResultVar,
@@ -362,9 +362,8 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocatedNonNativeFieldVar<
         let mut cur = *elem;
         for _ in 0..params.num_limbs {
             let cur_bits = cur.to_bits_be(); // `to_bits` is big endian
-            let cur_mod_r = <BaseField as PrimeField>::BigInteger::from_bits_be(
-                cur_bits[cur_bits.len() - params.bits_per_limb..].to_vec(),
-            ); // therefore, the lowest `bits_per_non_top_limb` bits is what we want.
+            let cur_mod_r =
+                <BaseField as PrimeField>::BigInteger::from_bits_be(&cur_bits[cur_bits.len() - params.bits_per_limb..]); // therefore, the lowest `bits_per_non_top_limb` bits is what we want.
             limbs.push(BaseField::from_repr(cur_mod_r).unwrap());
             cur.divn(params.bits_per_limb as u32);
         }

--- a/gadgets/src/nonnative/mod.rs
+++ b/gadgets/src/nonnative/mod.rs
@@ -64,7 +64,7 @@ use std::fmt::Debug;
 #[macro_export]
 macro_rules! overhead {
     ($x:expr) => {{
-        use snarkvm_utilities::biginteger::BigInteger;
+        use snarkvm_utilities::ToBits;
         let num = $x;
         let num_bits = num.into_repr().to_bits_be();
         let mut skipped_bits = 0;

--- a/gadgets/src/nonnative/nonnative_field_var.rs
+++ b/gadgets/src/nonnative/nonnative_field_var.rs
@@ -33,8 +33,8 @@ use snarkvm_fields::{FieldParameters, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, Assignment, ConstraintSystem};
 use snarkvm_utilities::{
     bititerator::{BitIteratorBE, BitIteratorLE},
-    bytes::ToBytes,
     to_bytes,
+    ToBytes,
 };
 
 use crate::nonnative::{AllocatedNonNativeFieldVar, NonNativeFieldMulResultVar};

--- a/gadgets/src/nonnative/nonnative_field_var.rs
+++ b/gadgets/src/nonnative/nonnative_field_var.rs
@@ -33,7 +33,7 @@ use snarkvm_fields::{FieldParameters, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, Assignment, ConstraintSystem};
 use snarkvm_utilities::{
     bititerator::{BitIteratorBE, BitIteratorLE},
-    to_bytes,
+    to_bytes_le,
     ToBytes,
 };
 
@@ -397,14 +397,14 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBytesGadget<BaseField>
     /// form.
     fn to_bytes<CS: ConstraintSystem<BaseField>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes![c].unwrap())),
+            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes_le![c].unwrap())),
             Self::Var(v) => v.to_bytes(cs.ns(|| "to_bytes")),
         }
     }
 
     fn to_bytes_strict<CS: ConstraintSystem<BaseField>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes![c].unwrap())),
+            Self::Constant(c) => Ok(UInt8::constant_vec(&to_bytes_le![c].unwrap())),
             Self::Var(v) => v.to_bytes_strict(cs.ns(|| "to_bytes_strict")),
         }
     }

--- a/gadgets/src/nonnative/reduce.rs
+++ b/gadgets/src/nonnative/reduce.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 use snarkvm_fields::{FieldParameters, PrimeField};
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
-use snarkvm_utilities::{biginteger::BigInteger, bititerator::BitIteratorBE};
+use snarkvm_utilities::{BigInteger, BitIteratorBE, ToBits};
 
 use crate::{
     nonnative::{params::get_params, AllocatedNonNativeFieldVar},

--- a/marlin/src/ahp/indexer/circuit_info.rs
+++ b/marlin/src/ahp/indexer/circuit_info.rs
@@ -47,9 +47,9 @@ impl<F: PrimeField> CircuitInfo<F> {
 }
 
 impl<F: PrimeField> ToBytes for CircuitInfo<F> {
-    fn write<W: Write>(&self, mut w: W) -> Result<(), std::io::Error> {
-        (self.num_variables as u64).write(&mut w)?;
-        (self.num_constraints as u64).write(&mut w)?;
-        (self.num_non_zero as u64).write(&mut w)
+    fn write_le<W: Write>(&self, mut w: W) -> Result<(), std::io::Error> {
+        (self.num_variables as u64).write_le(&mut w)?;
+        (self.num_constraints as u64).write_le(&mut w)?;
+        (self.num_non_zero as u64).write_le(&mut w)
     }
 }

--- a/marlin/src/ahp/prover/message.rs
+++ b/marlin/src/ahp/prover/message.rs
@@ -27,7 +27,7 @@ pub struct ProverMessage<F: Field> {
 }
 
 impl<F: Field> ToBytes for ProverMessage<F> {
-    fn write<W: Write>(&self, mut w: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("Could not serialize ProverMsg"))
     }
 }

--- a/marlin/src/ahp/prover/message.rs
+++ b/marlin/src/ahp/prover/message.rs
@@ -16,7 +16,7 @@
 
 use crate::Vec;
 use snarkvm_fields::Field;
-use snarkvm_utilities::{bytes::ToBytes, error, errors::SerializationError, serialize::*, Write};
+use snarkvm_utilities::{error, errors::SerializationError, serialize::*, ToBytes, Write};
 
 /// Each prover message that is not a list of oracles is a list of field elements.
 #[repr(transparent)]

--- a/marlin/src/constraints/ahp.rs
+++ b/marlin/src/constraints/ahp.rs
@@ -955,7 +955,7 @@ mod test {
         LabeledCommitment,
     };
     use snarkvm_r1cs::{ConstraintSynthesizer, SynthesisError, TestConstraintSystem};
-    use snarkvm_utilities::{test_rng, to_bytes, ToBytes, UniformRand};
+    use snarkvm_utilities::{test_rng, to_bytes_le, ToBytes, UniformRand};
 
     use crate::{
         ahp::AHPForR1CS as AHPForR1CSNative,
@@ -1091,11 +1091,11 @@ mod test {
         let fs_rng = &mut FS::new();
 
         if is_recursion {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME].unwrap());
             fs_rng.absorb_native_field_elements(&compute_vk_hash::<Fr, Fq, MultiPC, FS>(&circuit_vk).unwrap());
             fs_rng.absorb_nonnative_field_elements(&public_input, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
         }
 
         // Start first round.
@@ -1134,7 +1134,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![first_commitments, proof.prover_messages[0]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![first_commitments, proof.prover_messages[0]].unwrap());
         }
         // Execute the verifier first round.
         let (first_round_message, first_round_state) =
@@ -1223,11 +1223,11 @@ mod test {
         let fs_rng = &mut FS::new();
 
         if is_recursion {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME].unwrap());
             fs_rng.absorb_native_field_elements(&compute_vk_hash::<Fr, Fq, MultiPC, FS>(&circuit_vk).unwrap());
             fs_rng.absorb_nonnative_field_elements(&public_input, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
         }
 
         // Start first round.
@@ -1264,7 +1264,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![first_commitments, proof.prover_messages[0]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![first_commitments, proof.prover_messages[0]].unwrap());
         }
         // Execute the verifier first round.
         let (_first_round_message, first_round_state) =
@@ -1315,7 +1315,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![second_commitments, proof.prover_messages[1]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![second_commitments, proof.prover_messages[1]].unwrap());
         }
 
         // Execute the verifier second round.
@@ -1390,11 +1390,11 @@ mod test {
         let fs_rng = &mut FS::new();
 
         if is_recursion {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME].unwrap());
             fs_rng.absorb_native_field_elements(&compute_vk_hash::<Fr, Fq, MultiPC, FS>(&circuit_vk).unwrap());
             fs_rng.absorb_nonnative_field_elements(&public_input, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
         }
 
         // Start first round.
@@ -1431,7 +1431,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![first_commitments, proof.prover_messages[0]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![first_commitments, proof.prover_messages[0]].unwrap());
         }
         // Execute the verifier first round.
         let (_first_round_message, first_round_state) =
@@ -1482,7 +1482,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![second_commitments, proof.prover_messages[1]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![second_commitments, proof.prover_messages[1]].unwrap());
         }
 
         // Execute the verifier second round.
@@ -1533,7 +1533,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![third_commitments, proof.prover_messages[2]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![third_commitments, proof.prover_messages[2]].unwrap());
         }
 
         // Execute the verifier third round.
@@ -1610,11 +1610,11 @@ mod test {
         let fs_rng = &mut FS::new();
 
         if is_recursion {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME].unwrap());
             fs_rng.absorb_native_field_elements(&compute_vk_hash::<Fr, Fq, MultiPC, FS>(&circuit_vk).unwrap());
             fs_rng.absorb_nonnative_field_elements(&public_input, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
         }
 
         // Start first round.
@@ -1651,7 +1651,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![first_commitments, proof.prover_messages[0]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![first_commitments, proof.prover_messages[0]].unwrap());
         }
         // Execute the verifier first round.
         let (_first_round_message, first_round_state) =
@@ -1702,7 +1702,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![second_commitments, proof.prover_messages[1]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![second_commitments, proof.prover_messages[1]].unwrap());
         }
 
         // Execute the verifier second round.
@@ -1753,7 +1753,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![third_commitments, proof.prover_messages[2]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![third_commitments, proof.prover_messages[2]].unwrap());
         }
 
         // Execute the verifier third round.
@@ -1779,7 +1779,7 @@ mod test {
         if is_recursion {
             fs_rng.absorb_nonnative_field_elements(&proof.evaluations, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&proof.evaluations].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&proof.evaluations].unwrap());
         }
 
         let mut evaluations = Evaluations::new();
@@ -1911,11 +1911,11 @@ mod test {
         let fs_rng = &mut FS::new();
 
         if is_recursion {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME].unwrap());
             fs_rng.absorb_native_field_elements(&compute_vk_hash::<Fr, Fq, MultiPC, FS>(&circuit_vk).unwrap());
             fs_rng.absorb_nonnative_field_elements(&public_input, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&MarlinInst::PROTOCOL_NAME, &circuit_vk, &public_input].unwrap());
         }
 
         // Start first round.
@@ -1952,7 +1952,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![first_commitments, proof.prover_messages[0]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![first_commitments, proof.prover_messages[0]].unwrap());
         }
         // Execute the verifier first round.
         let (_first_round_message, first_round_state) =
@@ -2003,7 +2003,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![second_commitments, proof.prover_messages[1]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![second_commitments, proof.prover_messages[1]].unwrap());
         }
 
         // Execute the verifier second round.
@@ -2054,7 +2054,7 @@ mod test {
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![third_commitments, proof.prover_messages[2]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![third_commitments, proof.prover_messages[2]].unwrap());
         }
 
         // Execute the verifier third round.
@@ -2080,7 +2080,7 @@ mod test {
         if is_recursion {
             fs_rng.absorb_nonnative_field_elements(&proof.evaluations, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&proof.evaluations].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&proof.evaluations].unwrap());
         }
 
         let mut evaluations = Evaluations::new();

--- a/marlin/src/constraints/proof.rs
+++ b/marlin/src/constraints/proof.rs
@@ -389,7 +389,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<TargetField, PC> = FromBytes::read(&proof_bytes.borrow()[..])?;
+            let proof: Proof<TargetField, PC> = FromBytes::read_le(&proof_bytes.borrow()[..])?;
 
             Self::alloc(cs.ns(|| "alloc_bytes"), || Ok(proof))
         })
@@ -405,7 +405,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<TargetField, PC> = FromBytes::read(&proof_bytes.borrow()[..])?;
+            let proof: Proof<TargetField, PC> = FromBytes::read_le(&proof_bytes.borrow()[..])?;
 
             Self::alloc_input(cs.ns(|| "alloc_input_bytes"), || Ok(proof))
         })

--- a/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
@@ -472,7 +472,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let circuit_vk: CircuitVerifyingKey<TargetField, PC> = FromBytes::read(&vk_bytes.borrow()[..])?;
+            let circuit_vk: CircuitVerifyingKey<TargetField, PC> = FromBytes::read_le(&vk_bytes.borrow()[..])?;
             // TODO (raychu86): Preparing the verifying key natively is more efficient, however it is currently broken.
 
             let unprepared_vk_gadget =
@@ -494,7 +494,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let circuit_vk: CircuitVerifyingKey<TargetField, PC> = FromBytes::read(&vk_bytes.borrow()[..])?;
+            let circuit_vk: CircuitVerifyingKey<TargetField, PC> = FromBytes::read_le(&vk_bytes.borrow()[..])?;
             // TODO (raychu86): Preparing the verifying key natively is more efficient, however it is currently broken.
 
             let unprepared_vk_gadget = CircuitVerifyingKeyVar::<TargetField, BaseField, PC, PCG>::alloc_input(

--- a/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
@@ -29,7 +29,7 @@ use snarkvm_gadgets::{
 };
 use snarkvm_polycommit::{PCCheckVar, PrepareGadget};
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use crate::{
     constraints::{verifier::MarlinVerificationGadget, verifier_key::CircuitVerifyingKeyVar},
@@ -107,7 +107,7 @@ where
         vk: &CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>,
     ) -> Result<Self, SynthesisError> {
         let mut fs_rng_raw = PR::new();
-        fs_rng_raw.absorb_bytes(&to_bytes![
+        fs_rng_raw.absorb_bytes(&to_bytes_le![
             &MarlinVerificationGadget::<TargetField, BaseField, PC, PCG>::PROTOCOL_NAME
         ]?);
 
@@ -203,7 +203,7 @@ where
         };
 
         let mut fs_rng_raw = PR::new();
-        fs_rng_raw.absorb_bytes(&to_bytes![
+        fs_rng_raw.absorb_bytes(&to_bytes_le![
             &MarlinVerificationGadget::<TargetField, BaseField, PC, PCG>::PROTOCOL_NAME
         ]?);
 
@@ -267,7 +267,7 @@ where
         };
 
         let mut fs_rng_raw = PR::new();
-        fs_rng_raw.absorb_bytes(&to_bytes![
+        fs_rng_raw.absorb_bytes(&to_bytes_le![
             &MarlinVerificationGadget::<TargetField, BaseField, PC, PCG>::PROTOCOL_NAME
         ]?);
 
@@ -331,7 +331,7 @@ where
         };
 
         let mut fs_rng_raw = PR::new();
-        fs_rng_raw.absorb_bytes(&to_bytes![
+        fs_rng_raw.absorb_bytes(&to_bytes_le![
             &MarlinVerificationGadget::<TargetField, BaseField, PC, PCG>::PROTOCOL_NAME
         ]?);
 

--- a/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge.rs
@@ -26,7 +26,7 @@ use snarkvm_gadgets::{
     },
     overhead,
 };
-use snarkvm_utilities::BigInteger;
+use snarkvm_utilities::{FromBits, ToBits};
 
 use rand_core::{Error, RngCore};
 
@@ -80,7 +80,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField, S: AlgebraicSponge<BaseFiel
         }
         let elements = bits
             .chunks(capacity)
-            .map(|bits| BaseField::from_repr(BaseField::BigInteger::from_bits_be(bits.to_vec())).unwrap())
+            .map(|bits| BaseField::from_repr(BaseField::BigInteger::from_bits_be(bits)).unwrap())
             .collect::<Vec<BaseField>>();
 
         self.s.absorb(&elements);

--- a/marlin/src/fiat_shamir/fiat_shamir_chacha.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_chacha.rs
@@ -92,7 +92,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField, D: Digest> FiatShamirRng<Ta
     fn absorb_nonnative_field_elements(&mut self, elems: &[TargetField], _: OptimizationType) {
         let mut bytes = Vec::new();
         for elem in elems {
-            elem.write(&mut bytes).expect("failed to convert to bytes");
+            elem.write_le(&mut bytes).expect("failed to convert to bytes");
         }
         self.absorb_bytes(&bytes);
     }
@@ -105,7 +105,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField, D: Digest> FiatShamirRng<Ta
 
         let mut bytes = Vec::new();
         for elem in elems.iter() {
-            elem.write(&mut bytes).expect("failed to convert to bytes");
+            elem.write_le(&mut bytes).expect("failed to convert to bytes");
         }
         self.absorb_bytes(&bytes);
     }

--- a/marlin/src/marlin/circuit_proving_key.rs
+++ b/marlin/src/marlin/circuit_proving_key.rs
@@ -43,7 +43,7 @@ pub struct CircuitProvingKey<F: PrimeField, PC: PolynomialCommitment<F>> {
 }
 
 impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for CircuitProvingKey<F, PC> {
-    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         CanonicalSerialize::serialize(self, &mut writer).map_err(|_| error("could not serialize CircuitProvingKey"))
     }
 }

--- a/marlin/src/marlin/circuit_proving_key.rs
+++ b/marlin/src/marlin/circuit_proving_key.rs
@@ -45,7 +45,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for CircuitProvingKey<F
 
 impl<F: PrimeField, PC: PolynomialCommitment<F>> FromBytes for CircuitProvingKey<F, PC> {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         CanonicalDeserialize::deserialize(&mut reader).map_err(|_| error("could not deserialize CircuitProvingKey"))
     }
 }

--- a/marlin/src/marlin/circuit_proving_key.rs
+++ b/marlin/src/marlin/circuit_proving_key.rs
@@ -17,12 +17,7 @@
 use crate::{ahp::indexer::*, marlin::CircuitVerifyingKey, Vec};
 use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::PolynomialCommitment;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    error,
-    errors::SerializationError,
-    serialize::*,
-};
+use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
 use derivative::Derivative;
 use std::io::{Read, Result as IoResult, Write};

--- a/marlin/src/marlin/circuit_verifying_key.rs
+++ b/marlin/src/marlin/circuit_verifying_key.rs
@@ -50,7 +50,7 @@ pub struct CircuitVerifyingKey<F: PrimeField, PC: PolynomialCommitment<F>> {
 }
 
 impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for CircuitVerifyingKey<F, PC> {
-    fn write<W: Write>(&self, mut w: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("could not serialize CircuitVerifyingKey"))
     }
 }

--- a/marlin/src/marlin/circuit_verifying_key.rs
+++ b/marlin/src/marlin/circuit_verifying_key.rs
@@ -22,12 +22,7 @@ use crate::{
 };
 use snarkvm_fields::{PrimeField, ToConstraintField};
 use snarkvm_polycommit::PolynomialCommitment;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    error,
-    errors::SerializationError,
-    serialize::*,
-};
+use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
 use derivative::Derivative;
 use std::io::{

--- a/marlin/src/marlin/circuit_verifying_key.rs
+++ b/marlin/src/marlin/circuit_verifying_key.rs
@@ -51,7 +51,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for CircuitVerifyingKey
 }
 
 impl<F: PrimeField, PC: PolynomialCommitment<F>> FromBytes for CircuitVerifyingKey<F, PC> {
-    fn read<R: Read>(mut r: R) -> io::Result<Self> {
+    fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut r).map_err(|_| error("could not deserialize CircuitVerifyingKey"))
     }
 }

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -24,7 +24,7 @@ use snarkvm_fields::{PrimeField, ToConstraintField};
 use snarkvm_gadgets::nonnative::params::OptimizationType;
 use snarkvm_polycommit::{Evaluations, LabeledCommitment, LabeledPolynomial, PCUniversalParams, PolynomialCommitment};
 use snarkvm_r1cs::{ConstraintSynthesizer, SynthesisError};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use crate::marlin::PreparedCircuitVerifyingKey;
 use core::marker::PhantomData;
@@ -258,14 +258,14 @@ where
         let hiding = !is_recursion;
 
         if is_recursion {
-            fs_rng.absorb_bytes(&to_bytes![&Self::PROTOCOL_NAME].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME].unwrap());
             fs_rng.absorb_native_field_elements(&compute_vk_hash::<TargetField, BaseField, PC, FS>(
                 &circuit_proving_key.circuit_verifying_key,
             )?);
             fs_rng.absorb_nonnative_field_elements(&public_input, OptimizationType::Weight);
         } else {
             fs_rng.absorb_bytes(
-                &to_bytes![
+                &to_bytes_le![
                     &Self::PROTOCOL_NAME,
                     &circuit_proving_key.circuit_verifying_key,
                     &public_input
@@ -295,7 +295,7 @@ where
                 fs_rng.absorb_nonnative_field_elements(&prover_first_message.field_elements, OptimizationType::Weight);
             }
         } else {
-            fs_rng.absorb_bytes(&to_bytes![first_commitments, prover_first_message].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![first_commitments, prover_first_message].unwrap());
         }
 
         let (verifier_first_message, verifier_state) =
@@ -323,7 +323,7 @@ where
                 fs_rng.absorb_nonnative_field_elements(&prover_second_message.field_elements, OptimizationType::Weight);
             }
         } else {
-            fs_rng.absorb_bytes(&to_bytes![second_commitments, prover_second_message].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![second_commitments, prover_second_message].unwrap());
         }
 
         let (verifier_second_msg, verifier_state) = AHPForR1CS::verifier_second_round(verifier_state, &mut fs_rng)?;
@@ -349,7 +349,7 @@ where
                 fs_rng.absorb_nonnative_field_elements(&prover_third_message.field_elements, OptimizationType::Weight);
             }
         } else {
-            fs_rng.absorb_bytes(&to_bytes![third_commitments, prover_third_message].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![third_commitments, prover_third_message].unwrap());
         }
 
         let verifier_state = AHPForR1CS::verifier_third_round(verifier_state, &mut fs_rng)?;
@@ -457,7 +457,7 @@ where
         if is_recursion {
             fs_rng.absorb_nonnative_field_elements(&evaluations, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&evaluations].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&evaluations].unwrap());
         }
 
         let pc_proof = if is_recursion {
@@ -538,13 +538,13 @@ where
         let mut fs_rng = FS::new();
 
         if is_recursion {
-            fs_rng.absorb_bytes(&to_bytes![&Self::PROTOCOL_NAME].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME].unwrap());
             fs_rng.absorb_native_field_elements(&compute_vk_hash::<TargetField, BaseField, PC, FS>(
                 circuit_verifying_key,
             )?);
             fs_rng.absorb_nonnative_field_elements(&public_input, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&Self::PROTOCOL_NAME, &circuit_verifying_key, &public_input].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME, &circuit_verifying_key, &public_input].unwrap());
         }
 
         // --------------------------------------------------------------------
@@ -561,7 +561,7 @@ where
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![first_commitments, proof.prover_messages[0]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![first_commitments, proof.prover_messages[0]].unwrap());
         }
 
         let (_, verifier_state) = AHPForR1CS::verifier_first_round(circuit_verifying_key.circuit_info, &mut fs_rng)?;
@@ -580,7 +580,7 @@ where
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![second_commitments, proof.prover_messages[1]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![second_commitments, proof.prover_messages[1]].unwrap());
         }
 
         let (_, verifier_state) = AHPForR1CS::verifier_second_round(verifier_state, &mut fs_rng)?;
@@ -599,7 +599,7 @@ where
                 );
             };
         } else {
-            fs_rng.absorb_bytes(&to_bytes![third_commitments, proof.prover_messages[2]].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![third_commitments, proof.prover_messages[2]].unwrap());
         }
 
         let verifier_state = AHPForR1CS::verifier_third_round(verifier_state, &mut fs_rng)?;
@@ -638,7 +638,7 @@ where
         if is_recursion {
             fs_rng.absorb_nonnative_field_elements(&proof.evaluations, OptimizationType::Weight);
         } else {
-            fs_rng.absorb_bytes(&to_bytes![&proof.evaluations].unwrap());
+            fs_rng.absorb_bytes(&to_bytes_le![&proof.evaluations].unwrap());
         }
 
         let mut evaluations = Evaluations::new();

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -24,7 +24,7 @@ use snarkvm_fields::{PrimeField, ToConstraintField};
 use snarkvm_gadgets::nonnative::params::OptimizationType;
 use snarkvm_polycommit::{Evaluations, LabeledCommitment, LabeledPolynomial, PCUniversalParams, PolynomialCommitment};
 use snarkvm_r1cs::{ConstraintSynthesizer, SynthesisError};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use crate::marlin::PreparedCircuitVerifyingKey;
 use core::marker::PhantomData;

--- a/marlin/src/marlin/proof.rs
+++ b/marlin/src/marlin/proof.rs
@@ -17,12 +17,7 @@
 use crate::{ahp::prover::ProverMessage, Vec};
 use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::{BatchLCProof, PCCommitment, PolynomialCommitment};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    error,
-    errors::SerializationError,
-    serialize::*,
-};
+use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
 use derivative::Derivative;
 use std::io::{

--- a/marlin/src/marlin/proof.rs
+++ b/marlin/src/marlin/proof.rs
@@ -125,7 +125,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for Proof<F, PC> {
 }
 
 impl<F: PrimeField, PC: PolynomialCommitment<F>> FromBytes for Proof<F, PC> {
-    fn read<R: Read>(mut r: R) -> io::Result<Self> {
+    fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut r).map_err(|_| error("could not deserialize Proof"))
     }
 }

--- a/marlin/src/marlin/proof.rs
+++ b/marlin/src/marlin/proof.rs
@@ -124,7 +124,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>> Proof<F, PC> {
 }
 
 impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for Proof<F, PC> {
-    fn write<W: Write>(&self, mut w: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("could not serialize Proof"))
     }
 }

--- a/marlin/src/parameters.rs
+++ b/marlin/src/parameters.rs
@@ -76,7 +76,7 @@ impl<E: PairingEngine> ToBytes for Parameters<E> {
 }
 
 impl<E: PairingEngine> FromBytes for Parameters<E> {
-    fn read<R: Read>(mut r: R) -> io::Result<Self> {
+    fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
         // Signal that the SNARK params are being processed in order for the validation of affine values to be
         // deferred, while ensuring that this method is not called recursively; the expected number of entries is
         // counted with a thread-local SNARK_PARAMS_AFFINE_COUNT, which does not support recursion in its current form

--- a/marlin/src/parameters.rs
+++ b/marlin/src/parameters.rs
@@ -20,11 +20,12 @@ use snarkvm_curves::traits::{AffineCurve, PairingEngine};
 pub use snarkvm_polycommit::{marlin_pc::MarlinKZG10 as MultiPC, PCCommitment};
 use snarkvm_r1cs::{ConstraintSynthesizer, ToConstraintField};
 use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
     error,
     errors::SerializationError,
     io,
     serialize::*,
+    FromBytes,
+    ToBytes,
     PROCESSING_SNARK_PARAMS,
     SNARK_PARAMS_AFFINE_COUNT,
 };

--- a/marlin/src/parameters.rs
+++ b/marlin/src/parameters.rs
@@ -69,7 +69,7 @@ where
 }
 
 impl<E: PairingEngine> ToBytes for Parameters<E> {
-    fn write<W: Write>(&self, mut w: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("could not serialize parameters"))
     }
 }

--- a/parameters/examples/account_commitment.rs
+++ b/parameters/examples/account_commitment.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CommitmentError, traits::CommitmentScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CommitmentError> {
     let rng = &mut thread_rng();
     let account_commitment = <C::AccountCommitment as CommitmentScheme>::setup(rng);
     let account_commitment_parameters = account_commitment.parameters();
-    let account_commitment_parameters_bytes = to_bytes![account_commitment_parameters]?;
+    let account_commitment_parameters_bytes = account_commitment_parameters.to_bytes_le()?;
 
     let size = account_commitment_parameters_bytes.len();
     println!("account_commitment.params\n\tsize - {}", size);

--- a/parameters/examples/account_commitment.rs
+++ b/parameters/examples/account_commitment.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CommitmentError, traits::CommitmentScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/account_encryption.rs
+++ b/parameters/examples/account_encryption.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::EncryptionError, traits::EncryptionScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/account_encryption.rs
+++ b/parameters/examples/account_encryption.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::EncryptionError, traits::EncryptionScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, EncryptionError> {
     let rng = &mut thread_rng();
     let account_encryption = <C::AccountEncryption as EncryptionScheme>::setup(rng);
     let account_encryption_parameters = account_encryption.parameters();
-    let account_encryption_parameters_bytes = to_bytes![account_encryption_parameters]?;
+    let account_encryption_parameters_bytes = account_encryption_parameters.to_bytes_le()?;
 
     let size = account_encryption_parameters_bytes.len();
     println!("account_encryption.params\n\tsize - {}", size);

--- a/parameters/examples/account_signature.rs
+++ b/parameters/examples/account_signature.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::SignatureError, traits::SignatureScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, SignatureError> {
     let rng = &mut thread_rng();
     let account_signature = <C::AccountSignature as SignatureScheme>::setup(rng)?;
     let account_signature_parameters = account_signature.parameters();
-    let account_signature_parameters_bytes = to_bytes![account_signature_parameters]?;
+    let account_signature_parameters_bytes = account_signature_parameters.to_bytes_le()?;
 
     let size = account_signature_parameters_bytes.len();
     println!("account_signature.params\n\tsize - {}", size);

--- a/parameters/examples/account_signature.rs
+++ b/parameters/examples/account_signature.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::SignatureError, traits::SignatureScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/encrypted_record_crh.rs
+++ b/parameters/examples/encrypted_record_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{crh::sha256::sha256, errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::{

--- a/parameters/examples/encrypted_record_crh.rs
+++ b/parameters/examples/encrypted_record_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{crh::sha256::sha256, errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::{
@@ -32,7 +32,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     let rng = &mut thread_rng();
     let encrypted_record_crh = <C::EncryptedRecordCRH as CRH>::setup(rng);
     let encrypted_record_crh_parameters = encrypted_record_crh.parameters();
-    let encrypted_record_crh_parameters_bytes = to_bytes![encrypted_record_crh_parameters]?;
+    let encrypted_record_crh_parameters_bytes = encrypted_record_crh_parameters.to_bytes_le()?;
 
     let size = encrypted_record_crh_parameters_bytes.len();
     println!("encrypted_record_crh.params\n\tsize - {}", size);

--- a/parameters/examples/inner_circuit_id_crh.rs
+++ b/parameters/examples/inner_circuit_id_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     let rng = &mut thread_rng();
     let inner_circuit_id_crh = <C::InnerCircuitIDCRH as CRH>::setup(rng);
     let inner_circuit_id_crh_parameters = inner_circuit_id_crh.parameters();
-    let inner_circuit_id_crh_parameters_bytes = to_bytes![inner_circuit_id_crh_parameters]?;
+    let inner_circuit_id_crh_parameters_bytes = inner_circuit_id_crh_parameters.to_bytes_le()?;
 
     let size = inner_circuit_id_crh_parameters_bytes.len();
     println!("inner_circuit_id_crh.params\n\tsize - {}", size);

--- a/parameters/examples/inner_circuit_id_crh.rs
+++ b/parameters/examples/inner_circuit_id_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -28,10 +28,7 @@ use snarkvm_dpc::{
     },
 };
 use snarkvm_parameters::{traits::Parameter, LedgerMerkleTreeParameters};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -28,7 +28,7 @@ use snarkvm_dpc::{
     },
 };
 use snarkvm_parameters::{traits::Parameter, LedgerMerkleTreeParameters};
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};
@@ -49,9 +49,9 @@ pub fn setup<C: Testnet1Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         &InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
         rng,
     )?;
-    let inner_snark_pk = to_bytes![inner_snark_parameters.0]?;
+    let inner_snark_pk = inner_snark_parameters.0.to_bytes_le()?;
     let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey = inner_snark_parameters.1.into();
-    let inner_snark_vk = to_bytes![inner_snark_vk]?;
+    let inner_snark_vk = inner_snark_vk.to_bytes_le()?;
 
     println!("inner_snark_pk.params\n\tsize - {}", inner_snark_pk.len());
     println!("inner_snark_vk.params\n\tsize - {}", inner_snark_vk.len());

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -41,7 +41,7 @@ pub fn setup<C: Testnet1Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 
     // TODO (howardwu): Resolve this inconsistency on import structure with a new model once MerkleParameters are refactored.
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
-        From::from(FromBytes::read(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
+        From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
     let system_parameters = SystemParameters::<C>::load()?;

--- a/parameters/examples/ledger_merkle_tree.rs
+++ b/parameters/examples/ledger_merkle_tree.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::MerkleError, traits::MerkleParameters};
 use snarkvm_dpc::testnet1::{instantiated::Components, Testnet1Components};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: Testnet1Components>() -> Result<Vec<u8>, MerkleError> {
     let rng = &mut thread_rng();
 
     let ledger_merkle_tree_parameters = <C::MerkleParameters as MerkleParameters>::setup(rng);
-    let ledger_merkle_tree_parameters_bytes = to_bytes![ledger_merkle_tree_parameters.parameters()]?;
+    let ledger_merkle_tree_parameters_bytes = ledger_merkle_tree_parameters.parameters().to_bytes_le()?;
 
     let size = ledger_merkle_tree_parameters_bytes.len();
     println!("ledger_merkle_tree.params\n\tsize - {}", size);

--- a/parameters/examples/ledger_merkle_tree.rs
+++ b/parameters/examples/ledger_merkle_tree.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::MerkleError, traits::MerkleParameters};
 use snarkvm_dpc::testnet1::{instantiated::Components, Testnet1Components};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/local_data_commitment.rs
+++ b/parameters/examples/local_data_commitment.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CommitmentError, traits::CommitmentScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CommitmentError> {
     let rng = &mut thread_rng();
     let local_data_commitment = <C::LocalDataCommitment as CommitmentScheme>::setup(rng);
     let local_data_commitment_parameters = local_data_commitment.parameters();
-    let local_data_commitment_parameters_bytes = to_bytes![local_data_commitment_parameters]?;
+    let local_data_commitment_parameters_bytes = local_data_commitment_parameters.to_bytes_le()?;
 
     let size = local_data_commitment_parameters_bytes.len();
     println!("local_data_commitment.params\n\tsize - {}", size);

--- a/parameters/examples/local_data_commitment.rs
+++ b/parameters/examples/local_data_commitment.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CommitmentError, traits::CommitmentScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/local_data_crh.rs
+++ b/parameters/examples/local_data_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{crh::sha256::sha256, errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::{

--- a/parameters/examples/local_data_crh.rs
+++ b/parameters/examples/local_data_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{crh::sha256::sha256, errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::{
@@ -32,7 +32,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     let rng = &mut thread_rng();
     let local_data_crh = <C::LocalDataCRH as CRH>::setup(rng);
     let local_data_crh_parameters = local_data_crh.parameters();
-    let local_data_crh_parameters_bytes = to_bytes![local_data_crh_parameters]?;
+    let local_data_crh_parameters_bytes = local_data_crh_parameters.to_bytes_le()?;
 
     let size = local_data_crh_parameters_bytes.len();
     println!("local_data_crh.params\n\tsize - {}", size);

--- a/parameters/examples/noop_program_snark.rs
+++ b/parameters/examples/noop_program_snark.rs
@@ -19,7 +19,7 @@ use snarkvm_dpc::{
     DPCError,
     ProgramScheme,
 };
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -38,8 +38,8 @@ pub fn setup<C: Testnet1Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         rng,
     )?;
     let (proving_key, verifying_key) = noop_program.to_snark_parameters();
-    let noop_program_snark_pk = to_bytes![proving_key]?;
-    let noop_program_snark_vk = to_bytes![verifying_key]?;
+    let noop_program_snark_pk = proving_key.to_bytes_le()?;
+    let noop_program_snark_vk = verifying_key.to_bytes_le()?;
 
     println!("noop_program_snark_pk.params\n\tsize - {}", noop_program_snark_pk.len());
     println!("noop_program_snark_vk.params\n\tsize - {}", noop_program_snark_vk.len());

--- a/parameters/examples/noop_program_snark.rs
+++ b/parameters/examples/noop_program_snark.rs
@@ -19,7 +19,7 @@ use snarkvm_dpc::{
     DPCError,
     ProgramScheme,
 };
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -35,7 +35,7 @@ use snarkvm_parameters::{
     traits::Parameter,
     LedgerMerkleTreeParameters,
 };
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};
@@ -79,9 +79,9 @@ pub fn setup<C: Testnet1Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         rng,
     )?;
 
-    let outer_snark_pk = to_bytes![outer_snark_parameters.0]?;
+    let outer_snark_pk = outer_snark_parameters.0.to_bytes_le()?;
     let outer_snark_vk: <C::OuterSNARK as SNARK>::VerifyingKey = outer_snark_parameters.1.into();
-    let outer_snark_vk = to_bytes![outer_snark_vk]?;
+    let outer_snark_vk = outer_snark_vk.to_bytes_le()?;
 
     println!("outer_snark_pk.params\n\tsize - {}", outer_snark_pk.len());
     println!("outer_snark_vk.params\n\tsize - {}", outer_snark_vk.len());

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -35,10 +35,7 @@ use snarkvm_parameters::{
     traits::Parameter,
     LedgerMerkleTreeParameters,
 };
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -48,14 +48,14 @@ pub fn setup<C: Testnet1Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let system_parameters = SystemParameters::<C>::load()?;
 
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
-        From::from(FromBytes::read(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
+        From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
     let inner_snark_pk: <C::InnerSNARK as SNARK>::ProvingKey =
-        <C::InnerSNARK as SNARK>::ProvingKey::read(InnerSNARKPKParameters::load_bytes()?.as_slice())?;
+        <C::InnerSNARK as SNARK>::ProvingKey::read_le(InnerSNARKPKParameters::load_bytes()?.as_slice())?;
 
     let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey =
-        <C::InnerSNARK as SNARK>::VerifyingKey::read(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
+        <C::InnerSNARK as SNARK>::VerifyingKey::read_le(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
 
     let inner_snark_proof = C::InnerSNARK::prove(
         &inner_snark_pk,

--- a/parameters/examples/posw_snark.rs
+++ b/parameters/examples/posw_snark.rs
@@ -17,7 +17,7 @@
 use snarkvm_algorithms::crh::sha256;
 use snarkvm_dpc::errors::DPCError;
 use snarkvm_posw::PoswMarlin;
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -31,12 +31,15 @@ pub fn setup() -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), DPCError> {
 
     let srs = snarkvm_marlin::MarlinTestnet1::universal_setup(10000, 10000, 100000, rng).unwrap();
 
-    let srs_bytes = to_bytes![srs]?;
+    let srs_bytes = srs.to_bytes_le()?;
     let posw_snark = PoswMarlin::index(srs).expect("could not setup params");
 
-    let posw_snark_pk = to_bytes![posw_snark.pk.expect("posw_snark_pk should be populated")]?;
+    let posw_snark_pk = posw_snark
+        .pk
+        .expect("posw_snark_pk should be populated")
+        .to_bytes_le()?;
     let posw_snark_vk = posw_snark.vk;
-    let posw_snark_vk = to_bytes![posw_snark_vk]?;
+    let posw_snark_vk = posw_snark_vk.to_bytes_le()?;
 
     println!("posw_snark_pk.params\n\tsize - {}", posw_snark_pk.len());
     println!("posw_snark_vk.params\n\tsize - {}", posw_snark_vk.len());

--- a/parameters/examples/posw_snark.rs
+++ b/parameters/examples/posw_snark.rs
@@ -17,7 +17,7 @@
 use snarkvm_algorithms::crh::sha256;
 use snarkvm_dpc::errors::DPCError;
 use snarkvm_posw::PoswMarlin;
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/program_vk_crh.rs
+++ b/parameters/examples/program_vk_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/program_vk_crh.rs
+++ b/parameters/examples/program_vk_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     let rng = &mut thread_rng();
     let program_vk_crh = <C::ProgramVerificationKeyCRH as CRH>::setup(rng);
     let program_vk_crh_parameters = program_vk_crh.parameters();
-    let program_vk_crh_parameters_bytes = to_bytes![program_vk_crh_parameters]?;
+    let program_vk_crh_parameters_bytes = program_vk_crh_parameters.to_bytes_le()?;
 
     let size = program_vk_crh_parameters_bytes.len();
     println!("program_vk_crh.params\n\tsize - {}", size);

--- a/parameters/examples/record_commitment.rs
+++ b/parameters/examples/record_commitment.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CommitmentError, traits::CommitmentScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/record_commitment.rs
+++ b/parameters/examples/record_commitment.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CommitmentError, traits::CommitmentScheme};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CommitmentError> {
     let rng = &mut thread_rng();
     let record_commitment = <C::RecordCommitment as CommitmentScheme>::setup(rng);
     let record_commitment_parameters = record_commitment.parameters();
-    let record_commitment_parameters_bytes = to_bytes![record_commitment_parameters]?;
+    let record_commitment_parameters_bytes = record_commitment_parameters.to_bytes_le()?;
 
     let size = record_commitment_parameters_bytes.len();
     println!("record_commitment.params\n\tsize - {}", size);

--- a/parameters/examples/serial_number_nonce_crh.rs
+++ b/parameters/examples/serial_number_nonce_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/serial_number_nonce_crh.rs
+++ b/parameters/examples/serial_number_nonce_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet1::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     let rng = &mut thread_rng();
     let serial_number_nonce_crh = <C::SerialNumberNonceCRH as CRH>::setup(rng);
     let serial_number_nonce_crh_parameters = serial_number_nonce_crh.parameters();
-    let serial_number_nonce_crh_parameters_bytes = to_bytes![serial_number_nonce_crh_parameters]?;
+    let serial_number_nonce_crh_parameters_bytes = serial_number_nonce_crh_parameters.to_bytes_le()?;
 
     let size = serial_number_nonce_crh_parameters_bytes.len();
     println!("serial_number_nonce_crh.params\n\tsize - {}", size);

--- a/parameters/examples/testnet2_inner_snark.rs
+++ b/parameters/examples/testnet2_inner_snark.rs
@@ -28,10 +28,7 @@ use snarkvm_dpc::{
     },
 };
 use snarkvm_parameters::{traits::Parameter, LedgerMerkleTreeParameters};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};

--- a/parameters/examples/testnet2_inner_snark.rs
+++ b/parameters/examples/testnet2_inner_snark.rs
@@ -28,7 +28,7 @@ use snarkvm_dpc::{
     },
 };
 use snarkvm_parameters::{traits::Parameter, LedgerMerkleTreeParameters};
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};
@@ -49,9 +49,9 @@ pub fn setup<C: Testnet2Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         &InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
         rng,
     )?;
-    let inner_snark_pk = to_bytes![inner_snark_parameters.0]?;
+    let inner_snark_pk = inner_snark_parameters.0.to_bytes_le()?;
     let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey = inner_snark_parameters.1.into();
-    let inner_snark_vk = to_bytes![inner_snark_vk]?;
+    let inner_snark_vk = inner_snark_vk.to_bytes_le()?;
 
     println!("inner_snark_pk.params\n\tsize - {}", inner_snark_pk.len());
     println!("inner_snark_vk.params\n\tsize - {}", inner_snark_vk.len());

--- a/parameters/examples/testnet2_inner_snark.rs
+++ b/parameters/examples/testnet2_inner_snark.rs
@@ -41,7 +41,7 @@ pub fn setup<C: Testnet2Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 
     // TODO (howardwu): Resolve this inconsistency on import structure with a new model once MerkleParameters are refactored.
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
-        From::from(FromBytes::read(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
+        From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
     let system_parameters = SystemParameters::<C>::load()?;

--- a/parameters/examples/testnet2_noop_program_snark.rs
+++ b/parameters/examples/testnet2_noop_program_snark.rs
@@ -21,7 +21,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_fields::ToConstraintField;
 use snarkvm_marlin::PolynomialCommitment;
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -46,8 +46,8 @@ where
         rng,
     )?;
     let (proving_key, verifying_key) = noop_program.to_snark_parameters();
-    let noop_program_snark_pk = to_bytes![proving_key]?;
-    let noop_program_snark_vk = to_bytes![verifying_key]?;
+    let noop_program_snark_pk = proving_key.to_bytes_le()?;
+    let noop_program_snark_vk = verifying_key.to_bytes_le()?;
 
     println!("noop_program_snark_pk.params\n\tsize - {}", noop_program_snark_pk.len());
     println!("noop_program_snark_vk.params\n\tsize - {}", noop_program_snark_vk.len());

--- a/parameters/examples/testnet2_noop_program_snark.rs
+++ b/parameters/examples/testnet2_noop_program_snark.rs
@@ -21,7 +21,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_fields::ToConstraintField;
 use snarkvm_marlin::PolynomialCommitment;
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/testnet2_outer_snark.rs
+++ b/parameters/examples/testnet2_outer_snark.rs
@@ -35,7 +35,7 @@ use snarkvm_parameters::{
     traits::Parameter,
     LedgerMerkleTreeParameters,
 };
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};
@@ -79,9 +79,9 @@ pub fn setup<C: Testnet2Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         rng,
     )?;
 
-    let outer_snark_pk = to_bytes![outer_snark_parameters.0]?;
+    let outer_snark_pk = outer_snark_parameters.0.to_bytes_le()?;
     let outer_snark_vk: <C::OuterSNARK as SNARK>::VerifyingKey = outer_snark_parameters.1.into();
-    let outer_snark_vk = to_bytes![outer_snark_vk]?;
+    let outer_snark_vk = outer_snark_vk.to_bytes_le()?;
 
     println!("outer_snark_pk.params\n\tsize - {}", outer_snark_pk.len());
     println!("outer_snark_vk.params\n\tsize - {}", outer_snark_vk.len());

--- a/parameters/examples/testnet2_outer_snark.rs
+++ b/parameters/examples/testnet2_outer_snark.rs
@@ -35,10 +35,7 @@ use snarkvm_parameters::{
     traits::Parameter,
     LedgerMerkleTreeParameters,
 };
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use rand::thread_rng;
 use std::{path::PathBuf, sync::Arc};

--- a/parameters/examples/testnet2_outer_snark.rs
+++ b/parameters/examples/testnet2_outer_snark.rs
@@ -48,14 +48,14 @@ pub fn setup<C: Testnet2Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let system_parameters = SystemParameters::<C>::load()?;
 
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
-        From::from(FromBytes::read(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
+        From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
     let inner_snark_pk: <C::InnerSNARK as SNARK>::ProvingKey =
-        <C::InnerSNARK as SNARK>::ProvingKey::read(InnerSNARKPKParameters::load_bytes()?.as_slice())?;
+        <C::InnerSNARK as SNARK>::ProvingKey::read_le(InnerSNARKPKParameters::load_bytes()?.as_slice())?;
 
     let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey =
-        <C::InnerSNARK as SNARK>::VerifyingKey::read(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
+        <C::InnerSNARK as SNARK>::VerifyingKey::read_le(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
 
     let inner_snark_proof = C::InnerSNARK::prove(
         &inner_snark_pk,

--- a/parameters/examples/testnet2_program_vk_crh.rs
+++ b/parameters/examples/testnet2_program_vk_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet2::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/testnet2_program_vk_crh.rs
+++ b/parameters/examples/testnet2_program_vk_crh.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{errors::CRHError, traits::CRH};
 use snarkvm_dpc::{testnet2::instantiated::Components, traits::DPCComponents};
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     let rng = &mut thread_rng();
     let program_vk_crh = <C::ProgramVerificationKeyCRH as CRH>::setup(rng);
     let program_vk_crh_parameters = program_vk_crh.parameters();
-    let program_vk_crh_parameters_bytes = to_bytes![program_vk_crh_parameters]?;
+    let program_vk_crh_parameters_bytes = program_vk_crh_parameters.to_bytes_le()?;
 
     let size = program_vk_crh_parameters_bytes.len();
     println!("program_vk_crh.params\n\tsize - {}", size);

--- a/parameters/examples/testnet2_universal_srs.rs
+++ b/parameters/examples/testnet2_universal_srs.rs
@@ -20,7 +20,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_fields::ToConstraintField;
 use snarkvm_marlin::PolynomialCommitment;
-use snarkvm_utilities::{bytes::ToBytes, to_bytes};
+use snarkvm_utilities::{to_bytes, ToBytes};
 
 use rand::thread_rng;
 use std::path::PathBuf;

--- a/parameters/examples/testnet2_universal_srs.rs
+++ b/parameters/examples/testnet2_universal_srs.rs
@@ -20,7 +20,7 @@ use snarkvm_dpc::{
 };
 use snarkvm_fields::ToConstraintField;
 use snarkvm_marlin::PolynomialCommitment;
-use snarkvm_utilities::{to_bytes, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::path::PathBuf;
@@ -38,7 +38,7 @@ where
     let rng = &mut thread_rng();
 
     let universal_srs = ProgramSNARKUniversalSRS::<C>::setup(rng)?;
-    let universal_srs_bytes = to_bytes![universal_srs.0]?;
+    let universal_srs_bytes = universal_srs.0.to_bytes_le()?;
 
     println!("universal_srs.params\n\tsize - {}", universal_srs_bytes.len());
     Ok(universal_srs_bytes)

--- a/polycommit/src/data_structures.rs
+++ b/polycommit/src/data_structures.rs
@@ -382,7 +382,7 @@ impl<F: Field> core::ops::Deref for LinearCombination<F> {
 macro_rules! impl_bytes {
     ($ty: ident) => {
         impl<E: PairingEngine> FromBytes for $ty<E> {
-            fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+            fn read_le<R: Read>(mut reader: R) -> io::Result<Self> {
                 CanonicalDeserialize::deserialize(&mut reader).map_err(|_| error("could not deserialize struct"))
             }
         }

--- a/polycommit/src/data_structures.rs
+++ b/polycommit/src/data_structures.rs
@@ -192,7 +192,7 @@ impl<F: Field, C: PCCommitment + ToConstraintField<F>> ToConstraintField<F> for 
 // and you should construct the struct via the `LabeledCommitment::new` method after
 // deserializing the Commitment.
 impl<C: PCCommitment> ToBytes for LabeledCommitment<C> {
-    fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
         CanonicalSerialize::serialize(&self.commitment, &mut writer).map_err(|_| error_fn("could not serialize struct"))
     }
 }
@@ -393,7 +393,7 @@ macro_rules! impl_bytes {
         }
 
         impl<E: PairingEngine> ToBytes for $ty<E> {
-            fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+            fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
                 CanonicalSerialize::serialize(self, &mut writer).map_err(|_| error("could not serialize struct"))
             }
         }

--- a/polycommit/src/data_structures.rs
+++ b/polycommit/src/data_structures.rs
@@ -17,12 +17,7 @@
 use crate::{Arc, String, Vec};
 pub use snarkvm_algorithms::fft::DensePolynomial as Polynomial;
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    error as error_fn,
-    errors::SerializationError,
-    serialize::*,
-};
+use snarkvm_utilities::{error as error_fn, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
 use core::{
     borrow::Borrow,

--- a/polycommit/src/kzg10/data_structures.rs
+++ b/polycommit/src/kzg10/data_structures.rs
@@ -22,10 +22,10 @@ use snarkvm_curves::{
 };
 use snarkvm_fields::{ConstraintFieldError, PrimeField, ToConstraintField, Zero};
 use snarkvm_utilities::{
-    bytes::ToBytes,
     error,
     errors::SerializationError,
     serialize::{CanonicalDeserialize, CanonicalSerialize},
+    ToBytes,
 };
 
 use core::ops::Mul;

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -143,7 +143,7 @@ impl<F: Field, PC: PolynomialCommitment<F>> FromBytes for BatchLCProof<F, PC> {
 }
 
 impl<F: Field, PC: PolynomialCommitment<F>> ToBytes for BatchLCProof<F, PC> {
-    fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
         CanonicalSerialize::serialize(self, &mut writer).map_err(|_| error_fn("could not serialize struct"))
     }
 }

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -132,7 +132,7 @@ pub struct BatchLCProof<F: Field, PC: PolynomialCommitment<F>> {
 }
 
 impl<F: Field, PC: PolynomialCommitment<F>> FromBytes for BatchLCProof<F, PC> {
-    fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+    fn read_le<R: Read>(mut reader: R) -> io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut reader).map_err(|_| error_fn("could not deserialize struct"))
     }
 }

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -32,12 +32,7 @@ extern crate snarkvm_profiler;
 
 pub use snarkvm_algorithms::fft::DensePolynomial as Polynomial;
 use snarkvm_fields::Field;
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    error as error_fn,
-    errors::SerializationError,
-    serialize::*,
-};
+use snarkvm_utilities::{error as error_fn, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
 use core::fmt::Debug;
 use rand_core::RngCore;

--- a/polycommit/src/marlin_pc/data_structures.rs
+++ b/polycommit/src/marlin_pc/data_structures.rs
@@ -26,12 +26,7 @@ use crate::{
 };
 use snarkvm_curves::{traits::PairingEngine, Group};
 use snarkvm_fields::{ConstraintFieldError, PrimeField, ToConstraintField};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    error,
-    errors::SerializationError,
-    serialize::*,
-};
+use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
 use core::ops::{Add, AddAssign};
 use rand_core::RngCore;

--- a/polycommit/src/sonic_pc/data_structures.rs
+++ b/polycommit/src/sonic_pc/data_structures.rs
@@ -29,12 +29,7 @@ use snarkvm_curves::{
     Group,
 };
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    error,
-    errors::SerializationError,
-    serialize::*,
-};
+use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
 /// `UniversalParams` are the universal parameters for the KZG10 scheme.
 pub type UniversalParams<E> = kzg10::UniversalParams<E>;

--- a/posw/benches/posw.rs
+++ b/posw/benches/posw.rs
@@ -81,7 +81,7 @@ fn marlin_posw(c: &mut Criterion) {
     });
 
     let (nonce, proof) = posw.mine(&subroots, difficulty_target, rng, std::u32::MAX).unwrap();
-    let proof = <Marlin<Bls12_377> as SNARK>::Proof::read(&proof[..]).unwrap();
+    let proof = <Marlin<Bls12_377> as SNARK>::Proof::read_le(&proof[..]).unwrap();
 
     group.bench_function("verify", |b| {
         b.iter(|| {

--- a/posw/benches/posw.rs
+++ b/posw/benches/posw.rs
@@ -17,7 +17,7 @@
 use snarkvm_algorithms::traits::SNARK;
 use snarkvm_curves::bls12_377::Bls12_377;
 use snarkvm_posw::{txids_to_roots, Marlin, Posw, PoswMarlin, GM17};
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::SeedableRng;

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -132,7 +132,7 @@ mod test {
     };
     use snarkvm_fields::ToConstraintField;
     use snarkvm_gadgets::{algorithms::crh::PedersenCompressedCRHGadget, curves::edwards_bls12::EdwardsBls12Gadget};
-    use snarkvm_utilities::bytes::ToBytes;
+    use snarkvm_utilities::ToBytes;
 
     use super::{POSWCircuit, POSWCircuitParameters};
 

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -175,7 +175,7 @@ mod test {
         let tree = EdwardsMaskedMerkleTree::new(Arc::new(parameters.clone()), &leaves[..]).unwrap();
         let root = tree.root();
         let mut root_bytes = [0; 32];
-        root.write(&mut root_bytes[..]).unwrap();
+        root.write_le(&mut root_bytes[..]).unwrap();
 
         let mut h = Blake2s::new();
         h.update(nonce.as_ref());

--- a/posw/src/lib.rs
+++ b/posw/src/lib.rs
@@ -77,7 +77,7 @@ mod tests {
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use snarkvm_algorithms::traits::SNARK;
-    use snarkvm_utilities::bytes::FromBytes;
+    use snarkvm_utilities::FromBytes;
 
     #[test]
     fn test_load_verify_only() {

--- a/posw/src/lib.rs
+++ b/posw/src/lib.rs
@@ -138,7 +138,7 @@ mod tests {
 
         assert_eq!(proof.len(), 972); // NOTE: Marlin proofs use compressed serialization
 
-        let proof = <Marlin<Bls12_377> as SNARK>::Proof::read(&proof[..]).unwrap();
+        let proof = <Marlin<Bls12_377> as SNARK>::Proof::read_le(&proof[..]).unwrap();
         posw.verify(nonce, &proof, &pedersen_merkle_root).unwrap();
     }
 }

--- a/posw/src/posw.rs
+++ b/posw/src/posw.rs
@@ -46,7 +46,7 @@ use snarkvm_parameters::{
 };
 use snarkvm_polycommit::optional_rng::OptionalRng;
 use snarkvm_profiler::{end_timer, start_timer};
-use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use blake2::{digest::Digest, Blake2s};
 use rand::{rngs::OsRng, Rng};
@@ -229,7 +229,7 @@ where
             nonce = rng.gen_range(0..max_nonce);
             proof = Self::prove(&pk, nonce, subroots, rng)?;
 
-            serialized_proof = to_bytes!(proof)?;
+            serialized_proof = to_bytes_le!(proof)?;
             if self.check_difficulty(&serialized_proof, difficulty_target) {
                 break;
             }

--- a/posw/src/posw.rs
+++ b/posw/src/posw.rs
@@ -94,7 +94,7 @@ where
     /// Loads the PoSW runner from the locally stored parameters.
     pub fn verify_only() -> Result<Self, PoswError> {
         let params = PoswSNARKVKParameters::load_bytes()?;
-        let vk = S::VerifyingKey::read(&params[..])?;
+        let vk = S::VerifyingKey::read_le(&params[..])?;
 
         Ok(Self {
             pk: None,
@@ -105,8 +105,8 @@ where
 
     /// Loads the PoSW runner from the locally stored parameters.
     pub fn load() -> Result<Self, PoswError> {
-        let vk = S::VerifyingKey::read(&PoswSNARKVKParameters::load_bytes()?[..])?;
-        let pk = S::ProvingKey::read(&PoswSNARKPKParameters::load_bytes()?[..])?;
+        let vk = S::VerifyingKey::read_le(&PoswSNARKVKParameters::load_bytes()?[..])?;
+        let pk = S::ProvingKey::read_le(&PoswSNARKPKParameters::load_bytes()?[..])?;
 
         Ok(Self {
             pk: Some(pk),
@@ -270,7 +270,7 @@ where
         let mask = commit(nonce, pedersen_merkle_root);
 
         // get the mask and the root in public inputs format
-        let merkle_root = F::read(&pedersen_merkle_root.0[..])?;
+        let merkle_root = F::read_le(&pedersen_merkle_root.0[..])?;
         let inputs = [mask.to_field_elements()?, vec![merkle_root]].concat();
 
         let res = S::verify(&self.vk, &inputs, &proof)?;

--- a/posw/src/posw.rs
+++ b/posw/src/posw.rs
@@ -46,10 +46,7 @@ use snarkvm_parameters::{
 };
 use snarkvm_polycommit::optional_rng::OptionalRng;
 use snarkvm_profiler::{end_timer, start_timer};
-use snarkvm_utilities::{
-    bytes::{FromBytes, ToBytes},
-    to_bytes,
-};
+use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
 use blake2::{digest::Digest, Blake2s};
 use rand::{rngs::OsRng, Rng};

--- a/posw/tests/mod.rs
+++ b/posw/tests/mod.rs
@@ -42,7 +42,7 @@ fn test_posw_load_and_mine() {
     assert_eq!(proof.len(), 972); // NOTE: Marlin proofs use compressed serialization
 
     // Verify the proof is valid.
-    let posw_proof = <Marlin<Bls12_377> as SNARK>::Proof::read(&proof[..]).unwrap();
+    let posw_proof = <Marlin<Bls12_377> as SNARK>::Proof::read_le(&proof[..]).unwrap();
     assert!(posw.verify(nonce, &posw_proof, &pedersen_merkle_root).is_ok());
 
     println!("Nonce - {}", nonce);
@@ -71,7 +71,7 @@ fn test_posw_verify_testnet1() {
     let proof = {
         let bytes = hex::decode(POSW_PROOF).unwrap();
         assert_eq!(bytes.len(), 972); // NOTE: Marlin proofs use compressed serialization
-        <Marlin<Bls12_377> as SNARK>::Proof::read(&bytes[..]).unwrap()
+        <Marlin<Bls12_377> as SNARK>::Proof::read_le(&bytes[..]).unwrap()
     };
 
     let posw = PoswMarlin::load().unwrap();

--- a/posw/tests/mod.rs
+++ b/posw/tests/mod.rs
@@ -18,7 +18,7 @@ use snarkvm_algorithms::traits::SNARK;
 use snarkvm_curves::bls12_377::Bls12_377;
 use snarkvm_dpc::block::PedersenMerkleRootHash;
 use snarkvm_posw::{txids_to_roots, Marlin, PoswMarlin};
-use snarkvm_utilities::bytes::FromBytes;
+use snarkvm_utilities::FromBytes;
 
 use rand::SeedableRng;
 

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.7.2"
 optional = true
 
 [dependencies.anyhow]
-version = "1.0.41"
+version = "1.0"
 
 [dependencies.bincode]
 version = "1.3.3"

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -22,6 +22,9 @@ path = "../derives"
 version = "0.7.2"
 optional = true
 
+[dependencies.anyhow]
+version = "1.0.41"
+
 [dependencies.bincode]
 version = "1.3.3"
 

--- a/utilities/src/biginteger/biginteger.rs
+++ b/utilities/src/biginteger/biginteger.rs
@@ -113,19 +113,6 @@ pub trait BigInteger:
 
     /// Returns a vector for wnaf.
     fn find_wnaf(&self) -> Vec<i64>;
-
-    // /// Writes this `BigInteger` as little-endian bytes. Always writes
-    // /// `(num_bits` / 8) bytes.
-    // fn write_le<W: Write>(&self, writer: &mut W) -> IoResult<()> {
-    //     ToBytes::write_le(self, writer)
-    // }
-
-    /// Reads little-endian bytes occupying (`num_bits` / 8) bytes into this
-    /// representation.
-    fn read_le<R: Read>(&mut self, reader: &mut R) -> IoResult<()> {
-        *self = Self::read(reader)?;
-        Ok(())
-    }
 }
 
 pub mod arithmetic {
@@ -170,7 +157,7 @@ impl BigInteger256 {
 
         num.write_le(bytes.as_mut()).unwrap();
 
-        Self::read(&bytes[..]).unwrap()
+        Self::read_le(&bytes[..]).unwrap()
     }
 
     pub fn to_u128(&self) -> u128 {
@@ -179,6 +166,6 @@ impl BigInteger256 {
         self.write_le(bytes.as_mut()).unwrap();
 
         // We cut off the last 128 bits here
-        u128::read(&bytes[..16]).unwrap()
+        u128::read_le(&bytes[..16]).unwrap()
     }
 }

--- a/utilities/src/biginteger/biginteger.rs
+++ b/utilities/src/biginteger/biginteger.rs
@@ -18,7 +18,9 @@ use crate::{
     bititerator::{BitIteratorBE, BitIteratorLE},
     io::{Read, Result as IoResult, Write},
     rand::UniformRand,
+    FromBits,
     FromBytes,
+    ToBits,
     ToBytes,
 };
 
@@ -28,19 +30,21 @@ use rand::{
 };
 use std::fmt::{Debug, Display};
 
-bigint_impl!(BigInteger64, 1);
-bigint_impl!(BigInteger128, 2);
-bigint_impl!(BigInteger256, 4);
-bigint_impl!(BigInteger320, 5);
-bigint_impl!(BigInteger384, 6);
-bigint_impl!(BigInteger768, 12);
-bigint_impl!(BigInteger832, 13);
+biginteger!(BigInteger64, 1);
+biginteger!(BigInteger128, 2);
+biginteger!(BigInteger256, 4);
+biginteger!(BigInteger320, 5);
+biginteger!(BigInteger384, 6);
+biginteger!(BigInteger768, 12);
+biginteger!(BigInteger832, 13);
 
 /// TODO (howardwu): Update to use ToBits.
 /// This defines a `BigInteger`, a smart wrapper around a
 /// sequence of `u64` limbs, least-significant digit first.
 pub trait BigInteger:
-    ToBytes
+    ToBits
+    + FromBits
+    + ToBytes
     + FromBytes
     + Copy
     + Clone
@@ -96,20 +100,6 @@ pub trait BigInteger:
 
     /// Compute the `i`-th bit of `self`.
     fn get_bit(&self, i: usize) -> bool;
-
-    /// Returns the big integer representation of a given big endian boolean
-    /// array.
-    fn from_bits_be(bits: Vec<bool>) -> Self;
-
-    /// Returns the bit representation of the big integer in a big endian boolean array, without
-    /// leading zeros.
-    fn to_bits_be(&self) -> Vec<bool>;
-
-    /// Returns the bit representation of the big integer in a little endian boolean array,
-    /// with trailing zeroes.
-    fn to_bits_le(&self) -> Vec<bool> {
-        BitIteratorLE::new(self).collect::<Vec<_>>()
-    }
 
     /// Returns a vector for wnaf.
     fn find_wnaf(&self) -> Vec<i64>;

--- a/utilities/src/biginteger/biginteger.rs
+++ b/utilities/src/biginteger/biginteger.rs
@@ -113,13 +113,13 @@ pub trait BigInteger:
     /// Returns a vector for wnaf.
     fn find_wnaf(&self) -> Vec<i64>;
 
-    /// Writes this `BigInteger` as a big endian integer. Always writes
-    /// `(num_bits` / 8) bytes.
-    fn write_le<W: Write>(&self, writer: &mut W) -> IoResult<()> {
-        self.write(writer)
-    }
+    // /// Writes this `BigInteger` as little-endian bytes. Always writes
+    // /// `(num_bits` / 8) bytes.
+    // fn write_le<W: Write>(&self, writer: &mut W) -> IoResult<()> {
+    //     ToBytes::write_le(self, writer)
+    // }
 
-    /// Reads a big endian integer occupying (`num_bits` / 8) bytes into this
+    /// Reads little-endian bytes occupying (`num_bits` / 8) bytes into this
     /// representation.
     fn read_le<R: Read>(&mut self, reader: &mut R) -> IoResult<()> {
         *self = Self::read(reader)?;
@@ -167,7 +167,7 @@ impl BigInteger256 {
         // Takes a 256 bit buffer
         let mut bytes = [0u8; 32];
 
-        num.write(bytes.as_mut()).unwrap();
+        num.write_le(bytes.as_mut()).unwrap();
 
         Self::read(&bytes[..]).unwrap()
     }
@@ -175,7 +175,7 @@ impl BigInteger256 {
     pub fn to_u128(&self) -> u128 {
         let mut bytes = [0u8; 32];
 
-        self.write(bytes.as_mut()).unwrap();
+        self.write_le(bytes.as_mut()).unwrap();
 
         // We cut off the last 128 bits here
         u128::read(&bytes[..16]).unwrap()

--- a/utilities/src/biginteger/biginteger.rs
+++ b/utilities/src/biginteger/biginteger.rs
@@ -16,9 +16,10 @@
 
 use crate::{
     bititerator::{BitIteratorBE, BitIteratorLE},
-    bytes::{FromBytes, ToBytes},
     io::{Read, Result as IoResult, Write},
     rand::UniformRand,
+    FromBytes,
+    ToBytes,
 };
 
 use rand::{

--- a/utilities/src/biginteger/biginteger.rs
+++ b/utilities/src/biginteger/biginteger.rs
@@ -36,7 +36,7 @@ bigint_impl!(BigInteger384, 6);
 bigint_impl!(BigInteger768, 12);
 bigint_impl!(BigInteger832, 13);
 
-/// TODO (howardwu): Update to use ToBitsLE and ToBitsBE.
+/// TODO (howardwu): Update to use ToBits.
 /// This defines a `BigInteger`, a smart wrapper around a
 /// sequence of `u64` limbs, least-significant digit first.
 pub trait BigInteger:

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-macro_rules! bigint_impl {
+macro_rules! biginteger {
     ($name:ident, $num_limbs:expr) => {
         #[derive(Copy, Clone, PartialEq, Eq, Default, Hash)]
         pub struct $name(pub [u64; $num_limbs]);
@@ -164,33 +164,6 @@ macro_rules! bigint_impl {
                 }
             }
 
-            /// Constructs a `BigInteger` by parsing a vector of bits in big endian format
-            /// and transforms it into a vector of little endian u64 elements.
-            #[inline]
-            fn from_bits_be(mut bits: Vec<bool>) -> Self {
-                let mut res = Self::default();
-
-                bits.reverse();
-                for (i, bits64) in bits.chunks(64).enumerate() {
-                    let mut acc: u64 = 0;
-                    for bit in bits64.iter().rev() {
-                        acc <<= 1;
-                        acc += *bit as u64;
-                    }
-                    res.0[i] = acc;
-                }
-                res
-            }
-
-            #[inline]
-            fn to_bits_be(&self) -> Vec<bool> {
-                let mut res = Vec::with_capacity(256);
-                for b in BitIteratorBE::new(self.0) {
-                    res.push(b);
-                }
-                res
-            }
-
             #[inline]
             fn find_wnaf(&self) -> Vec<i64> {
                 let mut res = vec![];
@@ -213,6 +186,45 @@ macro_rules! bigint_impl {
                 }
 
                 res
+            }
+        }
+
+        impl ToBits for $name {
+            /// Returns `self` as a boolean array in little-endian order, with trailing zeros.
+            fn to_bits_le(&self) -> Vec<bool> {
+                BitIteratorLE::new(self).collect::<Vec<_>>()
+            }
+
+            /// Returns `self` as a boolean array in big-endian order, without leading zeros.
+            fn to_bits_be(&self) -> Vec<bool> {
+                BitIteratorBE::new(self).collect::<Vec<_>>()
+            }
+        }
+
+        impl FromBits for $name {
+            /// Returns a `BigInteger` by parsing a slice of bits in little-endian format
+            /// and transforms it into a slice of little-endian u64 elements.
+            fn from_bits_le(bits: &[bool]) -> Self {
+                let mut res = Self::default();
+
+                for (i, bits64) in bits.chunks(64).enumerate() {
+                    let mut acc: u64 = 0;
+                    for bit in bits64.iter().rev() {
+                        acc <<= 1;
+                        acc += *bit as u64;
+                    }
+                    res.0[i] = acc;
+                }
+                res
+            }
+
+            /// Returns a `BigInteger` by parsing a slice of bits in big-endian format
+            /// and transforms it into a slice of little-endian u64 elements.
+            fn from_bits_be(bits: &[bool]) -> Self {
+                let mut bits_reversed = bits.to_vec();
+                bits_reversed.reverse();
+
+                Self::from_bits_le(&bits_reversed)
             }
         }
 

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -225,8 +225,8 @@ macro_rules! bigint_impl {
 
         impl FromBytes for $name {
             #[inline]
-            fn read<R: Read>(reader: R) -> IoResult<Self> {
-                <[u64; $num_limbs]>::read(reader).map(Self::new)
+            fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+                <[u64; $num_limbs]>::read_le(reader).map(Self::new)
             }
         }
 

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -218,8 +218,8 @@ macro_rules! bigint_impl {
 
         impl ToBytes for $name {
             #[inline]
-            fn write<W: Write>(&self, writer: W) -> IoResult<()> {
-                self.0.write(writer)
+            fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
+                self.0.write_le(writer)
             }
         }
 

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -242,7 +242,7 @@ macro_rules! bigint_impl {
         impl Display for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 // TODO: Implement a native version, without the unwrap.
-                let bytes = crate::to_bytes![self.0].unwrap();
+                let bytes = self.0.to_bytes_le().unwrap();
                 write!(f, "{}", num_bigint::BigUint::from_bytes_le(&bytes))
             }
         }

--- a/utilities/src/biginteger/tests.rs
+++ b/utilities/src/biginteger/tests.rs
@@ -73,7 +73,7 @@ fn biginteger_bytes_test<B: BigInteger>() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
     let x: B = UniformRand::rand(&mut rng);
     x.write_le(bytes.as_mut()).unwrap();
-    let y = B::read(bytes.as_ref()).unwrap();
+    let y = B::read_le(bytes.as_ref()).unwrap();
     assert_eq!(x, y);
 }
 
@@ -99,7 +99,7 @@ fn biginteger_to_string_test<B: BigInteger>() {
                 .for_each(|(buf, val)| {
                     *buf = *val;
                 });
-            assert_eq!(format!("{}", integer), B::read(&*buffer).unwrap().to_string());
+            assert_eq!(format!("{}", integer), B::read_le(&*buffer).unwrap().to_string());
         }
     }
 

--- a/utilities/src/biginteger/tests.rs
+++ b/utilities/src/biginteger/tests.rs
@@ -72,7 +72,7 @@ fn biginteger_bytes_test<B: BigInteger>() {
     let mut bytes = [0u8; 256];
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
     let x: B = UniformRand::rand(&mut rng);
-    x.write(bytes.as_mut()).unwrap();
+    x.write_le(bytes.as_mut()).unwrap();
     let y = B::read(bytes.as_ref()).unwrap();
     assert_eq!(x, y);
 }

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -39,10 +39,16 @@ macro_rules! push_bits_to_vec {
 
 pub trait ToBits: Sized {
     /// Returns `self` as a boolean array in little-endian order.
-    fn to_bits_le(&self) -> anyhow::Result<Vec<bool>>;
+    fn to_bits_le(&self) -> Vec<bool>;
+
+    /// Returns `self` as a boolean array in big-endian order.
+    fn to_bits_be(&self) -> Vec<bool>;
 }
 
 pub trait FromBits: Sized {
-    /// Reads `Self` from `reader` as little-endian bits.
+    /// Reads `Self` from a boolean array in little-endian order.
     fn from_bits_le(bits: &[bool]) -> Self;
+
+    /// Reads `Self` from a boolean array in big-endian order.
+    fn from_bits_be(bits: &[bool]) -> Self;
 }

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::Vec;
+
+/// Takes as input a sequence of structs, and converts them to a series of little-endian bits.
+/// All traits that implement `ToBits` can be automatically converted to bits in this manner.
+#[macro_export]
+macro_rules! to_bits_le {
+    ($($x:expr),*) => ({
+        let mut buffer = $crate::vec![];
+        {$crate::push_bits_to_vec!(buffer, $($x),*)}.map(|_| buffer)
+    });
+}
+
+#[macro_export]
+macro_rules! push_bits_to_vec {
+    ($buffer:expr, $y:expr, $($x:expr),*) => ({
+        {ToBits::write_le(&$y, &mut $buffer)}.and({$crate::push_bits_to_vec!($buffer, $($x),*)})
+    });
+
+    ($buffer:expr, $x:expr) => ({
+        ToBits::write_le(&$x, &mut $buffer)
+    })
+}
+
+pub trait ToBits: Sized {
+    /// Returns `self` as a boolean array in little-endian order.
+    fn to_bits_le(&self) -> anyhow::Result<Vec<bool>>;
+}
+
+pub trait FromBits: Sized {
+    /// Reads `Self` from `reader` as little-endian bits.
+    fn from_bits_le(bits: &[bool]) -> Self;
+}

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -59,6 +59,7 @@ macro_rules! to_bytes_le {
     });
 }
 
+#[macro_export]
 macro_rules! push_to_vec {
     ($buffer:expr, $y:expr, $($x:expr),*) => ({
         {ToBytes::write_le(&$y, &mut $buffer)}.and({$crate::push_to_vec!($buffer, $($x),*)})

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -347,9 +347,13 @@ mod test {
     #[test]
     fn test_macro_empty() {
         let array: Vec<u8> = vec![];
-        let bytes: Vec<u8> = to_bytes![array].unwrap();
-        assert_eq!(&bytes, &array);
-        assert_eq!(bytes.len(), 0);
+        let bytes_a: Vec<u8> = to_bytes![array].unwrap();
+        assert_eq!(&array, &bytes_a);
+        assert_eq!(0, bytes_a.len());
+
+        let bytes_b: Vec<u8> = array.to_bytes_le().unwrap();
+        assert_eq!(&array, &bytes_b);
+        assert_eq!(0, bytes_b.len());
     }
 
     #[test]

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -83,6 +83,11 @@ pub trait ToBytes: Sized {
 pub trait FromBytes: Sized {
     /// Reads `Self` from `reader` as little-endian bytes.
     fn read_le<R: Read>(reader: R) -> IoResult<Self>;
+
+    /// Returns `Self` from a byte array in little-endian order.
+    fn from_bytes_le(bytes: &[u8]) -> anyhow::Result<Self> {
+        Ok(Self::read_le(bytes)?)
+    }
 }
 
 impl<const N: usize> ToBytes for [u8; N] {

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -153,26 +153,24 @@ impl<L: ToBytes, R: ToBytes> ToBytes for (L, R) {
 }
 
 /// Takes as input a sequence of structs, and converts them to a series of
-/// bytes. All traits that implement `Bytes` can be automatically converted to
+/// bytes. All traits that implement `ToBytes` can be automatically converted to
 /// bytes in this manner.
 #[macro_export]
 macro_rules! to_bytes {
     ($($x:expr),*) => ({
-        let mut buf = $crate::vec![];
-        {$crate::push_to_vec!(buf, $($x),*)}.map(|_| buf)
+        let mut buffer = $crate::vec![];
+        {$crate::push_to_vec!(buffer, $($x),*)}.map(|_| buffer)
     });
 }
 
 #[macro_export]
 macro_rules! push_to_vec {
-    ($buf:expr, $y:expr, $($x:expr),*) => ({
-        {
-            ToBytes::write_le(&$y, &mut $buf)
-        }.and({$crate::push_to_vec!($buf, $($x),*)})
+    ($buffer:expr, $y:expr, $($x:expr),*) => ({
+        {ToBytes::write_le(&$y, &mut $buffer)}.and({$crate::push_to_vec!($buffer, $($x),*)})
     });
 
-    ($buf:expr, $x:expr) => ({
-        ToBytes::write_le(&$x, &mut $buf)
+    ($buffer:expr, $x:expr) => ({
+        ToBytes::write_le(&$x, &mut $buffer)
     })
 }
 

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -56,7 +56,7 @@ pub trait ToBytes {
 
 pub trait FromBytes: Sized {
     /// Reads `Self` from `reader` as little-endian bytes.
-    fn read<R: Read>(reader: R) -> IoResult<Self>;
+    fn read_le<R: Read>(reader: R) -> IoResult<Self>;
 }
 
 impl<const N: usize> ToBytes for [u8; N] {
@@ -68,7 +68,7 @@ impl<const N: usize> ToBytes for [u8; N] {
 
 impl<const N: usize> FromBytes for [u8; N] {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut arr = [0u8; N];
         reader.read_exact(&mut arr)?;
         Ok(arr)
@@ -87,7 +87,7 @@ impl<const N: usize> ToBytes for [u16; N] {
 
 impl<const N: usize> FromBytes for [u16; N] {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut res = [0u16; N];
         for num in res.iter_mut() {
             let mut bytes = [0u8; 2];
@@ -110,7 +110,7 @@ impl<const N: usize> ToBytes for [u32; N] {
 
 impl<const N: usize> FromBytes for [u32; N] {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut res = [0u32; N];
         for num in res.iter_mut() {
             let mut bytes = [0u8; 4];
@@ -133,7 +133,7 @@ impl<const N: usize> ToBytes for [u64; N] {
 
 impl<const N: usize> FromBytes for [u64; N] {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut res = [0u64; N];
         for num in res.iter_mut() {
             let mut bytes = [0u8; 8];
@@ -185,7 +185,7 @@ impl ToBytes for u8 {
 
 impl FromBytes for u8 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut byte = [0u8];
         reader.read_exact(&mut byte)?;
         Ok(byte[0])
@@ -201,7 +201,7 @@ impl ToBytes for u16 {
 
 impl FromBytes for u16 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut bytes = [0u8; 2];
         reader.read_exact(&mut bytes)?;
         Ok(u16::from_le_bytes(bytes))
@@ -217,7 +217,7 @@ impl ToBytes for u32 {
 
 impl FromBytes for u32 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut bytes = [0u8; 4];
         reader.read_exact(&mut bytes)?;
         Ok(u32::from_le_bytes(bytes))
@@ -233,7 +233,7 @@ impl ToBytes for u64 {
 
 impl FromBytes for u64 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut bytes = [0u8; 8];
         reader.read_exact(&mut bytes)?;
         Ok(u64::from_le_bytes(bytes))
@@ -249,7 +249,7 @@ impl ToBytes for u128 {
 
 impl FromBytes for u128 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut bytes = [0u8; 16];
         reader.read_exact(&mut bytes)?;
         Ok(u128::from_le_bytes(bytes))
@@ -265,7 +265,7 @@ impl ToBytes for i64 {
 
 impl FromBytes for i64 {
     #[inline]
-    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let mut bytes = [0u8; 8];
         reader.read_exact(&mut bytes)?;
         Ok(i64::from_le_bytes(bytes))
@@ -281,7 +281,7 @@ impl ToBytes for () {
 
 impl FromBytes for () {
     #[inline]
-    fn read<R: Read>(_bytes: R) -> IoResult<Self> {
+    fn read_le<R: Read>(_bytes: R) -> IoResult<Self> {
         Ok(())
     }
 }
@@ -295,8 +295,8 @@ impl ToBytes for bool {
 
 impl FromBytes for bool {
     #[inline]
-    fn read<R: Read>(reader: R) -> IoResult<Self> {
-        match u8::read(reader) {
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        match u8::read_le(reader) {
             Ok(0) => Ok(false),
             Ok(1) => Ok(true),
             Ok(_) => Err(error("FromBytes::read failed")),

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -49,20 +49,20 @@ pub fn from_bits_le_to_bytes_le(bits: &[bool]) -> Vec<u8> {
     bytes
 }
 
-/// Takes as input a sequence of structs, and converts them to a series of bytes.
+/// Takes as input a sequence of structs, and converts them to a series of little-endian bytes.
 /// All traits that implement `ToBytes` can be automatically converted to bytes in this manner.
 #[macro_export]
 macro_rules! to_bytes_le {
     ($($x:expr),*) => ({
         let mut buffer = $crate::vec![];
-        {$crate::push_to_vec!(buffer, $($x),*)}.map(|_| buffer)
+        {$crate::push_bytes_to_vec!(buffer, $($x),*)}.map(|_| buffer)
     });
 }
 
 #[macro_export]
-macro_rules! push_to_vec {
+macro_rules! push_bytes_to_vec {
     ($buffer:expr, $y:expr, $($x:expr),*) => ({
-        {ToBytes::write_le(&$y, &mut $buffer)}.and({$crate::push_to_vec!($buffer, $($x),*)})
+        {ToBytes::write_le(&$y, &mut $buffer)}.and({$crate::push_bytes_to_vec!($buffer, $($x),*)})
     });
 
     ($buffer:expr, $x:expr) => ({

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -52,14 +52,13 @@ pub fn from_bits_le_to_bytes_le(bits: &[bool]) -> Vec<u8> {
 /// Takes as input a sequence of structs, and converts them to a series of bytes.
 /// All traits that implement `ToBytes` can be automatically converted to bytes in this manner.
 #[macro_export]
-macro_rules! to_bytes {
+macro_rules! to_bytes_le {
     ($($x:expr),*) => ({
         let mut buffer = $crate::vec![];
         {$crate::push_to_vec!(buffer, $($x),*)}.map(|_| buffer)
     });
 }
 
-#[macro_export]
 macro_rules! push_to_vec {
     ($buffer:expr, $y:expr, $($x:expr),*) => ({
         {ToBytes::write_le(&$y, &mut $buffer)}.and({$crate::push_to_vec!($buffer, $($x),*)})
@@ -76,7 +75,7 @@ pub trait ToBytes: Sized {
 
     /// Returns `self` as a byte array in little-endian order.
     fn to_bytes_le(&self) -> anyhow::Result<Vec<u8>> {
-        Ok(to_bytes![self]?)
+        Ok(to_bytes_le![self]?)
     }
 }
 
@@ -347,7 +346,7 @@ mod test {
     #[test]
     fn test_macro_empty() {
         let array: Vec<u8> = vec![];
-        let bytes_a: Vec<u8> = to_bytes![array].unwrap();
+        let bytes_a: Vec<u8> = to_bytes_le![array].unwrap();
         assert_eq!(&array, &bytes_a);
         assert_eq!(0, bytes_a.len());
 
@@ -361,7 +360,7 @@ mod test {
         let array1 = [1u8; 32];
         let array2 = [2u8; 16];
         let array3 = [3u8; 8];
-        let bytes = to_bytes![array1, array2, array3].unwrap();
+        let bytes = to_bytes_le![array1, array2, array3].unwrap();
         assert_eq!(bytes.len(), 56);
 
         let mut actual_bytes = Vec::new();

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -42,6 +42,10 @@ pub mod bititerator;
 pub use bititerator::*;
 
 #[macro_use]
+pub mod bits;
+pub use bits::*;
+
+#[macro_use]
 pub mod bytes;
 pub use bytes::*;
 

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -30,7 +30,7 @@ use std::{borrow::Cow, collections::BTreeMap, rc::Rc, sync::Arc};
 impl CanonicalSerialize for bool {
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        Ok(self.write(writer)?)
+        Ok(self.write_le(writer)?)
     }
 
     #[inline]

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -15,12 +15,13 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 pub use crate::{
-    bytes::{FromBytes, ToBytes},
     io::{
         Read,
         Write,
         {self},
     },
+    FromBytes,
+    ToBytes,
     Vec,
 };
 use crate::{serialize::traits::*, SerializationError};

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -43,7 +43,7 @@ impl CanonicalSerialize for bool {
 impl CanonicalDeserialize for bool {
     #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        Ok(bool::read(reader)?)
+        Ok(bool::read_le(reader)?)
     }
 }
 

--- a/utilities/src/serialize/traits.rs
+++ b/utilities/src/serialize/traits.rs
@@ -16,12 +16,13 @@
 
 use crate::SerializationError;
 pub use crate::{
-    bytes::{FromBytes, ToBytes},
     io::{
         Read,
         Write,
         {self},
     },
+    FromBytes,
+    ToBytes,
     Vec,
 };
 


### PR DESCRIPTION
## Motivation

- Adds `ToBytes::to_bytes_le(&self)` and `FromBytes::from_bytes_le(bytes: &[u8])`
- Adds `ToBits` and `FromBits` traits, and `to_bits_le![]` macro
- Renames `ToBytes::write()` to `ToBytes::write_le()`
- Renames `FromBytes::read()` to `FromBytes::read_le()`
- Renames `to_bytes![]` macro to `to_bytes_le![]`
- Updates `BigInteger` to use `FromBits` and `ToBits`