### PR TITLE
`CONTRIBUTING.md` basics section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,31 @@ Please follow the instructions below when filing pull requests:
 
 snarkVM is a big project, so (non-)adherence to best practices related to performance can have a considerable impact; below are the rules we try to follow at all times in order to ensure high quality of the code:
 
-### Memory handling
+### Basics
+
+#### Pull Requests
+
+In general, a happy reviewer equals a faster merge.
+
+- Write a precise description of the changes in the PR to make it easy for the reviewer to navigate the changeset. Comment on individual lines if you want to call them out.
+- Keep PRs self-contained. For example, renaming and refactoring should not be in the same PR as a bug fix.
+- Keep PRs small. Discounting any auto-generated updates like those to `Cargo.lock`, changesets should be well under +/- 1000.
+- Keep individual commits even smaller. This helps when `git bisecting`
+- Stick to the [conventional commits] standard for commit messages, e.g. `fix(profiler): fix typo in add_to_trace`. This helps during review time, as well as during the writing of release descriptions as it easily enumerates the changes.
+
+#### Tests and coverage
+
+- Test coverage should, at minimum, never decrease
+- Any bug fixes should have a corresponding test case to prove that the bug was fixed
+- Any new features should include tests for both the 'happy' and 'sad' paths of the functionality, i.e. testing failures and edge cases as well as success.
+
+[conventional commits]: https://www.conventionalcommits.org/en/v1.0.0/
+
+### Rust-specific Idioms
+
+The aforementioned `cargo clippy --all-targets --all-features` will help here, but it won't catch every optimization and pitfall.
+
+#### Memory handling
 - if the final size is known, pre-allocate the collections (`Vec`, `HashMap` etc.) using `with_capacity` or `reserve` - this ensures that there are both fewer allocations (which involve system calls) and that the final allocated capacity is as close to the required size as possible
 - create the collections right before they are populated/used, as opposed to e.g. creating a few big ones at the beginning of a function and only using them later on; this reduces the amount of time they occupy memory
 - if an intermediate vector is avoidable, use an `Iterator` instead; most of the time this just amounts to omitting the call to `.collect()` if a single-pass iteraton follows afterwards, or returning an `impl Iterator<Item = T>` from a function when the caller only needs to iterate over that result once
@@ -30,7 +54,7 @@ snarkVM is a big project, so (non-)adherence to best practices related to perfor
 - if possible, reuse collections; an example would be a loop that needs a clean vector on each iteration: instead of creating and allocating it over and over, create it _before_ the loop and use `.clear()` on every iteration instead
 - try to keep the sizes of `enum` variants uniform; use `Box<T>` on ones that are large
 
-### Misc. performance
+#### Misc. performance
 
 - avoid the `format!()` macro; if it is used only to convert a single value to a `String`, use `.to_string()` instead, which is also available to all the implementors of `Display`
 - don't check if an element belongs to a map (using `contains` or `get`) if you want to conditionally insert it too, as the return value of `insert` already indicates whether the value was present or not; use that or the `Entry` API instead

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 * [1. Overview](#1-overview)
 * [2. Build Guide](#2-build-guide)
-* [3. Usage Guide](#3-usage-guide)
+* [3. Contributing](#3-contributing)
 * [4. License](#4-license)
 
 ## 1. Overview
@@ -87,8 +87,6 @@ snarkvm
 
 PRs and issues are welcome. Please see the [contribution guide](./CONTRIBUTING.md) for more
 information about how to create a successful PR.
-
-## 3. Usage Guide
 
 ## 4. License
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Now to use `snarkvm`, in your terminal, run:
 snarkvm
 ```
 
+## 3. Contributing
+
+PRs and issues are welcome. Please see the [contribution guide](./CONTRIBUTING.md) for more
+information about how to create a successful PR.
+
 ## 3. Usage Guide
 
 ## 4. License


### PR DESCRIPTION
## Motivation

`snarkVM` is central to the entire Aleo ecosystem. The effects of bugs or even small changes to this codebase ripple outward from here and have unintended consequences, so it's imperative that software engineering best practices are followed to match the mathematical and cryptographic precision required by the VM.

The changes proposed are a mild set of quick and easily-enforceable idioms that EQ has found to improve not only the quality of the code, but the quality of experience of _working with_ the code.

Note: Here's the ink to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to draw it out of the `.md` file in the changeset
