### PR TITLE
Reduce the number of allocations used to deserialize snark proofs

### DIFF
--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -134,23 +134,21 @@ impl<E: PairingEngine> Proof<E> {
     pub fn read<R: Read>(mut reader: R) -> IoResult<Self> {
         // Construct the compressed reader.
         let compressed_proof_size = Self::compressed_proof_size()?;
-        let mut compressed_reader = vec![0u8; compressed_proof_size];
-        reader.read_exact(&mut compressed_reader)?;
-        let duplicate_compressed_reader = compressed_reader.clone();
+        let mut proof_reader = vec![0u8; compressed_proof_size];
+        reader.read_exact(&mut proof_reader)?;
 
         // Attempt to read the compressed proof.
-        if let Ok(proof) = Self::read_compressed(&compressed_reader[..]) {
+        if let Ok(proof) = Self::read_compressed(&proof_reader[..]) {
             return Ok(proof);
         }
 
         // Construct the uncompressed reader.
         let uncompressed_proof_size = Self::uncompressed_proof_size()?;
-        let mut uncompressed_reader = vec![0u8; uncompressed_proof_size - compressed_proof_size];
-        reader.read_exact(&mut uncompressed_reader)?;
-        uncompressed_reader = [duplicate_compressed_reader, uncompressed_reader].concat();
+        proof_reader.resize(uncompressed_proof_size, 0);
+        reader.read_exact(&mut proof_reader[compressed_proof_size..])?;
 
         // Attempt to read the uncompressed proof.
-        Self::read_uncompressed(&uncompressed_reader[..])
+        Self::read_uncompressed(&proof_reader[..])
     }
 
     /// Returns the number of bytes in a compressed proof serialization.

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -136,23 +136,21 @@ impl<E: PairingEngine> Proof<E> {
     pub fn read<R: Read>(mut reader: R) -> IoResult<Self> {
         // Construct the compressed reader.
         let compressed_proof_size = Self::compressed_proof_size()?;
-        let mut compressed_reader = vec![0u8; compressed_proof_size];
-        reader.read_exact(&mut compressed_reader)?;
-        let duplicate_compressed_reader = compressed_reader.clone();
+        let mut proof_reader = vec![0u8; compressed_proof_size];
+        reader.read_exact(&mut proof_reader)?;
 
         // Attempt to read the compressed proof.
-        if let Ok(proof) = Self::read_compressed(&compressed_reader[..]) {
+        if let Ok(proof) = Self::read_compressed(&proof_reader[..]) {
             return Ok(proof);
         }
 
         // Construct the uncompressed reader.
         let uncompressed_proof_size = Self::uncompressed_proof_size()?;
-        let mut uncompressed_reader = vec![0u8; uncompressed_proof_size - compressed_proof_size];
-        reader.read_exact(&mut uncompressed_reader)?;
-        uncompressed_reader = [duplicate_compressed_reader, uncompressed_reader].concat();
+        proof_reader.resize(uncompressed_proof_size, 0);
+        reader.read_exact(&mut proof_reader[compressed_proof_size..])?;
 
         // Attempt to read the uncompressed proof.
-        Self::read_uncompressed(&uncompressed_reader[..])
+        Self::read_uncompressed(&proof_reader[..])
     }
 
     /// Returns the number of bytes in a compressed proof serialization.


### PR DESCRIPTION
This PR makes the deserialization buffer handling in `Proof::read` for snarks faster (fewer allocations) and more idiomatic.

This was detected when profiling the snarkOS storage validator, as the `Proof::read` function was called a lot of times.