### PR TITLE
Adds a static `Parameters::inner_circuit_id()` to prevent recomputing unnecessarily

### DIFF
--- a/dpc/src/circuits/inner_circuit.rs
+++ b/dpc/src/circuits/inner_circuit.rs
@@ -45,7 +45,7 @@ pub struct InnerCircuit<C: Parameters> {
     program_commitment: <C::ProgramCommitmentScheme as CommitmentScheme>::Output,
     program_randomness: <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
 
-    local_data_root: C::LocalDataDigest,
+    local_data_root: C::LocalDataRoot,
     local_data_commitment_randomizers: Vec<<C::LocalDataCommitmentScheme as CommitmentScheme>::Randomness>,
 
     memo: [u8; 64],
@@ -78,7 +78,7 @@ impl<C: Parameters> InnerCircuit<C> {
         let program_commitment = <C::ProgramCommitmentScheme as CommitmentScheme>::Output::default();
         let program_randomness = <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness::default();
 
-        let local_data_root = C::LocalDataDigest::default();
+        let local_data_root = C::LocalDataRoot::default();
         let local_data_commitment_randomizers = vec![
             <C::LocalDataCommitmentScheme as CommitmentScheme>::Randomness::default();
             num_input_records + num_output_records
@@ -137,7 +137,7 @@ impl<C: Parameters> InnerCircuit<C> {
         program_commitment: <C::ProgramCommitmentScheme as CommitmentScheme>::Output,
         program_randomness: <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
 
-        local_data_root: C::LocalDataDigest,
+        local_data_root: C::LocalDataRoot,
         local_data_commitment_randomizers: Vec<<C::LocalDataCommitmentScheme as CommitmentScheme>::Randomness>,
 
         memo: [u8; 64],

--- a/dpc/src/circuits/inner_circuit_gadget.rs
+++ b/dpc/src/circuits/inner_circuit_gadget.rs
@@ -56,7 +56,7 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
     // Rest
     program_commitment: &<C::ProgramCommitmentScheme as CommitmentScheme>::Output,
     program_randomness: &<C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
-    local_data_root: &C::LocalDataDigest,
+    local_data_root: &C::LocalDataRoot,
     local_data_commitment_randomizers: &[<C::LocalDataCommitmentScheme as CommitmentScheme>::Randomness],
     memo: &[u8; 64],
     value_balance: AleoAmount,

--- a/dpc/src/circuits/inner_circuit_verifier_input.rs
+++ b/dpc/src/circuits/inner_circuit_verifier_input.rs
@@ -40,7 +40,7 @@ pub struct InnerCircuitVerifierInput<C: Parameters> {
     // These are required in natively verifying an inner circuit proof.
     // However for verification in the outer circuit, these must be provided as witness.
     pub program_commitment: Option<<C::ProgramCommitmentScheme as CommitmentScheme>::Output>,
-    pub local_data_root: Option<C::LocalDataDigest>,
+    pub local_data_root: Option<C::LocalDataRoot>,
 
     pub memo: [u8; 64],
     pub value_balance: AleoAmount,

--- a/dpc/src/circuits/outer_circuit.rs
+++ b/dpc/src/circuits/outer_circuit.rs
@@ -17,7 +17,7 @@
 use crate::{execute_outer_circuit, AleoAmount, Execution, Parameters, Transaction, TransactionScheme};
 use snarkvm_algorithms::{
     merkle_tree::MerkleTreeDigest,
-    traits::{CommitmentScheme, SignatureScheme, CRH, SNARK},
+    traits::{CommitmentScheme, SignatureScheme, SNARK},
 };
 use snarkvm_fields::ToConstraintField;
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
@@ -43,7 +43,7 @@ pub struct OuterCircuit<C: Parameters> {
     program_randomness: <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
     local_data_root: C::LocalDataDigest,
 
-    inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output,
+    inner_circuit_id: C::InnerCircuitID,
 }
 
 impl<C: Parameters> OuterCircuit<C> {
@@ -66,7 +66,7 @@ impl<C: Parameters> OuterCircuit<C> {
         let program_randomness = <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness::default();
         let local_data_root = C::LocalDataDigest::default();
 
-        let inner_circuit_id = <C::InnerCircuitIDCRH as CRH>::Output::default();
+        let inner_circuit_id = C::InnerCircuitID::default();
 
         Self {
             ledger_digest,
@@ -109,7 +109,7 @@ impl<C: Parameters> OuterCircuit<C> {
         local_data_root: C::LocalDataDigest,
 
         // Inner circuit ID
-        inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output,
+        inner_circuit_id: C::InnerCircuitID,
     ) -> Self {
         assert_eq!(C::NUM_TOTAL_RECORDS, program_proofs.len());
         assert_eq!(C::NUM_OUTPUT_RECORDS, new_commitments.len());

--- a/dpc/src/circuits/outer_circuit.rs
+++ b/dpc/src/circuits/outer_circuit.rs
@@ -41,7 +41,7 @@ pub struct OuterCircuit<C: Parameters> {
     program_proofs: Vec<Execution<C>>,
     program_commitment: <C::ProgramCommitmentScheme as CommitmentScheme>::Output,
     program_randomness: <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
-    local_data_root: C::LocalDataDigest,
+    local_data_root: C::LocalDataRoot,
 
     inner_circuit_id: C::InnerCircuitID,
 }
@@ -64,7 +64,7 @@ impl<C: Parameters> OuterCircuit<C> {
         let program_proofs = vec![program_snark_vk_and_proof.clone(); C::NUM_TOTAL_RECORDS];
         let program_commitment = <C::ProgramCommitmentScheme as CommitmentScheme>::Output::default();
         let program_randomness = <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness::default();
-        let local_data_root = C::LocalDataDigest::default();
+        let local_data_root = C::LocalDataRoot::default();
 
         let inner_circuit_id = C::InnerCircuitID::default();
 
@@ -106,7 +106,7 @@ impl<C: Parameters> OuterCircuit<C> {
         program_proofs: Vec<Execution<C>>,
         program_commitment: <C::ProgramCommitmentScheme as CommitmentScheme>::Output,
         program_randomness: <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
-        local_data_root: C::LocalDataDigest,
+        local_data_root: C::LocalDataRoot,
 
         // Inner circuit ID
         inner_circuit_id: C::InnerCircuitID,

--- a/dpc/src/circuits/outer_circuit_gadget.rs
+++ b/dpc/src/circuits/outer_circuit_gadget.rs
@@ -17,7 +17,7 @@
 use crate::{AleoAmount, Execution, Parameters, Transaction, TransactionScheme};
 use snarkvm_algorithms::{
     merkle_tree::MerkleTreeDigest,
-    traits::{CommitmentScheme, SignatureScheme, CRH, SNARK},
+    traits::{CommitmentScheme, SignatureScheme, SNARK},
 };
 use snarkvm_fields::ToConstraintField;
 use snarkvm_gadgets::{
@@ -120,7 +120,7 @@ pub fn execute_outer_circuit<C: Parameters, CS: ConstraintSystem<C::OuterScalarF
     program_randomness: &<C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
     local_data_root: &C::LocalDataDigest,
 
-    inner_circuit_id: &<C::InnerCircuitIDCRH as CRH>::Output,
+    inner_circuit_id: &C::InnerCircuitID,
 ) -> Result<(), SynthesisError> {
     // Declare public parameters.
     let (program_id_commitment_parameters, program_id_crh, inner_circuit_id_crh) = {

--- a/dpc/src/circuits/outer_circuit_gadget.rs
+++ b/dpc/src/circuits/outer_circuit_gadget.rs
@@ -118,7 +118,7 @@ pub fn execute_outer_circuit<C: Parameters, CS: ConstraintSystem<C::OuterScalarF
     // Rest
     program_commitment: &<C::ProgramCommitmentScheme as CommitmentScheme>::Output,
     program_randomness: &<C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
-    local_data_root: &C::LocalDataDigest,
+    local_data_root: &C::LocalDataRoot,
 
     inner_circuit_id: &C::InnerCircuitID,
 ) -> Result<(), SynthesisError> {

--- a/dpc/src/circuits/outer_circuit_verifier_input.rs
+++ b/dpc/src/circuits/outer_circuit_verifier_input.rs
@@ -15,10 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{InnerCircuitVerifierInput, Parameters};
-use snarkvm_algorithms::{
-    merkle_tree::MerkleTreeDigest,
-    traits::{CommitmentScheme, CRH},
-};
+use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, traits::CommitmentScheme};
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
 use snarkvm_utilities::ToBits;
 
@@ -26,7 +23,7 @@ use snarkvm_utilities::ToBits;
 #[derivative(Clone(bound = "C: Parameters"))]
 pub struct OuterCircuitVerifierInput<C: Parameters> {
     pub inner_snark_verifier_input: InnerCircuitVerifierInput<C>,
-    pub inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output,
+    pub inner_circuit_id: C::InnerCircuitID,
 }
 
 impl<C: Parameters> ToConstraintField<C::OuterScalarField> for OuterCircuitVerifierInput<C>

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -139,7 +139,7 @@ impl Parameters for Testnet1Parameters {
 
     type LocalDataCRH = BHPCompressedCRH<EdwardsBls12, 16, 32>;
     type LocalDataCRHGadget = BHPCompressedCRHGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 16, 32>;
-    type LocalDataDigest = <Self::LocalDataCRH as CRH>::Output;
+    type LocalDataRoot = <Self::LocalDataCRH as CRH>::Output;
 
     type PRF = Blake2s;
     type PRFGadget = Blake2sGadget;

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -132,7 +132,7 @@ impl Parameters for Testnet1Parameters {
 
     type InnerCircuitIDCRH = PoseidonCryptoHash<Self::OuterScalarField, 4, false>;
     type InnerCircuitIDCRHGadget = PoseidonCryptoHashGadget<Self::OuterScalarField, 4, false>;
-    type InnerCircuitIDCRHDigest = <Self::InnerCircuitIDCRH as CRH>::Output;
+    type InnerCircuitID = <Self::InnerCircuitIDCRH as CRH>::Output;
 
     type LocalDataCommitmentScheme = BHPCompressedCommitment<EdwardsBls12, 24, 62>;
     type LocalDataCommitmentGadget = BHPCompressedCommitmentGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 24, 62>;

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -41,6 +41,7 @@ use snarkvm_curves::{
     edwards_bls12::{EdwardsParameters, EdwardsProjective as EdwardsBls12},
     PairingEngine,
 };
+use snarkvm_fields::ToConstraintField;
 use snarkvm_gadgets::{
     algorithms::{
         commitment::{BHPCompressedCommitmentGadget, Blake2sCommitmentGadget},
@@ -182,6 +183,13 @@ impl Parameters for Testnet1Parameters {
     dpc_setup!{record_commitment_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoLedgerMerkleTreeCRH0"} // TODO (howardwu): Rename to "AleoRecordCommitmentTreeCRH0".
     dpc_setup!{record_serial_number_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoRecordSerialNumberTreeCRH0"}
     dpc_setup!{serial_number_nonce_crh, SERIAL_NUMBER_NONCE_CRH, SerialNumberNonceCRH, "AleoSerialNumberNonceCRH0"}
+
+    fn inner_circuit_id() -> &'static Self::InnerCircuitID {
+        static INNER_CIRCUIT_ID: OnceCell<<Testnet1Parameters as Parameters>::InnerCircuitID> = OnceCell::new();
+        INNER_CIRCUIT_ID.get_or_init(|| Self::inner_circuit_id_crh()
+            .hash_field_elements(&Self::inner_circuit_verifying_key().to_field_elements().expect("Failed to convert inner circuit verifying key to elements"))
+            .expect("Failed to hash inner circuit verifying key elements"))
+    }
 
     dpc_snark_setup_with_mode!{Testnet1Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -159,7 +159,7 @@ impl Parameters for Testnet2Parameters {
 
     type LocalDataCRH = BHPCompressedCRH<EdwardsBls12, 16, 32>;
     type LocalDataCRHGadget = BHPCompressedCRHGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 16, 32>;
-    type LocalDataDigest = <Self::LocalDataCRH as CRH>::Output;
+    type LocalDataRoot = <Self::LocalDataCRH as CRH>::Output;
 
     type PRF = Blake2s;
     type PRFGadget = Blake2sGadget;

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -152,7 +152,7 @@ impl Parameters for Testnet2Parameters {
 
     type InnerCircuitIDCRH = PoseidonCryptoHash<Self::OuterScalarField, 4, false>;
     type InnerCircuitIDCRHGadget = PoseidonCryptoHashGadget<Self::OuterScalarField, 4, false>;
-    type InnerCircuitIDCRHDigest = <Self::InnerCircuitIDCRH as CRH>::Output;
+    type InnerCircuitID = <Self::InnerCircuitIDCRH as CRH>::Output;
 
     type LocalDataCommitmentScheme = BHPCompressedCommitment<EdwardsBls12, 24, 62>;
     type LocalDataCommitmentGadget = BHPCompressedCommitmentGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 24, 62>;

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -41,6 +41,7 @@ use snarkvm_curves::{
     edwards_bls12::{EdwardsParameters, EdwardsProjective as EdwardsBls12},
     PairingEngine,
 };
+use snarkvm_fields::ToConstraintField;
 use snarkvm_gadgets::{
     algorithms::{
         commitment::{BHPCompressedCommitmentGadget, Blake2sCommitmentGadget},
@@ -203,6 +204,13 @@ impl Parameters for Testnet2Parameters {
     dpc_setup!{record_serial_number_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoRecordSerialNumberTreeCRH0"}
     dpc_setup!{serial_number_nonce_crh, SERIAL_NUMBER_NONCE_CRH, SerialNumberNonceCRH, "AleoSerialNumberNonceCRH0"}
 
+    fn inner_circuit_id() -> &'static Self::InnerCircuitID {
+        static INNER_CIRCUIT_ID: OnceCell<<Testnet2Parameters as Parameters>::InnerCircuitID> = OnceCell::new();
+        INNER_CIRCUIT_ID.get_or_init(|| Self::inner_circuit_id_crh()
+            .hash_field_elements(&Self::inner_circuit_verifying_key().to_field_elements().expect("Failed to convert inner circuit verifying key to elements"))
+            .expect("Failed to hash inner circuit verifying key elements"))
+    }
+    
     dpc_snark_setup_with_mode!{Testnet2Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
 

--- a/dpc/src/program/program.rs
+++ b/dpc/src/program/program.rs
@@ -35,12 +35,12 @@ pub struct Execution<C: Parameters> {
     Default(bound = "C: Parameters")
 )]
 pub struct ProgramPublicVariables<C: Parameters> {
-    pub local_data_root: C::LocalDataDigest,
+    pub local_data_root: C::LocalDataRoot,
     pub record_position: u8,
 }
 
 impl<C: Parameters> ProgramPublicVariables<C> {
-    pub fn new(local_data_root: &C::LocalDataDigest, record_position: u8) -> Self {
+    pub fn new(local_data_root: &C::LocalDataRoot, record_position: u8) -> Self {
         Self {
             local_data_root: local_data_root.clone(),
             record_position,

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -125,9 +125,9 @@ pub trait Parameters: 'static + Sized + Send + Sync {
 
     /// CRH for hash of the `Self::InnerSNARK` verifying keys.
     /// This is invoked only on the larger curve.
-    type InnerCircuitIDCRH: CRH<Output = Self::InnerCircuitIDCRHDigest>;
+    type InnerCircuitIDCRH: CRH<Output = Self::InnerCircuitID>;
     type InnerCircuitIDCRHGadget: CRHGadget<Self::InnerCircuitIDCRH, Self::OuterScalarField>;
-    type InnerCircuitIDCRHDigest: ToConstraintField<Self::OuterScalarField>
+    type InnerCircuitID: ToConstraintField<Self::OuterScalarField>
         + Clone
         + Debug
         + Display

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -145,9 +145,9 @@ pub trait Parameters: 'static + Sized + Send + Sync {
     type LocalDataCommitmentScheme: CommitmentScheme;
     type LocalDataCommitmentGadget: CommitmentGadget<Self::LocalDataCommitmentScheme, Self::InnerScalarField>;
 
-    type LocalDataCRH: CRH<Output = Self::LocalDataDigest>;
+    type LocalDataCRH: CRH<Output = Self::LocalDataRoot>;
     type LocalDataCRHGadget: CRHGadget<Self::LocalDataCRH, Self::InnerScalarField>;
-    type LocalDataDigest: ToConstraintField<Self::InnerScalarField>
+    type LocalDataRoot: ToConstraintField<Self::InnerScalarField>
         + Clone
         + Debug
         + Display

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -276,6 +276,7 @@ pub trait Parameters: 'static + Sized + Send + Sync {
 
     fn serial_number_nonce_crh() -> &'static Self::SerialNumberNonceCRH;
 
+    fn inner_circuit_id() -> &'static Self::InnerCircuitID;
     fn inner_circuit_proving_key(is_prover: bool) -> &'static Option<<Self::InnerSNARK as SNARK>::ProvingKey>;
     fn inner_circuit_verifying_key() -> &'static <Self::InnerSNARK as SNARK>::VerifyingKey;
 

--- a/dpc/src/transaction/local_data.rs
+++ b/dpc/src/transaction/local_data.rs
@@ -96,7 +96,7 @@ impl<C: Parameters> LocalData<C> {
         })
     }
 
-    pub fn root(&self) -> &<C::LocalDataCRH as CRH>::Output {
+    pub fn root(&self) -> &C::LocalDataRoot {
         &self.tree.root()
     }
 

--- a/dpc/src/transaction/transaction.rs
+++ b/dpc/src/transaction/transaction.rs
@@ -17,7 +17,7 @@
 use crate::{record::encrypted::*, AleoAmount, Network, Parameters, TransactionError, TransactionScheme};
 use snarkvm_algorithms::{
     merkle_tree::MerkleTreeDigest,
-    traits::{SignatureScheme, CRH, SNARK},
+    traits::{SignatureScheme, SNARK},
 };
 use snarkvm_utilities::{
     serialize::{CanonicalDeserialize, CanonicalSerialize},
@@ -57,7 +57,7 @@ pub struct Transaction<C: Parameters> {
     /// The root of the ledger commitment tree.
     pub ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters>,
     /// The ID of the inner circuit used to execute this transaction.
-    pub inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output,
+    pub inner_circuit_id: C::InnerCircuitID,
     /// The encrypted output records.
     pub encrypted_records: Vec<EncryptedRecord<C>>,
     #[derivative(PartialEq = "ignore")]
@@ -74,7 +74,7 @@ impl<C: Parameters> Transaction<C> {
         value_balance: AleoAmount,
         memo: <Self as TransactionScheme>::Memo,
         ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters>,
-        inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output,
+        inner_circuit_id: C::InnerCircuitID,
         proof: <C::OuterSNARK as SNARK>::Proof,
         signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
         encrypted_records: Vec<EncryptedRecord<C>>,
@@ -103,7 +103,7 @@ impl<C: Parameters> TransactionScheme for Transaction<C> {
     type Commitment = C::RecordCommitment;
     type Digest = MerkleTreeDigest<C::RecordCommitmentTreeParameters>;
     type EncryptedRecord = EncryptedRecord<C>;
-    type InnerCircuitID = <C::InnerCircuitIDCRH as CRH>::Output;
+    type InnerCircuitID = C::InnerCircuitID;
     type Memo = [u8; 64];
     type SerialNumber = <C::AccountSignatureScheme as SignatureScheme>::PublicKey;
     type Signature = <C::AccountSignatureScheme as SignatureScheme>::Signature;
@@ -227,7 +227,7 @@ impl<C: Parameters> FromBytes for Transaction<C> {
         }
 
         let ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters> = FromBytes::read_le(&mut reader)?;
-        let inner_circuit_id: <C::InnerCircuitIDCRH as CRH>::Output = FromBytes::read_le(&mut reader)?;
+        let inner_circuit_id: C::InnerCircuitID = FromBytes::read_le(&mut reader)?;
 
         // Read the encrypted records.
         let mut encrypted_records = Vec::with_capacity(C::NUM_OUTPUT_RECORDS);


### PR DESCRIPTION
## Motivation

This is a mild PR to reduce the cost of deriving the inner circuit ID by making it static, no circuit changes in this PR. This PR will allow `snarkOS` to derive the inner circuit ID in a network-agnostic manner.

- Adds a static `Parameters::inner_circuit_id()` to prevent recomputing unnecessarily
- Renames `Parameters::InnerCircuitIDCRHDigest` to `Parameters::InnerCircuitID`
- Renames `Parameters::LocalDataDigest` to `Parameters::LocalDataRoot`
- Updates `DPC::execute()` and `DPC::verify()` to use static `Parameters::inner_circuit_id()`
- Adds debug-only safety checks that loaded and saved inner circuit ID match
    - Remark: A desirable goal is to remove the inner and outer circuit parameter variables inside the DPC struct, as Parameters already has static getter methods for these. However to support `setup` based DPC (rather than `loaded`), we will need to refactor how these are stored/accessed. The good news is that addressing this (in a future PR) will halve the total memory footprint of DPC while removing the need for these debug checks.