### PR TITLE
Updates Schnorr native and circuit verifier challenge with public key, removing salt

### DIFF
--- a/algorithms/benches/signature/schnorr.rs
+++ b/algorithms/benches/signature/schnorr.rs
@@ -84,7 +84,7 @@ fn schnorr_signature_randomize_public_key(c: &mut Criterion) {
     let randomness: [u8; 32] = rng.gen();
 
     c.bench_function("Schnorr Signature Randomize Public Key", move |b| {
-        b.iter(|| Schnorr::randomize_public_key(&parameters, &public_key, &randomness).unwrap())
+        b.iter(|| Schnorr::randomize_private_key(&parameters, &public_key, &randomness).unwrap())
     });
 }
 

--- a/algorithms/benches/signature/schnorr.rs
+++ b/algorithms/benches/signature/schnorr.rs
@@ -18,7 +18,8 @@
 extern crate criterion;
 
 use snarkvm_algorithms::{signature::schnorr::Schnorr as SchnorrSignature, traits::SignatureScheme};
-use snarkvm_curves::edwards_bls12::EdwardsProjective;
+use snarkvm_curves::{edwards_bls12::EdwardsProjective, Group};
+use snarkvm_utilities::UniformRand;
 
 use criterion::Criterion;
 use rand::{self, thread_rng, Rng};
@@ -81,10 +82,10 @@ fn schnorr_signature_randomize_public_key(c: &mut Criterion) {
     let parameters = Schnorr::setup(&mut rng).unwrap();
     let private_key = Schnorr::generate_private_key(&parameters, rng).unwrap();
     let public_key = Schnorr::generate_public_key(&parameters, &private_key).unwrap();
-    let randomness: [u8; 32] = rng.gen();
+    let randomizer = <EdwardsProjective as Group>::ScalarField::rand(rng);
 
     c.bench_function("Schnorr Signature Randomize Public Key", move |b| {
-        b.iter(|| Schnorr::randomize_private_key(&parameters, &public_key, &randomness).unwrap())
+        b.iter(|| Schnorr::randomize_public_key(&parameters, &public_key, &randomizer).unwrap())
     });
 }
 
@@ -92,12 +93,13 @@ fn schnorr_signature_randomize_signature(c: &mut Criterion) {
     let mut rng = &mut thread_rng();
     let parameters = Schnorr::setup(&mut rng).unwrap();
     let private_key = Schnorr::generate_private_key(&parameters, rng).unwrap();
-    let randomness: [u8; 32] = rng.gen();
     let message = [100u8; 128];
-    let signature = Schnorr::sign(&parameters, &private_key, &message, &mut rng).unwrap();
+
+    let randomizer = <EdwardsProjective as Group>::ScalarField::rand(rng);
+    let randomized_private_key = Schnorr::randomize_private_key(&parameters, &private_key, &randomizer).unwrap();
 
     c.bench_function("Schnorr Signature Randomize Signature", move |b| {
-        b.iter(|| Schnorr::randomize_signature(&parameters, &signature, &randomness).unwrap())
+        b.iter(|| Schnorr::sign_randomized(&parameters, &randomized_private_key, &message, &mut rng).unwrap())
     });
 }
 criterion_group! {

--- a/algorithms/src/signature/group.rs
+++ b/algorithms/src/signature/group.rs
@@ -28,7 +28,7 @@ use snarkvm_curves::{
 use snarkvm_fields::ToConstraintField;
 use snarkvm_utilities::{serialize::*, to_bytes_le, FromBytes, ToBytes};
 
-use rand::Rng;
+use rand::{CryptoRng, Rng};
 use std::hash::Hash;
 
 /// Map the encryption group into the signature group.
@@ -79,7 +79,7 @@ where
     type Randomizer = <G as Group>::ScalarField;
     type Signature = SchnorrSignature<SG>;
 
-    fn setup<R: Rng>(rng: &mut R) -> Result<Self, SignatureError> {
+    fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, SignatureError> {
         Ok(<Self as EncryptionScheme>::setup(rng))
     }
 
@@ -87,7 +87,7 @@ where
         &self.parameters
     }
 
-    fn generate_private_key<R: Rng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError> {
+    fn generate_private_key<R: Rng + CryptoRng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError> {
         Ok(<Self as EncryptionScheme>::generate_private_key(self, rng))
     }
 
@@ -111,7 +111,7 @@ where
         unimplemented!()
     }
 
-    fn sign<R: Rng>(
+    fn sign<R: Rng + CryptoRng>(
         &self,
         private_key: &Self::PrivateKey,
         message: &[u8],
@@ -123,7 +123,7 @@ where
         Ok(schnorr_signature.sign(&private_key, message, rng)?)
     }
 
-    fn sign_randomized<R: Rng>(
+    fn sign_randomized<R: Rng + CryptoRng>(
         &self,
         _randomized_private_key: &Self::RandomizedPrivateKey,
         _message: &[u8],

--- a/algorithms/src/signature/group.rs
+++ b/algorithms/src/signature/group.rs
@@ -51,10 +51,7 @@ impl<G: ProjectiveCurve + CanonicalSerialize, SG: ProjectiveCurve + CanonicalDes
             .map(|p| into_signature_group(*p))
             .collect();
 
-        let parameters = SchnorrParameters {
-            generator_powers,
-            salt: parameters.salt,
-        };
+        let parameters = SchnorrParameters { generator_powers };
 
         Self { parameters }
     }
@@ -78,6 +75,7 @@ where
     type Parameters = GroupEncryptionParameters<G>;
     type PrivateKey = <G as Group>::ScalarField;
     type PublicKey = GroupEncryptionPublicKey<G>;
+    type RandomizedPrivateKey = <G as Group>::ScalarField;
     type Signature = SchnorrSignature<SG>;
 
     fn setup<R: Rng>(rng: &mut R) -> Result<Self, SignatureError> {
@@ -90,6 +88,14 @@ where
 
     fn generate_private_key<R: Rng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError> {
         Ok(<Self as EncryptionScheme>::generate_private_key(self, rng))
+    }
+
+    fn generate_randomized_private_key<R: Rng>(
+        &self,
+        _private_key: &Self::PrivateKey,
+        _rng: &mut R,
+    ) -> Result<Self::RandomizedPrivateKey, SignatureError> {
+        unimplemented!()
     }
 
     fn generate_public_key(&self, private_key: &Self::PrivateKey) -> Result<Self::PublicKey, SignatureError> {
@@ -108,6 +114,15 @@ where
         Ok(schnorr_signature.sign(&private_key, message, rng)?)
     }
 
+    fn sign_randomized<R: Rng>(
+        &self,
+        _randomized_private_key: &Self::RandomizedPrivateKey,
+        _message: &[u8],
+        _rng: &mut R,
+    ) -> Result<Self::Signature, SignatureError> {
+        unimplemented!()
+    }
+
     fn verify(
         &self,
         public_key: &Self::PublicKey,
@@ -118,21 +133,5 @@ where
         let schnorr_public_key: SchnorrPublicKey<SG> = (*public_key).into();
 
         Ok(schnorr_signature.verify(&schnorr_public_key, message, signature)?)
-    }
-
-    fn randomize_public_key(
-        &self,
-        _public_key: &Self::PublicKey,
-        _randomness: &[u8],
-    ) -> Result<Self::PublicKey, SignatureError> {
-        unimplemented!()
-    }
-
-    fn randomize_signature(
-        &self,
-        _signature: &Self::Signature,
-        _randomness: &[u8],
-    ) -> Result<Self::Signature, SignatureError> {
-        unimplemented!()
     }
 }

--- a/algorithms/src/signature/group.rs
+++ b/algorithms/src/signature/group.rs
@@ -76,6 +76,7 @@ where
     type PrivateKey = <G as Group>::ScalarField;
     type PublicKey = GroupEncryptionPublicKey<G>;
     type RandomizedPrivateKey = <G as Group>::ScalarField;
+    type Randomizer = <G as Group>::ScalarField;
     type Signature = SchnorrSignature<SG>;
 
     fn setup<R: Rng>(rng: &mut R) -> Result<Self, SignatureError> {
@@ -90,16 +91,24 @@ where
         Ok(<Self as EncryptionScheme>::generate_private_key(self, rng))
     }
 
-    fn generate_randomized_private_key<R: Rng>(
+    fn generate_public_key(&self, private_key: &Self::PrivateKey) -> Result<Self::PublicKey, SignatureError> {
+        Ok(<Self as EncryptionScheme>::generate_public_key(self, private_key).unwrap())
+    }
+
+    fn randomize_private_key(
         &self,
         _private_key: &Self::PrivateKey,
-        _rng: &mut R,
+        _randomizer: &Self::Randomizer,
     ) -> Result<Self::RandomizedPrivateKey, SignatureError> {
         unimplemented!()
     }
 
-    fn generate_public_key(&self, private_key: &Self::PrivateKey) -> Result<Self::PublicKey, SignatureError> {
-        Ok(<Self as EncryptionScheme>::generate_public_key(self, private_key).unwrap())
+    fn randomize_public_key(
+        &self,
+        _public_key: &Self::PublicKey,
+        _randomizer: &Self::Randomizer,
+    ) -> Result<Self::PublicKey, SignatureError> {
+        unimplemented!()
     }
 
     fn sign<R: Rng>(

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -34,7 +34,7 @@ use snarkvm_utilities::{
 };
 
 use itertools::Itertools;
-use rand::Rng;
+use rand::{CryptoRng, Rng};
 use std::{
     hash::Hash,
     io::{Read, Result as IoResult, Write},
@@ -131,7 +131,7 @@ where
     type Randomizer = <G as Group>::ScalarField;
     type Signature = SchnorrSignature<G>;
 
-    fn setup<R: Rng>(rng: &mut R) -> Result<Self, SignatureError> {
+    fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, SignatureError> {
         assert!(
             <<G as Group>::ScalarField as PrimeField>::Parameters::CAPACITY
                 < <<G::Affine as AffineCurve>::BaseField as PrimeField>::Parameters::CAPACITY
@@ -148,7 +148,7 @@ where
         &self.parameters
     }
 
-    fn generate_private_key<R: Rng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError> {
+    fn generate_private_key<R: Rng + CryptoRng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError> {
         let keygen_time = start_timer!(|| "SchnorrSignature::generate_private_key");
         let private_key = <G as Group>::ScalarField::rand(rng);
         end_timer!(keygen_time);
@@ -194,7 +194,7 @@ where
         Ok(SchnorrPublicKey(randomized_public_key))
     }
 
-    fn sign<R: Rng>(
+    fn sign<R: Rng + CryptoRng>(
         &self,
         private_key: &Self::PrivateKey,
         message: &[u8],
@@ -254,7 +254,7 @@ where
         Ok(signature)
     }
 
-    fn sign_randomized<R: Rng>(
+    fn sign_randomized<R: Rng + CryptoRng>(
         &self,
         randomized_private_key: &Self::RandomizedPrivateKey,
         message: &[u8],

--- a/algorithms/src/signature/schnorr_parameters.rs
+++ b/algorithms/src/signature/schnorr_parameters.rs
@@ -30,7 +30,6 @@ use std::io::{Read, Result as IoResult, Write};
 )]
 pub struct SchnorrParameters<G: Group> {
     pub generator_powers: Vec<G>,
-    pub salt: [u8; 32],
 }
 
 impl<G: Group> SchnorrParameters<G> {
@@ -46,10 +45,7 @@ impl<G: Group> SchnorrParameters<G> {
             generator.double_in_place();
         }
 
-        Self {
-            generator_powers,
-            salt: rng.gen(),
-        }
+        Self { generator_powers }
     }
 }
 
@@ -59,7 +55,7 @@ impl<G: Group> ToBytes for SchnorrParameters<G> {
         for g in &self.generator_powers {
             g.write_le(&mut writer)?;
         }
-        self.salt.write_le(&mut writer)
+        Ok(())
     }
 }
 
@@ -73,9 +69,7 @@ impl<G: Group> FromBytes for SchnorrParameters<G> {
             generator_powers.push(g);
         }
 
-        let salt: [u8; 32] = FromBytes::read_le(&mut reader)?;
-
-        Ok(Self { generator_powers, salt })
+        Ok(Self { generator_powers })
     }
 }
 

--- a/algorithms/src/signature/tests.rs
+++ b/algorithms/src/signature/tests.rs
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{encryption::GroupEncryption, signature::Schnorr, traits::SignatureScheme};
-use snarkvm_curves::{edwards_bls12::EdwardsProjective, edwards_bw6::EdwardsProjective as Edwards, traits::Group};
-use snarkvm_utilities::{rand::UniformRand, to_bytes_le, FromBytes, ToBytes};
+use crate::{encryption::GroupEncryption, signature::Schnorr, SignatureScheme};
+use snarkvm_curves::{edwards_bls12::EdwardsProjective, edwards_bw6::EdwardsProjective as Edwards, Group};
+use snarkvm_fields::PrimeField;
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes, UniformRand};
 
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
@@ -26,39 +27,49 @@ type TestGroupEncryptionSignature = GroupEncryption<EdwardsProjective, EdwardsPr
 
 fn sign_and_verify<S: SignatureScheme>(message: &[u8]) {
     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
-    let schnorr_signature = S::setup::<_>(rng).unwrap();
+    let schnorr = S::setup::<_>(rng).unwrap();
 
-    let private_key = schnorr_signature.generate_private_key(rng).unwrap();
-    let public_key = schnorr_signature.generate_public_key(&private_key).unwrap();
-    let signature = schnorr_signature.sign(&private_key, message, rng).unwrap();
-    assert!(schnorr_signature.verify(&public_key, &message, &signature).unwrap());
+    let private_key = schnorr.generate_private_key(rng).unwrap();
+    let public_key = schnorr.generate_public_key(&private_key).unwrap();
+    let signature = schnorr.sign(&private_key, message, rng).unwrap();
+    assert!(schnorr.verify(&public_key, &message, &signature).unwrap());
 }
 
 fn failed_verification<S: SignatureScheme>(message: &[u8], bad_message: &[u8]) {
     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
-    let schnorr_signature = S::setup::<_>(rng).unwrap();
+    let schnorr = S::setup::<_>(rng).unwrap();
 
-    let private_key = schnorr_signature.generate_private_key(rng).unwrap();
-    let public_key = schnorr_signature.generate_public_key(&private_key).unwrap();
-    let signature = schnorr_signature.sign(&private_key, message, rng).unwrap();
-    assert!(!schnorr_signature.verify(&public_key, bad_message, &signature).unwrap());
+    let private_key = schnorr.generate_private_key(rng).unwrap();
+    let public_key = schnorr.generate_public_key(&private_key).unwrap();
+    let signature = schnorr.sign(&private_key, message, rng).unwrap();
+    assert!(!schnorr.verify(&public_key, bad_message, &signature).unwrap());
 }
 
-#[rustfmt::skip]
-fn randomize_and_verify<S: SignatureScheme>(message: &[u8]) {
+fn randomize_and_verify<S: SignatureScheme<Randomizer = F>, F: PrimeField>(message: &[u8], randomizer: F) {
     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
-    let schnorr_signature = S::setup::<_>(rng).unwrap();
+    let schnorr = S::setup::<_>(rng).unwrap();
 
-    let private_key = schnorr_signature.generate_private_key(rng).unwrap();
-    let public_key = schnorr_signature.generate_public_key(&private_key).unwrap();
-    let signature = schnorr_signature.sign(&private_key, message, rng).unwrap();
-    assert!(schnorr_signature.verify(&public_key, message, &signature).unwrap());
+    let private_key = schnorr.generate_private_key(rng).unwrap();
+    let public_key = schnorr.generate_public_key(&private_key).unwrap();
+    let signature = schnorr.sign(&private_key, message, rng).unwrap();
+    assert!(schnorr.verify(&public_key, message, &signature).unwrap());
 
-    let randomized_private_key = schnorr_signature.generate_randomized_private_key(&private_key, rng).unwrap();
-    let randomized_signature = schnorr_signature.sign_randomized(&randomized_private_key, message, rng).unwrap();
-    let randomized_public_key = schnorr_signature.generate_public_key(&randomized_private_key.into()).unwrap();
+    let randomized_private_key = schnorr.randomize_private_key(&private_key, &randomizer).unwrap();
+    let randomized_public_key = schnorr.randomize_public_key(&public_key, &randomizer).unwrap();
+    assert_eq!(
+        randomized_public_key,
+        schnorr
+            .generate_public_key(&randomized_private_key.clone().into())
+            .unwrap()
+    );
+
+    let randomized_signature = schnorr.sign_randomized(&randomized_private_key, message, rng).unwrap();
     assert!(signature != randomized_signature);
-    assert!(schnorr_signature.verify(&randomized_public_key, &message, &randomized_signature).unwrap());
+    assert!(
+        schnorr
+            .verify(&randomized_public_key, &message, &randomized_signature)
+            .unwrap()
+    );
 }
 
 fn signature_scheme_parameter_serialization<S: SignatureScheme>() {
@@ -73,12 +84,42 @@ fn signature_scheme_parameter_serialization<S: SignatureScheme>() {
     assert_eq!(signature_scheme_parameters, &recovered_signature_scheme_parameters);
 }
 
+// #[test]
+// fn test_schnorr_randomize_public_key() {
+//     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+//
+//     let schnorr = TestSignature::setup::<_>(rng).unwrap();
+//     let generator_powers = schnorr.parameters.generator_powers;
+//
+//     let private_key = schnorr.generate_private_key(rng).unwrap();
+//     let public_key = schnorr.generate_public_key(&private_key).unwrap();
+//
+//     let randomizer = <Edwards as Group>::ScalarField::rand(rng);
+//     let randomized_private_key = schnorr.randomize_private_key(&private_key, &randomizer).unwrap();
+//     let randomized_public_key = schnorr.randomize_public_key(&public_key, &randomizer).unwrap();
+//     assert_eq!(randomized_public_key, schnorr.generate_public_key(&randomized_private_key)?);
+//
+//     let mut randomized_group = Edwards::zero();
+//     for (bit, base_power) in
+//         snarkvm_utilities::from_bytes_le_to_bits_le(&randomizer.to_bytes_le()?).zip_eq(&generator_powers)
+//     {
+//         if bit {
+//             randomized_group += base_power;
+//         }
+//     }
+//
+//     assert_eq!(randomized_public_key, randomized_private_key)
+// }
+
 #[test]
 fn schnorr_signature_test() {
     let message = "Hi, I am a Schnorr signature!";
     sign_and_verify::<TestSignature>(message.as_bytes());
     failed_verification::<TestSignature>(message.as_bytes(), b"Bad message");
-    randomize_and_verify::<TestSignature>(message.as_bytes());
+
+    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+    let randomizer = <Edwards as Group>::ScalarField::rand(rng);
+    randomize_and_verify::<TestSignature, <Edwards as Group>::ScalarField>(message.as_bytes(), randomizer);
 }
 
 #[test]

--- a/algorithms/src/signature/tests.rs
+++ b/algorithms/src/signature/tests.rs
@@ -20,13 +20,13 @@ use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes, UniformRand};
 
 use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
+use rand_chacha::ChaChaRng;
 
 type TestSignature = Schnorr<Edwards>;
 type TestGroupEncryptionSignature = GroupEncryption<EdwardsProjective, EdwardsProjective>;
 
 fn sign_and_verify<S: SignatureScheme>(message: &[u8]) {
-    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
     let schnorr = S::setup::<_>(rng).unwrap();
 
     let private_key = schnorr.generate_private_key(rng).unwrap();
@@ -36,7 +36,7 @@ fn sign_and_verify<S: SignatureScheme>(message: &[u8]) {
 }
 
 fn failed_verification<S: SignatureScheme>(message: &[u8], bad_message: &[u8]) {
-    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
     let schnorr = S::setup::<_>(rng).unwrap();
 
     let private_key = schnorr.generate_private_key(rng).unwrap();
@@ -46,7 +46,7 @@ fn failed_verification<S: SignatureScheme>(message: &[u8], bad_message: &[u8]) {
 }
 
 fn randomize_and_verify<S: SignatureScheme<Randomizer = F>, F: PrimeField>(message: &[u8], randomizer: F) {
-    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
     let schnorr = S::setup::<_>(rng).unwrap();
 
     let private_key = schnorr.generate_private_key(rng).unwrap();
@@ -73,7 +73,7 @@ fn randomize_and_verify<S: SignatureScheme<Randomizer = F>, F: PrimeField>(messa
 }
 
 fn signature_scheme_parameter_serialization<S: SignatureScheme>() {
-    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
     let signature_scheme = S::setup(rng).unwrap();
 
     let signature_scheme_parameters = signature_scheme.parameters();
@@ -84,40 +84,13 @@ fn signature_scheme_parameter_serialization<S: SignatureScheme>() {
     assert_eq!(signature_scheme_parameters, &recovered_signature_scheme_parameters);
 }
 
-// #[test]
-// fn test_schnorr_randomize_public_key() {
-//     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
-//
-//     let schnorr = TestSignature::setup::<_>(rng).unwrap();
-//     let generator_powers = schnorr.parameters.generator_powers;
-//
-//     let private_key = schnorr.generate_private_key(rng).unwrap();
-//     let public_key = schnorr.generate_public_key(&private_key).unwrap();
-//
-//     let randomizer = <Edwards as Group>::ScalarField::rand(rng);
-//     let randomized_private_key = schnorr.randomize_private_key(&private_key, &randomizer).unwrap();
-//     let randomized_public_key = schnorr.randomize_public_key(&public_key, &randomizer).unwrap();
-//     assert_eq!(randomized_public_key, schnorr.generate_public_key(&randomized_private_key)?);
-//
-//     let mut randomized_group = Edwards::zero();
-//     for (bit, base_power) in
-//         snarkvm_utilities::from_bytes_le_to_bits_le(&randomizer.to_bytes_le()?).zip_eq(&generator_powers)
-//     {
-//         if bit {
-//             randomized_group += base_power;
-//         }
-//     }
-//
-//     assert_eq!(randomized_public_key, randomized_private_key)
-// }
-
 #[test]
 fn schnorr_signature_test() {
     let message = "Hi, I am a Schnorr signature!";
     sign_and_verify::<TestSignature>(message.as_bytes());
     failed_verification::<TestSignature>(message.as_bytes(), b"Bad message");
 
-    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
+    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
     let randomizer = <Edwards as Group>::ScalarField::rand(rng);
     randomize_and_verify::<TestSignature, <Edwards as Group>::ScalarField>(message.as_bytes(), randomizer);
 }

--- a/algorithms/src/traits/signature.rs
+++ b/algorithms/src/traits/signature.rs
@@ -39,6 +39,7 @@ pub trait SignatureScheme: Sized + Clone + From<<Self as SignatureScheme>::Param
         + CanonicalDeserialize;
     type PrivateKey: Clone + Debug + Default + ToBytes + FromBytes + PartialEq + Eq;
     type RandomizedPrivateKey: Clone + Debug + Default + ToBytes + FromBytes + PartialEq + Eq + Into<Self::PrivateKey>;
+    type Randomizer: Clone + Debug + Default + ToBytes + FromBytes + PartialEq + Eq;
     type Signature: Clone + Debug + Default + ToBytes + FromBytes + Send + Sync + PartialEq + Eq;
 
     fn setup<R: Rng>(rng: &mut R) -> Result<Self, SignatureError>;
@@ -47,13 +48,19 @@ pub trait SignatureScheme: Sized + Clone + From<<Self as SignatureScheme>::Param
 
     fn generate_private_key<R: Rng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError>;
 
-    fn generate_randomized_private_key<R: Rng>(
+    fn generate_public_key(&self, private_key: &Self::PrivateKey) -> Result<Self::PublicKey, SignatureError>;
+
+    fn randomize_private_key(
         &self,
         private_key: &Self::PrivateKey,
-        rng: &mut R,
+        randomizer: &Self::Randomizer,
     ) -> Result<Self::RandomizedPrivateKey, SignatureError>;
 
-    fn generate_public_key(&self, private_key: &Self::PrivateKey) -> Result<Self::PublicKey, SignatureError>;
+    fn randomize_public_key(
+        &self,
+        public_key: &Self::PublicKey,
+        randomizer: &Self::Randomizer,
+    ) -> Result<Self::PublicKey, SignatureError>;
 
     fn sign<R: Rng>(
         &self,

--- a/algorithms/src/traits/signature.rs
+++ b/algorithms/src/traits/signature.rs
@@ -21,7 +21,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
-use rand::Rng;
+use rand::{CryptoRng, Rng};
 use std::{fmt::Debug, hash::Hash};
 
 pub trait SignatureScheme: Sized + Clone + From<<Self as SignatureScheme>::Parameters> {
@@ -42,11 +42,11 @@ pub trait SignatureScheme: Sized + Clone + From<<Self as SignatureScheme>::Param
     type Randomizer: Clone + Debug + Default + ToBytes + FromBytes + PartialEq + Eq;
     type Signature: Clone + Debug + Default + ToBytes + FromBytes + Send + Sync + PartialEq + Eq;
 
-    fn setup<R: Rng>(rng: &mut R) -> Result<Self, SignatureError>;
+    fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, SignatureError>;
 
     fn parameters(&self) -> &Self::Parameters;
 
-    fn generate_private_key<R: Rng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError>;
+    fn generate_private_key<R: Rng + CryptoRng>(&self, rng: &mut R) -> Result<Self::PrivateKey, SignatureError>;
 
     fn generate_public_key(&self, private_key: &Self::PrivateKey) -> Result<Self::PublicKey, SignatureError>;
 
@@ -62,14 +62,14 @@ pub trait SignatureScheme: Sized + Clone + From<<Self as SignatureScheme>::Param
         randomizer: &Self::Randomizer,
     ) -> Result<Self::PublicKey, SignatureError>;
 
-    fn sign<R: Rng>(
+    fn sign<R: Rng + CryptoRng>(
         &self,
         private_key: &Self::PrivateKey,
         message: &[u8],
         rng: &mut R,
     ) -> Result<Self::Signature, SignatureError>;
 
-    fn sign_randomized<R: Rng>(
+    fn sign_randomized<R: Rng + CryptoRng>(
         &self,
         randomized_private_key: &Self::RandomizedPrivateKey,
         message: &[u8],

--- a/dpc/src/errors/record.rs
+++ b/dpc/src/errors/record.rs
@@ -21,6 +21,9 @@ pub enum RecordError {
     #[error("{}", _0)]
     AccountError(#[from] crate::AccountError),
 
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
     #[error("Failed to build Record data type. See console logs for error")]
     BuilderError,
 

--- a/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet1/inner_circuit/inner_circuit_gadget.rs
@@ -44,7 +44,7 @@ use snarkvm_gadgets::{
     fields::FpGadget,
     integers::{int::Int64, uint::UInt8},
     traits::{
-        algorithms::{CRHGadget, CommitmentGadget, EncryptionGadget, PRFGadget, SignaturePublicKeyRandomizationGadget},
+        algorithms::{CRHGadget, CommitmentGadget, EncryptionGadget, PRFGadget, SignatureGadget},
         alloc::AllocGadget,
         eq::{ConditionalEqGadget, EqGadget, NEqGadget},
         fields::FieldGadget,
@@ -228,7 +228,7 @@ where
     RecordCommitment::Output: Eq,
     AccountCommitmentGadget: CommitmentGadget<AccountCommitment, C::InnerScalarField>,
     AccountEncryptionGadget: EncryptionGadget<AccountEncryption, C::InnerScalarField>,
-    AccountSignatureGadget: SignaturePublicKeyRandomizationGadget<AccountSignature, C::InnerScalarField>,
+    AccountSignatureGadget: SignatureGadget<AccountSignature, C::InnerScalarField>,
     RecordCommitmentGadget: CommitmentGadget<RecordCommitment, C::InnerScalarField>,
     EncryptedRecordCRHGadget: CRHGadget<EncryptedRecordCRH, C::InnerScalarField>,
     LocalDataCRHGadget: CRHGadget<LocalDataCRH, C::InnerScalarField>,
@@ -568,7 +568,7 @@ where
             )?;
             let randomizer_bytes = randomizer.to_bytes(&mut sn_cs.ns(|| "Convert randomizer to bytes"))?;
 
-            let candidate_serial_number_gadget = AccountSignatureGadget::check_randomization_gadget(
+            let candidate_serial_number_gadget = AccountSignatureGadget::randomize_public_key(
                 &mut sn_cs.ns(|| "Compute serial number"),
                 &account_signature_parameters,
                 &pk_sig,

--- a/dpc/src/testnet1/instantiated.rs
+++ b/dpc/src/testnet1/instantiated.rs
@@ -50,7 +50,7 @@ use snarkvm_gadgets::{
         crh::BoweHopwoodPedersenCompressedCRHGadget,
         encryption::GroupEncryptionGadget,
         prf::Blake2sGadget,
-        signature::SchnorrPublicKeyRandomizationGadget,
+        signature::SchnorrGadget,
         snark::{GM17VerifierGadget, Groth16VerifierGadget},
     },
     curves::{bls12_377::PairingGadget, edwards_bls12::EdwardsBls12Gadget, edwards_bw6::EdwardsBW6Gadget},
@@ -85,7 +85,7 @@ impl DPCComponents for Components {
     type AccountEncryptionGadget = GroupEncryptionGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
 
     type AccountSignature = Schnorr<EdwardsBls12>;
-    type AccountSignatureGadget = SchnorrPublicKeyRandomizationGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
+    type AccountSignatureGadget = SchnorrGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
     
     type EncryptedRecordCRH = BoweHopwoodPedersenCompressedCRH<EdwardsBls12, 48, 44>;
     type EncryptedRecordCRHGadget = BoweHopwoodPedersenCompressedCRHGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 48, 44>;

--- a/dpc/src/testnet1/mod.rs
+++ b/dpc/src/testnet1/mod.rs
@@ -476,19 +476,19 @@ where
 
         let mut signatures = Vec::with_capacity(C::NUM_INPUT_RECORDS);
         for i in 0..C::NUM_INPUT_RECORDS {
-            // Sign the transaction data
-            let account_signature = C::AccountSignature::sign(
+            // Randomize the private key.
+            let randomized_private_key = C::AccountSignature::randomize_private_key(
                 &self.system_parameters.account_signature,
                 &old_private_keys[i].sk_sig,
-                &signature_message,
-                rng,
+                &old_randomizers[i],
             )?;
 
-            // Randomize the signature
-            let randomized_signature = C::AccountSignature::randomize_signature(
+            // Sign the transaction data.
+            let randomized_signature = C::AccountSignature::sign_randomized(
                 &self.system_parameters.account_signature,
-                &account_signature,
-                &old_randomizers[i],
+                &randomized_private_key,
+                &signature_message,
+                rng,
             )?;
 
             signatures.push(randomized_signature);

--- a/dpc/src/testnet1/record/record.rs
+++ b/dpc/src/testnet1/record/record.rs
@@ -179,11 +179,18 @@ impl<C: Testnet1Components> Record<C> {
         }
     }
 
+    // TODO (howardwu) - Change the private_key input to a signature_public_key.
     pub fn to_serial_number(
         &self,
         signature_parameters: &C::AccountSignature,
         private_key: &PrivateKey<C>,
-    ) -> Result<(<C::AccountSignature as SignatureScheme>::PublicKey, Vec<u8>), RecordError> {
+    ) -> Result<
+        (
+            <C::AccountSignature as SignatureScheme>::PublicKey,
+            <C::AccountSignature as SignatureScheme>::Randomizer,
+        ),
+        RecordError,
+    > {
         let timer = start_timer!(|| "Generate serial number");
 
         // TODO (howardwu) - Implement after removing parameters from the inputs.
@@ -195,8 +202,8 @@ impl<C: Testnet1Components> Record<C> {
         // Compute the serial number.
         let seed = FromBytes::read_le(to_bytes_le!(&private_key.sk_prf)?.as_slice())?;
         let input = FromBytes::read_le(to_bytes_le!(self.serial_number_nonce)?.as_slice())?;
-        let randomizer = to_bytes_le![C::PRF::evaluate(&seed, &input)?]?;
-        let serial_number = C::AccountSignature::randomize_private_key(
+        let randomizer = FromBytes::from_bytes_le(&C::PRF::evaluate(&seed, &input)?.to_bytes_le()?)?;
+        let serial_number = C::AccountSignature::randomize_public_key(
             &signature_parameters,
             &private_key.pk_sig(&signature_parameters)?,
             &randomizer,

--- a/dpc/src/testnet1/record/record.rs
+++ b/dpc/src/testnet1/record/record.rs
@@ -196,7 +196,7 @@ impl<C: Testnet1Components> Record<C> {
         let seed = FromBytes::read_le(to_bytes_le!(&private_key.sk_prf)?.as_slice())?;
         let input = FromBytes::read_le(to_bytes_le!(self.serial_number_nonce)?.as_slice())?;
         let randomizer = to_bytes_le![C::PRF::evaluate(&seed, &input)?]?;
-        let serial_number = C::AccountSignature::randomize_public_key(
+        let serial_number = C::AccountSignature::randomize_private_key(
             &signature_parameters,
             &private_key.pk_sig(&signature_parameters)?,
             &randomizer,

--- a/dpc/src/testnet1/transaction/kernel.rs
+++ b/dpc/src/testnet1/transaction/kernel.rs
@@ -19,7 +19,7 @@ use crate::{
     testnet1::{EncryptedRecord, LocalData, Record, SystemParameters, Testnet1Components, Transaction},
 };
 use snarkvm_algorithms::{commitment_tree::CommitmentMerkleTree, prelude::*};
-use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use std::{
     fmt,
@@ -42,7 +42,7 @@ pub struct TransactionKernel<C: Testnet1Components> {
     // Old record stuff
     pub old_records: Vec<Record<C>>,
     pub old_serial_numbers: Vec<<C::AccountSignature as SignatureScheme>::PublicKey>,
-    pub old_randomizers: Vec<Vec<u8>>,
+    pub old_randomizers: Vec<<C::AccountSignature as SignatureScheme>::Randomizer>,
 
     // New record stuff
     pub new_records: Vec<Record<C>>,
@@ -97,7 +97,6 @@ impl<C: Testnet1Components> ToBytes for TransactionKernel<C> {
         }
 
         for old_randomizer in &self.old_randomizers {
-            variable_length_integer(old_randomizer.len() as u64).write_le(&mut writer)?;
             old_randomizer.write_le(&mut writer)?;
         }
 
@@ -166,14 +165,8 @@ impl<C: Testnet1Components> FromBytes for TransactionKernel<C> {
 
         let mut old_randomizers = vec![];
         for _ in 0..C::NUM_INPUT_RECORDS {
-            let num_bytes = read_variable_length_integer(&mut reader)?;
-            let mut randomizer = vec![];
-            for _ in 0..num_bytes {
-                let byte: u8 = FromBytes::read_le(&mut reader)?;
-                randomizer.push(byte);
-            }
-
-            old_randomizers.push(randomizer);
+            let old_randomizer: <C::AccountSignature as SignatureScheme>::Randomizer = FromBytes::read_le(&mut reader)?;
+            old_randomizers.push(old_randomizer);
         }
 
         // Read new record components

--- a/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/testnet2/inner_circuit/inner_circuit_gadget.rs
@@ -44,7 +44,7 @@ use snarkvm_gadgets::{
     fields::FpGadget,
     integers::{int::Int64, uint::UInt8},
     traits::{
-        algorithms::{CRHGadget, CommitmentGadget, EncryptionGadget, PRFGadget, SignaturePublicKeyRandomizationGadget},
+        algorithms::{CRHGadget, CommitmentGadget, EncryptionGadget, PRFGadget, SignatureGadget},
         alloc::AllocGadget,
         eq::{ConditionalEqGadget, EqGadget, NEqGadget},
         fields::FieldGadget,
@@ -228,7 +228,7 @@ where
     RecordCommitment::Output: Eq,
     AccountCommitmentGadget: CommitmentGadget<AccountCommitment, C::InnerScalarField>,
     AccountEncryptionGadget: EncryptionGadget<AccountEncryption, C::InnerScalarField>,
-    AccountSignatureGadget: SignaturePublicKeyRandomizationGadget<AccountSignature, C::InnerScalarField>,
+    AccountSignatureGadget: SignatureGadget<AccountSignature, C::InnerScalarField>,
     RecordCommitmentGadget: CommitmentGadget<RecordCommitment, C::InnerScalarField>,
     EncryptedRecordCRHGadget: CRHGadget<EncryptedRecordCRH, C::InnerScalarField>,
     LocalDataCRHGadget: CRHGadget<LocalDataCRH, C::InnerScalarField>,
@@ -568,7 +568,7 @@ where
             )?;
             let randomizer_bytes = randomizer.to_bytes(&mut sn_cs.ns(|| "Convert randomizer to bytes"))?;
 
-            let candidate_serial_number_gadget = AccountSignatureGadget::check_randomization_gadget(
+            let candidate_serial_number_gadget = AccountSignatureGadget::randomize_public_key(
                 &mut sn_cs.ns(|| "Compute serial number"),
                 &account_signature_parameters,
                 &pk_sig,

--- a/dpc/src/testnet2/instantiated.rs
+++ b/dpc/src/testnet2/instantiated.rs
@@ -50,7 +50,7 @@ use snarkvm_gadgets::{
         crh::BoweHopwoodPedersenCompressedCRHGadget,
         encryption::GroupEncryptionGadget,
         prf::Blake2sGadget,
-        signature::SchnorrPublicKeyRandomizationGadget,
+        signature::SchnorrGadget,
         snark::Groth16VerifierGadget,
     },
     curves::{bls12_377::PairingGadget, edwards_bls12::EdwardsBls12Gadget, edwards_bw6::EdwardsBW6Gadget},
@@ -93,7 +93,7 @@ impl DPCComponents for Components {
     type AccountEncryptionGadget = GroupEncryptionGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
 
     type AccountSignature = Schnorr<EdwardsBls12>;
-    type AccountSignatureGadget = SchnorrPublicKeyRandomizationGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
+    type AccountSignatureGadget = SchnorrGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
     
     type EncryptedRecordCRH = BoweHopwoodPedersenCompressedCRH<EdwardsBls12, 48, 44>;
     type EncryptedRecordCRHGadget = BoweHopwoodPedersenCompressedCRHGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 48, 44>;

--- a/dpc/src/testnet2/mod.rs
+++ b/dpc/src/testnet2/mod.rs
@@ -503,19 +503,19 @@ where
 
         let mut signatures = Vec::with_capacity(C::NUM_INPUT_RECORDS);
         for i in 0..C::NUM_INPUT_RECORDS {
-            // Sign the transaction data
-            let account_signature = C::AccountSignature::sign(
+            // Randomize the private key.
+            let randomized_private_key = C::AccountSignature::randomize_private_key(
                 &self.system_parameters.account_signature,
                 &old_private_keys[i].sk_sig,
-                &signature_message,
-                rng,
+                &old_randomizers[i],
             )?;
 
-            // Randomize the signature
-            let randomized_signature = C::AccountSignature::randomize_signature(
+            // Sign the transaction data.
+            let randomized_signature = C::AccountSignature::sign_randomized(
                 &self.system_parameters.account_signature,
-                &account_signature,
-                &old_randomizers[i],
+                &randomized_private_key,
+                &signature_message,
+                rng,
             )?;
 
             signatures.push(randomized_signature);

--- a/dpc/src/testnet2/record/record.rs
+++ b/dpc/src/testnet2/record/record.rs
@@ -196,7 +196,7 @@ impl<C: Testnet2Components> Record<C> {
         let seed = FromBytes::read_le(to_bytes_le!(&private_key.sk_prf)?.as_slice())?;
         let input = FromBytes::read_le(to_bytes_le!(self.serial_number_nonce)?.as_slice())?;
         let randomizer = to_bytes_le![C::PRF::evaluate(&seed, &input)?]?;
-        let serial_number = C::AccountSignature::randomize_public_key(
+        let serial_number = C::AccountSignature::randomize_private_key(
             &signature_parameters,
             &private_key.pk_sig(&signature_parameters)?,
             &randomizer,

--- a/dpc/src/traits/dpc_components.rs
+++ b/dpc/src/traits/dpc_components.rs
@@ -17,13 +17,7 @@
 use snarkvm_algorithms::traits::{CommitmentScheme, EncryptionScheme, SignatureScheme, CRH, PRF};
 use snarkvm_curves::PairingEngine;
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::algorithms::{
-    CRHGadget,
-    CommitmentGadget,
-    EncryptionGadget,
-    PRFGadget,
-    SignaturePublicKeyRandomizationGadget,
-};
+use snarkvm_gadgets::traits::algorithms::{CRHGadget, CommitmentGadget, EncryptionGadget, PRFGadget, SignatureGadget};
 
 pub trait DPCComponents: 'static + Sized {
     const NETWORK_ID: u8;
@@ -48,7 +42,7 @@ pub trait DPCComponents: 'static + Sized {
 
     /// Signature scheme for delegated compute.
     type AccountSignature: SignatureScheme;
-    type AccountSignatureGadget: SignaturePublicKeyRandomizationGadget<Self::AccountSignature, Self::InnerScalarField>;
+    type AccountSignatureGadget: SignatureGadget<Self::AccountSignature, Self::InnerScalarField>;
 
     /// CRH for the encrypted record.
     type EncryptedRecordCRH: CRH;

--- a/gadgets/src/algorithms/signature/schnorr.rs
+++ b/gadgets/src/algorithms/signature/schnorr.rs
@@ -18,7 +18,7 @@ use crate::{
     bits::{Boolean, ToBytesGadget},
     integers::uint::UInt8,
     traits::{
-        algorithms::SignaturePublicKeyRandomizationGadget,
+        algorithms::SignatureGadget,
         alloc::AllocGadget,
         curves::GroupGadget,
         eq::{ConditionalEqGadget, EqGadget},
@@ -276,7 +276,7 @@ impl<G: ProjectiveCurve, F: PrimeField> ToBytesGadget<F> for SchnorrSignatureGad
     }
 }
 
-pub struct SchnorrPublicKeyRandomizationGadget<
+pub struct SchnorrGadget<
     G: ProjectiveCurve,
     F: PrimeField + PoseidonDefaultParametersField,
     GG: GroupGadget<G, F> + ToConstraintFieldGadget<F>,
@@ -290,7 +290,7 @@ impl<
     G: ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize,
     GG: GroupGadget<G, F> + ToConstraintFieldGadget<F>,
     F: PrimeField + PoseidonDefaultParametersField,
-> SignaturePublicKeyRandomizationGadget<Schnorr<G>, F> for SchnorrPublicKeyRandomizationGadget<G, F, GG>
+> SignatureGadget<Schnorr<G>, F> for SchnorrGadget<G, F, GG>
 where
     <G::Affine as AffineCurve>::BaseField: PoseidonDefaultParametersField,
     G: ToConstraintField<<G::Affine as AffineCurve>::BaseField>,
@@ -299,21 +299,23 @@ where
     type PublicKeyGadget = SchnorrPublicKeyGadget<G, F, GG>;
     type SignatureGadget = SchnorrSignatureGadget<G, F>;
 
-    fn check_randomization_gadget<CS: ConstraintSystem<F>>(
+    fn randomize_public_key<CS: ConstraintSystem<F>>(
         mut cs: CS,
         parameters: &Self::ParametersGadget,
         public_key: &Self::PublicKeyGadget,
-        randomness: &[UInt8],
+        randomizer: &[UInt8],
     ) -> Result<Self::PublicKeyGadget, SynthesisError> {
-        let randomness = randomness.iter().flat_map(|b| b.to_bits_le()).collect::<Vec<_>>();
-        let mut rand_pk = public_key.public_key.clone();
-        rand_pk.scalar_multiplication(
+        let randomness = randomizer.iter().flat_map(|b| b.to_bits_le()).collect::<Vec<_>>();
+
+        let mut randomized_public_key = GG::zero(cs.ns(|| "zero"))?;
+        randomized_public_key.scalar_multiplication(
             cs.ns(|| "check_randomization_gadget"),
             randomness.iter().zip_eq(&parameters.parameters.generator_powers),
         )?;
+        randomized_public_key = randomized_public_key.add(cs.ns(|| "pk + rG"), &public_key.public_key)?;
 
         Ok(SchnorrPublicKeyGadget {
-            public_key: rand_pk,
+            public_key: randomized_public_key,
             _group: PhantomData,
             _engine: PhantomData,
         })
@@ -370,22 +372,15 @@ where
         )?;
 
         // Construct the hash
-        let mut hash_input = {
-            let salt_bytes_field_elements: Vec<F> = parameters.parameters.salt.to_field_elements().unwrap();
-
-            let mut res = Vec::new();
-
-            for (i, elem) in salt_bytes_field_elements.iter().enumerate() {
-                res.push(FpGadget::<F>::alloc_constant(
-                    cs.ns(|| format!("alloc salt byte field element {}", i)),
-                    || Ok((*elem).clone()),
-                )?);
-            }
-            res
-        };
+        let mut hash_input = Vec::new();
         hash_input.extend_from_slice(
             &claimed_prover_commitment
                 .to_constraint_field(cs.ns(|| "convert claimed_prover_commitment into field elements"))?,
+        );
+        hash_input.extend_from_slice(
+            &public_key
+                .public_key
+                .to_constraint_field(cs.ns(|| "convert public key into field elements"))?,
         );
         hash_input.push(FpGadget::<F>::Constant(F::from(message.len() as u128)));
         hash_input.extend_from_slice(&message.to_constraint_field(cs.ns(|| "convert message into field elements"))?);

--- a/gadgets/src/algorithms/signature/tests.rs
+++ b/gadgets/src/algorithms/signature/tests.rs
@@ -57,7 +57,7 @@ fn test_schnorr_signature_randomize_public_key_gadget() {
 
     let random_scalar = to_bytes_le!(<EdwardsProjective as Group>::ScalarField::rand(rng)).unwrap();
     let randomized_public_key = schnorr_signature
-        .randomize_public_key(&public_key, &random_scalar)
+        .randomize_private_key(&public_key, &random_scalar)
         .unwrap();
     let randomized_signature = schnorr_signature
         .randomize_signature(&signature, &random_scalar)

--- a/gadgets/src/algorithms/signature/tests.rs
+++ b/gadgets/src/algorithms/signature/tests.rs
@@ -15,98 +15,87 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    algorithms::signature::{SchnorrParametersGadget, SchnorrPublicKeyGadget, SchnorrPublicKeyRandomizationGadget},
+    algorithms::signature::{SchnorrGadget, SchnorrParametersGadget, SchnorrPublicKeyGadget},
     curves::edwards_bls12::EdwardsBls12Gadget,
     integers::uint::UInt8,
-    traits::{algorithms::SignaturePublicKeyRandomizationGadget, alloc::AllocGadget, eq::EqGadget},
+    traits::{algorithms::SignatureGadget, alloc::AllocGadget, eq::EqGadget},
     Boolean,
 };
 use snarkvm_algorithms::{signature::Schnorr, traits::SignatureScheme};
 use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective, traits::Group};
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{rand::UniformRand, to_bytes_le, ToBytes};
+use snarkvm_utilities::{ToBytes, UniformRand};
 
 use rand::{thread_rng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
 type SchnorrScheme = Schnorr<EdwardsProjective>;
 type TestSignature = Schnorr<EdwardsProjective>;
-type TestSignatureGadget = SchnorrPublicKeyRandomizationGadget<EdwardsProjective, Fr, EdwardsBls12Gadget>;
+type TestSignatureGadget = SchnorrGadget<EdwardsProjective, Fr, EdwardsBls12Gadget>;
 
 #[test]
 fn test_schnorr_signature_randomize_public_key_gadget() {
     // Setup environment
-
     let mut cs = TestConstraintSystem::<Fr>::new();
     let rng = &mut thread_rng();
 
     // Native Schnorr message
-
-    let mut message = [0u8; 32];
-    rng.fill(&mut message);
+    let message: [u8; 32] = rng.gen();
 
     // Native Schnorr signing
-
-    let schnorr_signature = SchnorrScheme::setup::<_>(rng).unwrap();
-    let private_key = schnorr_signature.generate_private_key(rng).unwrap();
-    let public_key = schnorr_signature.generate_public_key(&private_key).unwrap();
-    let signature = schnorr_signature.sign(&private_key, &message, rng).unwrap();
-    assert!(schnorr_signature.verify(&public_key, &message, &signature).unwrap());
+    let schnorr = SchnorrScheme::setup::<_>(rng).unwrap();
+    let private_key = schnorr.generate_private_key(rng).unwrap();
+    let public_key = schnorr.generate_public_key(&private_key).unwrap();
+    let signature = schnorr.sign(&private_key, &message, rng).unwrap();
+    assert!(schnorr.verify(&public_key, &message, &signature).unwrap());
 
     // Native Schnorr randomization
-
-    let random_scalar = to_bytes_le!(<EdwardsProjective as Group>::ScalarField::rand(rng)).unwrap();
-    let randomized_public_key = schnorr_signature
-        .randomize_private_key(&public_key, &random_scalar)
-        .unwrap();
-    let randomized_signature = schnorr_signature
-        .randomize_signature(&signature, &random_scalar)
-        .unwrap();
+    let randomizer = <EdwardsProjective as Group>::ScalarField::rand(rng);
+    let randomized_private_key = schnorr.randomize_private_key(&private_key, &randomizer).unwrap();
+    let randomized_public_key = schnorr.randomize_public_key(&public_key, &randomizer).unwrap();
+    let randomized_signature = schnorr.sign_randomized(&randomized_private_key, &message, rng).unwrap();
+    assert!(signature != randomized_signature);
     assert!(
-        schnorr_signature
+        schnorr
             .verify(&randomized_public_key, &message, &randomized_signature)
             .unwrap()
     );
 
-    // Circuit Schnorr randomized public key (candidate)
-
     let candidate_parameters_gadget =
         SchnorrParametersGadget::<EdwardsProjective, Fr>::alloc_input(&mut cs.ns(|| "candidate_parameters"), || {
-            Ok(schnorr_signature.parameters())
+            Ok(schnorr.parameters())
         })
         .unwrap();
 
-    let candidate_public_key_gadget = SchnorrPublicKeyGadget::<EdwardsProjective, Fr, EdwardsBls12Gadget>::alloc(
+    // Circuit Schnorr randomized public key (candidate)
+    let candidate_public_key = SchnorrPublicKeyGadget::<EdwardsProjective, Fr, EdwardsBls12Gadget>::alloc(
         &mut cs.ns(|| "candidate_public_key"),
         || Ok(&public_key),
     )
     .unwrap();
-
-    let candidate_randomizer = UInt8::alloc_vec(&mut cs.ns(|| "candidate_randomizer"), &random_scalar).unwrap();
-
-    let candidate_randomized_public_key_gadget = <SchnorrPublicKeyRandomizationGadget<
-        EdwardsProjective,
-        Fr,
-        EdwardsBls12Gadget,
-    > as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::check_randomization_gadget(
-        &mut cs.ns(|| "candidate_randomized_public_key"),
-        &candidate_parameters_gadget,
-        &candidate_public_key_gadget,
-        &candidate_randomizer,
+    let candidate_randomizer = UInt8::alloc_vec(
+        &mut cs.ns(|| "candidate_randomizer"),
+        &randomizer.to_bytes_le().unwrap(),
     )
     .unwrap();
-
-    // Circuit Schnorr randomized public key (given)
-
-    let given_randomized_public_key_gadget =
-        SchnorrPublicKeyGadget::<EdwardsProjective, Fr, EdwardsBls12Gadget>::alloc_input(
-            &mut cs.ns(|| "given_randomized_public_key"),
-            || Ok(randomized_public_key),
+    let candidate_randomized_public_key =
+        <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::randomize_public_key(
+            &mut cs.ns(|| "candidate_randomized_public_key"),
+            &candidate_parameters_gadget,
+            &candidate_public_key,
+            &candidate_randomizer,
         )
         .unwrap();
 
-    candidate_randomized_public_key_gadget
-        .enforce_equal(&mut cs.ns(|| "enforce_equal"), &given_randomized_public_key_gadget)
+    // Circuit Schnorr randomized public key (given)
+    let given_randomized_public_key = SchnorrPublicKeyGadget::<EdwardsProjective, Fr, EdwardsBls12Gadget>::alloc_input(
+        &mut cs.ns(|| "given_randomized_public_key"),
+        || Ok(randomized_public_key),
+    )
+    .unwrap();
+
+    candidate_randomized_public_key
+        .enforce_equal(&mut cs.ns(|| "enforce_equal"), &given_randomized_public_key)
         .unwrap();
 
     if !cs.is_satisfied() {
@@ -124,26 +113,23 @@ fn schnorr_signature_verification_test() {
     let private_key = schnorr_signature.generate_private_key(rng).unwrap();
     let public_key = schnorr_signature.generate_public_key(&private_key).unwrap();
     let signature = schnorr_signature.sign(&private_key, &message, rng).unwrap();
-
     assert!(schnorr_signature.verify(&public_key, &message, &signature).unwrap());
 
     let mut cs = TestConstraintSystem::<Fr>::new();
 
-    let parameter_gadget =
-        <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::ParametersGadget::alloc(
-            cs.ns(|| "alloc_parameters"),
-            || Ok(schnorr_signature.parameters),
-        )
-        .unwrap();
+    let parameter_gadget = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::ParametersGadget::alloc(
+        cs.ns(|| "alloc_parameters"),
+        || Ok(schnorr_signature.parameters),
+    )
+    .unwrap();
 
     assert_eq!(cs.num_constraints(), 0);
 
-    let public_key_gadget =
-        <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::PublicKeyGadget::alloc(
-            cs.ns(|| "alloc_public_key"),
-            || Ok(public_key),
-        )
-        .unwrap();
+    let public_key_gadget = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::PublicKeyGadget::alloc(
+        cs.ns(|| "alloc_public_key"),
+        || Ok(public_key),
+    )
+    .unwrap();
 
     assert_eq!(cs.num_constraints(), 13);
 
@@ -151,16 +137,15 @@ fn schnorr_signature_verification_test() {
 
     assert_eq!(cs.num_constraints(), 245);
 
-    let signature_gadget =
-        <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::SignatureGadget::alloc(
-            cs.ns(|| "alloc_signature"),
-            || Ok(signature),
-        )
-        .unwrap();
+    let signature_gadget = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::SignatureGadget::alloc(
+        cs.ns(|| "alloc_signature"),
+        || Ok(signature),
+    )
+    .unwrap();
 
     assert_eq!(cs.num_constraints(), 245);
 
-    let verification = <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::verify(
+    let verification = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::verify(
         cs.ns(|| "verify"),
         &parameter_gadget,
         &public_key_gadget,
@@ -197,30 +182,27 @@ fn failed_schnorr_signature_verification_test() {
 
     let mut cs = TestConstraintSystem::<Fr>::new();
 
-    let parameter_gadget =
-        <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::ParametersGadget::alloc(
-            cs.ns(|| "alloc_parameters"),
-            || Ok(schnorr_signature.parameters),
-        )
-        .unwrap();
+    let parameter_gadget = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::ParametersGadget::alloc(
+        cs.ns(|| "alloc_parameters"),
+        || Ok(schnorr_signature.parameters),
+    )
+    .unwrap();
 
-    let public_key_gadget =
-        <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::PublicKeyGadget::alloc(
-            cs.ns(|| "alloc_public_key"),
-            || Ok(public_key),
-        )
-        .unwrap();
+    let public_key_gadget = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::PublicKeyGadget::alloc(
+        cs.ns(|| "alloc_public_key"),
+        || Ok(public_key),
+    )
+    .unwrap();
 
     let bad_message_gadget = UInt8::alloc_vec(cs.ns(|| "alloc_message"), bad_message).unwrap();
 
-    let signature_gadget =
-        <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::SignatureGadget::alloc(
-            cs.ns(|| "alloc_signature"),
-            || Ok(signature),
-        )
-        .unwrap();
+    let signature_gadget = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::SignatureGadget::alloc(
+        cs.ns(|| "alloc_signature"),
+        || Ok(signature),
+    )
+    .unwrap();
 
-    let verification = <TestSignatureGadget as SignaturePublicKeyRandomizationGadget<SchnorrScheme, Fr>>::verify(
+    let verification = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::verify(
         cs.ns(|| "verify"),
         &parameter_gadget,
         &public_key_gadget,

--- a/gadgets/src/traits/algorithms/signature.rs
+++ b/gadgets/src/traits/algorithms/signature.rs
@@ -25,16 +25,16 @@ use crate::{
     Boolean,
 };
 
-pub trait SignaturePublicKeyRandomizationGadget<S: SignatureScheme, F: Field> {
+pub trait SignatureGadget<S: SignatureScheme, F: Field> {
     type ParametersGadget: AllocGadget<S::Parameters, F>;
     type PublicKeyGadget: ToBytesGadget<F> + EqGadget<F> + AllocGadget<S::PublicKey, F> + Clone;
     type SignatureGadget: ToBytesGadget<F> + EqGadget<F> + AllocGadget<S::Signature, F> + Clone;
 
-    fn check_randomization_gadget<CS: ConstraintSystem<F>>(
+    fn randomize_public_key<CS: ConstraintSystem<F>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         public_key: &Self::PublicKeyGadget,
-        randomness: &[UInt8],
+        randomizer: &[UInt8],
     ) -> Result<Self::PublicKeyGadget, SynthesisError>;
 
     fn verify<CS: ConstraintSystem<F>>(


### PR DESCRIPTION
## Motivation

- Updates Schnorr native and circuit verifier challenge with public key, removing the salt.
- Updates Schnorr native and circuit randomization scheme.
- Adds `CryptoRng` to Signature scheme traits.

## Approach

This implementation of Schnorr constructs a signature with a `verifier_challenge` defined as:
```
verifier_challenge := ToScalarField( H( prover_commitment || public_key || message_length || message ))
```
As part of this, the former `salt` has been removed. In addition, by introducing the public key to the hash, this requires rearchitecting signature randomization. Previously we employed randomization as follows:
```
[G] := {0, 1}*

private_key := {0, 1}*
[public_key] := private_key * [G]
message := "Hello World"
(prover_response, verifier_challenge) := Sign(private_key, message)

randomizer := {0, 1}*
[randomized_public_key] := randomizer * [public_key]
randomized_prover_response := prover_response - (verifier_challenge * randomizer)
randomized_verifier_challenge := verifier_challenge
```
However, with the public key in the preimage of the hash, we update the scheme to continue support for randomization  as follows (credits to @Pratyush):
```
[G] := {0, 1}*

private_key := {0, 1}*
[public_key] := private_key * [G]
message := "Hello World"
(prover_response, verifier_challenge) := Sign(private_key, message)

randomizer := {0, 1}*
randomized_private_key := private_key * randomizer
[randomized_public_key] := randomized_private_key * [G] == randomizer * [public_key]
(randomized_prover_response, randomized_verifier_challenge) := Sign(randomized_private_key, message)
```

## Test Plan

- Updates existing Schnorr tests to reflect the new convention.
- Adds a new check that `randomized_private_key * [G] == randomizer * [public_key]`