### PR TITLE
Deduplicate testnet-dpecific dpc macros

### DIFF
--- a/dpc/src/parameters/common.rs
+++ b/dpc/src/parameters/common.rs
@@ -1,0 +1,50 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+#[rustfmt::skip]
+macro_rules! dpc_snark_setup {
+    ($network_parameters: ident, $fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
+        #[inline]
+        fn $fn_name() -> &'static <Self::$snark_type as SNARK>::$key_type {
+            static $static_name: OnceCell<<<$network_parameters as Parameters>::$snark_type as SNARK>::$key_type> = OnceCell::new();
+            $static_name.get_or_init(|| {
+                <Self::$snark_type as SNARK>::$key_type::read_le(
+                    $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice()
+                ).expect(&format!("Failed to read {} from bytes", $message))
+            })
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! dpc_snark_setup_with_mode {
+    ($network_parameters: ident, $fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
+        #[inline]
+        fn $fn_name(is_prover: bool) -> &'static Option<<Self::$snark_type as SNARK>::$key_type> {
+            match is_prover {
+                true => {
+                    static $static_name: OnceCell<Option<<<$network_parameters as Parameters>::$snark_type as SNARK>::$key_type>> = OnceCell::new();
+                    $static_name.get_or_init(|| {
+                        Some(<Self::$snark_type as SNARK>::$key_type::read_le(
+                            $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice(),
+                        ).expect(&format!("Failed to read {} from bytes", $message)))
+                    })
+                }
+                false => &None,
+            }
+        }
+    };
+}

--- a/dpc/src/parameters/mod.rs
+++ b/dpc/src/parameters/mod.rs
@@ -14,45 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[macro_use]
+pub mod common;
+
 #[cfg(feature = "testnet1")]
 pub mod testnet1;
 
 #[cfg(feature = "testnet2")]
 pub mod testnet2;
-
-#[rustfmt::skip]
-#[macro_export]
-macro_rules! dpc_snark_setup {
-    ($network_parameters: ident, $fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
-        #[inline]
-        fn $fn_name() -> &'static <Self::$snark_type as SNARK>::$key_type {
-            static $static_name: OnceCell<<<$network_parameters as Parameters>::$snark_type as SNARK>::$key_type> = OnceCell::new();
-            $static_name.get_or_init(|| {
-                <Self::$snark_type as SNARK>::$key_type::read_le(
-                    $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice()
-                ).expect(&format!("Failed to read {} from bytes", $message))
-            })
-        }
-    };
-}
-
-#[rustfmt::skip]
-#[macro_export]
-macro_rules! dpc_snark_setup_with_mode {
-    ($network_parameters: ident, $fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
-        #[inline]
-        fn $fn_name(is_prover: bool) -> &'static Option<<Self::$snark_type as SNARK>::$key_type> {
-            match is_prover {
-                true => {
-                    static $static_name: OnceCell<Option<<<$network_parameters as Parameters>::$snark_type as SNARK>::$key_type>> = OnceCell::new();
-                    $static_name.get_or_init(|| {
-                        Some(<Self::$snark_type as SNARK>::$key_type::read_le(
-                            $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice(),
-                        ).expect(&format!("Failed to read {} from bytes", $message)))
-                    })
-                }
-                false => &None,
-            }
-        }
-    };
-}

--- a/dpc/src/parameters/mod.rs
+++ b/dpc/src/parameters/mod.rs
@@ -19,3 +19,40 @@ pub mod testnet1;
 
 #[cfg(feature = "testnet2")]
 pub mod testnet2;
+
+#[rustfmt::skip]
+#[macro_export]
+macro_rules! dpc_snark_setup {
+    ($network_parameters: ident, $fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
+        #[inline]
+        fn $fn_name() -> &'static <Self::$snark_type as SNARK>::$key_type {
+            static $static_name: OnceCell<<<$network_parameters as Parameters>::$snark_type as SNARK>::$key_type> = OnceCell::new();
+            $static_name.get_or_init(|| {
+                <Self::$snark_type as SNARK>::$key_type::read_le(
+                    $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice()
+                ).expect(&format!("Failed to read {} from bytes", $message))
+            })
+        }
+    };
+}
+
+#[rustfmt::skip]
+#[macro_export]
+macro_rules! dpc_snark_setup_with_mode {
+    ($network_parameters: ident, $fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
+        #[inline]
+        fn $fn_name(is_prover: bool) -> &'static Option<<Self::$snark_type as SNARK>::$key_type> {
+            match is_prover {
+                true => {
+                    static $static_name: OnceCell<Option<<<$network_parameters as Parameters>::$snark_type as SNARK>::$key_type>> = OnceCell::new();
+                    $static_name.get_or_init(|| {
+                        Some(<Self::$snark_type as SNARK>::$key_type::read_le(
+                            $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice(),
+                        ).expect(&format!("Failed to read {} from bytes", $message)))
+                    })
+                }
+                false => &None,
+            }
+        }
+    };
+}

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -16,8 +16,6 @@
 
 use crate::{
     account::{ACCOUNT_COMMITMENT_INPUT, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT},
-    dpc_snark_setup,
-    dpc_snark_setup_with_mode,
     InnerCircuitVerifierInput,
     Network,
     OuterCircuitVerifierInput,
@@ -168,10 +166,10 @@ impl Parameters for Testnet1Parameters {
 
     dpc_snark_setup_with_mode!{Testnet1Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
-    
+
     dpc_snark_setup!{Testnet1Parameters, noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
     dpc_snark_setup!{Testnet1Parameters, noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
-    
+
     dpc_snark_setup_with_mode!{Testnet1Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
 

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -16,6 +16,8 @@
 
 use crate::{
     account::{ACCOUNT_COMMITMENT_INPUT, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT},
+    dpc_snark_setup,
+    dpc_snark_setup_with_mode,
     InnerCircuitVerifierInput,
     Network,
     OuterCircuitVerifierInput,
@@ -66,41 +68,6 @@ macro_rules! dpc_setup {
         fn $fn_name() -> &'static Self::$type_name {
             static $static_name: OnceCell<<Testnet1Parameters as Parameters>::$type_name> = OnceCell::new();
             $static_name.get_or_init(|| Self::$type_name::setup($setup_msg))
-        }
-    };
-}
-
-#[rustfmt::skip]
-macro_rules! dpc_snark_setup {
-    ($fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
-        #[inline]
-        fn $fn_name() -> &'static <Self::$snark_type as SNARK>::$key_type {
-            static $static_name: OnceCell<<<Testnet1Parameters as Parameters>::$snark_type as SNARK>::$key_type> = OnceCell::new();
-            $static_name.get_or_init(|| {
-                <Self::$snark_type as SNARK>::$key_type::read_le(
-                    $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice()
-                ).expect(&format!("Failed to read {} from bytes", $message))
-            })
-        }
-    };
-}
-
-#[rustfmt::skip]
-macro_rules! dpc_snark_setup_with_mode {
-    ($fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
-        #[inline]
-        fn $fn_name(is_prover: bool) -> &'static Option<<Self::$snark_type as SNARK>::$key_type> {
-            match is_prover {
-                true => {
-                    static $static_name: OnceCell<Option<<<Testnet1Parameters as Parameters>::$snark_type as SNARK>::$key_type>> = OnceCell::new();
-                    $static_name.get_or_init(|| {
-                        Some(<Self::$snark_type as SNARK>::$key_type::read_le(
-                            $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice(),
-                        ).expect(&format!("Failed to read {} from bytes", $message)))
-                    })
-                }
-                false => &None,
-            }
         }
     };
 }
@@ -199,14 +166,14 @@ impl Parameters for Testnet1Parameters {
     dpc_setup!{record_commitment_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoLedgerMerkleTreeCRH0"} // TODO (howardwu): Rename to "AleoRecordCommitmentTreeCRH0".
     dpc_setup!{serial_number_nonce_crh, SERIAL_NUMBER_NONCE_CRH, SerialNumberNonceCRH, "AleoSerialNumberNonceCRH0"}
 
-    dpc_snark_setup_with_mode!{inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
-    dpc_snark_setup!{inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
+    dpc_snark_setup_with_mode!{Testnet1Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
+    dpc_snark_setup!{Testnet1Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
     
-    dpc_snark_setup!{noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
-    dpc_snark_setup!{noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
+    dpc_snark_setup!{Testnet1Parameters, noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
+    dpc_snark_setup!{Testnet1Parameters, noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
     
-    dpc_snark_setup_with_mode!{outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
-    dpc_snark_setup!{outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
+    dpc_snark_setup_with_mode!{Testnet1Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
+    dpc_snark_setup!{Testnet1Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
 
     // TODO (howardwu): TEMPORARY - Refactor this to a proper tree.
     fn record_commitment_tree_parameters() -> &'static Self::RecordCommitmentTreeParameters {

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -16,8 +16,6 @@
 
 use crate::{
     account::{ACCOUNT_COMMITMENT_INPUT, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT},
-    dpc_snark_setup,
-    dpc_snark_setup_with_mode,
     InnerCircuitVerifierInput,
     Network,
     OuterCircuitVerifierInput,
@@ -188,10 +186,10 @@ impl Parameters for Testnet2Parameters {
 
     dpc_snark_setup_with_mode!{Testnet2Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
-    
+
     dpc_snark_setup!{Testnet2Parameters, noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
     dpc_snark_setup!{Testnet2Parameters, noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
-    
+
     dpc_snark_setup_with_mode!{Testnet2Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
 

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -16,6 +16,8 @@
 
 use crate::{
     account::{ACCOUNT_COMMITMENT_INPUT, ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT},
+    dpc_snark_setup,
+    dpc_snark_setup_with_mode,
     InnerCircuitVerifierInput,
     Network,
     OuterCircuitVerifierInput,
@@ -73,41 +75,6 @@ macro_rules! dpc_setup {
         fn $fn_name() -> &'static Self::$type_name {
             static $static_name: OnceCell<<Testnet2Parameters as Parameters>::$type_name> = OnceCell::new();
             $static_name.get_or_init(|| Self::$type_name::setup($setup_msg))
-        }
-    };
-}
-
-#[rustfmt::skip]
-macro_rules! dpc_snark_setup {
-    ($fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
-        #[inline]
-        fn $fn_name() -> &'static <Self::$snark_type as SNARK>::$key_type {
-            static $static_name: OnceCell<<<Testnet2Parameters as Parameters>::$snark_type as SNARK>::$key_type> = OnceCell::new();
-            $static_name.get_or_init(|| {
-                <Self::$snark_type as SNARK>::$key_type::read_le(
-                    $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice()
-                ).expect(&format!("Failed to read {} from bytes", $message))
-            })
-        }
-    };
-}
-
-#[rustfmt::skip]
-macro_rules! dpc_snark_setup_with_mode {
-    ($fn_name: ident, $static_name: ident, $snark_type: ident, $key_type: ident, $parameter: ident, $message: expr) => {
-        #[inline]
-        fn $fn_name(is_prover: bool) -> &'static Option<<Self::$snark_type as SNARK>::$key_type> {
-            match is_prover {
-                true => {
-                    static $static_name: OnceCell<Option<<<Testnet2Parameters as Parameters>::$snark_type as SNARK>::$key_type>> = OnceCell::new();
-                    $static_name.get_or_init(|| {
-                        Some(<Self::$snark_type as SNARK>::$key_type::read_le(
-                            $parameter::load_bytes().expect(&format!("Failed to load parameter bytes for {}", $message)).as_slice(),
-                        ).expect(&format!("Failed to read {} from bytes", $message)))
-                    })
-                }
-                false => &None,
-            }
         }
     };
 }
@@ -219,14 +186,14 @@ impl Parameters for Testnet2Parameters {
     dpc_setup!{record_commitment_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoLedgerMerkleTreeCRH0"} // TODO (howardwu): Rename to "AleoRecordCommitmentTreeCRH0".
     dpc_setup!{serial_number_nonce_crh, SERIAL_NUMBER_NONCE_CRH, SerialNumberNonceCRH, "AleoSerialNumberNonceCRH0"}
 
-    dpc_snark_setup_with_mode!{inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
-    dpc_snark_setup!{inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
+    dpc_snark_setup_with_mode!{Testnet2Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
+    dpc_snark_setup!{Testnet2Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
     
-    dpc_snark_setup!{noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
-    dpc_snark_setup!{noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
+    dpc_snark_setup!{Testnet2Parameters, noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
+    dpc_snark_setup!{Testnet2Parameters, noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
     
-    dpc_snark_setup_with_mode!{outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
-    dpc_snark_setup!{outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
+    dpc_snark_setup_with_mode!{Testnet2Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
+    dpc_snark_setup!{Testnet2Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
 
     // TODO (howardwu): TEMPORARY - Refactor this to a proper tree.
     fn record_commitment_tree_parameters() -> &'static Self::RecordCommitmentTreeParameters {


### PR DESCRIPTION
This PR deduplicates 2 testnet-specific `dpc` macros, as suggested in https://github.com/AleoHQ/snarkVM/pull/320#discussion_r678908634.