### PR TITLE
Improves `Program` ergonomics

### DIFF
--- a/dpc/examples/account.rs
+++ b/dpc/examples/account.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkvm_dpc::{testnet2::Testnet2Parameters, Account, AccountScheme};
+
+use rand::thread_rng;
+
+fn main() {
+    let account = Account::<Testnet2Parameters>::new(&mut thread_rng()).unwrap();
+    println!("{}", account);
+}

--- a/dpc/src/errors/dpc.rs
+++ b/dpc/src/errors/dpc.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{AccountError, CircuitError, LedgerError, ProgramError, RecordError, TransactionError};
+use crate::{AccountError, CircuitError, ProgramError, RecordError, TransactionError};
 use snarkvm_algorithms::{
     CRHError,
     CommitmentError,
@@ -65,9 +65,6 @@ pub enum DPCError {
 
     #[error("{}", _0)]
     FromHexError(#[from] hex::FromHexError),
-
-    #[error("{}", _0)]
-    LedgerError(#[from] LedgerError),
 
     #[error("{}", _0)]
     MerkleError(#[from] MerkleError),

--- a/dpc/src/errors/mod.rs
+++ b/dpc/src/errors/mod.rs
@@ -23,9 +23,6 @@ pub use circuit::*;
 pub mod dpc;
 pub use dpc::*;
 
-pub mod ledger;
-pub use ledger::*;
-
 pub mod program;
 pub use program::*;
 

--- a/dpc/src/program/noop_program.rs
+++ b/dpc/src/program/noop_program.rs
@@ -28,11 +28,12 @@ use crate::{
 use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, prelude::*};
 
 use rand::{CryptoRng, Rng};
+use std::sync::Arc;
 
 #[derive(Derivative)]
-#[derivative(Debug(bound = "C: Parameters"))]
+#[derivative(Clone(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
 pub struct NoopProgram<C: Parameters> {
-    circuit_tree: ProgramCircuitTree<C>,
+    circuit_tree: Arc<ProgramCircuitTree<C>>,
 }
 
 impl<C: Parameters> Program<C> for NoopProgram<C> {
@@ -42,7 +43,9 @@ impl<C: Parameters> Program<C> for NoopProgram<C> {
         let mut circuit_tree = ProgramCircuitTree::new()?;
         circuit_tree.add_all(vec![Box::new(NoopCircuit::setup(rng)?)])?;
 
-        Ok(Self { circuit_tree })
+        Ok(Self {
+            circuit_tree: Arc::new(circuit_tree),
+        })
     }
 
     /// Loads an instance of the program.
@@ -51,7 +54,9 @@ impl<C: Parameters> Program<C> for NoopProgram<C> {
         let mut circuit_tree = ProgramCircuitTree::new()?;
         circuit_tree.add(Box::new(NoopCircuit::load()?))?;
 
-        Ok(Self { circuit_tree })
+        Ok(Self {
+            circuit_tree: Arc::new(circuit_tree),
+        })
     }
 
     /// Returns the program ID.

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -55,8 +55,8 @@ pub struct Record<C: Parameters> {
 
 impl<C: Parameters> Record<C> {
     #[allow(clippy::too_many_arguments)]
-    pub fn new_full<P: Program<C>, R: Rng + CryptoRng>(
-        program: &P,
+    pub fn new_full<R: Rng + CryptoRng>(
+        program: &dyn Program<C>,
         owner: Address<C>,
         is_dummy: bool,
         value: u64,
@@ -74,8 +74,8 @@ impl<C: Parameters> Record<C> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new<P: Program<C>, R: Rng + CryptoRng>(
-        program: &P,
+    pub fn new<R: Rng + CryptoRng>(
+        program: &dyn Program<C>,
         owner: Address<C>,
         is_dummy: bool,
         value: u64,

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -19,7 +19,7 @@ use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, CRH, SNARK};
 
 use rand::{CryptoRng, Rng};
 
-pub trait Program<C: Parameters>: Clone {
+pub trait Program<C: Parameters>: Send + Sync {
     /// Initializes a new instance of the program.
     fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, ProgramError>
     where

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -19,7 +19,7 @@ use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, CRH, SNARK};
 
 use rand::{CryptoRng, Rng};
 
-pub trait Program<C: Parameters> {
+pub trait Program<C: Parameters>: Clone {
     /// Initializes a new instance of the program.
     fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, ProgramError>
     where

--- a/ledger/src/errors/ledger.rs
+++ b/ledger/src/errors/ledger.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::errors::TransactionError;
 use snarkvm_algorithms::errors::MerkleError;
+use snarkvm_dpc::errors::TransactionError;
 
 #[derive(Debug, Error)]
 pub enum LedgerError {

--- a/ledger/src/errors/mod.rs
+++ b/ledger/src/errors/mod.rs
@@ -17,6 +17,9 @@
 pub mod block;
 pub use block::*;
 
+pub mod ledger;
+pub use ledger::*;
+
 pub mod posw;
 pub use posw::*;
 

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -152,7 +152,6 @@ pub fn generate<C: Parameters>(recipient: &Address<C>, value: u64) -> Result<(Ve
         nonce,
         proof: proof.into(),
     };
-
     assert!(genesis_header.is_genesis());
 
     Ok((genesis_header.serialize().to_vec(), transaction_bytes))


### PR DESCRIPTION
## Motivation

Improves `Program` ergonomics

- Arcs the usage of program circuit tree
- Allows `Record` to take dynamic program reference
- Adds an account creation example in the DPC crate
- Moves `LedgerError` to `snarkvm_ledger` (missed this migration earlier)