### PR TITLE
Tracking issue for trimmable SRS

### DIFF
--- a/algorithms/src/traits/snark.rs
+++ b/algorithms/src/traits/snark.rs
@@ -60,6 +60,13 @@ pub trait SNARK {
         unimplemented!()
     }
 
+    fn trim_universal_setup_parameters(
+        _long: &Self::UniversalSetupParameters,
+        _new_config: &Self::UniversalSetupConfig,
+    ) -> Result<Self::UniversalSetupParameters, SNARKError> {
+        unimplemented!()
+    }
+
     fn index<C: ConstraintSynthesizer<Self::ScalarField>>(
         _circuit: &C,
         _srs: &Self::UniversalSetupParameters,

--- a/marlin/src/parameters.rs
+++ b/marlin/src/parameters.rs
@@ -40,6 +40,16 @@ use std::{
     },
 };
 
+pub struct UniversalSetupConfig {
+    pub supported_degree : usize,
+    pub supported_hiding_bound : usize,
+}
+
+pub struct UniversalSetupParameters<E: PairingEngine> {
+    pub powers_of_g : Vec<E::G1Affine>,
+
+}
+
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""))]
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]

--- a/marlin/src/snark.rs
+++ b/marlin/src/snark.rs
@@ -116,6 +116,13 @@ where
         Ok(srs)
     }
 
+    fn trim_universal_setup_parameters(
+        _long: &Self::UniversalSetupParameters,
+        _new_config: &Self::UniversalSetupConfig,
+    ) -> Result<Self::UniversalSetupParameters, SNARKError> {
+        unimplemented!()
+    }
+
     fn index<C: ConstraintSynthesizer<E::Fr>>(
         circuit: &C,
         srs: &Self::UniversalSetupParameters,

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -88,6 +88,8 @@ pub struct MarlinKZG10<E: PairingEngine> {
     _engine: PhantomData<E>,
 }
 
+pub type UniversalSetupConfig = kzg10::UniversalSetupConfig;
+
 impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
     type BatchProof = Vec<Self::Proof>;
     type Commitment = Commitment<E>;
@@ -98,6 +100,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
     type Proof = kzg10::Proof<E>;
     type Randomness = Randomness<E>;
     type UniversalParams = UniversalParams<E>;
+    type UniversalSetupConfig = UniversalSetupConfig;
     type VerifierKey = VerifierKey<E>;
 
     /// Constructs public parameters when given as input the maximum degree `max_degree`
@@ -760,6 +763,10 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
             opening_challenges,
             rng,
         )
+    }
+
+    fn trim_srs(parameters: &Self::UniversalParams, new_config: &Self::UniversalSetupConfig) -> Result<Self::UniversalParams, Self::Error> {
+        todo!()
     }
 }
 

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -20,6 +20,7 @@ pub use crate::{
         Write,
         {self},
     },
+    ops::Range,
     FromBytes,
     ToBytes,
     Vec,
@@ -478,6 +479,35 @@ where
             map.insert(K::deserialize(reader)?, V::deserialize(reader)?);
         }
         Ok(map)
+    }
+}
+
+impl<T> CanonicalSerialize for Range<T>
+where
+    T: CanonicalSerialize,
+{
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+        self.start.serialize(writer)?;
+        self.end.serialize(writer)
+    }
+
+    fn serialized_size(&self) -> usize {
+        self.start.serialized_size() + self.end.serialized_size()
+    }
+}
+
+impl<T> CanonicalDeserialize for Range<T>
+where
+    T: CanonicalDeserialize,
+{
+    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+        let start = T::deserialize(reader)?;
+        let end = T::deserialize(reader)?;
+
+        Ok(Self {
+            start,
+            end
+        })
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR would consist of implementations toward making SRS trimmable. 

There are many things involved. We are currently at the first stage.
- make PolyCommit support SRS that is trimmable.
It is not finished yet.

This seems to already involve much changes, since SRS is not only about powers of `g`, but also:
- powers of `gamma_g` which in Marlin you only need 2 elements.
- negative powers of `g` in G2 which is not needed in Marlin but used in Sonic PC.
- powers of `g` but with degree `max_degree - i` which is used for degree bounds. In Marlin, all it needs has the shape of `2^t - 2`. 

Currently the setup is too long: it generates, up to the max_degree, of all of these.
And the SRS is too long: it contains all of these.

If we look at Marlin specifically, the actual effort of setup should be only 1/3, and the SRS would also be 1/3. 

Then, you can trim it further if you know that you only index and prove circuits of a specific level of complication.

## Test Plan

Will need several tests to ensure that the PC proof generated from the trimmed SRS matches those from the old, full SRS. Especially, pay attention to the hiding bounds. 
