### PR TITLE
Initial attempts to merge the Testnet1 and Testnet2 traits

### DIFF
--- a/algorithms/src/traits/snark.rs
+++ b/algorithms/src/traits/snark.rs
@@ -38,7 +38,7 @@ pub trait SNARK {
 
     // We can specify their defaults to `()` when `associated_type_defaults` feature becomes stable in Rust
     type UniversalSetupConfig: Clone;
-    type UniversalSetupParameters: Clone;
+    type UniversalSetupParameters: FromBytes + ToBytes + Clone;
 
     type VerifyingKey: Clone
         + ToBytes

--- a/dpc/src/testnet2/mod.rs
+++ b/dpc/src/testnet2/mod.rs
@@ -30,13 +30,7 @@ pub mod parameters;
 
 use crate::{Parameters, ProgramLocalData};
 use snarkvm_algorithms::prelude::*;
-use snarkvm_fields::ToConstraintField;
 use snarkvm_gadgets::{bits::Boolean, nonnative::NonNativeFieldVar, traits::algorithms::SNARKVerifierGadget};
-use snarkvm_marlin::{
-    marlin::{MarlinMode, UniversalSRS},
-    FiatShamirRng,
-};
-use snarkvm_polycommit::PolynomialCommitment;
 
 /// Trait that stores information about the testnet2 DPC scheme.
 pub trait Testnet2Components: Parameters {
@@ -47,7 +41,6 @@ pub trait Testnet2Components: Parameters {
     type ProgramSNARK: SNARK<
         ScalarField = Self::InnerScalarField,
         BaseField = Self::OuterScalarField,
-        UniversalSetupParameters = UniversalSRS<Self::InnerScalarField, Self::PolynomialCommitment>,
         VerifierInput = ProgramLocalData<Self>,
     >;
 
@@ -57,19 +50,4 @@ pub trait Testnet2Components: Parameters {
         Self::ProgramSNARK,
         Input = NonNativeFieldVar<Self::InnerScalarField, Self::OuterScalarField>,
     >;
-
-    /// Polynomial commitment scheme for Program SNARKS using Marlin.
-    type PolynomialCommitment: PolynomialCommitment<
-        Self::InnerScalarField,
-        VerifierKey = Self::PolynomialCommitmentVerifierKey,
-        Commitment = Self::PolynomialCommitmentCommitment,
-    >;
-    type PolynomialCommitmentVerifierKey: ToConstraintField<Self::OuterScalarField>;
-    type PolynomialCommitmentCommitment: ToConstraintField<Self::OuterScalarField>;
-
-    /// Fiat Shamir RNG scheme used for Marlin SNARKS.
-    type FiatShamirRng: FiatShamirRng<Self::InnerScalarField, Self::OuterScalarField>;
-
-    /// Specify the Marlin mode (recursive or non-recursive) for program SNARKS.
-    type MarlinMode: MarlinMode;
 }

--- a/dpc/src/testnet2/parameters.rs
+++ b/dpc/src/testnet2/parameters.rs
@@ -62,7 +62,6 @@ use snarkvm_marlin::{
 use snarkvm_polycommit::marlin_pc::{marlin_kzg10::MarlinKZG10Gadget, MarlinKZG10};
 
 use once_cell::sync::OnceCell;
-use snarkvm_polycommit::PolynomialCommitment;
 
 macro_rules! dpc_setup {
     ($fn_name: ident, $static_name: ident, $type_name: ident, $setup_msg: expr) => {
@@ -175,30 +174,23 @@ impl Parameters for Testnet2Parameters {
 }
 
 impl Testnet2Components for Testnet2Parameters {
-    type FiatShamirRng = FiatShamirAlgebraicSpongeRng<
-        Self::InnerScalarField,
-        Self::OuterScalarField,
-        PoseidonSponge<Self::OuterScalarField>,
-    >;
     type InnerSNARKGadget = Groth16VerifierGadget<Self::InnerCurve, PairingGadget>;
-    type MarlinMode = MarlinTestnet2Mode;
-    type PolynomialCommitment = MarlinKZG10<Self::InnerCurve>;
-    type PolynomialCommitmentCommitment =
-        <Self::PolynomialCommitment as PolynomialCommitment<Self::InnerScalarField>>::Commitment;
-    type PolynomialCommitmentVerifierKey =
-        <Self::PolynomialCommitment as PolynomialCommitment<Self::InnerScalarField>>::VerifierKey;
     type ProgramSNARK = MarlinSNARK<
         Self::InnerScalarField,
         Self::OuterScalarField,
-        Self::PolynomialCommitment,
-        Self::FiatShamirRng,
-        Self::MarlinMode,
+        MarlinKZG10<Self::InnerCurve>,
+        FiatShamirAlgebraicSpongeRng<
+            Self::InnerScalarField,
+            Self::OuterScalarField,
+            PoseidonSponge<Self::OuterScalarField>,
+        >,
+        MarlinTestnet2Mode,
         ProgramLocalData<Self>,
     >;
     type ProgramSNARKGadget = MarlinVerificationGadget<
         Self::InnerScalarField,
         Self::OuterScalarField,
-        Self::PolynomialCommitment,
+        MarlinKZG10<Self::InnerCurve>,
         MarlinKZG10Gadget<Self::InnerCurve, Self::OuterCurve, PairingGadget>,
     >;
 }

--- a/dpc/src/testnet2/program/noop_program.rs
+++ b/dpc/src/testnet2/program/noop_program.rs
@@ -25,7 +25,6 @@ use crate::{
     RecordScheme,
 };
 use snarkvm_algorithms::prelude::*;
-use snarkvm_marlin::marlin::UniversalSRS;
 use snarkvm_parameters::{
     testnet2::{NoopProgramSNARKPKParameters, NoopProgramSNARKVKParameters},
     Parameter,
@@ -59,8 +58,7 @@ impl<C: Testnet2Components> ProgramScheme for NoopProgram<C> {
 
     /// Initializes a new instance of the noop program.
     fn setup<R: Rng + CryptoRng>(_rng: &mut R) -> Result<Self, ProgramError> {
-        let universal_srs: UniversalSRS<C::InnerScalarField, C::PolynomialCommitment> =
-            ProgramSNARKUniversalSRS::<C>::load()?.0.clone();
+        let universal_srs = ProgramSNARKUniversalSRS::<C>::load()?.0.clone();
 
         let (proving_key, prepared_verifying_key) =
             <Self::ProofSystem as SNARK>::index(&NoopCircuit::<C>::blank(), &universal_srs)?;

--- a/marlin/src/constraints/ahp.rs
+++ b/marlin/src/constraints/ahp.rs
@@ -98,12 +98,9 @@ pub struct VerifierThirdMsgVar<TargetField: PrimeField, BaseField: PrimeField> {
 pub struct AHPForR1CS<
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-> where
-    PCG::VerifierKeyVar: ToConstraintFieldGadget<BaseField>,
-    PCG::CommitmentVar: ToConstraintFieldGadget<BaseField>,
-{
+> {
     field: PhantomData<TargetField>,
     constraint_field: PhantomData<BaseField>,
     polynomial_commitment: PhantomData<PC>,
@@ -113,12 +110,9 @@ pub struct AHPForR1CS<
 impl<
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
 > AHPForR1CS<TargetField, BaseField, PC, PCG>
-where
-    PCG::VerifierKeyVar: ToConstraintFieldGadget<BaseField>,
-    PCG::CommitmentVar: ToConstraintFieldGadget<BaseField>,
 {
     /// Returns the first message and next round state.
     #[allow(clippy::type_complexity)]
@@ -1028,9 +1022,9 @@ mod test {
         num_variables: usize,
         num_constraints: usize,
     ) -> (
-        CircuitProvingKey<Fr, MultiPC>,
-        CircuitVerifyingKey<Fr, MultiPC>,
-        Proof<Fr, MultiPC>,
+        CircuitProvingKey<Fr, Fq, MultiPC>,
+        CircuitVerifyingKey<Fr, Fq, MultiPC>,
+        Proof<Fr, Fq, MultiPC>,
         Vec<Fr>,
     ) {
         let rng = &mut test_rng();

--- a/marlin/src/constraints/mod.rs
+++ b/marlin/src/constraints/mod.rs
@@ -41,4 +41,4 @@ pub mod verifier_key;
 use crate::PolynomialCommitment;
 
 /// Syntactic sugar for the universal SRS in this context.
-pub type UniversalSRS<F, PC> = <PC as PolynomialCommitment<F>>::UniversalParams;
+pub type UniversalSRS<F, CF, PC> = <PC as PolynomialCommitment<F, CF>>::UniversalParams;

--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -37,11 +37,7 @@ use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     bits::Boolean,
     nonnative::{params::OptimizationType, NonNativeFieldVar},
-    traits::{
-        algorithms::SNARKVerifierGadget,
-        eq::EqGadget,
-        fields::{FieldGadget, ToConstraintFieldGadget},
-    },
+    traits::{algorithms::SNARKVerifierGadget, eq::EqGadget, fields::FieldGadget},
     PrepareGadget,
 };
 use snarkvm_polycommit::{PCCheckRandomDataVar, PCCheckVar};
@@ -51,7 +47,7 @@ use snarkvm_r1cs::{ConstraintSystem, SynthesisError, ToConstraintField};
 pub struct MarlinVerificationGadget<
     TargetField: PrimeField,
     BaseField: PrimeField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
 >(
     PhantomData<TargetField>,
@@ -72,12 +68,8 @@ impl<TargetField, BaseField, PC, PCG, FS, MM, V> SNARKVerifierGadget<MarlinSNARK
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
-    PC::VerifierKey: ToConstraintField<BaseField>,
-    PC::Commitment: ToConstraintField<BaseField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-    PCG::VerifierKeyVar: ToConstraintFieldGadget<BaseField>,
-    PCG::CommitmentVar: ToConstraintFieldGadget<BaseField>,
     FS: FiatShamirRng<TargetField, BaseField>,
     MM: MarlinMode,
     V: ToConstraintField<TargetField>,
@@ -123,11 +115,8 @@ impl<TargetField, BaseField, PC, PCG> MarlinVerificationGadget<TargetField, Base
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-    PC::Commitment: ToConstraintField<BaseField>,
-    PCG::VerifierKeyVar: ToConstraintFieldGadget<BaseField>,
-    PCG::CommitmentVar: ToConstraintFieldGadget<BaseField>,
 {
     /// The encoding of the protocol name for use as seed.
     pub const PROTOCOL_NAME: &'static [u8] = b"MARLIN-2019";

--- a/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
@@ -19,10 +19,7 @@ use std::marker::PhantomData;
 
 use snarkvm_algorithms::Prepare;
 use snarkvm_fields::{PrimeField, ToConstraintField};
-use snarkvm_gadgets::{
-    fields::FpGadget,
-    traits::{alloc::AllocGadget, fields::ToConstraintFieldGadget},
-};
+use snarkvm_gadgets::{fields::FpGadget, traits::alloc::AllocGadget};
 use snarkvm_polycommit::PCCheckVar;
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 use snarkvm_utilities::{to_bytes_le, ToBytes};
@@ -40,7 +37,7 @@ use snarkvm_algorithms::crypto_hash::PoseidonDefaultParametersField;
 pub struct PreparedCircuitVerifyingKeyVar<
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
@@ -66,7 +63,7 @@ pub struct PreparedCircuitVerifyingKeyVar<
 impl<
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
@@ -86,25 +83,22 @@ impl<
     }
 }
 
-impl<TargetField, BaseField, PC, PCG, PR, R> AllocGadget<PreparedCircuitVerifyingKey<TargetField, PC>, BaseField>
+impl<TargetField, BaseField, PC, PCG, PR, R>
+    AllocGadget<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>, BaseField>
     for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
-    PC::VerifierKey: ToConstraintField<BaseField>,
-    PC::Commitment: ToConstraintField<BaseField>,
-    PCG::VerifierKeyVar: ToConstraintFieldGadget<BaseField>,
-    PCG::CommitmentVar: ToConstraintFieldGadget<BaseField>,
 {
     #[inline]
     fn alloc_constant<FN, T, CS: ConstraintSystem<BaseField>>(mut cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<PreparedCircuitVerifyingKey<TargetField, PC>>,
+        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>>,
     {
         let tmp = value_gen()?;
         let obj = tmp.borrow();
@@ -170,7 +164,7 @@ where
     fn alloc<FN, T, CS: ConstraintSystem<BaseField>>(_cs: CS, _value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<PreparedCircuitVerifyingKey<TargetField, PC>>,
+        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>>,
     {
         unimplemented!();
         // the overhead is not worthwhile
@@ -180,32 +174,28 @@ where
     fn alloc_input<FN, T, CS: ConstraintSystem<BaseField>>(_cs: CS, _value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<PreparedCircuitVerifyingKey<TargetField, PC>>,
+        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>>,
     {
         unimplemented!();
         // the overhead is not worthwhile
     }
 }
 
-impl<TargetField, BaseField, PC, PCG, PR, R> AllocGadget<CircuitVerifyingKey<TargetField, PC>, BaseField>
+impl<TargetField, BaseField, PC, PCG, PR, R> AllocGadget<CircuitVerifyingKey<TargetField, BaseField, PC>, BaseField>
     for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
-    PC: PolynomialCommitment<TargetField>,
+    PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
-    PC::VerifierKey: ToConstraintField<BaseField>,
-    PC::Commitment: ToConstraintField<BaseField>,
-    PCG::VerifierKeyVar: ToConstraintFieldGadget<BaseField>,
-    PCG::CommitmentVar: ToConstraintFieldGadget<BaseField>,
 {
     #[inline]
     fn alloc_constant<FN, T, CS: ConstraintSystem<BaseField>>(cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
     {
         let tmp = value_gen()?;
         let vk = tmp.borrow();
@@ -219,7 +209,7 @@ where
     fn alloc<FN, T, CS: ConstraintSystem<BaseField>>(cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
     {
         let tmp = value_gen()?;
         let vk = tmp.borrow();
@@ -232,7 +222,7 @@ where
     fn alloc_input<FN, T, CS: ConstraintSystem<BaseField>>(cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
     {
         let tmp = value_gen()?;
         let vk = tmp.borrow();

--- a/marlin/src/marlin/circuit_proving_key.rs
+++ b/marlin/src/marlin/circuit_proving_key.rs
@@ -26,9 +26,9 @@ use std::io::{Read, Result as IoResult, Write};
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""))]
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct CircuitProvingKey<F: PrimeField, PC: PolynomialCommitment<F>> {
+pub struct CircuitProvingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> {
     /// The circuit verifying key.
-    pub circuit_verifying_key: CircuitVerifyingKey<F, PC>,
+    pub circuit_verifying_key: CircuitVerifyingKey<F, CF, PC>,
     /// The randomness for the circuit polynomial commitments.
     pub circuit_commitment_randomness: Vec<PC::Randomness>,
     /// The circuit itself.
@@ -37,13 +37,13 @@ pub struct CircuitProvingKey<F: PrimeField, PC: PolynomialCommitment<F>> {
     pub committer_key: PC::CommitterKey,
 }
 
-impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for CircuitProvingKey<F, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToBytes for CircuitProvingKey<F, CF, PC> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         CanonicalSerialize::serialize(self, &mut writer).map_err(|_| error("could not serialize CircuitProvingKey"))
     }
 }
 
-impl<F: PrimeField, PC: PolynomialCommitment<F>> FromBytes for CircuitProvingKey<F, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> FromBytes for CircuitProvingKey<F, CF, PC> {
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         CanonicalDeserialize::deserialize(&mut reader).map_err(|_| error("could not deserialize CircuitProvingKey"))

--- a/marlin/src/marlin/prepared_circuit_verifying_key.rs
+++ b/marlin/src/marlin/prepared_circuit_verifying_key.rs
@@ -20,7 +20,7 @@ use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::PolynomialCommitment;
 
 /// Verification key, prepared (preprocessed) for use in pairings.
-pub struct PreparedCircuitVerifyingKey<F: PrimeField, PC: PolynomialCommitment<F>> {
+pub struct PreparedCircuitVerifyingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> {
     /// Size of the variable domain.
     pub domain_h_size: u64,
     /// Size of the matrix domain.
@@ -32,10 +32,10 @@ pub struct PreparedCircuitVerifyingKey<F: PrimeField, PC: PolynomialCommitment<F
     /// Non-prepared verification key, for use in native "prepared verify" (which
     /// is actually standard verify), as well as in absorbing the original vk into
     /// the Fiat-Shamir sponge.
-    pub orig_vk: CircuitVerifyingKey<F, PC>,
+    pub orig_vk: CircuitVerifyingKey<F, CF, PC>,
 }
 
-impl<F: PrimeField, PC: PolynomialCommitment<F>> Clone for PreparedCircuitVerifyingKey<F, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> Clone for PreparedCircuitVerifyingKey<F, CF, PC> {
     fn clone(&self) -> Self {
         PreparedCircuitVerifyingKey {
             domain_h_size: self.domain_h_size,

--- a/marlin/src/marlin/proof.rs
+++ b/marlin/src/marlin/proof.rs
@@ -30,7 +30,7 @@ use std::io::{
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""), Clone(bound = ""))]
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct Proof<F: PrimeField, PC: PolynomialCommitment<F>> {
+pub struct Proof<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> {
     /// Commitments to the polynomials produced by the AHP prover.
     pub commitments: Vec<Vec<PC::Commitment>>,
     /// Evaluations of these polynomials.
@@ -38,16 +38,16 @@ pub struct Proof<F: PrimeField, PC: PolynomialCommitment<F>> {
     /// The field elements sent by the prover.
     pub prover_messages: Vec<ProverMessage<F>>,
     /// An evaluation proof from the polynomial commitment.
-    pub pc_proof: BatchLCProof<F, PC>,
+    pub pc_proof: BatchLCProof<F, CF, PC>,
 }
 
-impl<F: PrimeField, PC: PolynomialCommitment<F>> Proof<F, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> Proof<F, CF, PC> {
     /// Construct a new proof.
     pub fn new(
         commitments: Vec<Vec<PC::Commitment>>,
         evaluations: Vec<F>,
         prover_messages: Vec<ProverMessage<F>>,
-        pc_proof: BatchLCProof<F, PC>,
+        pc_proof: BatchLCProof<F, CF, PC>,
     ) -> Self {
         Self {
             commitments,
@@ -118,13 +118,13 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>> Proof<F, PC> {
     }
 }
 
-impl<F: PrimeField, PC: PolynomialCommitment<F>> ToBytes for Proof<F, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToBytes for Proof<F, CF, PC> {
     fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("could not serialize Proof"))
     }
 }
 
-impl<F: PrimeField, PC: PolynomialCommitment<F>> FromBytes for Proof<F, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> FromBytes for Proof<F, CF, PC> {
     fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut r).map_err(|_| error("could not deserialize Proof"))
     }

--- a/marlin/src/marlin/universal_srs.rs
+++ b/marlin/src/marlin/universal_srs.rs
@@ -17,4 +17,4 @@
 use snarkvm_polycommit::PolynomialCommitment;
 
 /// The universal public parameters for the argument system.
-pub type UniversalSRS<F, PC> = <PC as PolynomialCommitment<F>>::UniversalParams;
+pub type UniversalSRS<F, CF, PC> = <PC as PolynomialCommitment<F, CF>>::UniversalParams;

--- a/marlin/src/parameters.rs
+++ b/marlin/src/parameters.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{MarlinTestnet1, PolynomialCommitment, ProvingKey, VerifyingKey, SRS};
+use crate::{MarlinTestnet1, ProvingKey, VerifyingKey, SRS};
 use snarkvm_algorithms::errors::SNARKError;
 use snarkvm_curves::traits::{AffineCurve, PairingEngine};
 pub use snarkvm_polycommit::{marlin_pc::MarlinKZG10 as MultiPC, PCCommitment};
-use snarkvm_r1cs::{ConstraintSynthesizer, ToConstraintField};
+use snarkvm_r1cs::ConstraintSynthesizer;
 use snarkvm_utilities::{
     error,
     errors::SerializationError,
@@ -53,11 +53,7 @@ pub struct Parameters<E: PairingEngine> {
     pub verifying_key: VerifyingKey<E>,
 }
 
-impl<E: PairingEngine> Parameters<E>
-where
-    <MultiPC<E> as PolynomialCommitment<E::Fr>>::Commitment: ToConstraintField<E::Fq>,
-    <MultiPC<E> as PolynomialCommitment<E::Fr>>::VerifierKey: ToConstraintField<E::Fq>,
-{
+impl<E: PairingEngine> Parameters<E> {
     /// Creates an instance of `Parameters` from a given universal SRS.
     pub fn new<C: ConstraintSynthesizer<E::Fr>>(circuit: &C, universal_srs: &SRS<E>) -> Result<Self, SNARKError> {
         let (proving_key, verifying_key) = MarlinTestnet1::<E>::circuit_setup(universal_srs, circuit)

--- a/marlin/src/snark.rs
+++ b/marlin/src/snark.rs
@@ -35,16 +35,17 @@ use rand_core::RngCore;
 
 /// A structured reference string which will be used to derive a circuit-specific
 /// common reference string
-pub type SRS<E> = UniversalSRS<<E as PairingEngine>::Fr, MultiPC<E>>;
+pub type SRS<E> = UniversalSRS<<E as PairingEngine>::Fr, <E as PairingEngine>::Fq, MultiPC<E>>;
 
 /// A circuit-specific proving key.
-pub type ProvingKey<E> = CircuitProvingKey<<E as PairingEngine>::Fr, MultiPC<E>>;
+pub type ProvingKey<E> = CircuitProvingKey<<E as PairingEngine>::Fr, <E as PairingEngine>::Fq, MultiPC<E>>;
 
 /// A circuit-specific verifying key.
-pub type VerifyingKey<E> = CircuitVerifyingKey<<E as PairingEngine>::Fr, MultiPC<E>>;
+pub type VerifyingKey<E> = CircuitVerifyingKey<<E as PairingEngine>::Fr, <E as PairingEngine>::Fq, MultiPC<E>>;
 
 /// A prepared circuit-specific verifying key.
-pub type PreparedVerifyingKey<E> = PreparedCircuitVerifyingKey<<E as PairingEngine>::Fr, MultiPC<E>>;
+pub type PreparedVerifyingKey<E> =
+    PreparedCircuitVerifyingKey<<E as PairingEngine>::Fr, <E as PairingEngine>::Fq, MultiPC<E>>;
 
 impl<E: PairingEngine> From<Parameters<E>> for VerifyingKey<E> {
     fn from(parameters: Parameters<E>) -> Self {
@@ -67,8 +68,6 @@ pub struct MarlinTestnet1System<E, V>
 where
     E: PairingEngine,
     V: ToConstraintField<E::Fr>,
-    <MultiPC<E> as PolynomialCommitment<E::Fr>>::Commitment: ToConstraintField<E::Fq>,
-    <MultiPC<E> as PolynomialCommitment<E::Fr>>::VerifierKey: ToConstraintField<E::Fq>,
 {
     _engine: PhantomData<E>,
     _verifier_input: PhantomData<V>,
@@ -78,12 +77,10 @@ impl<E, V> SNARK for MarlinTestnet1System<E, V>
 where
     E: PairingEngine,
     V: ToConstraintField<E::Fr>,
-    <MultiPC<E> as PolynomialCommitment<E::Fr>>::Commitment: ToConstraintField<E::Fq>,
-    <MultiPC<E> as PolynomialCommitment<E::Fr>>::VerifierKey: ToConstraintField<E::Fq>,
 {
     type BaseField = E::Fq;
     type PreparedVerifyingKey = PreparedVerifyingKey<E>;
-    type Proof = Proof<<E as PairingEngine>::Fr, MultiPC<E>>;
+    type Proof = Proof<<E as PairingEngine>::Fr, <E as PairingEngine>::Fq, MultiPC<E>>;
     type ProvingKey = Parameters<E>;
     type ScalarField = E::Fr;
     type UniversalSetupConfig = MarlinBound;

--- a/parameters/examples/testnet2_noop_program_snark.rs
+++ b/parameters/examples/testnet2_noop_program_snark.rs
@@ -20,7 +20,6 @@ use snarkvm_dpc::{
     ProgramScheme,
 };
 use snarkvm_fields::ToConstraintField;
-use snarkvm_marlin::PolynomialCommitment;
 use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
@@ -34,10 +33,6 @@ use utils::store;
 pub fn setup<C: Testnet2Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError>
 where
     <C::ProgramSNARK as SNARK>::VerifyingKey: ToConstraintField<C::OuterScalarField>,
-    <C::PolynomialCommitment as PolynomialCommitment<C::InnerScalarField>>::VerifierKey:
-        ToConstraintField<C::OuterScalarField>,
-    <C::PolynomialCommitment as PolynomialCommitment<C::InnerScalarField>>::Commitment:
-        ToConstraintField<C::OuterScalarField>,
 {
     let rng = &mut thread_rng();
     let noop_program = NoopProgram::<C>::setup(rng)?;

--- a/polycommit/src/constraints.rs
+++ b/polycommit/src/constraints.rs
@@ -152,7 +152,9 @@ pub struct PCCheckRandomDataVar<TargetField: PrimeField, BaseField: PrimeField> 
 
 /// Describes the interface for a gadget for a `PolynomialCommitment`
 /// verifier.
-pub trait PCCheckVar<PCF: PrimeField, PC: PolynomialCommitment<PCF>, ConstraintF: PrimeField>: Clone {
+pub trait PCCheckVar<PCF: PrimeField, PC: PolynomialCommitment<PCF, ConstraintF>, ConstraintF: PrimeField>:
+    Clone
+{
     /// An allocated version of `PC::VerifierKey`.
     type VerifierKeyVar: AllocGadget<PC::VerifierKey, ConstraintF>
         + Clone
@@ -177,7 +179,7 @@ pub trait PCCheckVar<PCF: PrimeField, PC: PolynomialCommitment<PCF>, ConstraintF
     type ProofVar: AllocGadget<PC::Proof, ConstraintF> + Clone;
 
     /// An allocated version of `PC::BatchLCProof`.
-    type BatchLCProofVar: AllocGadget<BatchLCProof<PCF, PC>, ConstraintF> + Clone;
+    type BatchLCProofVar: AllocGadget<BatchLCProof<PCF, ConstraintF, PC>, ConstraintF> + Clone;
 
     /// Add to `ConstraintSystem<ConstraintF>` new constraints that check that `proof_i` is a valid evaluation
     /// proof at `point_i` for the polynomial in `commitment_i`.

--- a/polycommit/src/kzg10/data_structures.rs
+++ b/polycommit/src/kzg10/data_structures.rs
@@ -101,11 +101,7 @@ pub struct VerifierKey<E: PairingEngine> {
 }
 impl_bytes!(VerifierKey);
 
-impl<E: PairingEngine> ToConstraintField<E::Fq> for VerifierKey<E>
-where
-    E::G1Affine: ToConstraintField<E::Fq>,
-    E::G2Affine: ToConstraintField<E::Fq>,
-{
+impl<E: PairingEngine> ToConstraintField<E::Fq> for VerifierKey<E> {
     fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
         let mut res = Vec::new();
 
@@ -204,10 +200,7 @@ impl<'a, E: PairingEngine> AddAssign<(E::Fr, &'a Commitment<E>)> for Commitment<
     }
 }
 
-impl<E: PairingEngine> ToConstraintField<E::Fq> for Commitment<E>
-where
-    E::G1Affine: ToConstraintField<E::Fq>,
-{
+impl<E: PairingEngine> ToConstraintField<E::Fq> for Commitment<E> {
     fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
         self.0.to_field_elements()
     }

--- a/polycommit/src/marlin_pc/data_structures.rs
+++ b/polycommit/src/marlin_pc/data_structures.rs
@@ -132,11 +132,7 @@ impl<E: PairingEngine> PCVerifierKey for VerifierKey<E> {
     }
 }
 
-impl<E: PairingEngine> ToConstraintField<E::Fq> for VerifierKey<E>
-where
-    E::G1Affine: ToConstraintField<E::Fq>,
-    E::G2Affine: ToConstraintField<E::Fq>,
-{
+impl<E: PairingEngine> ToConstraintField<E::Fq> for VerifierKey<E> {
     fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
         let mut res = Vec::new();
         res.extend_from_slice(&self.vk.to_field_elements()?);
@@ -252,10 +248,7 @@ impl<E: PairingEngine> PCCommitment for Commitment<E> {
     }
 }
 
-impl<E: PairingEngine> ToConstraintField<E::Fq> for Commitment<E>
-where
-    E::G1Affine: ToConstraintField<E::Fq>,
-{
+impl<E: PairingEngine> ToConstraintField<E::Fq> for Commitment<E> {
     fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
         let mut res = Vec::new();
         res.extend_from_slice(&self.comm.to_field_elements()?);

--- a/polycommit/src/marlin_pc/gadgets/commitment/commitment.rs
+++ b/polycommit/src/marlin_pc/gadgets/commitment/commitment.rs
@@ -17,7 +17,7 @@
 use core::borrow::Borrow;
 
 use snarkvm_curves::{traits::AffineCurve, PairingEngine};
-use snarkvm_fields::{PrimeField, ToConstraintField};
+use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     bits::ToBytesGadget,
     fields::FpGadget,
@@ -41,10 +41,7 @@ pub struct CommitmentVar<
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-> where
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-{
+> {
     /// Commitment.
     pub comm: PG::G1Gadget,
     /// Shifted Commitment.
@@ -56,8 +53,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -73,8 +68,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
@@ -174,9 +167,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    PG::G1Gadget: ToConstraintFieldGadget<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn to_constraint_field<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
         &self,
@@ -208,8 +198,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn prepare<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
         &self,
@@ -237,8 +225,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn to_bytes<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
         &self,

--- a/polycommit/src/marlin_pc/gadgets/commitment/labeled_commitment.rs
+++ b/polycommit/src/marlin_pc/gadgets/commitment/labeled_commitment.rs
@@ -22,7 +22,7 @@ use snarkvm_gadgets::{
     traits::{alloc::AllocGadget, curves::PairingGadget},
     PrepareGadget,
 };
-use snarkvm_r1cs::{ConstraintSystem, SynthesisError, ToConstraintField};
+use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
 use crate::{
     marlin_pc::{Commitment, CommitmentVar, PreparedLabeledCommitmentVar},
@@ -36,10 +36,7 @@ pub struct LabeledCommitmentVar<
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-> where
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-{
+> {
     /// A text label for the commitment.
     pub label: String,
     /// The plain commitment.
@@ -53,8 +50,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         LabeledCommitmentVar {
@@ -72,8 +67,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
@@ -188,8 +181,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn prepare<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
         &self,

--- a/polycommit/src/marlin_pc/gadgets/commitment/prepared_commitment.rs
+++ b/polycommit/src/marlin_pc/gadgets/commitment/prepared_commitment.rs
@@ -17,7 +17,6 @@
 use core::borrow::Borrow;
 
 use snarkvm_curves::PairingEngine;
-use snarkvm_fields::ToConstraintField;
 use snarkvm_gadgets::traits::{alloc::AllocGadget, curves::PairingGadget};
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
@@ -29,10 +28,7 @@ pub struct PreparedCommitmentVar<
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-> where
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-{
+> {
     /// Prepared commitment.
     pub prepared_comm: Vec<PG::G1Gadget>,
     /// Shifted commitment.
@@ -44,8 +40,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -61,8 +55,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,

--- a/polycommit/src/marlin_pc/gadgets/commitment/prepared_labeled_commitment.rs
+++ b/polycommit/src/marlin_pc/gadgets/commitment/prepared_labeled_commitment.rs
@@ -16,7 +16,6 @@
 
 use snarkvm_curves::PairingEngine;
 use snarkvm_gadgets::{fields::FpGadget, traits::curves::PairingGadget};
-use snarkvm_r1cs::ToConstraintField;
 
 use crate::{marlin_pc::PreparedCommitmentVar, String};
 
@@ -25,10 +24,7 @@ pub struct PreparedLabeledCommitmentVar<
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-> where
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-{
+> {
     /// A text label for the commitment.
     pub label: String,
     /// The plain commitment.
@@ -42,8 +38,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         Self {

--- a/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
+++ b/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
@@ -28,7 +28,7 @@ use snarkvm_gadgets::{
         select::CondSelectGadget,
     },
 };
-use snarkvm_r1cs::{ConstraintSystem, SynthesisError, ToConstraintField};
+use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
 use crate::{
     marlin_pc::{
@@ -59,8 +59,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     _target_curve: PhantomData<TargetCurve>,
     _base_curve: PhantomData<BaseCurve>,
@@ -72,8 +70,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -86,11 +82,9 @@ where
 
 impl<TargetCurve, BaseCurve, PG> MarlinKZG10Gadget<TargetCurve, BaseCurve, PG>
 where
-    TargetCurve: PairingEngine,
+    TargetCurve: PairingEngine<Fq = <BaseCurve as PairingEngine>::Fr>,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]
     fn prepared_batch_check_evaluations<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
@@ -548,11 +542,9 @@ impl<TargetCurve, BaseCurve, PG>
     PCCheckVar<<TargetCurve as PairingEngine>::Fr, MarlinKZG10<TargetCurve>, <BaseCurve as PairingEngine>::Fr>
     for MarlinKZG10Gadget<TargetCurve, BaseCurve, PG>
 where
-    TargetCurve: PairingEngine,
+    TargetCurve: PairingEngine<Fq = <BaseCurve as PairingEngine>::Fr>,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     type BatchLCProofVar = BatchLCProofVar<TargetCurve, BaseCurve, PG>;
     type CommitmentVar = CommitmentVar<TargetCurve, BaseCurve, PG>;

--- a/polycommit/src/marlin_pc/gadgets/proof/batch_lc_proof.rs
+++ b/polycommit/src/marlin_pc/gadgets/proof/batch_lc_proof.rs
@@ -21,7 +21,7 @@ use snarkvm_gadgets::{
     nonnative::NonNativeFieldVar,
     traits::{alloc::AllocGadget, curves::PairingGadget},
 };
-use snarkvm_r1cs::{ConstraintSystem, SynthesisError, ToConstraintField};
+use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
 use crate::{
     kzg10::Proof,
@@ -36,10 +36,7 @@ pub struct BatchLCProofVar<
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-> where
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-{
+> {
     /// Evaluation proofs.
     pub proofs: Vec<ProofVar<TargetCurve, BaseCurve, PG>>,
     /// Evaluations required to verify the proof.
@@ -51,8 +48,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -64,19 +59,23 @@ where
 
 impl<TargetCurve, BaseCurve, PG>
     AllocGadget<
-        BatchLCProof<<TargetCurve as PairingEngine>::Fr, MarlinKZG10<TargetCurve>>,
+        BatchLCProof<<TargetCurve as PairingEngine>::Fr, <TargetCurve as PairingEngine>::Fq, MarlinKZG10<TargetCurve>>,
         <BaseCurve as PairingEngine>::Fr,
     > for BatchLCProofVar<TargetCurve, BaseCurve, PG>
 where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<BatchLCProof<<TargetCurve as PairingEngine>::Fr, MarlinKZG10<TargetCurve>>>,
+        T: Borrow<
+            BatchLCProof<
+                <TargetCurve as PairingEngine>::Fr,
+                <TargetCurve as PairingEngine>::Fq,
+                MarlinKZG10<TargetCurve>,
+            >,
+        >,
         CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>,
     >(
         mut cs: CS,
@@ -114,7 +113,13 @@ where
 
     fn alloc<
         Fn: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<BatchLCProof<<TargetCurve as PairingEngine>::Fr, MarlinKZG10<TargetCurve>>>,
+        T: Borrow<
+            BatchLCProof<
+                <TargetCurve as PairingEngine>::Fr,
+                <TargetCurve as PairingEngine>::Fq,
+                MarlinKZG10<TargetCurve>,
+            >,
+        >,
         CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>,
     >(
         mut cs: CS,
@@ -152,7 +157,13 @@ where
 
     fn alloc_input<
         Fn: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<BatchLCProof<<TargetCurve as PairingEngine>::Fr, MarlinKZG10<TargetCurve>>>,
+        T: Borrow<
+            BatchLCProof<
+                <TargetCurve as PairingEngine>::Fr,
+                <TargetCurve as PairingEngine>::Fq,
+                MarlinKZG10<TargetCurve>,
+            >,
+        >,
         CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>,
     >(
         mut cs: CS,

--- a/polycommit/src/marlin_pc/gadgets/proof/proof.rs
+++ b/polycommit/src/marlin_pc/gadgets/proof/proof.rs
@@ -21,7 +21,7 @@ use snarkvm_gadgets::{
     nonnative::NonNativeFieldVar,
     traits::{alloc::AllocGadget, curves::PairingGadget},
 };
-use snarkvm_r1cs::{ConstraintSystem, SynthesisError, ToConstraintField};
+use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
 use crate::kzg10::Proof;
 
@@ -31,10 +31,7 @@ pub struct ProofVar<
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-> where
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-{
+> {
     /// The commitment to the witness polynomial.
     pub w: PG::G1Gadget,
     /// The evaluation of the random hiding polynomial.
@@ -46,8 +43,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -63,8 +58,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,

--- a/polycommit/src/marlin_pc/gadgets/verifier_key/prepared_verifier_key.rs
+++ b/polycommit/src/marlin_pc/gadgets/verifier_key/prepared_verifier_key.rs
@@ -17,7 +17,7 @@
 use core::borrow::Borrow;
 
 use snarkvm_curves::{AffineCurve, PairingEngine};
-use snarkvm_fields::{PrimeField, ToConstraintField};
+use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     fields::FpGadget,
     traits::{
@@ -39,10 +39,7 @@ pub struct PreparedVerifierKeyVar<
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-> where
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-{
+> {
     /// Generator of G1.
     pub prepared_g: Vec<PG::G1Gadget>,
     /// The generator of G1 that is used for making a commitment hiding.
@@ -65,8 +62,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     /// Find the appropriate shift for the degree bound.
     pub fn get_shift_power<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
@@ -122,8 +117,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -144,8 +137,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn into(self) -> VerifierKeyVar<TargetCurve, BaseCurve, PG> {
         match self.origin_vk {
@@ -164,8 +155,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,

--- a/polycommit/src/marlin_pc/gadgets/verifier_key/verifier_key.rs
+++ b/polycommit/src/marlin_pc/gadgets/verifier_key/verifier_key.rs
@@ -17,7 +17,7 @@
 use core::borrow::Borrow;
 
 use snarkvm_curves::{AffineCurve, PairingEngine};
-use snarkvm_fields::{PrimeField, ToConstraintField};
+use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     bits::{Boolean, ToBytesGadget},
     fields::FpGadget,
@@ -366,8 +366,6 @@ where
     TargetCurve: PairingEngine,
     BaseCurve: PairingEngine,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn prepare<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
         &self,
@@ -423,10 +421,6 @@ where
     BaseCurve: PairingEngine,
     <BaseCurve as PairingEngine>::Fr: PrimeField,
     PG: PairingGadget<TargetCurve, <BaseCurve as PairingEngine>::Fr>,
-    PG::G1Gadget: ToConstraintFieldGadget<<BaseCurve as PairingEngine>::Fr>,
-    PG::G2Gadget: ToConstraintFieldGadget<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G1Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
-    <TargetCurve as PairingEngine>::G2Affine: ToConstraintField<<BaseCurve as PairingEngine>::Fr>,
 {
     fn to_constraint_field<CS: ConstraintSystem<<BaseCurve as PairingEngine>::Fr>>(
         &self,

--- a/polycommit/src/sonic_pc/data_structures.rs
+++ b/polycommit/src/sonic_pc/data_structures.rs
@@ -181,11 +181,7 @@ impl<E: PairingEngine> PCVerifierKey for VerifierKey<E> {
     }
 }
 
-impl<E: PairingEngine> ToConstraintField<E::Fq> for VerifierKey<E>
-where
-    E::G1Affine: ToConstraintField<E::Fq>,
-    E::G2Affine: ToConstraintField<E::Fq>,
-{
+impl<E: PairingEngine> ToConstraintField<E::Fq> for VerifierKey<E> {
     fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
         let mut res = Vec::new();
         res.extend_from_slice(&self.g.to_field_elements()?);


### PR DESCRIPTION
## Motivation

Our DPC has two sets of parameter traits:
    Testnet1Components and Testnet2Components 

Ideally this should be reduced into one trait, which allows bringing the Testnet1 and Testnet2 together.

This PR makes the initial attempts, which removes several differences between `Testnet1Components` and `Testnet2Components`.

At this moment, they look like:

```
pub trait Testnet1Components: Parameters {
    type InnerSNARKGadget: SNARKVerifierGadget<Self::InnerSNARK, Input = Vec<Boolean>>;

    type ProgramSNARK: SNARK<
        ScalarField = Self::InnerScalarField,
        BaseField = Self::OuterScalarField,
        VerifierInput = ProgramLocalData<Self>,
    >;

    type ProgramSNARKGadget: SNARKVerifierGadget<Self::ProgramSNARK, Input = Vec<Boolean>>;
}
pub trait Testnet2Components: Parameters {
    type InnerSNARKGadget: SNARKVerifierGadget<Self::InnerSNARK, Input = Vec<Boolean>>;

    type ProgramSNARK: SNARK<
        ScalarField = Self::InnerScalarField,
        BaseField = Self::OuterScalarField,
        VerifierInput = ProgramLocalData<Self>,
    >;

    type ProgramSNARKGadget: SNARKVerifierGadget<
        Self::ProgramSNARK,
        Input = NonNativeFieldVar<Self::InnerScalarField, Self::OuterScalarField>,
    >;
}
```

As one can see, the only issue now is that the Input trait for ProgramSNARKGadget is different. This would be done in a followup PR, as it may need some changes to the Groth16 gadget and may break testnet1.

## Test Plan

Passes some local tests. Expect to have some changes needed for integration tests and the parameters setup.
