### PR TITLE
Fix `GroupEncryptionGadget` Signature Verification

### DIFF
--- a/gadgets/src/algorithms/signature/group.rs
+++ b/gadgets/src/algorithms/signature/group.rs
@@ -398,6 +398,7 @@ where
             &claimed_prover_commitment
                 .to_constraint_field(cs.ns(|| "convert claimed_prover_commitment into field elements"))?,
         );
+        hash_input.push(FpGadget::<F>::Constant(F::from(message.len() as u128)));
         hash_input.extend_from_slice(&message.to_constraint_field(cs.ns(|| "convert message into field elements"))?);
 
         // Compute the hash on the base field

--- a/gadgets/src/algorithms/signature/tests.rs
+++ b/gadgets/src/algorithms/signature/tests.rs
@@ -22,12 +22,18 @@ use crate::{
     Boolean,
 };
 use snarkvm_algorithms::{signature::Schnorr, traits::SignatureScheme};
-use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsAffine, traits::Group};
+use snarkvm_curves::{
+    bls12_377::Fr,
+    edwards_bls12::{EdwardsAffine, EdwardsProjective},
+    traits::Group,
+};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
 use snarkvm_utilities::{rand::UniformRand, to_bytes_le, ToBytes};
 
+use crate::algorithms::signature::GroupEncryptionPublicKeyRandomizationGadget;
 use rand::{thread_rng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
+use snarkvm_algorithms::encryption::GroupEncryption;
 
 type SchnorrScheme = Schnorr<EdwardsAffine>;
 type TestSignature = Schnorr<EdwardsAffine>;
@@ -161,6 +167,76 @@ fn schnorr_signature_verification_test() {
     assert_eq!(cs.num_constraints(), 245);
 
     let verification = <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::verify(
+        cs.ns(|| "verify"),
+        &parameter_gadget,
+        &public_key_gadget,
+        &message_gadget,
+        &signature_gadget,
+    )
+    .unwrap();
+
+    assert_eq!(cs.num_constraints(), 6582);
+
+    verification
+        .enforce_equal(cs.ns(|| "check_verification"), &Boolean::constant(true))
+        .unwrap();
+
+    if !cs.is_satisfied() {
+        println!("which is unsatisfied: {:?}", cs.which_is_unsatisfied().unwrap());
+    }
+    assert!(cs.is_satisfied());
+}
+
+#[test]
+fn group_schnorr_signature_verification_test() {
+    type GroupSignature = GroupEncryption<EdwardsProjective, EdwardsAffine>;
+    type GroupSignatureGadget =
+        GroupEncryptionPublicKeyRandomizationGadget<EdwardsProjective, EdwardsAffine, Fr, EdwardsBls12Gadget>;
+
+    let message = "Hi, I am a Schnorr signature!".as_bytes();
+    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+
+    let schnorr_signature = GroupSignature::setup::<_>(rng).unwrap();
+    let private_key = schnorr_signature.generate_private_key(rng).unwrap();
+    let public_key = schnorr_signature.generate_public_key(&private_key).unwrap();
+    let signature = schnorr_signature.sign(&private_key, &message, rng).unwrap();
+
+    assert!(schnorr_signature.verify(&public_key, &message, &signature).unwrap());
+
+    let mut cs = TestConstraintSystem::<Fr>::new();
+
+    let parameter_gadget =
+        <GroupSignatureGadget as SignaturePublicKeyRandomizationGadget<GroupSignature, Fr>>::ParametersGadget::alloc(
+            cs.ns(|| "alloc_parameters"),
+            || Ok(&schnorr_signature.parameters),
+        )
+        .unwrap();
+
+    assert_eq!(cs.num_constraints(), 0);
+
+    let public_key_gadget =
+        <GroupSignatureGadget as SignaturePublicKeyRandomizationGadget<GroupSignature, Fr>>::PublicKeyGadget::alloc(
+            cs.ns(|| "alloc_public_key"),
+            || Ok(public_key),
+        )
+        .unwrap();
+
+    assert_eq!(cs.num_constraints(), 13);
+
+    let message_gadget = UInt8::alloc_vec(cs.ns(|| "alloc_message"), message).unwrap();
+    //
+    assert_eq!(cs.num_constraints(), 245);
+
+    let signature_gadget =
+        <GroupSignatureGadget as SignaturePublicKeyRandomizationGadget<GroupSignature, Fr>>::SignatureGadget::alloc(
+            cs.ns(|| "alloc_signature"),
+            || Ok(signature),
+        )
+        .unwrap();
+
+    assert_eq!(cs.num_constraints(), 245);
+
+    let verification = <GroupSignatureGadget as SignaturePublicKeyRandomizationGadget<GroupSignature, Fr>>::verify(
         cs.ns(|| "verify"),
         &parameter_gadget,
         &public_key_gadget,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

There was a minor issue with the signature verification check of the `GroupEncryptionGadget`, where the message length was not included in the Poseidon gadget hash input. 

## Test Plan

Tests have been added to check that the signature verification of the `GroupEncryptionGadget` is correct.
