### PR TITLE
Use Poseidon for Program/Inner Circuit ID in the field-element way

### DIFF
--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -36,6 +36,7 @@ use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 use itertools::Itertools;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
+use snarkvm_fields::ToConstraintField;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn testnet1_inner_circuit_id() -> anyhow::Result<Vec<u8>> {
@@ -485,8 +486,10 @@ fn test_testnet1_dpc_execute_constraints() {
     let inner_snark_vk: <<Testnet1Parameters as Parameters>::InnerSNARK as SNARK>::VerifyingKey =
         inner_snark_parameters.1.clone().into();
 
+    let inner_snark_vk_field_elements = inner_snark_vk.to_field_elements().unwrap();
+
     let inner_circuit_id = <Testnet1Parameters as Parameters>::inner_circuit_id_crh()
-        .hash(&inner_snark_vk.to_bytes_le().unwrap())
+        .hash_field_elements(&inner_snark_vk_field_elements)
         .unwrap();
 
     let inner_snark_proof = <Testnet1Parameters as Parameters>::InnerSNARK::prove(
@@ -552,7 +555,7 @@ fn test_testnet1_dpc_execute_constraints() {
         println!("=========================================================");
         let num_constraints = outer_circuit_cs.num_constraints();
         println!("Outer circuit num constraints: {:?}", num_constraints);
-        assert_eq!(403780, num_constraints);
+        assert_eq!(373250, num_constraints);
         println!("=========================================================");
     }
 

--- a/dpc/src/testnet1/dpc.rs
+++ b/dpc/src/testnet1/dpc.rs
@@ -585,13 +585,8 @@ impl<C: Testnet1Components> DPCScheme<C> for DPC<C> {
 
         let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey = self.inner_snark_parameters.1.clone().into();
 
-        let inner_snark_vk_bytes = match to_bytes_le![inner_snark_vk] {
-            Ok(bytes) => bytes,
-            _ => {
-                eprintln!("Unable to convert inner snark vk into bytes.");
-                return false;
-            }
-        };
+        let inner_snark_vk_field_elements =
+            ToConstraintField::<C::OuterScalarField>::to_field_elements(&inner_snark_vk).unwrap();
 
         let outer_snark_input = OuterCircuitVerifierInput {
             inner_snark_verifier_input: inner_snark_input,

--- a/dpc/src/testnet1/dpc.rs
+++ b/dpc/src/testnet1/dpc.rs
@@ -24,6 +24,7 @@ use snarkvm_utilities::{has_duplicates, rand::UniformRand, to_bytes_le, FromByte
 
 use itertools::Itertools;
 use rand::{CryptoRng, Rng};
+use snarkvm_fields::ToConstraintField;
 
 pub struct DPC<C: Testnet1Components> {
     pub noop_program: NoopProgram<C>,
@@ -412,7 +413,8 @@ impl<C: Testnet1Components> DPCScheme<C> for DPC<C> {
         }
 
         let inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey = self.inner_snark_parameters.1.clone().into();
-        let inner_circuit_id = C::inner_circuit_id_crh().hash(&inner_snark_vk.to_bytes_le()?)?;
+        let inner_snark_vk_field_elements = inner_snark_vk.to_field_elements()?;
+        let inner_circuit_id = C::inner_circuit_id_crh().hash_field_elements(&inner_snark_vk_field_elements)?;
 
         let transaction_proof = {
             let circuit = OuterCircuit::<C>::new(
@@ -593,7 +595,7 @@ impl<C: Testnet1Components> DPCScheme<C> for DPC<C> {
 
         let outer_snark_input = OuterCircuitVerifierInput {
             inner_snark_verifier_input: inner_snark_input,
-            inner_circuit_id: match C::inner_circuit_id_crh().hash(&inner_snark_vk_bytes) {
+            inner_circuit_id: match C::inner_circuit_id_crh().hash_field_elements(&inner_snark_vk_field_elements) {
                 Ok(hash) => hash,
                 _ => {
                     eprintln!("Unable to hash inner snark vk.");

--- a/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
@@ -29,6 +29,7 @@ use snarkvm_gadgets::{
         eq::EqGadget,
         integers::integer::Integer,
     },
+    ToConstraintFieldGadget,
 };
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSystem};
 use snarkvm_utilities::{to_bytes_le, ToBytes};

--- a/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet1/outer_circuit/outer_circuit_gadget.rs
@@ -25,7 +25,7 @@ use snarkvm_gadgets::{
     integers::uint::UInt8,
     traits::{
         algorithms::{CRHGadget, CommitmentGadget, SNARKVerifierGadget},
-        alloc::{AllocBytesGadget, AllocGadget},
+        alloc::AllocGadget,
         eq::EqGadget,
         integers::integer::Integer,
     },
@@ -336,22 +336,14 @@ pub fn execute_outer_circuit<C: Testnet1Components, CS: ConstraintSystem<C::Oute
     for (i, input) in program_proofs.iter().enumerate().take(C::NUM_INPUT_RECORDS) {
         let cs = &mut cs.ns(|| format!("Check death program for input record {}", i));
 
-        let death_program_proof_bytes = input
-            .proof
-            .to_bytes_le()
-            .expect("Unable to convert death program proof to bytes");
-        let death_program_proof = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::ProofGadget::alloc_bytes(
+        let death_program_proof = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::ProofGadget::alloc(
             &mut cs.ns(|| "Allocate proof"),
-            || Ok(&death_program_proof_bytes),
+            || Ok(&input.proof),
         )?;
 
-        let death_program_vk_bytes = input
-            .verifying_key
-            .to_bytes_le()
-            .expect("Unable to convert death program VK to bytes");
-        let death_program_vk = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::VerificationKeyGadget::alloc_bytes(
+        let death_program_vk = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::VerificationKeyGadget::alloc(
             &mut cs.ns(|| "Allocate verifying key"),
-            || Ok(&death_program_vk_bytes),
+            || Ok(&input.verifying_key),
         )?;
 
         let death_program_vk_field_elements =
@@ -385,22 +377,14 @@ pub fn execute_outer_circuit<C: Testnet1Components, CS: ConstraintSystem<C::Oute
     {
         let cs = &mut cs.ns(|| format!("Check birth program for output record {}", j));
 
-        let birth_program_proof_bytes = input
-            .proof
-            .to_bytes_le()
-            .expect("Unable to convert birth program proof to bytes");
-        let birth_program_proof = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::ProofGadget::alloc_bytes(
+        let birth_program_proof = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::ProofGadget::alloc(
             &mut cs.ns(|| "Allocate proof"),
-            || Ok(&birth_program_proof_bytes),
+            || Ok(&input.proof),
         )?;
 
-        let birth_program_vk_bytes = input
-            .verifying_key
-            .to_bytes_le()
-            .expect("Unable to convert birth program VK to bytes");
-        let birth_program_vk = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::VerificationKeyGadget::alloc_bytes(
+        let birth_program_vk = <C::ProgramSNARKGadget as SNARKVerifierGadget<_>>::VerificationKeyGadget::alloc(
             &mut cs.ns(|| "Allocate verifying key"),
-            || Ok(&birth_program_vk_bytes),
+            || Ok(&input.verifying_key),
         )?;
 
         let birth_program_vk_field_elements =

--- a/dpc/src/testnet1/program/noop_program.rs
+++ b/dpc/src/testnet1/program/noop_program.rs
@@ -32,6 +32,7 @@ use snarkvm_parameters::{
 use snarkvm_utilities::{FromBytes, ToBytes};
 
 use rand::{CryptoRng, Rng};
+use snarkvm_fields::ToConstraintField;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Testnet1Components"), Debug(bound = "C: Testnet1Components"))]
@@ -61,9 +62,11 @@ impl<C: Testnet1Components> ProgramScheme for NoopProgram<C> {
             <Self::ProofSystem as SNARK>::circuit_specific_setup(&NoopCircuit::<C>::blank(), rng)?;
         let verifying_key: Self::VerifyingKey = prepared_verifying_key.into();
 
+        let verifying_key_group_elements = verifying_key.to_field_elements()?;
+
         // Compute the program ID.
         let id = <C as Parameters>::program_id_crh()
-            .hash(&verifying_key.to_bytes_le()?)?
+            .hash_field_elements(&verifying_key_group_elements)?
             .to_bytes_le()?;
 
         Ok(Self {
@@ -82,9 +85,11 @@ impl<C: Testnet1Components> ProgramScheme for NoopProgram<C> {
             NoopProgramSNARKVKParameters::load_bytes()?.as_slice(),
         )?;
 
+        let verifying_key_group_elements = verifying_key.to_field_elements()?;
+
         // Compute the program ID.
         let id = <C as Parameters>::program_id_crh()
-            .hash(&verifying_key.to_bytes_le()?)?
+            .hash_field_elements(&verifying_key_group_elements)?
             .to_bytes_le()?;
 
         Ok(Self {

--- a/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
@@ -417,7 +417,6 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
             || Ok(&input.verifying_key),
         )?;
 
-        // Manually allocate the death program bytes instead of the conversion
         let birth_program_vk_field_elements =
             birth_program_vk.to_constraint_field(cs.ns(|| "birth_death_program_vk_field_elements"))?;
 


### PR DESCRIPTION
## Motivation

This PR will be into #279. It replaces the testnet1's calls to Poseidon from the byte manner to the field-element manner.

Expect the integration tests would fail due to the need to resample parameters and changing constraint counts.

## Test Plan

Let us wait for the CI.

## Related PRs

#279 