### PR TITLE
Fix a MerkleTree::new slowdown

### DIFF
--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -96,7 +96,7 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH
 
         let parameters = Self::Parameters::from(bases);
 
-        let bowe_hopwood_parameters = BoweHopwoodPedersenCRHParameters::new();
+        let bowe_hopwood_parameters = BoweHopwoodPedersenCRHParameters::setup(&parameters);
 
         Self {
             parameters,
@@ -138,7 +138,7 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH
         for bases in self.parameters.bases.iter() {
             assert_eq!(bases.len(), WINDOW_SIZE);
         }
-        let base_lookup = self.bowe_hopwood_parameters.base_lookup(&self.parameters);
+        let base_lookup = self.bowe_hopwood_parameters.base_lookup();
         assert_eq!(base_lookup.len(), NUM_WINDOWS);
         for bases in base_lookup.iter() {
             assert_eq!(bases.len(), WINDOW_SIZE);
@@ -179,7 +179,7 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>
 {
     fn from(parameters: PedersenCRHParameters<G, NUM_WINDOWS, WINDOW_SIZE>) -> Self {
         Self {
-            bowe_hopwood_parameters: BoweHopwoodPedersenCRHParameters::new(),
+            bowe_hopwood_parameters: BoweHopwoodPedersenCRHParameters::setup(&parameters),
             parameters,
         }
     }

--- a/algorithms/src/crh/bowe_hopwood_pedersen_compressed.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen_compressed.rs
@@ -77,7 +77,7 @@ impl<G: Group + ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: us
 {
     fn from(parameters: PedersenCRHParameters<G, NUM_WINDOWS, WINDOW_SIZE>) -> Self {
         Self {
-            bowe_hopwood_parameters: BoweHopwoodPedersenCRHParameters::new(),
+            bowe_hopwood_parameters: BoweHopwoodPedersenCRHParameters::setup(&parameters),
             parameters,
         }
     }

--- a/algorithms/src/crh/bowe_hopwood_pedersen_parameters.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen_parameters.rs
@@ -24,50 +24,43 @@ pub const BOWE_HOPWOOD_LOOKUP_SIZE: usize = 2usize.pow(BOWE_HOPWOOD_CHUNK_SIZE a
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use once_cell::sync::OnceCell;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BoweHopwoodPedersenCRHParameters<G: Group> {
-    base_lookup: OnceCell<Vec<Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>>>,
+    base_lookup: Vec<Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>>,
 }
 
 impl<G: Group> BoweHopwoodPedersenCRHParameters<G> {
-    pub fn new() -> Self {
-        Self {
-            base_lookup: OnceCell::new(),
-        }
+    pub fn setup<const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>(
+        parameters: &PedersenCRHParameters<G, NUM_WINDOWS, WINDOW_SIZE>,
+    ) -> Self {
+        let base_lookup = cfg_iter!(parameters.bases)
+            .map(|x| {
+                x.iter()
+                    .map(|g| {
+                        let mut out = [G::zero(); BOWE_HOPWOOD_LOOKUP_SIZE];
+                        for i in 0..BOWE_HOPWOOD_LOOKUP_SIZE {
+                            let mut encoded = *g;
+                            if (i & 0x01) != 0 {
+                                encoded += g;
+                            }
+                            if (i & 0x02) != 0 {
+                                encoded += g.double();
+                            }
+                            if (i & 0x04) != 0 {
+                                encoded = encoded.neg();
+                            }
+                            out[i] = encoded;
+                        }
+                        out
+                    })
+                    .collect()
+            })
+            .collect();
+
+        Self { base_lookup }
     }
 
-    pub fn base_lookup<const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>(
-        &self,
-        input: &PedersenCRHParameters<G, NUM_WINDOWS, WINDOW_SIZE>,
-    ) -> &Vec<Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>> {
-        self.base_lookup
-            .get_or_try_init::<_, ()>(|| {
-                Ok(cfg_iter!(input.bases)
-                    .map(|x| {
-                        x.iter()
-                            .map(|g| {
-                                let mut out = [G::zero(); BOWE_HOPWOOD_LOOKUP_SIZE];
-                                for i in 0..BOWE_HOPWOOD_LOOKUP_SIZE {
-                                    let mut encoded = *g;
-                                    if (i & 0x01) != 0 {
-                                        encoded += g;
-                                    }
-                                    if (i & 0x02) != 0 {
-                                        encoded += g.double();
-                                    }
-                                    if (i & 0x04) != 0 {
-                                        encoded = encoded.neg();
-                                    }
-                                    out[i] = encoded;
-                                }
-                                out
-                            })
-                            .collect()
-                    })
-                    .collect())
-            })
-            .expect("failed to init BoweHopwoodPedersenCRHParameters")
+    pub fn base_lookup(&self) -> &[Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>] {
+        &self.base_lookup
     }
 }


### PR DESCRIPTION
After the snarkOS update to `0.7.5` (and `0.7.6`), the storage loading process became significantly slower: https://github.com/AleoHQ/snarkOS/issues/1003. This was caused by the fact that due to aggressive parallelization, the value of `base_lookup` was initialized (or rather an attempt to initialize it was made) **many** times instead of just once.

The results of this PR for the storage loading process in snarkOS are as follows:
```
before: 107781ms
after:  4926ms
```