### PR TITLE
Updates trait `PrimeField` repr methods to correct convention

### DIFF
--- a/algorithms/benches/msm/variable_base.rs
+++ b/algorithms/benches/msm/variable_base.rs
@@ -33,7 +33,7 @@ fn variable_base(c: &mut Criterion) {
 
     let mut rng = XorShiftRng::seed_from_u64(234872845u64);
 
-    let v = (0..SAMPLES).map(|_| Fr::rand(&mut rng).into_repr()).collect::<Vec<_>>();
+    let v = (0..SAMPLES).map(|_| Fr::rand(&mut rng).to_repr()).collect::<Vec<_>>();
     let g = (0..SAMPLES)
         .map(|_| G1Projective::rand(&mut rng).into_affine())
         .collect::<Vec<_>>();

--- a/algorithms/src/commitment/pedersen.rs
+++ b/algorithms/src/commitment/pedersen.rs
@@ -56,7 +56,7 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CommitmentSch
         let mut output = self.parameters.crh.hash(&input)?;
 
         // Compute h^r.
-        let mut scalar_bits = BitIteratorBE::new(randomness.into_repr()).collect::<Vec<_>>();
+        let mut scalar_bits = BitIteratorBE::new(randomness.to_repr()).collect::<Vec<_>>();
         scalar_bits.reverse();
         for (bit, power) in scalar_bits.into_iter().zip(&self.parameters.random_base) {
             if bit {

--- a/algorithms/src/msm/fixed_base.rs
+++ b/algorithms/src/msm/fixed_base.rs
@@ -60,7 +60,7 @@ impl FixedBaseMSM {
         multiples_of_g: &[Vec<T>],
         scalar: &T::ScalarField,
     ) -> T {
-        let mut scalar_val = scalar.into_repr().to_bits_be();
+        let mut scalar_val = scalar.to_repr().to_bits_be();
         scalar_val.reverse();
 
         let mut res = multiples_of_g[0][0];

--- a/algorithms/src/msm/tests.rs
+++ b/algorithms/src/msm/tests.rs
@@ -43,7 +43,7 @@ fn variable_base_test_with_bls12() {
 
     let mut rng = XorShiftRng::seed_from_u64(234872845u64);
 
-    let v = (0..SAMPLES).map(|_| Fr::rand(&mut rng).into_repr()).collect::<Vec<_>>();
+    let v = (0..SAMPLES).map(|_| Fr::rand(&mut rng).to_repr()).collect::<Vec<_>>();
     let g = (0..SAMPLES)
         .map(|_| G1Projective::rand(&mut rng).into_affine())
         .collect::<Vec<_>>();
@@ -61,7 +61,7 @@ fn variable_base_test_with_bls12_unequal_numbers() {
     let mut rng = XorShiftRng::seed_from_u64(234872845u64);
 
     let v = (0..SAMPLES - 1)
-        .map(|_| Fr::rand(&mut rng).into_repr())
+        .map(|_| Fr::rand(&mut rng).to_repr())
         .collect::<Vec<_>>();
     let g = (0..SAMPLES)
         .map(|_| G1Projective::rand(&mut rng).into_affine())

--- a/algorithms/src/msm/variable_base/cuda.rs
+++ b/algorithms/src/msm/variable_base/cuda.rs
@@ -376,15 +376,15 @@ mod tests {
         let output: Vec<Fq> = run_roundtrip("mul_test", &inputs[..]);
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] * &input[1];
-            let output = output.into_repr_raw();
-            let rust_out = rust_out.into_repr_raw();
+            let output = output.into_repr_unsafe();
+            let rust_out = rust_out.into_repr_unsafe();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].into_repr_raw().as_ref(),
-                    input[1].into_repr_raw().as_ref()
+                    input[0].into_repr_unsafe().as_ref(),
+                    input[1].into_repr_unsafe().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
@@ -398,12 +398,12 @@ mod tests {
         let output: Vec<Fq> = run_roundtrip("sqr_test", &inputs[..]);
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0].square();
-            let output = output.into_repr_raw();
-            let rust_out = rust_out.into_repr_raw();
+            let output = output.into_repr_unsafe();
+            let rust_out = rust_out.into_repr_unsafe();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
-                eprintln!("inputs {:?}", input[0].into_repr_raw().as_ref());
+                eprintln!("inputs {:?}", input[0].into_repr_unsafe().as_ref());
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
         }
@@ -417,15 +417,15 @@ mod tests {
 
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] + &input[1];
-            let output = output.into_repr_raw();
-            let rust_out = rust_out.into_repr_raw();
+            let output = output.into_repr_unsafe();
+            let rust_out = rust_out.into_repr_unsafe();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].into_repr_raw().as_ref(),
-                    input[1].into_repr_raw().as_ref()
+                    input[0].into_repr_unsafe().as_ref(),
+                    input[1].into_repr_unsafe().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
@@ -519,14 +519,14 @@ mod tests {
 
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] - &input[1];
-            let output = output.into_repr_raw();
-            let rust_out = rust_out.into_repr_raw();
+            let output = output.into_repr_unsafe();
+            let rust_out = rust_out.into_repr_unsafe();
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].into_repr_raw().as_ref(),
-                    input[1].into_repr_raw().as_ref()
+                    input[0].into_repr_unsafe().as_ref(),
+                    input[1].into_repr_unsafe().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }

--- a/algorithms/src/msm/variable_base/cuda.rs
+++ b/algorithms/src/msm/variable_base/cuda.rs
@@ -376,15 +376,15 @@ mod tests {
         let output: Vec<Fq> = run_roundtrip("mul_test", &inputs[..]);
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] * &input[1];
-            let output = output.to_repr_unsafe();
-            let rust_out = rust_out.to_repr_unsafe();
+            let output = output.to_repr_unchecked();
+            let rust_out = rust_out.to_repr_unchecked();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].to_repr_unsafe().as_ref(),
-                    input[1].to_repr_unsafe().as_ref()
+                    input[0].to_repr_unchecked().as_ref(),
+                    input[1].to_repr_unchecked().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
@@ -398,12 +398,12 @@ mod tests {
         let output: Vec<Fq> = run_roundtrip("sqr_test", &inputs[..]);
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0].square();
-            let output = output.to_repr_unsafe();
-            let rust_out = rust_out.to_repr_unsafe();
+            let output = output.to_repr_unchecked();
+            let rust_out = rust_out.to_repr_unchecked();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
-                eprintln!("inputs {:?}", input[0].to_repr_unsafe().as_ref());
+                eprintln!("inputs {:?}", input[0].to_repr_unchecked().as_ref());
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
         }
@@ -417,15 +417,15 @@ mod tests {
 
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] + &input[1];
-            let output = output.to_repr_unsafe();
-            let rust_out = rust_out.to_repr_unsafe();
+            let output = output.to_repr_unchecked();
+            let rust_out = rust_out.to_repr_unchecked();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].to_repr_unsafe().as_ref(),
-                    input[1].to_repr_unsafe().as_ref()
+                    input[0].to_repr_unchecked().as_ref(),
+                    input[1].to_repr_unchecked().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
@@ -519,14 +519,14 @@ mod tests {
 
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] - &input[1];
-            let output = output.to_repr_unsafe();
-            let rust_out = rust_out.to_repr_unsafe();
+            let output = output.to_repr_unchecked();
+            let rust_out = rust_out.to_repr_unchecked();
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].to_repr_unsafe().as_ref(),
-                    input[1].to_repr_unsafe().as_ref()
+                    input[0].to_repr_unchecked().as_ref(),
+                    input[1].to_repr_unchecked().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }

--- a/algorithms/src/msm/variable_base/cuda.rs
+++ b/algorithms/src/msm/variable_base/cuda.rs
@@ -376,15 +376,15 @@ mod tests {
         let output: Vec<Fq> = run_roundtrip("mul_test", &inputs[..]);
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] * &input[1];
-            let output = output.into_repr_unsafe();
-            let rust_out = rust_out.into_repr_unsafe();
+            let output = output.to_repr_unsafe();
+            let rust_out = rust_out.to_repr_unsafe();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].into_repr_unsafe().as_ref(),
-                    input[1].into_repr_unsafe().as_ref()
+                    input[0].to_repr_unsafe().as_ref(),
+                    input[1].to_repr_unsafe().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
@@ -398,12 +398,12 @@ mod tests {
         let output: Vec<Fq> = run_roundtrip("sqr_test", &inputs[..]);
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0].square();
-            let output = output.into_repr_unsafe();
-            let rust_out = rust_out.into_repr_unsafe();
+            let output = output.to_repr_unsafe();
+            let rust_out = rust_out.to_repr_unsafe();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
-                eprintln!("inputs {:?}", input[0].into_repr_unsafe().as_ref());
+                eprintln!("inputs {:?}", input[0].to_repr_unsafe().as_ref());
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
         }
@@ -417,15 +417,15 @@ mod tests {
 
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] + &input[1];
-            let output = output.into_repr_unsafe();
-            let rust_out = rust_out.into_repr_unsafe();
+            let output = output.to_repr_unsafe();
+            let rust_out = rust_out.to_repr_unsafe();
 
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].into_repr_unsafe().as_ref(),
-                    input[1].into_repr_unsafe().as_ref()
+                    input[0].to_repr_unsafe().as_ref(),
+                    input[1].to_repr_unsafe().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }
@@ -519,14 +519,14 @@ mod tests {
 
         for (input, output) in inputs.iter().zip(output.iter()) {
             let rust_out = input[0] - &input[1];
-            let output = output.into_repr_unsafe();
-            let rust_out = rust_out.into_repr_unsafe();
+            let output = output.to_repr_unsafe();
+            let rust_out = rust_out.to_repr_unsafe();
             if rust_out != output {
                 eprintln!("test failed: {:?} != {:?}", rust_out.as_ref(), output.as_ref());
                 eprintln!(
                     "inputs {:?}, {:?}",
-                    input[0].into_repr_unsafe().as_ref(),
-                    input[1].into_repr_unsafe().as_ref()
+                    input[0].to_repr_unsafe().as_ref(),
+                    input[1].to_repr_unsafe().as_ref()
                 );
                 assert_eq!(rust_out.as_ref(), output.as_ref());
             }

--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -81,7 +81,7 @@ mod tests {
     fn test_data(seed: u64, samples: usize) -> (Vec<G1Affine>, Vec<BigInteger256>) {
         let mut rng = XorShiftRng::seed_from_u64(seed);
 
-        let v = (0..samples).map(|_| Fr::rand(&mut rng).into_repr()).collect::<Vec<_>>();
+        let v = (0..samples).map(|_| Fr::rand(&mut rng).to_repr()).collect::<Vec<_>>();
         let g = (0..samples)
             .map(|_| G1Projective::rand(&mut rng).into_affine())
             .collect::<Vec<_>>();

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -32,7 +32,7 @@ pub fn msm_standard<G: AffineCurve>(
     };
 
     let num_bits = <G::ScalarField as PrimeField>::Parameters::MODULUS_BITS as usize;
-    let fr_one = G::ScalarField::one().into_repr();
+    let fr_one = G::ScalarField::one().to_repr();
 
     let zero = G::zero().into_projective();
     let window_starts: Vec<_> = (0..num_bits).step_by(c).collect();

--- a/algorithms/src/snark/gm17/prover.rs
+++ b/algorithms/src/snark/gm17/prover.rs
@@ -258,20 +258,20 @@ where
 
     let input_assignment = full_input_assignment[1..prover.num_public_variables]
         .iter()
-        .map(|s| s.into_repr())
+        .map(|s| s.to_repr())
         .collect::<Vec<_>>();
 
     let aux_assignment = cfg_into_iter!(full_input_assignment[prover.num_public_variables..])
-        .map(|s| s.into_repr())
+        .map(|s| s.to_repr())
         .collect::<Vec<_>>();
     drop(full_input_assignment);
 
     let h_input = h[0..prover.num_public_variables]
         .iter()
-        .map(|s| s.into_repr())
+        .map(|s| s.to_repr())
         .collect::<Vec<_>>();
     let h_aux = cfg_into_iter!(h[prover.num_public_variables..])
-        .map(|s| s.into_repr())
+        .map(|s| s.to_repr())
         .collect::<Vec<_>>();
     drop(h);
 

--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -165,16 +165,16 @@ where
         .public_variables
         .iter()
         .skip(1)
-        .map(|s| s.into_repr())
+        .map(|s| s.to_repr())
         .collect::<Vec<_>>();
 
     let aux_assignment = cfg_into_iter!(prover.private_variables)
-        .map(|s| s.into_repr())
+        .map(|s| s.to_repr())
         .collect::<Vec<_>>();
 
     let assignment = [&input_assignment[..], &aux_assignment[..]].concat();
 
-    let h_assignment = cfg_into_iter!(h).map(|s| s.into_repr()).collect::<Vec<_>>();
+    let h_assignment = cfg_into_iter!(h).map(|s| s.to_repr()).collect::<Vec<_>>();
 
     // Compute A
     let a_acc_time = start_timer!(|| "Compute A");

--- a/curves/benches/bls12_377/fq.rs
+++ b/curves/benches/bls12_377/fq.rs
@@ -293,7 +293,7 @@ pub(crate) fn bench_fq_into_repr(c: &mut Criterion) {
     c.bench_function("bls12_377: fq_into_repr", |c| {
         c.iter(|| {
             count = (count + 1) % SAMPLES;
-            v[count].into_repr()
+            v[count].to_repr()
         })
     });
 }
@@ -303,7 +303,7 @@ pub(crate) fn bench_fq_from_repr(c: &mut Criterion) {
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    let v: Vec<FqRepr> = (0..SAMPLES).map(|_| Fq::rand(&mut rng).into_repr()).collect();
+    let v: Vec<FqRepr> = (0..SAMPLES).map(|_| Fq::rand(&mut rng).to_repr()).collect();
 
     let mut count = 0;
     c.bench_function("bls12_377: fq_from_repr", |c| {

--- a/curves/benches/bls12_377/fr.rs
+++ b/curves/benches/bls12_377/fr.rs
@@ -293,7 +293,7 @@ pub(crate) fn bench_fr_into_repr(c: &mut Criterion) {
     c.bench_function("bls12_377: fr_into_repr", |c| {
         c.iter(|| {
             count = (count + 1) % SAMPLES;
-            v[count].into_repr()
+            v[count].to_repr()
         })
     });
 }
@@ -303,7 +303,7 @@ pub(crate) fn bench_fr_from_repr(c: &mut Criterion) {
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    let v: Vec<FrRepr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng).into_repr()).collect();
+    let v: Vec<FrRepr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng).to_repr()).collect();
 
     let mut count = 0;
     c.bench_function("bls12_377: fr_from_repr", |c| {

--- a/curves/benches/bw6_761/fq.rs
+++ b/curves/benches/bw6_761/fq.rs
@@ -293,7 +293,7 @@ pub fn bench_fq_into_repr(c: &mut Criterion) {
     c.bench_function("bw6_761: fq_into_repr", |c| {
         c.iter(|| {
             count = (count + 1) % SAMPLES;
-            v[count].into_repr()
+            v[count].to_repr()
         })
     });
 }
@@ -303,7 +303,7 @@ pub fn bench_fq_from_repr(c: &mut Criterion) {
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    let v: Vec<FqRepr> = (0..SAMPLES).map(|_| Fq::rand(&mut rng).into_repr()).collect();
+    let v: Vec<FqRepr> = (0..SAMPLES).map(|_| Fq::rand(&mut rng).to_repr()).collect();
 
     let mut count = 0;
     c.bench_function("bw6_761: fq_from_repr", |c| {

--- a/curves/benches/bw6_761/fr.rs
+++ b/curves/benches/bw6_761/fr.rs
@@ -293,7 +293,7 @@ pub fn bench_fr_into_repr(c: &mut Criterion) {
     c.bench_function("bw6_761: fr_into_repr", |c| {
         c.iter(|| {
             count = (count + 1) % SAMPLES;
-            v[count].into_repr()
+            v[count].to_repr()
         })
     });
 }
@@ -303,7 +303,7 @@ pub fn bench_fr_from_repr(c: &mut Criterion) {
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-    let v: Vec<FrRepr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng).into_repr()).collect();
+    let v: Vec<FrRepr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng).to_repr()).collect();
 
     let mut count = 0;
     c.bench_function("bw6_761: fr_from_repr", |c| {

--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -614,7 +614,7 @@ fn test_bilinearity() {
 
     let ans1 = Bls12_377::pairing(sa, b);
     let ans2 = Bls12_377::pairing(a, sb);
-    let ans3 = Bls12_377::pairing(a, b).pow(s.into_repr());
+    let ans3 = Bls12_377::pairing(a, b).pow(s.to_repr());
 
     assert_eq!(ans1, ans2);
     assert_eq!(ans2, ans3);

--- a/curves/src/bw6_761/tests.rs
+++ b/curves/src/bw6_761/tests.rs
@@ -128,7 +128,7 @@ fn test_bilinearity() {
 
     let ans1 = BW6_761::pairing(sa, b);
     let ans2 = BW6_761::pairing(a, sb);
-    let ans3 = BW6_761::pairing(a, b).pow(s.into_repr());
+    let ans3 = BW6_761::pairing(a, b).pow(s.to_repr());
 
     assert_eq!(ans1, ans2);
     assert_eq!(ans2, ans3);

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -251,7 +251,7 @@ impl<P: Parameters> Mul<P::ScalarField> for Affine<P> {
     type Output = Self;
 
     fn mul(self, other: P::ScalarField) -> Self {
-        self.mul_bits(BitIteratorBE::new(other.into_repr())).into()
+        self.mul_bits(BitIteratorBE::new(other.to_repr())).into()
     }
 }
 

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -509,7 +509,7 @@ impl<P: Parameters> Mul<P::ScalarField> for Projective<P> {
 
         let mut found_one = false;
 
-        for i in BitIteratorBE::new(other.into_repr()) {
+        for i in BitIteratorBE::new(other.to_repr()) {
             if found_one {
                 res.double_in_place();
             } else {

--- a/curves/src/templates/short_weierstrass_projective/affine.rs
+++ b/curves/src/templates/short_weierstrass_projective/affine.rs
@@ -237,7 +237,7 @@ impl<P: Parameters> Mul<P::ScalarField> for Affine<P> {
     type Output = Self;
 
     fn mul(self, other: P::ScalarField) -> Self {
-        self.mul_bits(BitIteratorBE::new(other.into_repr())).into()
+        self.mul_bits(BitIteratorBE::new(other.to_repr())).into()
     }
 }
 

--- a/curves/src/templates/short_weierstrass_projective/projective.rs
+++ b/curves/src/templates/short_weierstrass_projective/projective.rs
@@ -388,7 +388,7 @@ impl<P: Parameters> Mul<P::ScalarField> for Projective<P> {
 
         let mut found_one = false;
 
-        for i in BitIteratorBE::new(other.into_repr()) {
+        for i in BitIteratorBE::new(other.to_repr()) {
             if found_one {
                 res.double_in_place();
             } else {

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -285,7 +285,7 @@ impl<P: Parameters> Mul<P::ScalarField> for Affine<P> {
     type Output = Self;
 
     fn mul(self, other: P::ScalarField) -> Self {
-        self.mul_bits(BitIteratorBE::new(other.into_repr())).into()
+        self.mul_bits(BitIteratorBE::new(other.to_repr())).into()
     }
 }
 

--- a/curves/src/templates/twisted_edwards_extended/projective.rs
+++ b/curves/src/templates/twisted_edwards_extended/projective.rs
@@ -346,7 +346,7 @@ impl<P: Parameters> Mul<P::ScalarField> for Projective<P> {
 
         let mut found_one = false;
 
-        for i in BitIteratorBE::new(other.into_repr()) {
+        for i in BitIteratorBE::new(other.to_repr()) {
             if found_one {
                 res.double_in_place();
             } else {

--- a/dpc/src/testnet1/record/encoded.rs
+++ b/dpc/src/testnet1/record/encoded.rs
@@ -176,8 +176,8 @@ impl<C: Testnet1Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
 
         // Process birth_program_id and death_program_id. (Assumption 2 and 3 applies)
 
-        let birth_program_id_biginteger = Self::OuterField::read_le(birth_program_id)?.into_repr();
-        let death_program_id_biginteger = Self::OuterField::read_le(death_program_id)?.into_repr();
+        let birth_program_id_biginteger = Self::OuterField::read_le(birth_program_id)?.to_repr();
+        let death_program_id_biginteger = Self::OuterField::read_le(death_program_id)?.to_repr();
 
         let mut birth_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);
         let mut death_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);

--- a/dpc/src/testnet2/record/encoded.rs
+++ b/dpc/src/testnet2/record/encoded.rs
@@ -177,8 +177,8 @@ impl<C: Testnet2Components, P: MontgomeryParameters + TwistedEdwardsParameters, 
 
         // Process birth_program_id and death_program_id. (Assumption 2 and 3 applies)
 
-        let birth_program_id_biginteger = Self::OuterField::read_le(birth_program_id)?.into_repr();
-        let death_program_id_biginteger = Self::OuterField::read_le(death_program_id)?.into_repr();
+        let birth_program_id_biginteger = Self::OuterField::read_le(birth_program_id)?.to_repr();
+        let death_program_id_biginteger = Self::OuterField::read_le(death_program_id)?.to_repr();
 
         let mut birth_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);
         let mut death_program_id_bits = Vec::with_capacity(Self::INNER_FIELD_BITSIZE);

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -315,7 +315,7 @@ impl<P: Fp256Parameters> PrimeField for Fp256<P> {
     }
 
     #[inline]
-    fn into_repr(&self) -> BigInteger {
+    fn to_repr(&self) -> BigInteger {
         let mut r = *self;
         r.mont_reduce((self.0).0[0], (self.0).0[1], (self.0).0[2], (self.0).0[3], 0, 0, 0, 0);
         r.0
@@ -328,7 +328,7 @@ impl<P: Fp256Parameters> PrimeField for Fp256<P> {
     }
 
     #[inline]
-    fn into_repr_unsafe(&self) -> BigInteger {
+    fn to_repr_unsafe(&self) -> BigInteger {
         let r = *self;
         r.0
     }
@@ -401,7 +401,7 @@ impl_mul_div_from_field_ref!(Fp256, Fp256Parameters);
 impl<P: Fp256Parameters> ToBytes for Fp256<P> {
     #[inline]
     fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.into_repr().write_le(writer)
+        self.to_repr().write_le(writer)
     }
 }
 
@@ -419,7 +419,7 @@ impl<P: Fp256Parameters> FromBytes for Fp256<P> {
 impl<P: Fp256Parameters> Ord for Fp256<P> {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.into_repr().cmp(&other.into_repr())
+        self.to_repr().cmp(&other.to_repr())
     }
 }
 
@@ -484,14 +484,14 @@ impl<P: Fp256Parameters> FromStr for Fp256<P> {
 impl<P: Fp256Parameters> Debug for Fp256<P> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "Fp256({})", self.into_repr())
+        write!(f, "Fp256({})", self.to_repr())
     }
 }
 
 impl<P: Fp256Parameters> Display for Fp256<P> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", self.into_repr())
+        write!(f, "{}", self.to_repr())
     }
 }
 

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -322,13 +322,13 @@ impl<P: Fp256Parameters> PrimeField for Fp256<P> {
     }
 
     #[inline]
-    fn from_repr_unsafe(r: BigInteger) -> Self {
+    fn from_repr_unchecked(r: BigInteger) -> Self {
         let r = Fp256(r, PhantomData);
         if r.is_valid() { r } else { Self::zero() }
     }
 
     #[inline]
-    fn to_repr_unsafe(&self) -> BigInteger {
+    fn to_repr_unchecked(&self) -> BigInteger {
         let r = *self;
         r.0
     }
@@ -622,7 +622,7 @@ impl<P: Fp256Parameters + PoseidonMDSParameters> PoseidonMDSField for Fp256<P> {
         for row in P::POSEIDON_MDS.iter() {
             mds.push(
                 row.iter()
-                    .map(|b| Self::from_repr_unsafe(*b))
+                    .map(|b| Self::from_repr_unchecked(*b))
                     .collect::<Vec<Self>>()
                     .to_vec(),
             );

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -322,13 +322,13 @@ impl<P: Fp256Parameters> PrimeField for Fp256<P> {
     }
 
     #[inline]
-    fn from_repr_raw(r: BigInteger) -> Self {
+    fn from_repr_unsafe(r: BigInteger) -> Self {
         let r = Fp256(r, PhantomData);
         if r.is_valid() { r } else { Self::zero() }
     }
 
     #[inline]
-    fn into_repr_raw(&self) -> BigInteger {
+    fn into_repr_unsafe(&self) -> BigInteger {
         let r = *self;
         r.0
     }
@@ -622,7 +622,7 @@ impl<P: Fp256Parameters + PoseidonMDSParameters> PoseidonMDSField for Fp256<P> {
         for row in P::POSEIDON_MDS.iter() {
             mds.push(
                 row.iter()
-                    .map(|b| Self::from_repr_raw(*b))
+                    .map(|b| Self::from_repr_unsafe(*b))
                     .collect::<Vec<Self>>()
                     .to_vec(),
             );

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -389,13 +389,13 @@ impl<P: Fp384Parameters> PrimeField for Fp384<P> {
     }
 
     #[inline]
-    fn from_repr_raw(r: BigInteger) -> Self {
+    fn from_repr_unsafe(r: BigInteger) -> Self {
         let r = Fp384(r, PhantomData);
         if r.is_valid() { r } else { Self::zero() }
     }
 
     #[inline]
-    fn into_repr_raw(&self) -> BigInteger {
+    fn into_repr_unsafe(&self) -> BigInteger {
         self.0
     }
 }
@@ -705,7 +705,7 @@ impl<P: Fp384Parameters + PoseidonMDSParameters> PoseidonMDSField for Fp384<P> {
         for row in P::POSEIDON_MDS.iter() {
             mds.push(
                 row.iter()
-                    .map(|b| Self::from_repr_raw(*b))
+                    .map(|b| Self::from_repr_unsafe(*b))
                     .collect::<Vec<Self>>()
                     .to_vec(),
             );

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -389,13 +389,13 @@ impl<P: Fp384Parameters> PrimeField for Fp384<P> {
     }
 
     #[inline]
-    fn from_repr_unsafe(r: BigInteger) -> Self {
+    fn from_repr_unchecked(r: BigInteger) -> Self {
         let r = Fp384(r, PhantomData);
         if r.is_valid() { r } else { Self::zero() }
     }
 
     #[inline]
-    fn to_repr_unsafe(&self) -> BigInteger {
+    fn to_repr_unchecked(&self) -> BigInteger {
         self.0
     }
 }
@@ -705,7 +705,7 @@ impl<P: Fp384Parameters + PoseidonMDSParameters> PoseidonMDSField for Fp384<P> {
         for row in P::POSEIDON_MDS.iter() {
             mds.push(
                 row.iter()
-                    .map(|b| Self::from_repr_unsafe(*b))
+                    .map(|b| Self::from_repr_unchecked(*b))
                     .collect::<Vec<Self>>()
                     .to_vec(),
             );

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -369,7 +369,7 @@ impl<P: Fp384Parameters> PrimeField for Fp384<P> {
     }
 
     #[inline]
-    fn into_repr(&self) -> BigInteger {
+    fn to_repr(&self) -> BigInteger {
         let mut r = *self;
         r.mont_reduce(
             (self.0).0[0],
@@ -395,7 +395,7 @@ impl<P: Fp384Parameters> PrimeField for Fp384<P> {
     }
 
     #[inline]
-    fn into_repr_unsafe(&self) -> BigInteger {
+    fn to_repr_unsafe(&self) -> BigInteger {
         self.0
     }
 }
@@ -451,7 +451,7 @@ impl<P: Fp384Parameters> SquareRootField for Fp384<P> {
 impl<P: Fp384Parameters> Ord for Fp384<P> {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.into_repr().cmp(&other.into_repr())
+        self.to_repr().cmp(&other.to_repr())
     }
 }
 
@@ -476,7 +476,7 @@ impl_mul_div_from_field_ref!(Fp384, Fp384Parameters);
 impl<P: Fp384Parameters> ToBytes for Fp384<P> {
     #[inline]
     fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.into_repr().write_le(writer)
+        self.to_repr().write_le(writer)
     }
 }
 
@@ -544,14 +544,14 @@ impl<P: Fp384Parameters> FromStr for Fp384<P> {
 impl<P: Fp384Parameters> Debug for Fp384<P> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "Fp384({})", self.into_repr())
+        write!(f, "Fp384({})", self.to_repr())
     }
 }
 
 impl<P: Fp384Parameters> Display for Fp384<P> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", self.into_repr())
+        write!(f, "{}", self.to_repr())
     }
 }
 

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -701,13 +701,13 @@ impl<P: Fp768Parameters> PrimeField for Fp768<P> {
     }
 
     #[inline]
-    fn from_repr_raw(r: BigInteger) -> Self {
+    fn from_repr_unsafe(r: BigInteger) -> Self {
         let r = Fp768(r, PhantomData);
         if r.is_valid() { r } else { Self::zero() }
     }
 
     #[inline]
-    fn into_repr_raw(&self) -> BigInteger {
+    fn into_repr_unsafe(&self) -> BigInteger {
         let r = *self;
         r.0
     }
@@ -1163,7 +1163,7 @@ impl<P: Fp768Parameters + PoseidonMDSParameters> PoseidonMDSField for Fp768<P> {
         for row in P::POSEIDON_MDS.iter() {
             mds.push(
                 row.iter()
-                    .map(|b| Self::from_repr_raw(*b))
+                    .map(|b| Self::from_repr_unsafe(*b))
                     .collect::<Vec<Self>>()
                     .to_vec(),
             );

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -701,13 +701,13 @@ impl<P: Fp768Parameters> PrimeField for Fp768<P> {
     }
 
     #[inline]
-    fn from_repr_unsafe(r: BigInteger) -> Self {
+    fn from_repr_unchecked(r: BigInteger) -> Self {
         let r = Fp768(r, PhantomData);
         if r.is_valid() { r } else { Self::zero() }
     }
 
     #[inline]
-    fn to_repr_unsafe(&self) -> BigInteger {
+    fn to_repr_unchecked(&self) -> BigInteger {
         let r = *self;
         r.0
     }
@@ -1163,7 +1163,7 @@ impl<P: Fp768Parameters + PoseidonMDSParameters> PoseidonMDSField for Fp768<P> {
         for row in P::POSEIDON_MDS.iter() {
             mds.push(
                 row.iter()
-                    .map(|b| Self::from_repr_unsafe(*b))
+                    .map(|b| Self::from_repr_unchecked(*b))
                     .collect::<Vec<Self>>()
                     .to_vec(),
             );

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -669,7 +669,7 @@ impl<P: Fp768Parameters> PrimeField for Fp768<P> {
     }
 
     #[inline]
-    fn into_repr(&self) -> BigInteger {
+    fn to_repr(&self) -> BigInteger {
         let mut r = *self;
         r.mont_reduce(
             (self.0).0[0],
@@ -707,7 +707,7 @@ impl<P: Fp768Parameters> PrimeField for Fp768<P> {
     }
 
     #[inline]
-    fn into_repr_unsafe(&self) -> BigInteger {
+    fn to_repr_unsafe(&self) -> BigInteger {
         let r = *self;
         r.0
     }
@@ -786,7 +786,7 @@ impl<P: Fp768Parameters> SquareRootField for Fp768<P> {
 impl<P: Fp768Parameters> Ord for Fp768<P> {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.into_repr().cmp(&other.into_repr())
+        self.to_repr().cmp(&other.to_repr())
     }
 }
 
@@ -811,7 +811,7 @@ impl_mul_div_from_field_ref!(Fp768, Fp768Parameters);
 impl<P: Fp768Parameters> ToBytes for Fp768<P> {
     #[inline]
     fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
-        self.into_repr().write_le(writer)
+        self.to_repr().write_le(writer)
     }
 }
 
@@ -879,14 +879,14 @@ impl<P: Fp768Parameters> FromStr for Fp768<P> {
 impl<P: Fp768Parameters> Debug for Fp768<P> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "Fp768({})", self.into_repr())
+        write!(f, "Fp768({})", self.to_repr())
     }
 }
 
 impl<P: Fp768Parameters> Display for Fp768<P> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", self.into_repr())
+        write!(f, "{}", self.to_repr())
     }
 }
 

--- a/fields/src/macros.rs
+++ b/fields/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! impl_field_into_biginteger {
     ($field: ident, $biginteger: ident, $parameters: ident) => {
         impl<P: $parameters> Into<$biginteger> for $field<P> {
             fn into(self) -> $biginteger {
-                self.into_repr()
+                self.to_repr()
             }
         }
     };

--- a/fields/src/tests_field.rs
+++ b/fields/src/tests_field.rs
@@ -365,12 +365,12 @@ pub fn fft_field_test<F: PrimeField + FftField>() {
 
 pub fn primefield_test<F: PrimeField>() {
     let one = F::one();
-    assert_eq!(F::from_repr(one.into_repr()).unwrap(), one);
+    assert_eq!(F::from_repr(one.to_repr()).unwrap(), one);
     assert_eq!(F::from_str("1").ok().unwrap(), one);
     assert_eq!(F::from_str(&one.to_string()).ok().unwrap(), one);
 
     let two = F::one().double();
-    assert_eq!(F::from_repr(two.into_repr()).unwrap(), two);
+    assert_eq!(F::from_repr(two.to_repr()).unwrap(), two);
     assert_eq!(F::from_str("2").ok().unwrap(), two);
     assert_eq!(F::from_str(&two.to_string()).ok().unwrap(), two);
 

--- a/fields/src/traits/prime_field.rs
+++ b/fields/src/traits/prime_field.rs
@@ -32,10 +32,10 @@ pub trait PrimeField: FftField<FftParameters = <Self as PrimeField>::Parameters>
     fn into_repr(&self) -> Self::BigInteger;
 
     /// Returns a prime field element from its underlying raw representation.
-    fn from_repr_raw(repr: Self::BigInteger) -> Self;
+    fn from_repr_unsafe(repr: Self::BigInteger) -> Self;
 
     /// Returns the underlying raw representation of the prime field element.
-    fn into_repr_raw(&self) -> Self::BigInteger;
+    fn into_repr_unsafe(&self) -> Self::BigInteger;
 
     /// Returns the field size in bits.
     fn size_in_bits() -> usize {

--- a/fields/src/traits/prime_field.rs
+++ b/fields/src/traits/prime_field.rs
@@ -32,10 +32,10 @@ pub trait PrimeField: FftField<FftParameters = <Self as PrimeField>::Parameters>
     fn to_repr(&self) -> Self::BigInteger;
 
     /// Returns a prime field element from its underlying raw representation.
-    fn from_repr_unsafe(repr: Self::BigInteger) -> Self;
+    fn from_repr_unchecked(repr: Self::BigInteger) -> Self;
 
     /// Returns the underlying raw representation of the prime field element.
-    fn to_repr_unsafe(&self) -> Self::BigInteger;
+    fn to_repr_unchecked(&self) -> Self::BigInteger;
 
     /// Returns the field size in bits.
     fn size_in_bits() -> usize {

--- a/fields/src/traits/prime_field.rs
+++ b/fields/src/traits/prime_field.rs
@@ -29,13 +29,13 @@ pub trait PrimeField: FftField<FftParameters = <Self as PrimeField>::Parameters>
     fn from_repr(repr: Self::BigInteger) -> Option<Self>;
 
     /// Returns the underlying representation of the prime field element.
-    fn into_repr(&self) -> Self::BigInteger;
+    fn to_repr(&self) -> Self::BigInteger;
 
     /// Returns a prime field element from its underlying raw representation.
     fn from_repr_unsafe(repr: Self::BigInteger) -> Self;
 
     /// Returns the underlying raw representation of the prime field element.
-    fn into_repr_unsafe(&self) -> Self::BigInteger;
+    fn to_repr_unsafe(&self) -> Self::BigInteger;
 
     /// Returns the field size in bits.
     fn size_in_bits() -> usize {

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -515,7 +515,7 @@ mod test {
             {
                 let mut cs = cs.ns(|| "Allocate Input");
                 for (i, input) in inputs.enumerate() {
-                    let mut input_bits = BitIteratorBE::new(input.into_repr()).collect::<Vec<_>>();
+                    let mut input_bits = BitIteratorBE::new(input.to_repr()).collect::<Vec<_>>();
                     // Input must be in little-endian, but BitIterator outputs in big-endian.
                     input_bits.reverse();
 
@@ -586,7 +586,7 @@ mod test {
             {
                 let mut cs = cs.ns(|| "Allocate Input");
                 for (i, input) in inputs.into_iter().enumerate() {
-                    let mut input_bits = BitIteratorBE::new(input.into_repr()).collect::<Vec<_>>();
+                    let mut input_bits = BitIteratorBE::new(input.to_repr()).collect::<Vec<_>>();
                     // Input must be in little-endian, but BitIterator outputs in big-endian.
                     input_bits.reverse();
 
@@ -660,7 +660,7 @@ mod test {
             {
                 let mut cs = cs.ns(|| "Allocate Input");
                 for (i, input) in inputs.enumerate() {
-                    let mut input_bits = BitIteratorBE::new(input.into_repr()).collect::<Vec<_>>();
+                    let mut input_bits = BitIteratorBE::new(input.to_repr()).collect::<Vec<_>>();
                     // Input must be in little-endian, but BitIterator outputs in big-endian.
                     input_bits.reverse();
 

--- a/gadgets/src/algorithms/snark/tests.rs
+++ b/gadgets/src/algorithms/snark/tests.rs
@@ -120,7 +120,7 @@ fn gm17_verifier_test() {
         {
             let mut cs = cs.ns(|| "Allocate Input");
             for (i, input) in inputs.into_iter().enumerate() {
-                let mut input_bits = BitIteratorBE::new(input.into_repr()).collect::<Vec<_>>();
+                let mut input_bits = BitIteratorBE::new(input.to_repr()).collect::<Vec<_>>();
                 // Input must be in little-endian, but BitIterator outputs in big-endian.
                 input_bits.reverse();
 
@@ -193,7 +193,7 @@ fn gm17_verifier_bytes_test() {
         {
             let mut cs = cs.ns(|| "Allocate Input");
             for (i, input) in inputs.into_iter().enumerate() {
-                let mut input_bits = BitIteratorBE::new(input.into_repr()).collect::<Vec<_>>();
+                let mut input_bits = BitIteratorBE::new(input.to_repr()).collect::<Vec<_>>();
                 // Input must be in little-endian, but BitIterator outputs in big-endian.
                 input_bits.reverse();
 
@@ -269,7 +269,7 @@ fn gm17_verifier_num_constraints_test() {
         {
             let mut cs = cs.ns(|| "Allocate Input");
             for (i, input) in inputs.into_iter().enumerate() {
-                let mut input_bits = BitIteratorBE::new(input.into_repr()).collect::<Vec<_>>();
+                let mut input_bits = BitIteratorBE::new(input.to_repr()).collect::<Vec<_>>();
                 // Input must be in little-endian, but BitIterator outputs in big-endian.
                 input_bits.reverse();
 

--- a/gadgets/src/bits/boolean.rs
+++ b/gadgets/src/bits/boolean.rs
@@ -1681,7 +1681,7 @@ mod test {
             let mut cs = TestConstraintSystem::<Fr>::new();
 
             let mut bits = vec![];
-            for (i, b) in BitIteratorBE::new(r.into_repr()).skip(1).enumerate() {
+            for (i, b) in BitIteratorBE::new(r.to_repr()).skip(1).enumerate() {
                 bits.push(Boolean::from(
                     AllocatedBit::alloc(cs.ns(|| format!("bit_gadget {}", i)), || Ok(b)).unwrap(),
                 ));

--- a/gadgets/src/bits/boolean_input.rs
+++ b/gadgets/src/bits/boolean_input.rs
@@ -65,7 +65,7 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
         // convert the elements into booleans (little-endian)
         let mut res = Vec::<Vec<Boolean>>::new();
         for (i, elem) in obj.borrow().iter().enumerate() {
-            let mut bits = elem.into_repr().to_bits_le();
+            let mut bits = elem.to_repr().to_bits_le();
             bits.truncate(F::size_in_bits());
 
             let mut booleans = Vec::<Boolean>::new();
@@ -95,7 +95,7 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
         // convert the elements into booleans (little-endian)
         let mut res = Vec::<Vec<Boolean>>::new();
         for (i, elem) in obj.borrow().iter().enumerate() {
-            let mut bits = elem.into_repr().to_bits_le();
+            let mut bits = elem.to_repr().to_bits_le();
             bits.truncate(F::size_in_bits());
 
             let mut booleans = Vec::<Boolean>::new();
@@ -122,7 +122,7 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
         // Step 1: obtain the bits of the F field elements (little-endian)
         let mut src_bits = Vec::<bool>::new();
         for elem in obj.borrow().iter() {
-            let mut bits = elem.into_repr().to_bits_le();
+            let mut bits = elem.to_repr().to_bits_le();
             bits.truncate(F::size_in_bits());
             for _ in bits.len()..F::size_in_bits() {
                 bits.push(false);

--- a/gadgets/src/curves/bls12_377.rs
+++ b/gadgets/src/curves/bls12_377.rs
@@ -156,7 +156,7 @@ mod test {
         let native_result = aa.mul(scalar) + b;
         let native_result = native_result.into_affine();
 
-        let mut scalar: Vec<bool> = BitIteratorBE::new(scalar.into_repr()).collect();
+        let mut scalar: Vec<bool> = BitIteratorBE::new(scalar.to_repr()).collect();
         // Get the scalar bits into little-endian form.
         scalar.reverse();
         let input = Vec::<Boolean>::alloc(cs.ns(|| "Input"), || Ok(scalar)).unwrap();

--- a/gadgets/src/curves/templates/bls12/affine.rs
+++ b/gadgets/src/curves/templates/bls12/affine.rs
@@ -462,7 +462,7 @@ impl<P: ShortWeierstrassParameters, F: PrimeField, FG: FieldGadget<P::BaseField,
     {
         let cofactor_weight = BitIteratorBE::new(P::COFACTOR).filter(|b| *b).count();
         // If we multiply by r, we actually multiply by r - 2.
-        let r_minus_1 = (-P::ScalarField::one()).into_repr();
+        let r_minus_1 = (-P::ScalarField::one()).to_repr();
         let r_weight = BitIteratorBE::new(&r_minus_1).filter(|b| *b).count();
 
         // We pick the most efficient method of performing the prime order check:

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -498,7 +498,7 @@ mod affine_impl {
         ) -> Result<Self, SynthesisError> {
             let cofactor_weight = BitIteratorBE::new(P::COFACTOR).filter(|b| *b).count();
             // If we multiply by r, we actually multiply by r - 2.
-            let r_minus_1 = (-P::ScalarField::one()).into_repr();
+            let r_minus_1 = (-P::ScalarField::one()).to_repr();
             let r_weight = BitIteratorBE::new(&r_minus_1).filter(|b| *b).count();
 
             // We pick the most efficient method of performing the prime order check:
@@ -1134,7 +1134,7 @@ mod projective_impl {
         {
             let cofactor_weight = BitIteratorBE::new(P::COFACTOR).filter(|b| *b).count();
             // If we multiply by r, we actually multiply by r - 2.
-            let r_minus_1 = (-P::ScalarField::one()).into_repr();
+            let r_minus_1 = (-P::ScalarField::one()).to_repr();
             let r_weight = BitIteratorBE::new(&r_minus_1).filter(|b| *b).count();
 
             // We pick the most efficient method of performing the prime order check:

--- a/gadgets/src/curves/templates/twisted_edwards/test.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/test.rs
@@ -49,7 +49,7 @@ where
     let scalar: <TEAffine<P> as Group>::ScalarField = UniformRand::rand(&mut thread_rng());
     let native_result = a.mul(scalar);
 
-    let mut scalar: Vec<bool> = BitIteratorBE::new(scalar.into_repr()).collect();
+    let mut scalar: Vec<bool> = BitIteratorBE::new(scalar.to_repr()).collect();
     // Get the scalar bits into little-endian form.
     scalar.reverse();
     let input = Vec::<Boolean>::alloc(cs.ns(|| "Input"), || Ok(scalar)).unwrap();

--- a/gadgets/src/curves/tests_curve.rs
+++ b/gadgets/src/curves/tests_curve.rs
@@ -68,13 +68,13 @@ fn bls12_377_gadget_bilinearity_test() {
     };
 
     let (ans3_g, ans3_n) = {
-        let s_iter = BitIteratorBE::new(s.into_repr())
+        let s_iter = BitIteratorBE::new(s.to_repr())
             .map(Boolean::constant)
             .collect::<Vec<_>>();
 
         let mut ans_g = Bls12PairingGadget::pairing(cs.ns(|| "pair(a, b)"), a_prep_g, b_prep_g).unwrap();
         let mut ans_n = Bls12_377::pairing(a, b);
-        ans_n = ans_n.pow(s.into_repr());
+        ans_n = ans_n.pow(s.to_repr());
         ans_g = ans_g.pow(cs.ns(|| "pow"), &s_iter).unwrap();
 
         (ans_g, ans_n)

--- a/gadgets/src/fields/fp.rs
+++ b/gadgets/src/fields/fp.rs
@@ -440,7 +440,7 @@ impl<F: PrimeField> ToBitsBEGadget<F> for AllocatedFp<F> {
                 let mut field_char = BitIteratorBE::new(F::characteristic());
                 let mut tmp = Vec::with_capacity(num_bits as usize);
                 let mut found_one = false;
-                for b in BitIteratorBE::new(value.into_repr()) {
+                for b in BitIteratorBE::new(value.to_repr()) {
                     // Skip leading bits
                     found_one |= field_char.next().unwrap();
                     if !found_one {
@@ -493,7 +493,7 @@ impl<F: PrimeField> ToBitsLEGadget<F> for AllocatedFp<F> {
         let mut bit_values = match self.value {
             Some(value) => {
                 let field_char = BitIteratorBE::new(F::characteristic());
-                let bits: Vec<_> = BitIteratorBE::new(value.into_repr())
+                let bits: Vec<_> = BitIteratorBE::new(value.to_repr())
                     .zip(field_char)
                     .skip_while(|(_, c)| !*c)
                     .map(|(b, _)| Some(b))
@@ -540,7 +540,7 @@ impl<F: PrimeField> ToBitsLEGadget<F> for AllocatedFp<F> {
 impl<F: PrimeField> ToBytesGadget<F> for AllocatedFp<F> {
     fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         let byte_values = match self.value {
-            Some(value) => to_bytes_le![&value.into_repr()]?
+            Some(value) => to_bytes_le![&value.to_repr()]?
                 .into_iter()
                 .map(Some)
                 .collect::<Vec<_>>(),
@@ -1123,7 +1123,7 @@ impl<F: PrimeField> ToBitsBEGadget<F> for FpGadget<F> {
 
     fn to_bits_be_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(BitIteratorBE::new(&c.into_repr())
+            Self::Constant(c) => Ok(BitIteratorBE::new(&c.to_repr())
                 .take((F::Parameters::MODULUS_BITS) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
@@ -1144,7 +1144,7 @@ impl<F: PrimeField> ToBitsLEGadget<F> for FpGadget<F> {
 
     fn to_bits_le_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
+            Self::Constant(c) => Ok(BitIteratorLE::new(&c.to_repr())
                 .take((F::Parameters::MODULUS_BITS) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),

--- a/gadgets/src/nonnative/allocated_nonnative_field_var.rs
+++ b/gadgets/src/nonnative/allocated_nonnative_field_var.rs
@@ -65,7 +65,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocatedNonNativeFieldVar<
             optimization_type,
         );
 
-        let mut base_repr: <TargetField as PrimeField>::BigInteger = TargetField::one().into_repr();
+        let mut base_repr: <TargetField as PrimeField>::BigInteger = TargetField::one().to_repr();
 
         // Convert 2^{(params.bits_per_limb - 1)} into the TargetField and then double the base
         // This is because 2^{(params.bits_per_limb)} might indeed be larger than the target field's prime.
@@ -81,7 +81,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocatedNonNativeFieldVar<
             let mut cur = TargetField::one();
 
             // Iterate over limb bits (big endian).
-            for bit in limb.into_repr().to_bits_be().iter().rev() {
+            for bit in limb.to_repr().to_bits_be().iter().rev() {
                 if *bit {
                     val += &cur;
                 }
@@ -218,7 +218,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocatedNonNativeFieldVar<
         }
 
         // Step 2: Construct the padding
-        let mut pad_non_top_limb_repr: <BaseField as PrimeField>::BigInteger = BaseField::one().into_repr();
+        let mut pad_non_top_limb_repr: <BaseField as PrimeField>::BigInteger = BaseField::one().to_repr();
         let mut pad_top_limb_repr: <BaseField as PrimeField>::BigInteger = pad_non_top_limb_repr;
 
         pad_non_top_limb_repr.muln((surfeit + params.bits_per_limb) as u32);
@@ -343,7 +343,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> AllocatedNonNativeFieldVar<
         elem: &TargetField,
         optimization_type: OptimizationType,
     ) -> Result<Vec<BaseField>, SynthesisError> {
-        Self::get_limbs_representations_from_big_integer(&elem.into_repr(), optimization_type)
+        Self::get_limbs_representations_from_big_integer(&elem.to_repr(), optimization_type)
     }
 
     /// Obtain the limbs directly from a big int

--- a/gadgets/src/nonnative/mod.rs
+++ b/gadgets/src/nonnative/mod.rs
@@ -66,7 +66,7 @@ macro_rules! overhead {
     ($x:expr) => {{
         use snarkvm_utilities::ToBits;
         let num = $x;
-        let num_bits = num.into_repr().to_bits_be();
+        let num_bits = num.to_repr().to_bits_be();
         let mut skipped_bits = 0;
         for b in num_bits.iter() {
             if *b == false {

--- a/gadgets/src/nonnative/nonnative_field_var.rs
+++ b/gadgets/src/nonnative/nonnative_field_var.rs
@@ -360,7 +360,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBitsBEGadget<BaseField>
 
     fn to_bits_be_strict<CS: ConstraintSystem<BaseField>>(&self, mut cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(BitIteratorBE::new(&c.into_repr())
+            Self::Constant(c) => Ok(BitIteratorBE::new(&c.to_repr())
                 .take((TargetField::Parameters::MODULUS_BITS) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
@@ -381,7 +381,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> ToBitsLEGadget<BaseField>
 
     fn to_bits_le_strict<CS: ConstraintSystem<BaseField>>(&self, mut cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         match self {
-            Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
+            Self::Constant(c) => Ok(BitIteratorLE::new(&c.to_repr())
                 .take((TargetField::Parameters::MODULUS_BITS) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),

--- a/gadgets/src/nonnative/reduce.rs
+++ b/gadgets/src/nonnative/reduce.rs
@@ -52,7 +52,7 @@ pub fn limbs_to_bigint<BaseField: PrimeField>(bits_per_limb: usize, limbs: &[Bas
     let mut big_cur = BigUint::one();
     let two = BigUint::from(2u32);
     for limb in limbs.iter().rev() {
-        let limb_repr = limb.into_repr().to_bits_le();
+        let limb_repr = limb.to_repr().to_bits_le();
         let mut small_cur = big_cur.clone();
         for limb_bit in limb_repr.iter() {
             if *limb_bit {
@@ -102,7 +102,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> Reducer<TargetField, BaseFi
         let mut bits_considered = Vec::with_capacity(num_bits);
         let limb_value = limb.get_value().unwrap_or_default();
 
-        for b in BitIteratorBE::new(limb_value.into_repr()).skip(
+        for b in BitIteratorBE::new(limb_value.to_repr()).skip(
             <<BaseField as PrimeField>::Parameters as FieldParameters>::REPR_SHAVE_BITS as usize
                 + (BaseField::size_in_bits() - num_bits),
         ) {
@@ -250,7 +250,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> Reducer<TargetField, BaseFi
 
         let shift_array = {
             let mut array = Vec::new();
-            let mut cur = BaseField::one().into_repr();
+            let mut cur = BaseField::one().to_repr();
             for _ in 0..num_limb_in_a_group {
                 array.push(BaseField::from_repr(cur).unwrap());
                 cur.muln(shift_per_limb as u32);
@@ -293,7 +293,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> Reducer<TargetField, BaseFi
         for (group_id, (left_total_limb, right_total_limb, num_limb_in_this_group)) in
             groupped_limb_pairs.iter().enumerate()
         {
-            let mut pad_limb_repr: <BaseField as PrimeField>::BigInteger = BaseField::one().into_repr();
+            let mut pad_limb_repr: <BaseField as PrimeField>::BigInteger = BaseField::one().to_repr();
 
             pad_limb_repr.muln(
                 (surfeit + (bits_per_limb - shift_per_limb) + shift_per_limb * num_limb_in_this_group + 1 + 1) as u32,
@@ -305,7 +305,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField> Reducer<TargetField, BaseFi
 
             let mut carry_value = left_total_limb_value + carry_in_value + pad_limb - right_total_limb_value;
 
-            let mut carry_repr = carry_value.into_repr();
+            let mut carry_repr = carry_value.to_repr();
             carry_repr.divn((shift_per_limb * num_limb_in_this_group) as u32);
 
             carry_value = BaseField::from_repr(carry_repr).unwrap();

--- a/gadgets/tests/nonnative/arithmetic_tests.rs
+++ b/gadgets/tests/nonnative/arithmetic_tests.rs
@@ -80,8 +80,8 @@ fn multiplication_test<TargetField: PrimeField, BaseField: PrimeField, CS: Const
         a_times_b_actual.eq(&a_times_b_expected),
         "a_times_b = {:?}, a_times_b_actual = {:?}, a_times_b_expected = {:?}",
         a_times_b,
-        a_times_b_actual.into_repr().as_ref(),
-        a_times_b_expected.into_repr().as_ref()
+        a_times_b_actual.to_repr().as_ref(),
+        a_times_b_expected.to_repr().as_ref()
     );
 }
 
@@ -141,51 +141,51 @@ fn edge_cases_test<TargetField: PrimeField, BaseField: PrimeField, CS: Constrain
     assert!(
         a_plus_zero_native.eq(&a_native),
         "a_plus_zero = {:?}, a = {:?}",
-        a_plus_zero_native.into_repr().as_ref(),
-        a_native.into_repr().as_ref()
+        a_plus_zero_native.to_repr().as_ref(),
+        a_native.to_repr().as_ref()
     );
     assert!(
         a_minus_zero_native.eq(&a_native),
         "a_minus_zero = {:?}, a = {:?}",
-        a_minus_zero_native.into_repr().as_ref(),
-        a_native.into_repr().as_ref()
+        a_minus_zero_native.to_repr().as_ref(),
+        a_native.to_repr().as_ref()
     );
 
     assert!(
         zero_minus_a_native.eq(&minus_a_native),
         "zero_minus_a = {:?}, minus_a = {:?}",
-        zero_minus_a_native.into_repr().as_ref(),
-        minus_a_native.into_repr().as_ref()
+        zero_minus_a_native.to_repr().as_ref(),
+        minus_a_native.to_repr().as_ref()
     );
     assert!(
         a_times_zero_native.eq(&zero_native),
         "a_times_zero = {:?}, zero = {:?}",
-        a_times_zero_native.into_repr().as_ref(),
-        zero_native.into_repr().as_ref()
+        a_times_zero_native.to_repr().as_ref(),
+        zero_native.to_repr().as_ref()
     );
     assert!(
         zero_plus_a_native.eq(&a_native),
         "zero_plus_a = {:?}, a = {:?}",
-        zero_plus_a_native.into_repr().as_ref(),
-        a_native.into_repr().as_ref()
+        zero_plus_a_native.to_repr().as_ref(),
+        a_native.to_repr().as_ref()
     );
     assert!(
         zero_times_a_native.eq(&zero_native),
         "zero_times_a = {:?}, zero = {:?}",
-        zero_times_a_native.into_repr().as_ref(),
-        zero_native.into_repr().as_ref()
+        zero_times_a_native.to_repr().as_ref(),
+        zero_native.to_repr().as_ref()
     );
     assert!(
         a_times_one_native.eq(&a_native),
         "a_times_one = {:?}, a = {:?}",
-        a_times_one_native.into_repr().as_ref(),
-        a_native.into_repr().as_ref()
+        a_times_one_native.to_repr().as_ref(),
+        a_native.to_repr().as_ref()
     );
     assert!(
         one_times_a_native.eq(&a_native),
         "one_times_a = {:?}, a = {:?}",
-        one_times_a_native.into_repr().as_ref(),
-        a_native.into_repr().as_ref()
+        one_times_a_native.to_repr().as_ref(),
+        a_native.to_repr().as_ref()
     );
 }
 

--- a/marlin/src/ahp/ahp.rs
+++ b/marlin/src/ahp/ahp.rs
@@ -440,7 +440,7 @@ mod tests {
             divisor
                 .coeffs
                 .iter()
-                .filter_map(|f| if !f.is_zero() { Some(f.into_repr()) } else { None })
+                .filter_map(|f| if !f.is_zero() { Some(f.to_repr()) } else { None })
                 .collect::<Vec<_>>()
         );
 
@@ -467,7 +467,7 @@ mod tests {
             quotient
                 .coeffs
                 .iter()
-                .filter_map(|f| if !f.is_zero() { Some(f.into_repr()) } else { None })
+                .filter_map(|f| if !f.is_zero() { Some(f.to_repr()) } else { None })
                 .collect::<Vec<_>>()
         );
 

--- a/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge.rs
@@ -144,7 +144,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField, S: AlgebraicSponge<BaseFiel
 
         let mut bits = Vec::<bool>::new();
         for elem in elements.iter() {
-            let mut elem_bits = elem.into_repr().to_bits_be();
+            let mut elem_bits = elem.to_repr().to_bits_be();
             elem_bits.reverse();
             bits.extend_from_slice(&elem_bits[0..capacity]);
         }
@@ -255,7 +255,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField, S: AlgebraicSponge<BaseFiel
         let skip = (BaseField::Parameters::REPR_SHAVE_BITS + 1) as usize;
         for elem in src_elements.iter() {
             // discard the highest bit
-            let elem_bits = elem.into_repr().to_bits_be();
+            let elem_bits = elem.to_repr().to_bits_be();
             dest_bits.extend_from_slice(&elem_bits[skip..]);
         }
 

--- a/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge_gadget.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge_gadget.rs
@@ -566,12 +566,12 @@ mod tests {
             .enumerate()
         {
             assert_eq!(
-                left.into_repr(),
-                right.value().unwrap().into_repr(),
+                left.to_repr(),
+                right.value().unwrap().to_repr(),
                 "{}: left = {:?}, right = {:?}",
                 i,
-                left.into_repr(),
-                right.value().unwrap().into_repr()
+                left.to_repr(),
+                right.value().unwrap().to_repr()
             );
         }
 
@@ -582,11 +582,11 @@ mod tests {
             .enumerate()
         {
             assert!(
-                left.into_repr().eq(&right.value().unwrap().into_repr()),
+                left.to_repr().eq(&right.value().unwrap().to_repr()),
                 "{}: left = {:?}, right = {:?}",
                 i,
-                left.into_repr(),
-                right.value().unwrap().into_repr()
+                left.to_repr(),
+                right.value().unwrap().to_repr()
             );
         }
 

--- a/marlin/src/marlin/proof.rs
+++ b/marlin/src/marlin/proof.rs
@@ -59,7 +59,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>> Proof<F, PC> {
 
     /// Prints information about the size of the proof.
     pub fn print_size_info(&self) {
-        let size_of_fe_in_bytes = F::zero().into_repr().as_ref().len() * 8;
+        let size_of_fe_in_bytes = F::zero().to_repr().as_ref().len() * 8;
         let mut num_comms_without_degree_bounds = 0;
         let mut num_comms_with_degree_bounds = 0;
         let mut size_bytes_comms_without_degree_bounds = 0;

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -430,7 +430,7 @@ fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField>(p: &Polynomial<F>) -
 
 fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInteger> {
     let to_bigint_time = start_timer!(|| "Converting polynomial coeffs to bigints");
-    let coeffs = cfg_iter!(p).map(|s| s.into_repr()).collect::<Vec<_>>();
+    let coeffs = cfg_iter!(p).map(|s| s.to_repr()).collect::<Vec<_>>();
     end_timer!(to_bigint_time);
     coeffs
 }

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -20,7 +20,7 @@ macro_rules! biginteger {
         pub struct $name(pub [u64; $num_limbs]);
 
         impl $name {
-            pub fn new(value: [u64; $num_limbs]) -> Self {
+            pub const fn new(value: [u64; $num_limbs]) -> Self {
                 $name(value)
             }
         }


### PR DESCRIPTION
## Motivation

`PrimeField` traits currently provide `PrimeField::into_repr` and `PrimeField::into_repr_raw`, which do not consume `self`, but rather use `&self` to construct a new instance.

In addition the `PrimeField::into_repr_raw` and `PrimeField::from_repr_raw` methods are unsafe to use as each `PrimeField` is in Montgomery representation (not standard form). Attempting to use these methods and introduce them without Montgomery conversion results in elliptic curve points (one level above) that do not lie on the correct curve (as they do not satisfy the corresponding curve equation).

As such, this PR renames these 4 `PrimeField` methods as `PrimeField::to_repr`, `PrimeField::to_repr_unchecked`, `PrimeField::from_repr`, and `PrimeField::from_repr_unchecked`.

