### PR TITLE
Use `alloc_constant` for parameters for crypto primitives

### DIFF
--- a/dpc/src/circuits/inner_circuit_gadget.rs
+++ b/dpc/src/circuits/inner_circuit_gadget.rs
@@ -185,21 +185,11 @@ where
     PGadget: PRFGadget<P, C::InnerScalarField>,
 {
     // Order for allocation of input:
-    // 1. account_commitment_parameters
-    // 2. account_encryption_parameters
-    // 3. account_signature_parameters
-    // 4. record_commitment_parameters
-    // 5. encrypted_record_crh_parameters
-    // 6. program_vk_commitment_parameters
-    // 7. local_data_crh_parameters
-    // 8. local_data_commitment_parameters
-    // 9. serial_number_nonce_crh_parameters
-    // 10. record_commitment_tree_parameters
-    // 11. ledger_digest
-    // 12. for i in 0..NUM_INPUT_RECORDS: old_serial_numbers[i]
-    // 13. for j in 0..NUM_OUTPUT_RECORDS: new_commitments[i], new_encrypted_record_hashes[i]
-    // 14. program_commitment
-    // 15. local_data_root
+    // 1. ledger_digest
+    // 2. for i in 0..NUM_INPUT_RECORDS: old_serial_numbers[i]
+    // 3. for j in 0..NUM_OUTPUT_RECORDS: new_commitments[i], new_encrypted_record_hashes[i]
+    // 4. program_commitment
+    // 5. local_data_root
     let (
         account_commitment_parameters,
         account_encryption_parameters,
@@ -214,63 +204,53 @@ where
     ) = {
         let cs = &mut cs.ns(|| "Declare commitment and CRH parameters");
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
         let account_commitment_parameters =
-            C::AccountCommitmentGadget::alloc_input(&mut cs.ns(|| "Declare account commit parameters"), || {
+            C::AccountCommitmentGadget::alloc_constant(&mut cs.ns(|| "Declare account commit parameters"), || {
                 Ok(C::account_commitment_scheme().clone())
             })?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
         let account_encryption_parameters =
-            C::AccountEncryptionGadget::alloc_input(&mut cs.ns(|| "Declare account encryption parameters"), || {
+            C::AccountEncryptionGadget::alloc_constant(&mut cs.ns(|| "Declare account encryption parameters"), || {
                 Ok(C::account_encryption_scheme().clone())
             })?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
         let account_signature_parameters =
-            C::AccountSignatureGadget::alloc_input(&mut cs.ns(|| "Declare account signature parameters"), || {
+            C::AccountSignatureGadget::alloc_constant(&mut cs.ns(|| "Declare account signature parameters"), || {
                 Ok(C::account_signature_scheme().clone())
             })?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
         let record_commitment_parameters =
-            C::RecordCommitmentGadget::alloc_input(&mut cs.ns(|| "Declare record commitment parameters"), || {
+            C::RecordCommitmentGadget::alloc_constant(&mut cs.ns(|| "Declare record commitment parameters"), || {
                 Ok(C::record_commitment_scheme().clone())
             })?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
-        let encrypted_record_crh_parameters = C::EncryptedRecordCRHGadget::alloc_input(
+        let encrypted_record_crh_parameters = C::EncryptedRecordCRHGadget::alloc_constant(
             &mut cs.ns(|| "Declare record ciphertext CRH parameters"),
             || Ok(C::encrypted_record_crh().clone()),
         )?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
-        let program_id_commitment_parameters =
-            C::ProgramCommitmentGadget::alloc_input(&mut cs.ns(|| "Declare program ID commitment parameters"), || {
-                Ok(C::program_commitment_scheme().clone())
-            })?;
+        let program_id_commitment_parameters = C::ProgramCommitmentGadget::alloc_constant(
+            &mut cs.ns(|| "Declare program ID commitment parameters"),
+            || Ok(C::program_commitment_scheme().clone()),
+        )?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
         let local_data_crh_parameters =
-            C::LocalDataCRHGadget::alloc_input(&mut cs.ns(|| "Declare local data CRH parameters"), || {
+            C::LocalDataCRHGadget::alloc_constant(&mut cs.ns(|| "Declare local data CRH parameters"), || {
                 Ok(C::local_data_crh().clone())
             })?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
-        let local_data_commitment_parameters = C::LocalDataCommitmentGadget::alloc_input(
+        let local_data_commitment_parameters = C::LocalDataCommitmentGadget::alloc_constant(
             &mut cs.ns(|| "Declare local data commitment parameters"),
             || Ok(C::local_data_commitment_scheme().clone()),
         )?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
-        let serial_number_nonce_crh_parameters = C::SerialNumberNonceCRHGadget::alloc_input(
+        let serial_number_nonce_crh_parameters = C::SerialNumberNonceCRHGadget::alloc_constant(
             &mut cs.ns(|| "Declare serial number nonce CRH parameters"),
             || Ok(C::serial_number_nonce_crh().clone()),
         )?;
 
-        // TODO (howardwu): This is allocating nothing. Why is this an alloc.
         let record_commitment_tree_parameters =
-            C::RecordCommitmentTreeCRHGadget::alloc_input(&mut cs.ns(|| "Declare ledger parameters"), || {
+            C::RecordCommitmentTreeCRHGadget::alloc_constant(&mut cs.ns(|| "Declare ledger parameters"), || {
                 Ok(C::record_commitment_tree_parameters().crh())
             })?;
 

--- a/dpc/src/circuits/inner_circuit_verifier_input.rs
+++ b/dpc/src/circuits/inner_circuit_verifier_input.rs
@@ -56,22 +56,6 @@ where
 {
     fn to_field_elements(&self) -> Result<Vec<C::InnerScalarField>, ConstraintFieldError> {
         let mut v = Vec::new();
-        v.extend_from_slice(&C::account_commitment_scheme().to_field_elements()?);
-        v.extend_from_slice(&C::account_encryption_scheme().to_field_elements()?);
-        v.extend_from_slice(&C::account_signature_scheme().to_field_elements()?);
-        v.extend_from_slice(&C::record_commitment_scheme().to_field_elements()?);
-        v.extend_from_slice(&C::encrypted_record_crh().to_field_elements()?);
-        v.extend_from_slice(&C::program_commitment_scheme().to_field_elements()?);
-        v.extend_from_slice(&C::local_data_crh().to_field_elements()?);
-        v.extend_from_slice(&C::local_data_commitment_scheme().to_field_elements()?);
-        v.extend_from_slice(&C::serial_number_nonce_crh().to_field_elements()?);
-        v.extend_from_slice(
-            &C::record_commitment_tree_parameters()
-                .crh()
-                .parameters()
-                .to_field_elements()?,
-        );
-
         v.extend_from_slice(&self.ledger_digest.to_field_elements()?);
 
         for sn in &self.old_serial_numbers {

--- a/dpc/src/circuits/outer_circuit_verifier_input.rs
+++ b/dpc/src/circuits/outer_circuit_verifier_input.rs
@@ -31,11 +31,7 @@ pub struct OuterCircuitVerifierInput<C: Parameters> {
 
 impl<C: Parameters> ToConstraintField<C::OuterScalarField> for OuterCircuitVerifierInput<C>
 where
-    <C::ProgramCommitmentScheme as CommitmentScheme>::Output: ToConstraintField<C::OuterScalarField>,
-    <C::ProgramIDCRH as CRH>::Parameters: ToConstraintField<C::OuterScalarField>,
-    <C::InnerCircuitIDCRH as CRH>::Parameters: ToConstraintField<C::OuterScalarField>,
     <C::InnerCircuitIDCRH as CRH>::Output: ToConstraintField<C::OuterScalarField>,
-
     <C::AccountCommitmentScheme as CommitmentScheme>::Output: ToConstraintField<C::InnerScalarField>,
     <<C::RecordCommitmentTreeParameters as MerkleParameters>::H as CRH>::Parameters:
         ToConstraintField<C::InnerScalarField>,
@@ -43,12 +39,8 @@ where
 {
     fn to_field_elements(&self) -> Result<Vec<C::OuterScalarField>, ConstraintFieldError> {
         let mut v = Vec::new();
-        v.extend_from_slice(&C::program_commitment_scheme().to_field_elements()?);
-        v.extend_from_slice(&C::program_id_crh().parameters().to_field_elements()?);
-        v.extend_from_slice(&C::inner_circuit_id_crh().parameters().to_field_elements()?);
 
         // Convert inner snark verifier inputs into `OuterField` field elements
-
         let inner_snark_field_elements = &self.inner_snark_verifier_input.to_field_elements()?;
 
         for inner_snark_fe in inner_snark_field_elements {

--- a/dpc/src/testnet1/program/noop_program_circuit.rs
+++ b/dpc/src/testnet1/program/noop_program_circuit.rs
@@ -52,11 +52,6 @@ impl<C: Testnet1Components> ConstraintSynthesizer<C::InnerScalarField> for NoopC
 
         let _position = UInt8::alloc_input_vec_le(cs.ns(|| "Alloc position"), &[position])?;
 
-        let _local_data_commitment_parameters_gadget = C::LocalDataCommitmentGadget::alloc_input(
-            &mut cs.ns(|| "Declare local data commitment parameters"),
-            || Ok(C::local_data_commitment_scheme().clone()),
-        )?;
-
         let _local_data_root_gadget = <C::LocalDataCRHGadget as CRHGadget<_, _>>::OutputGadget::alloc_input(
             cs.ns(|| "Allocate local data root"),
             || Ok(local_data_root),

--- a/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/testnet2/outer_circuit/outer_circuit_gadget.rs
@@ -17,7 +17,7 @@
 use crate::{testnet2::Testnet2Components, AleoAmount, Execution, Transaction, TransactionScheme};
 use snarkvm_algorithms::{
     merkle_tree::MerkleTreeDigest,
-    traits::{CommitmentScheme, MerkleParameters, SignatureScheme, CRH, SNARK},
+    traits::{CommitmentScheme, SignatureScheme, CRH, SNARK},
 };
 use snarkvm_fields::ToConstraintField;
 use snarkvm_gadgets::{
@@ -101,20 +101,20 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
     let (program_id_commitment_parameters, program_id_crh, inner_circuit_id_crh) = {
         let cs = &mut cs.ns(|| "Declare Comm and CRH parameters");
 
-        let program_id_commitment_parameters =
-            C::ProgramCommitmentGadget::alloc_input(&mut cs.ns(|| "Declare program_id_commitment_parameters"), || {
-                Ok(C::program_commitment_scheme().clone())
-            })?;
+        let program_id_commitment_parameters = C::ProgramCommitmentGadget::alloc_constant(
+            &mut cs.ns(|| "Declare program_id_commitment_parameters"),
+            || Ok(C::program_commitment_scheme().clone()),
+        )?;
 
         let program_id_crh: C::ProgramIDCRHGadget =
-            C::ProgramIDCRHGadget::alloc_input(&mut cs.ns(|| "Declare program_id_crh_parameters"), || {
+            C::ProgramIDCRHGadget::alloc_constant(&mut cs.ns(|| "Declare program_id_crh_parameters"), || {
                 Ok(C::program_id_crh().clone())
             })?;
 
-        let inner_circuit_id_crh =
-            C::InnerCircuitIDCRHGadget::alloc_input(&mut cs.ns(|| "Declare inner_circuit_id_crh_parameters"), || {
-                Ok(C::inner_circuit_id_crh().clone())
-            })?;
+        let inner_circuit_id_crh = C::InnerCircuitIDCRHGadget::alloc_constant(
+            &mut cs.ns(|| "Declare inner_circuit_id_crh_parameters"),
+            || Ok(C::inner_circuit_id_crh().clone()),
+        )?;
 
         (program_id_commitment_parameters, program_id_crh, inner_circuit_id_crh)
     };
@@ -124,48 +124,6 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
     // ************************************************************************
 
     // Declare inner snark verifier inputs as `CoreCheckF` field elements
-
-    let account_commitment_parameters_fe = C::account_commitment_scheme()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let account_encryption_parameters_fe = C::account_encryption_scheme()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let account_signature_fe = C::account_signature_scheme()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let record_commitment_parameters_fe = C::record_commitment_scheme()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let encrypted_record_crh_parameters_fe = C::encrypted_record_crh()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let program_id_commitment_parameters_fe = C::program_commitment_scheme()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let local_data_crh_parameters_fe = C::local_data_crh()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let local_data_commitment_parameters_fe = C::local_data_commitment_scheme()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let serial_number_nonce_crh_parameters_fe = C::serial_number_nonce_crh()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
-    let record_commitment_tree_parameters_fe = C::record_commitment_tree_parameters()
-        .crh()
-        .to_field_elements()
-        .map_err(|_| SynthesisError::AssignmentMissing)?;
-
     let ledger_digest_fe = ToConstraintField::<C::InnerScalarField>::to_field_elements(ledger_digest)
         .map_err(|_| SynthesisError::AssignmentMissing)?;
 
@@ -187,36 +145,6 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
         .map_err(|_| SynthesisError::AssignmentMissing)?;
 
     // Allocate field element bytes
-
-    let account_commitment_fe_bytes =
-        alloc_input_field_element_to_bytes::<C, _>(cs, account_commitment_parameters_fe, "account commitment pp")?;
-    let account_encryption_fe_bytes =
-        alloc_input_field_element_to_bytes::<C, _>(cs, account_encryption_parameters_fe, "account encryption pp")?;
-    let account_signature_fe_bytes =
-        alloc_input_field_element_to_bytes::<C, _>(cs, account_signature_fe, "account signature pp")?;
-    let record_commitment_parameters_fe_bytes =
-        alloc_input_field_element_to_bytes::<C, _>(cs, record_commitment_parameters_fe, "record commitment pp")?;
-    let encrypted_record_crh_parameters_fe_bytes =
-        alloc_input_field_element_to_bytes::<C, _>(cs, encrypted_record_crh_parameters_fe, "encrypted record crh pp")?;
-    let program_id_commitment_parameters_fe_bytes = alloc_input_field_element_to_bytes::<C, _>(
-        cs,
-        program_id_commitment_parameters_fe,
-        "program ID commitment pp",
-    )?;
-    let local_data_crh_parameters_fe_bytes =
-        alloc_input_field_element_to_bytes::<C, _>(cs, local_data_crh_parameters_fe.clone(), "local data crh pp")?;
-    let local_data_commitment_parameters_fe_bytes = alloc_input_field_element_to_bytes::<C, _>(
-        cs,
-        local_data_commitment_parameters_fe.clone(),
-        "local data commitment pp",
-    )?;
-    let serial_number_nonce_crh_parameters_fe_bytes = alloc_input_field_element_to_bytes::<C, _>(
-        cs,
-        serial_number_nonce_crh_parameters_fe,
-        "serial number nonce crh pp",
-    )?;
-    let record_commitment_tree_parameters_fe_bytes =
-        alloc_input_field_element_to_bytes::<C, _>(cs, record_commitment_tree_parameters_fe, "ledger pp")?;
     let ledger_digest_fe_bytes = alloc_input_field_element_to_bytes::<C, _>(cs, ledger_digest_fe, "ledger digest")?;
 
     let mut serial_number_fe_bytes = vec![];
@@ -267,16 +195,6 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
     // Construct inner snark input as bytes
 
     let mut inner_snark_input_bytes = vec![];
-    inner_snark_input_bytes.extend(account_commitment_fe_bytes);
-    inner_snark_input_bytes.extend(account_encryption_fe_bytes);
-    inner_snark_input_bytes.extend(account_signature_fe_bytes);
-    inner_snark_input_bytes.extend(record_commitment_parameters_fe_bytes);
-    inner_snark_input_bytes.extend(encrypted_record_crh_parameters_fe_bytes);
-    inner_snark_input_bytes.extend(program_id_commitment_parameters_fe_bytes);
-    inner_snark_input_bytes.extend(local_data_crh_parameters_fe_bytes);
-    inner_snark_input_bytes.extend(local_data_commitment_parameters_fe_bytes.clone());
-    inner_snark_input_bytes.extend(serial_number_nonce_crh_parameters_fe_bytes);
-    inner_snark_input_bytes.extend(record_commitment_tree_parameters_fe_bytes);
     inner_snark_input_bytes.extend(ledger_digest_fe_bytes);
     inner_snark_input_bytes.extend(serial_number_fe_bytes);
     inner_snark_input_bytes.extend(commitment_and_encrypted_record_hash_fe_bytes);
@@ -327,7 +245,6 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
     // Reuse inner snark verifier inputs
 
     let mut program_input_bytes = vec![];
-    program_input_bytes.extend(local_data_commitment_parameters_fe_bytes);
     program_input_bytes.extend(local_data_root_fe_bytes);
 
     let mut program_input_bits = Vec::with_capacity(program_input_bytes.len());
@@ -377,7 +294,6 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
         let mut program_input_field_elements = vec![];
 
         program_input_field_elements.extend(position_fe);
-        program_input_field_elements.extend(local_data_commitment_parameters_fe.clone());
         program_input_field_elements.extend(local_data_root_fe.clone());
 
         let mut program_snark_input = vec![];
@@ -434,7 +350,6 @@ pub fn execute_outer_circuit<C: Testnet2Components, CS: ConstraintSystem<C::Oute
         let mut program_input_field_elements = vec![];
 
         program_input_field_elements.extend(position_fe);
-        program_input_field_elements.extend(local_data_crh_parameters_fe.clone());
         program_input_field_elements.extend(local_data_root_fe.clone());
 
         let mut program_snark_input = vec![];

--- a/dpc/src/testnet2/program/noop_program_circuit.rs
+++ b/dpc/src/testnet2/program/noop_program_circuit.rs
@@ -52,7 +52,7 @@ impl<C: Parameters> ConstraintSynthesizer<C::InnerScalarField> for NoopCircuit<C
 
         let _position = UInt8::alloc_input_vec_le(cs.ns(|| "Alloc position"), &[position])?;
 
-        let _local_data_commitment_parameters_gadget = C::LocalDataCommitmentGadget::alloc_input(
+        let _local_data_commitment_parameters_gadget = C::LocalDataCommitmentGadget::alloc_constant(
             &mut cs.ns(|| "Declare local data commitment parameters"),
             || Ok(C::local_data_commitment_scheme().clone()),
         )?;

--- a/gadgets/src/algorithms/commitment/bhp.rs
+++ b/gadgets/src/algorithms/commitment/bhp.rs
@@ -65,12 +65,11 @@ pub struct BHPCommitmentGadget<
     random_base: Vec<G>,
 }
 
-// TODO (howardwu): This should be only `alloc_constant`. This is unsafe convention.
 impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>
     AllocGadget<BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE>, F>
     for BHPCommitmentGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -80,9 +79,20 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS
     ) -> Result<Self, SynthesisError> {
         let bhp: BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().into();
         Ok(Self {
-            bhp_crh_gadget: BHPCRHGadget::alloc(cs, || Ok(bhp.bhp_crh.clone()))?,
+            bhp_crh_gadget: BHPCRHGadget::alloc_constant(cs, || Ok(bhp.bhp_crh.clone()))?,
             random_base: bhp.random_base,
         })
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
     }
 
     fn alloc_input<
@@ -90,14 +100,10 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS
         T: Borrow<BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
-        cs: CS,
-        value_gen: Fn,
+        _cs: CS,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let bhp: BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().into();
-        Ok(Self {
-            bhp_crh_gadget: BHPCRHGadget::alloc_input(cs, || Ok(bhp.bhp_crh.clone()))?,
-            random_base: bhp.random_base,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/commitment/bhp_compressed.rs
+++ b/gadgets/src/algorithms/commitment/bhp_compressed.rs
@@ -40,7 +40,6 @@ pub struct BHPCompressedCommitmentGadget<
     bhp_commitment_gadget: BHPCommitmentGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>,
 }
 
-// TODO (howardwu): This should be only `alloc_constant`. This is unsafe convention.
 impl<
     G: ProjectiveCurve,
     F: PrimeField,
@@ -50,7 +49,7 @@ impl<
 > AllocGadget<BHPCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>, F>
     for BHPCompressedCommitmentGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<BHPCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -60,8 +59,19 @@ impl<
     ) -> Result<Self, SynthesisError> {
         let bhp: BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().into();
         Ok(Self {
-            bhp_commitment_gadget: BHPCommitmentGadget::alloc(cs, || Ok(bhp))?,
+            bhp_commitment_gadget: BHPCommitmentGadget::alloc_constant(cs, || Ok(bhp))?,
         })
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<BHPCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
     }
 
     fn alloc_input<
@@ -69,13 +79,10 @@ impl<
         T: Borrow<BHPCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
-        cs: CS,
-        value_gen: Fn,
+        _cs: CS,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let bhp: BHPCommitment<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().into();
-        Ok(Self {
-            bhp_commitment_gadget: BHPCommitmentGadget::alloc_input(cs, || Ok(bhp))?,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/commitment/blake2s.rs
+++ b/gadgets/src/algorithms/commitment/blake2s.rs
@@ -29,8 +29,18 @@ use std::borrow::Borrow;
 #[derive(Clone)]
 pub struct Blake2sRandomnessGadget(pub Vec<UInt8>);
 
-// TODO (howardwu): Find a better convention than this.
 impl<F: PrimeField> AllocGadget<[u8; 32], F> for Blake2sRandomnessGadget {
+    #[inline]
+    fn alloc_constant<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<[u8; 32]>, CS: ConstraintSystem<F>>(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        Ok(Blake2sRandomnessGadget(<UInt8>::constant_vec(&match value_gen() {
+            Ok(val) => *(val.borrow()),
+            Err(_) => [0u8; 32],
+        })))
+    }
+
     #[inline]
     fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<[u8; 32]>, CS: ConstraintSystem<F>>(
         cs: CS,
@@ -61,18 +71,29 @@ impl<F: PrimeField> AllocGadget<[u8; 32], F> for Blake2sRandomnessGadget {
 pub struct Blake2sCommitmentGadget;
 
 impl<F: Field> AllocGadget<Blake2sCommitment, F> for Blake2sCommitmentGadget {
-    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Blake2sCommitment>, CS: ConstraintSystem<F>>(
+    fn alloc_constant<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<Blake2sCommitment>,
+        CS: ConstraintSystem<F>,
+    >(
         _: CS,
         _: Fn,
     ) -> Result<Self, SynthesisError> {
         Ok(Self)
     }
 
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Blake2sCommitment>, CS: ConstraintSystem<F>>(
+        _: CS,
+        _: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
     fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Blake2sCommitment>, CS: ConstraintSystem<F>>(
         _: CS,
         _: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self)
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/commitment/pedersen.rs
+++ b/gadgets/src/algorithms/commitment/pedersen.rs
@@ -33,6 +33,14 @@ use std::{
 pub struct PedersenRandomnessGadget<G: ProjectiveCurve>(pub Vec<UInt8>, PhantomData<G>);
 
 impl<G: ProjectiveCurve, F: PrimeField> AllocGadget<G::ScalarField, F> for PedersenRandomnessGadget<G> {
+    fn alloc_constant<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<G::ScalarField>, CS: ConstraintSystem<F>>(
+        _cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        let randomness = to_bytes_le![value_gen()?.borrow()].unwrap();
+        Ok(PedersenRandomnessGadget(UInt8::constant_vec(&randomness), PhantomData))
+    }
+
     fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<G::ScalarField>, CS: ConstraintSystem<F>>(
         cs: CS,
         value_gen: Fn,
@@ -74,7 +82,7 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS
     AllocGadget<PedersenCommitment<G, NUM_WINDOWS, WINDOW_SIZE>, F>
     for PedersenCommitmentGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PedersenCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -89,19 +97,26 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS
         })
     }
 
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<PedersenCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
     fn alloc_input<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PedersenCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
         _cs: CS,
-        value_gen: Fn,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            pedersen: value_gen()?.borrow().clone(),
-            _group_gadget: PhantomData,
-            _field: PhantomData,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/commitment/pedersen_compressed.rs
+++ b/gadgets/src/algorithms/commitment/pedersen_compressed.rs
@@ -40,7 +40,6 @@ pub struct PedersenCompressedCommitmentGadget<
     pedersen: PedersenCommitmentGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>,
 }
 
-// TODO (howardwu): This should be only `alloc_constant`. This is unsafe convention.
 impl<
     G: ProjectiveCurve,
     F: PrimeField,
@@ -50,7 +49,7 @@ impl<
 > AllocGadget<PedersenCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>, F>
     for PedersenCompressedCommitmentGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PedersenCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -60,8 +59,21 @@ impl<
     ) -> Result<Self, SynthesisError> {
         let commitment: PedersenCommitment<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().into();
         Ok(Self {
-            pedersen: PedersenCommitmentGadget::<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>::alloc(cs, || Ok(commitment))?,
+            pedersen: PedersenCommitmentGadget::<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>::alloc_constant(cs, || {
+                Ok(commitment)
+            })?,
         })
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<PedersenCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
     }
 
     fn alloc_input<
@@ -69,13 +81,10 @@ impl<
         T: Borrow<PedersenCompressedCommitment<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
-        cs: CS,
-        value_gen: Fn,
+        _cs: CS,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let commitment: PedersenCommitment<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().into();
-        Ok(Self {
-            pedersen: PedersenCommitmentGadget::<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>::alloc(cs, || Ok(commitment))?,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/commitment/tests.rs
+++ b/gadgets/src/algorithms/commitment/tests.rs
@@ -64,7 +64,8 @@ fn native_and_gadget_equivalence_test<Native: CommitmentScheme, Gadget: Commitme
             Ok(&randomness)
         })
         .unwrap();
-    let commitment_gadget = Gadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&commitment_scheme)).unwrap();
+    let commitment_gadget =
+        Gadget::alloc_constant(&mut cs.ns(|| "parameters_gadget"), || Ok(&commitment_scheme)).unwrap();
     let gadget_output = commitment_gadget
         .check_commitment_gadget(&mut cs.ns(|| "commitment_gadget"), &input_bytes, &randomness_gadget)
         .unwrap();
@@ -150,7 +151,7 @@ fn blake2s_commitment_gadget_test() {
     let randomness_bytes = Blake2sRandomnessGadget(randomness_bytes);
 
     let blake2s_gadget =
-        Blake2sCommitmentGadget::alloc(&mut cs.ns(|| "gadget_parameters"), || Ok(&commitment)).unwrap();
+        Blake2sCommitmentGadget::alloc_constant(&mut cs.ns(|| "gadget_parameters"), || Ok(&commitment)).unwrap();
     let gadget_result = blake2s_gadget
         .check_commitment_gadget(&mut cs.ns(|| "gadget_evaluation"), &input_bytes, &randomness_bytes)
         .unwrap();

--- a/gadgets/src/algorithms/commitment_tree/tests.rs
+++ b/gadgets/src/algorithms/commitment_tree/tests.rs
@@ -115,7 +115,8 @@ fn commitment_tree_test<
         num_constraints = cs.num_constraints();
 
         // Allocate CRH
-        let crh_parameters = HG::alloc(&mut cs.ns(|| format!("new_crh_parameters_{}", i)), || Ok(crh.clone())).unwrap();
+        let crh_parameters =
+            HG::alloc_constant(&mut cs.ns(|| format!("new_crh_parameters_{}", i)), || Ok(crh.clone())).unwrap();
 
         println!(
             "constraints from crh parameters: {}",

--- a/gadgets/src/algorithms/crh/bhp.rs
+++ b/gadgets/src/algorithms/crh/bhp.rs
@@ -39,11 +39,10 @@ pub struct BHPCRHGadget<
     _group: PhantomData<GG>,
 }
 
-// TODO (howardwu): This should be only `alloc_constant`. This is unsafe convention.
 impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>
     AllocGadget<BHPCRH<G, NUM_WINDOWS, WINDOW_SIZE>, F> for BHPCRHGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<BHPCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -58,19 +57,26 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS
         })
     }
 
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<BHPCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
     fn alloc_input<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<BHPCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
         _cs: CS,
-        value_gen: Fn,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            crh: value_gen()?.borrow().clone(),
-            _field: PhantomData,
-            _group: PhantomData,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/crh/bhp_compressed.rs
+++ b/gadgets/src/algorithms/crh/bhp_compressed.rs
@@ -40,7 +40,6 @@ pub struct BHPCompressedCRHGadget<
     bhp_gadget: BHPCRHGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>,
 }
 
-// TODO (howardwu): This should be only `alloc_constant`. This is unsafe convention.
 impl<
     G: ProjectiveCurve,
     F: PrimeField,
@@ -50,7 +49,7 @@ impl<
 > AllocGadget<BHPCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>, F>
     for BHPCompressedCRHGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<BHPCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -60,8 +59,19 @@ impl<
     ) -> Result<Self, SynthesisError> {
         let bhp: BHPCRH<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().clone().into();
         Ok(Self {
-            bhp_gadget: BHPCRHGadget::alloc(cs, || Ok(bhp))?,
+            bhp_gadget: BHPCRHGadget::alloc_constant(cs, || Ok(bhp))?,
         })
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<BHPCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
     }
 
     fn alloc_input<
@@ -69,13 +79,10 @@ impl<
         T: Borrow<BHPCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
-        cs: CS,
-        value_gen: Fn,
+        _cs: CS,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let bhp: BHPCRH<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().clone().into();
-        Ok(Self {
-            bhp_gadget: BHPCRHGadget::alloc_input(cs, || Ok(bhp))?,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/crh/pedersen.rs
+++ b/gadgets/src/algorithms/crh/pedersen.rs
@@ -44,11 +44,10 @@ pub struct PedersenCRHGadget<
     _engine: PhantomData<F>,
 }
 
-// TODO (howardwu): This should be only `alloc_constant`. This is unsafe convention.
 impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>
     AllocGadget<PedersenCRH<G, NUM_WINDOWS, WINDOW_SIZE>, F> for PedersenCRHGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PedersenCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -63,19 +62,26 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: CurveGadget<G, F>, const NUM_WINDOWS
         })
     }
 
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<PedersenCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
     fn alloc_input<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PedersenCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
         _cs: CS,
-        value_gen: Fn,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            crh: value_gen()?.borrow().clone(),
-            _group: PhantomData,
-            _engine: PhantomData,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/crh/pedersen_compressed.rs
+++ b/gadgets/src/algorithms/crh/pedersen_compressed.rs
@@ -54,7 +54,7 @@ impl<
 > AllocGadget<PedersenCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>, F>
     for PedersenCompressedCRHGadget<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PedersenCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
@@ -64,8 +64,19 @@ impl<
     ) -> Result<Self, SynthesisError> {
         let crh: PedersenCRH<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().clone().into();
         Ok(Self {
-            crh_gadget: PedersenCRHGadget::<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>::alloc(cs, || Ok(crh))?,
+            crh_gadget: PedersenCRHGadget::<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>::alloc_constant(cs, || Ok(crh))?,
         })
+    }
+
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<PedersenCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
     }
 
     fn alloc_input<
@@ -73,13 +84,10 @@ impl<
         T: Borrow<PedersenCompressedCRH<G, NUM_WINDOWS, WINDOW_SIZE>>,
         CS: ConstraintSystem<F>,
     >(
-        cs: CS,
-        value_gen: Fn,
+        _cs: CS,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        let crh: PedersenCRH<G, NUM_WINDOWS, WINDOW_SIZE> = value_gen()?.borrow().parameters().clone().into();
-        Ok(Self {
-            crh_gadget: PedersenCRHGadget::<G, F, GG, NUM_WINDOWS, WINDOW_SIZE>::alloc_input(cs, || Ok(crh))?,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/crh/tests.rs
+++ b/gadgets/src/algorithms/crh/tests.rs
@@ -78,7 +78,7 @@ fn primitive_crh_gadget_test<F: PrimeField, H: CRH, CG: CRHGadget<H, F>>(hash_co
     let crh = H::setup("primitive_crh_gadget_test");
     let native_result = crh.hash(&input).unwrap();
 
-    let crh_gadget = CG::alloc(&mut cs.ns(|| "gadget_parameters"), || Ok(crh)).unwrap();
+    let crh_gadget = CG::alloc_constant(&mut cs.ns(|| "gadget_parameters"), || Ok(crh)).unwrap();
     assert_eq!(cs.num_constraints(), 1536);
 
     let output_gadget = crh_gadget
@@ -110,11 +110,12 @@ fn masked_crh_gadget_test<F: PrimeField, H: CRH, CG: MaskedCRHGadget<H, F>>() {
     let mask_parameters = H::setup("masked_crh_gadget_test_1");
     let native_result = crh.hash(&input).unwrap();
 
-    let crh_gadget = CG::alloc(&mut cs.ns(|| "gadget_parameters"), || Ok(crh)).unwrap();
+    let crh_gadget = CG::alloc_constant(&mut cs.ns(|| "gadget_parameters"), || Ok(crh)).unwrap();
     assert_eq!(cs.num_constraints(), 1536);
 
     let mask_parameters_gadget =
-        CG::MaskParametersGadget::alloc(&mut cs.ns(|| "gadget_mask_parameters"), || Ok(mask_parameters)).unwrap();
+        CG::MaskParametersGadget::alloc_constant(&mut cs.ns(|| "gadget_mask_parameters"), || Ok(mask_parameters))
+            .unwrap();
     assert_eq!(cs.num_constraints(), 1536);
 
     let masked_output_gadget = <CG as MaskedCRHGadget<_, _>>::check_evaluation_gadget_masked(

--- a/gadgets/src/algorithms/crypto_hash/poseidon.rs
+++ b/gadgets/src/algorithms/crypto_hash/poseidon.rs
@@ -208,16 +208,7 @@ impl<F: PrimeField> PoseidonSpongeGadget<F> {
 }
 
 impl<F: PrimeField> AllocGadget<PoseidonParameters<F>, F> for PoseidonSpongeGadget<F> {
-    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<PoseidonParameters<F>>, CS: ConstraintSystem<F>>(
-        cs: CS,
-        value_gen: Fn,
-    ) -> Result<Self, SynthesisError> {
-        let parameters = value_gen()?.borrow().clone();
-
-        Ok(Self::new(cs, &parameters))
-    }
-
-    fn alloc_input<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PoseidonParameters<F>>,
         CS: ConstraintSystem<F>,
@@ -228,6 +219,24 @@ impl<F: PrimeField> AllocGadget<PoseidonParameters<F>, F> for PoseidonSpongeGadg
         let parameters = value_gen()?.borrow().clone();
 
         Ok(Self::new(cs, &parameters))
+    }
+
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<PoseidonParameters<F>>, CS: ConstraintSystem<F>>(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<PoseidonParameters<F>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
     }
 }
 
@@ -338,7 +347,7 @@ impl<F: PrimeField + PoseidonDefaultParametersField, const RATE: usize, const OP
     AllocGadget<PoseidonCryptoHash<F, RATE, OPTIMIZED_FOR_WEIGHTS>, F>
     for PoseidonCryptoHashGadget<F, RATE, OPTIMIZED_FOR_WEIGHTS>
 {
-    fn alloc<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PoseidonCryptoHash<F, RATE, OPTIMIZED_FOR_WEIGHTS>>,
         CS: ConstraintSystem<F>,
@@ -351,6 +360,17 @@ impl<F: PrimeField + PoseidonDefaultParametersField, const RATE: usize, const OP
         })
     }
 
+    fn alloc<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<PoseidonCryptoHash<F, RATE, OPTIMIZED_FOR_WEIGHTS>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _f: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
     fn alloc_input<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<PoseidonCryptoHash<F, RATE, OPTIMIZED_FOR_WEIGHTS>>,
@@ -359,8 +379,6 @@ impl<F: PrimeField + PoseidonDefaultParametersField, const RATE: usize, const OP
         _cs: CS,
         _f: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            field_phantom: PhantomData,
-        })
+        unimplemented!()
     }
 }

--- a/gadgets/src/algorithms/encryption/ecies_poseidon.rs
+++ b/gadgets/src/algorithms/encryption/ecies_poseidon.rs
@@ -252,12 +252,9 @@ impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> AllocGadget<ECI
         CS: ConstraintSystem<F>,
     >(
         _cs: CS,
-        value_gen: Fn,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            encryption: (*value_gen()?.borrow()).clone(),
-            f_phantom: PhantomData,
-        })
+        unimplemented!()
     }
 
     fn alloc_input<
@@ -266,12 +263,9 @@ impl<TE: TwistedEdwardsParameters<BaseField = F>, F: PrimeField> AllocGadget<ECI
         CS: ConstraintSystem<F>,
     >(
         _cs: CS,
-        value_gen: Fn,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            encryption: (*value_gen()?.borrow()).clone(),
-            f_phantom: PhantomData,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/encryption/group.rs
+++ b/gadgets/src/algorithms/encryption/group.rs
@@ -463,18 +463,7 @@ pub struct GroupEncryptionGadget<G: ProjectiveCurve, F: PrimeField, GG: Compress
 impl<G: ProjectiveCurve, F: PrimeField, GG: CompressedGroupGadget<G, F>> AllocGadget<GroupEncryption<G>, F>
     for GroupEncryptionGadget<G, F, GG>
 {
-    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<GroupEncryption<G>>, CS: ConstraintSystem<F>>(
-        _cs: CS,
-        value_gen: Fn,
-    ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            encryption: value_gen()?.borrow().clone(),
-            _group_gadget: PhantomData,
-            _engine: PhantomData,
-        })
-    }
-
-    fn alloc_input<
+    fn alloc_constant<
         Fn: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<GroupEncryption<G>>,
         CS: ConstraintSystem<F>,
@@ -487,6 +476,24 @@ impl<G: ProjectiveCurve, F: PrimeField, GG: CompressedGroupGadget<G, F>> AllocGa
             _group_gadget: PhantomData,
             _engine: PhantomData,
         })
+    }
+
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<GroupEncryption<G>>, CS: ConstraintSystem<F>>(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
+    fn alloc_input<
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<GroupEncryption<G>>,
+        CS: ConstraintSystem<F>,
+    >(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/encryption/tests.rs
+++ b/gadgets/src/algorithms/encryption/tests.rs
@@ -50,7 +50,8 @@ mod group_encryption {
         let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
 
         let encryption =
-            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+            TestEncryptionSchemeGadget::alloc_constant(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme))
+                .unwrap();
         let private_key_gadget =
             <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PrivateKeyGadget::alloc(
                 &mut cs.ns(|| "private_key_gadget"),
@@ -104,7 +105,8 @@ mod group_encryption {
 
         // Alloc parameters, public key, plaintext, randomness, and blinding exponents
         let encryption =
-            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+            TestEncryptionSchemeGadget::alloc_constant(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme))
+                .unwrap();
         let public_key_gadget =
             <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
                 &mut cs.ns(|| "public_key_gadget"),
@@ -198,7 +200,8 @@ mod ecies_poseidon {
         let public_key = encryption_scheme.generate_public_key(&private_key).unwrap();
 
         let encryption =
-            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+            TestEncryptionSchemeGadget::alloc_constant(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme))
+                .unwrap();
         let private_key_gadget =
             <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PrivateKeyGadget::alloc(
                 &mut cs.ns(|| "private_key_gadget"),
@@ -252,7 +255,8 @@ mod ecies_poseidon {
 
         // Alloc parameters, public key, plaintext, randomness, and blinding exponents
         let encryption =
-            TestEncryptionSchemeGadget::alloc(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme)).unwrap();
+            TestEncryptionSchemeGadget::alloc_constant(&mut cs.ns(|| "parameters_gadget"), || Ok(&encryption_scheme))
+                .unwrap();
         let public_key_gadget =
             <TestEncryptionSchemeGadget as EncryptionGadget<TestEncryptionScheme, _>>::PublicKeyGadget::alloc(
                 &mut cs.ns(|| "public_key_gadget"),

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -76,7 +76,7 @@ fn generate_merkle_tree<P: MerkleParameters, F: PrimeField, HG: CRHGadget<P::H, 
         println!("constraints from digest: {}", constraints_from_digest);
 
         // Allocate CRH
-        let crh_parameters = HG::alloc(&mut cs.ns(|| format!("new_parameters_{}", i)), || {
+        let crh_parameters = HG::alloc_constant(&mut cs.ns(|| format!("new_parameters_{}", i)), || {
             Ok(parameters.crh().clone())
         })
         .unwrap();
@@ -144,13 +144,13 @@ fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: Mas
     let mask = h.finalize().to_vec();
     let mask_bytes = UInt8::alloc_vec(cs.ns(|| "mask"), &mask).unwrap();
 
-    let crh_parameters = HG::alloc(&mut cs.ns(|| "new_parameters"), || Ok(parameters.crh().clone())).unwrap();
+    let crh_parameters = HG::alloc_constant(&mut cs.ns(|| "new_parameters"), || Ok(parameters.crh().clone())).unwrap();
 
-    let mask_crh_parameters =
-        <HG as MaskedCRHGadget<_, _>>::MaskParametersGadget::alloc(&mut cs.ns(|| "new_mask_parameters"), || {
-            Ok(parameters.mask_parameters().clone())
-        })
-        .unwrap();
+    let mask_crh_parameters = <HG as MaskedCRHGadget<_, _>>::MaskParametersGadget::alloc_constant(
+        &mut cs.ns(|| "new_mask_parameters"),
+        || Ok(parameters.mask_parameters().clone()),
+    )
+    .unwrap();
 
     let computed_root = compute_root::<_, HG, _, _, _>(
         cs.ns(|| "compute masked root"),
@@ -204,7 +204,7 @@ fn update_merkle_tree<P: MerkleParameters, F: PrimeField, HG: CRHGadget<P::H, F>
 
         let mut cs = TestConstraintSystem::<F>::new();
 
-        let crh = HG::alloc(&mut cs.ns(|| "crh"), || Ok(merkle_parameters.crh())).unwrap();
+        let crh = HG::alloc_constant(&mut cs.ns(|| "crh"), || Ok(merkle_parameters.crh())).unwrap();
 
         // Allocate Merkle tree root
         let root = <HG as CRHGadget<_, _>>::OutputGadget::alloc(&mut cs.ns(|| "root"), || Ok(root.clone())).unwrap();

--- a/gadgets/src/algorithms/signature/schnorr.rs
+++ b/gadgets/src/algorithms/signature/schnorr.rs
@@ -278,7 +278,7 @@ where
     <G::Affine as AffineCurve>::BaseField: PoseidonDefaultParametersField,
     G: ToConstraintField<<G::Affine as AffineCurve>::BaseField>,
 {
-    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Schnorr<G>>, CS: ConstraintSystem<F>>(
+    fn alloc_constant<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Schnorr<G>>, CS: ConstraintSystem<F>>(
         _cs: CS,
         value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
@@ -289,15 +289,18 @@ where
         })
     }
 
+    fn alloc<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Schnorr<G>>, CS: ConstraintSystem<F>>(
+        _cs: CS,
+        _value_gen: Fn,
+    ) -> Result<Self, SynthesisError> {
+        unimplemented!()
+    }
+
     fn alloc_input<Fn: FnOnce() -> Result<T, SynthesisError>, T: Borrow<Schnorr<G>>, CS: ConstraintSystem<F>>(
         _cs: CS,
-        value_gen: Fn,
+        _value_gen: Fn,
     ) -> Result<Self, SynthesisError> {
-        Ok(Self {
-            signature: value_gen()?.borrow().clone(),
-            _group_gadget: PhantomData,
-            _engine: PhantomData,
-        })
+        unimplemented!()
     }
 }
 

--- a/gadgets/src/algorithms/signature/tests.rs
+++ b/gadgets/src/algorithms/signature/tests.rs
@@ -62,7 +62,7 @@ fn test_schnorr_signature_randomize_public_key_gadget() {
     );
 
     // Circuit Schnorr randomized public key (candidate)
-    let schnorr_gadget = TestSignatureGadget::alloc_input(&mut cs.ns(|| "schnorr_gadget"), || Ok(schnorr)).unwrap();
+    let schnorr_gadget = TestSignatureGadget::alloc_constant(&mut cs.ns(|| "schnorr_gadget"), || Ok(schnorr)).unwrap();
     let candidate_public_key = SchnorrPublicKeyGadget::<EdwardsProjective, Fr, EdwardsBls12Gadget>::alloc(
         &mut cs.ns(|| "candidate_public_key"),
         || Ok(&public_key),
@@ -111,7 +111,7 @@ fn schnorr_signature_verification_test() {
 
     let mut cs = TestConstraintSystem::<Fr>::new();
 
-    let schnorr_gadget = TestSignatureGadget::alloc_input(&mut cs.ns(|| "schnorr_gadget"), || Ok(schnorr)).unwrap();
+    let schnorr_gadget = TestSignatureGadget::alloc_constant(&mut cs.ns(|| "schnorr_gadget"), || Ok(schnorr)).unwrap();
 
     assert_eq!(cs.num_constraints(), 0);
 
@@ -172,7 +172,7 @@ fn failed_schnorr_signature_verification_test() {
 
     let mut cs = TestConstraintSystem::<Fr>::new();
 
-    let schnorr_gadget = TestSignatureGadget::alloc_input(&mut cs.ns(|| "schnorr_gadget"), || Ok(schnorr)).unwrap();
+    let schnorr_gadget = TestSignatureGadget::alloc_constant(&mut cs.ns(|| "schnorr_gadget"), || Ok(schnorr)).unwrap();
 
     let public_key_gadget = <TestSignatureGadget as SignatureGadget<SchnorrScheme, Fr>>::PublicKeyGadget::alloc(
         cs.ns(|| "alloc_public_key"),

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -61,8 +61,8 @@ impl<F: PrimeField, M: MaskedMerkleParameters, HG: MaskedCRHGadget<M::H, F>, CP:
         }
         let mask_bytes = UInt8::alloc_input_vec_le(cs.ns(|| "mask"), &mask)?;
 
-        let crh_parameters = HG::alloc(&mut cs.ns(|| "new_parameters"), || Ok(self.merkle_parameters.crh()))?;
-        let mask_crh_parameters = <HG as MaskedCRHGadget<M::H, F>>::MaskParametersGadget::alloc(
+        let crh_parameters = HG::alloc_constant(&mut cs.ns(|| "new_parameters"), || Ok(self.merkle_parameters.crh()))?;
+        let mask_crh_parameters = <HG as MaskedCRHGadget<M::H, F>>::MaskParametersGadget::alloc_constant(
             &mut cs.ns(|| "new_mask_parameters"),
             || {
                 let crh_parameters = self.merkle_parameters.mask_parameters();


### PR DESCRIPTION
## Motivation

This PR makes two changes:
- force all the crypto primitives parameters to be allocated only through `alloc_constant`, and `alloc`/`alloc_input` is now "unimplemented" and will cause a panic
- update the DPC to allocate the cryptographic primitive gadgets using `alloc_constant`
- remove the serialization of cryptographic primitive parameters (which at this moment is empty).

## Test Plan

Some tests have been executed in `gadgets` and related dirs.

