### PR TITLE
Adds enhancements for the DPC program model

### DIFF
--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -73,7 +73,7 @@ fn dpc_testnet1_integration_test() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_input_noop(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -210,7 +210,7 @@ fn test_testnet1_transaction_authorization_serialization() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_input_noop(&dpc.noop_program, test_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(&dpc.noop_program, test_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -282,7 +282,7 @@ fn test_testnet1_dpc_execute_constraints() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_input_noop(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -75,7 +75,7 @@ fn dpc_testnet1_integration_test() {
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
         let input_record = Record::new(
             &dpc.noop_program,
-            genesis_account.address.clone(),
+            genesis_account.address,
             true, // The input record is dummy
             0,
             Payload::default(),
@@ -100,7 +100,7 @@ fn dpc_testnet1_integration_test() {
         output_records.push(
             Record::new_full(
                 &dpc.noop_program,
-                recipient.address.clone(),
+                recipient.address,
                 false,
                 10,
                 Payload::default(),
@@ -215,7 +215,7 @@ fn test_testnet1_transaction_authorization_serialization() {
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
         let input_record = Record::new(
             &dpc.noop_program,
-            test_account.address.clone(),
+            test_account.address,
             true,
             0,
             Payload::default(),
@@ -240,7 +240,7 @@ fn test_testnet1_transaction_authorization_serialization() {
         output_records.push(
             Record::new_full(
                 &dpc.noop_program,
-                test_account.address.clone(),
+                test_account.address,
                 false,
                 10,
                 Payload::default(),
@@ -298,7 +298,7 @@ fn test_testnet1_dpc_execute_constraints() {
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
         let input_record = Record::new(
             &alternate_noop_program,
-            dummy_account.address.clone(),
+            dummy_account.address,
             true,
             0,
             Payload::default(),
@@ -326,7 +326,7 @@ fn test_testnet1_dpc_execute_constraints() {
         output_records.push(
             Record::new_full(
                 &dpc.noop_program,
-                new_account.address.clone(),
+                new_account.address,
                 false,
                 10,
                 Payload::default(),

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -118,7 +118,7 @@ fn dpc_testnet1_integration_test() {
     // Generate the program proofs.
     let mut program_proofs = vec![];
     for i in 0..Testnet1Parameters::NUM_TOTAL_RECORDS {
-        let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
+        let public_variables = ProgramPublicVariables::new(i as u8, local_data.root());
         program_proofs.push(
             dpc.noop_program
                 .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
@@ -336,7 +336,7 @@ fn test_testnet1_dpc_execute_constraints() {
     // Generate the program proofs.
     let mut program_proofs = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
+        let public_variables = ProgramPublicVariables::new(i as u8, local_data.root());
         program_proofs.push(
             alternate_noop_program
                 .execute(
@@ -349,7 +349,7 @@ fn test_testnet1_dpc_execute_constraints() {
     }
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         let public_variables =
-            ProgramPublicVariables::new(local_data.root(), (Testnet1Parameters::NUM_INPUT_RECORDS + j) as u8);
+            ProgramPublicVariables::new((Testnet1Parameters::NUM_INPUT_RECORDS + j) as u8, local_data.root());
         program_proofs.push(
             dpc.noop_program
                 .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -120,13 +120,21 @@ fn dpc_testnet1_integration_test() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
+    // Fetch the noop circuit ID.
+    let noop_circuit_id = dpc
+        .noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)
+        .unwrap()
+        .circuit_id();
+
     // Generate the program proofs.
     let mut program_proofs = vec![];
     for i in 0..Testnet1Parameters::NUM_TOTAL_RECORDS {
         let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
         program_proofs.push(
             dpc.noop_program
-                .execute(0, &public_variables, &NoopPrivateVariables::new())
+                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
                 .unwrap(),
         );
     }
@@ -345,13 +353,21 @@ fn test_testnet1_dpc_execute_constraints() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
+    // Fetch the noop circuit ID.
+    let noop_circuit_id = dpc
+        .noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)
+        .unwrap()
+        .circuit_id();
+
     // Generate the program proofs.
     let mut program_proofs = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
         let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
         program_proofs.push(
             alternate_noop_program
-                .execute(0, &public_variables, &NoopPrivateVariables::new())
+                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
                 .unwrap(),
         );
     }
@@ -360,7 +376,7 @@ fn test_testnet1_dpc_execute_constraints() {
             ProgramPublicVariables::new(local_data.root(), (Testnet1Parameters::NUM_INPUT_RECORDS + j) as u8);
         program_proofs.push(
             dpc.noop_program
-                .execute(0, &public_variables, &NoopPrivateVariables::new())
+                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
                 .unwrap(),
         );
     }

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -73,18 +73,7 @@ fn dpc_testnet1_integration_test() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new(
-            &dpc.noop_program,
-            genesis_account.address,
-            true, // The input record is dummy
-            0,
-            Payload::default(),
-            <Testnet1Parameters as Parameters>::serial_number_nonce_crh()
-                .hash(&[64u8 + (i as u8); 1])
-                .unwrap(),
-            &mut rng,
-        )
-        .unwrap();
+        let input_record = Record::new_input_noop(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -98,7 +87,7 @@ fn dpc_testnet1_integration_test() {
     let mut output_records = vec![];
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
-            Record::new_full(
+            Record::new_output(
                 &dpc.noop_program,
                 recipient.address,
                 false,
@@ -221,18 +210,7 @@ fn test_testnet1_transaction_authorization_serialization() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new(
-            &dpc.noop_program,
-            test_account.address,
-            true,
-            0,
-            Payload::default(),
-            <Testnet1Parameters as Parameters>::serial_number_nonce_crh()
-                .hash(&[0u8; 1])
-                .unwrap(),
-            &mut rng,
-        )
-        .unwrap();
+        let input_record = Record::new_input_noop(&dpc.noop_program, test_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -246,7 +224,7 @@ fn test_testnet1_transaction_authorization_serialization() {
     let mut output_records = vec![];
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
-            Record::new_full(
+            Record::new_output(
                 &dpc.noop_program,
                 test_account.address,
                 false,
@@ -304,18 +282,7 @@ fn test_testnet1_dpc_execute_constraints() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new(
-            &alternate_noop_program,
-            dummy_account.address,
-            true,
-            0,
-            Payload::default(),
-            <Testnet1Parameters as Parameters>::serial_number_nonce_crh()
-                .hash(&[0u8; 1])
-                .unwrap(),
-            &mut rng,
-        )
-        .unwrap();
+        let input_record = Record::new_input_noop(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -332,7 +299,7 @@ fn test_testnet1_dpc_execute_constraints() {
     let mut output_records = vec![];
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
-            Record::new_full(
+            Record::new_output(
                 &dpc.noop_program,
                 new_account.address,
                 false,

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -82,8 +82,6 @@ fn dpc_testnet1_integration_test() {
     }
 
     // Construct new records.
-
-    // Set the new records' program to be the "always-accept" program.
     let mut output_records = vec![];
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
@@ -320,6 +318,13 @@ fn test_testnet1_dpc_execute_constraints() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
+    // Fetch the alternate noop circuit ID.
+    let alternate_noop_circuit_id = alternate_noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)
+        .unwrap()
+        .circuit_id();
+
     // Fetch the noop circuit ID.
     let noop_circuit_id = dpc
         .noop_program
@@ -334,7 +339,11 @@ fn test_testnet1_dpc_execute_constraints() {
         let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
         program_proofs.push(
             alternate_noop_program
-                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
+                .execute(
+                    alternate_noop_circuit_id,
+                    &public_variables,
+                    &NoopPrivateVariables::new(),
+                )
                 .unwrap(),
         );
     }

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -121,13 +121,21 @@ fn dpc_testnet2_integration_test() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
+    // Fetch the noop circuit ID.
+    let noop_circuit_id = dpc
+        .noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)
+        .unwrap()
+        .circuit_id();
+
     // Generate the program proofs
     let mut program_proofs = vec![];
     for i in 0..Testnet2Parameters::NUM_TOTAL_RECORDS {
         let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
         program_proofs.push(
             dpc.noop_program
-                .execute(0, &public_variables, &NoopPrivateVariables::new())
+                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
                 .unwrap(),
         );
     }
@@ -347,13 +355,21 @@ fn test_testnet2_dpc_execute_constraints() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
+    // Fetch the noop circuit ID.
+    let noop_circuit_id = dpc
+        .noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)
+        .unwrap()
+        .circuit_id();
+
     // Generate the program proofs
     let mut program_proofs = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
         let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
         program_proofs.push(
             alternate_noop_program
-                .execute(0, &public_variables, &NoopPrivateVariables::new())
+                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
                 .unwrap(),
         );
     }
@@ -362,7 +378,7 @@ fn test_testnet2_dpc_execute_constraints() {
             ProgramPublicVariables::new(local_data.root(), (Testnet2Parameters::NUM_INPUT_RECORDS + j) as u8);
         program_proofs.push(
             dpc.noop_program
-                .execute(0, &public_variables, &NoopPrivateVariables::new())
+                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
                 .unwrap(),
         );
     }

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -74,7 +74,7 @@ fn dpc_testnet2_integration_test() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_input_noop(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -211,7 +211,7 @@ fn test_testnet_2_transaction_authorization_serialization() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let old_record = Record::new_input_noop(&dpc.noop_program, test_account.address, &mut rng).unwrap();
+        let old_record = Record::new_noop_input(&dpc.noop_program, test_account.address, &mut rng).unwrap();
 
         let (sn, _) = old_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -284,7 +284,7 @@ fn test_testnet2_dpc_execute_constraints() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_input_noop(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -76,7 +76,7 @@ fn dpc_testnet2_integration_test() {
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
         let input_record = Record::new(
             &dpc.noop_program,
-            genesis_account.address.clone(),
+            genesis_account.address,
             true, // The input record is dummy
             0,
             Payload::default(),
@@ -101,7 +101,7 @@ fn dpc_testnet2_integration_test() {
         output_records.push(
             Record::new_full(
                 &dpc.noop_program,
-                recipient.address.clone(),
+                recipient.address,
                 false,
                 10,
                 Payload::default(),
@@ -216,7 +216,7 @@ fn test_testnet_2_transaction_authorization_serialization() {
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
         let old_record = Record::new(
             &dpc.noop_program,
-            test_account.address.clone(),
+            test_account.address,
             true,
             0,
             Payload::default(),
@@ -241,7 +241,7 @@ fn test_testnet_2_transaction_authorization_serialization() {
         output_records.push(
             Record::new_full(
                 &dpc.noop_program,
-                test_account.address.clone(),
+                test_account.address,
                 false,
                 10,
                 Payload::default(),
@@ -300,7 +300,7 @@ fn test_testnet2_dpc_execute_constraints() {
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
         let input_record = Record::new(
             &alternate_noop_program,
-            dummy_account.address.clone(),
+            dummy_account.address,
             true,
             0,
             Payload::default(),
@@ -328,7 +328,7 @@ fn test_testnet2_dpc_execute_constraints() {
         output_records.push(
             Record::new_full(
                 &dpc.noop_program,
-                new_account.address.clone(),
+                new_account.address,
                 false,
                 10,
                 Payload::default(),

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -83,8 +83,6 @@ fn dpc_testnet2_integration_test() {
     }
 
     // Construct new records.
-
-    // Set the new records' program to be the "always-accept" program.
     let mut output_records = vec![];
     for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
@@ -322,6 +320,13 @@ fn test_testnet2_dpc_execute_constraints() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
+    // Fetch the alternate noop circuit ID.
+    let alternate_noop_circuit_id = alternate_noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)
+        .unwrap()
+        .circuit_id();
+
     // Fetch the noop circuit ID.
     let noop_circuit_id = dpc
         .noop_program
@@ -336,7 +341,11 @@ fn test_testnet2_dpc_execute_constraints() {
         let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
         program_proofs.push(
             alternate_noop_program
-                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
+                .execute(
+                    alternate_noop_circuit_id,
+                    &public_variables,
+                    &NoopPrivateVariables::new(),
+                )
                 .unwrap(),
         );
     }

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -74,18 +74,7 @@ fn dpc_testnet2_integration_test() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new(
-            &dpc.noop_program,
-            genesis_account.address,
-            true, // The input record is dummy
-            0,
-            Payload::default(),
-            <Testnet2Parameters as Parameters>::serial_number_nonce_crh()
-                .hash(&[64u8 + (i as u8); 1])
-                .unwrap(),
-            &mut rng,
-        )
-        .unwrap();
+        let input_record = Record::new_input_noop(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -99,7 +88,7 @@ fn dpc_testnet2_integration_test() {
     let mut output_records = vec![];
     for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
-            Record::new_full(
+            Record::new_output(
                 &dpc.noop_program,
                 recipient.address,
                 false,
@@ -222,18 +211,7 @@ fn test_testnet_2_transaction_authorization_serialization() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let old_record = Record::new(
-            &dpc.noop_program,
-            test_account.address,
-            true,
-            0,
-            Payload::default(),
-            <Testnet2Parameters as Parameters>::serial_number_nonce_crh()
-                .hash(&[0u8; 1])
-                .unwrap(),
-            &mut rng,
-        )
-        .unwrap();
+        let old_record = Record::new_input_noop(&dpc.noop_program, test_account.address, &mut rng).unwrap();
 
         let (sn, _) = old_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -247,7 +225,7 @@ fn test_testnet_2_transaction_authorization_serialization() {
     let mut output_records = vec![];
     for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
-            Record::new_full(
+            Record::new_output(
                 &dpc.noop_program,
                 test_account.address,
                 false,
@@ -306,18 +284,7 @@ fn test_testnet2_dpc_execute_constraints() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new(
-            &alternate_noop_program,
-            dummy_account.address,
-            true,
-            0,
-            Payload::default(),
-            <Testnet2Parameters as Parameters>::serial_number_nonce_crh()
-                .hash(&[0u8; 1])
-                .unwrap(),
-            &mut rng,
-        )
-        .unwrap();
+        let input_record = Record::new_input_noop(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -334,7 +301,7 @@ fn test_testnet2_dpc_execute_constraints() {
     let mut output_records = vec![];
     for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
-            Record::new_full(
+            Record::new_output(
                 &dpc.noop_program,
                 new_account.address,
                 false,

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -25,7 +25,10 @@ use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 /// TODO (howardwu): Update this to the correct inner circuit ID when the final parameters are set.
 #[ignore]
@@ -105,9 +108,6 @@ fn dpc_testnet2_integration_test() {
         .authorize(&private_keys, input_records, output_records, None, &mut rng)
         .unwrap();
 
-    // Generate the local data.
-    let local_data = authorization.to_local_data(&mut rng).unwrap();
-
     // Fetch the noop circuit ID.
     let noop_circuit_id = dpc
         .noop_program
@@ -116,28 +116,14 @@ fn dpc_testnet2_integration_test() {
         .unwrap()
         .circuit_id();
 
-    // Generate the program proofs
-    let mut program_proofs = vec![];
-    for i in 0..Testnet2Parameters::NUM_TOTAL_RECORDS {
-        let public_variables = ProgramPublicVariables::new(i as u8, local_data.root());
-        program_proofs.push(
-            dpc.noop_program
-                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
-                .unwrap(),
-        );
-    }
+    // Construct the executable.
+    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()), *noop_circuit_id);
+    let executables = vec![noop.clone(), noop.clone(), noop.clone(), noop];
 
     let new_records = authorization.output_records.clone();
 
     let transaction = dpc
-        .execute(
-            &private_keys,
-            authorization,
-            &local_data,
-            program_proofs,
-            &ledger,
-            &mut rng,
-        )
+        .execute(&private_keys, authorization, executables, &ledger, &mut rng)
         .unwrap();
 
     // Check that the transaction is serialized and deserialized correctly
@@ -335,28 +321,15 @@ fn test_testnet2_dpc_execute_constraints() {
         .unwrap()
         .circuit_id();
 
-    // Generate the program proofs
-    let mut program_proofs = vec![];
-    for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let public_variables = ProgramPublicVariables::new(i as u8, local_data.root());
-        program_proofs.push(
-            alternate_noop_program
-                .execute(
-                    alternate_noop_circuit_id,
-                    &public_variables,
-                    &NoopPrivateVariables::new(),
-                )
-                .unwrap(),
-        );
-    }
-    for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
-        let public_variables =
-            ProgramPublicVariables::new((Testnet2Parameters::NUM_INPUT_RECORDS + j) as u8, local_data.root());
-        program_proofs.push(
-            dpc.noop_program
-                .execute(noop_circuit_id, &public_variables, &NoopPrivateVariables::new())
-                .unwrap(),
-        );
+    // Construct the executable.
+    let alternate_noop = Executable::Noop(Arc::new(alternate_noop_program.clone()), *alternate_noop_circuit_id);
+    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()), *noop_circuit_id);
+    let executables = vec![alternate_noop.clone(), alternate_noop, noop.clone(), noop];
+
+    // Execute the programs.
+    let mut executions = Vec::with_capacity(Testnet2Parameters::NUM_TOTAL_RECORDS);
+    for (i, executable) in executables.iter().enumerate() {
+        executions.push(executable.execute(i as u8, &local_data).unwrap());
     }
 
     // Compute the program commitment.
@@ -498,7 +471,7 @@ fn test_testnet2_dpc_execute_constraints() {
         network_id,
         &inner_snark_vk,
         &inner_snark_proof,
-        &program_proofs,
+        &executions,
         &program_commitment,
         &program_randomness,
         &local_data_root,

--- a/algorithms/src/errors/merkle.rs
+++ b/algorithms/src/errors/merkle.rs
@@ -43,8 +43,8 @@ pub enum MerkleError {
     #[error("{}", _0)]
     Message(String),
 
-    #[error("Missing entry at leaf index: {}", _0)]
-    MissingLeafIndex(usize),
+    #[error("Missing leaf entry: {}", _0)]
+    MissingLeaf(String),
 }
 
 impl From<std::io::Error> for MerkleError {

--- a/algorithms/src/traits/encryption.rs
+++ b/algorithms/src/traits/encryption.rs
@@ -25,7 +25,7 @@ pub trait EncryptionScheme:
 {
     type Parameters: Clone + Debug + Eq;
     type PrivateKey: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + UniformRand;
-    type PublicKey: Clone + Debug + Default + Eq + ToBytes + FromBytes;
+    type PublicKey: Copy + Clone + Debug + Default + Eq + ToBytes + FromBytes;
     type Randomness: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + UniformRand;
 
     fn setup(message: &str) -> Self;

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -30,6 +30,7 @@ use std::{
 #[derive(Derivative)]
 #[derivative(
     Default(bound = "C: Parameters"),
+    Copy(bound = "C: Parameters"),
     Clone(bound = "C: Parameters"),
     PartialEq(bound = "C: Parameters"),
     Eq(bound = "C: Parameters")

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -194,15 +194,23 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
         authorization: Self::Authorization,
-        local_data: &LocalData<C>,
-        program_proofs: Vec<Self::Execution>,
+        executables: Vec<Executable<C>>,
         ledger: &L,
         rng: &mut R,
     ) -> Result<Self::Transaction> {
         assert_eq!(C::NUM_INPUT_RECORDS, private_keys.len());
-        assert_eq!(C::NUM_TOTAL_RECORDS, program_proofs.len());
+        assert_eq!(C::NUM_TOTAL_RECORDS, executables.len());
 
-        let execution_timer = start_timer!(|| "DPC::execute_online_phase");
+        let execution_timer = start_timer!(|| "DPC::execute");
+
+        // Generate the local data.
+        let local_data = authorization.to_local_data(rng)?;
+
+        // Execute the programs.
+        let mut executions = Vec::with_capacity(C::NUM_TOTAL_RECORDS);
+        for (i, executable) in executables.iter().enumerate() {
+            executions.push(executable.execute(i as u8, &local_data).unwrap());
+        }
 
         // Compute the program commitment.
         let (program_commitment, program_randomness) = authorization.to_program_commitment(rng)?;
@@ -307,7 +315,7 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
                 network_id,
                 inner_snark_vk,
                 inner_proof,
-                program_proofs,
+                executions.to_vec(),
                 program_commitment.clone(),
                 program_randomness,
                 local_data.root().clone(),

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -46,7 +46,10 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
 
         let noop_program_timer = start_timer!(|| "Noop program SNARK setup");
         let noop_program = NoopProgram::setup(rng)?;
-        let noop_program_execution = noop_program.execute_blank(0)?;
+        let noop_circuit = noop_program
+            .find_circuit_by_index(0)
+            .ok_or(DPCError::MissingNoopCircuit)?;
+        let noop_program_execution = noop_program.execute_blank(noop_circuit.circuit_id())?;
         end_timer!(noop_program_timer);
 
         let snark_setup_time = start_timer!(|| "Execute inner SNARK setup");

--- a/dpc/src/errors/dpc.rs
+++ b/dpc/src/errors/dpc.rs
@@ -83,6 +83,9 @@ pub enum DPCError {
     #[error("missing inner snark proving parameters")]
     MissingInnerSnarkProvingParameters,
 
+    #[error("missing noop circuit")]
+    MissingNoopCircuit,
+
     #[error("missing outer snark proving parameters")]
     MissingOuterSnarkProvingParameters,
 

--- a/dpc/src/errors/dpc.rs
+++ b/dpc/src/errors/dpc.rs
@@ -83,6 +83,9 @@ pub enum DPCError {
     #[error("missing inner snark proving parameters")]
     MissingInnerSnarkProvingParameters,
 
+    #[error("Missing circuit - {}", _0)]
+    MissingCircuit(&'static str),
+
     #[error("missing noop circuit")]
     MissingNoopCircuit,
 

--- a/dpc/src/errors/record.rs
+++ b/dpc/src/errors/record.rs
@@ -54,6 +54,9 @@ pub enum RecordError {
     #[error("Attempted to build a record with an invalid commitment. Try `calculate_commitment()`")]
     InvalidCommitment,
 
+    #[error("Invalid output record position - {}", _0)]
+    InvalidOutputPosition(u8),
+
     #[error("Missing Record field: {0}")]
     MissingField(String),
 

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -194,8 +194,8 @@ impl Parameters for Testnet1Parameters {
     dpc_snark_setup_with_mode!{Testnet1Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
 
-    dpc_snark_setup!{Testnet1Parameters, noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
-    dpc_snark_setup!{Testnet1Parameters, noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
+    dpc_snark_setup!{Testnet1Parameters, noop_circuit_proving_key, NOOP_CIRCUIT_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop circuit proving key"}
+    dpc_snark_setup!{Testnet1Parameters, noop_circuit_verifying_key, NOOP_CIRCUIT_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop circuit verifying key"}
 
     dpc_snark_setup_with_mode!{Testnet1Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -194,6 +194,11 @@ impl Parameters for Testnet1Parameters {
     dpc_snark_setup_with_mode!{Testnet1Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
 
+    fn noop_circuit_id() -> &'static Self::ProgramCircuitID {
+        static NOOP_CIRCUIT_ID: OnceCell<<Testnet1Parameters as Parameters>::InnerCircuitID> = OnceCell::new();
+        NOOP_CIRCUIT_ID.get_or_init(|| Self::program_circuit_id(Self::noop_circuit_verifying_key()).expect("Failed to hash noop circuit verifying key"))
+    }
+    
     dpc_snark_setup!{Testnet1Parameters, noop_circuit_proving_key, NOOP_CIRCUIT_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, noop_circuit_verifying_key, NOOP_CIRCUIT_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop circuit verifying key"}
 

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -76,7 +76,7 @@ pub type Testnet1Transaction = Transaction<Testnet1Parameters>;
 
 define_merkle_tree_parameters!(
     ProgramIDMerkleTreeParameters,
-    <Testnet1Parameters as Parameters>::ProgramIDCRH,
+    <Testnet1Parameters as Parameters>::ProgramCircuitIDCRH,
     8
 );
 
@@ -149,10 +149,10 @@ impl Parameters for Testnet1Parameters {
     type ProgramCommitmentGadget = Blake2sCommitmentGadget;
     type ProgramCommitment = <Self::ProgramCommitmentScheme as CommitmentScheme>::Output;
 
-    type ProgramIDCRH = PoseidonCryptoHash<Self::OuterScalarField, 4, false>;
-    type ProgramIDCRHGadget = PoseidonCryptoHashGadget<Self::OuterScalarField, 4, false>;
-    type ProgramIDTreeDigest = <Self::ProgramIDCRH as CRH>::Output;
-    type ProgramIDTreeParameters = ProgramIDMerkleTreeParameters;
+    type ProgramCircuitIDCRH = PoseidonCryptoHash<Self::OuterScalarField, 4, false>;
+    type ProgramCircuitIDCRHGadget = PoseidonCryptoHashGadget<Self::OuterScalarField, 4, false>;
+    type ProgramCircuitID = <Self::ProgramCircuitIDCRH as CRH>::Output;
+    type ProgramCircuitTreeParameters = ProgramIDMerkleTreeParameters;
     
     type RecordCommitmentScheme = BHPCompressedCommitment<EdwardsBls12, 48, 50>;
     type RecordCommitmentGadget = BHPCompressedCommitmentGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 48, 50>;
@@ -178,7 +178,7 @@ impl Parameters for Testnet1Parameters {
     dpc_setup!{local_data_commitment_scheme, LOCAL_DATA_COMMITMENT_SCHEME, LocalDataCommitmentScheme, "AleoLocalDataCommitment0"} // TODO (howardwu): Rename to "AleoLocalDataCommitmentScheme0".
     dpc_setup!{local_data_crh, LOCAL_DATA_CRH, LocalDataCRH, "AleoLocalDataCRH0"}
     dpc_setup!{program_commitment_scheme, PROGRAM_COMMITMENT_SCHEME, ProgramCommitmentScheme, "AleoProgramIDCommitment0"} // TODO (howardwu): Rename to "AleoProgramCommitmentScheme0".
-    dpc_setup!{program_id_crh, PROGRAM_ID_CRH, ProgramIDCRH, "AleoProgramIDCRH0"}
+    dpc_setup!{program_circuit_id_crh, PROGRAM_CIRCUIT_ID_CRH, ProgramCircuitIDCRH, "AleoProgramIDCRH0"} // TODO (howardwu): Rename to "AleoProgramCircuitIDCRH0".
     dpc_setup!{record_commitment_scheme, RECORD_COMMITMENT_SCHEME, RecordCommitmentScheme, "AleoRecordCommitment0"} // TODO (howardwu): Rename to "AleoRecordCommitmentScheme0".
     dpc_setup!{record_commitment_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoLedgerMerkleTreeCRH0"} // TODO (howardwu): Rename to "AleoRecordCommitmentTreeCRH0".
     dpc_setup!{record_serial_number_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoRecordSerialNumberTreeCRH0"}
@@ -199,10 +199,10 @@ impl Parameters for Testnet1Parameters {
 
     dpc_snark_setup_with_mode!{Testnet1Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{Testnet1Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
-
-    fn program_id_tree_parameters() -> &'static Self::ProgramIDTreeParameters {
-        static PROGRAM_ID_TREE_PARAMETERS: OnceCell<<Testnet1Parameters as Parameters>::ProgramIDTreeParameters> = OnceCell::new();
-        PROGRAM_ID_TREE_PARAMETERS.get_or_init(|| Self::ProgramIDTreeParameters::from(Self::program_id_crh().clone()))
+    
+    fn program_circuit_tree_parameters() -> &'static Self::ProgramCircuitTreeParameters {
+        static PROGRAM_ID_TREE_PARAMETERS: OnceCell<<Testnet1Parameters as Parameters>::ProgramCircuitTreeParameters> = OnceCell::new();
+        PROGRAM_ID_TREE_PARAMETERS.get_or_init(|| Self::ProgramCircuitTreeParameters::from(Self::program_circuit_id_crh().clone()))
     }
     
     fn record_commitment_tree_parameters() -> &'static Self::RecordCommitmentTreeParameters {

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -20,7 +20,7 @@ use crate::{
     Network,
     OuterCircuitVerifierInput,
     Parameters,
-    ProgramPublicVariables,
+    PublicVariables,
     Transaction,
     DPC,
 };
@@ -113,7 +113,7 @@ impl Parameters for Testnet1Parameters {
 
     type OuterSNARK = Groth16<Self::OuterCurve, OuterCircuitVerifierInput<Testnet1Parameters>>;
 
-    type ProgramSNARK = Groth16<Self::InnerCurve, ProgramPublicVariables<Self>>;
+    type ProgramSNARK = Groth16<Self::InnerCurve, PublicVariables<Self>>;
     type ProgramSNARKGadget = Groth16VerifierGadget<Self::InnerCurve, PairingGadget>;
 
     type AccountCommitmentScheme = BHPCompressedCommitment<EdwardsBls12, 33, 48>;

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -214,8 +214,8 @@ impl Parameters for Testnet2Parameters {
     dpc_snark_setup_with_mode!{Testnet2Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
 
-    dpc_snark_setup!{Testnet2Parameters, noop_program_proving_key, NOOP_PROGRAM_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop program proving key"}
-    dpc_snark_setup!{Testnet2Parameters, noop_program_verifying_key, NOOP_PROGRAM_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop program verifying key"}
+    dpc_snark_setup!{Testnet2Parameters, noop_circuit_proving_key, NOOP_CIRCUIT_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop circuit proving key"}
+    dpc_snark_setup!{Testnet2Parameters, noop_circuit_verifying_key, NOOP_CIRCUIT_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop circuit verifying key"}
 
     dpc_snark_setup_with_mode!{Testnet2Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -83,7 +83,7 @@ pub type Testnet2Transaction = Transaction<Testnet2Parameters>;
 
 define_merkle_tree_parameters!(
     ProgramIDMerkleTreeParameters,
-    <Testnet2Parameters as Parameters>::ProgramIDCRH,
+    <Testnet2Parameters as Parameters>::ProgramCircuitIDCRH,
     8
 );
 
@@ -169,10 +169,10 @@ impl Parameters for Testnet2Parameters {
     type ProgramCommitmentGadget = Blake2sCommitmentGadget;
     type ProgramCommitment = <Self::ProgramCommitmentScheme as CommitmentScheme>::Output;
 
-    type ProgramIDCRH = PoseidonCryptoHash<Self::OuterScalarField, 4, false>;
-    type ProgramIDCRHGadget = PoseidonCryptoHashGadget<Self::OuterScalarField, 4, false>;
-    type ProgramIDTreeDigest = <Self::ProgramIDCRH as CRH>::Output;
-    type ProgramIDTreeParameters = ProgramIDMerkleTreeParameters;
+    type ProgramCircuitIDCRH = PoseidonCryptoHash<Self::OuterScalarField, 4, false>;
+    type ProgramCircuitIDCRHGadget = PoseidonCryptoHashGadget<Self::OuterScalarField, 4, false>;
+    type ProgramCircuitID = <Self::ProgramCircuitIDCRH as CRH>::Output;
+    type ProgramCircuitTreeParameters = ProgramIDMerkleTreeParameters;
     
     type RecordCommitmentScheme = BHPCompressedCommitment<EdwardsBls12, 48, 50>;
     type RecordCommitmentGadget = BHPCompressedCommitmentGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget, 48, 50>;
@@ -198,7 +198,7 @@ impl Parameters for Testnet2Parameters {
     dpc_setup!{local_data_commitment_scheme, LOCAL_DATA_COMMITMENT_SCHEME, LocalDataCommitmentScheme, "AleoLocalDataCommitment0"} // TODO (howardwu): Rename to "AleoLocalDataCommitmentScheme0".
     dpc_setup!{local_data_crh, LOCAL_DATA_CRH, LocalDataCRH, "AleoLocalDataCRH0"}
     dpc_setup!{program_commitment_scheme, PROGRAM_COMMITMENT_SCHEME, ProgramCommitmentScheme, "AleoProgramIDCommitment0"} // TODO (howardwu): Rename to "AleoProgramCommitmentScheme0".
-    dpc_setup!{program_id_crh, PROGRAM_ID_CRH, ProgramIDCRH, "AleoProgramIDCRH0"}
+    dpc_setup!{program_circuit_id_crh, PROGRAM_CIRCUIT_ID_CRH, ProgramCircuitIDCRH, "AleoProgramIDCRH0"} // TODO (howardwu): Rename to "AleoProgramCircuitIDCRH0".
     dpc_setup!{record_commitment_scheme, RECORD_COMMITMENT_SCHEME, RecordCommitmentScheme, "AleoRecordCommitment0"} // TODO (howardwu): Rename to "AleoRecordCommitmentScheme0".
     dpc_setup!{record_commitment_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoLedgerMerkleTreeCRH0"} // TODO (howardwu): Rename to "AleoRecordCommitmentTreeCRH0".
     dpc_setup!{record_serial_number_tree_crh, RECORD_COMMITMENT_TREE_CRH, RecordCommitmentTreeCRH, "AleoRecordSerialNumberTreeCRH0"}
@@ -220,9 +220,9 @@ impl Parameters for Testnet2Parameters {
     dpc_snark_setup_with_mode!{Testnet2Parameters, outer_circuit_proving_key, OUTER_CIRCUIT_PROVING_KEY, OuterSNARK, ProvingKey, OuterSNARKPKParameters, "outer circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, outer_circuit_verifying_key, OUTER_CIRCUIT_VERIFYING_KEY, OuterSNARK, VerifyingKey, OuterSNARKVKParameters, "outer circuit verifying key"}
     
-    fn program_id_tree_parameters() -> &'static Self::ProgramIDTreeParameters {
-        static PROGRAM_ID_TREE_PARAMETERS: OnceCell<<Testnet2Parameters as Parameters>::ProgramIDTreeParameters> = OnceCell::new();
-        PROGRAM_ID_TREE_PARAMETERS.get_or_init(|| Self::ProgramIDTreeParameters::from(Self::program_id_crh().clone()))
+    fn program_circuit_tree_parameters() -> &'static Self::ProgramCircuitTreeParameters {
+        static PROGRAM_ID_TREE_PARAMETERS: OnceCell<<Testnet2Parameters as Parameters>::ProgramCircuitTreeParameters> = OnceCell::new();
+        PROGRAM_ID_TREE_PARAMETERS.get_or_init(|| Self::ProgramCircuitTreeParameters::from(Self::program_circuit_id_crh().clone()))
     }
     
     fn record_commitment_tree_parameters() -> &'static Self::RecordCommitmentTreeParameters {

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -20,7 +20,7 @@ use crate::{
     Network,
     OuterCircuitVerifierInput,
     Parameters,
-    ProgramPublicVariables,
+    PublicVariables,
     Transaction,
     DPC,
 };
@@ -127,7 +127,7 @@ impl Parameters for Testnet2Parameters {
         MarlinKZG10<Self::InnerCurve>,
         FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::OuterScalarField, PoseidonSponge<Self::OuterScalarField>>,
         MarlinTestnet2Mode,
-        ProgramPublicVariables<Self>,
+        PublicVariables<Self>,
     >;
     type ProgramSNARKGadget = MarlinVerificationGadget<
         Self::InnerScalarField,

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -214,6 +214,11 @@ impl Parameters for Testnet2Parameters {
     dpc_snark_setup_with_mode!{Testnet2Parameters, inner_circuit_proving_key, INNER_CIRCUIT_PROVING_KEY, InnerSNARK, ProvingKey, InnerSNARKPKParameters, "inner circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, inner_circuit_verifying_key, INNER_CIRCUIT_VERIFYING_KEY, InnerSNARK, VerifyingKey, InnerSNARKVKParameters, "inner circuit verifying key"}
 
+    fn noop_circuit_id() -> &'static Self::ProgramCircuitID {
+        static NOOP_CIRCUIT_ID: OnceCell<<Testnet2Parameters as Parameters>::InnerCircuitID> = OnceCell::new();
+        NOOP_CIRCUIT_ID.get_or_init(|| Self::program_circuit_id(Self::noop_circuit_verifying_key()).expect("Failed to hash noop circuit verifying key"))
+    }
+    
     dpc_snark_setup!{Testnet2Parameters, noop_circuit_proving_key, NOOP_CIRCUIT_PROVING_KEY, ProgramSNARK, ProvingKey, NoopProgramSNARKPKParameters, "noop circuit proving key"}
     dpc_snark_setup!{Testnet2Parameters, noop_circuit_verifying_key, NOOP_CIRCUIT_VERIFYING_KEY, ProgramSNARK, VerifyingKey, NoopProgramSNARKVKParameters, "noop circuit verifying key"}
 

--- a/dpc/src/program/executable.rs
+++ b/dpc/src/program/executable.rs
@@ -18,10 +18,11 @@ use crate::{
     Execution,
     LocalData,
     NoopPrivateVariables,
+    NoopProgram,
     Parameters,
+    PrivateVariables,
     Program,
-    ProgramPrivateVariables,
-    ProgramPublicVariables,
+    PublicVariables,
 };
 
 use anyhow::Result;
@@ -30,18 +31,15 @@ use std::{ops::Deref, sync::Arc};
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"))]
 pub enum Executable<C: Parameters> {
-    Noop(Arc<dyn Program<C>>, C::ProgramCircuitID),
-    Circuit(
-        Arc<dyn Program<C>>,
-        C::ProgramCircuitID,
-        Arc<dyn ProgramPrivateVariables<C>>,
-    ),
+    Noop(Arc<NoopProgram<C>>, C::ProgramCircuitID),
+    Circuit(Arc<dyn Program<C>>, C::ProgramCircuitID, Arc<dyn PrivateVariables<C>>),
 }
 
 impl<C: Parameters> Executable<C> {
+    /// Returns the execution of the executable given the public variables.
     pub fn execute(&self, record_position: u8, local_data: &LocalData<C>) -> Result<Execution<C>> {
         // Construct the public variables.
-        let public_variables = ProgramPublicVariables::new(record_position, local_data.root());
+        let public_variables = PublicVariables::new(record_position, local_data.root());
         // Execute the program circuit with the declared private variables.
         match self {
             Self::Noop(program, circuit_id) => {

--- a/dpc/src/program/executable.rs
+++ b/dpc/src/program/executable.rs
@@ -1,0 +1,55 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    Execution,
+    LocalData,
+    NoopPrivateVariables,
+    Parameters,
+    Program,
+    ProgramPrivateVariables,
+    ProgramPublicVariables,
+};
+
+use anyhow::Result;
+use std::{ops::Deref, sync::Arc};
+
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: Parameters"))]
+pub enum Executable<C: Parameters> {
+    Noop(Arc<dyn Program<C>>, C::ProgramCircuitID),
+    Circuit(
+        Arc<dyn Program<C>>,
+        C::ProgramCircuitID,
+        Arc<dyn ProgramPrivateVariables<C>>,
+    ),
+}
+
+impl<C: Parameters> Executable<C> {
+    pub fn execute(&self, record_position: u8, local_data: &LocalData<C>) -> Result<Execution<C>> {
+        // Construct the public variables.
+        let public_variables = ProgramPublicVariables::new(record_position, local_data.root());
+        // Execute the program circuit with the declared private variables.
+        match self {
+            Self::Noop(program, circuit_id) => {
+                Ok(program.execute(circuit_id, &public_variables, &NoopPrivateVariables::new())?)
+            }
+            Self::Circuit(program, circuit_id, private_variables) => {
+                Ok(program.execute(circuit_id, &public_variables, private_variables.deref())?)
+            }
+        }
+    }
+}

--- a/dpc/src/program/execution.rs
+++ b/dpc/src/program/execution.rs
@@ -14,20 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod executable;
-pub use executable::*;
+use crate::Parameters;
+use snarkvm_algorithms::{merkle_tree::MerklePath, SNARK};
 
-pub mod execution;
-pub use execution::*;
-
-pub mod noop_circuit;
-pub use noop_circuit::*;
-
-pub mod noop_program;
-pub use noop_program::*;
-
-pub mod program_circuit_tree;
-pub use program_circuit_tree::*;
-
-pub mod public_variables;
-pub use public_variables::*;
+/// Program index, path, verifying key, and proof.
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: Parameters"))]
+pub struct Execution<C: Parameters> {
+    pub program_path: MerklePath<C::ProgramCircuitTreeParameters>,
+    pub verifying_key: <C::ProgramSNARK as SNARK>::VerifyingKey,
+    pub proof: <C::ProgramSNARK as SNARK>::Proof,
+}

--- a/dpc/src/program/mod.rs
+++ b/dpc/src/program/mod.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod program_circuit_tree;
-pub use program_circuit_tree::*;
+pub mod executable;
+pub use executable::*;
 
 pub mod noop_circuit;
 pub use noop_circuit::*;
@@ -25,3 +25,6 @@ pub use noop_program::*;
 
 pub mod program;
 pub use program::*;
+
+pub mod program_circuit_tree;
+pub use program_circuit_tree::*;

--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -26,6 +26,12 @@ pub struct NoopPrivateVariables<C: Parameters>(PhantomData<C>);
 
 impl<C: Parameters> ProgramPrivateVariables<C> for NoopPrivateVariables<C> {}
 
+impl<C: Parameters> ProgramPrivateVariables<C> for NoopPrivateVariables<C> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 impl<C: Parameters> NoopPrivateVariables<C> {
     pub fn new() -> Self {
         Self(PhantomData)

--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{CircuitError, Parameters, ProgramCircuit, ProgramPrivateVariables, ProgramPublicVariables};
+use crate::{CircuitError, Parameters, PrivateVariables, ProgramCircuit, PublicVariables};
 use snarkvm_algorithms::prelude::*;
 use snarkvm_gadgets::prelude::*;
 use snarkvm_r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 
 pub struct NoopPrivateVariables<C: Parameters>(PhantomData<C>);
 
-impl<C: Parameters> ProgramPrivateVariables<C> for NoopPrivateVariables<C> {
+impl<C: Parameters> PrivateVariables<C> for NoopPrivateVariables<C> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -88,8 +88,8 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
     /// Executes the circuit, returning an proof.
     fn execute(
         &self,
-        public: &ProgramPublicVariables<C>,
-        _private: &dyn ProgramPrivateVariables<C>,
+        public: &PublicVariables<C>,
+        _private: &dyn PrivateVariables<C>,
     ) -> Result<<C::ProgramSNARK as SNARK>::Proof, CircuitError> {
         // Compute the proof.
         let rng = &mut rand::thread_rng();
@@ -109,7 +109,7 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
     }
 
     /// Returns true if the execution of the circuit is valid.
-    fn verify(&self, public: &ProgramPublicVariables<C>, proof: &<C::ProgramSNARK as SNARK>::Proof) -> bool {
+    fn verify(&self, public: &PublicVariables<C>, proof: &<C::ProgramSNARK as SNARK>::Proof) -> bool {
         <C::ProgramSNARK as SNARK>::verify(&self.verifying_key.clone().into(), public, proof)
             .expect("Failed to verify program execution proof")
     }
@@ -118,7 +118,7 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
 #[derive(Derivative)]
 #[derivative(Default(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
 struct NoopAllocatedCircuit<C: Parameters> {
-    public: ProgramPublicVariables<C>,
+    public: PublicVariables<C>,
 }
 
 impl<C: Parameters> ConstraintSynthesizer<C::InnerScalarField> for NoopAllocatedCircuit<C> {

--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -24,8 +24,6 @@ use std::marker::PhantomData;
 
 pub struct NoopPrivateVariables<C: Parameters>(PhantomData<C>);
 
-impl<C: Parameters> ProgramPrivateVariables<C> for NoopPrivateVariables<C> {}
-
 impl<C: Parameters> ProgramPrivateVariables<C> for NoopPrivateVariables<C> {
     fn as_any(&self) -> &dyn std::any::Any {
         self

--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -63,8 +63,8 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
 
     /// Loads an instance of the noop circuit.
     fn load() -> Result<Self, CircuitError> {
-        let proving_key = C::noop_program_proving_key().clone();
-        let verifying_key = C::noop_program_verifying_key().clone();
+        let proving_key = C::noop_circuit_proving_key().clone();
+        let verifying_key = C::noop_circuit_verifying_key().clone();
 
         Ok(Self {
             circuit_id: <C as Parameters>::program_circuit_id(&verifying_key)?,

--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -63,13 +63,10 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
 
     /// Loads an instance of the noop circuit.
     fn load() -> Result<Self, CircuitError> {
-        let proving_key = C::noop_circuit_proving_key().clone();
-        let verifying_key = C::noop_circuit_verifying_key().clone();
-
         Ok(Self {
-            circuit_id: <C as Parameters>::program_circuit_id(&verifying_key)?,
-            proving_key,
-            verifying_key,
+            circuit_id: C::noop_circuit_id().clone(),
+            proving_key: C::noop_circuit_proving_key().clone(),
+            verifying_key: C::noop_circuit_verifying_key().clone(),
         })
     }
 

--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -35,7 +35,7 @@ impl<C: Parameters> NoopPrivateVariables<C> {
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
 pub struct NoopCircuit<C: Parameters> {
-    circuit_id: <C::ProgramIDCRH as CRH>::Output,
+    circuit_id: <C::ProgramCircuitIDCRH as CRH>::Output,
     #[derivative(Debug = "ignore")]
     proving_key: <C::ProgramSNARK as SNARK>::ProvingKey,
     #[derivative(Debug = "ignore")]
@@ -52,8 +52,7 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
         let verifying_key: <C::ProgramSNARK as SNARK>::VerifyingKey = prepared_verifying_key.into();
 
         // Compute the noop circuit ID.
-        let circuit_id =
-            <C as Parameters>::program_id_crh().hash_field_elements(&verifying_key.to_field_elements()?)?;
+        let circuit_id = <C as Parameters>::program_circuit_id(&verifying_key)?;
 
         Ok(Self {
             circuit_id,
@@ -69,7 +68,7 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
 
         // Compute the circuit ID.
         let circuit_id =
-            <C as Parameters>::program_id_crh().hash_field_elements(&verifying_key.to_field_elements()?)?;
+            <C as Parameters>::program_circuit_id_crh().hash_field_elements(&verifying_key.to_field_elements()?)?;
 
         Ok(Self {
             circuit_id,
@@ -79,7 +78,7 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
     }
 
     /// Returns the circuit ID.
-    fn circuit_id(&self) -> &<C::ProgramIDCRH as CRH>::Output {
+    fn circuit_id(&self) -> &<C::ProgramCircuitIDCRH as CRH>::Output {
         &self.circuit_id
     }
 

--- a/dpc/src/program/noop_circuit.rs
+++ b/dpc/src/program/noop_circuit.rs
@@ -39,7 +39,7 @@ impl<C: Parameters> NoopPrivateVariables<C> {
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
 pub struct NoopCircuit<C: Parameters> {
-    circuit_id: <C::ProgramCircuitIDCRH as CRH>::Output,
+    circuit_id: C::ProgramCircuitID,
     #[derivative(Debug = "ignore")]
     proving_key: <C::ProgramSNARK as SNARK>::ProvingKey,
     #[derivative(Debug = "ignore")]
@@ -82,7 +82,7 @@ impl<C: Parameters> ProgramCircuit<C> for NoopCircuit<C> {
     }
 
     /// Returns the circuit ID.
-    fn circuit_id(&self) -> &<C::ProgramCircuitIDCRH as CRH>::Output {
+    fn circuit_id(&self) -> &C::ProgramCircuitID {
         &self.circuit_id
     }
 

--- a/dpc/src/program/noop_program.rs
+++ b/dpc/src/program/noop_program.rs
@@ -60,7 +60,7 @@ impl<C: Parameters> Program<C> for NoopProgram<C> {
     }
 
     /// Returns the program ID.
-    fn program_id(&self) -> &MerkleTreeDigest<C::ProgramIDTreeParameters> {
+    fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters> {
         self.circuit_tree.to_program_id()
     }
 

--- a/dpc/src/program/noop_program.rs
+++ b/dpc/src/program/noop_program.rs
@@ -18,12 +18,12 @@ use crate::{
     Execution,
     NoopCircuit,
     Parameters,
+    PrivateVariables,
     Program,
     ProgramCircuit,
     ProgramCircuitTree,
     ProgramError,
-    ProgramPrivateVariables,
-    ProgramPublicVariables,
+    PublicVariables,
 };
 use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, prelude::*};
 
@@ -82,8 +82,8 @@ impl<C: Parameters> Program<C> for NoopProgram<C> {
     fn execute(
         &self,
         circuit_id: &C::ProgramCircuitID,
-        public: &ProgramPublicVariables<C>,
-        private: &dyn ProgramPrivateVariables<C>,
+        public: &PublicVariables<C>,
+        private: &dyn PrivateVariables<C>,
     ) -> Result<Execution<C>, ProgramError> {
         // Fetch the circuit from the tree.
         let circuit = match self.circuits.get_circuit(circuit_id) {

--- a/dpc/src/program/noop_program.rs
+++ b/dpc/src/program/noop_program.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
 pub struct NoopProgram<C: Parameters> {
-    circuit_tree: Arc<ProgramCircuitTree<C>>,
+    circuits: Arc<ProgramCircuitTree<C>>,
 }
 
 impl<C: Parameters> Program<C> for NoopProgram<C> {
@@ -44,7 +44,7 @@ impl<C: Parameters> Program<C> for NoopProgram<C> {
         circuit_tree.add_all(vec![Box::new(NoopCircuit::setup(rng)?)])?;
 
         Ok(Self {
-            circuit_tree: Arc::new(circuit_tree),
+            circuits: Arc::new(circuit_tree),
         })
     }
 
@@ -55,64 +55,71 @@ impl<C: Parameters> Program<C> for NoopProgram<C> {
         circuit_tree.add(Box::new(NoopCircuit::load()?))?;
 
         Ok(Self {
-            circuit_tree: Arc::new(circuit_tree),
+            circuits: Arc::new(circuit_tree),
         })
     }
 
     /// Returns the program ID.
     fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters> {
-        self.circuit_tree.to_program_id()
+        self.circuits.to_program_id()
     }
 
-    fn get_circuit(&self, circuit_index: u8) -> Result<&Box<dyn ProgramCircuit<C>>, ProgramError> {
-        // Fetch the circuit from the tree.
-        match self.circuit_tree.get_circuit(circuit_index) {
-            Some(circuit) => Ok(circuit),
-            _ => Err(MerkleError::MissingLeafIndex(circuit_index as usize).into()),
-        }
+    /// Returns `true` if the given circuit ID exists in the program.
+    fn contains_circuit(&self, circuit_id: &C::ProgramCircuitID) -> bool {
+        self.circuits.contains_circuit(circuit_id)
+    }
+
+    /// Returns the circuit given the circuit ID, if it exists.
+    fn get_circuit(&self, circuit_id: &C::ProgramCircuitID) -> Option<&Box<dyn ProgramCircuit<C>>> {
+        self.circuits.get_circuit(circuit_id)
+    }
+
+    /// Returns the circuit given the circuit index, if it exists.
+    fn find_circuit_by_index(&self, circuit_index: u8) -> Option<&Box<dyn ProgramCircuit<C>>> {
+        self.circuits.find_circuit_by_index(circuit_index)
     }
 
     fn execute(
         &self,
-        circuit_index: u8,
+        circuit_id: &C::ProgramCircuitID,
         public: &ProgramPublicVariables<C>,
         private: &dyn ProgramPrivateVariables<C>,
     ) -> Result<Execution<C>, ProgramError> {
         // Fetch the circuit from the tree.
-        let circuit = match self.circuit_tree.get_circuit(circuit_index) {
+        let circuit = match self.circuits.get_circuit(circuit_id) {
             Some(circuit) => circuit,
-            _ => return Err(MerkleError::MissingLeafIndex(circuit_index as usize).into()),
+            _ => return Err(MerkleError::MissingLeaf(format!("{}", circuit_id)).into()),
         };
+        debug_assert_eq!(circuit.circuit_id(), circuit_id);
 
-        let program_path = self.circuit_tree.get_program_path(circuit_index)?;
-        debug_assert!(program_path.verify(self.program_id(), &circuit.circuit_id())?);
+        let program_path = self.circuits.get_program_path(circuit_id)?;
+        debug_assert!(program_path.verify(self.program_id(), circuit_id)?);
 
         let proof = circuit.execute(public, private)?;
         let verifying_key = circuit.verifying_key().clone();
 
         Ok(Execution {
-            circuit_index,
             program_path,
             verifying_key,
             proof,
         })
     }
 
-    fn execute_blank(&self, circuit_index: u8) -> Result<Execution<C>, ProgramError> {
+    fn execute_blank(&self, circuit_id: &C::ProgramCircuitID) -> Result<Execution<C>, ProgramError> {
         // Fetch the circuit from the tree.
-        let circuit = match self.circuit_tree.get_circuit(circuit_index) {
+        let circuit = match self.circuits.get_circuit(circuit_id) {
             Some(circuit) => circuit,
-            _ => return Err(MerkleError::MissingLeafIndex(circuit_index as usize).into()),
+            _ => return Err(MerkleError::MissingLeaf(format!("{}", circuit_id)).into()),
         };
+        debug_assert_eq!(circuit.circuit_id(), circuit_id);
 
-        let program_path = self.circuit_tree.get_program_path(circuit_index)?;
-        debug_assert!(program_path.verify(self.program_id(), &circuit.circuit_id())?);
+        let program_path = self.circuits.get_program_path(circuit_id)?;
+        debug_assert!(program_path.verify(self.program_id(), circuit_id)?);
 
         let proof = circuit.execute_blank()?;
         let verifying_key = circuit.verifying_key().clone();
 
         Ok(Execution {
-            circuit_index,
             program_path,
             verifying_key,
             proof,

--- a/dpc/src/program/program.rs
+++ b/dpc/src/program/program.rs
@@ -22,7 +22,6 @@ use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"))]
 pub struct Execution<C: Parameters> {
-    pub circuit_index: u8,
     pub program_path: MerklePath<C::ProgramCircuitTreeParameters>,
     pub verifying_key: <C::ProgramSNARK as SNARK>::VerifyingKey,
     pub proof: <C::ProgramSNARK as SNARK>::Proof,

--- a/dpc/src/program/program.rs
+++ b/dpc/src/program/program.rs
@@ -39,7 +39,7 @@ pub struct ProgramPublicVariables<C: Parameters> {
 }
 
 impl<C: Parameters> ProgramPublicVariables<C> {
-    pub fn new(local_data_root: &C::LocalDataRoot, record_position: u8) -> Self {
+    pub fn new(record_position: u8, local_data_root: &C::LocalDataRoot) -> Self {
         Self {
             local_data_root: local_data_root.clone(),
             record_position,

--- a/dpc/src/program/program.rs
+++ b/dpc/src/program/program.rs
@@ -23,7 +23,7 @@ use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
 #[derivative(Clone(bound = "C: Parameters"))]
 pub struct Execution<C: Parameters> {
     pub circuit_index: u8,
-    pub program_path: MerklePath<C::ProgramIDTreeParameters>,
+    pub program_path: MerklePath<C::ProgramCircuitTreeParameters>,
     pub verifying_key: <C::ProgramSNARK as SNARK>::VerifyingKey,
     pub proof: <C::ProgramSNARK as SNARK>::Proof,
 }

--- a/dpc/src/program/program_circuit_tree.rs
+++ b/dpc/src/program/program_circuit_tree.rs
@@ -30,7 +30,7 @@ pub struct ProgramCircuitTree<C: Parameters> {
     #[derivative(Debug = "ignore")]
     tree: MerkleTree<C::ProgramCircuitTreeParameters>,
     #[derivative(Debug = "ignore")]
-    circuits: HashMap<u8, Box<dyn ProgramCircuit<C>>>,
+    circuits: HashMap<C::ProgramCircuitID, (u8, Box<dyn ProgramCircuit<C>>)>,
     last_circuit_index: u8,
 }
 
@@ -50,11 +50,18 @@ impl<C: Parameters> ProgramCircuitTree<C> {
     /// TODO (howardwu): Add safety checks for u8 (max 255 circuits).
     /// Adds the given circuit to the tree, returning its circuit index in the tree.
     pub fn add(&mut self, circuit: Box<dyn ProgramCircuit<C>>) -> Result<u8> {
+        // Ensure the circuit does not already exist in the tree.
+        if self.contains_circuit(circuit.circuit_id()) {
+            return Err(MerkleError::MissingLeaf(format!("{}", circuit.circuit_id())).into());
+        }
+
         self.tree = self
             .tree
             .rebuild(self.last_circuit_index as usize, &[circuit.circuit_id()])?;
 
-        self.circuits.insert(self.last_circuit_index, circuit);
+        self.circuits
+            .insert(circuit.circuit_id().clone(), (self.last_circuit_index, circuit));
+
         self.last_circuit_index += 1;
         Ok(self.last_circuit_index - 1)
     }
@@ -67,6 +74,12 @@ impl<C: Parameters> ProgramCircuitTree<C> {
             return Err(anyhow!("The list of of circuits must be non-empty"));
         }
 
+        // Ensure the circuits do not already exist in the tree.
+        let circuits: Vec<_> = circuits
+            .into_iter()
+            .filter(|c| !self.contains_circuit(c.circuit_id()))
+            .collect();
+
         self.tree = self.tree.rebuild(
             self.last_circuit_index as usize,
             &circuits.iter().map(|c| c.circuit_id()).collect::<Vec<_>>(),
@@ -74,33 +87,53 @@ impl<C: Parameters> ProgramCircuitTree<C> {
 
         let start_index = self.last_circuit_index;
         let num_circuits = circuits.len();
+
         self.circuits.extend(
             circuits
                 .into_iter()
                 .enumerate()
-                .map(|(index, circuit)| (start_index + index as u8, circuit)),
+                .map(|(index, circuit)| (circuit.circuit_id().clone(), (start_index + index as u8, circuit))),
         );
+
         self.last_circuit_index += num_circuits as u8;
         let end_index = self.last_circuit_index - 1;
 
         Ok((start_index, end_index))
     }
 
+    /// Returns `true` if the given circuit ID exists.
+    pub fn contains_circuit(&self, circuit_id: &C::ProgramCircuitID) -> bool {
+        self.circuits.get(circuit_id).is_some()
+    }
+
+    /// Returns the circuit index given the circuit ID, if it exists.
+    pub fn get_circuit_index(&self, circuit_id: &C::ProgramCircuitID) -> Option<u8> {
+        self.circuits.get(circuit_id).and_then(|(index, _)| Some(*index))
+    }
+
+    /// Returns the circuit given the circuit ID, if it exists.
+    pub fn get_circuit(&self, circuit_id: &C::ProgramCircuitID) -> Option<&Box<dyn ProgramCircuit<C>>> {
+        self.circuits.get(circuit_id).and_then(|(__, circuit)| Some(circuit))
+    }
+
     /// Returns the circuit given the circuit index, if it exists.
-    pub fn get_circuit(&self, circuit_index: u8) -> Option<&Box<dyn ProgramCircuit<C>>> {
-        self.circuits.get(&circuit_index)
+    pub fn find_circuit_by_index(&self, circuit_index: u8) -> Option<&Box<dyn ProgramCircuit<C>>> {
+        self.circuits
+            .iter()
+            .find_map(|(_, (index, circuit))| match *index == circuit_index {
+                true => Some(circuit),
+                false => None,
+            })
     }
 
-    /// Returns the circuit ID given the circuit index, if it exists.
-    pub fn get_circuit_id(&self, circuit_index: u8) -> Option<&C::ProgramCircuitID> {
-        self.circuits.get(&circuit_index).and_then(|c| Some(c.circuit_id()))
-    }
-
-    /// Returns the program path (the Merkle path for a given circuit index).
-    pub fn get_program_path(&self, circuit_index: u8) -> Result<MerklePath<C::ProgramCircuitTreeParameters>> {
-        match self.get_circuit(circuit_index) {
-            Some(circuit) => Ok(self.tree.generate_proof(circuit_index as usize, circuit.circuit_id())?),
-            _ => Err(MerkleError::MissingLeafIndex(circuit_index as usize).into()),
+    /// Returns the program path (the Merkle path for a given circuit ID).
+    pub fn get_program_path(
+        &self,
+        circuit_id: &C::ProgramCircuitID,
+    ) -> Result<MerklePath<C::ProgramCircuitTreeParameters>> {
+        match self.get_circuit_index(circuit_id) {
+            Some(index) => Ok(self.tree.generate_proof(index as usize, circuit_id)?),
+            _ => Err(MerkleError::MissingLeaf(format!("{}", circuit_id)).into()),
         }
     }
 

--- a/dpc/src/program/program_circuit_tree.rs
+++ b/dpc/src/program/program_circuit_tree.rs
@@ -28,7 +28,7 @@ use std::{collections::HashMap, sync::Arc};
 #[derivative(Debug(bound = "C: Parameters"))]
 pub struct ProgramCircuitTree<C: Parameters> {
     #[derivative(Debug = "ignore")]
-    tree: MerkleTree<C::ProgramIDTreeParameters>,
+    tree: MerkleTree<C::ProgramCircuitTreeParameters>,
     #[derivative(Debug = "ignore")]
     circuits: HashMap<u8, Box<dyn ProgramCircuit<C>>>,
     last_circuit_index: u8,
@@ -38,8 +38,8 @@ impl<C: Parameters> ProgramCircuitTree<C> {
     /// Initializes an empty circuit tree.
     pub fn new() -> Result<Self> {
         Ok(Self {
-            tree: MerkleTree::<C::ProgramIDTreeParameters>::new::<<C::ProgramIDCRH as CRH>::Output>(
-                Arc::new(C::program_id_tree_parameters().clone()),
+            tree: MerkleTree::<C::ProgramCircuitTreeParameters>::new::<<C::ProgramCircuitIDCRH as CRH>::Output>(
+                Arc::new(C::program_circuit_tree_parameters().clone()),
                 &vec![],
             )?,
             circuits: Default::default(),
@@ -92,12 +92,12 @@ impl<C: Parameters> ProgramCircuitTree<C> {
     }
 
     /// Returns the circuit ID given the circuit index, if it exists.
-    pub fn get_circuit_id(&self, circuit_index: u8) -> Option<&<C::ProgramIDCRH as CRH>::Output> {
+    pub fn get_circuit_id(&self, circuit_index: u8) -> Option<&<C::ProgramCircuitIDCRH as CRH>::Output> {
         self.circuits.get(&circuit_index).and_then(|c| Some(c.circuit_id()))
     }
 
     /// Returns the program path (the Merkle path for a given circuit index).
-    pub fn get_program_path(&self, circuit_index: u8) -> Result<MerklePath<C::ProgramIDTreeParameters>> {
+    pub fn get_program_path(&self, circuit_index: u8) -> Result<MerklePath<C::ProgramCircuitTreeParameters>> {
         match self.get_circuit(circuit_index) {
             Some(circuit) => Ok(self.tree.generate_proof(circuit_index as usize, circuit.circuit_id())?),
             _ => Err(MerkleError::MissingLeafIndex(circuit_index as usize).into()),
@@ -105,7 +105,7 @@ impl<C: Parameters> ProgramCircuitTree<C> {
     }
 
     /// Returns the program ID.
-    pub fn to_program_id(&self) -> &MerkleTreeDigest<C::ProgramIDTreeParameters> {
+    pub fn to_program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters> {
         self.tree.root()
     }
 }

--- a/dpc/src/program/program_circuit_tree.rs
+++ b/dpc/src/program/program_circuit_tree.rs
@@ -38,7 +38,7 @@ impl<C: Parameters> ProgramCircuitTree<C> {
     /// Initializes an empty circuit tree.
     pub fn new() -> Result<Self> {
         Ok(Self {
-            tree: MerkleTree::<C::ProgramCircuitTreeParameters>::new::<<C::ProgramCircuitIDCRH as CRH>::Output>(
+            tree: MerkleTree::<C::ProgramCircuitTreeParameters>::new::<C::ProgramCircuitID>(
                 Arc::new(C::program_circuit_tree_parameters().clone()),
                 &vec![],
             )?,
@@ -92,7 +92,7 @@ impl<C: Parameters> ProgramCircuitTree<C> {
     }
 
     /// Returns the circuit ID given the circuit index, if it exists.
-    pub fn get_circuit_id(&self, circuit_index: u8) -> Option<&<C::ProgramCircuitIDCRH as CRH>::Output> {
+    pub fn get_circuit_id(&self, circuit_index: u8) -> Option<&C::ProgramCircuitID> {
         self.circuits.get(&circuit_index).and_then(|c| Some(c.circuit_id()))
     }
 

--- a/dpc/src/program/public_variables.rs
+++ b/dpc/src/program/public_variables.rs
@@ -15,17 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::Parameters;
-use snarkvm_algorithms::{merkle_tree::MerklePath, SNARK};
 use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
-
-/// Program index, path, verifying key, and proof.
-#[derive(Derivative)]
-#[derivative(Clone(bound = "C: Parameters"))]
-pub struct Execution<C: Parameters> {
-    pub program_path: MerklePath<C::ProgramCircuitTreeParameters>,
-    pub verifying_key: <C::ProgramSNARK as SNARK>::VerifyingKey,
-    pub proof: <C::ProgramSNARK as SNARK>::Proof,
-}
 
 #[derive(Derivative)]
 #[derivative(
@@ -33,22 +23,22 @@ pub struct Execution<C: Parameters> {
     Debug(bound = "C: Parameters"),
     Default(bound = "C: Parameters")
 )]
-pub struct ProgramPublicVariables<C: Parameters> {
-    pub local_data_root: C::LocalDataRoot,
+pub struct PublicVariables<C: Parameters> {
     pub record_position: u8,
+    pub local_data_root: C::LocalDataRoot,
 }
 
-impl<C: Parameters> ProgramPublicVariables<C> {
+impl<C: Parameters> PublicVariables<C> {
     pub fn new(record_position: u8, local_data_root: &C::LocalDataRoot) -> Self {
         Self {
-            local_data_root: local_data_root.clone(),
             record_position,
+            local_data_root: local_data_root.clone(),
         }
     }
 }
 
-/// Converts the program public variables into bytes and packs them into field elements.
-impl<C: Parameters> ToConstraintField<C::InnerScalarField> for ProgramPublicVariables<C> {
+/// Converts the public variables into bytes and packs them into field elements.
+impl<C: Parameters> ToConstraintField<C::InnerScalarField> for PublicVariables<C> {
     fn to_field_elements(&self) -> Result<Vec<C::InnerScalarField>, ConstraintFieldError> {
         let mut v = ToConstraintField::<C::InnerScalarField>::to_field_elements(&[self.record_position][..])?;
         v.extend_from_slice(&self.local_data_root.to_field_elements()?);

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -106,7 +106,7 @@ impl<C: Parameters> EncryptedRecord<C> {
         let mut cursor = Cursor::new(plaintext);
 
         // Program ID
-        let program_id_length = to_bytes_le!(<C::ProgramIDCRH as CRH>::Output::default())?.len();
+        let program_id_length = to_bytes_le!(<C::ProgramCircuitIDCRH as CRH>::Output::default())?.len();
         let program_id = {
             let mut program_id = vec![0u8; program_id_length];
             cursor.read_exact(&mut program_id)?;

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -131,12 +131,7 @@ impl<C: Parameters> EncryptedRecord<C> {
         // Determine if the record is a dummy
         // TODO (raychu86) Establish `is_dummy` flag properly by checking that the value is 0 and the programs are equivalent to a global dummy
         let dummy_program = program_id.clone();
-
         let is_dummy = (value == 0) && (payload == Payload::default()) && (program_id == dummy_program);
-
-        // Calculate record commitment
-        let commitment_input = to_bytes_le![program_id, owner, is_dummy, value, payload, serial_number_nonce]?;
-        let commitment = C::record_commitment_scheme().commit(&commitment_input, &commitment_randomness)?;
 
         Ok(Record::from(
             &program_id,
@@ -145,9 +140,8 @@ impl<C: Parameters> EncryptedRecord<C> {
             value,
             payload,
             serial_number_nonce,
-            commitment,
             commitment_randomness,
-        ))
+        )?)
     }
 
     /// Returns the encrypted record hash.

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -106,7 +106,7 @@ impl<C: Parameters> EncryptedRecord<C> {
         let mut cursor = Cursor::new(plaintext);
 
         // Program ID
-        let program_id_length = to_bytes_le!(<C::ProgramCircuitIDCRH as CRH>::Output::default())?.len();
+        let program_id_length = to_bytes_le!(C::ProgramCircuitID::default())?.len();
         let program_id = {
             let mut program_id = vec![0u8; program_id_length];
             cursor.read_exact(&mut program_id)?;

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -153,10 +153,7 @@ impl<C: Parameters> EncryptedRecord<C> {
 
 impl<C: Parameters> Default for EncryptedRecord<C> {
     fn default() -> Self {
-        let default_record = Record::<C>::default();
-        let mut rng = thread_rng();
-
-        let (record, _randomness) = Self::encrypt(&default_record, &mut rng).unwrap();
+        let (record, _randomness) = Self::encrypt(&Record::default(), &mut thread_rng()).unwrap();
         record
     }
 }

--- a/dpc/src/record/payload.rs
+++ b/dpc/src/record/payload.rs
@@ -24,6 +24,10 @@ pub const PAYLOAD_SIZE: usize = 128;
 pub struct Payload([u8; PAYLOAD_SIZE]);
 
 impl Payload {
+    pub fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     pub fn to_bytes(&self) -> &[u8] {
         &self.0[..]
     }

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Address, Parameters, Payload, PrivateKey, Program, RecordError, RecordScheme};
+use crate::{Address, NoopProgram, Parameters, Payload, PrivateKey, Program, RecordError, RecordScheme};
 use snarkvm_algorithms::traits::{CommitmentScheme, SignatureScheme, CRH, PRF};
 use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
 
@@ -53,11 +53,11 @@ pub struct Record<C: Parameters> {
 impl<C: Parameters> Record<C> {
     /// Returns a new noop input record.
     pub fn new_noop_input<R: Rng + CryptoRng>(
-        noop_program: &dyn Program<C>,
+        noop_program: &NoopProgram<C>,
         owner: Address<C>,
         rng: &mut R,
     ) -> Result<Self, RecordError> {
-        Ok(Self::new_input(
+        Self::new_input(
             noop_program,
             owner,
             true,
@@ -65,18 +65,18 @@ impl<C: Parameters> Record<C> {
             Payload::default(),
             C::serial_number_nonce_crh().hash(&rng.gen::<[u8; 32]>())?,
             rng,
-        )?)
+        )
     }
 
     /// Returns a new noop output record.
     pub fn new_noop_output<R: Rng + CryptoRng>(
-        noop_program: &dyn Program<C>,
+        noop_program: &NoopProgram<C>,
         owner: Address<C>,
         position: u8,
         joint_serial_numbers: Vec<u8>,
         rng: &mut R,
     ) -> Result<Self, RecordError> {
-        Ok(Self::new_output(
+        Self::new_output(
             noop_program,
             owner,
             true,
@@ -85,7 +85,7 @@ impl<C: Parameters> Record<C> {
             position,
             joint_serial_numbers,
             rng,
-        )?)
+        )
     }
 
     /// Returns a new input record.
@@ -102,7 +102,7 @@ impl<C: Parameters> Record<C> {
         // Sample a new record commitment randomness.
         let commitment_randomness = <C::RecordCommitmentScheme as CommitmentScheme>::Randomness::rand(rng);
 
-        Ok(Self::from(
+        Self::from(
             &program.program_id().to_bytes_le()?,
             owner,
             is_dummy,
@@ -110,7 +110,7 @@ impl<C: Parameters> Record<C> {
             payload,
             serial_number_nonce,
             commitment_randomness,
-        )?)
+        )
     }
 
     /// Returns a new output record.
@@ -135,7 +135,7 @@ impl<C: Parameters> Record<C> {
         // Sample a new record commitment randomness.
         let commitment_randomness = <C::RecordCommitmentScheme as CommitmentScheme>::Randomness::rand(rng);
 
-        Ok(Self::from(
+        Self::from(
             &program.program_id().to_bytes_le()?,
             owner,
             is_dummy,
@@ -143,7 +143,7 @@ impl<C: Parameters> Record<C> {
             payload,
             serial_number_nonce,
             commitment_randomness,
-        )?)
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -48,9 +48,6 @@ pub struct Record<C: Parameters> {
     pub(crate) serial_number_nonce: <C::SerialNumberNonceCRH as CRH>::Output,
     pub(crate) commitment: C::RecordCommitment,
     pub(crate) commitment_randomness: <C::RecordCommitmentScheme as CommitmentScheme>::Randomness,
-
-    #[derivative(PartialEq = "ignore")]
-    pub(crate) position: Option<u8>,
 }
 
 impl<C: Parameters> Record<C> {
@@ -67,8 +64,7 @@ impl<C: Parameters> Record<C> {
     ) -> Result<Self, RecordError> {
         let timer = start_timer!(|| "Generate record");
         let serial_number_nonce = C::serial_number_nonce_crh().hash(&to_bytes_le![position, joint_serial_numbers]?)?;
-        let mut record = Self::new(program, owner, is_dummy, value, payload, serial_number_nonce, rng)?;
-        record.position = Some(position);
+        let record = Self::new(program, owner, is_dummy, value, payload, serial_number_nonce, rng)?;
         end_timer!(timer);
         Ok(record)
     }
@@ -134,7 +130,6 @@ impl<C: Parameters> Record<C> {
             serial_number_nonce,
             commitment,
             commitment_randomness,
-            position: None,
         }
     }
 
@@ -254,7 +249,6 @@ impl<C: Parameters> FromBytes for Record<C> {
             serial_number_nonce,
             commitment,
             commitment_randomness,
-            position: None,
         })
     }
 }

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -38,7 +38,7 @@ fn default_program_id<C: CRH>() -> Vec<u8> {
     Eq(bound = "C: Parameters")
 )]
 pub struct Record<C: Parameters> {
-    #[derivative(Default(value = "default_program_id::<C::ProgramIDCRH>()"))]
+    #[derivative(Default(value = "default_program_id::<C::ProgramCircuitIDCRH>()"))]
     pub(crate) program_id: Vec<u8>,
     pub(crate) owner: Address<C>,
     pub(crate) is_dummy: bool,

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -51,8 +51,43 @@ pub struct Record<C: Parameters> {
 }
 
 impl<C: Parameters> Record<C> {
+    pub fn new_input_noop<R: Rng + CryptoRng>(
+        noop_program: &dyn Program<C>,
+        owner: Address<C>,
+        rng: &mut R,
+    ) -> Result<Self, RecordError> {
+        Ok(Record::new(
+            noop_program,
+            owner,
+            true, // The input record is a noop.
+            0,
+            Payload::default(),
+            C::serial_number_nonce_crh().hash(&rng.gen::<[u8; 32]>())?,
+            rng,
+        )?)
+    }
+
+    pub fn new_output_noop<R: Rng + CryptoRng>(
+        noop_program: &dyn Program<C>,
+        owner: Address<C>,
+        position: u8,
+        joint_serial_numbers: Vec<u8>,
+        rng: &mut R,
+    ) -> Result<Self, RecordError> {
+        Ok(Record::new_output(
+            noop_program,
+            owner,
+            true, // The input record is a noop.
+            0,
+            Payload::default(),
+            position,
+            joint_serial_numbers,
+            rng,
+        )?)
+    }
+
     #[allow(clippy::too_many_arguments)]
-    pub fn new_full<R: Rng + CryptoRng>(
+    pub fn new_output<R: Rng + CryptoRng>(
         program: &dyn Program<C>,
         owner: Address<C>,
         is_dummy: bool,

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -218,7 +218,6 @@ impl<C: Parameters> RecordScheme for Record<C> {
     type Payload = Payload;
     type SerialNumber = <C::AccountSignatureScheme as SignatureScheme>::PublicKey;
     type SerialNumberNonce = <C::SerialNumberNonceCRH as CRH>::Output;
-    type Value = u64;
 
     fn program_id(&self) -> &[u8] {
         &self.program_id
@@ -232,7 +231,7 @@ impl<C: Parameters> RecordScheme for Record<C> {
         self.is_dummy
     }
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> u64 {
         self.value
     }
 

--- a/dpc/src/record/tests.rs
+++ b/dpc/src/record/tests.rs
@@ -48,7 +48,7 @@ fn test_record_encryption() {
             let mut payload = [0u8; PAYLOAD_SIZE];
             rng.fill(&mut payload);
 
-            let given_record = Record::new(
+            let given_record = Record::new_input(
                 &noop_program,
                 dummy_account.address,
                 false,

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -23,7 +23,7 @@ use crate::{
         RecordSerialNumberTree,
         TransactionScheme,
     },
-    LocalData,
+    Executable,
 };
 
 use anyhow::Result;
@@ -58,8 +58,7 @@ pub trait DPCScheme<C: Parameters>: Sized {
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
         authorization: Self::Authorization,
-        local_data: &LocalData<C>,
-        program_proofs: Vec<Self::Execution>,
+        executables: Vec<Executable<C>>,
         ledger: &L,
         rng: &mut R,
     ) -> Result<Self::Transaction>;

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -277,6 +277,7 @@ pub trait Parameters: 'static + Sized + Send + Sync {
     fn inner_circuit_proving_key(is_prover: bool) -> &'static Option<<Self::InnerSNARK as SNARK>::ProvingKey>;
     fn inner_circuit_verifying_key() -> &'static <Self::InnerSNARK as SNARK>::VerifyingKey;
 
+    fn noop_circuit_id() -> &'static Self::ProgramCircuitID;
     fn noop_circuit_proving_key() -> &'static <Self::ProgramSNARK as SNARK>::ProvingKey;
     fn noop_circuit_verifying_key() -> &'static <Self::ProgramSNARK as SNARK>::VerifyingKey;
 

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{InnerCircuitVerifierInput, OuterCircuitVerifierInput, ProgramPublicVariables};
+use crate::{InnerCircuitVerifierInput, OuterCircuitVerifierInput, PublicVariables};
 use snarkvm_algorithms::{crypto_hash::PoseidonDefaultParametersField, prelude::*};
 use snarkvm_curves::PairingEngine;
 use snarkvm_fields::{PrimeField, ToConstraintField};
@@ -69,7 +69,7 @@ pub trait Parameters: 'static + Sized + Send + Sync {
     type ProgramSNARK: SNARK<
         ScalarField = Self::InnerScalarField,
         BaseField = Self::OuterScalarField,
-        VerifierInput = ProgramPublicVariables<Self>,
+        VerifierInput = PublicVariables<Self>,
     >;
     /// Program SNARK verifier gadget for Aleo applications.
     type ProgramSNARKGadget: SNARKVerifierGadget<Self::ProgramSNARK>;

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -31,6 +31,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
+use anyhow::Result;
 use rand::{CryptoRng, Rng};
 use std::{cell::RefCell, rc::Rc};
 
@@ -178,9 +179,9 @@ pub trait Parameters: 'static + Sized + Send + Sync {
         + Send;
 
     /// CRH for program ID hashing. Invoked only over `Self::OuterScalarField`.
-    type ProgramIDCRH: CRH;
-    type ProgramIDCRHGadget: CRHGadget<Self::ProgramIDCRH, Self::OuterScalarField>;
-    type ProgramIDTreeDigest: ToConstraintField<Self::OuterScalarField>
+    type ProgramCircuitIDCRH: CRH<Output = Self::ProgramCircuitID>;
+    type ProgramCircuitIDCRHGadget: CRHGadget<Self::ProgramCircuitIDCRH, Self::OuterScalarField>;
+    type ProgramCircuitID: ToConstraintField<Self::OuterScalarField>
         + Clone
         + Debug
         + Display
@@ -192,7 +193,7 @@ pub trait Parameters: 'static + Sized + Send + Sync {
         + Send
         + Sync
         + Copy;
-    type ProgramIDTreeParameters: LoadableMerkleParameters<H = Self::ProgramIDCRH>;
+    type ProgramCircuitTreeParameters: LoadableMerkleParameters<H = Self::ProgramCircuitIDCRH>;
 
     /// PRF for computing serial numbers. Invoked only over `Self::InnerScalarField`.
     type PRF: PRF;
@@ -254,17 +255,13 @@ pub trait Parameters: 'static + Sized + Send + Sync {
     fn account_signature_scheme() -> &'static Self::AccountSignatureScheme;
 
     fn encrypted_record_crh() -> &'static Self::EncryptedRecordCRH;
-
     fn inner_circuit_id_crh() -> &'static Self::InnerCircuitIDCRH;
-
     fn local_data_commitment_scheme() -> &'static Self::LocalDataCommitmentScheme;
-
     fn local_data_crh() -> &'static Self::LocalDataCRH;
-
     fn program_commitment_scheme() -> &'static Self::ProgramCommitmentScheme;
 
-    fn program_id_crh() -> &'static Self::ProgramIDCRH;
-    fn program_id_tree_parameters() -> &'static Self::ProgramIDTreeParameters;
+    fn program_circuit_id_crh() -> &'static Self::ProgramCircuitIDCRH;
+    fn program_circuit_tree_parameters() -> &'static Self::ProgramCircuitTreeParameters;
 
     fn record_commitment_scheme() -> &'static Self::RecordCommitmentScheme;
 
@@ -285,6 +282,13 @@ pub trait Parameters: 'static + Sized + Send + Sync {
 
     fn outer_circuit_proving_key(is_prover: bool) -> &'static Option<<Self::OuterSNARK as SNARK>::ProvingKey>;
     fn outer_circuit_verifying_key() -> &'static <Self::OuterSNARK as SNARK>::VerifyingKey;
+
+    /// Returns the program circuit ID given a program circuit verifying key.
+    fn program_circuit_id(
+        verifying_key: &<Self::ProgramSNARK as SNARK>::VerifyingKey,
+    ) -> Result<Self::ProgramCircuitID> {
+        Ok(Self::program_circuit_id_crh().hash_field_elements(&verifying_key.to_field_elements()?)?)
+    }
 
     /// Returns the program SRS for Aleo applications.
     fn program_srs<R: Rng + CryptoRng>(

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -277,8 +277,8 @@ pub trait Parameters: 'static + Sized + Send + Sync {
     fn inner_circuit_proving_key(is_prover: bool) -> &'static Option<<Self::InnerSNARK as SNARK>::ProvingKey>;
     fn inner_circuit_verifying_key() -> &'static <Self::InnerSNARK as SNARK>::VerifyingKey;
 
-    fn noop_program_proving_key() -> &'static <Self::ProgramSNARK as SNARK>::ProvingKey;
-    fn noop_program_verifying_key() -> &'static <Self::ProgramSNARK as SNARK>::VerifyingKey;
+    fn noop_circuit_proving_key() -> &'static <Self::ProgramSNARK as SNARK>::ProvingKey;
+    fn noop_circuit_verifying_key() -> &'static <Self::ProgramSNARK as SNARK>::VerifyingKey;
 
     fn outer_circuit_proving_key(is_prover: bool) -> &'static Option<<Self::OuterSNARK as SNARK>::ProvingKey>;
     fn outer_circuit_verifying_key() -> &'static <Self::OuterSNARK as SNARK>::VerifyingKey;

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -33,24 +33,30 @@ pub trait Program<C: Parameters>: Send + Sync {
     /// Returns the program ID.
     fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters>;
 
-    /// Returns the circuit given the circuit index.
-    fn get_circuit(&self, circuit_index: u8) -> Result<&Box<dyn ProgramCircuit<C>>, ProgramError>;
+    /// Returns `true` if the given circuit ID exists in the program.
+    fn contains_circuit(&self, circuit_id: &C::ProgramCircuitID) -> bool;
+
+    /// Returns the circuit given the circuit ID, if it exists.
+    fn get_circuit(&self, circuit_id: &C::ProgramCircuitID) -> Option<&Box<dyn ProgramCircuit<C>>>;
+
+    /// Returns the circuit given the circuit index, if it exists.
+    fn find_circuit_by_index(&self, circuit_index: u8) -> Option<&Box<dyn ProgramCircuit<C>>>;
 
     /// Returns the execution of the program.
     fn execute(
         &self,
-        circuit_index: u8,
+        circuit_id: &C::ProgramCircuitID,
         public: &ProgramPublicVariables<C>,
         private: &dyn ProgramPrivateVariables<C>,
     ) -> Result<Execution<C>, ProgramError>;
 
     /// Returns the blank execution of the program, typically used for a SNARK setup.
-    fn execute_blank(&self, circuit_index: u8) -> Result<Execution<C>, ProgramError>;
+    fn execute_blank(&self, circuit_id: &C::ProgramCircuitID) -> Result<Execution<C>, ProgramError>;
 
     /// Returns the native evaluation of the program on given public and private variables.
     fn evaluate(
         &self,
-        _circuit_index: u8,
+        _circuit_id: &C::ProgramCircuitID,
         _public: &ProgramPublicVariables<C>,
         _private: &dyn ProgramPrivateVariables<C>,
     ) -> bool {

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{CircuitError, Execution, Parameters, ProgramError, ProgramPublicVariables};
-use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, CRH, SNARK};
+use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, SNARK};
 
 use rand::{CryptoRng, Rng};
 
@@ -69,8 +69,8 @@ pub trait ProgramCircuit<C: Parameters>: Send + Sync {
     where
         Self: Sized;
 
-    /// Returns the circuit ID.
-    fn circuit_id(&self) -> &<C::ProgramCircuitIDCRH as CRH>::Output;
+    /// Returns the program circuit ID.
+    fn circuit_id(&self) -> &C::ProgramCircuitID;
 
     /// Returns the circuit proving key.
     fn proving_key(&self) -> &<C::ProgramSNARK as SNARK>::ProvingKey;

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -31,7 +31,7 @@ pub trait Program<C: Parameters>: Send + Sync {
         Self: Sized;
 
     /// Returns the program ID.
-    fn program_id(&self) -> &MerkleTreeDigest<C::ProgramIDTreeParameters>;
+    fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters>;
 
     /// Returns the circuit given the circuit index.
     fn get_circuit(&self, circuit_index: u8) -> Result<&Box<dyn ProgramCircuit<C>>, ProgramError>;
@@ -70,7 +70,7 @@ pub trait ProgramCircuit<C: Parameters>: Send + Sync {
         Self: Sized;
 
     /// Returns the circuit ID.
-    fn circuit_id(&self) -> &<C::ProgramIDCRH as CRH>::Output;
+    fn circuit_id(&self) -> &<C::ProgramCircuitIDCRH as CRH>::Output;
 
     /// Returns the circuit proving key.
     fn proving_key(&self) -> &<C::ProgramSNARK as SNARK>::ProvingKey;

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{CircuitError, Execution, Parameters, ProgramError, ProgramPublicVariables};
+use crate::{CircuitError, Execution, Parameters, ProgramError, PublicVariables};
 use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, SNARK};
 
 use rand::{CryptoRng, Rng};
@@ -46,8 +46,8 @@ pub trait Program<C: Parameters>: Send + Sync {
     fn execute(
         &self,
         circuit_id: &C::ProgramCircuitID,
-        public: &ProgramPublicVariables<C>,
-        private: &dyn ProgramPrivateVariables<C>,
+        public: &PublicVariables<C>,
+        private: &dyn PrivateVariables<C>,
     ) -> Result<Execution<C>, ProgramError>;
 
     /// Returns the blank execution of the program, typically used for a SNARK setup.
@@ -57,8 +57,8 @@ pub trait Program<C: Parameters>: Send + Sync {
     fn evaluate(
         &self,
         _circuit_id: &C::ProgramCircuitID,
-        _public: &ProgramPublicVariables<C>,
-        _private: &dyn ProgramPrivateVariables<C>,
+        _public: &PublicVariables<C>,
+        _private: &dyn PrivateVariables<C>,
     ) -> bool {
         unimplemented!("The native evaluation of this program is unimplemented")
     }
@@ -87,22 +87,22 @@ pub trait ProgramCircuit<C: Parameters>: Send + Sync {
     /// Returns the execution of the circuit.
     fn execute(
         &self,
-        public: &ProgramPublicVariables<C>,
-        private: &dyn ProgramPrivateVariables<C>,
+        public: &PublicVariables<C>,
+        private: &dyn PrivateVariables<C>,
     ) -> Result<<C::ProgramSNARK as SNARK>::Proof, CircuitError>;
 
     /// Returns the blank execution of the circuit, typically used for a SNARK setup.
     fn execute_blank(&self) -> Result<<C::ProgramSNARK as SNARK>::Proof, CircuitError>;
 
     /// Returns true if the execution of the circuit is valid.
-    fn verify(&self, public: &ProgramPublicVariables<C>, proof: &<C::ProgramSNARK as SNARK>::Proof) -> bool;
+    fn verify(&self, public: &PublicVariables<C>, proof: &<C::ProgramSNARK as SNARK>::Proof) -> bool;
 
     /// Returns the native evaluation of the circuit on given public and private variables.
-    fn evaluate(&self, _public: &ProgramPublicVariables<C>, _private: &dyn ProgramPrivateVariables<C>) -> bool {
+    fn evaluate(&self, _public: &PublicVariables<C>, _private: &dyn PrivateVariables<C>) -> bool {
         unimplemented!("The native evaluation of this circuit is unimplemented")
     }
 }
 
-pub trait ProgramPrivateVariables<C: Parameters>: Send + Sync {
+pub trait PrivateVariables<C: Parameters>: Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
 }

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -97,4 +97,6 @@ pub trait ProgramCircuit<C: Parameters>: Send + Sync {
     }
 }
 
-pub trait ProgramPrivateVariables<C: Parameters>: Send + Sync {}
+pub trait ProgramPrivateVariables<C: Parameters>: Send + Sync {
+    fn as_any(&self) -> &dyn std::any::Any;
+}

--- a/dpc/src/traits/record.rs
+++ b/dpc/src/traits/record.rs
@@ -25,7 +25,6 @@ pub trait RecordScheme: Default + FromBytes + ToBytes {
     type Payload;
     type SerialNumberNonce;
     type SerialNumber: Clone + Eq + Hash + FromBytes + ToBytes;
-    type Value: FromBytes + ToBytes;
 
     /// Returns the program id of this record.
     fn program_id(&self) -> &[u8];
@@ -37,7 +36,7 @@ pub trait RecordScheme: Default + FromBytes + ToBytes {
     fn is_dummy(&self) -> bool;
 
     /// Returns the record value.
-    fn value(&self) -> Self::Value;
+    fn value(&self) -> u64;
 
     /// Returns the record payload.
     fn payload(&self) -> &Self::Payload;

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -62,7 +62,7 @@ pub fn generate<C: Parameters>(recipient: &Address<C>, value: u64) -> Result<(Ve
     for i in 0..C::NUM_INPUT_RECORDS {
         let old_record = Record::new(
             &dpc.noop_program,
-            genesis_account.address.clone(),
+            genesis_account.address,
             true, // The input record is a noop.
             0,
             Payload::default(),

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -59,7 +59,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
     let mut joint_serial_numbers = Vec::with_capacity(C::NUM_INPUT_RECORDS);
     let mut input_records = Vec::with_capacity(C::NUM_INPUT_RECORDS);
     for i in 0..C::NUM_INPUT_RECORDS {
-        let input_record = Record::new_input_noop(&dpc.noop_program, genesis_account.address, rng)?;
+        let input_record = Record::new_noop_input(&dpc.noop_program, genesis_account.address, rng)?;
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i])?;
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn]?);
@@ -79,7 +79,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
         joint_serial_numbers.clone(),
         rng,
     )?);
-    output_records.push(Record::new_output_noop(
+    output_records.push(Record::new_noop_output(
         &dpc.noop_program,
         recipient,
         (C::NUM_INPUT_RECORDS + 1) as u8,

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -103,7 +103,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
     // Generate the program proofs
     let mut program_proofs = Vec::with_capacity(C::NUM_TOTAL_RECORDS);
     for i in 0..C::NUM_TOTAL_RECORDS {
-        let public_variables = ProgramPublicVariables::new(local_data.root(), i as u8);
+        let public_variables = ProgramPublicVariables::new(i as u8, local_data.root());
         program_proofs.push(dpc.noop_program.execute(
             noop_circuit_id,
             &public_variables,

--- a/parameters/examples/noop_program_snark.rs
+++ b/parameters/examples/noop_program_snark.rs
@@ -27,7 +27,9 @@ use utils::store;
 pub fn setup<C: Parameters>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let rng = &mut thread_rng();
     let noop_program = NoopProgram::<C>::setup(rng)?;
-    let noop_circuit = noop_program.get_circuit(0)?;
+    let noop_circuit = noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)?;
     let noop_program_snark_pk = noop_circuit.proving_key().to_bytes_le()?;
     let noop_program_snark_vk = noop_circuit.verifying_key().to_bytes_le()?;
 

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -40,9 +40,17 @@ pub fn setup<C: Parameters>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let inner_snark_proof = C::InnerSNARK::prove(&inner_snark_pk, &InnerCircuit::<C>::blank(), rng)?;
 
     let noop_program = NoopProgram::<C>::load()?;
+    let noop_circuit_id = noop_program
+        .find_circuit_by_index(0)
+        .ok_or(DPCError::MissingNoopCircuit)?
+        .circuit_id();
 
     let outer_snark_parameters = C::OuterSNARK::setup(
-        &OuterCircuit::<C>::blank(inner_snark_vk, inner_snark_proof, noop_program.execute_blank(0)?),
+        &OuterCircuit::<C>::blank(
+            inner_snark_vk,
+            inner_snark_proof,
+            noop_program.execute_blank(noop_circuit_id)?,
+        ),
         &mut SRS::CircuitSpecific(rng),
     )?;
 


### PR DESCRIPTION
## Motivation

Adds enhancements for the DPC program model.

## Changes to Accounts

- Adds `Copy` trait to `Address` struct

## Changes to Records

- Removes `position` from `Record` struct (it is never used)
- Adds `Record::new_noop_input()` and `Record::new_noop_output()`
- Adds `Record::new_input()` and `Record::new_output()`

## Changes to Programs

- Includes #343 
- Reverses program public variables declaration to match allocation order
- Changes program circuits to be referenced from `circuit_id` instead of `circuit_index` (error-prone convention)
- Adds `Parameters::noop_circuit_id()` only for use in `load()` methods
- Adds helper method `fn program_circuit_id(verifying_key: &<Self::ProgramSNARK as SNARK>::VerifyingKey) -> Result<Self::ProgramCircuitID>` into `Parameters`
- Renames `Parameters::program_id_crh()` to `Parameters::program_circuit_id_crh()`
- Renames `Parameters::program_id_tree_parameters()` to `Parameters::program_circuit_tree_parameters()`

## Changes to DPC

- Introduces `Executable` to `DPC::execute()` which leverage trait objects to abstract the program executions
- Adds `DPCError::MissingCircuit`