### PR TITLE
fix(issue-template): change to non-404 link

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -31,4 +31,4 @@ labels: feature
     How should this feature be implemented?
 -->
 
-**Are you willing to open a pull request?** (See [CONTRIBUTING](../../CONTRIBUTING.md))
+**Are you willing to open a pull request?** (See [CONTRIBUTING](../CONTRIBUTING.md))


### PR DESCRIPTION
## Motivation

This commit removes one set of `../`s from the issue template so that it links to `AleoHQ/snarkVM/CONTRIBUTING.md` instead of `AleoHQ/CONTRIBUTING.md`, a 404.