### PR TITLE
Add ECIES Poseidon encryption

### DIFF
--- a/algorithms/src/encryption/ecies_poseidon.rs
+++ b/algorithms/src/encryption/ecies_poseidon.rs
@@ -1,0 +1,191 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    crypto_hash::{CryptographicSponge, PoseidonDefaultParametersField, PoseidonSponge},
+    hash_to_curve::hash_to_curve,
+    EncryptionError,
+    EncryptionScheme,
+};
+use rand::{CryptoRng, Rng};
+use snarkvm_curves::{
+    templates::twisted_edwards_extended::Affine as TEAffine,
+    AffineCurve,
+    ProjectiveCurve,
+    TwistedEdwardsParameters,
+};
+use snarkvm_fields::{ConstraintFieldError, PrimeField, ToConstraintField};
+use snarkvm_utilities::{io::Result as IoResult, ops::Mul, FromBytes, Read, ToBytes, UniformRand, Write};
+
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "TE: TwistedEdwardsParameters"),
+    Debug(bound = "TE: TwistedEdwardsParameters"),
+    PartialEq(bound = "TE: TwistedEdwardsParameters"),
+    Eq(bound = "TE: TwistedEdwardsParameters"),
+    Default(bound = "TE: TwistedEdwardsParameters")
+)]
+pub struct ECIESPoseidonEncryption<TE: TwistedEdwardsParameters> {
+    pub generator: TEAffine<TE>,
+}
+
+impl<TE: TwistedEdwardsParameters> EncryptionScheme for ECIESPoseidonEncryption<TE>
+where
+    TE::BaseField: PoseidonDefaultParametersField,
+{
+    type EncryptionWitness = ();
+    type Parameters = TEAffine<TE>;
+    type PrivateKey = TE::ScalarField;
+    type PublicKey = TEAffine<TE>;
+    type Randomness = TE::ScalarField;
+    type Text = TE::BaseField;
+
+    fn setup(message: &str) -> Self {
+        let (generator, _, _) = hash_to_curve::<TEAffine<TE>>(message);
+        Self { generator }
+    }
+
+    fn generate_private_key<R: Rng + CryptoRng>(&self, rng: &mut R) -> <Self as EncryptionScheme>::PrivateKey {
+        Self::PrivateKey::rand(rng)
+    }
+
+    fn generate_public_key(
+        &self,
+        private_key: &<Self as EncryptionScheme>::PrivateKey,
+    ) -> Result<<Self as EncryptionScheme>::PublicKey, EncryptionError> {
+        Ok(self.generator.into_projective().mul(*private_key).into_affine())
+    }
+
+    fn generate_randomness<R: Rng + CryptoRng>(
+        &self,
+        _public_key: &<Self as EncryptionScheme>::PublicKey,
+        rng: &mut R,
+    ) -> Result<Self::Randomness, EncryptionError> {
+        Ok(Self::Randomness::rand(rng))
+    }
+
+    fn generate_encryption_witness(
+        &self,
+        _public_key: &<Self as EncryptionScheme>::PublicKey,
+        _randomness: &Self::Randomness,
+        _message_length: usize,
+    ) -> Result<Vec<Self::EncryptionWitness>, EncryptionError> {
+        Ok(vec![])
+    }
+
+    fn encrypt(
+        &self,
+        public_key: &<Self as EncryptionScheme>::PublicKey,
+        randomness: &Self::Randomness,
+        message: &[Self::Text],
+    ) -> Result<Vec<Self::Text>, EncryptionError> {
+        let ecdh_value = public_key.into_projective().mul((*randomness).clone()).into_affine();
+
+        let params =
+            <TE::BaseField as PoseidonDefaultParametersField>::get_default_poseidon_parameters(4, false).unwrap();
+        let mut sponge = PoseidonSponge::<TE::BaseField>::new(&params);
+
+        sponge.absorb(&[ecdh_value.x]); // For TE curves, only one of (x, y) and (x, -y) would be on the curve.
+
+        let mut results = sponge.squeeze_field_elements(message.len());
+        for (i, elem) in message.iter().enumerate() {
+            results[i] += elem;
+        }
+
+        results.push(
+            self.generator
+                .into_projective()
+                .mul((*randomness).clone())
+                .into_affine()
+                .to_x_coordinate(),
+        );
+
+        Ok(results)
+    }
+
+    fn decrypt(
+        &self,
+        private_key: &<Self as EncryptionScheme>::PrivateKey,
+        ciphertext: &[Self::Text],
+    ) -> Result<Vec<Self::Text>, EncryptionError> {
+        assert!(ciphertext.len() >= 1);
+
+        let random_elem_x = ciphertext.last().unwrap().clone();
+        let random_elem = {
+            let mut first = TEAffine::<TE>::from_x_coordinate(random_elem_x.clone(), true);
+            if first.is_some() && !first.unwrap().is_in_correct_subgroup_assuming_on_curve() {
+                first = None;
+            }
+            let mut second = TEAffine::<TE>::from_x_coordinate(random_elem_x, false);
+            if second.is_some() && !second.unwrap().is_in_correct_subgroup_assuming_on_curve() {
+                second = None;
+            }
+            first.or(second).unwrap()
+        };
+
+        let ecdh_value = random_elem.into_projective().mul((*private_key).clone()).into_affine();
+
+        let params =
+            <TE::BaseField as PoseidonDefaultParametersField>::get_default_poseidon_parameters(4, false).unwrap();
+        let mut sponge = PoseidonSponge::<TE::BaseField>::new(&params);
+
+        sponge.absorb(&[ecdh_value.x]); // For TE curves, only one of (x, y) and (x, -y) would be on the curve.
+
+        let len = ciphertext.len() - 1;
+
+        let mut results = sponge.squeeze_field_elements(len);
+        for (i, elem) in ciphertext.iter().take(len).enumerate() {
+            results[i] = *elem - results[i];
+        }
+
+        Ok(results)
+    }
+
+    fn parameters(&self) -> &<Self as EncryptionScheme>::Parameters {
+        &self.generator
+    }
+
+    fn private_key_size_in_bits() -> usize {
+        Self::PrivateKey::size_in_bits()
+    }
+}
+
+impl<TE: TwistedEdwardsParameters> From<TEAffine<TE>> for ECIESPoseidonEncryption<TE> {
+    fn from(generator: TEAffine<TE>) -> Self {
+        Self { generator }
+    }
+}
+
+impl<TE: TwistedEdwardsParameters> ToBytes for ECIESPoseidonEncryption<TE> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.generator.write_le(&mut writer)
+    }
+}
+
+impl<TE: TwistedEdwardsParameters> FromBytes for ECIESPoseidonEncryption<TE> {
+    #[inline]
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        let generator = TEAffine::<TE>::read_le(reader)?;
+        Ok(Self { generator })
+    }
+}
+
+impl<TE: TwistedEdwardsParameters> ToConstraintField<TE::BaseField> for ECIESPoseidonEncryption<TE> {
+    #[inline]
+    fn to_field_elements(&self) -> Result<Vec<TE::BaseField>, ConstraintFieldError> {
+        Ok(Vec::new())
+    }
+}

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -91,7 +91,7 @@ pub struct GroupEncryption<G: ProjectiveCurve> {
 }
 
 impl<G: ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize> EncryptionScheme for GroupEncryption<G> {
-    type BlindingExponent = <G as Group>::ScalarField;
+    type EncryptionWitness = <G as Group>::ScalarField;
     type Parameters = Vec<G>;
     type PrivateKey = <G as Group>::ScalarField;
     type PublicKey = GroupEncryptionPublicKey<G>;
@@ -159,12 +159,12 @@ impl<G: ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize> EncryptionS
         Ok(y)
     }
 
-    fn generate_blinding_exponents(
+    fn generate_encryption_witness(
         &self,
         public_key: &<Self as EncryptionScheme>::PublicKey,
         randomness: &Self::Randomness,
         message_length: usize,
-    ) -> Result<Vec<Self::BlindingExponent>, EncryptionError> {
+    ) -> Result<Vec<Self::EncryptionWitness>, EncryptionError> {
         let record_view_key = public_key.0.mul(*randomness);
 
         let affine = record_view_key.into_affine();
@@ -209,7 +209,7 @@ impl<G: ProjectiveCurve + CanonicalSerialize + CanonicalDeserialize> EncryptionS
         let one = Self::Randomness::one();
         let mut i = Self::Randomness::one();
 
-        let blinding_exponents = self.generate_blinding_exponents(public_key, randomness, message.len())?;
+        let blinding_exponents = self.generate_encryption_witness(public_key, randomness, message.len())?;
 
         for (m_i, blinding_exp) in message.iter().zip_eq(blinding_exponents) {
             // h_i <- 1 [/] (z [+] i) * record_view_key

--- a/algorithms/src/encryption/mod.rs
+++ b/algorithms/src/encryption/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod ecies_poseidon;
+pub use ecies_poseidon::*;
+
 pub mod group;
 pub use group::*;
 

--- a/algorithms/src/encryption/tests.rs
+++ b/algorithms/src/encryption/tests.rs
@@ -14,53 +14,107 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{encryption::GroupEncryption, traits::EncryptionScheme};
-use snarkvm_curves::{edwards_bls12::EdwardsProjective, traits::ProjectiveCurve};
-use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
+mod group_encryption {
+    use crate::{encryption::GroupEncryption, traits::EncryptionScheme};
+    use snarkvm_curves::{edwards_bls12::EdwardsProjective, traits::ProjectiveCurve};
+    use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaChaRng;
 
-type TestEncryptionScheme = GroupEncryption<EdwardsProjective>;
+    type TestEncryptionScheme = GroupEncryption<EdwardsProjective>;
 
-pub const ITERATIONS: usize = 1000;
+    pub const ITERATIONS: usize = 1000;
 
-fn generate_input<G: ProjectiveCurve, R: Rng>(input_size: usize, rng: &mut R) -> Vec<G> {
-    (0..input_size).map(|_| G::rand(rng)).collect()
-}
+    fn generate_input<G: ProjectiveCurve, R: Rng>(input_size: usize, rng: &mut R) -> Vec<G> {
+        (0..input_size).map(|_| G::rand(rng)).collect()
+    }
 
-#[test]
-fn simple_encryption() {
-    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+    #[test]
+    fn simple_encryption() {
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
 
-    let encryption_scheme = TestEncryptionScheme::setup("simple_encryption");
+        let encryption_scheme = TestEncryptionScheme::setup("simple_encryption");
 
-    let private_key = encryption_scheme.generate_private_key(rng);
-    let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
-
-    let randomness = encryption_scheme.generate_randomness(&public_key, rng).unwrap();
-    let message = generate_input(32, rng);
-
-    let ciphertext = encryption_scheme.encrypt(&public_key, &randomness, &message).unwrap();
-    let decrypted_message = encryption_scheme.decrypt(&private_key, &ciphertext).unwrap();
-
-    assert_eq!(message, decrypted_message);
-}
-
-#[test]
-fn encryption_public_key_serialization() {
-    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
-
-    let encryption_scheme = TestEncryptionScheme::setup("encryption_public_key_serialization");
-
-    for _ in 0..ITERATIONS {
         let private_key = encryption_scheme.generate_private_key(rng);
         let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
 
-        let public_key_bytes = to_bytes_le![public_key].unwrap();
-        let recovered_public_key =
-            <TestEncryptionScheme as EncryptionScheme>::PublicKey::read_le(&public_key_bytes[..]).unwrap();
+        let randomness = encryption_scheme.generate_randomness(&public_key, rng).unwrap();
+        let message = generate_input(32, rng);
 
-        assert_eq!(public_key, recovered_public_key);
+        let ciphertext = encryption_scheme.encrypt(&public_key, &randomness, &message).unwrap();
+        let decrypted_message = encryption_scheme.decrypt(&private_key, &ciphertext).unwrap();
+
+        assert_eq!(message, decrypted_message);
+    }
+
+    #[test]
+    fn encryption_public_key_serialization() {
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+
+        let encryption_scheme = TestEncryptionScheme::setup("encryption_public_key_serialization");
+
+        for _ in 0..ITERATIONS {
+            let private_key = encryption_scheme.generate_private_key(rng);
+            let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+
+            let public_key_bytes = to_bytes_le![public_key].unwrap();
+            let recovered_public_key =
+                <TestEncryptionScheme as EncryptionScheme>::PublicKey::read_le(&public_key_bytes[..]).unwrap();
+
+            assert_eq!(public_key, recovered_public_key);
+        }
+    }
+}
+
+mod ecies {
+    use crate::{encryption::ECIESPoseidonEncryption, EncryptionScheme};
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaChaRng;
+    use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsParameters};
+    use snarkvm_fields::PrimeField;
+    use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
+
+    type TestEncryptionScheme = ECIESPoseidonEncryption<EdwardsParameters>;
+    pub const ITERATIONS: usize = 1000;
+
+    fn generate_input<F: PrimeField, R: Rng>(input_size: usize, rng: &mut R) -> Vec<F> {
+        (0..input_size).map(|_| F::rand(rng)).collect()
+    }
+
+    #[test]
+    fn simple_encryption() {
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+
+        let encryption_scheme = TestEncryptionScheme::setup("simple_encryption");
+
+        let private_key = encryption_scheme.generate_private_key(rng);
+        let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+
+        let randomness = encryption_scheme.generate_randomness(&public_key, rng).unwrap();
+        let message = generate_input(32, rng);
+
+        let ciphertext = encryption_scheme.encrypt(&public_key, &randomness, &message).unwrap();
+        let decrypted_message = encryption_scheme.decrypt(&private_key, &ciphertext).unwrap();
+
+        assert_eq!(message, decrypted_message);
+    }
+
+    #[test]
+    fn encryption_public_key_serialization() {
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+
+        let encryption_scheme = TestEncryptionScheme::setup("encryption_public_key_serialization");
+
+        for _ in 0..ITERATIONS {
+            let private_key = encryption_scheme.generate_private_key(rng);
+            let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+
+            let public_key_bytes = to_bytes_le![public_key].unwrap();
+            let recovered_public_key =
+                <TestEncryptionScheme as EncryptionScheme>::PublicKey::read_le(&public_key_bytes[..]).unwrap();
+
+            assert_eq!(public_key, recovered_public_key);
+        }
     }
 }

--- a/algorithms/src/traits/encryption.rs
+++ b/algorithms/src/traits/encryption.rs
@@ -28,7 +28,7 @@ pub trait EncryptionScheme:
     type PublicKey: Clone + Debug + Default + Eq + ToBytes + FromBytes;
     type Text: Clone + Debug + Default + Eq + ToBytes + FromBytes;
     type Randomness: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + UniformRand;
-    type BlindingExponent: Clone + Debug + Default + Eq + Hash + ToBytes;
+    type EncryptionWitness: Clone + Debug + Default + Eq + Hash + ToBytes;
 
     fn setup(message: &str) -> Self;
 
@@ -45,12 +45,12 @@ pub trait EncryptionScheme:
         rng: &mut R,
     ) -> Result<Self::Randomness, EncryptionError>;
 
-    fn generate_blinding_exponents(
+    fn generate_encryption_witness(
         &self,
         public_key: &<Self as EncryptionScheme>::PublicKey,
         randomness: &Self::Randomness,
         message_length: usize,
-    ) -> Result<Vec<Self::BlindingExponent>, EncryptionError>;
+    ) -> Result<Vec<Self::EncryptionWitness>, EncryptionError>;
 
     fn encrypt(
         &self,

--- a/dpc/src/circuits/inner_circuit_gadget.rs
+++ b/dpc/src/circuits/inner_circuit_gadget.rs
@@ -1095,7 +1095,7 @@ where
                 || Ok(encryption_randomness),
             )?;
 
-            let encryption_blinding_exponents_gadget = AccountEncryptionGadget::BlindingExponentGadget::alloc(
+            let encryption_blinding_exponents_gadget = AccountEncryptionGadget::EncryptionWitnessGadget::alloc(
                 &mut encryption_cs.ns(|| format!("output record {} encryption_blinding_exponents", j)),
                 || Ok(encryption_blinding_exponents),
             )?;

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -62,7 +62,7 @@ pub struct RecordEncryptionGadgetComponents<C: Parameters> {
     /// Record fq high selectors - Used for plaintext serialization/deserialization
     pub fq_high_selectors: Vec<bool>,
     /// Record ciphertext blinding exponents used to encrypt the record
-    pub encryption_blinding_exponents: Vec<<C::AccountEncryptionScheme as EncryptionScheme>::BlindingExponent>,
+    pub encryption_blinding_exponents: Vec<<C::AccountEncryptionScheme as EncryptionScheme>::EncryptionWitness>,
 }
 
 impl<C: Parameters> Default for RecordEncryptionGadgetComponents<C> {
@@ -79,7 +79,10 @@ impl<C: Parameters> Default for RecordEncryptionGadgetComponents<C> {
         let fq_high_selectors = vec![false; record_encoding_length];
 
         let encryption_blinding_exponents =
-            vec![<C::AccountEncryptionScheme as EncryptionScheme>::BlindingExponent::default(); record_encoding_length];
+            vec![
+                <C::AccountEncryptionScheme as EncryptionScheme>::EncryptionWitness::default();
+                record_encoding_length
+            ];
 
         Self {
             record_field_elements,
@@ -332,7 +335,7 @@ impl<C: Parameters> EncryptedRecord<C> {
 
         // Encrypt the record plaintext
         let record_public_key = record.owner().into_repr();
-        let encryption_blinding_exponents = C::account_encryption_scheme().generate_blinding_exponents(
+        let encryption_blinding_exponents = C::account_encryption_scheme().generate_encryption_witness(
             record_public_key,
             encryption_randomness,
             record_plaintexts.len(),

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -78,8 +78,7 @@ impl<C: Parameters> Default for RecordEncryptionGadgetComponents<C> {
         let ciphertext_selectors = vec![false; record_encoding_length + 1];
         let fq_high_selectors = vec![false; record_encoding_length];
 
-        let encryption_blinding_exponents =
-            vec![
+        let encryption_blinding_exponents = vec![
                 <C::AccountEncryptionScheme as EncryptionScheme>::EncryptionWitness::default();
                 record_encoding_length
             ];

--- a/gadgets/src/algorithms/encryption/ecies_poseidon.rs
+++ b/gadgets/src/algorithms/encryption/ecies_poseidon.rs
@@ -1,0 +1,439 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    algorithms::crypto_hash::{CryptographicSpongeVar, PoseidonSpongeGadget},
+    AllocGadget,
+    Boolean,
+    ConditionalEqGadget,
+    EncryptionGadget,
+    EqGadget,
+    FieldGadget,
+    FpGadget,
+    GroupGadget,
+    Integer,
+    ToBytesGadget,
+    UInt8,
+};
+use itertools::Itertools;
+use snarkvm_algorithms::{crypto_hash::PoseidonDefaultParametersField, encryption::ECIESPoseidonEncryption};
+use snarkvm_curves::{
+    templates::twisted_edwards_extended::{Affine as TEAffine, Projective as TEProjective},
+    AffineCurve,
+    Group,
+    ProjectiveCurve,
+    TwistedEdwardsParameters,
+};
+use snarkvm_fields::PrimeField;
+use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
+use snarkvm_utilities::{borrow::Borrow, to_bytes_le, ToBytes};
+use std::marker::PhantomData;
+
+type TEAffineGadget<TE, F> = crate::curves::templates::twisted_edwards::AffineGadget<TE, F, FpGadget<F>>;
+
+/// Group encryption private key gadget
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    PartialEq(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    Eq(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    Debug(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField")
+)]
+pub struct ECIESPoseidonEncryptionPrivateKeyGadget<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField>(
+    pub Vec<UInt8>,
+    PhantomData<TE>,
+    PhantomData<F>,
+);
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> AllocGadget<TE::ScalarField, F>
+    for ECIESPoseidonEncryptionPrivateKeyGadget<TE, F>
+{
+    fn alloc_constant<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<TE::ScalarField>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let private_key = to_bytes_le![value_gen()?.borrow()].unwrap();
+        Ok(ECIESPoseidonEncryptionPrivateKeyGadget(
+            UInt8::constant_vec(&private_key),
+            PhantomData,
+            PhantomData,
+        ))
+    }
+
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<TE::ScalarField>, CS: ConstraintSystem<F>>(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let private_key = to_bytes_le![value_gen()?.borrow()].unwrap();
+        Ok(ECIESPoseidonEncryptionPrivateKeyGadget(
+            UInt8::alloc_vec(cs, &private_key)?,
+            PhantomData,
+            PhantomData,
+        ))
+    }
+
+    fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<TE::ScalarField>, CS: ConstraintSystem<F>>(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let private_key = to_bytes_le![value_gen()?.borrow()].unwrap();
+        Ok(ECIESPoseidonEncryptionPrivateKeyGadget(
+            UInt8::alloc_input_vec_le(cs, &private_key)?,
+            PhantomData,
+            PhantomData,
+        ))
+    }
+}
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> ToBytesGadget<F>
+    for ECIESPoseidonEncryptionPrivateKeyGadget<TE, F>
+{
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        self.0.to_bytes(&mut cs.ns(|| "to_bytes"))
+    }
+
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        self.0.to_bytes_strict(&mut cs.ns(|| "to_bytes_strict"))
+    }
+}
+
+/// Group encryption randomness gadget
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "TE: TwistedEdwardsParameters"),
+    PartialEq(bound = "TE: TwistedEdwardsParameters"),
+    Eq(bound = "TE: TwistedEdwardsParameters"),
+    Debug(bound = "TE: TwistedEdwardsParameters")
+)]
+pub struct ECIESPoseidonEncryptionRandomnessGadget<TE: TwistedEdwardsParameters>(pub Vec<UInt8>, PhantomData<TE>);
+
+impl<TE: TwistedEdwardsParameters> AllocGadget<TE::ScalarField, TE::BaseField>
+    for ECIESPoseidonEncryptionRandomnessGadget<TE>
+where
+    TE::BaseField: PrimeField,
+{
+    fn alloc_constant<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<TE::ScalarField>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
+        Ok(ECIESPoseidonEncryptionRandomnessGadget(
+            UInt8::constant_vec(&randomness),
+            PhantomData,
+        ))
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<TE::ScalarField>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
+        Ok(ECIESPoseidonEncryptionRandomnessGadget(
+            UInt8::alloc_vec(cs, &randomness)?,
+            PhantomData,
+        ))
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<TE::ScalarField>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
+        Ok(ECIESPoseidonEncryptionRandomnessGadget(
+            UInt8::alloc_input_vec_le(cs, &randomness)?,
+            PhantomData,
+        ))
+    }
+}
+
+/// Group encryption blinding exponents gadget
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "TE: TwistedEdwardsParameters"),
+    PartialEq(bound = "TE: TwistedEdwardsParameters"),
+    Eq(bound = "TE: TwistedEdwardsParameters"),
+    Debug(bound = "TE: TwistedEdwardsParameters")
+)]
+pub struct ECIESPoseidonEncryptionWitnessGadget<TE: TwistedEdwardsParameters>(pub PhantomData<TE>);
+
+impl<TE: TwistedEdwardsParameters> AllocGadget<Vec<()>, TE::BaseField> for ECIESPoseidonEncryptionWitnessGadget<TE> {
+    fn alloc_constant<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<Vec<()>>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self { 0: PhantomData })
+    }
+
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Vec<()>>, CS: ConstraintSystem<TE::BaseField>>(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self { 0: PhantomData })
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<Vec<()>>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self { 0: PhantomData })
+    }
+}
+
+/// ECIES Poseidon encryption gadget
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    PartialEq(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    Eq(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    Debug(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField")
+)]
+pub struct ECIESPoseidonEncryptionGadget<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> {
+    encryption: ECIESPoseidonEncryption<TE>,
+    f_phantom: PhantomData<F>,
+}
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> AllocGadget<ECIESPoseidonEncryption<TE>, F>
+    for ECIESPoseidonEncryptionGadget<TE, F>
+{
+    fn alloc_constant<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<ECIESPoseidonEncryption<TE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            encryption: (*value_gen()?.borrow()).clone(),
+            f_phantom: PhantomData,
+        })
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<ECIESPoseidonEncryption<TE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            encryption: (*value_gen()?.borrow()).clone(),
+            f_phantom: PhantomData,
+        })
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<ECIESPoseidonEncryption<TE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            encryption: (*value_gen()?.borrow()).clone(),
+            f_phantom: PhantomData,
+        })
+    }
+}
+
+/// ECIES Poseidon public key gadget
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    PartialEq(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    Eq(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField"),
+    Debug(bound = "TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField")
+)]
+pub struct ECIESPoseidonEncryptionPublicKeyGadget<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField>(
+    TEAffineGadget<TE, F>,
+);
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> AllocGadget<TEAffine<TE>, F>
+    for ECIESPoseidonEncryptionPublicKeyGadget<TE, F>
+where
+    TEAffineGadget<TE, F>: GroupGadget<TEAffine<TE>, F>,
+{
+    fn alloc_constant<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<TEAffine<TE>>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            0: TEAffineGadget::<TE, F>::alloc_constant(cs, value_gen)?,
+        })
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<TEAffine<TE>>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            0: TEAffineGadget::<TE, F>::alloc(cs, value_gen)?,
+        })
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<TEAffine<TE>>,
+        CS: ConstraintSystem<TE::BaseField>,
+    >(
+        cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Self {
+            0: TEAffineGadget::<TE, F>::alloc_input(cs, value_gen)?,
+        })
+    }
+}
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> ConditionalEqGadget<F>
+    for ECIESPoseidonEncryptionPublicKeyGadget<TE, F>
+{
+    fn conditional_enforce_equal<CS: ConstraintSystem<F>>(
+        &self,
+        cs: CS,
+        other: &Self,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError> {
+        self.0.conditional_enforce_equal(cs, &other.0, condition)
+    }
+
+    fn cost() -> usize {
+        <TEAffineGadget<TE, F> as ConditionalEqGadget<F>>::cost()
+    }
+}
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> ToBytesGadget<F>
+    for ECIESPoseidonEncryptionPublicKeyGadget<TE, F>
+{
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        self.0.to_bytes(cs)
+    }
+
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        self.0.to_bytes_strict(cs)
+    }
+}
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> EqGadget<F>
+    for ECIESPoseidonEncryptionPublicKeyGadget<TE, F>
+{
+}
+
+impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField + PoseidonDefaultParametersField>
+    EncryptionGadget<ECIESPoseidonEncryption<TE>, F> for ECIESPoseidonEncryptionGadget<TE, F>
+{
+    type CiphertextGadget = Vec<FpGadget<F>>;
+    type EncryptionWitnessGadget = ECIESPoseidonEncryptionWitnessGadget<TE>;
+    type PlaintextGadget = Vec<FpGadget<F>>;
+    type PrivateKeyGadget = ECIESPoseidonEncryptionPrivateKeyGadget<TE, F>;
+    type PublicKeyGadget = ECIESPoseidonEncryptionPublicKeyGadget<TE, F>;
+    type RandomnessGadget = ECIESPoseidonEncryptionRandomnessGadget<TE>;
+
+    fn check_public_key_gadget<CS: ConstraintSystem<TE::BaseField>>(
+        &self,
+        mut cs: CS,
+        private_key: &Self::PrivateKeyGadget,
+    ) -> Result<Self::PublicKeyGadget, SynthesisError> {
+        let private_key_bits = private_key.0.iter().flat_map(|b| b.to_bits_le()).collect::<Vec<_>>();
+        let mut public_key = <TEAffineGadget<TE, F> as GroupGadget<TEAffine<TE>, F>>::zero(cs.ns(|| "zero"))?;
+
+        let num_powers = private_key_bits.len();
+
+        let generator_powers: Vec<TEAffine<TE>> = {
+            let mut generator_powers = Vec::new();
+            let mut generator = self.encryption.generator.into_projective();
+            for _ in 0..num_powers {
+                generator_powers.push(generator.clone());
+                generator.double_in_place();
+            }
+            TEProjective::<TE>::batch_normalization(&mut generator_powers);
+            generator_powers.into_iter().map(|v| v.into()).collect()
+        };
+
+        public_key.scalar_multiplication(
+            cs.ns(|| "check_public_key_gadget"),
+            private_key_bits.iter().zip_eq(&generator_powers),
+        )?;
+
+        Ok(ECIESPoseidonEncryptionPublicKeyGadget::<TE, F> { 0: public_key })
+    }
+
+    fn check_encryption_gadget<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        randomness: &Self::RandomnessGadget,
+        public_key: &Self::PublicKeyGadget,
+        input: &Self::PlaintextGadget,
+        _encryption_witness: &Self::EncryptionWitnessGadget,
+    ) -> Result<Self::CiphertextGadget, SynthesisError> {
+        let zero: TEAffineGadget<TE, F> =
+            <TEAffineGadget<TE, F> as GroupGadget<TEAffine<TE>, F>>::zero(cs.ns(|| "zero")).unwrap();
+
+        let randomness_bits = randomness.0.iter().flat_map(|b| b.to_bits_le()).collect::<Vec<_>>();
+        let ecdh_value = <TEAffineGadget<TE, F> as GroupGadget<TEAffine<TE>, F>>::mul_bits(
+            &public_key.0,
+            cs.ns(|| "compute_ecdh_value"),
+            &zero,
+            randomness_bits.iter().copied(),
+        )?;
+
+        let params =
+            <TE::BaseField as PoseidonDefaultParametersField>::get_default_poseidon_parameters(4, false).unwrap();
+        let mut sponge = PoseidonSpongeGadget::<TE::BaseField>::new(cs.ns(|| "sponge"), &params);
+        sponge.absorb(cs.ns(|| "absorb"), [ecdh_value.x].iter())?;
+
+        let mut results = sponge.squeeze_field_elements(cs.ns(|| "squeeze"), input.len())?;
+        for (i, elem) in input.iter().enumerate() {
+            results[i].add_in_place(cs.ns(|| format!("encryption_{}", i)), elem)?;
+        }
+
+        Ok(results)
+    }
+}

--- a/gadgets/src/algorithms/encryption/mod.rs
+++ b/gadgets/src/algorithms/encryption/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod ecies_poseidon;
+pub use ecies_poseidon::*;
+
 pub mod group;
 pub use group::*;
 

--- a/gadgets/src/algorithms/encryption/tests.rs
+++ b/gadgets/src/algorithms/encryption/tests.rs
@@ -14,152 +14,302 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    algorithms::encryption::*,
-    curves::edwards_bls12::EdwardsBls12Gadget,
-    traits::{algorithms::EncryptionGadget, alloc::AllocGadget, eq::EqGadget},
-};
-use snarkvm_algorithms::{encryption::GroupEncryption, traits::EncryptionScheme};
-use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective, traits::ProjectiveCurve};
-use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
+mod group_encryption {
+    use crate::{
+        algorithms::encryption::*,
+        curves::edwards_bls12::EdwardsBls12Gadget,
+        traits::{algorithms::EncryptionGadget, alloc::AllocGadget, eq::EqGadget},
+    };
+    use snarkvm_algorithms::{encryption::GroupEncryption, traits::EncryptionScheme};
+    use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective, traits::ProjectiveCurve};
+    use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
 
-use rand::{CryptoRng, Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+    use rand::{CryptoRng, Rng, SeedableRng};
+    use rand_chacha::ChaChaRng;
 
-type TestEncryptionScheme = GroupEncryption<EdwardsProjective>;
-type TestEncryptionSchemeGadget = GroupEncryptionGadget<EdwardsProjective, Fr, EdwardsBls12Gadget>;
+    type TestEncryptionScheme = GroupEncryption<EdwardsProjective>;
+    type TestEncryptionSchemeGadget = GroupEncryptionGadget<EdwardsProjective, Fr, EdwardsBls12Gadget>;
 
-fn generate_input<G: ProjectiveCurve, R: Rng + CryptoRng>(input_size: usize, rng: &mut R) -> Vec<G> {
-    let mut input = vec![];
-    for _ in 0..input_size {
-        input.push(G::rand(rng))
+    fn generate_input<G: ProjectiveCurve, R: Rng + CryptoRng>(input_size: usize, rng: &mut R) -> Vec<G> {
+        let mut input = vec![];
+        for _ in 0..input_size {
+            input.push(G::rand(rng))
+        }
+
+        input
     }
 
-    input
+    #[test]
+    fn test_group_encryption_public_key_gadget() {
+        let mut cs = TestConstraintSystem::<Fr>::new();
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+
+        let encryption_scheme = TestEncryptionScheme::setup("test_group_encryption_public_key_gadget");
+
+        let private_key = encryption_scheme.generate_private_key(rng);
+        let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+
+        let encryption =
+            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+        let private_key_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PrivateKeyGadget::alloc(
+                &mut cs.ns(|| "private_key_gadget"),
+                || Ok(&private_key),
+            )
+            .unwrap();
+        let expected_public_key_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
+                &mut cs.ns(|| "public_key_gadget"),
+                || Ok(&public_key),
+            )
+            .unwrap();
+
+        println!("number of constraints for inputs: {}", cs.num_constraints());
+
+        let public_key_gadget = encryption
+            .check_public_key_gadget(&mut cs.ns(|| "public_key_gadget_evaluation"), &private_key_gadget)
+            .unwrap();
+
+        expected_public_key_gadget
+            .enforce_equal(
+                cs.ns(|| "Check that declared and computed public keys are equal"),
+                &public_key_gadget,
+            )
+            .unwrap();
+
+        println!("number of constraints total: {}", cs.num_constraints());
+
+        if !cs.is_satisfied() {
+            println!("which is unsatisfied: {:?}", cs.which_is_unsatisfied().unwrap());
+        }
+        assert!(cs.is_satisfied());
+    }
+
+    #[test]
+    fn test_group_encryption_gadget() {
+        let mut cs = TestConstraintSystem::<Fr>::new();
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+
+        let encryption_scheme = TestEncryptionScheme::setup("test_group_encryption_gadget");
+
+        let private_key = encryption_scheme.generate_private_key(rng);
+        let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+
+        let randomness = encryption_scheme.generate_randomness(&public_key, rng).unwrap();
+        let message = generate_input(10, rng);
+        let blinding_exponents = encryption_scheme
+            .generate_encryption_witness(&public_key, &randomness, message.len())
+            .unwrap();
+        let ciphertext = encryption_scheme.encrypt(&public_key, &randomness, &message).unwrap();
+
+        // Alloc parameters, public key, plaintext, randomness, and blinding exponents
+        let encryption =
+            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+        let public_key_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
+                &mut cs.ns(|| "public_key_gadget"),
+                || Ok(&public_key),
+            )
+            .unwrap();
+        let plaintext_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PlaintextGadget::alloc(
+                &mut cs.ns(|| "plaintext_gadget"),
+                || Ok(&message),
+            )
+            .unwrap();
+        let randomness_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::RandomnessGadget::alloc(
+                &mut cs.ns(|| "randomness_gadget"),
+                || Ok(&randomness),
+            )
+            .unwrap();
+        let blinding_exponents_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::EncryptionWitnessGadget::alloc(
+                &mut cs.ns(|| "blinding_exponents_gadget"),
+                || Ok(&blinding_exponents),
+            )
+            .unwrap();
+
+        // Expected ciphertext gadget
+        let expected_ciphertext_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::CiphertextGadget::alloc(
+                &mut cs.ns(|| "ciphertext_gadget"),
+                || Ok(&ciphertext),
+            )
+            .unwrap();
+
+        println!("number of constraints for inputs: {}", cs.num_constraints());
+
+        let ciphertext_gadget = encryption
+            .check_encryption_gadget(
+                &mut cs.ns(|| "ciphertext_gadget_evaluation"),
+                &randomness_gadget,
+                &public_key_gadget,
+                &plaintext_gadget,
+                &blinding_exponents_gadget,
+            )
+            .unwrap();
+
+        expected_ciphertext_gadget
+            .enforce_equal(
+                cs.ns(|| "Check that declared and computed ciphertexts are equal"),
+                &ciphertext_gadget,
+            )
+            .unwrap();
+
+        println!("number of constraints total: {}", cs.num_constraints());
+
+        if !cs.is_satisfied() {
+            println!("which is unsatisfied: {:?}", cs.which_is_unsatisfied().unwrap());
+        }
+        assert!(cs.is_satisfied());
+    }
 }
 
-#[test]
-fn test_group_encryption_public_key_gadget() {
-    let mut cs = TestConstraintSystem::<Fr>::new();
-    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+mod ecies_poseidon {
+    use crate::{algorithms::encryption::ECIESPoseidonEncryptionGadget, AllocGadget, EncryptionGadget, EqGadget};
+    use rand::{CryptoRng, Rng, SeedableRng};
+    use rand_chacha::ChaChaRng;
+    use snarkvm_algorithms::{encryption::ECIESPoseidonEncryption, EncryptionScheme};
+    use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsParameters};
+    use snarkvm_fields::PrimeField;
+    use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
 
-    let encryption_scheme = TestEncryptionScheme::setup("test_group_encryption_public_key_gadget");
+    type TestEncryptionScheme = ECIESPoseidonEncryption<EdwardsParameters>;
+    type TestEncryptionSchemeGadget = ECIESPoseidonEncryptionGadget<EdwardsParameters, Fr>;
 
-    let private_key = encryption_scheme.generate_private_key(rng);
-    let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+    fn generate_input<F: PrimeField, R: Rng + CryptoRng>(input_size: usize, rng: &mut R) -> Vec<F> {
+        let mut input = vec![];
+        for _ in 0..input_size {
+            input.push(F::rand(rng))
+        }
 
-    let encryption =
-        TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
-    let private_key_gadget =
-        <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PrivateKeyGadget::alloc(
-            &mut cs.ns(|| "private_key_gadget"),
-            || Ok(&private_key),
-        )
-        .unwrap();
-    let expected_public_key_gadget =
-        <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
-            &mut cs.ns(|| "public_key_gadget"),
-            || Ok(&public_key),
-        )
-        .unwrap();
-
-    println!("number of constraints for inputs: {}", cs.num_constraints());
-
-    let public_key_gadget = encryption
-        .check_public_key_gadget(&mut cs.ns(|| "public_key_gadget_evaluation"), &private_key_gadget)
-        .unwrap();
-
-    expected_public_key_gadget
-        .enforce_equal(
-            cs.ns(|| "Check that declared and computed public keys are equal"),
-            &public_key_gadget,
-        )
-        .unwrap();
-
-    println!("number of constraints total: {}", cs.num_constraints());
-
-    if !cs.is_satisfied() {
-        println!("which is unsatisfied: {:?}", cs.which_is_unsatisfied().unwrap());
+        input
     }
-    assert!(cs.is_satisfied());
-}
 
-#[test]
-fn test_group_encryption_gadget() {
-    let mut cs = TestConstraintSystem::<Fr>::new();
-    let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+    #[test]
+    fn test_ecies_poseidon_encryption_public_key_gadget() {
+        let mut cs = TestConstraintSystem::<Fr>::new();
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
 
-    let encryption_scheme = TestEncryptionScheme::setup("test_group_encryption_gadget");
+        let encryption_scheme = TestEncryptionScheme::setup("test_group_encryption_public_key_gadget");
 
-    let private_key = encryption_scheme.generate_private_key(rng);
-    let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+        let private_key = encryption_scheme.generate_private_key(rng);
+        let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
 
-    let randomness = encryption_scheme.generate_randomness(&public_key, rng).unwrap();
-    let message = generate_input(10, rng);
-    let blinding_exponents = encryption_scheme
-        .generate_blinding_exponents(&public_key, &randomness, message.len())
-        .unwrap();
-    let ciphertext = encryption_scheme.encrypt(&public_key, &randomness, &message).unwrap();
+        let encryption =
+            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+        let private_key_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PrivateKeyGadget::alloc(
+                &mut cs.ns(|| "private_key_gadget"),
+                || Ok(&private_key),
+            )
+            .unwrap();
+        let expected_public_key_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
+                &mut cs.ns(|| "public_key_gadget"),
+                || Ok(&public_key),
+            )
+            .unwrap();
 
-    // Alloc parameters, public key, plaintext, randomness, and blinding exponents
-    let encryption =
-        TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
-    let public_key_gadget =
-        <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
-            &mut cs.ns(|| "public_key_gadget"),
-            || Ok(&public_key),
-        )
-        .unwrap();
-    let plaintext_gadget =
-        <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PlaintextGadget::alloc(
-            &mut cs.ns(|| "plaintext_gadget"),
-            || Ok(&message),
-        )
-        .unwrap();
-    let randomness_gadget =
-        <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::RandomnessGadget::alloc(
-            &mut cs.ns(|| "randomness_gadget"),
-            || Ok(&randomness),
-        )
-        .unwrap();
-    let blinding_exponents_gadget =
-        <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::BlindingExponentGadget::alloc(
-            &mut cs.ns(|| "blinding_exponents_gadget"),
-            || Ok(&blinding_exponents),
-        )
-        .unwrap();
+        println!("number of constraints for inputs: {}", cs.num_constraints());
 
-    // Expected ciphertext gadget
-    let expected_ciphertext_gadget =
-        <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::CiphertextGadget::alloc(
-            &mut cs.ns(|| "ciphertext_gadget"),
-            || Ok(&ciphertext),
-        )
-        .unwrap();
+        let public_key_gadget = encryption
+            .check_public_key_gadget(&mut cs.ns(|| "public_key_gadget_evaluation"), &private_key_gadget)
+            .unwrap();
 
-    println!("number of constraints for inputs: {}", cs.num_constraints());
+        expected_public_key_gadget
+            .enforce_equal(
+                cs.ns(|| "Check that declared and computed public keys are equal"),
+                &public_key_gadget,
+            )
+            .unwrap();
 
-    let ciphertext_gadget = encryption
-        .check_encryption_gadget(
-            &mut cs.ns(|| "ciphertext_gadget_evaluation"),
-            &randomness_gadget,
-            &public_key_gadget,
-            &plaintext_gadget,
-            &blinding_exponents_gadget,
-        )
-        .unwrap();
+        println!("number of constraints total: {}", cs.num_constraints());
 
-    expected_ciphertext_gadget
-        .enforce_equal(
-            cs.ns(|| "Check that declared and computed ciphertexts are equal"),
-            &ciphertext_gadget,
-        )
-        .unwrap();
-
-    println!("number of constraints total: {}", cs.num_constraints());
-
-    if !cs.is_satisfied() {
-        println!("which is unsatisfied: {:?}", cs.which_is_unsatisfied().unwrap());
+        if !cs.is_satisfied() {
+            println!("which is unsatisfied: {:?}", cs.which_is_unsatisfied().unwrap());
+        }
+        assert!(cs.is_satisfied());
     }
-    assert!(cs.is_satisfied());
+
+    #[test]
+    fn test_ecies_poseidon_encryption_gadget() {
+        let mut cs = TestConstraintSystem::<Fr>::new();
+        let rng = &mut ChaChaRng::seed_from_u64(1231275789u64);
+
+        let encryption_scheme = TestEncryptionScheme::setup("test_group_encryption_gadget");
+
+        let private_key = encryption_scheme.generate_private_key(rng);
+        let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
+
+        let randomness = encryption_scheme.generate_randomness(&public_key, rng).unwrap();
+        let message = generate_input(10, rng);
+        let blinding_exponents = encryption_scheme
+            .generate_encryption_witness(&public_key, &randomness, message.len())
+            .unwrap();
+        let ciphertext = encryption_scheme.encrypt(&public_key, &randomness, &message).unwrap();
+
+        // Alloc parameters, public key, plaintext, randomness, and blinding exponents
+        let encryption =
+            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+        let public_key_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
+                &mut cs.ns(|| "public_key_gadget"),
+                || Ok(&public_key),
+            )
+            .unwrap();
+        let plaintext_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PlaintextGadget::alloc(
+                &mut cs.ns(|| "plaintext_gadget"),
+                || Ok(&message),
+            )
+            .unwrap();
+        let randomness_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::RandomnessGadget::alloc(
+                &mut cs.ns(|| "randomness_gadget"),
+                || Ok(&randomness),
+            )
+            .unwrap();
+        let blinding_exponents_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::EncryptionWitnessGadget::alloc(
+                &mut cs.ns(|| "blinding_exponents_gadget"),
+                || Ok(&blinding_exponents),
+            )
+            .unwrap();
+
+        // Expected ciphertext gadget
+        let expected_ciphertext_gadget =
+            <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::CiphertextGadget::alloc(
+                &mut cs.ns(|| "ciphertext_gadget"),
+                || Ok(&ciphertext),
+            )
+            .unwrap();
+
+        println!("number of constraints for inputs: {}", cs.num_constraints());
+
+        let ciphertext_gadget = encryption
+            .check_encryption_gadget(
+                &mut cs.ns(|| "ciphertext_gadget_evaluation"),
+                &randomness_gadget,
+                &public_key_gadget,
+                &plaintext_gadget,
+                &blinding_exponents_gadget,
+            )
+            .unwrap();
+
+        expected_ciphertext_gadget
+            .enforce_equal(
+                cs.ns(|| "Check that declared and computed ciphertexts are equal"),
+                &ciphertext_gadget,
+            )
+            .unwrap();
+
+        println!("number of constraints total: {}", cs.num_constraints());
+
+        if !cs.is_satisfied() {
+            println!("which is unsatisfied: {:?}", cs.which_is_unsatisfied().unwrap());
+        }
+        assert!(cs.is_satisfied());
+    }
 }

--- a/gadgets/src/bits/to_bytes.rs
+++ b/gadgets/src/bits/to_bytes.rs
@@ -26,16 +26,6 @@ pub trait ToBytesGadget<F: Field> {
     fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError>;
 }
 
-impl<F: Field> ToBytesGadget<F> for [UInt8] {
-    fn to_bytes<CS: ConstraintSystem<F>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        Ok(self.to_vec())
-    }
-
-    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        self.to_bytes(cs)
-    }
-}
-
 impl<'a, F: Field, T: 'a + ToBytesGadget<F>> ToBytesGadget<F> for &'a T {
     fn to_bytes<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         (*self).to_bytes(cs)
@@ -46,22 +36,56 @@ impl<'a, F: Field, T: 'a + ToBytesGadget<F>> ToBytesGadget<F> for &'a T {
     }
 }
 
-impl<'a, F: Field> ToBytesGadget<F> for &'a [UInt8] {
-    fn to_bytes<CS: ConstraintSystem<F>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        Ok(self.to_vec())
+impl<'a, F: Field, T: 'a + ToBytesGadget<F>> ToBytesGadget<F> for &'a [T] {
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let mut vec = vec![];
+        for (i, elem) in self.iter().enumerate() {
+            vec.append(&mut elem.to_bytes(cs.ns(|| format!("to_bytes_{}", i)))?);
+        }
+        Ok(vec)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        self.to_bytes(cs)
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let mut vec = vec![];
+        for (i, elem) in self.iter().enumerate() {
+            vec.append(&mut elem.to_bytes_strict(cs.ns(|| format!("to_bytes_{}", i)))?);
+        }
+        Ok(vec)
     }
 }
 
-impl<F: Field> ToBytesGadget<F> for Vec<UInt8> {
-    fn to_bytes<CS: ConstraintSystem<F>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        Ok(self.to_vec())
+impl<F: Field, T: ToBytesGadget<F>> ToBytesGadget<F> for [T] {
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let mut vec = vec![];
+        for (i, elem) in self.iter().enumerate() {
+            vec.append(&mut elem.to_bytes(cs.ns(|| format!("to_bytes_{}", i)))?);
+        }
+        Ok(vec)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
-        self.to_bytes(cs)
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let mut vec = vec![];
+        for (i, elem) in self.iter().enumerate() {
+            vec.append(&mut elem.to_bytes_strict(cs.ns(|| format!("to_bytes_{}", i)))?);
+        }
+        Ok(vec)
+    }
+}
+
+impl<F: Field, T: ToBytesGadget<F>> ToBytesGadget<F> for Vec<T> {
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let mut vec = vec![];
+        for (i, elem) in self.iter().enumerate() {
+            vec.append(&mut elem.to_bytes(cs.ns(|| format!("to_bytes_{}", i)))?);
+        }
+        Ok(vec)
+    }
+
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let mut vec = vec![];
+        for (i, elem) in self.iter().enumerate() {
+            vec.append(&mut elem.to_bytes_strict(cs.ns(|| format!("to_bytes_{}", i)))?);
+        }
+        Ok(vec)
     }
 }

--- a/gadgets/src/traits/algorithms/encryption.rs
+++ b/gadgets/src/traits/algorithms/encryption.rs
@@ -40,7 +40,7 @@ pub trait EncryptionGadget<E: EncryptionScheme, F: Field>: AllocGadget<E, F> + C
     type CiphertextGadget: AllocGadget<Vec<E::Text>, F> + ToBytesGadget<F> + EqGadget<F> + Clone + Sized + Debug;
     type PlaintextGadget: AllocGadget<Vec<E::Text>, F> + EqGadget<F> + Clone + Sized + Debug;
     type RandomnessGadget: AllocGadget<E::Randomness, F> + Clone + Sized + Debug;
-    type BlindingExponentGadget: AllocGadget<Vec<E::BlindingExponent>, F> + Clone + Sized + Debug;
+    type EncryptionWitnessGadget: AllocGadget<Vec<E::EncryptionWitness>, F> + Clone + Sized + Debug;
 
     fn check_public_key_gadget<CS: ConstraintSystem<F>>(
         &self,
@@ -54,6 +54,6 @@ pub trait EncryptionGadget<E: EncryptionScheme, F: Field>: AllocGadget<E, F> + C
         randomness: &Self::RandomnessGadget,
         public_key: &Self::PublicKeyGadget,
         input: &Self::PlaintextGadget,
-        blinding_exponents: &Self::BlindingExponentGadget,
+        encryption_witness: &Self::EncryptionWitnessGadget,
     ) -> Result<Self::CiphertextGadget, SynthesisError>;
 }

--- a/gadgets/src/traits/alloc.rs
+++ b/gadgets/src/traits/alloc.rs
@@ -86,8 +86,8 @@ pub trait AllocGadget<V: ?Sized, F: Field>: Sized {
     }
 }
 
-impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
-    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<[I]>, CS: ConstraintSystem<F>>(
+impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<Vec<I>, F> for Vec<A> {
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Vec<I>>, CS: ConstraintSystem<F>>(
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {
@@ -99,7 +99,7 @@ impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
         Ok(vec)
     }
 
-    fn alloc_checked<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<[I]>, CS: ConstraintSystem<F>>(
+    fn alloc_checked<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Vec<I>>, CS: ConstraintSystem<F>>(
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {
@@ -113,7 +113,7 @@ impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
         Ok(vec)
     }
 
-    fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<[I]>, CS: ConstraintSystem<F>>(
+    fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Vec<I>>, CS: ConstraintSystem<F>>(
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {
@@ -127,7 +127,7 @@ impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
         Ok(vec)
     }
 
-    fn alloc_input_checked<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<[I]>, CS: ConstraintSystem<F>>(
+    fn alloc_input_checked<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Vec<I>>, CS: ConstraintSystem<F>>(
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {


### PR DESCRIPTION
## Motivation

This PR supples the ECIES Poseidon encryption, which is likely going to replace group encryption. 

Currently the group encryption has certain challenges: (1) elligator is not performing ideally for a few reasons and (2) it seems to complicate our serialization.

This one supplies an ECIES Poseidon encryption, which is likely to be faster than the group encryption, and can work securely when the same key is also used with Schnorr signatures. 

There is a possibility of using ElGamal hybrid encryption later, which will also be using Poseidon for the symmetric encryption part, and can reuse the code here.

## Test Plan

The ECIES Poseidon uses the same tests as used by group encryption.

