### PR TITLE
Implement `is_eq` for Schnorr gadgets

### DIFF
--- a/gadgets/src/algorithms/signature/schnorr.rs
+++ b/gadgets/src/algorithms/signature/schnorr.rs
@@ -108,7 +108,11 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: GroupGadget<G, F>> ConditionalEqGadg
     }
 }
 
-impl<G: ProjectiveCurve, F: PrimeField, GG: GroupGadget<G, F>> EqGadget<F> for SchnorrPublicKeyGadget<G, F, GG> {}
+impl<G: ProjectiveCurve, F: PrimeField, GG: GroupGadget<G, F>> EqGadget<F> for SchnorrPublicKeyGadget<G, F, GG> {
+    fn is_eq<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Boolean, SynthesisError> {
+        self.public_key.is_eq(cs.ns(|| "public_key_is_eq"), &other.public_key)
+    }
+}
 
 impl<G: ProjectiveCurve, F: PrimeField, GG: GroupGadget<G, F>> ToBytesGadget<F> for SchnorrPublicKeyGadget<G, F, GG> {
     fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
@@ -317,7 +321,6 @@ where
         })
     }
 
-    // TODO (raychu86): Make the blake2s usage generic for all PRFs.
     fn verify<CS: ConstraintSystem<F>>(
         &self,
         mut cs: CS,

--- a/gadgets/src/algorithms/signature/schnorr.rs
+++ b/gadgets/src/algorithms/signature/schnorr.rs
@@ -210,7 +210,22 @@ impl<G: ProjectiveCurve, F: PrimeField> ConditionalEqGadget<F> for SchnorrSignat
     }
 }
 
-impl<G: ProjectiveCurve, F: PrimeField> EqGadget<F> for SchnorrSignatureGadget<G, F> {}
+impl<G: ProjectiveCurve, F: PrimeField> EqGadget<F> for SchnorrSignatureGadget<G, F> {
+    fn is_eq<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Boolean, SynthesisError> {
+        let prover_response_is_eq = self
+            .prover_response
+            .is_eq(cs.ns(|| "prover_response_is_eq"), &other.prover_response)?;
+        let verifier_challenge_is_eq = self
+            .verifier_challenge
+            .is_eq(cs.ns(|| "verifier_challenge_is_eq"), &other.verifier_challenge)?;
+
+        Boolean::and(
+            cs.ns(|| "signature_is_eq"),
+            &prover_response_is_eq,
+            &verifier_challenge_is_eq,
+        )
+    }
+}
 
 impl<G: ProjectiveCurve, F: PrimeField> ToBytesGadget<F> for SchnorrSignatureGadget<G, F> {
     fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Very minor changes in this PR, which simply implements the `is_eq` function for `SchnorrPublicKeyGadget` and `SchnorrSignatureGadget`. 

This is needed to support the `is_eq` functionality of Aleo addresses in the gadget world.

