### PR TITLE
Updates accounts, records, programs, transactions, and DPC with new functionality

### DIFF
--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -26,6 +26,7 @@ use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use std::{
+    ops::Deref,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -89,7 +90,7 @@ fn dpc_testnet1_integration_test() {
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
             Record::new_output(
-                &dpc.noop_program,
+                dpc.noop_program.deref(),
                 recipient.address,
                 false,
                 10,
@@ -209,7 +210,7 @@ fn test_testnet1_transaction_authorization_serialization() {
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
             Record::new_output(
-                &dpc.noop_program,
+                dpc.noop_program.deref(),
                 test_account.address,
                 false,
                 10,
@@ -284,7 +285,7 @@ fn test_testnet1_dpc_execute_constraints() {
     for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
             Record::new_output(
-                &dpc.noop_program,
+                dpc.noop_program.deref(),
                 new_account.address,
                 false,
                 10,

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -77,7 +77,7 @@ fn dpc_testnet1_integration_test() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(dpc.noop_program.deref(), genesis_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -108,16 +108,8 @@ fn dpc_testnet1_integration_test() {
         .authorize(&private_keys, input_records, output_records, None, &mut rng)
         .unwrap();
 
-    // Fetch the noop circuit ID.
-    let noop_circuit_id = dpc
-        .noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)
-        .unwrap()
-        .circuit_id();
-
     // Construct the executable.
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()), *noop_circuit_id);
+    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
     let executables = vec![noop.clone(), noop.clone(), noop.clone(), noop];
 
     let new_records = authorization.output_records.clone();
@@ -195,7 +187,7 @@ fn test_testnet1_transaction_authorization_serialization() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(&dpc.noop_program, test_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(dpc.noop_program.deref(), test_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -267,7 +259,8 @@ fn test_testnet1_dpc_execute_constraints() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
+        let input_record =
+            Record::new_noop_input(alternate_noop_program.deref(), dummy_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -305,24 +298,9 @@ fn test_testnet1_dpc_execute_constraints() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
-    // Fetch the alternate noop circuit ID.
-    let alternate_noop_circuit_id = alternate_noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)
-        .unwrap()
-        .circuit_id();
-
-    // Fetch the noop circuit ID.
-    let noop_circuit_id = dpc
-        .noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)
-        .unwrap()
-        .circuit_id();
-
     // Construct the executable.
-    let alternate_noop = Executable::Noop(Arc::new(alternate_noop_program.clone()), *alternate_noop_circuit_id);
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()), *noop_circuit_id);
+    let alternate_noop = Executable::Noop(Arc::new(alternate_noop_program.clone()));
+    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
     let executables = vec![alternate_noop.clone(), alternate_noop, noop.clone(), noop];
 
     // Execute the programs.

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -26,6 +26,7 @@ use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use std::{
+    ops::Deref,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -90,7 +91,7 @@ fn dpc_testnet2_integration_test() {
     for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
             Record::new_output(
-                &dpc.noop_program,
+                dpc.noop_program.deref(),
                 recipient.address,
                 false,
                 10,
@@ -210,7 +211,7 @@ fn test_testnet_2_transaction_authorization_serialization() {
     for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
             Record::new_output(
-                &dpc.noop_program,
+                dpc.noop_program.deref(),
                 test_account.address,
                 false,
                 10,
@@ -286,7 +287,7 @@ fn test_testnet2_dpc_execute_constraints() {
     for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
         output_records.push(
             Record::new_output(
-                &dpc.noop_program,
+                dpc.noop_program.deref(),
                 new_account.address,
                 false,
                 10,

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -78,7 +78,7 @@ fn dpc_testnet2_integration_test() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(&dpc.noop_program, genesis_account.address, &mut rng).unwrap();
+        let input_record = Record::new_noop_input(dpc.noop_program.deref(), genesis_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -109,16 +109,8 @@ fn dpc_testnet2_integration_test() {
         .authorize(&private_keys, input_records, output_records, None, &mut rng)
         .unwrap();
 
-    // Fetch the noop circuit ID.
-    let noop_circuit_id = dpc
-        .noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)
-        .unwrap()
-        .circuit_id();
-
     // Construct the executable.
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()), *noop_circuit_id);
+    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
     let executables = vec![noop.clone(), noop.clone(), noop.clone(), noop];
 
     let new_records = authorization.output_records.clone();
@@ -196,7 +188,7 @@ fn test_testnet_2_transaction_authorization_serialization() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let old_record = Record::new_noop_input(&dpc.noop_program, test_account.address, &mut rng).unwrap();
+        let old_record = Record::new_noop_input(dpc.noop_program.deref(), test_account.address, &mut rng).unwrap();
 
         let (sn, _) = old_record.to_serial_number(&old_private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -269,7 +261,8 @@ fn test_testnet2_dpc_execute_constraints() {
     let mut joint_serial_numbers = vec![];
     let mut input_records = vec![];
     for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(&alternate_noop_program, dummy_account.address, &mut rng).unwrap();
+        let input_record =
+            Record::new_noop_input(alternate_noop_program.deref(), dummy_account.address, &mut rng).unwrap();
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
@@ -307,24 +300,9 @@ fn test_testnet2_dpc_execute_constraints() {
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
 
-    // Fetch the alternate noop circuit ID.
-    let alternate_noop_circuit_id = alternate_noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)
-        .unwrap()
-        .circuit_id();
-
-    // Fetch the noop circuit ID.
-    let noop_circuit_id = dpc
-        .noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)
-        .unwrap()
-        .circuit_id();
-
     // Construct the executable.
-    let alternate_noop = Executable::Noop(Arc::new(alternate_noop_program.clone()), *alternate_noop_circuit_id);
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()), *noop_circuit_id);
+    let alternate_noop = Executable::Noop(Arc::new(alternate_noop_program.clone()));
+    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
     let executables = vec![alternate_noop.clone(), alternate_noop, noop.clone(), noop];
 
     // Execute the programs.

--- a/algorithms/src/traits/encryption.rs
+++ b/algorithms/src/traits/encryption.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::EncryptionError;
-use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBytes};
+use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBits, ToBytes};
 
 use rand::{CryptoRng, Rng};
 use std::{fmt::Debug, hash::Hash};
@@ -24,7 +24,7 @@ pub trait EncryptionScheme:
     Sized + ToBytes + FromBytes + Debug + Clone + Eq + From<<Self as EncryptionScheme>::Parameters>
 {
     type Parameters: Clone + Debug + Eq;
-    type PrivateKey: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + UniformRand;
+    type PrivateKey: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + ToBits + UniformRand;
     type PublicKey: Copy + Clone + Debug + Default + Eq + ToBytes + FromBytes;
     type Randomness: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + UniformRand;
 

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -18,6 +18,11 @@ license = "GPL-3.0"
 edition = "2018"
 
 [[bench]]
+name = "account"
+path = "benches/account.rs"
+harness = false
+
+[[bench]]
 name = "noop_program"
 path = "benches/noop_program.rs"
 harness = false

--- a/dpc/benches/account.rs
+++ b/dpc/benches/account.rs
@@ -27,7 +27,7 @@ fn account_private_key(c: &mut Criterion) {
 
     c.bench_function("account_private_key", move |b| {
         b.iter(|| {
-            let _private_key = PrivateKey::<Testnet2Parameters>::new(rng).unwrap();
+            let _private_key = PrivateKey::<Testnet2Parameters>::new(rng);
         })
     });
 }
@@ -36,7 +36,7 @@ fn account_view_key(c: &mut Criterion) {
     let rng = &mut thread_rng();
 
     c.bench_function("account_view_key", move |b| {
-        let private_key = PrivateKey::<Testnet2Parameters>::new(rng).unwrap();
+        let private_key = PrivateKey::<Testnet2Parameters>::new(rng);
 
         b.iter(|| {
             let _view_key = ViewKey::from_private_key(&private_key).unwrap();
@@ -48,7 +48,7 @@ fn account_address(c: &mut Criterion) {
     let rng = &mut thread_rng();
 
     c.bench_function("account_address", move |b| {
-        let private_key = PrivateKey::<Testnet2Parameters>::new(rng).unwrap();
+        let private_key = PrivateKey::<Testnet2Parameters>::new(rng);
 
         b.iter(|| {
             let _address = Address::from_private_key(&private_key).unwrap();

--- a/dpc/benches/account.rs
+++ b/dpc/benches/account.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate criterion;
+
+use snarkvm_dpc::{prelude::*, testnet2::Testnet2Parameters};
+
+use criterion::Criterion;
+use rand::thread_rng;
+
+fn account_private_key(c: &mut Criterion) {
+    let rng = &mut thread_rng();
+
+    c.bench_function("account_private_key", move |b| {
+        b.iter(|| {
+            let _private_key = PrivateKey::<Testnet2Parameters>::new(rng).unwrap();
+        })
+    });
+}
+
+fn account_view_key(c: &mut Criterion) {
+    let rng = &mut thread_rng();
+
+    c.bench_function("account_view_key", move |b| {
+        let private_key = PrivateKey::<Testnet2Parameters>::new(rng).unwrap();
+
+        b.iter(|| {
+            let _view_key = ViewKey::from_private_key(&private_key).unwrap();
+        })
+    });
+}
+
+fn account_address(c: &mut Criterion) {
+    let rng = &mut thread_rng();
+
+    c.bench_function("account_address", move |b| {
+        let private_key = PrivateKey::<Testnet2Parameters>::new(rng).unwrap();
+
+        b.iter(|| {
+            let _address = Address::from_private_key(&private_key).unwrap();
+        })
+    });
+}
+
+criterion_group! {
+    name = account;
+    config = Criterion::default().sample_size(20);
+    targets = account_private_key, account_view_key, account_address
+}
+
+criterion_main!(account);

--- a/dpc/benches/transaction.rs
+++ b/dpc/benches/transaction.rs
@@ -23,7 +23,7 @@ use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use criterion::Criterion;
 use rand::thread_rng;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 fn coinbase_transaction<C: Parameters>(
     dpc: &DPC<C>,
@@ -53,7 +53,7 @@ fn coinbase_transaction<C: Parameters>(
     // Construct the output records.
     let mut output_records = Vec::with_capacity(C::NUM_OUTPUT_RECORDS);
     output_records.push(Record::new_output(
-        &dpc.noop_program,
+        dpc.noop_program.deref(),
         recipient,
         false,
         value,

--- a/dpc/src/account/account.rs
+++ b/dpc/src/account/account.rs
@@ -34,7 +34,7 @@ impl<C: Parameters> AccountScheme for Account<C> {
 
     /// Creates a new account.
     fn new<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, AccountError> {
-        let private_key = PrivateKey::new(rng)?;
+        let private_key = PrivateKey::new(rng);
         let view_key = ViewKey::try_from(&private_key)?;
         let address = Address::try_from(&view_key)?;
 

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -55,11 +55,7 @@ impl<C: Parameters> Address<C> {
 
     /// Verifies a signature on a message signed by the account view key.
     /// Returns `true` if the signature is valid. Otherwise, returns `false`.
-    pub fn verify_signature(
-        &self,
-        message: &[u8],
-        signature: &<C::AccountSignatureScheme as SignatureScheme>::Signature,
-    ) -> Result<bool, AccountError> {
+    pub fn verify_signature(&self, message: &[u8], signature: &C::AccountSignature) -> Result<bool, AccountError> {
         let signature_public_key = self.to_signature_public_key()?;
         Ok(C::account_signature_scheme().verify(&signature_public_key, message, signature)?)
     }

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -39,9 +39,11 @@ pub struct PrivateKey<C: Parameters> {
     pub sk_prf: <C::PRF as PRF>::Seed,
     pub r_pk: <C::AccountCommitmentScheme as CommitmentScheme>::Randomness,
     pub r_pk_counter: u16,
-    // This dummy flag is set to true for use in the `inner_snark` setup.
+    // This dummy flag is set to true for use in the `inner_circuit` setup.
     #[derivative(Default(value = "true"))]
-    pub is_dummy: bool,
+    is_dummy: bool,
+    pk_sig: C::AccountSignaturePublicKey,
+    commitment_input: Vec<u8>,
 }
 
 impl<C: Parameters> PrivateKey<C> {
@@ -60,54 +62,53 @@ impl<C: Parameters> PrivateKey<C> {
             let seed: [u8; 32] = rng.gen();
 
             // Returns the private key if it is valid.
-            match Self::from_seed(&seed) {
-                Ok(private_key) => return Ok(private_key),
-                _ => continue,
-            };
+            if let Ok(private_key) = Self::from_seed(&seed) {
+                return Ok(private_key);
+            }
         }
     }
 
     /// Derives the account private key from a given seed and verifies it is well-formed.
     pub fn from_seed(seed: &[u8; 32]) -> Result<Self, AccountError> {
         // Generate the SIG key pair.
-        let sk_sig_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?;
-        let sk_sig = <C::AccountSignatureScheme as SignatureScheme>::PrivateKey::read_le(&sk_sig_bytes[..])?;
+        let sk_sig: <C::AccountSignatureScheme as SignatureScheme>::PrivateKey =
+            FromBytes::read_le(Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?.as_ref())?;
+        let pk_sig = C::account_signature_scheme().generate_public_key(&sk_sig)?;
 
         // Generate the PRF secret key.
-        let sk_prf_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_PRF)?;
-        let sk_prf = <C::PRF as PRF>::Seed::read_le(&sk_prf_bytes[..])?;
+        let sk_prf: <C::PRF as PRF>::Seed =
+            FromBytes::read_le(Blake2s::evaluate(&seed, &Self::INPUT_SK_PRF)?.as_ref())?;
 
-        let mut r_pk_counter = Self::INITIAL_R_PK_COUNTER;
-        loop {
-            if r_pk_counter == u16::MAX {
-                return Err(AccountError::InvalidPrivateKeySeed);
-            }
+        // Construct the commitment input for the account address.
+        let commitment_input = to_bytes_le![pk_sig, sk_prf]?;
 
-            // Derive the private key by iterating on the r_pk counter
-            let private_key = match Self::derive_r_pk(seed, r_pk_counter) {
-                Ok(r_pk) => Self {
-                    seed: *seed,
-                    sk_sig: sk_sig.clone(),
-                    sk_prf: sk_prf.clone(),
-                    r_pk,
-                    r_pk_counter,
-                    is_dummy: false,
-                },
-                _ => {
-                    r_pk_counter += 1;
-                    continue;
-                }
-            };
+        // Initialize a candidate private key.
+        let mut private_key = Self {
+            seed: *seed,
+            sk_sig,
+            sk_prf,
+            r_pk: Default::default(),
+            r_pk_counter: Self::INITIAL_R_PK_COUNTER,
+            is_dummy: false,
+            pk_sig,
+            commitment_input,
+        };
 
-            // Returns the private key if it is valid.
-            match private_key.is_valid() {
-                true => return Ok(private_key),
-                false => {
-                    r_pk_counter += 1;
-                    continue;
+        // Derive the private key by iterating on the r_pk counter, until a valid r_pk is found.
+        for r_pk_counter in Self::INITIAL_R_PK_COUNTER..u16::MAX {
+            if let Ok(r_pk) = Self::derive_r_pk(seed, r_pk_counter) {
+                // Update the candidate private key with the derived values.
+                private_key.r_pk = r_pk;
+                private_key.r_pk_counter = r_pk_counter;
+
+                // Returns the private key if it is valid.
+                if private_key.is_valid() {
+                    return Ok(private_key);
                 }
             }
         }
+
+        Err(AccountError::InvalidPrivateKeySeed)
     }
 
     /// Returns `true` if the private key is well-formed. Otherwise, returns `false`.
@@ -119,70 +120,86 @@ impl<C: Parameters> PrivateKey<C> {
     pub fn to_decryption_key(
         &self,
     ) -> Result<<C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey, AccountError> {
-        let commitment = self.commit()?;
-        let decryption_key_bytes = to_bytes_le![commitment]?;
+        // If this private key is a dummy, then immediately return a fake value.
+        if self.is_dummy {
+            return Ok(<C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey::default());
+        }
 
-        // This operation implicitly enforces that the unused MSB bits
-        // for the scalar field representation are correctly set to 0.
-        let decryption_key = match self.is_dummy {
-            true => <C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey::default(),
-            false => <C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey::read_le(&decryption_key_bytes[..])?,
+        // Compute the commitment, which is used as the decryption key.
+        let commitment = C::account_commitment_scheme().commit(&self.commitment_input, &self.r_pk)?;
+        let commitment_bytes = commitment.to_bytes_le()?;
+
+        // Determine the number of MSB bits we must enforce are zero,
+        // for the isomorphism from the base field to the scalar field.
+        let enforce_zero_on_num_bits = {
+            debug_assert!(C::AccountEncryptionScheme::private_key_size_in_bits() > 0);
+            // We must enforce that the MSB bit of the scalar field is also set to 0.
+            let capacity = C::AccountEncryptionScheme::private_key_size_in_bits() - 1;
+            let commitment_num_bits = commitment_bytes.len() * 8;
+            assert!(capacity < commitment_num_bits);
+
+            commitment_num_bits - capacity
         };
 
         // This operation explicitly enforces that the unused MSB bits
         // for the scalar field representation are correctly set to 0.
-        //
-        // To simplify verification of this isomorphism from the base field
-        // to the scalar field in the `inner_snark`, we additionally enforce
-        // that the MSB bit of the scalar field is also set to 0.
-        if !self.is_dummy {
-            let account_decryption_key_bits = from_bytes_le_to_bits_le(&decryption_key_bytes[..]).collect::<Vec<_>>();
-            let account_decryption_key_length = account_decryption_key_bits.len();
-
-            let decryption_private_key_length = C::AccountEncryptionScheme::private_key_size_in_bits();
-            assert!(decryption_private_key_length > 0);
-            assert!(decryption_private_key_length <= account_decryption_key_length);
-
-            for i in (decryption_private_key_length - 1)..account_decryption_key_length {
-                let bit_index = account_decryption_key_length - i - 1;
-                if account_decryption_key_bits[bit_index] {
-                    return Err(AccountError::InvalidAccountCommitment);
-                }
+        for msb_bit in from_bytes_le_to_bits_le(&commitment_bytes[..]).take(enforce_zero_on_num_bits) {
+            // Pop the next MSB bit, and enforce it is zero.
+            if msb_bit {
+                return Err(AccountError::InvalidAccountCommitment);
             }
         }
+
+        // This operation implicitly enforces that the unused MSB bits
+        // for the scalar field representation are correctly set to 0.
+        let decryption_key: <C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey =
+            FromBytes::read_le(&commitment_bytes[..])?;
 
         Ok(decryption_key)
     }
 
     /// Returns the signature public key for deriving the account view key.
-    pub fn pk_sig(&self) -> Result<C::AccountSignaturePublicKey, AccountError> {
-        Ok(C::account_signature_scheme().generate_public_key(&self.sk_sig)?)
+    pub fn pk_sig(&self) -> &C::AccountSignaturePublicKey {
+        &self.pk_sig
     }
 
     /// Derives the account private key from a given seed and counter without verifying if it is well-formed.
-    fn from_seed_and_counter_unsafe(seed: &[u8; 32], r_pk_counter: u16) -> Result<Self, AccountError> {
+    fn from_seed_and_counter(seed: &[u8; 32], r_pk_counter: u16) -> Result<Self, AccountError> {
         // Generate the SIG key pair.
-        let sk_sig_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?;
-        let sk_sig = <C::AccountSignatureScheme as SignatureScheme>::PrivateKey::read_le(&sk_sig_bytes[..])?;
+        let sk_sig: <C::AccountSignatureScheme as SignatureScheme>::PrivateKey =
+            FromBytes::read_le(Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?.as_ref())?;
+        let pk_sig = C::account_signature_scheme().generate_public_key(&sk_sig)?;
 
         // Generate the PRF secret key.
-        let sk_prf_bytes = Blake2s::evaluate(&seed, &Self::INPUT_SK_PRF)?;
-        let sk_prf = <C::PRF as PRF>::Seed::read_le(&sk_prf_bytes[..])?;
+        let sk_prf: <C::PRF as PRF>::Seed =
+            FromBytes::read_le(Blake2s::evaluate(&seed, &Self::INPUT_SK_PRF)?.as_ref())?;
 
         // Generate the randomness rpk for the commitment scheme.
         let r_pk = Self::derive_r_pk(seed, r_pk_counter)?;
 
-        Ok(Self {
+        // Construct the commitment input for the account address.
+        let commitment_input = to_bytes_le![pk_sig, sk_prf]?;
+
+        // Construct the candidate private key.
+        let private_key = Self {
             seed: *seed,
             sk_sig,
             sk_prf,
             r_pk,
             r_pk_counter,
             is_dummy: false,
-        })
+            pk_sig,
+            commitment_input,
+        };
+
+        // Returns the private key if it is valid.
+        match private_key.is_valid() {
+            true => Ok(private_key),
+            false => Err(AccountError::InvalidPrivateKey),
+        }
     }
 
-    /// Generate the randomness rpk for the commitment scheme from a given seed and counter
+    /// Generate the randomness r_pk for the commitment scheme from a given seed and counter.
     fn derive_r_pk(
         seed: &[u8; 32],
         counter: u16,
@@ -190,19 +207,8 @@ impl<C: Parameters> PrivateKey<C> {
         let mut r_pk_input = [0u8; 32];
         r_pk_input[0..2].copy_from_slice(&counter.to_le_bytes());
 
-        // Generate the randomness rpk for the commitment scheme.
-        let r_pk_bytes = Blake2s::evaluate(seed, &r_pk_input)?;
-        let r_pk = <C::AccountCommitmentScheme as CommitmentScheme>::Randomness::read_le(&r_pk_bytes[..])?;
-
-        Ok(r_pk)
-    }
-
-    /// Returns the commitment output of the private key.
-    fn commit(&self) -> Result<<C::AccountCommitmentScheme as CommitmentScheme>::Output, AccountError> {
-        // Construct the commitment input for the account address.
-        let commit_input = to_bytes_le![self.pk_sig()?, self.sk_prf]?;
-
-        Ok(C::account_commitment_scheme().commit(&commit_input, &self.r_pk)?)
+        // Generate the randomness r_pk for the commitment scheme.
+        Ok(FromBytes::read_le(Blake2s::evaluate(seed, &r_pk_input)?.as_ref())?)
     }
 }
 
@@ -224,7 +230,7 @@ impl<C: Parameters> FromStr for PrivateKey<C> {
         let counter_bytes: [u8; 2] = FromBytes::read_le(&mut reader)?;
         let seed: [u8; 32] = FromBytes::read_le(&mut reader)?;
 
-        Self::from_seed_and_counter_unsafe(&seed, u16::from_le_bytes(counter_bytes))
+        Self::from_seed_and_counter(&seed, u16::from_le_bytes(counter_bytes))
     }
 }
 

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -143,7 +143,10 @@ impl<C: Parameters> PrivateKey<C> {
 
         // This operation explicitly enforces that the unused MSB bits
         // for the scalar field representation are correctly set to 0.
-        for msb_bit in from_bytes_le_to_bits_le(&commitment_bytes[..]).take(enforce_zero_on_num_bits) {
+        for msb_bit in from_bytes_le_to_bits_le(&commitment_bytes[..])
+            .rev()
+            .take(enforce_zero_on_num_bits)
+        {
             // Pop the next MSB bit, and enforce it is zero.
             if msb_bit {
                 return Err(AccountError::InvalidAccountCommitment);

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -19,7 +19,7 @@ use snarkvm_algorithms::{
     prf::Blake2s,
     traits::{CommitmentScheme, EncryptionScheme, SignatureScheme, PRF},
 };
-use snarkvm_utilities::{from_bytes_le_to_bits_le, to_bytes_le, FromBytes, ToBytes};
+use snarkvm_utilities::{from_bytes_le_to_bits_le, to_bytes_le, FromBytes, ToBits, ToBytes};
 
 use base58::{FromBase58, ToBase58};
 use rand::{thread_rng, CryptoRng, Rng};

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -145,10 +145,13 @@ impl<C: Parameters> PrivateKey<C> {
             }
         }
 
-        // This operation implicitly enforces that the unused MSB bits
-        // for the scalar field representation are correctly set to 0.
+        // This operation enforces that the base field element fits within the scalar field.
+        // However, this operation does not enforce that the MSB of the scalar field element is 0.
         let decryption_key: <C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey =
             FromBytes::read_le(&commitment_bytes[..])?;
+
+        // Enforce the MSB of the scalar field element is 0 by convention.
+        debug_assert_eq!(Some(&false), decryption_key.to_bits_be().iter().next());
 
         Ok(decryption_key)
     }

--- a/dpc/src/account/tests.rs
+++ b/dpc/src/account/tests.rs
@@ -22,9 +22,9 @@ mod testnet1 {
     use rand_chacha::ChaChaRng;
     use std::{convert::TryInto, str::FromStr};
 
-    const ALEO_TESTNET1_PRIVATE_KEY: &str = "APrivateKey1tn8cnHPNtcZ9pH89YBMmpPS3fP5kxooguzpbRz3pLWoSzhg";
-    const ALEO_TESTNET1_VIEW_KEY: &str = "AViewKey1m9cmnBtfWziAmT1SBC63a96fo18hLddrjweMxhcqhNo5";
-    const ALEO_TESTNET1_ADDRESS: &str = "aleo1h47qwdqqv25gwp0fkxgnqvm7ykrz0ud2vaw2cj4ac68w8wq5vqqqv58jvr";
+    const ALEO_TESTNET1_PRIVATE_KEY: &str = "APrivateKey1tyBgFoCXAq8RfZT3W2mzVV9XzJb2hVFL2LrHLToEC37tXrz";
+    const ALEO_TESTNET1_VIEW_KEY: &str = "AViewKey1gFRs4gG66wFW1FypYRfwy6pDqix6rtquQ8uJ15RgHCC8";
+    const ALEO_TESTNET1_ADDRESS: &str = "aleo1shhq355tyaptcej65tkrweej5wth7wqg5hcqg3hf8as5s9rtrypqs8vy3u";
 
     const ITERATIONS: usize = 25;
 
@@ -163,9 +163,9 @@ mod testnet2 {
     use rand_chacha::ChaChaRng;
     use std::{convert::TryInto, str::FromStr};
 
-    const ALEO_TESTNET2_PRIVATE_KEY: &str = "APrivateKey1tn8cnHPNtcZ9pH89YBMmpPS3fP5kxooguzpbRz3pLWoSzhg";
-    const ALEO_TESTNET2_VIEW_KEY: &str = "AViewKey1m9cmnBtfWziAmT1SBC63a96fo18hLddrjweMxhcqhNo5";
-    const ALEO_TESTNET2_ADDRESS: &str = "aleo1h47qwdqqv25gwp0fkxgnqvm7ykrz0ud2vaw2cj4ac68w8wq5vqqqv58jvr";
+    const ALEO_TESTNET2_PRIVATE_KEY: &str = "APrivateKey1tyBgFoCXAq8RfZT3W2mzVV9XzJb2hVFL2LrHLToEC37tXrz";
+    const ALEO_TESTNET2_VIEW_KEY: &str = "AViewKey1gFRs4gG66wFW1FypYRfwy6pDqix6rtquQ8uJ15RgHCC8";
+    const ALEO_TESTNET2_ADDRESS: &str = "aleo1shhq355tyaptcej65tkrweej5wth7wqg5hcqg3hf8as5s9rtrypqs8vy3u";
 
     const ITERATIONS: usize = 25;
 

--- a/dpc/src/account/tests.rs
+++ b/dpc/src/account/tests.rs
@@ -17,8 +17,9 @@
 #[cfg(test)]
 mod testnet1 {
     use crate::{testnet1::Testnet1Parameters, Account, AccountScheme, Address, PrivateKey, ViewKey};
+    use snarkvm_utilities::ToBits;
 
-    use rand::SeedableRng;
+    use rand::{thread_rng, SeedableRng};
     use rand_chacha::ChaChaRng;
     use std::{convert::TryInto, str::FromStr};
 
@@ -26,7 +27,7 @@ mod testnet1 {
     const ALEO_TESTNET1_VIEW_KEY: &str = "AViewKey1gFRs4gG66wFW1FypYRfwy6pDqix6rtquQ8uJ15RgHCC8";
     const ALEO_TESTNET1_ADDRESS: &str = "aleo1shhq355tyaptcej65tkrweej5wth7wqg5hcqg3hf8as5s9rtrypqs8vy3u";
 
-    const ITERATIONS: usize = 25;
+    const ITERATIONS: usize = 1000;
 
     #[test]
     fn test_account_new() {
@@ -53,6 +54,17 @@ mod testnet1 {
         assert_eq!(ALEO_TESTNET1_PRIVATE_KEY, private_key.to_string());
         assert_eq!(ALEO_TESTNET1_VIEW_KEY, view_key.to_string());
         assert_eq!(ALEO_TESTNET1_ADDRESS, address.to_string());
+    }
+
+    #[test]
+    fn test_private_key_to_decryption_key() {
+        // Attempt to sample for a new account ITERATIONS times.
+        for _ in 0..ITERATIONS {
+            let private_key = PrivateKey::<Testnet1Parameters>::new(&mut thread_rng());
+            let decryption_key = private_key.to_decryption_key().unwrap();
+            // Enforce the MSB of the scalar field element is 0 by convention.
+            assert_eq!(Some(&false), decryption_key.to_bits_be().iter().next());
+        }
     }
 
     #[test]
@@ -122,7 +134,7 @@ mod testnet1 {
 
     #[test]
     fn test_account_encryption_and_signature_compatibility() {
-        let rng = &mut rand::thread_rng();
+        let rng = &mut thread_rng();
 
         let private_key = PrivateKey::<Testnet1Parameters>::from_str(ALEO_TESTNET1_PRIVATE_KEY).unwrap();
         let view_key = ViewKey::<Testnet1Parameters>::from_private_key(&private_key).unwrap();
@@ -138,7 +150,7 @@ mod testnet1 {
 
     #[test]
     fn test_invalid_account_encryption_and_signature_compatibility() {
-        let rng = &mut rand::thread_rng();
+        let rng = &mut thread_rng();
 
         let private_key = PrivateKey::<Testnet1Parameters>::from_str(ALEO_TESTNET1_PRIVATE_KEY).unwrap();
         let view_key = ViewKey::<Testnet1Parameters>::from_private_key(&private_key).unwrap();
@@ -158,8 +170,9 @@ mod testnet1 {
 #[cfg(test)]
 mod testnet2 {
     use crate::{testnet2::Testnet2Parameters, Account, AccountScheme, Address, PrivateKey, ViewKey};
+    use snarkvm_utilities::ToBits;
 
-    use rand::SeedableRng;
+    use rand::{thread_rng, SeedableRng};
     use rand_chacha::ChaChaRng;
     use std::{convert::TryInto, str::FromStr};
 
@@ -167,7 +180,7 @@ mod testnet2 {
     const ALEO_TESTNET2_VIEW_KEY: &str = "AViewKey1gFRs4gG66wFW1FypYRfwy6pDqix6rtquQ8uJ15RgHCC8";
     const ALEO_TESTNET2_ADDRESS: &str = "aleo1shhq355tyaptcej65tkrweej5wth7wqg5hcqg3hf8as5s9rtrypqs8vy3u";
 
-    const ITERATIONS: usize = 25;
+    const ITERATIONS: usize = 1000;
 
     #[test]
     fn test_account_new() {
@@ -194,6 +207,17 @@ mod testnet2 {
         assert_eq!(ALEO_TESTNET2_PRIVATE_KEY, private_key.to_string());
         assert_eq!(ALEO_TESTNET2_VIEW_KEY, view_key.to_string());
         assert_eq!(ALEO_TESTNET2_ADDRESS, address.to_string());
+    }
+
+    #[test]
+    fn test_private_key_to_decryption_key() {
+        // Attempt to sample for a new account ITERATIONS times.
+        for _ in 0..ITERATIONS {
+            let private_key = PrivateKey::<Testnet2Parameters>::new(&mut thread_rng());
+            let decryption_key = private_key.to_decryption_key().unwrap();
+            // Enforce the MSB of the scalar field element is 0 by convention.
+            assert_eq!(Some(&false), decryption_key.to_bits_be().iter().next());
+        }
     }
 
     #[test]
@@ -264,7 +288,7 @@ mod testnet2 {
 
     #[test]
     fn test_account_encryption_and_signature_compatibility() {
-        let rng = &mut rand::thread_rng();
+        let rng = &mut thread_rng();
 
         let private_key = PrivateKey::<Testnet2Parameters>::from_str(ALEO_TESTNET2_PRIVATE_KEY).unwrap();
         let view_key = ViewKey::<Testnet2Parameters>::from_private_key(&private_key).unwrap();
@@ -280,7 +304,7 @@ mod testnet2 {
 
     #[test]
     fn test_invalid_account_encryption_and_signature_compatibility() {
-        let rng = &mut rand::thread_rng();
+        let rng = &mut thread_rng();
 
         let private_key = PrivateKey::<Testnet2Parameters>::from_str(ALEO_TESTNET2_PRIVATE_KEY).unwrap();
         let view_key = ViewKey::<Testnet2Parameters>::from_private_key(&private_key).unwrap();

--- a/dpc/src/account/view_key.rs
+++ b/dpc/src/account/view_key.rs
@@ -47,11 +47,7 @@ impl<C: Parameters> ViewKey<C> {
     }
 
     /// Signs a message using the account view key.
-    pub fn sign<R: Rng + CryptoRng>(
-        &self,
-        message: &[u8],
-        rng: &mut R,
-    ) -> Result<<C::AccountSignatureScheme as SignatureScheme>::Signature, AccountError> {
+    pub fn sign<R: Rng + CryptoRng>(&self, message: &[u8], rng: &mut R) -> Result<C::AccountSignature, AccountError> {
         let signature_private_key = FromBytes::from_bytes_le(&self.decryption_key.to_bytes_le()?)?;
         Ok(C::account_signature_scheme().sign(&signature_private_key, message, rng)?)
     }

--- a/dpc/src/circuits/inner_circuit.rs
+++ b/dpc/src/circuits/inner_circuit.rs
@@ -305,6 +305,11 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
                     &r_pk,
                 )?;
 
+                // TODO (howardwu): Enforce 6 MSB bits are 0.
+                {
+                    // TODO (howardwu): Enforce 6 MSB bits are 0.
+                }
+
                 // Enforce the account commitment bytes (padded) correspond to the
                 // given account's view key bytes (padded). This is equivalent to
                 // verifying that the base field element from the computed account

--- a/dpc/src/circuits/inner_circuit.rs
+++ b/dpc/src/circuits/inner_circuit.rs
@@ -150,7 +150,7 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
     // Declares a constant for a 0 value in a record.
     let zero_value = UInt8::constant_vec(&(0u64).to_bytes_le()?);
     // Declares a constant for an empty payload in a record.
-    let empty_payload = UInt8::constant_vec(&Payload::default().to_bytes());
+    let empty_payload = UInt8::constant_vec(&Payload::default().to_bytes_le()?);
 
     let digest_gadget = <C::RecordCommitmentTreeCRHGadget as CRHGadget<_, _>>::OutputGadget::alloc_input(
         &mut cs.ns(|| "Declare ledger digest"),
@@ -205,7 +205,8 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
 
             let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &record.value().to_bytes_le()?)?;
 
-            let given_payload = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes())?;
+            let given_payload =
+                UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes_le()?)?;
 
             let given_serial_number_nonce_bytes = UInt8::alloc_vec(
                 &mut declare_cs.ns(|| "given_serial_number_nonce_bytes"),
@@ -484,7 +485,8 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
 
             let given_value = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_value"), &record.value().to_bytes_le()?)?;
 
-            let given_payload = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes())?;
+            let given_payload =
+                UInt8::alloc_vec(&mut declare_cs.ns(|| "given_payload"), &record.payload().to_bytes_le()?)?;
 
             let given_serial_number_nonce = <C::SerialNumberNonceCRHGadget as CRHGadget<
                 C::SerialNumberNonceCRH,

--- a/dpc/src/circuits/inner_circuit.rs
+++ b/dpc/src/circuits/inner_circuit.rs
@@ -274,14 +274,12 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
 
             // Allocate the account private key.
             let (pk_sig, sk_prf, r_pk) = {
-                let pk_sig_native = account_private_key
-                    .pk_sig()
-                    .map_err(|_| SynthesisError::AssignmentMissing)?;
+                let pk_sig_native = account_private_key.pk_sig();
                 let pk_sig = <C::AccountSignatureGadget as SignatureGadget<
                     C::AccountSignatureScheme,
                     C::InnerScalarField,
                 >>::PublicKeyGadget::alloc(
-                    &mut account_cs.ns(|| "Declare pk_sig"), || Ok(&pk_sig_native)
+                    &mut account_cs.ns(|| "Declare pk_sig"), || Ok(pk_sig_native)
                 )?;
                 let sk_prf =
                     C::PRFGadget::new_seed(&mut account_cs.ns(|| "Declare sk_prf"), &account_private_key.sk_prf);

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -309,25 +309,13 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
         };
         end_timer!(execution_timer);
 
-        let TransactionKernel {
-            network_id,
-            serial_numbers,
-            commitments,
-            value_balance,
-            memo,
-        } = kernel;
-
-        Ok(Self::Transaction::new(
-            Network::from_id(network_id),
-            serial_numbers,
-            commitments,
-            value_balance,
-            memo,
+        Ok(Self::Transaction::from(
+            kernel,
+            signatures,
             ledger_digest,
             C::inner_circuit_id().clone(),
-            transaction_proof,
-            signatures,
             encrypted_records,
+            transaction_proof,
         ))
     }
 

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -42,10 +42,7 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
 
         let noop_program_timer = start_timer!(|| "Noop program SNARK setup");
         let noop_program = NoopProgram::setup(rng)?;
-        let noop_circuit = noop_program
-            .find_circuit_by_index(0)
-            .ok_or(DPCError::MissingNoopCircuit)?;
-        let noop_program_execution = noop_program.execute_blank(noop_circuit.circuit_id())?;
+        let noop_program_execution = noop_program.execute_blank_noop()?;
         end_timer!(noop_program_timer);
 
         let snark_setup_time = start_timer!(|| "Execute inner SNARK setup");

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -380,7 +380,7 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
 
         // Returns false if the number of signatures in the transaction is incorrect.
         if transaction.signatures().len() != C::NUM_OUTPUT_RECORDS {
-            eprintln!("Transaction contains incorrect number of commitments");
+            eprintln!("Transaction contains incorrect number of signatures");
             return false;
         }
 

--- a/dpc/src/errors/account.rs
+++ b/dpc/src/errors/account.rs
@@ -48,6 +48,9 @@ pub enum AccountError {
     #[error("invalid prefix bytes: {:?}", _0)]
     InvalidPrefixBytes(Vec<u8>),
 
+    #[error("invalid account private key")]
+    InvalidPrivateKey,
+
     #[error("invalid account private key seed")]
     InvalidPrivateKeySeed,
 

--- a/dpc/src/lib.rs
+++ b/dpc/src/lib.rs
@@ -84,6 +84,9 @@ pub use program::*;
 pub mod record;
 pub use record::*;
 
+pub mod state;
+pub use state::*;
+
 pub mod traits;
 pub use traits::*;
 
@@ -91,5 +94,15 @@ pub mod transaction;
 pub use transaction::*;
 
 pub mod prelude {
-    pub use crate::{account::*, circuits::*, dpc::*, errors::*, program::*, record::*, traits::*, transaction::*};
+    pub use crate::{
+        account::*,
+        circuits::*,
+        dpc::*,
+        errors::*,
+        program::*,
+        record::*,
+        state::*,
+        traits::*,
+        transaction::*,
+    };
 }

--- a/dpc/src/parameters/testnet1.rs
+++ b/dpc/src/parameters/testnet1.rs
@@ -126,6 +126,7 @@ impl Parameters for Testnet1Parameters {
     type AccountSignatureScheme = Schnorr<EdwardsBls12>;
     type AccountSignatureGadget = SchnorrGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
     type AccountSignaturePublicKey = <Self::AccountSignatureScheme as SignatureScheme>::PublicKey;
+    type AccountSignature = <Self::AccountSignatureScheme as SignatureScheme>::Signature;
 
     type EncryptedRecordCRH = PoseidonCryptoHash<Self::InnerScalarField, 4, false>;
     type EncryptedRecordCRHGadget = PoseidonCryptoHashGadget<Self::InnerScalarField, 4, false>;

--- a/dpc/src/parameters/testnet2.rs
+++ b/dpc/src/parameters/testnet2.rs
@@ -146,6 +146,7 @@ impl Parameters for Testnet2Parameters {
     type AccountSignatureScheme = Schnorr<EdwardsBls12>;
     type AccountSignatureGadget = SchnorrGadget<EdwardsBls12, Self::InnerScalarField, EdwardsBls12Gadget>;
     type AccountSignaturePublicKey = <Self::AccountSignatureScheme as SignatureScheme>::PublicKey;
+    type AccountSignature = <Self::AccountSignatureScheme as SignatureScheme>::Signature;
 
     type EncryptedRecordCRH = PoseidonCryptoHash<Self::InnerScalarField, 4, false>;
     type EncryptedRecordCRHGadget = PoseidonCryptoHashGadget<Self::InnerScalarField, 4, false>;

--- a/dpc/src/program/executable.rs
+++ b/dpc/src/program/executable.rs
@@ -21,7 +21,7 @@ use crate::{
     NoopProgram,
     Parameters,
     PrivateVariables,
-    Program,
+    ProgramScheme,
     PublicVariables,
 };
 
@@ -32,7 +32,11 @@ use std::{ops::Deref, sync::Arc};
 #[derivative(Clone(bound = "C: Parameters"))]
 pub enum Executable<C: Parameters> {
     Noop(Arc<NoopProgram<C>>, C::ProgramCircuitID),
-    Circuit(Arc<dyn Program<C>>, C::ProgramCircuitID, Arc<dyn PrivateVariables<C>>),
+    Circuit(
+        Arc<dyn ProgramScheme<C>>,
+        C::ProgramCircuitID,
+        Arc<dyn PrivateVariables<C>>,
+    ),
 }
 
 impl<C: Parameters> Executable<C> {

--- a/dpc/src/program/mod.rs
+++ b/dpc/src/program/mod.rs
@@ -26,6 +26,9 @@ pub use noop_circuit::*;
 pub mod noop_program;
 pub use noop_program::*;
 
+pub mod program;
+pub use program::*;
+
 pub mod program_circuit_tree;
 pub use program_circuit_tree::*;
 

--- a/dpc/src/program/noop_program.rs
+++ b/dpc/src/program/noop_program.rs
@@ -14,115 +14,31 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    Execution,
-    NoopCircuit,
-    Parameters,
-    PrivateVariables,
-    Program,
-    ProgramCircuit,
-    ProgramCircuitTree,
-    ProgramError,
-    PublicVariables,
-};
-use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, prelude::*};
+use crate::{NoopCircuit, Parameters, Program, ProgramCircuit, ProgramError, ProgramScheme};
 
 use rand::{CryptoRng, Rng};
-use std::sync::Arc;
+use std::ops::Deref;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
-pub struct NoopProgram<C: Parameters> {
-    circuits: Arc<ProgramCircuitTree<C>>,
-}
+pub struct NoopProgram<C: Parameters>(Program<C>);
 
-impl<C: Parameters> Program<C> for NoopProgram<C> {
+impl<C: Parameters> NoopProgram<C> {
     /// Initializes a new instance of the program.
-    fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, ProgramError> {
-        // Initialize a new program circuit tree, and add all circuits to the tree.
-        let mut circuit_tree = ProgramCircuitTree::new()?;
-        circuit_tree.add_all(vec![Box::new(NoopCircuit::setup(rng)?)])?;
-
-        Ok(Self {
-            circuits: Arc::new(circuit_tree),
-        })
+    pub fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, ProgramError> {
+        Ok(Self(Program::new(vec![Box::new(NoopCircuit::setup(rng)?)])?))
     }
 
     /// Loads an instance of the program.
-    fn load() -> Result<Self, ProgramError> {
-        // Initialize a new program circuit tree, and add all circuits to the tree.
-        let mut circuit_tree = ProgramCircuitTree::new()?;
-        circuit_tree.add(Box::new(NoopCircuit::load()?))?;
-
-        Ok(Self {
-            circuits: Arc::new(circuit_tree),
-        })
+    pub fn load() -> Result<Self, ProgramError> {
+        Ok(Self(Program::new(vec![Box::new(NoopCircuit::load()?)])?))
     }
+}
 
-    /// Returns the program ID.
-    fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters> {
-        self.circuits.to_program_id()
-    }
+impl<C: Parameters> Deref for NoopProgram<C> {
+    type Target = Program<C>;
 
-    /// Returns `true` if the given circuit ID exists in the program.
-    fn contains_circuit(&self, circuit_id: &C::ProgramCircuitID) -> bool {
-        self.circuits.contains_circuit(circuit_id)
-    }
-
-    /// Returns the circuit given the circuit ID, if it exists.
-    fn get_circuit(&self, circuit_id: &C::ProgramCircuitID) -> Option<&Box<dyn ProgramCircuit<C>>> {
-        self.circuits.get_circuit(circuit_id)
-    }
-
-    /// Returns the circuit given the circuit index, if it exists.
-    fn find_circuit_by_index(&self, circuit_index: u8) -> Option<&Box<dyn ProgramCircuit<C>>> {
-        self.circuits.find_circuit_by_index(circuit_index)
-    }
-
-    fn execute(
-        &self,
-        circuit_id: &C::ProgramCircuitID,
-        public: &PublicVariables<C>,
-        private: &dyn PrivateVariables<C>,
-    ) -> Result<Execution<C>, ProgramError> {
-        // Fetch the circuit from the tree.
-        let circuit = match self.circuits.get_circuit(circuit_id) {
-            Some(circuit) => circuit,
-            _ => return Err(MerkleError::MissingLeaf(format!("{}", circuit_id)).into()),
-        };
-        debug_assert_eq!(circuit.circuit_id(), circuit_id);
-
-        let program_path = self.circuits.get_program_path(circuit_id)?;
-        debug_assert!(program_path.verify(self.program_id(), circuit_id)?);
-
-        let proof = circuit.execute(public, private)?;
-        let verifying_key = circuit.verifying_key().clone();
-
-        Ok(Execution {
-            program_path,
-            verifying_key,
-            proof,
-        })
-    }
-
-    fn execute_blank(&self, circuit_id: &C::ProgramCircuitID) -> Result<Execution<C>, ProgramError> {
-        // Fetch the circuit from the tree.
-        let circuit = match self.circuits.get_circuit(circuit_id) {
-            Some(circuit) => circuit,
-            _ => return Err(MerkleError::MissingLeaf(format!("{}", circuit_id)).into()),
-        };
-        debug_assert_eq!(circuit.circuit_id(), circuit_id);
-
-        let program_path = self.circuits.get_program_path(circuit_id)?;
-        debug_assert!(program_path.verify(self.program_id(), circuit_id)?);
-
-        let proof = circuit.execute_blank()?;
-        let verifying_key = circuit.verifying_key().clone();
-
-        Ok(Execution {
-            program_path,
-            verifying_key,
-            proof,
-        })
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/dpc/src/program/noop_program.rs
+++ b/dpc/src/program/noop_program.rs
@@ -14,24 +14,73 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{NoopCircuit, Parameters, Program, ProgramCircuit, ProgramError, ProgramScheme};
+use crate::{
+    Execution,
+    NoopCircuit,
+    NoopPrivateVariables,
+    Parameters,
+    Program,
+    ProgramCircuit,
+    ProgramError,
+    ProgramScheme,
+    PublicVariables,
+};
 
 use rand::{CryptoRng, Rng};
 use std::ops::Deref;
 
+/// As there is only one circuit in a noop program, this struct explicitly stores
+/// the noop circuit ID and provides a convenience method to execute the noop circuit directly.
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
-pub struct NoopProgram<C: Parameters>(Program<C>);
+pub struct NoopProgram<C: Parameters> {
+    program: Program<C>,
+    noop_circuit_id: C::ProgramCircuitID,
+}
 
 impl<C: Parameters> NoopProgram<C> {
     /// Initializes a new instance of the program.
     pub fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, ProgramError> {
-        Ok(Self(Program::new(vec![Box::new(NoopCircuit::setup(rng)?)])?))
+        let noop_circuit = NoopCircuit::setup(rng)?;
+        let noop_circuit_id = *noop_circuit.circuit_id();
+        Ok(Self::from((
+            Program::new(vec![Box::new(noop_circuit)])?,
+            noop_circuit_id,
+        )))
     }
 
     /// Loads an instance of the program.
     pub fn load() -> Result<Self, ProgramError> {
-        Ok(Self(Program::new(vec![Box::new(NoopCircuit::load()?)])?))
+        let noop_circuit = NoopCircuit::load()?;
+        let noop_circuit_id = *noop_circuit.circuit_id();
+        Ok(Self::from((
+            Program::new(vec![Box::new(noop_circuit)])?,
+            noop_circuit_id,
+        )))
+    }
+
+    /// Returns the noop execution with the given public variables.
+    pub fn execute_noop(&self, public: &PublicVariables<C>) -> Result<Execution<C>, ProgramError> {
+        debug_assert!(self.program.contains_circuit(&self.noop_circuit_id));
+        Ok(self
+            .program
+            .execute(&self.noop_circuit_id, &public, &NoopPrivateVariables::new())?)
+    }
+
+    /// Returns a blank noop execution.
+    pub fn execute_blank_noop(&self) -> Result<Execution<C>, ProgramError> {
+        debug_assert!(self.program.contains_circuit(&self.noop_circuit_id));
+        Ok(self.program.execute_blank(&self.noop_circuit_id)?)
+    }
+}
+
+impl<C: Parameters> From<(Program<C>, C::ProgramCircuitID)> for NoopProgram<C> {
+    fn from((program, noop_circuit_id): (Program<C>, C::ProgramCircuitID)) -> Self {
+        debug_assert!(program.contains_circuit(&noop_circuit_id));
+        Self {
+            program,
+            noop_circuit_id,
+        }
     }
 }
 
@@ -39,6 +88,6 @@ impl<C: Parameters> Deref for NoopProgram<C> {
     type Target = Program<C>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.program
     }
 }

--- a/dpc/src/program/program.rs
+++ b/dpc/src/program/program.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    Execution,
+    Parameters,
+    PrivateVariables,
+    ProgramCircuit,
+    ProgramCircuitTree,
+    ProgramError,
+    ProgramScheme,
+    PublicVariables,
+};
+use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, prelude::*};
+
+use std::sync::Arc;
+
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: Parameters"), Debug(bound = "C: Parameters"))]
+pub struct Program<C: Parameters> {
+    circuits: Arc<ProgramCircuitTree<C>>,
+}
+
+impl<C: Parameters> ProgramScheme<C> for Program<C> {
+    /// Initializes an instance of the program with the given circuits.
+    fn new(circuits: Vec<Box<dyn ProgramCircuit<C>>>) -> Result<Self, ProgramError> {
+        // Initialize a new program circuit tree, and add all circuits to the tree.
+        let mut circuit_tree = ProgramCircuitTree::new()?;
+        circuit_tree.add_all(circuits)?;
+
+        Ok(Self {
+            circuits: Arc::new(circuit_tree),
+        })
+    }
+
+    /// Returns the program ID.
+    fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters> {
+        self.circuits.to_program_id()
+    }
+
+    /// Returns `true` if the given circuit ID exists in the program.
+    fn contains_circuit(&self, circuit_id: &C::ProgramCircuitID) -> bool {
+        self.circuits.contains_circuit(circuit_id)
+    }
+
+    /// Returns the circuit given the circuit ID, if it exists.
+    fn get_circuit(&self, circuit_id: &C::ProgramCircuitID) -> Option<&Box<dyn ProgramCircuit<C>>> {
+        self.circuits.get_circuit(circuit_id)
+    }
+
+    /// Returns the circuit given the circuit index, if it exists.
+    fn find_circuit_by_index(&self, circuit_index: u8) -> Option<&Box<dyn ProgramCircuit<C>>> {
+        self.circuits.find_circuit_by_index(circuit_index)
+    }
+
+    fn execute(
+        &self,
+        circuit_id: &C::ProgramCircuitID,
+        public: &PublicVariables<C>,
+        private: &dyn PrivateVariables<C>,
+    ) -> Result<Execution<C>, ProgramError> {
+        // Fetch the circuit from the tree.
+        let circuit = match self.circuits.get_circuit(circuit_id) {
+            Some(circuit) => circuit,
+            _ => return Err(MerkleError::MissingLeaf(format!("{}", circuit_id)).into()),
+        };
+        debug_assert_eq!(circuit.circuit_id(), circuit_id);
+
+        let program_path = self.circuits.get_program_path(circuit_id)?;
+        debug_assert!(program_path.verify(self.program_id(), circuit_id)?);
+
+        let proof = circuit.execute(public, private)?;
+        let verifying_key = circuit.verifying_key().clone();
+
+        Ok(Execution {
+            program_path,
+            verifying_key,
+            proof,
+        })
+    }
+
+    fn execute_blank(&self, circuit_id: &C::ProgramCircuitID) -> Result<Execution<C>, ProgramError> {
+        // Fetch the circuit from the tree.
+        let circuit = match self.circuits.get_circuit(circuit_id) {
+            Some(circuit) => circuit,
+            _ => return Err(MerkleError::MissingLeaf(format!("{}", circuit_id)).into()),
+        };
+        debug_assert_eq!(circuit.circuit_id(), circuit_id);
+
+        let program_path = self.circuits.get_program_path(circuit_id)?;
+        debug_assert!(program_path.verify(self.program_id(), circuit_id)?);
+
+        let proof = circuit.execute_blank()?;
+        let verifying_key = circuit.verifying_key().clone();
+
+        Ok(Execution {
+            program_path,
+            verifying_key,
+            proof,
+        })
+    }
+}

--- a/dpc/src/record/payload.rs
+++ b/dpc/src/record/payload.rs
@@ -24,23 +24,26 @@ pub const PAYLOAD_SIZE: usize = 128;
 pub struct Payload([u8; PAYLOAD_SIZE]);
 
 impl Payload {
-    pub fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
+    pub fn from(bytes: &[u8]) -> Self {
+        assert!(bytes.len() <= PAYLOAD_SIZE);
 
-    pub fn to_bytes(&self) -> &[u8] {
-        &self.0[..]
-    }
+        // Pad the bytes up to PAYLOAD_SIZE.
+        let mut buffer = bytes.to_vec();
+        buffer.resize(PAYLOAD_SIZE, 0u8);
 
-    pub fn from_bytes(bytes: &[u8]) -> Self {
+        // Copy exactly PAYLOAD_SIZE.
         let mut payload = [0u8; PAYLOAD_SIZE];
-        payload.copy_from_slice(&bytes);
+        payload.copy_from_slice(&buffer);
 
         Self(payload)
     }
 
-    pub fn size(&self) -> usize {
-        self.0.len()
+    pub fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    pub const fn size(&self) -> usize {
+        PAYLOAD_SIZE
     }
 }
 

--- a/dpc/src/record/payload.rs
+++ b/dpc/src/record/payload.rs
@@ -66,3 +66,22 @@ impl Default for Payload {
         Self([0u8; PAYLOAD_SIZE])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_utilities::UniformRand;
+
+    #[test]
+    fn test_payload_from() {
+        let rng = &mut rand::thread_rng();
+
+        // Create a random byte array, construct a payload from it, and check its byte array matches.
+        for i in 0..PAYLOAD_SIZE {
+            let expected_payload = (0..i).map(|_| u8::rand(rng)).collect::<Vec<u8>>();
+            let candidate_payload = Payload::from(&expected_payload).to_bytes_le().unwrap();
+            assert_eq!(expected_payload, candidate_payload[0..i]);
+            assert_eq!(vec![0u8; PAYLOAD_SIZE - i], candidate_payload[i..]);
+        }
+    }
+}

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Address, NoopProgram, Parameters, Payload, PrivateKey, ProgramScheme, RecordError, RecordScheme};
+use crate::{Address, Parameters, Payload, PrivateKey, ProgramScheme, RecordError, RecordScheme};
 use snarkvm_algorithms::traits::{CommitmentScheme, SignatureScheme, CRH, PRF};
 use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
 
@@ -22,7 +22,6 @@ use rand::{CryptoRng, Rng};
 use std::{
     fmt,
     io::{Read, Result as IoResult, Write},
-    ops::Deref,
     str::FromStr,
 };
 
@@ -54,12 +53,13 @@ pub struct Record<C: Parameters> {
 impl<C: Parameters> Record<C> {
     /// Returns a new noop input record.
     pub fn new_noop_input<R: Rng + CryptoRng>(
-        noop_program: &NoopProgram<C>,
+        // TODO (howardwu): TEMPORARY - `noop_program: &dyn ProgramScheme<C>` will be removed when `DPC::setup` and `DPC::load` are refactored.
+        noop_program: &dyn ProgramScheme<C>,
         owner: Address<C>,
         rng: &mut R,
     ) -> Result<Self, RecordError> {
         Self::new_input(
-            noop_program.deref(),
+            noop_program,
             owner,
             true,
             0,
@@ -71,14 +71,15 @@ impl<C: Parameters> Record<C> {
 
     /// Returns a new noop output record.
     pub fn new_noop_output<R: Rng + CryptoRng>(
-        noop_program: &NoopProgram<C>,
+        // TODO (howardwu): TEMPORARY - `noop_program: &dyn ProgramScheme<C>` will be removed when `DPC::setup` and `DPC::load` are refactored.
+        noop_program: &dyn ProgramScheme<C>,
         owner: Address<C>,
         position: u8,
         joint_serial_numbers: Vec<u8>,
         rng: &mut R,
     ) -> Result<Self, RecordError> {
         Self::new_output(
-            noop_program.deref(),
+            noop_program,
             owner,
             true,
             0,

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -206,7 +206,7 @@ impl<C: Parameters> Record<C> {
         let seed = FromBytes::read_le(to_bytes_le!(&private_key.sk_prf)?.as_slice())?;
         let input = FromBytes::read_le(to_bytes_le!(self.serial_number_nonce)?.as_slice())?;
         let randomizer = FromBytes::from_bytes_le(&C::PRF::evaluate(&seed, &input)?.to_bytes_le()?)?;
-        let serial_number = C::account_signature_scheme().randomize_public_key(&private_key.pk_sig()?, &randomizer)?;
+        let serial_number = C::account_signature_scheme().randomize_public_key(private_key.pk_sig(), &randomizer)?;
 
         end_timer!(timer);
         Ok((serial_number, randomizer))

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Address, NoopProgram, Parameters, Payload, PrivateKey, Program, RecordError, RecordScheme};
+use crate::{Address, NoopProgram, Parameters, Payload, PrivateKey, ProgramScheme, RecordError, RecordScheme};
 use snarkvm_algorithms::traits::{CommitmentScheme, SignatureScheme, CRH, PRF};
 use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
 
@@ -22,6 +22,7 @@ use rand::{CryptoRng, Rng};
 use std::{
     fmt,
     io::{Read, Result as IoResult, Write},
+    ops::Deref,
     str::FromStr,
 };
 
@@ -58,7 +59,7 @@ impl<C: Parameters> Record<C> {
         rng: &mut R,
     ) -> Result<Self, RecordError> {
         Self::new_input(
-            noop_program,
+            noop_program.deref(),
             owner,
             true,
             0,
@@ -77,7 +78,7 @@ impl<C: Parameters> Record<C> {
         rng: &mut R,
     ) -> Result<Self, RecordError> {
         Self::new_output(
-            noop_program,
+            noop_program.deref(),
             owner,
             true,
             0,
@@ -91,7 +92,7 @@ impl<C: Parameters> Record<C> {
     /// Returns a new input record.
     #[allow(clippy::too_many_arguments)]
     pub fn new_input<R: Rng + CryptoRng>(
-        program: &dyn Program<C>,
+        program: &dyn ProgramScheme<C>,
         owner: Address<C>,
         is_dummy: bool,
         value: u64,
@@ -116,7 +117,7 @@ impl<C: Parameters> Record<C> {
     /// Returns a new output record.
     #[allow(clippy::too_many_arguments)]
     pub fn new_output<R: Rng + CryptoRng>(
-        program: &dyn Program<C>,
+        program: &dyn ProgramScheme<C>,
         owner: Address<C>,
         is_dummy: bool,
         value: u64,

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -188,7 +188,7 @@ impl<C: Parameters> Record<C> {
         private_key: &PrivateKey<C>,
     ) -> Result<
         (
-            <C::AccountSignatureScheme as SignatureScheme>::PublicKey,
+            C::AccountSignaturePublicKey,
             <C::AccountSignatureScheme as SignatureScheme>::Randomizer,
         ),
         RecordError,
@@ -217,7 +217,7 @@ impl<C: Parameters> RecordScheme for Record<C> {
     type CommitmentRandomness = <C::RecordCommitmentScheme as CommitmentScheme>::Randomness;
     type Owner = Address<C>;
     type Payload = Payload;
-    type SerialNumber = <C::AccountSignatureScheme as SignatureScheme>::PublicKey;
+    type SerialNumber = C::AccountSignaturePublicKey;
     type SerialNumberNonce = C::SerialNumberNonce;
 
     fn program_id(&self) -> &[u8] {

--- a/dpc/src/record/tests.rs
+++ b/dpc/src/record/tests.rs
@@ -26,8 +26,8 @@ use crate::{
     ViewKey,
     PAYLOAD_SIZE,
 };
-use snarkvm_algorithms::traits::CRH;
-use snarkvm_utilities::FromBytes;
+use snarkvm_algorithms::traits::{CommitmentScheme, CRH};
+use snarkvm_utilities::{FromBytes, UniformRand};
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
@@ -50,6 +50,12 @@ fn test_record_encryption() {
             let mut payload = [0u8; PAYLOAD_SIZE];
             rng.fill(&mut payload);
 
+            // Sample a new record commitment randomness.
+            let commitment_randomness =
+                <<Testnet2Parameters as Parameters>::RecordCommitmentScheme as CommitmentScheme>::Randomness::rand(
+                    &mut rng,
+                );
+
             let given_record = Record::new_input(
                 noop_program.deref(),
                 dummy_account.address,
@@ -59,7 +65,7 @@ fn test_record_encryption() {
                 <Testnet2Parameters as Parameters>::serial_number_nonce_crh()
                     .hash(&sn_nonce_input)
                     .unwrap(),
-                &mut rng,
+                commitment_randomness,
             )
             .unwrap();
 

--- a/dpc/src/record/tests.rs
+++ b/dpc/src/record/tests.rs
@@ -22,14 +22,15 @@ use crate::{
     NoopProgram,
     Parameters,
     Payload,
-    Program,
     Record,
     ViewKey,
     PAYLOAD_SIZE,
 };
+use snarkvm_algorithms::traits::CRH;
+
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
-use snarkvm_algorithms::traits::CRH;
+use std::ops::Deref;
 
 pub(crate) const ITERATIONS: usize = 5;
 
@@ -49,7 +50,7 @@ fn test_record_encryption() {
             rng.fill(&mut payload);
 
             let given_record = Record::new_input(
-                &noop_program,
+                noop_program.deref(),
                 dummy_account.address,
                 false,
                 value,

--- a/dpc/src/record/tests.rs
+++ b/dpc/src/record/tests.rs
@@ -27,6 +27,7 @@ use crate::{
     PAYLOAD_SIZE,
 };
 use snarkvm_algorithms::traits::CRH;
+use snarkvm_utilities::FromBytes;
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
@@ -54,7 +55,7 @@ fn test_record_encryption() {
                 dummy_account.address,
                 false,
                 value,
-                Payload::from_bytes(&payload),
+                Payload::from_bytes_le(&payload).unwrap(),
                 <Testnet2Parameters as Parameters>::serial_number_nonce_crh()
                     .hash(&sn_nonce_input)
                     .unwrap(),

--- a/dpc/src/state/input.rs
+++ b/dpc/src/state/input.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::prelude::*;
-use snarkvm_algorithms::SignatureScheme;
+use snarkvm_algorithms::{CommitmentScheme, SignatureScheme};
 
 use anyhow::Result;
 use rand::{CryptoRng, Rng};
@@ -59,14 +59,14 @@ impl<C: Parameters> Input<C> {
     }
 
     /// Initializes a new instance of `Input`.
-    pub fn new<R: Rng + CryptoRng>(
+    pub fn new(
         private_key: PrivateKey<C>,
         executable: Executable<C>,
         is_dummy: bool,
         value: u64,
         payload: Payload,
         serial_number_nonce: C::SerialNumberNonce,
-        rng: &mut R,
+        commitment_randomness: <C::RecordCommitmentScheme as CommitmentScheme>::Randomness,
     ) -> Result<Self> {
         // Derive the account address.
         let address = Address::from_private_key(&private_key)?;
@@ -79,7 +79,7 @@ impl<C: Parameters> Input<C> {
             value,
             payload,
             serial_number_nonce,
-            rng,
+            commitment_randomness,
         )?;
 
         // Compute the serial number.

--- a/dpc/src/state/input.rs
+++ b/dpc/src/state/input.rs
@@ -37,7 +37,7 @@ impl<C: Parameters> Input<C> {
         let executable = Executable::Noop(noop);
 
         // Sample a burner noop private key.
-        let noop_private_key = PrivateKey::new(rng)?;
+        let noop_private_key = PrivateKey::new(rng);
         let noop_address = Address::from_private_key(&noop_private_key)?;
 
         // Construct the noop input record.

--- a/dpc/src/state/input.rs
+++ b/dpc/src/state/input.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::prelude::*;
+use snarkvm_algorithms::SignatureScheme;
+
+use anyhow::Result;
+use rand::{CryptoRng, Rng};
+use std::sync::Arc;
+
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: Parameters"))]
+pub struct Input<C: Parameters> {
+    executable: Executable<C>,
+    record: Record<C>,
+    serial_number: C::AccountSignaturePublicKey,
+    randomized_private_key: <C::AccountSignatureScheme as SignatureScheme>::RandomizedPrivateKey,
+}
+
+impl<C: Parameters> Input<C> {
+    /// TODO (howardwu): TEMPORARY - `noop: Arc<NoopProgram<C>>` will be removed when `DPC::setup` and `DPC::load` are refactored.
+    pub fn new_noop<R: Rng + CryptoRng>(noop: Arc<NoopProgram<C>>, rng: &mut R) -> Result<Self> {
+        // Construct the noop executable.
+        let executable = Executable::Noop(noop);
+
+        // Sample a burner noop private key.
+        let noop_private_key = PrivateKey::new(rng)?;
+        let noop_address = Address::from_private_key(&noop_private_key)?;
+
+        // Construct the noop input record.
+        let record = Record::new_noop_input(executable.program(), noop_address, rng)?;
+
+        // Compute the serial numbers.
+        let (serial_number, signature_randomizer) = record.to_serial_number(&noop_private_key)?;
+
+        // Randomize the private key.
+        let randomized_private_key =
+            C::account_signature_scheme().randomize_private_key(&noop_private_key.sk_sig, &signature_randomizer)?;
+
+        Ok(Self {
+            executable,
+            record,
+            serial_number,
+            randomized_private_key,
+        })
+    }
+
+    /// Returns a reference to the input serial number.
+    pub fn serial_number(&self) -> &C::AccountSignaturePublicKey {
+        &self.serial_number
+    }
+}

--- a/dpc/src/state/mod.rs
+++ b/dpc/src/state/mod.rs
@@ -1,0 +1,27 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+pub mod input;
+pub use input::*;
+
+pub mod state;
+pub use state::*;
+
+pub mod output;
+pub use output::*;
+
+// #[cfg(test)]
+// mod tests;

--- a/dpc/src/state/output.rs
+++ b/dpc/src/state/output.rs
@@ -38,7 +38,7 @@ impl<C: Parameters> Output<C> {
         let executable = Executable::Noop(noop);
 
         // Sample a burner noop private key.
-        let noop_private_key = PrivateKey::new(rng)?;
+        let noop_private_key = PrivateKey::new(rng);
         let noop_address = noop_private_key.try_into()?;
 
         Ok(Self {

--- a/dpc/src/state/output.rs
+++ b/dpc/src/state/output.rs
@@ -45,6 +45,32 @@ impl<C: Parameters> Output<C> {
         // Construct the noop output record.
         let record = Record::new_noop_output(executable.program(), noop_address, position, joint_serial_numbers, rng)?;
 
-        Ok(Self { record, executable })
+        Ok(Self { executable, record })
+    }
+
+    /// Initializes a new instance of `Output`.
+    pub fn new<R: Rng + CryptoRng>(
+        executable: Executable<C>,
+        address: Address<C>,
+        is_dummy: bool,
+        value: u64,
+        payload: Payload,
+        position: u8,
+        joint_serial_numbers: Vec<u8>,
+        rng: &mut R,
+    ) -> Result<Self> {
+        // Construct the output record.
+        let record = Record::new_output(
+            executable.program(),
+            address,
+            is_dummy,
+            value,
+            payload,
+            position,
+            joint_serial_numbers,
+            rng,
+        )?;
+
+        Ok(Self { executable, record })
     }
 }

--- a/dpc/src/state/output.rs
+++ b/dpc/src/state/output.rs
@@ -1,0 +1,50 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::prelude::*;
+
+use anyhow::Result;
+use rand::{CryptoRng, Rng};
+use std::{convert::TryInto, sync::Arc};
+
+#[derive(Derivative)]
+#[derivative(Clone(bound = "C: Parameters"))]
+pub struct Output<C: Parameters> {
+    executable: Executable<C>,
+    record: Record<C>,
+}
+
+impl<C: Parameters> Output<C> {
+    /// TODO (howardwu): TEMPORARY - `noop: Arc<NoopProgram<C>>` will be removed when `DPC::setup` and `DPC::load` are refactored.
+    pub fn new_noop<R: Rng + CryptoRng>(
+        noop: Arc<NoopProgram<C>>,
+        position: u8,
+        joint_serial_numbers: Vec<u8>,
+        rng: &mut R,
+    ) -> Result<Self> {
+        // Construct the noop executable.
+        let executable = Executable::Noop(noop);
+
+        // Sample a burner noop private key.
+        let noop_private_key = PrivateKey::new(rng)?;
+        let noop_address = noop_private_key.try_into()?;
+
+        // Construct the noop output record.
+        let record = Record::new_noop_output(executable.program(), noop_address, position, joint_serial_numbers, rng)?;
+
+        Ok(Self { record, executable })
+    }
+}

--- a/dpc/src/state/state.rs
+++ b/dpc/src/state/state.rs
@@ -111,6 +111,8 @@ impl<C: Parameters> StateBuilder<C> {
     }
 
     fn update_joint_serial_numbers(&mut self) -> Result<()> {
+        assert_eq!(C::NUM_INPUT_RECORDS, self.inputs.len());
+
         // Compute the joint serial numbers.
         let mut joint_serial_numbers = Vec::with_capacity(C::NUM_INPUT_RECORDS);
         for input in self.inputs.iter().take(C::NUM_INPUT_RECORDS) {

--- a/dpc/src/state/state.rs
+++ b/dpc/src/state/state.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::prelude::*;
+use snarkvm_utilities::ToBytes;
+
+use anyhow::Result;
+use rand::{CryptoRng, Rng};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct State<C: Parameters> {
+    inputs: Vec<Input<C>>,
+    outputs: Vec<Output<C>>,
+}
+
+impl<C: Parameters> State<C> {
+    /// Returns a new instance of `StateBuilder`.
+    pub fn builder() -> StateBuilder<C> {
+        StateBuilder::new()
+    }
+}
+
+#[derive(Clone)]
+pub struct StateBuilder<C: Parameters> {
+    inputs: Vec<Input<C>>,
+    outputs: Vec<Output<C>>,
+}
+
+impl<C: Parameters> StateBuilder<C> {
+    /// Returns a new instance of `StateBuilder`.
+    pub fn new() -> Self {
+        Self {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        }
+    }
+
+    /// TODO (howardwu): TEMPORARY - `noop: Arc<NoopProgram<C>>` will be removed when `DPC::setup` and `DPC::load` are refactored.
+    /// Finalizes the builder and returns a new instance of `State`.
+    pub fn build<R: Rng + CryptoRng>(&self, noop: Arc<NoopProgram<C>>, rng: &mut R) -> Result<State<C>> {
+        // Construct the inputs.
+        let mut inputs = self.inputs.clone();
+        // Pad the inputs with noop inputs if necessary.
+        while inputs.len() < C::NUM_INPUT_RECORDS {
+            // TODO (howardwu): Decide whether to "push" or "push_front" for program flow.
+            inputs.push(Input::new_noop(noop.clone(), rng)?);
+        }
+
+        // Compute the joint serial numbers.
+        let mut joint_serial_numbers = Vec::with_capacity(C::NUM_INPUT_RECORDS);
+        for input in inputs.iter().take(C::NUM_INPUT_RECORDS) {
+            joint_serial_numbers.extend_from_slice(&input.serial_number().to_bytes_le()?);
+        }
+
+        // Construct the outputs.
+        let mut outputs = self.outputs.clone();
+        // Pad the outputs with noop outputs if necessary.
+        while outputs.len() < C::NUM_OUTPUT_RECORDS {
+            let position = (C::NUM_INPUT_RECORDS + outputs.len()) as u8;
+            // TODO (howardwu): Decide whether to "push" or "push_front" for program flow.
+            outputs.push(Output::new_noop(
+                noop.clone(),
+                position,
+                joint_serial_numbers.clone(),
+                rng,
+            )?);
+        }
+
+        Ok(State { inputs, outputs })
+    }
+}

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -93,7 +93,10 @@ pub trait Parameters: 'static + Sized + Send + Sync {
     type AccountEncryptionGadget: EncryptionGadget<Self::AccountEncryptionScheme, Self::InnerScalarField>;
 
     /// Signature scheme for delegated compute. Invoked only over `Self::InnerScalarField`.
-    type AccountSignatureScheme: SignatureScheme<PublicKey = Self::AccountSignaturePublicKey>;
+    type AccountSignatureScheme: SignatureScheme<
+        PublicKey = Self::AccountSignaturePublicKey,
+        Signature = Self::AccountSignature,
+    >;
     type AccountSignatureGadget: SignatureGadget<Self::AccountSignatureScheme, Self::InnerScalarField>;
     type AccountSignaturePublicKey: ToConstraintField<Self::InnerScalarField>
         + Clone
@@ -107,6 +110,7 @@ pub trait Parameters: 'static + Sized + Send + Sync {
         + Sync
         + CanonicalSerialize
         + CanonicalDeserialize;
+    type AccountSignature: Clone + Debug + Default + ToBytes + FromBytes + Send + Sync + PartialEq + Eq;
 
     /// CRH for the encrypted record. Invoked only over `Self::InnerScalarField`.
     type EncryptedRecordCRH: CRH<Output = Self::EncryptedRecordDigest>;

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -19,14 +19,9 @@ use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, SNARK};
 
 use rand::{CryptoRng, Rng};
 
-pub trait Program<C: Parameters>: Send + Sync {
-    /// Initializes a new instance of the program.
-    fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, ProgramError>
-    where
-        Self: Sized;
-
-    /// Loads an instance of a program.
-    fn load() -> Result<Self, ProgramError>
+pub trait ProgramScheme<C: Parameters>: Send + Sync {
+    /// Initializes an instance of the program with the given circuits.
+    fn new(circuits: Vec<Box<dyn ProgramCircuit<C>>>) -> Result<Self, ProgramError>
     where
         Self: Sized;
 

--- a/dpc/src/traits/transaction.rs
+++ b/dpc/src/traits/transaction.rs
@@ -58,7 +58,4 @@ pub trait TransactionScheme: Clone + Eq + FromBytes + ToBytes + Send + Sync {
 
     /// Returns the encrypted records
     fn encrypted_records(&self) -> &[Self::EncryptedRecord];
-
-    /// Returns the transaction size in bytes.
-    fn size(&self) -> usize;
 }

--- a/dpc/src/traits/transaction.rs
+++ b/dpc/src/traits/transaction.rs
@@ -35,26 +35,26 @@ pub trait TransactionScheme: Clone + Eq + FromBytes + ToBytes + Send + Sync {
     /// Returns the network_id in the transaction.
     fn network_id(&self) -> u8;
 
-    /// Returns the ledger digest.
-    fn ledger_digest(&self) -> &Self::Digest;
-
-    /// Returns the inner circuit ID.
-    fn inner_circuit_id(&self) -> &Self::InnerCircuitID;
-
     /// Returns the old serial numbers.
     fn serial_numbers(&self) -> &[Self::SerialNumber];
 
     /// Returns the new commitments.
     fn commitments(&self) -> &[Self::Commitment];
 
-    /// Returns the memorandum.
-    fn memo(&self) -> &Self::Memo;
-
     /// Returns the value balance in the transaction.
     fn value_balance(&self) -> Self::ValueBalance;
 
+    /// Returns the memorandum.
+    fn memo(&self) -> &Self::Memo;
+
     /// Returns the signatures.
     fn signatures(&self) -> &[Self::Signature];
+
+    /// Returns the ledger digest.
+    fn ledger_digest(&self) -> &Self::Digest;
+
+    /// Returns the inner circuit ID.
+    fn inner_circuit_id(&self) -> &Self::InnerCircuitID;
 
     /// Returns the encrypted records
     fn encrypted_records(&self) -> &[Self::EncryptedRecord];

--- a/dpc/src/traits/transaction.rs
+++ b/dpc/src/traits/transaction.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::errors::TransactionError;
 use snarkvm_utilities::{FromBytes, ToBytes};
 
+use anyhow::Result;
 use std::hash::Hash;
 
 pub trait TransactionScheme: Clone + Eq + FromBytes + ToBytes + Send + Sync {
@@ -30,7 +30,7 @@ pub trait TransactionScheme: Clone + Eq + FromBytes + ToBytes + Send + Sync {
     type Signature: Clone + Eq + FromBytes + ToBytes;
 
     /// Returns the transaction identifier.
-    fn transaction_id(&self) -> Result<[u8; 32], TransactionError>;
+    fn transaction_id(&self) -> Result<[u8; 32]>;
 
     /// Returns the network_id in the transaction.
     fn network_id(&self) -> u8;

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -44,7 +44,7 @@ pub struct TransactionAuthorization<C: Parameters> {
     pub kernel: TransactionKernel<C>,
     pub input_records: Vec<Record<C>>,
     pub output_records: Vec<Record<C>>,
-    pub signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
+    pub signatures: Vec<C::AccountSignature>,
 }
 
 impl<C: Parameters> TransactionAuthorization<C> {
@@ -126,8 +126,7 @@ impl<C: Parameters> FromBytes for TransactionAuthorization<C> {
             output_records.push(FromBytes::read_le(&mut reader)?);
         }
 
-        let mut signatures =
-            Vec::<<C::AccountSignatureScheme as SignatureScheme>::Signature>::with_capacity(C::NUM_INPUT_RECORDS);
+        let mut signatures = Vec::<C::AccountSignature>::with_capacity(C::NUM_INPUT_RECORDS);
         for _ in 0..C::NUM_INPUT_RECORDS {
             signatures.push(FromBytes::read_le(&mut reader)?);
         }

--- a/dpc/src/transaction/transaction.rs
+++ b/dpc/src/transaction/transaction.rs
@@ -62,6 +62,7 @@ pub struct Transaction<C: Parameters> {
 }
 
 impl<C: Parameters> Transaction<C> {
+    /// Initializes a new instance of `Transaction` from the given inputs.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         network: Network,
@@ -69,11 +70,11 @@ impl<C: Parameters> Transaction<C> {
         commitments: Vec<<Self as TransactionScheme>::Commitment>,
         value_balance: AleoAmount,
         memo: <Self as TransactionScheme>::Memo,
+        signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
         ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters>,
         inner_circuit_id: C::InnerCircuitID,
-        proof: <C::OuterSNARK as SNARK>::Proof,
-        signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
         encrypted_records: Vec<EncryptedRecord<C>>,
+        proof: <C::OuterSNARK as SNARK>::Proof,
     ) -> Self {
         assert_eq!(C::NUM_INPUT_RECORDS, serial_numbers.len());
         assert_eq!(C::NUM_OUTPUT_RECORDS, commitments.len());
@@ -84,14 +85,45 @@ impl<C: Parameters> Transaction<C> {
             network,
             serial_numbers,
             commitments,
+            value_balance,
             memo,
+            signatures,
             ledger_digest,
             inner_circuit_id,
-            proof,
-            value_balance,
-            signatures,
             encrypted_records,
+            proof,
         }
+    }
+
+    /// Initializes an instance of `Transaction` from the given inputs.
+    pub fn from(
+        kernel: TransactionKernel<C>,
+        signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
+        ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters>,
+        inner_circuit_id: C::InnerCircuitID,
+        encrypted_records: Vec<EncryptedRecord<C>>,
+        proof: <C::OuterSNARK as SNARK>::Proof,
+    ) -> Self {
+        let TransactionKernel {
+            network_id,
+            serial_numbers,
+            commitments,
+            value_balance,
+            memo,
+        } = kernel;
+
+        Self::new(
+            Network::from_id(network_id),
+            serial_numbers,
+            commitments,
+            value_balance,
+            memo,
+            signatures,
+            ledger_digest,
+            inner_circuit_id,
+            encrypted_records,
+            proof,
+        )
     }
 
     /// Returns the kernel of the transaction.

--- a/dpc/src/transaction/transaction.rs
+++ b/dpc/src/transaction/transaction.rs
@@ -15,10 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{record::*, AleoAmount, Network, Parameters, TransactionKernel, TransactionScheme};
-use snarkvm_algorithms::{
-    merkle_tree::MerkleTreeDigest,
-    traits::{SignatureScheme, SNARK},
-};
+use snarkvm_algorithms::{merkle_tree::MerkleTreeDigest, traits::SNARK};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
 use anyhow::Result;
@@ -49,7 +46,7 @@ pub struct Transaction<C: Parameters> {
     #[derivative(Default(value = "[0u8; 64]"))]
     pub memo: [u8; 64],
     /// The signatures that authorized the transaction kernel.
-    pub signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
+    pub signatures: Vec<C::AccountSignature>,
     /// The root of the ledger commitment tree.
     pub ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters>,
     /// The ID of the inner circuit used to execute this transaction.
@@ -70,7 +67,7 @@ impl<C: Parameters> Transaction<C> {
         commitments: Vec<<Self as TransactionScheme>::Commitment>,
         value_balance: AleoAmount,
         memo: <Self as TransactionScheme>::Memo,
-        signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
+        signatures: Vec<C::AccountSignature>,
         ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters>,
         inner_circuit_id: C::InnerCircuitID,
         encrypted_records: Vec<EncryptedRecord<C>>,
@@ -98,7 +95,7 @@ impl<C: Parameters> Transaction<C> {
     /// Initializes an instance of `Transaction` from the given inputs.
     pub fn from(
         kernel: TransactionKernel<C>,
-        signatures: Vec<<C::AccountSignatureScheme as SignatureScheme>::Signature>,
+        signatures: Vec<C::AccountSignature>,
         ledger_digest: MerkleTreeDigest<C::RecordCommitmentTreeParameters>,
         inner_circuit_id: C::InnerCircuitID,
         encrypted_records: Vec<EncryptedRecord<C>>,
@@ -159,7 +156,7 @@ impl<C: Parameters> TransactionScheme for Transaction<C> {
     type InnerCircuitID = C::InnerCircuitID;
     type Memo = [u8; 64];
     type SerialNumber = C::AccountSignaturePublicKey;
-    type Signature = <C::AccountSignatureScheme as SignatureScheme>::Signature;
+    type Signature = C::AccountSignature;
     type ValueBalance = AleoAmount;
 
     /// Transaction ID = Hash(network ID || serial numbers || commitments || value balance || memo)

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -406,8 +406,8 @@ impl<P: Fp256Parameters> ToBits for Fp256<P> {
     }
 
     fn to_bits_be(&self) -> Vec<bool> {
-        let mut bits_vec = self.to_repr().to_bits_be();
-        bits_vec.truncate(P::MODULUS_BITS as usize);
+        let mut bits_vec = self.to_bits_le();
+        bits_vec.reverse();
 
         bits_vec
     }

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -481,8 +481,8 @@ impl<P: Fp384Parameters> ToBits for Fp384<P> {
     }
 
     fn to_bits_be(&self) -> Vec<bool> {
-        let mut bits_vec = self.to_repr().to_bits_be();
-        bits_vec.truncate(P::MODULUS_BITS as usize);
+        let mut bits_vec = self.to_bits_le();
+        bits_vec.reverse();
 
         bits_vec
     }

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -816,8 +816,8 @@ impl<P: Fp768Parameters> ToBits for Fp768<P> {
     }
 
     fn to_bits_be(&self) -> Vec<bool> {
-        let mut bits_vec = self.to_repr().to_bits_be();
-        bits_vec.truncate(P::MODULUS_BITS as usize);
+        let mut bits_vec = self.to_bits_le();
+        bits_vec.reverse();
 
         bits_vec
     }

--- a/ledger/src/block/transactions.rs
+++ b/ledger/src/block/transactions.rs
@@ -23,6 +23,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
+use anyhow::Result;
 use std::{
     io::{Read, Result as IoResult, Write},
     ops::{Deref, DerefMut},
@@ -48,7 +49,7 @@ impl<T: TransactionScheme> Transactions<T> {
     }
 
     /// Returns the transaction ids.
-    pub fn to_transaction_ids(&self) -> Result<Vec<[u8; 32]>, TransactionError> {
+    pub fn to_transaction_ids(&self) -> Result<Vec<[u8; 32]>> {
         self.0.iter().map(|tx| tx.transaction_id()).collect()
     }
 

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -26,6 +26,7 @@ use rand::thread_rng;
 use std::{
     fs::File,
     io::{Result as IoResult, Write},
+    ops::Deref,
     path::Path,
     str::FromStr,
     sync::Arc,
@@ -71,7 +72,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
     // Construct the output records.
     let mut output_records = Vec::with_capacity(C::NUM_OUTPUT_RECORDS);
     output_records.push(Record::new_output(
-        &dpc.noop_program,
+        dpc.noop_program.deref(),
         recipient,
         false,
         value,

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -61,7 +61,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
     let mut joint_serial_numbers = Vec::with_capacity(C::NUM_INPUT_RECORDS);
     let mut input_records = Vec::with_capacity(C::NUM_INPUT_RECORDS);
     for i in 0..C::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(&dpc.noop_program, genesis_account.address, rng)?;
+        let input_record = Record::new_noop_input(dpc.noop_program.deref(), genesis_account.address, rng)?;
 
         let (sn, _) = input_record.to_serial_number(&private_keys[i])?;
         joint_serial_numbers.extend_from_slice(&to_bytes_le![sn]?);
@@ -82,7 +82,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
         rng,
     )?);
     output_records.push(Record::new_noop_output(
-        &dpc.noop_program,
+        dpc.noop_program.deref(),
         recipient,
         (C::NUM_INPUT_RECORDS + 1) as u8,
         joint_serial_numbers.clone(),
@@ -92,15 +92,8 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
     // Offline execution to generate a transaction authorization.
     let authorization = dpc.authorize(&private_keys, input_records, output_records, None, rng)?;
 
-    // Fetch the noop circuit ID.
-    let noop_circuit_id = dpc
-        .noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)?
-        .circuit_id();
-
     // Construct the executable.
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()), *noop_circuit_id);
+    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
     let executables = vec![noop.clone(), noop.clone(), noop.clone(), noop];
 
     let transaction = dpc.execute(&private_keys, authorization, executables, &temporary_ledger, rng)?;

--- a/parameters/examples/noop_program_snark.rs
+++ b/parameters/examples/noop_program_snark.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_dpc::{DPCError, NoopProgram, Parameters, Program};
+use snarkvm_dpc::{DPCError, NoopProgram, Parameters, ProgramScheme};
 use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkvm_algorithms::{crh::sha256::sha256, SNARK, SRS};
-use snarkvm_dpc::{DPCError, InnerCircuit, NoopProgram, OuterCircuit, Parameters, Program};
+use snarkvm_dpc::{DPCError, InnerCircuit, NoopProgram, OuterCircuit, Parameters, ProgramScheme};
 use snarkvm_parameters::{
     testnet1::{InnerSNARKPKParameters, InnerSNARKVKParameters},
     traits::Parameter,

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkvm_algorithms::{crh::sha256::sha256, SNARK, SRS};
-use snarkvm_dpc::{DPCError, InnerCircuit, NoopProgram, OuterCircuit, Parameters, ProgramScheme};
+use snarkvm_dpc::{DPCError, InnerCircuit, NoopProgram, OuterCircuit, Parameters};
 use snarkvm_parameters::{
     testnet1::{InnerSNARKPKParameters, InnerSNARKVKParameters},
     traits::Parameter,
@@ -40,17 +40,9 @@ pub fn setup<C: Parameters>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let inner_snark_proof = C::InnerSNARK::prove(&inner_snark_pk, &InnerCircuit::<C>::blank(), rng)?;
 
     let noop_program = NoopProgram::<C>::load()?;
-    let noop_circuit_id = noop_program
-        .find_circuit_by_index(0)
-        .ok_or(DPCError::MissingNoopCircuit)?
-        .circuit_id();
 
     let outer_snark_parameters = C::OuterSNARK::setup(
-        &OuterCircuit::<C>::blank(
-            inner_snark_vk,
-            inner_snark_proof,
-            noop_program.execute_blank(noop_circuit_id)?,
-        ),
+        &OuterCircuit::<C>::blank(inner_snark_vk, inner_snark_proof, noop_program.execute_blank_noop()?),
         &mut SRS::CircuitSpecific(rng),
     )?;
 

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -200,7 +200,7 @@ macro_rules! biginteger {
                 BitIteratorLE::new(self).collect::<Vec<_>>()
             }
 
-            /// Returns `self` as a boolean array in big-endian order, without leading zeros.
+            /// Returns `self` as a boolean array in big-endian order, with leading zeros.
             fn to_bits_be(&self) -> Vec<bool> {
                 BitIteratorBE::new(self).collect::<Vec<_>>()
             }

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[inline]
-pub fn from_bytes_le_to_bits_le(bytes: &[u8]) -> impl Iterator<Item = bool> + '_ {
+pub fn from_bytes_le_to_bits_le(bytes: &[u8]) -> impl Iterator<Item = bool> + DoubleEndedIterator<Item = bool> + '_ {
     bytes
         .iter()
         .map(|byte| (0..8).map(move |i| (*byte >> i) & 1 == 1))


### PR DESCRIPTION
## Motivation

### Accounts
- Improves private key generation performance by 98%: removes unnecessary clones, removes unnecessary recomputation of `pk_sig` on every iteration of deriving a valid `r_pk`
```
account_private_key     time:   [7.7360 ms 8.4321 ms 9.1586 ms]                               
                        change: [-98.960% -98.518% -97.638%] (p = 0.00 < 0.05)
                        Performance has improved.
```
- Adds proper `Default` impl of `PrivateKey` as `Self::new(&mut thread_rng())`
- Adds a bench program for accounts

### Records
- Updates `Payload` struct to support constructing from byte arrays less than `PAYLOAD_SIZE`

### Programs
- Generalizes `Program` struct for common use across programs.

### Transactions
- Adds `network_id` and `value_balance` to preimage of transaction ID (prevents potential merge spending)
    - Transaction ID is now the hash of the transaction kernel
```
Transaction ID = Hash(network ID || serial numbers || commitments || value balance || memo)
```
- Adds `Transaction::from()`
- Removes `TransactionScheme::size()`

### DPC
- Adds `State` struct with builder
- Adds `Parameters::AccountSignature` associated type

## Test Plan

- Adds `test_private_key_to_decryption_key()` to sanity check the MSB bit of the scalar field element is 0
- Adds `test_payload_from()` which creates a random byte array, construct a payload from it, and check its byte array matches
- All existing tests pass