### PR TITLE
Randomized Merkle tree leaves in tests

### DIFF
--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -22,7 +22,24 @@ use crate::{
 };
 use snarkvm_utilities::{to_bytes_le, ToBytes};
 
+use rand::{thread_rng, Rng};
+
 use std::sync::Arc;
+
+/// Generates the specified number of random Merkle tree leaves.
+macro_rules! generate_random_leaves {
+    ($num_leaves:expr, $leaf_size:expr) => {{
+        let mut rng = thread_rng();
+
+        let mut vec = Vec::with_capacity($num_leaves);
+        for _ in 0..$num_leaves {
+            let mut id = [0u8; $leaf_size];
+            rng.fill(&mut id);
+            vec.push(id);
+        }
+        vec
+    }};
+}
 
 /// Generates a valid Merkle tree and verifies the Merkle path witness for each leaf.
 fn generate_merkle_tree<P: LoadableMerkleParameters, L: ToBytes + Send + Sync + Clone + Eq>(
@@ -58,32 +75,20 @@ fn run_empty_merkle_tree_test<P: LoadableMerkleParameters>() {
 fn run_good_root_test<P: LoadableMerkleParameters>() {
     let parameters = &P::setup("merkle_tree_test");
 
-    let mut leaves = vec![];
-    for i in 0..4u8 {
-        leaves.push([i, i, i, i, i, i, i, i]);
-    }
+    let leaves = generate_random_leaves!(4, 8);
     generate_merkle_tree::<P, _>(&leaves, parameters);
 
-    let mut leaves = vec![];
-    for i in 0..15u8 {
-        leaves.push([i, i, i, i, i, i, i, i]);
-    }
+    let leaves = generate_random_leaves!(15, 8);
     generate_merkle_tree::<P, _>(&leaves, parameters);
 }
 
 fn run_bad_root_test<P: LoadableMerkleParameters>() {
     let parameters = &P::setup("merkle_tree_test");
 
-    let mut leaves = vec![];
-    for i in 0..4u8 {
-        leaves.push([i, i, i, i, i, i, i, i]);
-    }
+    let leaves = generate_random_leaves!(4, 8);
     generate_merkle_tree::<P, _>(&leaves, parameters);
 
-    let mut leaves = vec![];
-    for i in 0..15u8 {
-        leaves.push([i, i, i, i, i, i, i, i]);
-    }
+    let leaves = generate_random_leaves!(15, 8);
     bad_merkle_tree_verify::<P, _>(&leaves, parameters);
 }
 
@@ -91,14 +96,8 @@ fn depth_2_merkle_tree_test<P: LoadableMerkleParameters>() {
     let parameters = &P::setup("merkle_tree_test");
     let crh = parameters.crh();
 
-    // Generate the test leaves.
-    let mut leaves = Vec::new();
-    for i in 0..4u8 {
-        let input = [i; 64];
-        leaves.push(input.to_vec());
-    }
-
     // Evaluate the Merkle tree root.
+    let leaves = generate_random_leaves!(4, 64);
     let merkle_tree = generate_merkle_tree(&leaves, parameters);
     let merkle_tree_root = merkle_tree.root();
 
@@ -126,14 +125,9 @@ fn padded_merkle_tree_test<P: LoadableMerkleParameters>() {
     let parameters = &P::setup("merkle_tree_test");
     let crh = parameters.crh();
 
-    // Generate the test leaves.
-    let mut leaves = Vec::new();
-    for i in 0..4u8 {
-        let input = [i; 64];
-        leaves.push(input.to_vec());
-    }
+    // Evaluate the Merkle tree root
 
-    // Evaluate the Merkle tree root.
+    let leaves = generate_random_leaves!(4, 64);
     let merkle_tree = generate_merkle_tree(&leaves, parameters);
     let merkle_tree_root = merkle_tree.root();
 

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use blake2::{digest::Digest, Blake2s};
+use rand::{thread_rng, Rng};
 
 use snarkvm_algorithms::{
     crh::{BHPCompressedCRH, PedersenCRH, PedersenCompressedCRH},
@@ -247,9 +248,12 @@ mod merkle_tree_pedersen_crh_on_projective {
 
     #[test]
     fn good_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, false);
@@ -258,9 +262,12 @@ mod merkle_tree_pedersen_crh_on_projective {
     #[should_panic]
     #[test]
     fn bad_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, true);
@@ -268,9 +275,12 @@ mod merkle_tree_pedersen_crh_on_projective {
 
     #[test]
     fn update_merkle_tree_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         update_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves);
@@ -293,9 +303,12 @@ mod merkle_tree_compressed_pedersen_crh_on_projective {
 
     #[test]
     fn good_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, false);
@@ -304,9 +317,12 @@ mod merkle_tree_compressed_pedersen_crh_on_projective {
     #[should_panic]
     #[test]
     fn bad_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, true);
@@ -314,9 +330,12 @@ mod merkle_tree_compressed_pedersen_crh_on_projective {
 
     #[test]
     fn good_masked_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_masked_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, false);
@@ -325,9 +344,12 @@ mod merkle_tree_compressed_pedersen_crh_on_projective {
     #[should_panic]
     #[test]
     fn bad_masked_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_masked_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, true);
@@ -335,9 +357,12 @@ mod merkle_tree_compressed_pedersen_crh_on_projective {
 
     #[test]
     fn update_merkle_tree_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         update_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves);
@@ -354,9 +379,12 @@ mod merkle_tree_bowe_hopwood_pedersen_compressed_crh_on_projective {
 
     #[test]
     fn good_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, false);
@@ -365,9 +393,12 @@ mod merkle_tree_bowe_hopwood_pedersen_compressed_crh_on_projective {
     #[should_panic]
     #[test]
     fn bad_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, true);
@@ -375,9 +406,12 @@ mod merkle_tree_bowe_hopwood_pedersen_compressed_crh_on_projective {
 
     #[test]
     fn update_merkle_tree_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         update_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves);
@@ -396,9 +430,12 @@ mod merkle_tree_poseidon {
 
     #[test]
     fn good_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, false);
@@ -407,9 +444,12 @@ mod merkle_tree_poseidon {
     #[should_panic]
     #[test]
     fn bad_root_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         generate_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves, true);
@@ -417,9 +457,12 @@ mod merkle_tree_poseidon {
 
     #[test]
     fn update_merkle_tree_test() {
+        let mut rng = thread_rng();
         let mut leaves = Vec::new();
-        for i in 0..1 << EdwardsMerkleParameters::DEPTH {
-            let input = [i; 30];
+
+        for _ in 0..1 << EdwardsMerkleParameters::DEPTH {
+            let mut input = [0u8; 30];
+            rng.fill(&mut input);
             leaves.push(input);
         }
         update_merkle_tree::<EdwardsMerkleParameters, Fr, HG>(&leaves);

--- a/ledger/src/posw/mod.rs
+++ b/ledger/src/posw/mod.rs
@@ -99,4 +99,58 @@ mod tests {
         let proof = <Marlin<Bls12_377> as SNARK>::Proof::read_le(&proof[..]).unwrap();
         posw.verify(nonce, &proof, &pedersen_merkle_root).unwrap();
     }
+
+    #[test]
+    fn test_changing_tx_roots() {
+        let mut rng = thread_rng();
+
+        // The number of transactions for which to check subsequent merkle tree root values.
+        let num_txs: usize = rng.gen_range(1..256);
+
+        // Create a vector with transaction ids consisting of random values.
+        let transaction_ids = {
+            let mut vec = Vec::with_capacity(num_txs);
+            for _ in 0..num_txs {
+                let mut id = [0u8; 32];
+                rng.fill(&mut id);
+                vec.push(id);
+            }
+            vec
+        };
+
+        // Collect the transactions into a collection of their growing sequences, i.e.
+        // [[tx0], [tx0, tx1], [tx0, tx1, tx2], ..., [tx0, ..., num_txs]].
+        let growing_tx_ids = transaction_ids
+            .into_iter()
+            .scan(Vec::with_capacity(num_txs), |acc, tx_id| {
+                acc.push(tx_id);
+                Some(acc.clone())
+            })
+            .collect::<Vec<_>>();
+
+        // Calculate the root hashes for the sequences of transactions.
+        let subsequent_root_hashes = growing_tx_ids
+            .into_iter()
+            .map(|tx_ids| {
+                let (root, pedersen_root, _subroots) = txids_to_roots(&tx_ids);
+                (root, pedersen_root)
+            })
+            .collect::<Vec<_>>();
+
+        // Ensure that the subsequent roots differ for every new transaction.
+        let mut hashes_differ = true;
+        for window in subsequent_root_hashes.windows(2) {
+            match window {
+                [(root1, pedersen_root1), (root2, pedersen_root2)] => {
+                    if root1 == root2 || pedersen_root1 == pedersen_root2 {
+                        hashes_differ = false;
+                        break;
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        assert!(hashes_differ);
+    }
 }

--- a/ledger/src/posw/mod.rs
+++ b/ledger/src/posw/mod.rs
@@ -74,11 +74,11 @@ mod tests {
 
     #[test]
     fn test_posw_marlin() {
-        let rng = &mut ChaChaRng::seed_from_u64(1234567);
+        let mut rng = thread_rng();
 
         // run the trusted setup
         let max_degree = snarkvm_marlin::AHPForR1CS::<Fr>::max_degree(10000, 10000, 100000).unwrap();
-        let universal_srs = snarkvm_marlin::MarlinTestnet1::universal_setup(max_degree, rng).unwrap();
+        let universal_srs = snarkvm_marlin::MarlinTestnet1::universal_setup(max_degree, &mut rng).unwrap();
 
         // run the deterministic setup
         let posw = PoswMarlin::index::<_, ChaChaRng>(&universal_srs).unwrap();
@@ -86,7 +86,20 @@ mod tests {
         // super low difficulty so we find a solution immediately
         let difficulty_target = 0xFFFF_FFFF_FFFF_FFFF_u64;
 
-        let transaction_ids = vec![[1u8; 32]; 8];
+        // The number of transactions for which to check subsequent merkle tree root values.
+        let num_txs: usize = rng.gen_range(1..256);
+
+        // Create a vector with transaction ids consisting of random values.
+        let transaction_ids = {
+            let mut vec = Vec::with_capacity(num_txs);
+            for _ in 0..num_txs {
+                let mut id = [0u8; 32];
+                rng.fill(&mut id);
+                vec.push(id);
+            }
+            vec
+        };
+
         let (_, pedersen_merkle_root, subroots) = txids_to_roots(&transaction_ids);
 
         // generate the proof

--- a/ledger/src/posw/mod.rs
+++ b/ledger/src/posw/mod.rs
@@ -59,8 +59,7 @@ mod tests {
     use snarkvm_curves::bls12_377::Fr;
     use snarkvm_utilities::FromBytes;
 
-    use rand::SeedableRng;
-    use rand_chacha::ChaChaRng;
+    use rand::{rngs::ThreadRng, thread_rng, Rng};
 
     #[test]
     fn test_load_verify_only() {
@@ -81,7 +80,7 @@ mod tests {
         let universal_srs = snarkvm_marlin::MarlinTestnet1::universal_setup(max_degree, &mut rng).unwrap();
 
         // run the deterministic setup
-        let posw = PoswMarlin::index::<_, ChaChaRng>(&universal_srs).unwrap();
+        let posw = PoswMarlin::index::<_, ThreadRng>(&universal_srs).unwrap();
 
         // super low difficulty so we find a solution immediately
         let difficulty_target = 0xFFFF_FFFF_FFFF_FFFF_u64;
@@ -104,7 +103,7 @@ mod tests {
 
         // generate the proof
         let (nonce, proof) = posw
-            .mine(&subroots, difficulty_target, &mut rand::thread_rng(), std::u32::MAX)
+            .mine(&subroots, difficulty_target, &mut rng, std::u32::MAX)
             .unwrap();
 
         assert_eq!(proof.len(), 972); // NOTE: Marlin proofs use compressed serialization

--- a/ledger/tests/mod.rs
+++ b/ledger/tests/mod.rs
@@ -22,21 +22,36 @@ use snarkvm_ledger::{
 };
 use snarkvm_utilities::FromBytes;
 
-use rand::SeedableRng;
+use rand::{thread_rng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
 /// TODO (howardwu): Update this when testnet2 is live.
 #[ignore]
 #[test]
 fn test_posw_load_and_mine() {
+    let mut rng = thread_rng();
+
     // Load the PoSW Marlin parameters.
     let posw = PoswMarlin::load().unwrap();
 
     // Use the minimum difficulty to find a solution immediately.
     let difficulty_target = 0xFFFF_FFFF_FFFF_FFFF_u64;
 
+    // The number of transactions for which to check subsequent merkle tree root values.
+    let num_txs: usize = rng.gen_range(1..256);
+
+    // Create a vector with transaction ids consisting of random values.
+    let transaction_ids = {
+        let mut vec = Vec::with_capacity(num_txs);
+        for _ in 0..num_txs {
+            let mut id = [0u8; 32];
+            rng.fill(&mut id);
+            vec.push(id);
+        }
+        vec
+    };
+
     // Create the Pedersen Merkle tree.
-    let transaction_ids = vec![[1u8; 32]; 8];
     let (_, pedersen_merkle_root, subroots) = txids_to_roots(&transaction_ids);
 
     // Generate the proof.


### PR DESCRIPTION
This PR was motivated by https://github.com/AleoHQ/snarkVM/issues/280, where a test was using technically invalid test values (as there were non-unique Merkle tree leaves), which initially led to some misleading results. While that specific test is going away when https://github.com/AleoHQ/snarkVM/pull/298 gets merged, there are still some tests that are using dummy values as inputs; with this PR, randomized values for Merkle tree leaves are used instead, improving the quality of the affected tests.

note: this PR was done against the upcoming `testnet2` branch, in order to avoid any conflicts with it.