### PR TITLE
Run testnet 2 integration tests on CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 60m
-          command: cd .integration && RUST_MIN_STACK=67108864 cargo test testnet1
+          command: cd .integration && RUST_MIN_STACK=67108864 cargo test testnet2
       - clear_environment:
           cache_key: snarkvm-stable-testnet2-cache
 


### PR DESCRIPTION
The circle-ci "integration-testnet2" job was running testnet 1 integration tests.