### PR TITLE
No more gd `bitvec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,18 +100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +530,6 @@ name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures-channel"
@@ -1261,12 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,7 +1609,6 @@ name = "snarkvm-algorithms"
 version = "0.7.5"
 dependencies = [
  "anyhow",
- "bitvec",
  "blake2",
  "blake2s_simd",
  "criterion",
@@ -1987,12 +1962,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2409,9 +2378,3 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -94,9 +94,6 @@ default-features = false
 [dependencies.anyhow]
 version = "1.0"
 
-[dependencies.bitvec]
-version = "0.19.4"
-
 [dependencies.blake2]
 version = "0.9"
 optional = true

--- a/algorithms/src/crh/bhp.rs
+++ b/algorithms/src/crh/bhp.rs
@@ -17,9 +17,8 @@
 use crate::{hash_to_curve::hash_to_curve, CRHError, CRH};
 use snarkvm_curves::{AffineCurve, ProjectiveCurve};
 use snarkvm_fields::{ConstraintFieldError, Field, PrimeField, ToConstraintField};
-use snarkvm_utilities::{BigInteger, FromBytes, ToBytes};
+use snarkvm_utilities::{from_bytes_le_to_bits_le, BigInteger, FromBytes, ToBytes};
 
-use bitvec::{order::Lsb0, view::BitView};
 use once_cell::sync::OnceCell;
 use std::{
     fmt::Debug,
@@ -99,7 +98,7 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH
         // overzealous but stack allocation
         let mut buffer = [0u8; MAX_WINDOW_SIZE * MAX_NUM_WINDOWS / 8 + BOWE_HOPWOOD_CHUNK_SIZE + 1];
         buffer[..input.len()].copy_from_slice(input);
-        let buf_slice = (&buffer[..]).view_bits::<Lsb0>();
+        let buf_slice = from_bytes_le_to_bits_le(&buffer[..]).collect::<Vec<_>>();
 
         let mut bit_len = WINDOW_SIZE * NUM_WINDOWS;
         if bit_len % BOWE_HOPWOOD_CHUNK_SIZE != 0 {

--- a/algorithms/src/crh/pedersen.rs
+++ b/algorithms/src/crh/pedersen.rs
@@ -17,9 +17,8 @@
 use crate::{hash_to_curve::hash_to_curve, CRHError, CRH};
 use snarkvm_curves::{AffineCurve, ProjectiveCurve};
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
-use snarkvm_utilities::{FromBytes, ToBytes};
+use snarkvm_utilities::{from_bytes_le_to_bits_le, FromBytes, ToBytes};
 
-use bitvec::{order::Lsb0, view::BitView};
 use std::{
     fmt::Debug,
     io::{Read, Result as IoResult, Write},
@@ -66,7 +65,7 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH
         }
 
         // Compute sum of h_i^{m_i} for all i.
-        let bits = input.view_bits::<Lsb0>();
+        let bits = from_bytes_le_to_bits_le(input).collect::<Vec<_>>();
         let result = bits
             .chunks(WINDOW_SIZE)
             .zip(&self.bases)


### PR DESCRIPTION
## Motivation

No more gd `bitvec`.

```
Before
-------
Pedersen CRH setup      time:   [635.04 us 636.57 us 638.71 us]                               
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe

Pedersen CRH hash       time:   [62.865 us 62.992 us 63.120 us]                             
Found 4 outliers among 50 measurements (8.00%)
  3 (6.00%) high mild
  1 (2.00%) high severe

After
------
Pedersen CRH setup      time:   [636.88 us 639.05 us 642.13 us]                               
                        change: [-0.2128% +0.5658% +1.5633%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe

Pedersen CRH hash       time:   [63.615 us 63.723 us 63.845 us]                             
                        change: [+0.5504% +0.8897% +1.2171%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe
```