### PR TITLE
Implement `is_eq` for group gadgets

### DIFF
--- a/gadgets/src/curves/bls12_377.rs
+++ b/gadgets/src/curves/bls12_377.rs
@@ -215,4 +215,54 @@ mod test {
 
         assert!(cs.is_satisfied());
     }
+
+    #[test]
+    fn bls12_g1_gadget_is_eq_test() {
+        let mut cs = TestConstraintSystem::<Fq>::new();
+
+        let a: G1 = rand::random();
+        let b: G1 = a.clone();
+        let c: G1 = rand::random();
+
+        let a = G1Gadget::alloc(&mut cs.ns(|| "generate_a"), || Ok(a)).unwrap();
+        let b = G1Gadget::alloc(&mut cs.ns(|| "generate_b"), || Ok(b)).unwrap();
+        let c = G1Gadget::alloc(&mut cs.ns(|| "generate_c"), || Ok(c)).unwrap();
+
+        let a_is_eq_b = a.is_eq(cs.ns(|| "a_is_eq_b"), &b).unwrap();
+        let a_is_eq_c = a.is_eq(cs.ns(|| "a_is_eq_c"), &c).unwrap();
+
+        a_is_eq_b
+            .enforce_equal(cs.ns(|| " a_is_eq_b is true"), &Boolean::constant(true))
+            .unwrap();
+        a_is_eq_c
+            .enforce_equal(cs.ns(|| " a_is_eq_c is false"), &Boolean::constant(false))
+            .unwrap();
+
+        assert!(cs.is_satisfied());
+    }
+
+    #[test]
+    fn bls12_g2_gadget_is_eq_test() {
+        let mut cs = TestConstraintSystem::<Fq>::new();
+
+        let a: G2 = rand::random();
+        let b: G2 = a.clone();
+        let c: G2 = rand::random();
+
+        let a = G2Gadget::alloc(&mut cs.ns(|| "generate_a"), || Ok(a)).unwrap();
+        let b = G2Gadget::alloc(&mut cs.ns(|| "generate_b"), || Ok(b)).unwrap();
+        let c = G2Gadget::alloc(&mut cs.ns(|| "generate_c"), || Ok(c)).unwrap();
+
+        let a_is_eq_b = a.is_eq(cs.ns(|| "a_is_eq_b"), &b).unwrap();
+        let a_is_eq_c = a.is_eq(cs.ns(|| "a_is_eq_c"), &c).unwrap();
+
+        a_is_eq_b
+            .enforce_equal(cs.ns(|| " a_is_eq_b is true"), &Boolean::constant(true))
+            .unwrap();
+        a_is_eq_c
+            .enforce_equal(cs.ns(|| " a_is_eq_c is false"), &Boolean::constant(false))
+            .unwrap();
+
+        assert!(cs.is_satisfied());
+    }
 }

--- a/gadgets/src/curves/edwards_bls12.rs
+++ b/gadgets/src/curves/edwards_bls12.rs
@@ -28,7 +28,8 @@ mod test {
             templates::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
             tests_group::group_test,
         },
-        traits::alloc::AllocGadget,
+        traits::{alloc::AllocGadget, eq::EqGadget},
+        Boolean,
     };
     use snarkvm_curves::edwards_bls12::{EdwardsParameters, EdwardsProjective, Fq};
     use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
@@ -57,5 +58,30 @@ mod test {
         let a = EdwardsBls12Gadget::alloc(&mut cs.ns(|| "generate_a"), || Ok(a)).unwrap();
         let b = EdwardsBls12Gadget::alloc(&mut cs.ns(|| "generate_b"), || Ok(b)).unwrap();
         group_test::<_, EdwardsProjective, _, _>(&mut cs.ns(|| "GroupTest(a, b)"), a, b);
+    }
+
+    #[test]
+    fn edwards_bls12_group_gadgets_is_eq_test() {
+        let mut cs = TestConstraintSystem::<Fq>::new();
+
+        let a: EdwardsProjective = rand::random();
+        let b: EdwardsProjective = a.clone();
+        let c: EdwardsProjective = rand::random();
+
+        let a = EdwardsBls12Gadget::alloc(&mut cs.ns(|| "generate_a"), || Ok(a)).unwrap();
+        let b = EdwardsBls12Gadget::alloc(&mut cs.ns(|| "generate_b"), || Ok(b)).unwrap();
+        let c = EdwardsBls12Gadget::alloc(&mut cs.ns(|| "generate_c"), || Ok(c)).unwrap();
+
+        let a_is_eq_b = a.is_eq(cs.ns(|| "a_is_eq_b"), &b).unwrap();
+        let a_is_eq_c = a.is_eq(cs.ns(|| "a_is_eq_c"), &c).unwrap();
+
+        a_is_eq_b
+            .enforce_equal(cs.ns(|| " a_is_eq_b is true"), &Boolean::constant(true))
+            .unwrap();
+        a_is_eq_c
+            .enforce_equal(cs.ns(|| " a_is_eq_c is false"), &Boolean::constant(false))
+            .unwrap();
+
+        assert!(cs.is_satisfied());
     }
 }

--- a/gadgets/src/curves/edwards_bw6.rs
+++ b/gadgets/src/curves/edwards_bw6.rs
@@ -29,7 +29,8 @@ mod test {
             templates::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
             tests_group::group_test,
         },
-        traits::alloc::AllocGadget,
+        traits::{alloc::AllocGadget, eq::EqGadget},
+        Boolean,
     };
     use snarkvm_curves::edwards_bw6::{EdwardsParameters, EdwardsProjective, Fq};
     use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
@@ -58,5 +59,30 @@ mod test {
         let a = EdwardsBW6Gadget::alloc(&mut cs.ns(|| "generate_a"), || Ok(a)).unwrap();
         let b = EdwardsBW6Gadget::alloc(&mut cs.ns(|| "generate_b"), || Ok(b)).unwrap();
         group_test::<_, EdwardsProjective, _, _>(&mut cs.ns(|| "GroupTest(a, b)"), a, b);
+    }
+
+    #[test]
+    fn edwards_bw6_group_gadgets_is_eq_test() {
+        let mut cs = TestConstraintSystem::<Fq>::new();
+
+        let a: EdwardsProjective = rand::random();
+        let b: EdwardsProjective = a.clone();
+        let c: EdwardsProjective = rand::random();
+
+        let a = EdwardsBW6Gadget::alloc(&mut cs.ns(|| "generate_a"), || Ok(a)).unwrap();
+        let b = EdwardsBW6Gadget::alloc(&mut cs.ns(|| "generate_b"), || Ok(b)).unwrap();
+        let c = EdwardsBW6Gadget::alloc(&mut cs.ns(|| "generate_c"), || Ok(c)).unwrap();
+
+        let a_is_eq_b = a.is_eq(cs.ns(|| "a_is_eq_b"), &b).unwrap();
+        let a_is_eq_c = a.is_eq(cs.ns(|| "a_is_eq_c"), &c).unwrap();
+
+        a_is_eq_b
+            .enforce_equal(cs.ns(|| " a_is_eq_b is true"), &Boolean::constant(true))
+            .unwrap();
+        a_is_eq_c
+            .enforce_equal(cs.ns(|| " a_is_eq_c is false"), &Boolean::constant(false))
+            .unwrap();
+
+        assert!(cs.is_satisfied());
     }
 }

--- a/gadgets/src/curves/templates/bls12/affine.rs
+++ b/gadgets/src/curves/templates/bls12/affine.rs
@@ -360,6 +360,14 @@ where
     F: Field,
     FG: FieldGadget<P::BaseField, F>,
 {
+    fn is_eq<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Boolean, SynthesisError> {
+        let x = self.x.is_eq(cs.ns(|| "x_is_eq"), &other.x)?;
+        let y = self.y.is_eq(cs.ns(|| "y_is_eq"), &other.y)?;
+        let infinity = self.infinity.is_eq(cs.ns(|| "infinity_is_eq"), &other.infinity)?;
+
+        let x_and_y = Boolean::and(cs.ns(|| "x_and_y"), &x, &y)?;
+        Boolean::and(cs.ns(|| "x_and_y_and_infinity"), &x_and_y, &infinity)
+    }
 }
 
 impl<P, F, FG> ConditionalEqGadget<F> for AffineGadget<P, F, FG>

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -1268,7 +1268,13 @@ impl<P: TwistedEdwardsParameters, F: Field, FG: FieldGadget<P::BaseField, F>> Co
     }
 }
 
-impl<P: TwistedEdwardsParameters, F: Field, FG: FieldGadget<P::BaseField, F>> EqGadget<F> for AffineGadget<P, F, FG> {}
+impl<P: TwistedEdwardsParameters, F: Field, FG: FieldGadget<P::BaseField, F>> EqGadget<F> for AffineGadget<P, F, FG> {
+    fn is_eq<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Boolean, SynthesisError> {
+        let x = self.x.is_eq(cs.ns(|| "x_is_eq"), &other.x)?;
+        let y = self.y.is_eq(cs.ns(|| "y_is_eq"), &other.y)?;
+        Boolean::and(cs.ns(|| "x_and_y"), &x, &y)
+    }
+}
 
 impl<P: TwistedEdwardsParameters, F: Field, FG: FieldGadget<P::BaseField, F>> ConditionalEqGadget<F>
     for AffineGadget<P, F, FG>


### PR DESCRIPTION
## Motivation

This PR is quite minor as it simply implements the `is_eq` for the `GroupGadget`s. The underlying `FieldGadget`s should already have the `is_eq` implementations.

## Test Plan

Tests have been added for each `GroupGadget` instantiation.