### PR TITLE
Implement casting for ProgramPrivateVariables trait

### DIFF
--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -24,7 +24,11 @@ use std::marker::PhantomData;
 
 pub struct NoopPrivateVariables<C: Parameters>(PhantomData<C>);
 
-impl<C: Parameters> ProgramPrivateVariables<C> for NoopPrivateVariables<C> {}
+impl<C: Parameters> ProgramPrivateVariables<C> for NoopPrivateVariables<C> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 impl<C: Parameters> NoopPrivateVariables<C> {
     pub fn new() -> Self {

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -97,4 +97,6 @@ pub trait ProgramCircuit<C: Parameters>: Send + Sync {
     }
 }
 
-pub trait ProgramPrivateVariables<C: Parameters>: Send + Sync {}
+pub trait ProgramPrivateVariables<C: Parameters>: Send + Sync {
+    fn as_any(&self) -> &dyn std::any::Any;
+}


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This adds a required function `as_any` to the `ProgramPrivateVariables` trait, to facilitate casting casting the `private: &dyn ProgramPrivateVariables<C>` variable into usable structs without having to use unsafe transmutes.

