### PR TITLE
Adds record serial number tree parameters, enforce new ledger block height of 1

### DIFF
--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -287,7 +287,7 @@ fn test_testnet1_dpc_execute_constraints() {
             previous_block_hash: BlockHeaderHash([0u8; 32]),
             merkle_root_hash: MerkleRootHash([0u8; 32]),
             time: 0,
-            difficulty_target: 0x07FF_FFFF_FFFF_FFFF_u64,
+            difficulty_target: 0xFFFF_FFFF_FFFF_FFFF_u64,
             nonce: 0,
             pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
             proof: ProofOfSuccinctWork([0u8; 972]),

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -71,10 +71,10 @@ fn dpc_testnet1_integration_test() {
             previous_block_hash: BlockHeaderHash([0u8; 32]),
             merkle_root_hash: MerkleRootHash([0u8; 32]),
             pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
-            time: 0,
-            difficulty_target: 0x07FF_FFFF_FFFF_FFFF_u64,
-            nonce: 0,
             proof: ProofOfSuccinctWork([0u8; 972]),
+            time: 0,
+            difficulty_target: 0xFFFF_FFFF_FFFF_FFFF_u64,
+            nonce: 0,
         },
         transactions: Transactions::new(),
     };
@@ -201,7 +201,7 @@ fn dpc_testnet1_integration_test() {
     let block = Block { header, transactions };
 
     ledger.insert_and_commit(&block).unwrap();
-    assert_eq!(ledger.block_height(), 1);
+    assert_eq!(ledger.block_height(), 2);
 }
 
 #[test]

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -74,10 +74,10 @@ fn dpc_testnet2_integration_test() {
             previous_block_hash: BlockHeaderHash([0u8; 32]),
             merkle_root_hash: MerkleRootHash([0u8; 32]),
             pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
-            time: 0,
-            difficulty_target: 0x07FF_FFFF_FFFF_FFFF_u64,
-            nonce: 0,
             proof: ProofOfSuccinctWork([0u8; 972]),
+            time: 0,
+            difficulty_target: 0xFFFF_FFFF_FFFF_FFFF_u64,
+            nonce: 0,
         },
         transactions: Transactions::new(),
     };
@@ -202,7 +202,7 @@ fn dpc_testnet2_integration_test() {
     let block = Block { header, transactions };
 
     ledger.insert_and_commit(&block).unwrap();
-    assert_eq!(ledger.block_height(), 1);
+    assert_eq!(ledger.block_height(), 2);
 }
 
 #[test]

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -288,7 +288,7 @@ fn test_testnet2_dpc_execute_constraints() {
             previous_block_hash: BlockHeaderHash([0u8; 32]),
             merkle_root_hash: MerkleRootHash([0u8; 32]),
             time: 0,
-            difficulty_target: 0x07FF_FFFF_FFFF_FFFF_u64,
+            difficulty_target: 0xFFFF_FFFF_FFFF_FFFF_u64,
             nonce: 0,
             pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
             proof: ProofOfSuccinctWork([0u8; 972]),

--- a/algorithms/src/merkle_tree/mod.rs
+++ b/algorithms/src/merkle_tree/mod.rs
@@ -29,13 +29,6 @@ pub mod tests;
 /// Defines a Merkle tree using the provided hash and depth.
 macro_rules! define_merkle_tree_parameters {
     ($struct_name:ident, $hash:ty, $depth:expr) => {
-#[rustfmt::skip]
-        #[allow(unused_imports)]
-        use $crate::{
-            merkle_tree::MerkleTree, MerkleError,
-            traits::{CRH, LoadableMerkleParameters, MerkleParameters},
-        };
-
         #[derive(Clone, PartialEq, Eq, Debug)]
         pub struct $struct_name($hash);
 

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     crh::{PedersenCRH, PedersenCompressedCRH},
     define_merkle_tree_parameters,
     merkle_tree::MerkleTree,
-    traits::{crh::CRH, merkle_tree::LoadableMerkleParameters},
+    traits::{LoadableMerkleParameters, MerkleParameters, CRH},
 };
 use snarkvm_utilities::{to_bytes_le, ToBytes};
 

--- a/dpc/src/errors/ledger.rs
+++ b/dpc/src/errors/ledger.rs
@@ -40,6 +40,9 @@ pub enum LedgerError {
     #[error("invalid cm index during proving")]
     InvalidCmIndex,
 
+    #[error("Invalid genesis block header")]
+    InvalidGenesisBlockHeader,
+
     #[error("{}", _0)]
     MerkleError(#[from] MerkleError),
 

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -114,6 +114,12 @@ define_merkle_tree_parameters!(
     32
 );
 
+define_merkle_tree_parameters!(
+    SerialNumberMerkleTreeParameters,
+    <Testnet1Parameters as Parameters>::RecordSerialNumberTreeCRH,
+    32
+);
+
 pub struct Testnet1Parameters;
 
 #[rustfmt::skip]
@@ -183,9 +189,13 @@ impl Parameters for Testnet1Parameters {
     type RecordCommitmentTreeDigest = <Self::RecordCommitmentTreeCRH as CRH>::Output;
     type RecordCommitmentTreeParameters = CommitmentMerkleTreeParameters;
 
+    type RecordSerialNumberTreeCRH = BHPCompressedCRH<EdwardsBls12, 8, 32>;
+    type RecordSerialNumberTreeDigest = <Self::RecordSerialNumberTreeCRH as CRH>::Output;
+    type RecordSerialNumberTreeParameters = SerialNumberMerkleTreeParameters;
+    
     type SerialNumberNonceCRH = BHPCompressedCRH<EdwardsBls12, 32, 63>;
     type SerialNumberNonceCRHGadget = BHPCompressedCRHGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 32, 63>;
-
+    
     dpc_setup!{account_commitment_scheme, ACCOUNT_COMMITMENT_SCHEME, AccountCommitmentScheme, ACCOUNT_COMMITMENT_INPUT} // TODO (howardwu): Rename to "AleoAccountCommitmentScheme0".
     dpc_setup!{account_encryption_scheme, ACCOUNT_ENCRYPTION_SCHEME, AccountEncryptionScheme, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT}
     dpc_setup!{account_signature_scheme, ACCOUNT_SIGNATURE_SCHEME, AccountSignatureScheme, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT}
@@ -197,6 +207,7 @@ impl Parameters for Testnet1Parameters {
     dpc_setup!{program_id_crh, PROGRAM_ID_CRH, ProgramIDCRH, "AleoProgramIDCRH0"}
     dpc_setup!{record_commitment_scheme, RECORD_COMMITMENT_SCHEME, RecordCommitmentScheme, "AleoRecordCommitment0"} // TODO (howardwu): Rename to "AleoRecordCommitmentScheme0".
     dpc_setup!{record_commitment_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoLedgerMerkleTreeCRH0"} // TODO (howardwu): Rename to "AleoRecordCommitmentTreeCRH0".
+    dpc_setup!{record_serial_number_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoRecordSerialNumberTreeCRH0"}
     dpc_setup!{serial_number_nonce_crh, SERIAL_NUMBER_NONCE_CRH, SerialNumberNonceCRH, "AleoSerialNumberNonceCRH0"}
 
     dpc_snark_setup_with_mode!{inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
@@ -208,10 +219,14 @@ impl Parameters for Testnet1Parameters {
     dpc_snark_setup_with_mode!{outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
 
-    // TODO (howardwu): TEMPORARY - Refactor this to a proper tree.
     fn record_commitment_tree_parameters() -> &'static Self::RecordCommitmentTreeParameters {
         static RECORD_COMMITMENT_TREE_PARAMETERS: OnceCell<<Testnet1Parameters as Parameters>::RecordCommitmentTreeParameters> = OnceCell::new();
         RECORD_COMMITMENT_TREE_PARAMETERS.get_or_init(|| Self::RecordCommitmentTreeParameters::from(Self::record_commitment_tree_crh().clone()))
+    }
+    
+    fn record_serial_number_tree_parameters() -> &'static Self::RecordSerialNumberTreeParameters {
+        static RECORD_SERIAL_NUMBER_TREE_PARAMETERS: OnceCell<<Testnet1Parameters as Parameters>::RecordSerialNumberTreeParameters> = OnceCell::new();
+        RECORD_SERIAL_NUMBER_TREE_PARAMETERS.get_or_init(|| Self::RecordSerialNumberTreeParameters::from(Self::record_serial_number_tree_crh().clone()))
     }
 
     /// Returns the program SRS for Aleo applications.

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -121,6 +121,12 @@ define_merkle_tree_parameters!(
     32
 );
 
+define_merkle_tree_parameters!(
+    SerialNumberMerkleTreeParameters,
+    <Testnet2Parameters as Parameters>::RecordSerialNumberTreeCRH,
+    32
+);
+
 pub struct Testnet2Parameters;
 
 // TODO (raychu86): Optimize each of the window sizes in the type declarations below.
@@ -203,9 +209,13 @@ impl Parameters for Testnet2Parameters {
     type RecordCommitmentTreeDigest = <Self::RecordCommitmentTreeCRH as CRH>::Output;
     type RecordCommitmentTreeParameters = CommitmentMerkleTreeParameters;
 
+    type RecordSerialNumberTreeCRH = BHPCompressedCRH<EdwardsBls12, 8, 32>;
+    type RecordSerialNumberTreeDigest = <Self::RecordSerialNumberTreeCRH as CRH>::Output;
+    type RecordSerialNumberTreeParameters = SerialNumberMerkleTreeParameters;
+    
     type SerialNumberNonceCRH = BHPCompressedCRH<EdwardsBls12, 32, 63>;
     type SerialNumberNonceCRHGadget = BHPCompressedCRHGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 32, 63>;
-
+    
     dpc_setup!{account_commitment_scheme, ACCOUNT_COMMITMENT_SCHEME, AccountCommitmentScheme, ACCOUNT_COMMITMENT_INPUT} // TODO (howardwu): Rename to "AleoAccountCommitmentScheme0".
     dpc_setup!{account_encryption_scheme, ACCOUNT_ENCRYPTION_SCHEME, AccountEncryptionScheme, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT}
     dpc_setup!{account_signature_scheme, ACCOUNT_SIGNATURE_SCHEME, AccountSignatureScheme, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT}
@@ -217,6 +227,7 @@ impl Parameters for Testnet2Parameters {
     dpc_setup!{program_id_crh, PROGRAM_ID_CRH, ProgramIDCRH, "AleoProgramIDCRH0"}
     dpc_setup!{record_commitment_scheme, RECORD_COMMITMENT_SCHEME, RecordCommitmentScheme, "AleoRecordCommitment0"} // TODO (howardwu): Rename to "AleoRecordCommitmentScheme0".
     dpc_setup!{record_commitment_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoLedgerMerkleTreeCRH0"} // TODO (howardwu): Rename to "AleoRecordCommitmentTreeCRH0".
+    dpc_setup!{record_serial_number_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoRecordSerialNumberTreeCRH0"}
     dpc_setup!{serial_number_nonce_crh, SERIAL_NUMBER_NONCE_CRH, SerialNumberNonceCRH, "AleoSerialNumberNonceCRH0"}
 
     dpc_snark_setup_with_mode!{inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
@@ -228,10 +239,14 @@ impl Parameters for Testnet2Parameters {
     dpc_snark_setup_with_mode!{outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
 
-    // TODO (howardwu): TEMPORARY - Refactor this to a proper tree.
     fn record_commitment_tree_parameters() -> &'static Self::RecordCommitmentTreeParameters {
         static RECORD_COMMITMENT_TREE_PARAMETERS: OnceCell<<Testnet2Parameters as Parameters>::RecordCommitmentTreeParameters> = OnceCell::new();
         RECORD_COMMITMENT_TREE_PARAMETERS.get_or_init(|| Self::RecordCommitmentTreeParameters::from(Self::record_commitment_tree_crh().clone()))
+    }
+
+    fn record_serial_number_tree_parameters() -> &'static Self::RecordSerialNumberTreeParameters {
+        static RECORD_SERIAL_NUMBER_TREE_PARAMETERS: OnceCell<<Testnet2Parameters as Parameters>::RecordSerialNumberTreeParameters> = OnceCell::new();
+        RECORD_SERIAL_NUMBER_TREE_PARAMETERS.get_or_init(|| Self::RecordSerialNumberTreeParameters::from(Self::record_serial_number_tree_crh().clone()))
     }
 
     // TODO (howardwu): TEMPORARY - Making this oncecell.

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -199,7 +199,7 @@ pub trait Parameters: 'static + Sized {
         + Sync
         + Send;
 
-    /// Record commitment tree instantiation for the ledger digest.
+    /// Record commitment tree instantiation.
     type RecordCommitmentTreeCRH: CRH<Output = Self::RecordCommitmentTreeDigest>;
     type RecordCommitmentTreeCRHGadget: CRHGadget<Self::RecordCommitmentTreeCRH, Self::InnerScalarField>;
     type RecordCommitmentTreeDigest: ToConstraintField<Self::InnerScalarField>
@@ -216,21 +216,33 @@ pub trait Parameters: 'static + Sized {
         + Copy;
     type RecordCommitmentTreeParameters: LoadableMerkleParameters<H = Self::RecordCommitmentTreeCRH>;
 
+    /// Record serial number tree instantiation.
+    type RecordSerialNumberTreeCRH: CRH<Output = Self::RecordSerialNumberTreeDigest>;
+    type RecordSerialNumberTreeDigest: ToConstraintField<Self::InnerScalarField>
+        + Clone
+        + Debug
+        + Display
+        + ToBytes
+        + FromBytes
+        + Eq
+        + Hash
+        + Default
+        + Send
+        + Sync
+        + Copy;
+    type RecordSerialNumberTreeParameters: LoadableMerkleParameters<H = Self::RecordSerialNumberTreeCRH>;
+
     /// CRH for computing the serial number nonce. Invoked only over `Self::InnerScalarField`.
     type SerialNumberNonceCRH: CRH;
     type SerialNumberNonceCRHGadget: CRHGadget<Self::SerialNumberNonceCRH, Self::InnerScalarField>;
 
     fn account_commitment_scheme() -> &'static Self::AccountCommitmentScheme;
-
     fn account_encryption_scheme() -> &'static Self::AccountEncryptionScheme;
-
     fn account_signature_scheme() -> &'static Self::AccountSignatureScheme;
 
     fn encrypted_record_crh() -> &'static Self::EncryptedRecordCRH;
 
     fn inner_circuit_id_crh() -> &'static Self::InnerCircuitIDCRH;
-
-    fn record_commitment_tree_crh() -> &'static Self::RecordCommitmentTreeCRH;
 
     fn local_data_commitment_scheme() -> &'static Self::LocalDataCommitmentScheme;
 
@@ -242,7 +254,11 @@ pub trait Parameters: 'static + Sized {
 
     fn record_commitment_scheme() -> &'static Self::RecordCommitmentScheme;
 
+    fn record_commitment_tree_crh() -> &'static Self::RecordCommitmentTreeCRH;
     fn record_commitment_tree_parameters() -> &'static Self::RecordCommitmentTreeParameters;
+
+    fn record_serial_number_tree_crh() -> &'static Self::RecordSerialNumberTreeCRH;
+    fn record_serial_number_tree_parameters() -> &'static Self::RecordSerialNumberTreeParameters;
 
     fn serial_number_nonce_crh() -> &'static Self::SerialNumberNonceCRH;
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -112,6 +112,12 @@ version = "1.0"
 [dev-dependencies.criterion]
 version = "0.3.4"
 
+[dev-dependencies.snarkvm-dpc]
+path = "../dpc"
+version = "0.7.5"
+default-features = false
+features = ["testnet2"]
+
 [dev-dependencies.hex]
 version = "0.4"
 

--- a/ledger/src/block/block_header.rs
+++ b/ledger/src/block/block_header.rs
@@ -201,11 +201,11 @@ mod tests {
         let block_header = BlockHeader {
             previous_block_hash: BlockHeaderHash([0u8; 32]),
             merkle_root_hash: MerkleRootHash([0u8; 32]),
+            pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
+            proof: ProofOfSuccinctWork([0u8; ProofOfSuccinctWork::size()]),
             time: Utc::now().timestamp(),
             difficulty_target: 0u64,
             nonce: 0u32,
-            pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
-            proof: ProofOfSuccinctWork([0u8; ProofOfSuccinctWork::size()]),
         };
 
         let serialized1 = block_header.serialize();

--- a/ledger/src/block/block_header.rs
+++ b/ledger/src/block/block_header.rs
@@ -59,6 +59,16 @@ impl BlockHeader {
         HEADER_SIZE
     }
 
+    /// Returns `true` if the block header is uniquely a genesis block header.
+    pub fn is_genesis(&self) -> bool {
+        // Ensure the previous block hash in the genesis block is 0.
+        self.previous_block_hash == BlockHeaderHash([0u8; 32])
+            // Ensure the timestamp in the genesis block is 0.
+            && self.time == 0
+            // Ensure the difficulty target in the genesis block is 0xFFFF_FFFF_FFFF_FFFF_u64.
+            && self.difficulty_target == 0xFFFF_FFFF_FFFF_FFFF_u64
+    }
+
     pub fn serialize(&self) -> [u8; HEADER_SIZE] {
         let mut header_bytes = [0u8; HEADER_SIZE];
         let mut start = 0;

--- a/ledger/src/block/block_header.rs
+++ b/ledger/src/block/block_header.rs
@@ -61,12 +61,10 @@ impl BlockHeader {
 
     /// Returns `true` if the block header is uniquely a genesis block header.
     pub fn is_genesis(&self) -> bool {
-        // Ensure the previous block hash in the genesis block is 0.
-        self.previous_block_hash == BlockHeaderHash([0u8; 32])
-            // Ensure the timestamp in the genesis block is 0.
-            && self.time == 0
-            // Ensure the difficulty target in the genesis block is 0xFFFF_FFFF_FFFF_FFFF_u64.
-            && self.difficulty_target == 0xFFFF_FFFF_FFFF_FFFF_u64
+        // Ensure the timestamp in the genesis block is 0.
+        self.time == 0
+            // Ensure the previous block hash in the genesis block is 0.
+            || self.previous_block_hash == BlockHeaderHash([0u8; 32])
     }
 
     pub fn serialize(&self) -> [u8; HEADER_SIZE] {

--- a/ledger/src/errors/storage.rs
+++ b/ledger/src/errors/storage.rs
@@ -49,6 +49,9 @@ pub enum StorageError {
     #[error("Can't decommit the genesis block")]
     InvalidBlockDecommit,
 
+    #[error("Invalid block header")]
+    InvalidBlockHeader,
+
     #[error("Can't remove a canon block with hash")]
     InvalidBlockRemovalCanon(String),
 
@@ -57,6 +60,9 @@ pub enum StorageError {
 
     #[error("invalid column family {}", _0)]
     InvalidColumnFamily(u32),
+
+    #[error("Invalid genesis block header")]
+    InvalidGenesisBlockHeader,
 
     #[error("missing outpoint with transaction with id {} and index {}", _0, _1)]
     InvalidOutpoint(String, usize),

--- a/ledger/src/ledger/ledger.rs
+++ b/ledger/src/ledger/ledger.rs
@@ -156,11 +156,6 @@ impl<C: Parameters, S: Storage> RecordSerialNumberTree<C> for Ledger<C, S> {
 }
 
 impl<C: Parameters, S: Storage> Ledger<C, S> {
-    /// Returns true if there are no blocks in the ledger.
-    pub fn is_empty(&self) -> bool {
-        self.latest_block().is_err()
-    }
-
     /// Find the potential child block hashes given a parent block header.
     pub fn get_child_block_hashes(
         &self,
@@ -200,7 +195,7 @@ impl<C: Parameters, S: Storage> Ledger<C, S> {
     }
 
     /// Get the current commitment index
-    pub fn current_cm_index(&self) -> Result<usize, StorageError> {
+    fn current_cm_index(&self) -> Result<usize, StorageError> {
         match self.storage.get(COL_META, KEY_CURR_CM_INDEX.as_bytes())? {
             Some(cm_index_bytes) => Ok(bytes_to_u32(&cm_index_bytes) as usize),
             None => Ok(0),
@@ -208,7 +203,7 @@ impl<C: Parameters, S: Storage> Ledger<C, S> {
     }
 
     /// Get the current serial number index
-    pub fn current_sn_index(&self) -> Result<usize, StorageError> {
+    fn current_sn_index(&self) -> Result<usize, StorageError> {
         match self.storage.get(COL_META, KEY_CURR_SN_INDEX.as_bytes())? {
             Some(sn_index_bytes) => Ok(bytes_to_u32(&sn_index_bytes) as usize),
             None => Ok(0),
@@ -216,7 +211,7 @@ impl<C: Parameters, S: Storage> Ledger<C, S> {
     }
 
     /// Get serial number index.
-    pub fn get_sn_index(&self, sn_bytes: &[u8]) -> Result<Option<usize>, StorageError> {
+    fn get_sn_index(&self, sn_bytes: &[u8]) -> Result<Option<usize>, StorageError> {
         match self.storage.get(COL_SERIAL_NUMBER, sn_bytes)? {
             Some(sn_index_bytes) => {
                 let mut sn_index = [0u8; 4];
@@ -229,7 +224,7 @@ impl<C: Parameters, S: Storage> Ledger<C, S> {
     }
 
     /// Get commitment index
-    pub fn get_cm_index(&self, cm_bytes: &[u8]) -> Result<Option<usize>, StorageError> {
+    fn get_cm_index(&self, cm_bytes: &[u8]) -> Result<Option<usize>, StorageError> {
         match self.storage.get(COL_COMMITMENT, cm_bytes)? {
             Some(cm_index_bytes) => {
                 let mut cm_index = [0u8; 4];

--- a/ledger/src/ledger/ledger.rs
+++ b/ledger/src/ledger/ledger.rs
@@ -42,6 +42,7 @@ pub type BlockHeight = u32;
 pub struct Ledger<C: Parameters, S: Storage> {
     pub current_block_height: AtomicU32,
     pub record_commitment_tree: RwLock<MerkleTree<C::RecordCommitmentTreeParameters>>,
+    pub record_serial_number_tree: RwLock<MerkleTree<C::RecordSerialNumberTreeParameters>>,
     pub storage: S,
 }
 
@@ -65,11 +66,14 @@ impl<C: Parameters, S: Storage> LedgerScheme<C> for Ledger<C, S> {
         }
 
         let leaves: &[[u8; 32]] = &[];
-        let parameters = Arc::new(C::record_commitment_tree_parameters().clone());
+        let record_commitment_tree = MerkleTree::new(Arc::new(C::record_commitment_tree_parameters().clone()), leaves)?;
+        let record_serial_number_tree =
+            MerkleTree::new(Arc::new(C::record_serial_number_tree_parameters().clone()), leaves)?;
 
         let ledger = Self {
             current_block_height: Default::default(),
-            record_commitment_tree: RwLock::new(MerkleTree::new(parameters, leaves)?),
+            record_commitment_tree: RwLock::new(record_commitment_tree),
+            record_serial_number_tree: RwLock::new(record_serial_number_tree),
             storage,
         };
 

--- a/ledger/src/ledger/ledger.rs
+++ b/ledger/src/ledger/ledger.rs
@@ -51,6 +51,11 @@ impl<C: Parameters, S: Storage> LedgerScheme<C> for Ledger<C, S> {
 
     /// Instantiates a new ledger with a genesis block.
     fn new(path: Option<&Path>, genesis_block: Self::Block) -> anyhow::Result<Self> {
+        // Ensure the given block is a genesis block.
+        if !genesis_block.header().is_genesis() {
+            return Err(LedgerError::InvalidGenesisBlockHeader.into());
+        }
+
         let storage = if let Some(path) = path {
             fs::create_dir_all(&path).map_err(|err| LedgerError::Message(err.to_string()))?;
 

--- a/ledger/src/ledger/mod.rs
+++ b/ledger/src/ledger/mod.rs
@@ -20,6 +20,9 @@ pub use ledger::*;
 pub mod memdb;
 pub use memdb::*;
 
+#[cfg(test)]
+mod tests;
+
 use snarkvm_utilities::{FromBytes, ToBytes};
 
 use std::io::{Read, Result as IoResult, Write};

--- a/ledger/src/ledger/tests.rs
+++ b/ledger/src/ledger/tests.rs
@@ -45,4 +45,7 @@ fn test_new_ledger_with_genesis_block() {
     assert_eq!(ledger.get_block_hash(1).unwrap(), expected_genesis_block_hash.clone());
     assert_eq!(ledger.get_block(&expected_genesis_block_hash).unwrap(), genesis_block);
     assert_eq!(ledger.contains_block_hash(&expected_genesis_block_hash), true);
+
+    assert!(ledger.get_block_hash(0).is_err());
+    assert!(ledger.get_block(&BlockHeaderHash([0u8; 32])).is_err());
 }

--- a/ledger/src/ledger/tests.rs
+++ b/ledger/src/ledger/tests.rs
@@ -24,10 +24,10 @@ fn test_new_ledger_with_genesis_block() {
             previous_block_hash: BlockHeaderHash([0u8; 32]),
             merkle_root_hash: MerkleRootHash([0u8; 32]),
             pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
+            proof: ProofOfSuccinctWork([0u8; 972]),
             time: 0,
             difficulty_target: 0xFFFF_FFFF_FFFF_FFFF_u64,
             nonce: 0,
-            proof: ProofOfSuccinctWork([0u8; 972]),
         },
         transactions: Transactions::new(),
     };

--- a/ledger/src/ledger/tests.rs
+++ b/ledger/src/ledger/tests.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::prelude::*;
+use snarkvm_dpc::parameters::testnet2::Testnet2Parameters;
+
+#[test]
+fn test_new_ledger_with_genesis_block() {
+    let genesis_block = Block {
+        header: BlockHeader {
+            previous_block_hash: BlockHeaderHash([0u8; 32]),
+            merkle_root_hash: MerkleRootHash([0u8; 32]),
+            pedersen_merkle_root_hash: PedersenMerkleRootHash([0u8; 32]),
+            time: 0,
+            difficulty_target: 0xFFFF_FFFF_FFFF_FFFF_u64,
+            nonce: 0,
+            proof: ProofOfSuccinctWork([0u8; 972]),
+        },
+        transactions: Transactions::new(),
+    };
+
+    // If the underlying hash function is changed, this expected block hash will need to be updated.
+    let expected_genesis_block_hash = BlockHeaderHash([
+        215, 251, 137, 243, 59, 18, 138, 175, 132, 222, 67, 161, 9, 37, 39, 228, 77, 110, 32, 174, 55, 65, 58, 177,
+        122, 117, 87, 96, 102, 156, 1, 182,
+    ]);
+
+    let ledger = Ledger::<Testnet2Parameters, MemDb>::new(None, genesis_block.clone()).unwrap();
+
+    assert_eq!(ledger.block_height(), 1);
+    assert_eq!(ledger.latest_block().unwrap(), genesis_block.clone());
+    assert_eq!(ledger.get_block_hash(1).unwrap(), expected_genesis_block_hash.clone());
+    assert_eq!(ledger.get_block(&expected_genesis_block_hash).unwrap(), genesis_block);
+    assert_eq!(ledger.contains_block_hash(&expected_genesis_block_hash), true);
+}

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -152,6 +152,8 @@ pub fn generate<C: Parameters>(recipient: &Address<C>, value: u64) -> Result<(Ve
         proof: proof.into(),
     };
 
+    assert!(genesis_header.is_genesis());
+
     Ok((genesis_header.serialize().to_vec(), transaction_bytes))
 }
 


### PR DESCRIPTION
## Motivation

This PR adds parameters for a record serial number tree, which after discussion is necessary for light client support. In addition, to enable consensus on the genesis block, we set the initialized ledger's block height to a convention of 1.

- Adds record serial number tree parameters
- Enforces a newly-initialized ledger has block height of 1
- Adds a basic convention for a genesis block header