### PR TITLE
Gracefully return an error message upon division by zero for signed integers

### DIFF
--- a/gadgets/src/integers/int/arithmetic/div.rs
+++ b/gadgets/src/integers/int/arithmetic/div.rs
@@ -61,6 +61,13 @@ macro_rules! div_int_impl {
                 // else
                 //    !Q                      -- negative result
 
+                // Check if other is already known to be zero.
+                if let Some(value) = other.value {
+                    if value == 0 as <$gadget as Integer>::IntegerType {
+                        return Err(SignedIntegerError::DivisionByZero.into());
+                    }
+                }
+
                 // If `self` and `other` are both constants, return the constant result instead of generating constraints.
                 if self.is_constant() && other.is_constant() {
                     return Ok(Self::constant(self.value.unwrap().wrapping_div(other.value.unwrap())));


### PR DESCRIPTION
## Motivation

This is to fix the bug caught by fuzzing in Leo: https://github.com/AleoHQ/leo/issues/1170

I personally consider it a minor bug, since when this happens, it should either be Rust panicking or Leo showing an error message. 

This PR does the latter instead of the former, as it may confuse the users and provide insufficient debug information.

## Test Plan

A similar test appears in the unsigned integer part. So this should work fine. I will wait for the CI.

## Related PRs

https://github.com/AleoHQ/leo/issues/1170