### PR TITLE
Introduces `StateTransition` to `DPC` struct

### DIFF
--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -206,7 +206,7 @@ fn test_testnet1_dpc_execute_constraints() {
         authorization.to_encrypted_records(&mut rng).unwrap();
 
     let TransactionAuthorization {
-        compute_keys: prover_keys,
+        compute_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,
@@ -245,7 +245,7 @@ fn test_testnet1_dpc_execute_constraints() {
     let inner_private_variables = InnerPrivateVariables::new(
         old_records.clone(),
         old_witnesses,
-        prover_keys,
+        compute_keys,
         new_records.clone(),
         encrypted_record_randomizers,
         program_randomness.clone(),

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -86,7 +86,7 @@ fn dpc_testnet1_integration_test() {
     // Check that new_records can be decrypted from the transaction.
     {
         let encrypted_records = transaction.encrypted_records();
-        let new_account_private_keys = vec![recipient.private_key; Testnet1Parameters::NUM_OUTPUT_RECORDS];
+        let new_account_private_keys = vec![recipient.private_key(); Testnet1Parameters::NUM_OUTPUT_RECORDS];
 
         for ((encrypted_record, private_key), new_record) in
             encrypted_records.iter().zip(new_account_private_keys).zip(new_records)

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -26,7 +26,6 @@ use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use std::{
-    ops::Deref,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -48,10 +47,6 @@ fn test_testnet1_inner_circuit_sanity_check() {
 fn dpc_testnet1_integration_test() {
     let mut rng = ChaChaRng::seed_from_u64(1231275789u64);
 
-    // Generate accounts.
-    let genesis_account = Account::new(&mut rng).unwrap();
-    let recipient = Account::new(&mut rng).unwrap();
-
     // Create a genesis block.
     let genesis_block = Block {
         header: BlockHeader {
@@ -70,52 +65,17 @@ fn dpc_testnet1_integration_test() {
 
     // Generate or load DPC.
     let dpc = setup_or_load_dpc(false, &mut rng);
+    let noop = Arc::new(dpc.noop_program.clone());
 
-    // Generate dummy input records having as address the genesis address.
-    let private_keys = vec![genesis_account.private_key.clone(); Testnet1Parameters::NUM_INPUT_RECORDS];
-
-    let mut joint_serial_numbers = vec![];
-    let mut input_records = vec![];
-    for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(dpc.noop_program.deref(), genesis_account.address, &mut rng).unwrap();
-
-        let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
-
-        input_records.push(input_record);
-    }
-
-    // Construct new records.
-    let mut output_records = vec![];
-    for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
-        output_records.push(
-            Record::new_output(
-                dpc.noop_program.deref(),
-                recipient.address,
-                false,
-                10,
-                Payload::default(),
-                (Testnet1Parameters::NUM_INPUT_RECORDS + j) as u8,
-                joint_serial_numbers.clone(),
-                &mut rng,
-            )
-            .unwrap(),
-        );
-    }
-
-    // Offline execution to generate a transaction authorization.
-    let authorization = dpc
-        .authorize(&private_keys, input_records, output_records, None, &mut rng)
-        .unwrap();
-
-    // Construct the executable.
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
-    let executables = vec![noop.clone(), noop.clone(), noop.clone(), noop];
+    let recipient = Account::new(&mut rng).unwrap();
+    let amount = AleoAmount::from_bytes(10 as i64);
+    let state = StateTransition::new_coinbase(recipient.address, amount, noop, &mut rng).unwrap();
+    let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
     let new_records = authorization.output_records.clone();
 
     let transaction = dpc
-        .execute(&private_keys, authorization, executables, &ledger, &mut rng)
+        .execute(authorization, state.executables(), &ledger, &mut rng)
         .unwrap();
 
     // Check that the transaction is serialized and deserialized correctly
@@ -176,66 +136,24 @@ fn dpc_testnet1_integration_test() {
 fn test_testnet1_transaction_authorization_serialization() {
     let mut rng = ChaChaRng::seed_from_u64(1231275789u64);
 
-    let dpc = Testnet1DPC::load(false).unwrap();
+    // Generate or load DPC.
+    let dpc = setup_or_load_dpc(false, &mut rng);
+    let noop = Arc::new(dpc.noop_program.clone());
 
-    // Generate metadata and an account for a dummy initial record.
-    let test_account = Account::new(&mut rng).unwrap();
+    let recipient = Account::new(&mut rng).unwrap();
+    let amount = AleoAmount::from_bytes(10 as i64);
+    let state = StateTransition::new_coinbase(recipient.address, amount, noop, &mut rng).unwrap();
+    let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
-    let old_private_keys = vec![test_account.private_key.clone(); Testnet1Parameters::NUM_INPUT_RECORDS];
+    // Serialize and recover the transaction authorization.
+    let recovered_authorization = FromBytes::read_le(&authorization.to_bytes_le().unwrap()[..]).unwrap();
 
-    // Set the input records for our transaction to be the initial dummy records.
-    let mut joint_serial_numbers = vec![];
-    let mut input_records = vec![];
-    for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(dpc.noop_program.deref(), test_account.address, &mut rng).unwrap();
-
-        let (sn, _) = input_record.to_serial_number(&old_private_keys[i]).unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
-
-        input_records.push(input_record);
-    }
-
-    // Construct new records.
-
-    // Set the new record's program to be the "always-accept" program.
-    let mut output_records = vec![];
-    for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
-        output_records.push(
-            Record::new_output(
-                dpc.noop_program.deref(),
-                test_account.address,
-                false,
-                10,
-                Payload::default(),
-                (Testnet1Parameters::NUM_INPUT_RECORDS + j) as u8,
-                joint_serial_numbers.clone(),
-                &mut rng,
-            )
-            .unwrap(),
-        );
-    }
-
-    // Generate transaction authorization.
-    let authorization = dpc
-        .authorize(&old_private_keys, input_records, output_records, None, &mut rng)
-        .unwrap();
-
-    // Serialize the transaction kernel.
-    let recovered_transaction_authorization = FromBytes::read_le(&authorization.to_bytes_le().unwrap()[..]).unwrap();
-
-    assert_eq!(authorization, recovered_transaction_authorization);
+    assert_eq!(authorization, recovered_authorization);
 }
 
 #[test]
 fn test_testnet1_dpc_execute_constraints() {
     let mut rng = ChaChaRng::seed_from_u64(1231275789u64);
-
-    let dpc = Testnet1DPC::setup(&mut rng).unwrap();
-
-    let alternate_noop_program = NoopProgram::<Testnet1Parameters>::setup(&mut rng).unwrap();
-
-    // Generate metadata and an account for a dummy initial record.
-    let dummy_account = Account::new(&mut rng).unwrap();
 
     let genesis_block = Block {
         header: BlockHeader {
@@ -253,55 +171,26 @@ fn test_testnet1_dpc_execute_constraints() {
     // Use genesis block to initialize the ledger.
     let ledger = Ledger::<Testnet1Parameters, MemDb>::new(None, genesis_block).unwrap();
 
-    let private_keys = vec![dummy_account.private_key; Testnet1Parameters::NUM_INPUT_RECORDS];
+    let dpc = Testnet1DPC::setup(&mut rng).unwrap();
+    let noop = Arc::new(dpc.noop_program.clone());
 
-    // Set the input records for our transaction to be the initial dummy records.
-    let mut joint_serial_numbers = vec![];
-    let mut input_records = vec![];
-    for i in 0..Testnet1Parameters::NUM_INPUT_RECORDS {
-        let input_record =
-            Record::new_noop_input(alternate_noop_program.deref(), dummy_account.address, &mut rng).unwrap();
+    let alternate_noop_program = NoopProgram::<Testnet1Parameters>::setup(&mut rng).unwrap();
+    let alternate_noop = Arc::new(alternate_noop_program.clone());
 
-        let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
+    let recipient = Account::new(&mut rng).unwrap();
+    let amount = AleoAmount::from_bytes(10 as i64);
 
-        input_records.push(input_record);
-    }
-
-    // Create an account for an actual new record.
-    let new_account = Account::new(&mut rng).unwrap();
-
-    // Construct new records.
-
-    // Set the new record's program to be the "always-accept" program.
-    let mut output_records = vec![];
-    for j in 0..Testnet1Parameters::NUM_OUTPUT_RECORDS {
-        output_records.push(
-            Record::new_output(
-                dpc.noop_program.deref(),
-                new_account.address,
-                false,
-                10,
-                Payload::default(),
-                (Testnet1Parameters::NUM_INPUT_RECORDS + j) as u8,
-                joint_serial_numbers.clone(),
-                &mut rng,
-            )
-            .unwrap(),
-        );
-    }
-
-    let authorization = dpc
-        .authorize(&private_keys, input_records, output_records, None, &mut rng)
+    let state = StateTransition::builder()
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, alternate_noop).unwrap())
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, noop.clone()).unwrap())
+        .build(noop, &mut rng)
         .unwrap();
+    let executables = state.executables();
+
+    let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
-
-    // Construct the executable.
-    let alternate_noop = Executable::Noop(Arc::new(alternate_noop_program.clone()));
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
-    let executables = vec![alternate_noop.clone(), alternate_noop, noop.clone(), noop];
 
     // Execute the programs.
     let mut executions = Vec::with_capacity(Testnet1Parameters::NUM_TOTAL_RECORDS);
@@ -317,6 +206,7 @@ fn test_testnet1_dpc_execute_constraints() {
         authorization.to_encrypted_records(&mut rng).unwrap();
 
     let TransactionAuthorization {
+        prover_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,
@@ -355,7 +245,7 @@ fn test_testnet1_dpc_execute_constraints() {
     let inner_private_variables = InnerPrivateVariables::new(
         old_records.clone(),
         old_witnesses,
-        private_keys.clone(),
+        prover_keys,
         new_records.clone(),
         encrypted_record_randomizers,
         program_randomness.clone(),

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -75,7 +75,7 @@ fn dpc_testnet1_integration_test() {
     let new_records = authorization.output_records.clone();
 
     let transaction = dpc
-        .execute(authorization, state.executables(), &ledger, &mut rng)
+        .execute(&vec![], authorization, state.executables(), &ledger, &mut rng)
         .unwrap();
 
     // Check that the transaction is serialized and deserialized correctly
@@ -205,14 +205,12 @@ fn test_testnet1_dpc_execute_constraints() {
     let (_encrypted_records, encrypted_record_hashes, encrypted_record_randomizers) =
         authorization.to_encrypted_records(&mut rng).unwrap();
 
-    // Fetch the compute keys.
-    let compute_keys = vec![recipient.compute_key().clone(), recipient.compute_key().clone()];
-
     let TransactionAuthorization {
         kernel,
         input_records: old_records,
         output_records: new_records,
         signatures: _,
+        noop_compute_keys,
     } = authorization;
 
     let local_data_root = local_data.root();
@@ -247,7 +245,7 @@ fn test_testnet1_dpc_execute_constraints() {
     let inner_private_variables = InnerPrivateVariables::new(
         old_records.clone(),
         old_witnesses,
-        compute_keys,
+        noop_compute_keys.iter().map(|key| key.clone().unwrap()).collect(), // This is safe only for this test case.
         new_records.clone(),
         encrypted_record_randomizers,
         program_randomness.clone(),

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -205,8 +205,10 @@ fn test_testnet1_dpc_execute_constraints() {
     let (_encrypted_records, encrypted_record_hashes, encrypted_record_randomizers) =
         authorization.to_encrypted_records(&mut rng).unwrap();
 
+    // Fetch the compute keys.
+    let compute_keys = vec![recipient.compute_key().clone(), recipient.compute_key().clone()];
+
     let TransactionAuthorization {
-        compute_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -206,7 +206,7 @@ fn test_testnet1_dpc_execute_constraints() {
         authorization.to_encrypted_records(&mut rng).unwrap();
 
     let TransactionAuthorization {
-        prover_keys,
+        compute_keys: prover_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -69,7 +69,11 @@ fn dpc_testnet1_integration_test() {
 
     let recipient = Account::new(&mut rng).unwrap();
     let amount = AleoAmount::from_bytes(10 as i64);
-    let state = StateTransition::new_coinbase(recipient.address, amount, noop, &mut rng).unwrap();
+    let state = StateTransition::builder()
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, noop.clone()).unwrap())
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, noop.clone()).unwrap())
+        .build(noop, &mut rng)
+        .unwrap();
     let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
     let new_records = authorization.output_records.clone();

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -207,7 +207,7 @@ fn test_testnet2_dpc_execute_constraints() {
         authorization.to_encrypted_records(&mut rng).unwrap();
 
     let TransactionAuthorization {
-        prover_keys,
+        compute_keys: prover_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -87,7 +87,7 @@ fn dpc_testnet2_integration_test() {
     // Check that new_records can be decrypted from the transaction
     {
         let encrypted_records = transaction.encrypted_records();
-        let new_account_private_keys = vec![recipient.private_key; Testnet2Parameters::NUM_OUTPUT_RECORDS];
+        let new_account_private_keys = vec![recipient.private_key(); Testnet2Parameters::NUM_OUTPUT_RECORDS];
 
         for ((encrypted_record, private_key), new_record) in
             encrypted_records.iter().zip(new_account_private_keys).zip(new_records)

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -70,7 +70,11 @@ fn dpc_testnet2_integration_test() {
 
     let recipient = Account::new(&mut rng).unwrap();
     let amount = AleoAmount::from_bytes(10 as i64);
-    let state = StateTransition::new_coinbase(recipient.address, amount, noop, &mut rng).unwrap();
+    let state = StateTransition::builder()
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, noop.clone()).unwrap())
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, noop.clone()).unwrap())
+        .build(noop, &mut rng)
+        .unwrap();
     let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
     let new_records = authorization.output_records.clone();

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -207,7 +207,7 @@ fn test_testnet2_dpc_execute_constraints() {
         authorization.to_encrypted_records(&mut rng).unwrap();
 
     let TransactionAuthorization {
-        compute_keys: prover_keys,
+        compute_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,
@@ -246,7 +246,7 @@ fn test_testnet2_dpc_execute_constraints() {
     let inner_private_variables = InnerPrivateVariables::new(
         old_records.clone(),
         old_witnesses,
-        prover_keys,
+        compute_keys,
         new_records.clone(),
         encrypted_record_randomizers,
         program_randomness.clone(),

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -206,9 +206,6 @@ fn test_testnet2_dpc_execute_constraints() {
     let (_encrypted_records, encrypted_record_hashes, encrypted_record_randomizers) =
         authorization.to_encrypted_records(&mut rng).unwrap();
 
-    // Fetch the compute keys.
-    let compute_keys = vec![recipient.compute_key().clone(), recipient.compute_key().clone()];
-
     let TransactionAuthorization {
         kernel,
         input_records: old_records,

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -76,7 +76,7 @@ fn dpc_testnet2_integration_test() {
     let new_records = authorization.output_records.clone();
 
     let transaction = dpc
-        .execute(authorization, state.executables(), &ledger, &mut rng)
+        .execute(&vec![], authorization, state.executables(), &ledger, &mut rng)
         .unwrap();
 
     // Check that the transaction is serialized and deserialized correctly
@@ -214,6 +214,7 @@ fn test_testnet2_dpc_execute_constraints() {
         input_records: old_records,
         output_records: new_records,
         signatures: _,
+        noop_compute_keys,
     } = authorization;
 
     let local_data_root = local_data.root();
@@ -248,7 +249,7 @@ fn test_testnet2_dpc_execute_constraints() {
     let inner_private_variables = InnerPrivateVariables::new(
         old_records.clone(),
         old_witnesses,
-        compute_keys,
+        noop_compute_keys.iter().map(|key| key.clone().unwrap()).collect(), // This is safe only for this test case.
         new_records.clone(),
         encrypted_record_randomizers,
         program_randomness.clone(),

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -26,7 +26,6 @@ use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use std::{
-    ops::Deref,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -49,10 +48,6 @@ fn test_testnet2_inner_circuit_sanity_check() {
 fn dpc_testnet2_integration_test() {
     let mut rng = ChaChaRng::seed_from_u64(1231275789u64);
 
-    // Generate accounts.
-    let genesis_account = Account::new(&mut rng).unwrap();
-    let recipient = Account::new(&mut rng).unwrap();
-
     // Create a genesis block.
     let genesis_block = Block {
         header: BlockHeader {
@@ -71,52 +66,17 @@ fn dpc_testnet2_integration_test() {
 
     // Generate or load DPC.
     let dpc = setup_or_load_dpc(false, &mut rng);
+    let noop = Arc::new(dpc.noop_program.clone());
 
-    // Generate dummy input records having as address the genesis address.
-    let private_keys = vec![genesis_account.private_key.clone(); Testnet2Parameters::NUM_INPUT_RECORDS];
-
-    let mut joint_serial_numbers = vec![];
-    let mut input_records = vec![];
-    for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(dpc.noop_program.deref(), genesis_account.address, &mut rng).unwrap();
-
-        let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
-
-        input_records.push(input_record);
-    }
-
-    // Construct new records.
-    let mut output_records = vec![];
-    for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
-        output_records.push(
-            Record::new_output(
-                dpc.noop_program.deref(),
-                recipient.address,
-                false,
-                10,
-                Payload::default(),
-                (Testnet2Parameters::NUM_INPUT_RECORDS + j) as u8,
-                joint_serial_numbers.clone(),
-                &mut rng,
-            )
-            .unwrap(),
-        );
-    }
-
-    // Offline execution to generate a transaction authorization.
-    let authorization = dpc
-        .authorize(&private_keys, input_records, output_records, None, &mut rng)
-        .unwrap();
-
-    // Construct the executable.
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
-    let executables = vec![noop.clone(), noop.clone(), noop.clone(), noop];
+    let recipient = Account::new(&mut rng).unwrap();
+    let amount = AleoAmount::from_bytes(10 as i64);
+    let state = StateTransition::new_coinbase(recipient.address, amount, noop, &mut rng).unwrap();
+    let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
     let new_records = authorization.output_records.clone();
 
     let transaction = dpc
-        .execute(&private_keys, authorization, executables, &ledger, &mut rng)
+        .execute(authorization, state.executables(), &ledger, &mut rng)
         .unwrap();
 
     // Check that the transaction is serialized and deserialized correctly
@@ -177,67 +137,24 @@ fn dpc_testnet2_integration_test() {
 fn test_testnet_2_transaction_authorization_serialization() {
     let mut rng = ChaChaRng::seed_from_u64(1231275789u64);
 
-    let dpc = Testnet2DPC::load(false).unwrap();
+    // Generate or load DPC.
+    let dpc = setup_or_load_dpc(false, &mut rng);
+    let noop = Arc::new(dpc.noop_program.clone());
 
-    // Generate metadata and an account for a dummy initial record.
-    let test_account = Account::new(&mut rng).unwrap();
+    let recipient = Account::new(&mut rng).unwrap();
+    let amount = AleoAmount::from_bytes(10 as i64);
+    let state = StateTransition::new_coinbase(recipient.address, amount, noop, &mut rng).unwrap();
+    let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
-    let old_private_keys = vec![test_account.private_key.clone(); Testnet2Parameters::NUM_INPUT_RECORDS];
+    // Serialize and recover the transaction authorization.
+    let recovered_authorization = FromBytes::read_le(&authorization.to_bytes_le().unwrap()[..]).unwrap();
 
-    // Set the input records for our transaction to be the initial dummy records.
-    let mut joint_serial_numbers = vec![];
-    let mut input_records = vec![];
-    for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let old_record = Record::new_noop_input(dpc.noop_program.deref(), test_account.address, &mut rng).unwrap();
-
-        let (sn, _) = old_record.to_serial_number(&old_private_keys[i]).unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
-
-        input_records.push(old_record);
-    }
-
-    // Construct new records.
-
-    // Set the new record's program to be the "always-accept" program.
-    let mut output_records = vec![];
-    for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
-        output_records.push(
-            Record::new_output(
-                dpc.noop_program.deref(),
-                test_account.address,
-                false,
-                10,
-                Payload::default(),
-                (Testnet2Parameters::NUM_INPUT_RECORDS + j) as u8,
-                joint_serial_numbers.clone(),
-                &mut rng,
-            )
-            .unwrap(),
-        );
-    }
-
-    // Generate transaction authorization
-    let transaction_authorization = dpc
-        .authorize(&old_private_keys, input_records, output_records, None, &mut rng)
-        .unwrap();
-
-    // Serialize the transaction kernel
-    let recovered_transaction_authorization =
-        FromBytes::read_le(&transaction_authorization.to_bytes_le().unwrap()[..]).unwrap();
-
-    assert_eq!(transaction_authorization, recovered_transaction_authorization);
+    assert_eq!(authorization, recovered_authorization);
 }
 
 #[test]
 fn test_testnet2_dpc_execute_constraints() {
     let mut rng = ChaChaRng::seed_from_u64(1231275789u64);
-
-    let dpc = Testnet2DPC::setup(&mut rng).unwrap();
-
-    let alternate_noop_program = NoopProgram::<Testnet2Parameters>::setup(&mut rng).unwrap();
-
-    // Generate metadata and an account for a dummy initial record.
-    let dummy_account = Account::new(&mut rng).unwrap();
 
     let genesis_block = Block {
         header: BlockHeader {
@@ -255,55 +172,26 @@ fn test_testnet2_dpc_execute_constraints() {
     // Use genesis block to initialize the ledger.
     let ledger = Ledger::<Testnet2Parameters, MemDb>::new(None, genesis_block).unwrap();
 
-    let private_keys = vec![dummy_account.private_key; Testnet2Parameters::NUM_INPUT_RECORDS];
+    let dpc = Testnet2DPC::setup(&mut rng).unwrap();
+    let noop = Arc::new(dpc.noop_program.clone());
 
-    // Set the input records for our transaction to be the initial dummy records.
-    let mut joint_serial_numbers = vec![];
-    let mut input_records = vec![];
-    for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
-        let input_record =
-            Record::new_noop_input(alternate_noop_program.deref(), dummy_account.address, &mut rng).unwrap();
+    let alternate_noop_program = NoopProgram::<Testnet2Parameters>::setup(&mut rng).unwrap();
+    let alternate_noop = Arc::new(alternate_noop_program.clone());
 
-        let (sn, _) = input_record.to_serial_number(&private_keys[i]).unwrap();
-        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn].unwrap());
+    let recipient = Account::new(&mut rng).unwrap();
+    let amount = AleoAmount::from_bytes(10 as i64);
 
-        input_records.push(input_record);
-    }
-
-    // Create an account for an actual new record.
-    let new_account = Account::new(&mut rng).unwrap();
-
-    // Construct new records.
-
-    // Set the new record's program to be the "always-accept" program.
-    let mut output_records = vec![];
-    for j in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS {
-        output_records.push(
-            Record::new_output(
-                dpc.noop_program.deref(),
-                new_account.address,
-                false,
-                10,
-                Payload::default(),
-                (Testnet2Parameters::NUM_INPUT_RECORDS + j) as u8,
-                joint_serial_numbers.clone(),
-                &mut rng,
-            )
-            .unwrap(),
-        );
-    }
-
-    let authorization = dpc
-        .authorize(&private_keys, input_records, output_records, None, &mut rng)
+    let state = StateTransition::builder()
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, alternate_noop).unwrap())
+        .add_output(Output::new(recipient.address, amount, Payload::default(), None, noop.clone()).unwrap())
+        .build(noop, &mut rng)
         .unwrap();
+    let executables = state.executables();
+
+    let authorization = dpc.authorize(&vec![], &state, &mut rng).unwrap();
 
     // Generate the local data.
     let local_data = authorization.to_local_data(&mut rng).unwrap();
-
-    // Construct the executable.
-    let alternate_noop = Executable::Noop(Arc::new(alternate_noop_program.clone()));
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
-    let executables = vec![alternate_noop.clone(), alternate_noop, noop.clone(), noop];
 
     // Execute the programs.
     let mut executions = Vec::with_capacity(Testnet2Parameters::NUM_TOTAL_RECORDS);
@@ -319,6 +207,7 @@ fn test_testnet2_dpc_execute_constraints() {
         authorization.to_encrypted_records(&mut rng).unwrap();
 
     let TransactionAuthorization {
+        prover_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,
@@ -357,7 +246,7 @@ fn test_testnet2_dpc_execute_constraints() {
     let inner_private_variables = InnerPrivateVariables::new(
         old_records.clone(),
         old_witnesses,
-        private_keys.clone(),
+        prover_keys,
         new_records.clone(),
         encrypted_record_randomizers,
         program_randomness.clone(),

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -206,8 +206,10 @@ fn test_testnet2_dpc_execute_constraints() {
     let (_encrypted_records, encrypted_record_hashes, encrypted_record_randomizers) =
         authorization.to_encrypted_records(&mut rng).unwrap();
 
+    // Fetch the compute keys.
+    let compute_keys = vec![recipient.compute_key().clone(), recipient.compute_key().clone()];
+
     let TransactionAuthorization {
-        compute_keys,
         kernel,
         input_records: old_records,
         output_records: new_records,

--- a/algorithms/src/encryption/ecies_poseidon.rs
+++ b/algorithms/src/encryption/ecies_poseidon.rs
@@ -278,7 +278,7 @@ where
 
         if bits.len() % 8 != 0 {
             return Err(EncryptionError::Message(
-                "The number of bits in the packed field elements is not a multiply of 8.".to_string(),
+                "The number of bits in the packed field elements is not a multiple of 8.".to_string(),
             )
             .into());
         }

--- a/dpc/benches/transaction.rs
+++ b/dpc/benches/transaction.rs
@@ -37,7 +37,7 @@ fn coinbase_transaction<C: Parameters>(
     let amount = AleoAmount::from_bytes(value as i64);
     let state = StateTransition::new_coinbase(recipient, amount, noop, rng)?;
     let authorization = dpc.authorize(&vec![], &state, rng)?;
-    let transaction = dpc.execute(authorization, state.executables(), &ledger, rng)?;
+    let transaction = dpc.execute(&vec![], authorization, state.executables(), &ledger, rng)?;
 
     Ok(transaction)
 }

--- a/dpc/benches/transaction.rs
+++ b/dpc/benches/transaction.rs
@@ -59,14 +59,14 @@ fn coinbase_transaction<C: Parameters>(
         value,
         Payload::default(),
         C::NUM_INPUT_RECORDS as u8,
-        joint_serial_numbers.clone(),
+        &joint_serial_numbers,
         rng,
     )?);
     output_records.push(Record::new_noop_output(
         dpc.noop_program.deref(),
         recipient,
         (C::NUM_INPUT_RECORDS + 1) as u8,
-        joint_serial_numbers.clone(),
+        &joint_serial_numbers,
         rng,
     )?);
 

--- a/dpc/benches/transaction.rs
+++ b/dpc/benches/transaction.rs
@@ -19,11 +19,10 @@ extern crate criterion;
 
 use snarkvm_dpc::{prelude::*, testnet1::*, testnet2::*};
 use snarkvm_ledger::{ledger::*, prelude::*};
-use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use criterion::Criterion;
 use rand::thread_rng;
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 fn coinbase_transaction<C: Parameters>(
     dpc: &DPC<C>,
@@ -37,7 +36,7 @@ fn coinbase_transaction<C: Parameters>(
     let amount = AleoAmount::from_bytes(value as i64);
     let state = StateTransition::new_coinbase(recipient, amount, noop, rng)?;
     let authorization = dpc.authorize(&vec![], &state, rng)?;
-    let transaction = dpc.execute(&vec![], authorization, state.executables(), &ledger, rng)?;
+    let transaction = dpc.execute(&vec![], authorization, state.executables(), ledger, rng)?;
 
     Ok(transaction)
 }

--- a/dpc/src/account/account.rs
+++ b/dpc/src/account/account.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{AccountError, AccountScheme, Address, Parameters, PrivateKey, ViewKey};
+use crate::{AccountError, AccountScheme, Address, ComputeKey, Parameters, PrivateKey, ViewKey};
 
 use rand::{CryptoRng, Rng};
 use std::{convert::TryFrom, fmt};
@@ -22,13 +22,14 @@ use std::{convert::TryFrom, fmt};
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Parameters"))]
 pub struct Account<C: Parameters> {
-    pub private_key: PrivateKey<C>,
+    private_key: PrivateKey<C>,
     pub view_key: ViewKey<C>,
     pub address: Address<C>,
 }
 
 impl<C: Parameters> AccountScheme for Account<C> {
     type Address = Address<C>;
+    type ComputeKey = ComputeKey<C>;
     type PrivateKey = PrivateKey<C>;
     type ViewKey = ViewKey<C>;
 
@@ -43,6 +44,16 @@ impl<C: Parameters> AccountScheme for Account<C> {
             view_key,
             address,
         })
+    }
+
+    /// Returns a reference to the private key.
+    fn private_key(&self) -> &Self::PrivateKey {
+        &self.private_key
+    }
+
+    /// Returns a reference to the compute key.
+    fn compute_key(&self) -> &Self::ComputeKey {
+        self.private_key.compute_key()
     }
 }
 

--- a/dpc/src/account/account_format.rs
+++ b/dpc/src/account/account_format.rs
@@ -18,6 +18,6 @@ pub static ACCOUNT_COMMITMENT_INPUT: &str = "AleoAccountCommitment0";
 pub static ACCOUNT_ENCRYPTION_AND_SIGNATURE_INPUT: &str = "AleoAccountEncryptionAndSignatureScheme0";
 
 pub static PRIVATE_KEY_PREFIX: [u8; 9] = [127, 134, 189, 116, 210, 221, 210, 137, 144]; // APrivateKey1
-pub static _PROVING_KEY_PREFIX: [u8; 10] = [109, 249, 98, 224, 36, 15, 213, 187, 79, 190]; // AProvingKey1
+pub static _COMPUTE_KEY_PREFIX: [u8; 10] = [109, 249, 98, 224, 36, 15, 213, 187, 79, 190]; // AComputeKey1
 pub static VIEW_KEY_PREFIX: [u8; 7] = [14, 138, 223, 204, 247, 224, 122]; // AViewKey1
 pub static ADDRESS_PREFIX: &str = "aleo";

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{account_format, traits::Parameters, AccountError, PrivateKey, ViewKey};
+use crate::{account_format, AccountError, ComputeKey, Parameters, PrivateKey, ViewKey};
 use snarkvm_algorithms::{EncryptionScheme, SignatureScheme};
 use snarkvm_curves::AffineCurve;
 use snarkvm_utilities::{FromBytes, ToBytes};
@@ -42,7 +42,12 @@ pub struct Address<C: Parameters> {
 impl<C: Parameters> Address<C> {
     /// Derives the account address from an account private key.
     pub fn from_private_key(private_key: &PrivateKey<C>) -> Result<Self, AccountError> {
-        let decryption_key = private_key.to_decryption_key()?;
+        Self::from_compute_key(private_key.compute_key())
+    }
+
+    /// Derives the account address from an account compute key.
+    pub fn from_compute_key(compute_key: &ComputeKey<C>) -> Result<Self, AccountError> {
+        let decryption_key = compute_key.to_decryption_key()?;
         let encryption_key = C::account_encryption_scheme().generate_public_key(&decryption_key)?;
         Ok(Self { encryption_key })
     }

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -82,8 +82,8 @@ impl<C: Parameters> Address<C> {
     }
 
     /// Returns the address as an encryption public key.
-    pub fn to_encryption_key(&self) -> &<C::AccountEncryptionScheme as EncryptionScheme>::PublicKey {
-        &self.encryption_key
+    pub fn to_encryption_key(self) -> <C::AccountEncryptionScheme as EncryptionScheme>::PublicKey {
+        self.encryption_key
     }
 }
 

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -87,7 +87,7 @@ impl<C: Parameters> Address<C> {
     }
 
     /// Returns the address as an encryption public key.
-    pub fn to_encryption_key(self) -> <C::AccountEncryptionScheme as EncryptionScheme>::PublicKey {
+    pub fn to_encryption_key(&self) -> <C::AccountEncryptionScheme as EncryptionScheme>::PublicKey {
         self.encryption_key
     }
 }

--- a/dpc/src/account/compute_key.rs
+++ b/dpc/src/account/compute_key.rs
@@ -1,0 +1,143 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{AccountError, Parameters, PrivateKey};
+use snarkvm_algorithms::{CommitmentScheme, EncryptionScheme, PRF};
+use snarkvm_utilities::{from_bytes_le_to_bits_le, to_bytes_le, FromBytes, ToBits, ToBytes};
+
+use rand::thread_rng;
+use std::fmt;
+
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "C: Parameters"),
+    PartialEq(bound = "C: Parameters"),
+    Eq(bound = "C: Parameters")
+)]
+pub struct ComputeKey<C: Parameters> {
+    pk_sig: C::AccountSignaturePublicKey,
+    sk_prf: <C::PRF as PRF>::Seed,
+    pub(super) r_pk: <C::AccountCommitmentScheme as CommitmentScheme>::Randomness,
+    commitment_input: Vec<u8>,
+}
+
+impl<C: Parameters> ComputeKey<C> {
+    /// Creates a new account compute key.
+    ///
+    /// This constructor is currently limited for internal use.
+    /// The general convention for deriving a compute key should be from a private key.
+    pub(crate) fn new(
+        pk_sig: C::AccountSignaturePublicKey,
+        sk_prf: <C::PRF as PRF>::Seed,
+        r_pk: <C::AccountCommitmentScheme as CommitmentScheme>::Randomness,
+    ) -> Result<Self, AccountError> {
+        // Construct the commitment input for the account address.
+        let commitment_input = to_bytes_le![pk_sig, sk_prf]?;
+
+        // Initialize a candidate compute key.
+        let compute_key = Self {
+            pk_sig,
+            sk_prf,
+            r_pk,
+            commitment_input,
+        };
+
+        // Returns the compute key if it is valid.
+        match compute_key.is_valid() {
+            true => Ok(compute_key),
+            false => Err(AccountError::InvalidComputeKey),
+        }
+    }
+
+    /// Returns `true` if the private key is well-formed. Otherwise, returns `false`.
+    pub fn is_valid(&self) -> bool {
+        self.to_decryption_key().is_ok()
+    }
+
+    /// Returns a reference to the signature public key.
+    pub fn pk_sig(&self) -> &C::AccountSignaturePublicKey {
+        &self.pk_sig
+    }
+
+    /// Returns a reference to the PRF secret key.
+    pub fn sk_prf(&self) -> &<C::PRF as PRF>::Seed {
+        &self.sk_prf
+    }
+
+    /// Returns a reference to the commitment randomness for the decryption key.
+    pub fn r_pk(&self) -> &<C::AccountCommitmentScheme as CommitmentScheme>::Randomness {
+        &self.r_pk
+    }
+
+    /// Returns the decryption key for the account view key.
+    pub fn to_decryption_key(
+        &self,
+    ) -> Result<<C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey, AccountError> {
+        // Compute the commitment, which is used as the decryption key.
+        let commitment = C::account_commitment_scheme().commit(&self.commitment_input, &self.r_pk)?;
+        let commitment_bytes = commitment.to_bytes_le()?;
+
+        // Determine the number of MSB bits we must enforce are zero,
+        // for the isomorphism from the base field to the scalar field.
+        let enforce_zero_on_num_bits = {
+            debug_assert!(C::AccountEncryptionScheme::private_key_size_in_bits() > 0);
+            // We must enforce that the MSB bit of the scalar field is also set to 0.
+            let capacity = C::AccountEncryptionScheme::private_key_size_in_bits() - 1;
+            let commitment_num_bits = commitment_bytes.len() * 8;
+            assert!(capacity < commitment_num_bits);
+
+            commitment_num_bits - capacity
+        };
+
+        // This operation explicitly enforces that the unused MSB bits
+        // for the scalar field representation are correctly set to 0.
+        for msb_bit in from_bytes_le_to_bits_le(&commitment_bytes[..])
+            .rev()
+            .take(enforce_zero_on_num_bits)
+        {
+            // Pop the next MSB bit, and enforce it is zero.
+            if msb_bit {
+                return Err(AccountError::InvalidAccountCommitment);
+            }
+        }
+
+        // This operation enforces that the base field element fits within the scalar field.
+        // However, this operation does not enforce that the MSB of the scalar field element is 0.
+        let decryption_key: <C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey =
+            FromBytes::read_le(&commitment_bytes[..])?;
+
+        // Enforce the MSB of the scalar field element is 0 by convention.
+        debug_assert_eq!(Some(&false), decryption_key.to_bits_be().iter().next());
+
+        Ok(decryption_key)
+    }
+}
+
+impl<C: Parameters> fmt::Debug for ComputeKey<C> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ComputeKey {{ pk_sig: {:?}, sk_prf: {:?}, r_pk: {:?} }}",
+            self.pk_sig, self.sk_prf, self.r_pk
+        )
+    }
+}
+
+impl<C: Parameters> Default for ComputeKey<C> {
+    fn default() -> Self {
+        PrivateKey::new(&mut thread_rng()).compute_key().clone()
+    }
+}

--- a/dpc/src/account/mod.rs
+++ b/dpc/src/account/mod.rs
@@ -25,6 +25,9 @@ pub use account_format::*;
 pub mod address;
 pub use address::*;
 
+pub mod compute_key;
+pub use compute_key::*;
+
 pub mod private_key;
 pub use private_key::*;
 

--- a/dpc/src/account/private_key.rs
+++ b/dpc/src/account/private_key.rs
@@ -14,15 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{account_format, traits::Parameters, AccountError};
+use crate::{account_format, AccountError, ComputeKey, Parameters};
 use snarkvm_algorithms::{
     prf::Blake2s,
-    traits::{CommitmentScheme, EncryptionScheme, SignatureScheme, PRF},
+    traits::{CommitmentScheme, SignatureScheme, PRF},
 };
-use snarkvm_utilities::{from_bytes_le_to_bits_le, to_bytes_le, FromBytes, ToBits, ToBytes};
+use snarkvm_utilities::{FromBytes, ToBytes};
 
 use base58::{FromBase58, ToBase58};
-use rand::{thread_rng, CryptoRng, Rng};
+use rand::{CryptoRng, Rng};
 use std::{fmt, str::FromStr};
 
 #[derive(Derivative)]
@@ -33,15 +33,10 @@ use std::{fmt, str::FromStr};
 )]
 pub struct PrivateKey<C: Parameters> {
     pub seed: [u8; 32],
-    // Derived private attributes from the seed.
-    pub sk_sig: <C::AccountSignatureScheme as SignatureScheme>::PrivateKey,
-    pub sk_prf: <C::PRF as PRF>::Seed,
-    pub r_pk: <C::AccountCommitmentScheme as CommitmentScheme>::Randomness,
     pub r_pk_counter: u16,
-    // TODO (howardwu): Move this into a `ProverKey` struct.
-    pk_sig: C::AccountSignaturePublicKey,
-    // TODO (howardwu): Move this into a `ProverKey` struct.
-    commitment_input: Vec<u8>,
+    // Derived private attributes from the seed.
+    sk_sig: <C::AccountSignatureScheme as SignatureScheme>::PrivateKey,
+    compute_key: ComputeKey<C>,
 }
 
 impl<C: Parameters> PrivateKey<C> {
@@ -68,39 +63,34 @@ impl<C: Parameters> PrivateKey<C> {
 
     /// Derives the account private key from a given seed and verifies it is well-formed.
     pub fn from_seed(seed: &[u8; 32]) -> Result<Self, AccountError> {
-        // Generate the SIG key pair.
+        // Generate the signature private key.
         let sk_sig: <C::AccountSignatureScheme as SignatureScheme>::PrivateKey =
             FromBytes::read_le(Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?.as_ref())?;
+
+        // Derive the signature public key.
         let pk_sig = C::account_signature_scheme().generate_public_key(&sk_sig)?;
 
         // Generate the PRF secret key.
         let sk_prf: <C::PRF as PRF>::Seed =
             FromBytes::read_le(Blake2s::evaluate(&seed, &Self::INPUT_SK_PRF)?.as_ref())?;
 
-        // Construct the commitment input for the account address.
-        let commitment_input = to_bytes_le![pk_sig, sk_prf]?;
-
-        // Initialize a candidate private key.
-        let mut private_key = Self {
-            seed: *seed,
-            sk_sig,
-            sk_prf,
-            r_pk: Default::default(),
-            r_pk_counter: Self::INITIAL_R_PK_COUNTER,
-            pk_sig,
-            commitment_input,
-        };
+        // Initialize a candidate compute key.
+        let mut compute_key = ComputeKey::new(pk_sig, sk_prf, Default::default())?;
 
         // Derive the private key by iterating on the r_pk counter, until a valid r_pk is found.
         for r_pk_counter in Self::INITIAL_R_PK_COUNTER..u16::MAX {
             if let Ok(r_pk) = Self::derive_r_pk(seed, r_pk_counter) {
-                // Update the candidate private key with the derived values.
-                private_key.r_pk = r_pk;
-                private_key.r_pk_counter = r_pk_counter;
+                // Update the candidate compute key with the derived value.
+                compute_key.r_pk = r_pk;
 
-                // Returns the private key if it is valid.
-                if private_key.is_valid() {
-                    return Ok(private_key);
+                // Returns the private key if its compute key is valid.
+                if compute_key.is_valid() {
+                    return Ok(Self {
+                        seed: *seed,
+                        r_pk_counter,
+                        sk_sig,
+                        compute_key,
+                    });
                 }
             }
         }
@@ -108,64 +98,13 @@ impl<C: Parameters> PrivateKey<C> {
         Err(AccountError::InvalidPrivateKeySeed)
     }
 
-    /// Returns `true` if the private key is well-formed. Otherwise, returns `false`.
-    pub fn is_valid(&self) -> bool {
-        self.to_decryption_key().is_ok()
-    }
-
-    /// Returns the decryption key for the account view key.
-    pub fn to_decryption_key(
-        &self,
-    ) -> Result<<C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey, AccountError> {
-        // Compute the commitment, which is used as the decryption key.
-        let commitment = C::account_commitment_scheme().commit(&self.commitment_input, &self.r_pk)?;
-        let commitment_bytes = commitment.to_bytes_le()?;
-
-        // Determine the number of MSB bits we must enforce are zero,
-        // for the isomorphism from the base field to the scalar field.
-        let enforce_zero_on_num_bits = {
-            debug_assert!(C::AccountEncryptionScheme::private_key_size_in_bits() > 0);
-            // We must enforce that the MSB bit of the scalar field is also set to 0.
-            let capacity = C::AccountEncryptionScheme::private_key_size_in_bits() - 1;
-            let commitment_num_bits = commitment_bytes.len() * 8;
-            assert!(capacity < commitment_num_bits);
-
-            commitment_num_bits - capacity
-        };
-
-        // This operation explicitly enforces that the unused MSB bits
-        // for the scalar field representation are correctly set to 0.
-        for msb_bit in from_bytes_le_to_bits_le(&commitment_bytes[..])
-            .rev()
-            .take(enforce_zero_on_num_bits)
-        {
-            // Pop the next MSB bit, and enforce it is zero.
-            if msb_bit {
-                return Err(AccountError::InvalidAccountCommitment);
-            }
-        }
-
-        // This operation enforces that the base field element fits within the scalar field.
-        // However, this operation does not enforce that the MSB of the scalar field element is 0.
-        let decryption_key: <C::AccountEncryptionScheme as EncryptionScheme>::PrivateKey =
-            FromBytes::read_le(&commitment_bytes[..])?;
-
-        // Enforce the MSB of the scalar field element is 0 by convention.
-        debug_assert_eq!(Some(&false), decryption_key.to_bits_be().iter().next());
-
-        Ok(decryption_key)
-    }
-
-    /// Returns the signature public key for deriving the account view key.
-    pub fn pk_sig(&self) -> &C::AccountSignaturePublicKey {
-        &self.pk_sig
-    }
-
     /// Derives the account private key from a given seed and counter without verifying if it is well-formed.
     fn from_seed_and_counter(seed: &[u8; 32], r_pk_counter: u16) -> Result<Self, AccountError> {
-        // Generate the SIG key pair.
+        // Generate the signature private key.
         let sk_sig: <C::AccountSignatureScheme as SignatureScheme>::PrivateKey =
             FromBytes::read_le(Blake2s::evaluate(&seed, &Self::INPUT_SK_SIG)?.as_ref())?;
+
+        // Derive the signature public key.
         let pk_sig = C::account_signature_scheme().generate_public_key(&sk_sig)?;
 
         // Generate the PRF secret key.
@@ -175,18 +114,15 @@ impl<C: Parameters> PrivateKey<C> {
         // Generate the randomness rpk for the commitment scheme.
         let r_pk = Self::derive_r_pk(seed, r_pk_counter)?;
 
-        // Construct the commitment input for the account address.
-        let commitment_input = to_bytes_le![pk_sig, sk_prf]?;
+        // Initialize a candidate compute key.
+        let compute_key = ComputeKey::new(pk_sig, sk_prf, r_pk)?;
 
         // Construct the candidate private key.
         let private_key = Self {
             seed: *seed,
-            sk_sig,
-            sk_prf,
-            r_pk,
             r_pk_counter,
-            pk_sig,
-            commitment_input,
+            sk_sig,
+            compute_key,
         };
 
         // Returns the private key if it is valid.
@@ -194,6 +130,21 @@ impl<C: Parameters> PrivateKey<C> {
             true => Ok(private_key),
             false => Err(AccountError::InvalidPrivateKey),
         }
+    }
+
+    /// Returns `true` if the private key is well-formed. Otherwise, returns `false`.
+    pub fn is_valid(&self) -> bool {
+        self.r_pk_counter >= Self::INITIAL_R_PK_COUNTER && self.compute_key.is_valid()
+    }
+
+    /// Returns a reference to the signature private key.
+    pub fn sk_sig(&self) -> &<C::AccountSignatureScheme as SignatureScheme>::PrivateKey {
+        &self.sk_sig
+    }
+
+    /// Returns a reference to the compute key.
+    pub fn compute_key(&self) -> &ComputeKey<C> {
+        &self.compute_key
     }
 
     /// Generate the randomness r_pk for the commitment scheme from a given seed and counter.
@@ -254,11 +205,5 @@ impl<C: Parameters> fmt::Debug for PrivateKey<C> {
             "PrivateKey {{ seed: {:?}, r_pk_counter: {:?} }}",
             self.seed, self.r_pk_counter
         )
-    }
-}
-
-impl<C: Parameters> Default for PrivateKey<C> {
-    fn default() -> Self {
-        Self::new(&mut thread_rng())
     }
 }

--- a/dpc/src/account/tests.rs
+++ b/dpc/src/account/tests.rs
@@ -35,7 +35,7 @@ mod testnet1 {
 
         // Check the seeded derivation matches the hardcoded value, as a sanity check.
         let account = Account::<Testnet1Parameters>::new(&mut rng).unwrap();
-        assert_eq!(ALEO_TESTNET1_PRIVATE_KEY, account.private_key.to_string());
+        assert_eq!(ALEO_TESTNET1_PRIVATE_KEY, account.private_key().to_string());
         assert_eq!(ALEO_TESTNET1_VIEW_KEY, account.view_key.to_string());
         assert_eq!(ALEO_TESTNET1_ADDRESS, account.address.to_string());
 
@@ -188,7 +188,7 @@ mod testnet2 {
 
         // Check the seeded derivation matches the hardcoded value, as a sanity check.
         let account = Account::<Testnet2Parameters>::new(&mut rng).unwrap();
-        assert_eq!(ALEO_TESTNET2_PRIVATE_KEY, account.private_key.to_string());
+        assert_eq!(ALEO_TESTNET2_PRIVATE_KEY, account.private_key().to_string());
         assert_eq!(ALEO_TESTNET2_VIEW_KEY, account.view_key.to_string());
         assert_eq!(ALEO_TESTNET2_ADDRESS, account.address.to_string());
 

--- a/dpc/src/account/tests.rs
+++ b/dpc/src/account/tests.rs
@@ -61,7 +61,7 @@ mod testnet1 {
         // Attempt to sample for a new account ITERATIONS times.
         for _ in 0..ITERATIONS {
             let private_key = PrivateKey::<Testnet1Parameters>::new(&mut thread_rng());
-            let decryption_key = private_key.to_decryption_key().unwrap();
+            let decryption_key = private_key.compute_key().to_decryption_key().unwrap();
             // Enforce the MSB of the scalar field element is 0 by convention.
             assert_eq!(Some(&false), decryption_key.to_bits_be().iter().next());
         }
@@ -214,7 +214,7 @@ mod testnet2 {
         // Attempt to sample for a new account ITERATIONS times.
         for _ in 0..ITERATIONS {
             let private_key = PrivateKey::<Testnet2Parameters>::new(&mut thread_rng());
-            let decryption_key = private_key.to_decryption_key().unwrap();
+            let decryption_key = private_key.compute_key().to_decryption_key().unwrap();
             // Enforce the MSB of the scalar field element is 0 by convention.
             assert_eq!(Some(&false), decryption_key.to_bits_be().iter().next());
         }

--- a/dpc/src/account/view_key.rs
+++ b/dpc/src/account/view_key.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{account_format, traits::Parameters, AccountError, PrivateKey};
+use crate::{account_format, AccountError, ComputeKey, Parameters, PrivateKey};
 use snarkvm_algorithms::{traits::EncryptionScheme, SignatureScheme};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
@@ -41,8 +41,13 @@ pub struct ViewKey<C: Parameters> {
 impl<C: Parameters> ViewKey<C> {
     /// Creates a new account view key from an account private key.
     pub fn from_private_key(private_key: &PrivateKey<C>) -> Result<Self, AccountError> {
+        Self::from_compute_key(private_key.compute_key())
+    }
+
+    /// Creates a new account view key from an account compute key.
+    pub fn from_compute_key(compute_key: &ComputeKey<C>) -> Result<Self, AccountError> {
         Ok(Self {
-            decryption_key: private_key.to_decryption_key()?,
+            decryption_key: compute_key.to_decryption_key()?,
         })
     }
 

--- a/dpc/src/circuits/inner_circuit.rs
+++ b/dpc/src/circuits/inner_circuit.rs
@@ -185,7 +185,10 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
         ) = {
             let declare_cs = &mut cs.ns(|| "Declare input record");
 
-            let given_program_id = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_program_id"), &record.program_id())?;
+            let given_program_id = UInt8::alloc_vec(
+                &mut declare_cs.ns(|| "given_program_id"),
+                &record.program_id().to_bytes_le()?,
+            )?;
             old_program_ids_gadgets.push(given_program_id.clone());
 
             // No need to check that commitments, public keys and hashes are in
@@ -473,7 +476,10 @@ pub fn execute_inner_circuit<C: Parameters, CS: ConstraintSystem<C::InnerScalarF
         ) = {
             let declare_cs = &mut cs.ns(|| "Declare output record");
 
-            let given_program_id = UInt8::alloc_vec(&mut declare_cs.ns(|| "given_program_id"), &record.program_id())?;
+            let given_program_id = UInt8::alloc_vec(
+                &mut declare_cs.ns(|| "given_program_id"),
+                &record.program_id().to_bytes_le()?,
+            )?;
             new_program_ids_gadgets.push(given_program_id.clone());
 
             let given_owner = <C::AccountEncryptionGadget as EncryptionGadget<

--- a/dpc/src/circuits/inner_private_variables.rs
+++ b/dpc/src/circuits/inner_private_variables.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Parameters, PrivateKey, Record};
+use crate::{Parameters, ProverKey, Record};
 use snarkvm_algorithms::{
     merkle_tree::MerklePath,
     traits::{CommitmentScheme, EncryptionScheme},
@@ -26,7 +26,7 @@ pub struct InnerPrivateVariables<C: Parameters> {
     // Inputs records.
     pub(super) input_records: Vec<Record<C>>,
     pub(super) input_witnesses: Vec<MerklePath<C::RecordCommitmentTreeParameters>>,
-    pub(super) private_keys: Vec<PrivateKey<C>>,
+    pub(super) prover_keys: Vec<ProverKey<C>>,
     // Output records.
     pub(super) output_records: Vec<Record<C>>,
     // Encryption of output records.
@@ -41,7 +41,7 @@ impl<C: Parameters> InnerPrivateVariables<C> {
         Self {
             input_records: vec![Record::default(); C::NUM_INPUT_RECORDS],
             input_witnesses: vec![MerklePath::default(); C::NUM_INPUT_RECORDS],
-            private_keys: vec![PrivateKey::default(); C::NUM_INPUT_RECORDS],
+            prover_keys: vec![ProverKey::<C>::default(); C::NUM_INPUT_RECORDS],
             output_records: vec![Record::default(); C::NUM_OUTPUT_RECORDS],
             encrypted_record_randomizers: vec![
                 <C::AccountEncryptionScheme as EncryptionScheme>::Randomness::default();
@@ -58,27 +58,27 @@ impl<C: Parameters> InnerPrivateVariables<C> {
     pub fn new(
         input_records: Vec<Record<C>>,
         old_witnesses: Vec<MerklePath<C::RecordCommitmentTreeParameters>>,
-        old_private_keys: Vec<PrivateKey<C>>,
-        new_records: Vec<Record<C>>,
-        new_records_encryption_randomness: Vec<<C::AccountEncryptionScheme as EncryptionScheme>::Randomness>,
+        prover_keys: Vec<ProverKey<C>>,
+        output_records: Vec<Record<C>>,
+        encrypted_record_randomizers: Vec<<C::AccountEncryptionScheme as EncryptionScheme>::Randomness>,
         program_randomness: <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
-        local_data_commitment_randomizers: Vec<<C::LocalDataCommitmentScheme as CommitmentScheme>::Randomness>,
+        local_data_leaf_randomizers: Vec<<C::LocalDataCommitmentScheme as CommitmentScheme>::Randomness>,
     ) -> Self {
         assert_eq!(C::NUM_INPUT_RECORDS, input_records.len());
         assert_eq!(C::NUM_INPUT_RECORDS, old_witnesses.len());
-        assert_eq!(C::NUM_INPUT_RECORDS, old_private_keys.len());
-        assert_eq!(C::NUM_OUTPUT_RECORDS, new_records.len());
-        assert_eq!(C::NUM_OUTPUT_RECORDS, new_records_encryption_randomness.len());
-        assert_eq!(C::NUM_TOTAL_RECORDS, local_data_commitment_randomizers.len());
+        assert_eq!(C::NUM_INPUT_RECORDS, prover_keys.len());
+        assert_eq!(C::NUM_OUTPUT_RECORDS, output_records.len());
+        assert_eq!(C::NUM_OUTPUT_RECORDS, encrypted_record_randomizers.len());
+        assert_eq!(C::NUM_TOTAL_RECORDS, local_data_leaf_randomizers.len());
 
         Self {
             input_records,
             input_witnesses: old_witnesses,
-            private_keys: old_private_keys,
-            output_records: new_records,
-            encrypted_record_randomizers: new_records_encryption_randomness,
+            prover_keys,
+            output_records,
+            encrypted_record_randomizers,
             program_randomness,
-            local_data_leaf_randomizers: local_data_commitment_randomizers,
+            local_data_leaf_randomizers,
         }
     }
 }

--- a/dpc/src/circuits/inner_private_variables.rs
+++ b/dpc/src/circuits/inner_private_variables.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Parameters, ProverKey, Record};
+use crate::{ComputeKey, Parameters, Record};
 use snarkvm_algorithms::{
     merkle_tree::MerklePath,
     traits::{CommitmentScheme, EncryptionScheme},
@@ -26,7 +26,7 @@ pub struct InnerPrivateVariables<C: Parameters> {
     // Inputs records.
     pub(super) input_records: Vec<Record<C>>,
     pub(super) input_witnesses: Vec<MerklePath<C::RecordCommitmentTreeParameters>>,
-    pub(super) prover_keys: Vec<ProverKey<C>>,
+    pub(super) compute_keys: Vec<ComputeKey<C>>,
     // Output records.
     pub(super) output_records: Vec<Record<C>>,
     // Encryption of output records.
@@ -41,7 +41,7 @@ impl<C: Parameters> InnerPrivateVariables<C> {
         Self {
             input_records: vec![Record::default(); C::NUM_INPUT_RECORDS],
             input_witnesses: vec![MerklePath::default(); C::NUM_INPUT_RECORDS],
-            prover_keys: vec![ProverKey::<C>::default(); C::NUM_INPUT_RECORDS],
+            compute_keys: vec![ComputeKey::<C>::default(); C::NUM_INPUT_RECORDS],
             output_records: vec![Record::default(); C::NUM_OUTPUT_RECORDS],
             encrypted_record_randomizers: vec![
                 <C::AccountEncryptionScheme as EncryptionScheme>::Randomness::default();
@@ -57,24 +57,24 @@ impl<C: Parameters> InnerPrivateVariables<C> {
 
     pub fn new(
         input_records: Vec<Record<C>>,
-        old_witnesses: Vec<MerklePath<C::RecordCommitmentTreeParameters>>,
-        prover_keys: Vec<ProverKey<C>>,
+        input_witnesses: Vec<MerklePath<C::RecordCommitmentTreeParameters>>,
+        compute_keys: Vec<ComputeKey<C>>,
         output_records: Vec<Record<C>>,
         encrypted_record_randomizers: Vec<<C::AccountEncryptionScheme as EncryptionScheme>::Randomness>,
         program_randomness: <C::ProgramCommitmentScheme as CommitmentScheme>::Randomness,
         local_data_leaf_randomizers: Vec<<C::LocalDataCommitmentScheme as CommitmentScheme>::Randomness>,
     ) -> Self {
         assert_eq!(C::NUM_INPUT_RECORDS, input_records.len());
-        assert_eq!(C::NUM_INPUT_RECORDS, old_witnesses.len());
-        assert_eq!(C::NUM_INPUT_RECORDS, prover_keys.len());
+        assert_eq!(C::NUM_INPUT_RECORDS, input_witnesses.len());
+        assert_eq!(C::NUM_INPUT_RECORDS, compute_keys.len());
         assert_eq!(C::NUM_OUTPUT_RECORDS, output_records.len());
         assert_eq!(C::NUM_OUTPUT_RECORDS, encrypted_record_randomizers.len());
         assert_eq!(C::NUM_TOTAL_RECORDS, local_data_leaf_randomizers.len());
 
         Self {
             input_records,
-            input_witnesses: old_witnesses,
-            prover_keys,
+            input_witnesses,
+            compute_keys,
             output_records,
             encrypted_record_randomizers,
             program_randomness,

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -95,8 +95,6 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
         state: &Self::StateTransition,
         rng: &mut R,
     ) -> Result<Self::Authorization> {
-        assert_eq!(C::NUM_INPUT_RECORDS, private_keys.len());
-
         // Keep a cursor for the private keys.
         let mut index = 0;
 

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -17,7 +17,7 @@
 use crate::prelude::*;
 use snarkvm_algorithms::{merkle_tree::MerklePath, prelude::*};
 use snarkvm_fields::ToConstraintField;
-use snarkvm_utilities::{has_duplicates, to_bytes_le, ToBytes, UniformRand};
+use snarkvm_utilities::{has_duplicates, to_bytes_le, ToBytes};
 
 use anyhow::Result;
 use rand::{CryptoRng, Rng};
@@ -95,8 +95,6 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
         rng: &mut R,
     ) -> Result<Self::Authorization> {
         assert_eq!(C::NUM_INPUT_RECORDS, private_keys.len());
-        assert_eq!(C::NUM_INPUT_RECORDS, input_records.len());
-        assert_eq!(C::NUM_OUTPUT_RECORDS, output_records.len());
 
         // Construct the signature message.
         let signature_message = state.transaction_kernel().to_signature_message()?;

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -165,7 +165,7 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
             authorization.to_encrypted_records(rng)?;
 
         let TransactionAuthorization {
-            compute_keys: prover_keys,
+            compute_keys,
             kernel,
             input_records,
             output_records,
@@ -195,7 +195,7 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
         let inner_private_variables = InnerPrivateVariables::new(
             input_records,
             old_witnesses,
-            prover_keys,
+            compute_keys,
             output_records.clone(),
             encrypted_record_randomizers,
             program_randomness.clone(),

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -92,17 +92,17 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
     fn authorize<R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
-        state_transition: Self::StateTransition,
+        state: Self::StateTransition,
         rng: &mut R,
     ) -> Result<Self::Authorization> {
         assert_eq!(C::NUM_INPUT_RECORDS, private_keys.len());
 
         // Construct the signature message.
-        let signature_message = state_transition.kernel().to_signature_message()?;
+        let signature_message = state.kernel().to_signature_message()?;
 
         // Sign the transaction kernel to authorize the transaction.
         let mut signatures = Vec::with_capacity(C::NUM_INPUT_RECORDS);
-        for (i, signature_randomizer) in state_transition
+        for (i, signature_randomizer) in state
             .signature_randomizers()
             .iter()
             .enumerate()
@@ -121,12 +121,7 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
         }
 
         // Return the transaction authorization.
-        Ok(TransactionAuthorization {
-            kernel: state_transition.kernel().clone(),
-            input_records: state_transition.input_records().clone(),
-            output_records: state_transition.output_records().clone(),
-            signatures,
-        })
+        Ok(TransactionAuthorization::from(state, signatures))
     }
 
     /// Returns a transaction by executing an authorized state transition.

--- a/dpc/src/dpc.rs
+++ b/dpc/src/dpc.rs
@@ -34,7 +34,7 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
     type Account = Account<C>;
     type Authorization = TransactionAuthorization<C>;
     type Execution = Execution<C>;
-    type Record = Record<C>;
+    type State = State<C>;
     type Transaction = Transaction<C>;
 
     fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self> {
@@ -91,80 +91,31 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
     fn authorize<R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
-        input_records: Vec<Self::Record>,
-        output_records: Vec<Self::Record>,
-        memo: Option<<Self::Transaction as TransactionScheme>::Memo>,
+        state: Self::State,
         rng: &mut R,
     ) -> Result<Self::Authorization> {
         assert_eq!(C::NUM_INPUT_RECORDS, private_keys.len());
         assert_eq!(C::NUM_INPUT_RECORDS, input_records.len());
         assert_eq!(C::NUM_OUTPUT_RECORDS, output_records.len());
 
-        // Initialize the transaction kernel.
-        let mut kernel = TransactionKernel {
-            network_id: C::NETWORK_ID,
-            serial_numbers: Vec::with_capacity(C::NUM_INPUT_RECORDS),
-            commitments: Vec::with_capacity(C::NUM_OUTPUT_RECORDS),
-            value_balance: AleoAmount::ZERO,
-            memo: [0u8; 64],
-        };
-
-        // Initialize a vector for randomized private keys.
-        let mut randomized_private_keys = Vec::with_capacity(C::NUM_INPUT_RECORDS);
-
-        // Process the input records.
-        for (i, record) in input_records.iter().enumerate().take(C::NUM_INPUT_RECORDS) {
-            // Compute the serial numbers.
-            let (serial_number, signature_randomizer) = record.to_serial_number(&private_keys[i])?;
-            kernel.serial_numbers.push(serial_number);
-
-            // Randomize the private key.
-            randomized_private_keys.push(
-                C::account_signature_scheme().randomize_private_key(&private_keys[i].sk_sig, &signature_randomizer)?,
-            );
-
-            if !record.is_dummy() {
-                kernel.value_balance = kernel.value_balance.add(AleoAmount::from_bytes(record.value() as i64));
-            }
-        }
-
-        // Process the output records.
-        for record in output_records.iter().take(C::NUM_OUTPUT_RECORDS) {
-            // Compute the commitments.
-            kernel.commitments.push(record.commitment());
-
-            if !record.is_dummy() {
-                kernel.value_balance = kernel.value_balance.sub(AleoAmount::from_bytes(record.value() as i64));
-            }
-        }
-
-        // Process the memo.
-        match memo {
-            Some(memo) => memo.write_le(&mut kernel.memo[..])?,
-            None => (0..64)
-                .map(|_| u8::rand(rng))
-                .collect::<Vec<u8>>()
-                .write_le(&mut kernel.memo[..])?,
-        };
-
         // Construct the signature message.
-        let signature_message = match kernel.is_valid() {
-            true => kernel.to_signature_message()?,
-            false => {
-                return Err(DPCError::InvalidKernel(
-                    kernel.network_id,
-                    kernel.serial_numbers.len(),
-                    kernel.commitments.len(),
-                )
-                .into());
-            }
-        };
+        let signature_message = state.transaction_kernel().to_signature_message()?;
 
         // Sign the transaction kernel to authorize the transaction.
         let mut signatures = Vec::with_capacity(C::NUM_INPUT_RECORDS);
-        for i in 0..C::NUM_INPUT_RECORDS {
+        for (i, signature_randomizer) in state
+            .signature_randomizers()
+            .iter()
+            .enumerate()
+            .take(C::NUM_INPUT_RECORDS)
+        {
+            // Randomize the private key.
+            let randomized_private_key =
+                C::account_signature_scheme().randomize_private_key(&private_keys[i].sk_sig, &signature_randomizer)?;
+
+            // Sign and randomize the signature.
             signatures.push(C::account_signature_scheme().sign_randomized(
-                &randomized_private_keys[i],
+                &randomized_private_key,
                 &signature_message,
                 rng,
             )?);
@@ -172,9 +123,9 @@ impl<C: Parameters> DPCScheme<C> for DPC<C> {
 
         // Return the transaction authorization.
         Ok(TransactionAuthorization {
-            kernel,
-            input_records,
-            output_records,
+            kernel: state.transaction_kernel().clone(),
+            input_records: state.input_records().clone(),
+            output_records: state.output_records().clone(),
             signatures,
         })
     }

--- a/dpc/src/errors/account.rs
+++ b/dpc/src/errors/account.rs
@@ -42,6 +42,9 @@ pub enum AccountError {
     #[error("invalid character length: {}", _0)]
     InvalidCharacterLength(usize),
 
+    #[error("invalid account compute key")]
+    InvalidComputeKey,
+
     #[error("invalid prefix: {:?}", _0)]
     InvalidPrefix(String),
 

--- a/dpc/src/errors/account.rs
+++ b/dpc/src/errors/account.rs
@@ -84,3 +84,9 @@ impl From<std::io::Error> for AccountError {
         AccountError::Crate("std::io", format!("{:?}", error))
     }
 }
+
+impl From<AccountError> for std::io::Error {
+    fn from(error: AccountError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", error))
+    }
+}

--- a/dpc/src/program/executable.rs
+++ b/dpc/src/program/executable.rs
@@ -15,6 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Execution, LocalData, NoopProgram, Parameters, PrivateVariables, ProgramScheme, PublicVariables};
+use snarkvm_algorithms::merkle_tree::MerkleTreeDigest;
 
 use anyhow::Result;
 use std::{ops::Deref, sync::Arc};
@@ -37,6 +38,14 @@ impl<C: Parameters> Executable<C> {
         match self {
             Self::Noop(_) => true,
             _ => false,
+        }
+    }
+
+    /// Returns a reference to the program ID of the executable.
+    pub fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters> {
+        match self {
+            Self::Noop(program) => program.program_id(),
+            Self::Circuit(program, _, _) => program.program_id(),
         }
     }
 

--- a/dpc/src/program/executable.rs
+++ b/dpc/src/program/executable.rs
@@ -32,6 +32,14 @@ pub enum Executable<C: Parameters> {
 }
 
 impl<C: Parameters> Executable<C> {
+    /// Returns `true` if the executable is a noop.
+    pub fn is_noop(&self) -> bool {
+        match self {
+            Self::Noop(_) => true,
+            _ => false,
+        }
+    }
+
     /// Returns the execution of the executable given the public variables.
     pub fn execute(&self, record_position: u8, local_data: &LocalData<C>) -> Result<Execution<C>> {
         // Construct the public variables.

--- a/dpc/src/program/program.rs
+++ b/dpc/src/program/program.rs
@@ -46,7 +46,7 @@ impl<C: Parameters> ProgramScheme<C> for Program<C> {
         })
     }
 
-    /// Returns the program ID.
+    /// Returns a reference to the program ID.
     fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters> {
         self.circuits.to_program_id()
     }

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -91,11 +91,11 @@ impl<C: Parameters> EncryptedRecord<C> {
             "The DPC assumes that the record is less than 65535 bytes."
         );
 
-        // Encrypt the record plaintext
-        let record_public_key = record.owner().to_encryption_key();
-        let encryption_randomness = C::account_encryption_scheme().generate_randomness(record_public_key, rng)?;
+        // Encrypt the record plaintext.
+        let encryption_key = record.owner().to_encryption_key();
+        let encryption_randomness = C::account_encryption_scheme().generate_randomness(encryption_key, rng)?;
         let encrypted_record =
-            C::account_encryption_scheme().encrypt(record_public_key, &encryption_randomness, &bytes)?;
+            C::account_encryption_scheme().encrypt(encryption_key, &encryption_randomness, &bytes)?;
         let encrypted_record = Self::new(encrypted_record);
 
         Ok((encrypted_record, encryption_randomness))

--- a/dpc/src/record/encrypted.rs
+++ b/dpc/src/record/encrypted.rs
@@ -93,9 +93,9 @@ impl<C: Parameters> EncryptedRecord<C> {
 
         // Encrypt the record plaintext.
         let encryption_key = record.owner().to_encryption_key();
-        let encryption_randomness = C::account_encryption_scheme().generate_randomness(encryption_key, rng)?;
+        let encryption_randomness = C::account_encryption_scheme().generate_randomness(&encryption_key, rng)?;
         let encrypted_record =
-            C::account_encryption_scheme().encrypt(encryption_key, &encryption_randomness, &bytes)?;
+            C::account_encryption_scheme().encrypt(&encryption_key, &encryption_randomness, &bytes)?;
         let encrypted_record = Self::new(encrypted_record);
 
         Ok((encrypted_record, encryption_randomness))

--- a/dpc/src/record/payload.rs
+++ b/dpc/src/record/payload.rs
@@ -38,6 +38,10 @@ impl Payload {
         Self(payload)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0 == [0u8; PAYLOAD_SIZE]
+    }
+
     pub fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -124,7 +124,7 @@ impl<C: Parameters> Record<C> {
         value: u64,
         payload: Payload,
         position: u8,
-        joint_serial_numbers: Vec<u8>,
+        joint_serial_numbers: &Vec<u8>,
         rng: &mut R,
     ) -> Result<Self, RecordError> {
         // Ensure the output record position is valid.

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -181,7 +181,6 @@ impl<C: Parameters> Record<C> {
         })
     }
 
-    // TODO (howardwu) - Change the private_key input to a signature_public_key.
     pub fn to_serial_number(
         &self,
         private_key: &PrivateKey<C>,
@@ -224,8 +223,8 @@ impl<C: Parameters> RecordScheme for Record<C> {
         &self.program_id
     }
 
-    fn owner(&self) -> &Self::Owner {
-        &self.owner
+    fn owner(&self) -> Self::Owner {
+        self.owner
     }
 
     fn is_dummy(&self) -> bool {

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -15,8 +15,11 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Address, Parameters, Payload, PrivateKey, ProgramScheme, RecordError, RecordScheme};
-use snarkvm_algorithms::traits::{CommitmentScheme, SignatureScheme, CRH, PRF};
-use snarkvm_utilities::{to_bytes_le, variable_length_integer::*, FromBytes, ToBytes, UniformRand};
+use snarkvm_algorithms::{
+    merkle_tree::MerkleTreeDigest,
+    traits::{CommitmentScheme, SignatureScheme, CRH, PRF},
+};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes, UniformRand};
 
 use rand::{CryptoRng, Rng};
 use std::{
@@ -24,10 +27,6 @@ use std::{
     io::{Read, Result as IoResult, Write},
     str::FromStr,
 };
-
-fn default_program_id<C: CRH>() -> Vec<u8> {
-    C::Output::default().to_bytes_le().unwrap()
-}
 
 #[derive(Derivative)]
 #[derivative(
@@ -38,8 +37,7 @@ fn default_program_id<C: CRH>() -> Vec<u8> {
     Eq(bound = "C: Parameters")
 )]
 pub struct Record<C: Parameters> {
-    #[derivative(Default(value = "default_program_id::<C::ProgramCircuitIDCRH>()"))]
-    pub(crate) program_id: Vec<u8>,
+    pub(crate) program_id: MerkleTreeDigest<C::ProgramCircuitTreeParameters>,
     pub(crate) owner: Address<C>,
     pub(crate) is_dummy: bool,
     // TODO (raychu86) use AleoAmount which will guard the value range
@@ -84,7 +82,7 @@ impl<C: Parameters> Record<C> {
         commitment_randomness: <C::RecordCommitmentScheme as CommitmentScheme>::Randomness,
     ) -> Result<Self, RecordError> {
         Self::from(
-            &program.program_id().to_bytes_le()?,
+            program.program_id(),
             owner,
             is_dummy,
             value,
@@ -100,7 +98,7 @@ impl<C: Parameters> Record<C> {
         noop_program: &dyn ProgramScheme<C>,
         owner: Address<C>,
         position: u8,
-        joint_serial_numbers: Vec<u8>,
+        joint_serial_numbers: &Vec<u8>,
         rng: &mut R,
     ) -> Result<Self, RecordError> {
         Self::new_output(
@@ -138,7 +136,7 @@ impl<C: Parameters> Record<C> {
         let commitment_randomness = <C::RecordCommitmentScheme as CommitmentScheme>::Randomness::rand(rng);
 
         Self::from(
-            &program.program_id().to_bytes_le()?,
+            program.program_id(),
             owner,
             is_dummy,
             value,
@@ -150,7 +148,7 @@ impl<C: Parameters> Record<C> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn from(
-        program_id: &Vec<u8>,
+        program_id: &MerkleTreeDigest<C::ProgramCircuitTreeParameters>,
         owner: Address<C>,
         is_dummy: bool,
         value: u64,
@@ -218,10 +216,11 @@ impl<C: Parameters> RecordScheme for Record<C> {
     type CommitmentRandomness = <C::RecordCommitmentScheme as CommitmentScheme>::Randomness;
     type Owner = Address<C>;
     type Payload = Payload;
+    type ProgramID = MerkleTreeDigest<C::ProgramCircuitTreeParameters>;
     type SerialNumber = C::AccountSignaturePublicKey;
     type SerialNumberNonce = C::SerialNumberNonce;
 
-    fn program_id(&self) -> &[u8] {
+    fn program_id(&self) -> &Self::ProgramID {
         &self.program_id
     }
 
@@ -257,9 +256,7 @@ impl<C: Parameters> RecordScheme for Record<C> {
 impl<C: Parameters> ToBytes for Record<C> {
     #[inline]
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        variable_length_integer(self.program_id.len() as u64).write_le(&mut writer)?;
         self.program_id.write_le(&mut writer)?;
-
         self.owner.write_le(&mut writer)?;
         self.is_dummy.write_le(&mut writer)?;
         self.value.write_le(&mut writer)?;
@@ -273,13 +270,7 @@ impl<C: Parameters> ToBytes for Record<C> {
 impl<C: Parameters> FromBytes for Record<C> {
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let program_id_size: usize = read_variable_length_integer(&mut reader)?;
-        let mut program_id = Vec::with_capacity(program_id_size);
-        for _ in 0..program_id_size {
-            let byte: u8 = FromBytes::read_le(&mut reader)?;
-            program_id.push(byte);
-        }
-
+        let program_id: MerkleTreeDigest<C::ProgramCircuitTreeParameters> = FromBytes::read_le(&mut reader)?;
         let owner: Address<C> = FromBytes::read_le(&mut reader)?;
         let is_dummy: bool = FromBytes::read_le(&mut reader)?;
         let value: u64 = FromBytes::read_le(&mut reader)?;

--- a/dpc/src/record/tests.rs
+++ b/dpc/src/record/tests.rs
@@ -71,7 +71,7 @@ fn test_record_encryption() {
 
             // Encrypt the record
             let (encryped_record, _) = EncryptedRecord::encrypt(&given_record, &mut rng).unwrap();
-            let account_view_key = ViewKey::from_private_key(&dummy_account.private_key).unwrap();
+            let account_view_key = ViewKey::from_private_key(&dummy_account.private_key()).unwrap();
 
             // Decrypt the record
             let decrypted_record = encryped_record.decrypt(&account_view_key).unwrap();

--- a/dpc/src/state/builder.rs
+++ b/dpc/src/state/builder.rs
@@ -271,9 +271,8 @@ mod tests {
 
                 let account = Account::new(rng).unwrap();
                 let input_record = Record::new_noop_input(noop_program.deref(), account.address, rng).unwrap();
-                let (serial_number, signature_randomizer) = input_record
-                    .to_serial_number(&account.private_key.compute_key())
-                    .unwrap();
+                let (serial_number, signature_randomizer) =
+                    input_record.to_serial_number(&account.compute_key()).unwrap();
 
                 (input_record, serial_number, signature_randomizer)
             };

--- a/dpc/src/state/builder.rs
+++ b/dpc/src/state/builder.rs
@@ -135,11 +135,18 @@ impl<C: Parameters> StateBuilder<C> {
             .map(|input| input.serial_number().clone())
             .collect();
 
-        // Compute the signature randomizers and noop private keys.
+        // Compute the signature randomizers.
         let signature_randomizers: Vec<_> = inputs
             .iter()
             .take(C::NUM_INPUT_RECORDS)
-            .map(|input| (input.signature_randomizer().clone(), input.noop_private_key().clone()))
+            .map(|input| input.signature_randomizer().clone())
+            .collect();
+
+        // Compute the noop private keys.
+        let noop_private_keys: Vec<_> = inputs
+            .iter()
+            .take(C::NUM_INPUT_RECORDS)
+            .map(|input| input.noop_private_key().clone())
             .collect();
 
         // Compute an instance of the output records, commitments, and value balance.
@@ -200,6 +207,7 @@ impl<C: Parameters> StateBuilder<C> {
             input_records,
             output_records,
             signature_randomizers,
+            noop_private_keys,
             executables,
         })
     }

--- a/dpc/src/state/builder.rs
+++ b/dpc/src/state/builder.rs
@@ -135,11 +135,11 @@ impl<C: Parameters> StateBuilder<C> {
             .map(|input| input.serial_number().clone())
             .collect();
 
-        // Compute the signature randomizers.
+        // Compute the signature randomizers and noop private keys.
         let signature_randomizers: Vec<_> = inputs
             .iter()
             .take(C::NUM_INPUT_RECORDS)
-            .map(|input| input.signature_randomizer().clone())
+            .map(|input| (input.signature_randomizer().clone(), input.noop_private_key().clone()))
             .collect();
 
         // Compute an instance of the output records, commitments, and value balance.

--- a/dpc/src/state/builder.rs
+++ b/dpc/src/state/builder.rs
@@ -98,7 +98,7 @@ impl<C: Parameters> StateBuilder<C> {
     ///
     pub fn append_memo(mut self, data: &Vec<u8>) -> Self {
         // TODO (howardwu): Change this to not be hardcoded to 64.
-        match self.memo.len() < 64 && (self.memo.len() + data.len()) < 64 {
+        match self.memo.len() < 64 && (self.memo.len() + data.len()) <= 64 {
             true => self.memo.extend_from_slice(data),
             false => self.errors.push("Builder exceeded maximum memo size".into()),
         };

--- a/dpc/src/state/builder.rs
+++ b/dpc/src/state/builder.rs
@@ -271,8 +271,9 @@ mod tests {
 
                 let account = Account::new(rng).unwrap();
                 let input_record = Record::new_noop_input(noop_program.deref(), account.address, rng).unwrap();
-                let (serial_number, signature_randomizer) =
-                    input_record.to_serial_number(&account.private_key).unwrap();
+                let (serial_number, signature_randomizer) = input_record
+                    .to_serial_number(&account.private_key.compute_key())
+                    .unwrap();
 
                 (input_record, serial_number, signature_randomizer)
             };

--- a/dpc/src/state/input.rs
+++ b/dpc/src/state/input.rs
@@ -17,7 +17,7 @@
 use crate::prelude::*;
 use snarkvm_algorithms::{CommitmentScheme, SignatureScheme};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use rand::{CryptoRng, Rng};
 use std::sync::Arc;
 

--- a/dpc/src/state/input.rs
+++ b/dpc/src/state/input.rs
@@ -183,11 +183,14 @@ mod tests {
 
                 let account = Account::new(rng).unwrap();
                 let input_record = Record::new_noop_input(noop_program.deref(), account.address, rng).unwrap();
-                let (serial_number, signature_randomizer) = input_record
-                    .to_serial_number(&account.private_key.compute_key())
-                    .unwrap();
-
-                (input_record, serial_number, signature_randomizer, account.private_key)
+                let (serial_number, signature_randomizer) =
+                    input_record.to_serial_number(&account.compute_key()).unwrap();
+                (
+                    input_record,
+                    serial_number,
+                    signature_randomizer,
+                    account.private_key().clone(),
+                )
             };
 
             // Generate the candidate input state.

--- a/dpc/src/state/mod.rs
+++ b/dpc/src/state/mod.rs
@@ -26,5 +26,5 @@ pub use output::*;
 pub mod transition;
 pub use transition::*;
 
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;

--- a/dpc/src/state/mod.rs
+++ b/dpc/src/state/mod.rs
@@ -14,14 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod builder;
+pub use builder::*;
+
 pub mod input;
 pub use input::*;
 
-pub mod state;
-pub use state::*;
-
 pub mod output;
 pub use output::*;
+
+pub mod transition;
+pub use transition::*;
 
 // #[cfg(test)]
 // mod tests;

--- a/dpc/src/state/output.rs
+++ b/dpc/src/state/output.rs
@@ -25,7 +25,7 @@ use std::{convert::TryInto, sync::Arc};
 pub struct Output<C: Parameters> {
     executable: Executable<C>,
     address: Address<C>,
-    value: u64,
+    value: AleoAmount,
     payload: Payload,
     is_dummy: bool,
 }
@@ -43,7 +43,7 @@ impl<C: Parameters> Output<C> {
         Ok(Self {
             executable,
             address: noop_address,
-            value: 0,
+            value: AleoAmount::from_bytes(0),
             payload: Payload::default(),
             is_dummy: true,
         })
@@ -53,7 +53,7 @@ impl<C: Parameters> Output<C> {
     /// Initializes a new instance of `Output`.
     pub fn new(
         address: Address<C>,
-        value: u64,
+        value: AleoAmount,
         payload: Payload,
         executable: Option<Executable<C>>,
         noop: Arc<NoopProgram<C>>,
@@ -65,7 +65,7 @@ impl<C: Parameters> Output<C> {
         };
 
         // Determine if the record is a dummy.
-        let is_dummy = value == 0 && payload.is_empty() && executable.is_noop();
+        let is_dummy = value == AleoAmount::from_bytes(0) && payload.is_empty() && executable.is_noop();
 
         Ok(Self {
             executable,
@@ -87,7 +87,7 @@ impl<C: Parameters> Output<C> {
             self.executable.program(),
             self.address,
             self.is_dummy,
-            self.value,
+            self.value.0 as u64,
             self.payload.clone(),
             position,
             joint_serial_numbers,

--- a/dpc/src/state/tests.rs
+++ b/dpc/src/state/tests.rs
@@ -1,0 +1,100 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+mod coinbase {
+    use crate::{prelude::*, testnet2::*};
+    use snarkvm_utilities::ToBytes;
+
+    use rand::{thread_rng, Rng, SeedableRng};
+    use rand_chacha::ChaChaRng;
+    use std::{ops::Deref, sync::Arc};
+
+    const ITERATIONS: usize = 100;
+
+    #[test]
+    fn test_new_coinbase() {
+        let noop_program = NoopProgram::<Testnet2Parameters>::load().unwrap();
+        let noop = Arc::new(noop_program.clone());
+
+        for _ in 0..ITERATIONS {
+            // Sample a random seed for the RNG.
+            let seed: u64 = thread_rng().gen();
+
+            // Generate the expected state transition.
+            let (expected_account, expected_record, expected_joint_serial_numbers) = {
+                let rng = &mut ChaChaRng::seed_from_u64(seed);
+
+                // Generate the expected coinbase account.
+                let coinbase_account = Account::new(rng).unwrap();
+
+                // Compute the padded inputs to keep the RNG in sync.
+                let mut inputs = Vec::with_capacity(Testnet2Parameters::NUM_INPUT_RECORDS);
+                let mut joint_serial_numbers = Vec::with_capacity(Testnet2Parameters::NUM_INPUT_RECORDS);
+                for _ in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
+                    let input = Input::new_noop(noop.clone(), rng).unwrap();
+                    joint_serial_numbers.extend_from_slice(&input.serial_number().to_bytes_le().unwrap());
+                    inputs.push(input);
+                }
+
+                // Compute the remaining padded outputs to keep the RNG in sync.
+                let mut outputs = Vec::with_capacity(Testnet2Parameters::NUM_OUTPUT_RECORDS);
+                for _ in 0..Testnet2Parameters::NUM_OUTPUT_RECORDS - 1 {
+                    outputs.push(Output::new_noop(noop.clone(), rng).unwrap());
+                }
+
+                // Generate the expected coinbase record.
+                let coinbase_record = {
+                    Record::new_output(
+                        noop_program.deref(),
+                        coinbase_account.address,
+                        false,
+                        123456,
+                        Payload::default(),
+                        Testnet2Parameters::NUM_INPUT_RECORDS as u8,
+                        &joint_serial_numbers,
+                        rng,
+                    )
+                    .unwrap()
+                };
+
+                (coinbase_account, coinbase_record, joint_serial_numbers)
+            };
+
+            // Generate the candidate state transition.
+            let (candidate_account, candidate_state, candidate_joint_serial_numbers) = {
+                let rng = &mut ChaChaRng::seed_from_u64(seed);
+
+                let account = Account::new(rng).unwrap();
+                let state =
+                    StateTransition::new_coinbase(account.address, AleoAmount::from_bytes(123456), noop.clone(), rng)
+                        .unwrap();
+                let joint_serial_numbers = state.kernel().to_joint_serial_numbers().unwrap();
+
+                (account, state, joint_serial_numbers)
+            };
+
+            assert_eq!(expected_account.address, candidate_account.address);
+            for i in 0..Testnet2Parameters::NUM_INPUT_RECORDS {
+                assert!(candidate_state.input_records()[i].is_dummy());
+            }
+            for j in 1..Testnet2Parameters::NUM_OUTPUT_RECORDS {
+                assert!(candidate_state.output_records()[j].is_dummy());
+            }
+            assert_eq!(expected_joint_serial_numbers, candidate_joint_serial_numbers);
+            assert_eq!(expected_record, candidate_state.output_records()[0].clone());
+        }
+    }
+}

--- a/dpc/src/state/transition.rs
+++ b/dpc/src/state/transition.rs
@@ -22,14 +22,15 @@ use rand::{CryptoRng, Rng};
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct State<C: Parameters> {
+pub struct StateTransition<C: Parameters> {
     pub(super) kernel: TransactionKernel<C>,
     pub(super) input_records: Vec<Record<C>>,
     pub(super) output_records: Vec<Record<C>>,
     pub(super) signature_randomizers: Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer>,
+    pub(super) executables: Vec<Executable<C>>,
 }
 
-impl<C: Parameters> State<C> {
+impl<C: Parameters> StateTransition<C> {
     /// Returns a new state transition with no operations performed.
     pub fn new_noop<R: Rng + CryptoRng>(noop: Arc<NoopProgram<C>>, rng: &mut R) -> Result<Self> {
         Ok(Self::builder().build(noop, rng)?)
@@ -98,7 +99,7 @@ impl<C: Parameters> State<C> {
     }
 
     /// Returns a reference to the transaction kernel.
-    pub fn transaction_kernel(&self) -> &TransactionKernel<C> {
+    pub fn kernel(&self) -> &TransactionKernel<C> {
         &self.kernel
     }
 
@@ -115,5 +116,10 @@ impl<C: Parameters> State<C> {
     /// Returns a reference to the signature randomizers.
     pub fn signature_randomizers(&self) -> &Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer> {
         &self.signature_randomizers
+    }
+
+    /// Returns a reference to the executables.
+    pub fn executables(&self) -> &Vec<Executable<C>> {
+        &self.executables
     }
 }

--- a/dpc/src/state/transition.rs
+++ b/dpc/src/state/transition.rs
@@ -75,7 +75,7 @@ impl<C: Parameters> StateTransition<C> {
         let mut inputs = Vec::with_capacity(C::NUM_INPUT_RECORDS);
         for record in records {
             balance = balance.add(AleoAmount::from_bytes(record.value() as i64));
-            inputs.push(Input::new(sender, record.clone(), None, noop.clone())?);
+            inputs.push(Input::new(sender.compute_key(), record.clone(), None, noop.clone())?);
         }
 
         // Ensure the sender has sufficient balance.

--- a/dpc/src/state/transition.rs
+++ b/dpc/src/state/transition.rs
@@ -1,0 +1,119 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::prelude::*;
+use snarkvm_algorithms::SignatureScheme;
+
+use anyhow::{anyhow, Result};
+use rand::{CryptoRng, Rng};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct State<C: Parameters> {
+    pub(super) kernel: TransactionKernel<C>,
+    pub(super) input_records: Vec<Record<C>>,
+    pub(super) output_records: Vec<Record<C>>,
+    pub(super) signature_randomizers: Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer>,
+}
+
+impl<C: Parameters> State<C> {
+    /// Returns a new state transition with no operations performed.
+    pub fn new_noop<R: Rng + CryptoRng>(noop: Arc<NoopProgram<C>>, rng: &mut R) -> Result<Self> {
+        Ok(Self::builder().build(noop, rng)?)
+    }
+
+    /// Returns a new state transition that mints the given amount to the recipient.
+    pub fn new_coinbase<R: Rng + CryptoRng>(
+        recipient: Address<C>,
+        amount: AleoAmount,
+        noop: Arc<NoopProgram<C>>,
+        rng: &mut R,
+    ) -> Result<Self> {
+        Ok(Self::builder()
+            .add_output(Output::new(recipient, amount, Payload::default(), None, noop.clone())?)
+            .build(noop, rng)?)
+    }
+
+    /// Returns a new state transition that transfers a given amount of Aleo credits from a sender to a recipient.
+    pub fn new_transfer<R: Rng + CryptoRng>(
+        sender: &PrivateKey<C>,
+        records: &Vec<Record<C>>,
+        recipient: Address<C>,
+        amount: AleoAmount,
+        fee: AleoAmount,
+        noop: Arc<NoopProgram<C>>,
+        rng: &mut R,
+    ) -> Result<Self> {
+        assert!(records.len() <= C::NUM_INPUT_RECORDS);
+
+        // Calculate the available balance of the sender.
+        let mut balance = AleoAmount::ZERO;
+        let mut inputs = Vec::with_capacity(C::NUM_INPUT_RECORDS);
+        for record in records {
+            balance = balance.add(AleoAmount::from_bytes(record.value() as i64));
+            inputs.push(Input::new(sender, record.clone(), None, noop.clone())?);
+        }
+
+        // Ensure the sender has sufficient balance.
+        let total_cost = amount.add(fee);
+        if balance < total_cost {
+            return Err(anyhow!("Sender(s) has insufficient balance"));
+        }
+
+        // Construct the recipient output.
+        let recipient_output = Output::new(recipient, amount, Payload::default(), None, noop.clone())?;
+
+        // Construct the change output for the sender.
+        let sender_output = Output::new(
+            Address::from_private_key(sender)?,
+            balance.sub(total_cost),
+            Payload::default(),
+            None,
+            noop.clone(),
+        )?;
+
+        Ok(Self::builder()
+            .add_inputs(inputs)
+            .add_output(recipient_output)
+            .add_output(sender_output)
+            .build(noop, rng)?)
+    }
+
+    /// Returns a new instance of `StateBuilder`.
+    pub fn builder() -> StateBuilder<C> {
+        StateBuilder::new()
+    }
+
+    /// Returns a reference to the transaction kernel.
+    pub fn transaction_kernel(&self) -> &TransactionKernel<C> {
+        &self.kernel
+    }
+
+    /// Returns a reference to the input records.
+    pub fn input_records(&self) -> &Vec<Record<C>> {
+        &self.input_records
+    }
+
+    /// Returns a reference to the output records.
+    pub fn output_records(&self) -> &Vec<Record<C>> {
+        &self.output_records
+    }
+
+    /// Returns a reference to the signature randomizers.
+    pub fn signature_randomizers(&self) -> &Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer> {
+        &self.signature_randomizers
+    }
+}

--- a/dpc/src/state/transition.rs
+++ b/dpc/src/state/transition.rs
@@ -32,10 +32,8 @@ pub struct StateTransition<C: Parameters> {
     pub(super) kernel: TransactionKernel<C>,
     pub(super) input_records: Vec<Record<C>>,
     pub(super) output_records: Vec<Record<C>>,
-    pub(super) signature_randomizers: Vec<(
-        <C::AccountSignatureScheme as SignatureScheme>::Randomizer,
-        Option<PrivateKey<C>>,
-    )>,
+    pub(super) signature_randomizers: Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer>,
+    pub(super) noop_private_keys: Vec<Option<PrivateKey<C>>>,
     #[derivative(PartialEq = "ignore", Debug = "ignore")]
     pub(super) executables: Vec<Executable<C>>,
 }
@@ -124,17 +122,28 @@ impl<C: Parameters> StateTransition<C> {
     }
 
     /// Returns a reference to the signature randomizers.
-    pub fn signature_randomizers(
-        &self,
-    ) -> &Vec<(
-        <C::AccountSignatureScheme as SignatureScheme>::Randomizer,
-        Option<PrivateKey<C>>,
-    )> {
+    pub fn signature_randomizers(&self) -> &Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer> {
         &self.signature_randomizers
+    }
+
+    /// Returns a reference to the noop private keys.
+    pub fn noop_private_keys(&self) -> &Vec<Option<PrivateKey<C>>> {
+        &self.noop_private_keys
     }
 
     /// Returns a reference to the executables.
     pub fn executables(&self) -> &Vec<Executable<C>> {
         &self.executables
+    }
+
+    /// Returns a reference to the noop compute keys.
+    pub fn to_noop_compute_keys(&self) -> Vec<Option<ComputeKey<C>>> {
+        self.noop_private_keys
+            .into_iter()
+            .map(|key| match key {
+                Some(private_key) => Some(private_key.compute_key().clone()),
+                None => None,
+            })
+            .collect::<Vec<_>>()
     }
 }

--- a/dpc/src/state/transition.rs
+++ b/dpc/src/state/transition.rs
@@ -21,12 +21,19 @@ use anyhow::{anyhow, Result};
 use rand::{CryptoRng, Rng};
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "C: Parameters"),
+    Debug(bound = "C: Parameters"),
+    PartialEq(bound = "C: Parameters"),
+    Eq(bound = "C: Parameters")
+)]
 pub struct StateTransition<C: Parameters> {
     pub(super) kernel: TransactionKernel<C>,
     pub(super) input_records: Vec<Record<C>>,
     pub(super) output_records: Vec<Record<C>>,
     pub(super) signature_randomizers: Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer>,
+    #[derivative(PartialEq = "ignore", Debug = "ignore")]
     pub(super) executables: Vec<Executable<C>>,
 }
 

--- a/dpc/src/state/transition.rs
+++ b/dpc/src/state/transition.rs
@@ -32,7 +32,10 @@ pub struct StateTransition<C: Parameters> {
     pub(super) kernel: TransactionKernel<C>,
     pub(super) input_records: Vec<Record<C>>,
     pub(super) output_records: Vec<Record<C>>,
-    pub(super) signature_randomizers: Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer>,
+    pub(super) signature_randomizers: Vec<(
+        <C::AccountSignatureScheme as SignatureScheme>::Randomizer,
+        Option<PrivateKey<C>>,
+    )>,
     #[derivative(PartialEq = "ignore", Debug = "ignore")]
     pub(super) executables: Vec<Executable<C>>,
 }
@@ -121,7 +124,12 @@ impl<C: Parameters> StateTransition<C> {
     }
 
     /// Returns a reference to the signature randomizers.
-    pub fn signature_randomizers(&self) -> &Vec<<C::AccountSignatureScheme as SignatureScheme>::Randomizer> {
+    pub fn signature_randomizers(
+        &self,
+    ) -> &Vec<(
+        <C::AccountSignatureScheme as SignatureScheme>::Randomizer,
+        Option<PrivateKey<C>>,
+    )> {
         &self.signature_randomizers
     }
 

--- a/dpc/src/state/transition.rs
+++ b/dpc/src/state/transition.rs
@@ -139,7 +139,7 @@ impl<C: Parameters> StateTransition<C> {
     /// Returns a reference to the noop compute keys.
     pub fn to_noop_compute_keys(&self) -> Vec<Option<ComputeKey<C>>> {
         self.noop_private_keys
-            .into_iter()
+            .iter()
             .map(|key| match key {
                 Some(private_key) => Some(private_key.compute_key().clone()),
                 None => None,

--- a/dpc/src/traits/account.rs
+++ b/dpc/src/traits/account.rs
@@ -20,8 +20,16 @@ use rand::{CryptoRng, Rng};
 
 pub trait AccountScheme: Sized {
     type Address: Default;
+    type ComputeKey;
     type PrivateKey;
     type ViewKey;
 
+    /// Creates a new account.
     fn new<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, AccountError>;
+
+    /// Returns a reference to the private key.
+    fn private_key(&self) -> &Self::PrivateKey;
+
+    /// Returns a reference to the compute key.
+    fn compute_key(&self) -> &Self::ComputeKey;
 }

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -15,14 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    traits::{
-        AccountScheme,
-        Parameters,
-        RecordCommitmentTree,
-        RecordScheme,
-        RecordSerialNumberTree,
-        TransactionScheme,
-    },
+    traits::{AccountScheme, Parameters, RecordCommitmentTree, RecordSerialNumberTree, TransactionScheme},
     Executable,
 };
 
@@ -47,7 +40,7 @@ pub trait DPCScheme<C: Parameters>: Sized {
     fn authorize<R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
-        state: Vec<Self::State>,
+        state: Self::State,
         rng: &mut R,
     ) -> Result<Self::Authorization>;
 

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -26,7 +26,7 @@ pub trait DPCScheme<C: Parameters>: Sized {
     type Account: AccountScheme;
     type Authorization;
     type Execution;
-    type State;
+    type StateTransition;
     type Transaction: TransactionScheme;
 
     /// Initializes a new instance of DPC.
@@ -35,16 +35,15 @@ pub trait DPCScheme<C: Parameters>: Sized {
     /// Loads the saved instance of DPC.
     fn load(verify_only: bool) -> Result<Self>;
 
-    /// Returns a transaction authorization to execute an Aleo transaction.
-    #[allow(clippy::too_many_arguments)]
+    /// Returns an authorization to execute a state transition.
     fn authorize<R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
-        state: Self::State,
+        state_transition: Self::StateTransition,
         rng: &mut R,
     ) -> Result<Self::Authorization>;
 
-    /// Returns a transaction based on the transaction authorization.
+    /// Returns a transaction by executing an authorized state transition.
     fn execute<L: RecordCommitmentTree<C>, R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -46,6 +46,7 @@ pub trait DPCScheme<C: Parameters>: Sized {
     /// Returns a transaction by executing an authorized state transition.
     fn execute<L: RecordCommitmentTree<C>, R: Rng + CryptoRng>(
         &self,
+        compute_keys: &Vec<<Self::Account as AccountScheme>::ComputeKey>,
         authorization: Self::Authorization,
         executables: &Vec<Executable<C>>,
         ledger: &L,

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -39,7 +39,7 @@ pub trait DPCScheme<C: Parameters>: Sized {
     fn authorize<R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
-        state_transition: Self::StateTransition,
+        state: Self::StateTransition,
         rng: &mut R,
     ) -> Result<Self::Authorization>;
 

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -33,8 +33,8 @@ pub trait DPCScheme<C: Parameters>: Sized {
     type Account: AccountScheme;
     type Authorization;
     type Execution;
-    type Record: RecordScheme<Owner = <Self::Account as AccountScheme>::Address>;
-    type Transaction: TransactionScheme<SerialNumber = <Self::Record as RecordScheme>::SerialNumber>;
+    type State;
+    type Transaction: TransactionScheme;
 
     /// Initializes a new instance of DPC.
     fn setup<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self>;
@@ -47,9 +47,7 @@ pub trait DPCScheme<C: Parameters>: Sized {
     fn authorize<R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
-        input_records: Vec<Self::Record>,
-        output_records: Vec<Self::Record>,
-        memo: Option<<Self::Transaction as TransactionScheme>::Memo>,
+        state: Vec<Self::State>,
         rng: &mut R,
     ) -> Result<Self::Authorization>;
 

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -39,16 +39,15 @@ pub trait DPCScheme<C: Parameters>: Sized {
     fn authorize<R: Rng + CryptoRng>(
         &self,
         private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
-        state: Self::StateTransition,
+        state: &Self::StateTransition,
         rng: &mut R,
     ) -> Result<Self::Authorization>;
 
     /// Returns a transaction by executing an authorized state transition.
     fn execute<L: RecordCommitmentTree<C>, R: Rng + CryptoRng>(
         &self,
-        private_keys: &Vec<<Self::Account as AccountScheme>::PrivateKey>,
         authorization: Self::Authorization,
-        executables: Vec<Executable<C>>,
+        executables: &Vec<Executable<C>>,
         ledger: &L,
         rng: &mut R,
     ) -> Result<Self::Transaction>;

--- a/dpc/src/traits/parameters.rs
+++ b/dpc/src/traits/parameters.rs
@@ -105,11 +105,13 @@ pub trait Parameters: 'static + Sized + Send + Sync {
         + ToBytes
         + FromBytes
         + Hash
+        + PartialEq
         + Eq
         + Send
         + Sync
         + CanonicalSerialize
-        + CanonicalDeserialize;
+        + CanonicalDeserialize
+        + PartialEq;
     type AccountSignature: Clone + Debug + Default + ToBytes + FromBytes + Send + Sync + PartialEq + Eq;
 
     /// CRH for the encrypted record. Invoked only over `Self::InnerScalarField`.

--- a/dpc/src/traits/program.rs
+++ b/dpc/src/traits/program.rs
@@ -25,7 +25,7 @@ pub trait ProgramScheme<C: Parameters>: Send + Sync {
     where
         Self: Sized;
 
-    /// Returns the program ID.
+    /// Returns a reference to the program ID.
     fn program_id(&self) -> &MerkleTreeDigest<C::ProgramCircuitTreeParameters>;
 
     /// Returns `true` if the given circuit ID exists in the program.

--- a/dpc/src/traits/record.rs
+++ b/dpc/src/traits/record.rs
@@ -19,6 +19,7 @@ use snarkvm_utilities::{FromBytes, ToBytes};
 use std::hash::Hash;
 
 pub trait RecordScheme: Default + FromBytes + ToBytes {
+    type ProgramID;
     type Owner;
     type Commitment: FromBytes + ToBytes;
     type CommitmentRandomness;
@@ -27,7 +28,7 @@ pub trait RecordScheme: Default + FromBytes + ToBytes {
     type SerialNumber: Clone + Eq + Hash + FromBytes + ToBytes;
 
     /// Returns the program id of this record.
-    fn program_id(&self) -> &[u8];
+    fn program_id(&self) -> &Self::ProgramID;
 
     /// Returns the record owner.
     fn owner(&self) -> &Self::Owner;

--- a/dpc/src/traits/record.rs
+++ b/dpc/src/traits/record.rs
@@ -31,7 +31,7 @@ pub trait RecordScheme: Default + FromBytes + ToBytes {
     fn program_id(&self) -> &Self::ProgramID;
 
     /// Returns the record owner.
-    fn owner(&self) -> &Self::Owner;
+    fn owner(&self) -> Self::Owner;
 
     /// Returns whether or not the record is dummy.
     fn is_dummy(&self) -> bool;

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -49,6 +49,21 @@ pub struct TransactionAuthorization<C: Parameters> {
 
 impl<C: Parameters> TransactionAuthorization<C> {
     #[inline]
+    pub fn from(state: StateTransition<C>, signatures: Vec<C::AccountSignature>) -> Self {
+        debug_assert!(state.kernel().is_valid());
+        debug_assert_eq!(C::NUM_INPUT_RECORDS, state.input_records().len());
+        debug_assert_eq!(C::NUM_OUTPUT_RECORDS, state.output_records().len());
+        debug_assert_eq!(C::NUM_INPUT_RECORDS, signatures.len());
+
+        Self {
+            kernel: state.kernel().clone(),
+            input_records: state.input_records().clone(),
+            output_records: state.output_records().clone(),
+            signatures,
+        }
+    }
+
+    #[inline]
     pub fn to_local_data<R: Rng + CryptoRng>(&self, rng: &mut R) -> Result<LocalData<C>> {
         Ok(LocalData::new(
             &self.kernel,

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{prelude::*, EncryptedRecord, Parameters, Record};
+use crate::prelude::*;
 use snarkvm_algorithms::prelude::*;
 use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes, UniformRand};
 

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -16,7 +16,7 @@
 
 use crate::prelude::*;
 use snarkvm_algorithms::prelude::*;
-use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes, UniformRand};
+use snarkvm_utilities::{to_bytes_le, variable_length_integer, FromBytes, ToBytes, UniformRand};
 
 use anyhow::Result;
 use rand::{CryptoRng, Rng};
@@ -128,7 +128,21 @@ impl<C: Parameters> ToBytes for TransactionAuthorization<C> {
         self.kernel.write_le(&mut writer)?;
         self.input_records.write_le(&mut writer)?;
         self.output_records.write_le(&mut writer)?;
-        self.signatures.write_le(&mut writer)
+        self.signatures.write_le(&mut writer)?;
+
+        // Serialize the noop compute keys with Option ordering in order to
+        // dedup with user-specified compute keys during execution.
+        variable_length_integer(self.noop_compute_keys.len() as u64).write_le(&mut writer)?;
+        for noop_compute_key in self.noop_compute_keys.iter().take(C::NUM_INPUT_RECORDS) {
+            match noop_compute_key {
+                Some(noop_compute_key) => {
+                    true.write_le(&mut writer)?;
+                    noop_compute_key.write_le(&mut writer)?;
+                }
+                None => false.write_le(&mut writer)?,
+            }
+        }
+        Ok(())
     }
 }
 
@@ -152,16 +166,21 @@ impl<C: Parameters> FromBytes for TransactionAuthorization<C> {
             signatures.push(FromBytes::read_le(&mut reader)?);
         }
 
-        // let mut noop_compute_keys = Vec::<Option<ComputeKey<C>>>::with_capacity(C::NUM_INPUT_RECORDS);
-        // for _ in 0..C::NUM_INPUT_RECORDS {
-        //     noop_compute_keys.push(FromBytes::read_le(&mut reader)?);
-        // }
+        let mut noop_compute_keys = Vec::<Option<ComputeKey<C>>>::with_capacity(C::NUM_INPUT_RECORDS);
+        for _ in 0..C::NUM_INPUT_RECORDS {
+            let option_indicator: bool = FromBytes::read_le(&mut reader)?;
+            match option_indicator {
+                true => noop_compute_keys.push(Some(FromBytes::read_le(&mut reader)?)),
+                false => noop_compute_keys.push(None),
+            }
+        }
 
         Ok(Self {
             kernel,
             input_records,
             output_records,
             signatures,
+            noop_compute_keys,
         })
     }
 }

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -26,6 +26,14 @@ use std::{
     str::FromStr,
 };
 
+/// TODO (howardwu): TEMPORARY - Implement a proper struct.
+pub type ProverKey<C> = (
+    <C as Parameters>::AccountSignaturePublicKey,
+    <<C as Parameters>::PRF as PRF>::Seed,
+    <<C as Parameters>::AccountCommitmentScheme as CommitmentScheme>::Randomness,
+    <<C as Parameters>::AccountEncryptionScheme as EncryptionScheme>::PrivateKey,
+);
+
 type EncryptedRecordHash<C> = <<C as Parameters>::EncryptedRecordCRH as CRH>::Output;
 type EncryptedRecordRandomizer<C> = <<C as Parameters>::AccountEncryptionScheme as EncryptionScheme>::Randomness;
 type ProgramCommitment<C> = <<C as Parameters>::ProgramCommitmentScheme as CommitmentScheme>::Output;
@@ -41,6 +49,7 @@ type ProgramCommitmentRandomness<C> = <<C as Parameters>::ProgramCommitmentSchem
     Eq(bound = "C: Parameters")
 )]
 pub struct TransactionAuthorization<C: Parameters> {
+    pub prover_keys: Vec<ProverKey<C>>,
     pub kernel: TransactionKernel<C>,
     pub input_records: Vec<Record<C>>,
     pub output_records: Vec<Record<C>>,
@@ -49,13 +58,19 @@ pub struct TransactionAuthorization<C: Parameters> {
 
 impl<C: Parameters> TransactionAuthorization<C> {
     #[inline]
-    pub fn from(state: StateTransition<C>, signatures: Vec<C::AccountSignature>) -> Self {
+    pub fn from(
+        prover_keys: Vec<ProverKey<C>>,
+        state: &StateTransition<C>,
+        signatures: Vec<C::AccountSignature>,
+    ) -> Self {
+        debug_assert_eq!(C::NUM_INPUT_RECORDS, prover_keys.len());
         debug_assert!(state.kernel().is_valid());
         debug_assert_eq!(C::NUM_INPUT_RECORDS, state.input_records().len());
         debug_assert_eq!(C::NUM_OUTPUT_RECORDS, state.output_records().len());
         debug_assert_eq!(C::NUM_INPUT_RECORDS, signatures.len());
 
         Self {
+            prover_keys,
             kernel: state.kernel().clone(),
             input_records: state.input_records().clone(),
             output_records: state.output_records().clone(),
@@ -151,6 +166,8 @@ impl<C: Parameters> FromBytes for TransactionAuthorization<C> {
         }
 
         Ok(Self {
+            // TODO (howardwu): TEMPORARY - Fix me when a proper ProverKey struct is implemented.
+            prover_keys: vec![],
             kernel,
             input_records,
             output_records,

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -26,14 +26,6 @@ use std::{
     str::FromStr,
 };
 
-/// TODO (howardwu): TEMPORARY - Implement a proper struct.
-pub type ProverKey<C> = (
-    <C as Parameters>::AccountSignaturePublicKey,
-    <<C as Parameters>::PRF as PRF>::Seed,
-    <<C as Parameters>::AccountCommitmentScheme as CommitmentScheme>::Randomness,
-    <<C as Parameters>::AccountEncryptionScheme as EncryptionScheme>::PrivateKey,
-);
-
 type EncryptedRecordHash<C> = <<C as Parameters>::EncryptedRecordCRH as CRH>::Output;
 type EncryptedRecordRandomizer<C> = <<C as Parameters>::AccountEncryptionScheme as EncryptionScheme>::Randomness;
 type ProgramCommitment<C> = <<C as Parameters>::ProgramCommitmentScheme as CommitmentScheme>::Output;
@@ -49,7 +41,7 @@ type ProgramCommitmentRandomness<C> = <<C as Parameters>::ProgramCommitmentSchem
     Eq(bound = "C: Parameters")
 )]
 pub struct TransactionAuthorization<C: Parameters> {
-    pub prover_keys: Vec<ProverKey<C>>,
+    pub compute_keys: Vec<ComputeKey<C>>,
     pub kernel: TransactionKernel<C>,
     pub input_records: Vec<Record<C>>,
     pub output_records: Vec<Record<C>>,
@@ -59,18 +51,18 @@ pub struct TransactionAuthorization<C: Parameters> {
 impl<C: Parameters> TransactionAuthorization<C> {
     #[inline]
     pub fn from(
-        prover_keys: Vec<ProverKey<C>>,
+        compute_keys: Vec<ComputeKey<C>>,
         state: &StateTransition<C>,
         signatures: Vec<C::AccountSignature>,
     ) -> Self {
-        debug_assert_eq!(C::NUM_INPUT_RECORDS, prover_keys.len());
+        debug_assert_eq!(C::NUM_INPUT_RECORDS, compute_keys.len());
         debug_assert!(state.kernel().is_valid());
         debug_assert_eq!(C::NUM_INPUT_RECORDS, state.input_records().len());
         debug_assert_eq!(C::NUM_OUTPUT_RECORDS, state.output_records().len());
         debug_assert_eq!(C::NUM_INPUT_RECORDS, signatures.len());
 
         Self {
-            prover_keys,
+            compute_keys,
             kernel: state.kernel().clone(),
             input_records: state.input_records().clone(),
             output_records: state.output_records().clone(),
@@ -167,7 +159,7 @@ impl<C: Parameters> FromBytes for TransactionAuthorization<C> {
 
         Ok(Self {
             // TODO (howardwu): TEMPORARY - Fix me when a proper ProverKey struct is implemented.
-            prover_keys: vec![],
+            compute_keys: vec![],
             kernel,
             input_records,
             output_records,

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -68,9 +68,13 @@ impl<C: Parameters> TransactionAuthorization<C> {
             .iter()
             .chain(self.output_records.iter())
             .take(C::NUM_TOTAL_RECORDS)
-            .flat_map(|r| r.program_id())
-            .cloned()
-            .collect::<Vec<u8>>();
+            .flat_map(|record| {
+                record
+                    .program_id()
+                    .to_bytes_le()
+                    .expect("Failed to convert program ID to bytes")
+            })
+            .collect::<Vec<_>>();
 
         let program_randomness = UniformRand::rand(rng);
         let program_commitment = C::program_commitment_scheme().commit(&program_ids, &program_randomness)?;

--- a/dpc/src/transaction/authorization.rs
+++ b/dpc/src/transaction/authorization.rs
@@ -16,7 +16,7 @@
 
 use crate::prelude::*;
 use snarkvm_algorithms::prelude::*;
-use snarkvm_utilities::{to_bytes_le, variable_length_integer, FromBytes, ToBytes, UniformRand};
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes, UniformRand};
 
 use anyhow::Result;
 use rand::{CryptoRng, Rng};
@@ -132,7 +132,6 @@ impl<C: Parameters> ToBytes for TransactionAuthorization<C> {
 
         // Serialize the noop compute keys with Option ordering in order to
         // dedup with user-specified compute keys during execution.
-        variable_length_integer(self.noop_compute_keys.len() as u64).write_le(&mut writer)?;
         for noop_compute_key in self.noop_compute_keys.iter().take(C::NUM_INPUT_RECORDS) {
             match noop_compute_key {
                 Some(noop_compute_key) => {

--- a/dpc/src/transaction/kernel.rs
+++ b/dpc/src/transaction/kernel.rs
@@ -45,11 +45,61 @@ pub struct TransactionKernel<C: Parameters> {
 }
 
 impl<C: Parameters> TransactionKernel<C> {
+    /// Initializes a new instance of a transaction kernel.
+    #[inline]
+    pub fn new(
+        serial_numbers: Vec<C::AccountSignaturePublicKey>,
+        commitments: Vec<C::RecordCommitment>,
+        value_balance: AleoAmount,
+        memo: <Transaction<C> as TransactionScheme>::Memo,
+    ) -> Result<Self> {
+        // Construct the transaction kernel.
+        let kernel = Self {
+            network_id: C::NETWORK_ID,
+            serial_numbers,
+            commitments,
+            value_balance,
+            memo,
+        };
+
+        // Ensure the transaction kernel is well-formed.
+        match kernel.is_valid() {
+            true => Ok(kernel),
+            false => Err(
+                DPCError::InvalidKernel(C::NETWORK_ID, kernel.serial_numbers.len(), kernel.commitments.len()).into(),
+            ),
+        }
+    }
+
+    /// Returns `true` if the transaction kernel is well-formed.
     #[inline]
     pub fn is_valid(&self) -> bool {
         self.network_id == C::NETWORK_ID
             && self.serial_numbers.len() == C::NUM_INPUT_RECORDS
             && self.commitments.len() == C::NUM_OUTPUT_RECORDS
+    }
+
+    /// Returns a reference to the serial numbers.
+    #[inline]
+    pub fn serial_numbers(&self) -> &Vec<C::AccountSignaturePublicKey> {
+        &self.serial_numbers
+    }
+
+    /// Returns a reference to the commitments.
+    #[inline]
+    pub fn commitments(&self) -> &Vec<C::RecordCommitment> {
+        &self.commitments
+    }
+
+    /// Returns a reference to the value balance.
+    #[inline]
+    pub fn value_balance(&self) -> &AleoAmount {
+        &self.value_balance
+    }
+
+    /// Returns a reference to the memo.
+    pub fn memo(&self) -> &<Transaction<C> as TransactionScheme>::Memo {
+        &self.memo
     }
 
     #[inline]

--- a/ledger/src/block/block_header.rs
+++ b/ledger/src/block/block_header.rs
@@ -24,6 +24,16 @@ use std::{
     mem::size_of,
 };
 
+const HEADER_SIZE: usize = {
+    BlockHeaderHash::size()
+        + MerkleRootHash::size()
+        + PedersenMerkleRootHash::size()
+        + ProofOfSuccinctWork::size()
+        + size_of::<i64>()
+        + size_of::<u64>()
+        + size_of::<u32>()
+};
+
 /// Block header.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockHeader {
@@ -43,16 +53,6 @@ pub struct BlockHeader {
     /// Nonce for solving the PoW puzzle - 4 bytes
     pub nonce: u32,
 }
-
-const HEADER_SIZE: usize = {
-    BlockHeaderHash::size()
-        + MerkleRootHash::size()
-        + PedersenMerkleRootHash::size()
-        + ProofOfSuccinctWork::size()
-        + size_of::<i64>()
-        + size_of::<u64>()
-        + size_of::<u32>()
-};
 
 impl BlockHeader {
     pub const fn size() -> usize {

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -55,7 +55,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
     let amount = AleoAmount::from_bytes(value as i64);
     let state = StateTransition::new_coinbase(recipient, amount, noop, rng)?;
     let authorization = dpc.authorize(&vec![], &state, rng)?;
-    let transaction = dpc.execute(authorization, state.executables(), &temporary_ledger, rng)?;
+    let transaction = dpc.execute(&vec![], authorization, state.executables(), &temporary_ledger, rng)?;
 
     let transaction_bytes = transaction.to_bytes_le()?;
     println!("transaction size - {}\n", transaction_bytes.len());

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -51,56 +51,15 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
     .unwrap();
 
     let dpc = DPC::<C>::load(false)?;
+    let noop = Arc::new(dpc.noop_program.clone());
 
-    // Generate accounts.
-    let genesis_account = Account::new(rng)?;
-
-    // Generate input records having as address the genesis address.
-    let private_keys = vec![genesis_account.private_key.clone(); C::NUM_INPUT_RECORDS];
-
-    let mut joint_serial_numbers = Vec::with_capacity(C::NUM_INPUT_RECORDS);
-    let mut input_records = Vec::with_capacity(C::NUM_INPUT_RECORDS);
-    for i in 0..C::NUM_INPUT_RECORDS {
-        let input_record = Record::new_noop_input(dpc.noop_program.deref(), genesis_account.address, rng)?;
-
-        let (sn, _) = input_record.to_serial_number(&private_keys[i])?;
-        joint_serial_numbers.extend_from_slice(&to_bytes_le![sn]?);
-
-        input_records.push(input_record);
-    }
-
-    // Construct the output records.
-    let mut output_records = Vec::with_capacity(C::NUM_OUTPUT_RECORDS);
-    output_records.push(Record::new_output(
-        dpc.noop_program.deref(),
-        recipient,
-        false,
-        value,
-        Payload::default(),
-        C::NUM_INPUT_RECORDS as u8,
-        joint_serial_numbers.clone(),
-        rng,
-    )?);
-    output_records.push(Record::new_noop_output(
-        dpc.noop_program.deref(),
-        recipient,
-        (C::NUM_INPUT_RECORDS + 1) as u8,
-        joint_serial_numbers.clone(),
-        rng,
-    )?);
-
-    // Offline execution to generate a transaction authorization.
-    let authorization = dpc.authorize(&private_keys, input_records, output_records, None, rng)?;
-
-    // Construct the executable.
-    let noop = Executable::Noop(Arc::new(dpc.noop_program.clone()));
-    let executables = vec![noop.clone(), noop.clone(), noop.clone(), noop];
-
+    let amount = AleoAmount::from_bytes(value as i64);
+    let state = StateTransition::new_coinbase(recipient, amount, noop, rng)?;
+    let authorization = dpc.authorize(&private_keys, state, None, rng)?;
     let transaction = dpc.execute(&private_keys, authorization, executables, &temporary_ledger, rng)?;
 
     let transaction_bytes = transaction.to_bytes_le()?;
-    let transaction_size = transaction_bytes.len();
-    println!("transaction size - {}\n", transaction_size);
+    println!("transaction size - {}\n", transaction_bytes.len());
 
     // Add genesis transaction to block.
     let mut transactions = Transactions::new();
@@ -136,7 +95,7 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
 
     println!(
         "block size - {}\n",
-        transaction_size + BlockHeader::size() + 1 /* variable_length_integer for number of transaction */
+        transaction_bytes.len() + BlockHeader::size() + 1 /* variable_length_integer for number of transaction */
     );
 
     Ok((genesis_header.serialize().to_vec(), transaction_bytes))

--- a/parameters/examples/genesis.rs
+++ b/parameters/examples/genesis.rs
@@ -20,13 +20,12 @@ use snarkvm_ledger::{
     posw::{txids_to_roots, PoswMarlin},
     prelude::*,
 };
-use snarkvm_utilities::{to_bytes_le, ToBytes};
+use snarkvm_utilities::ToBytes;
 
 use rand::thread_rng;
 use std::{
     fs::File,
     io::{Result as IoResult, Write},
-    ops::Deref,
     path::Path,
     str::FromStr,
     sync::Arc,
@@ -55,8 +54,8 @@ pub fn generate<C: Parameters>(recipient: Address<C>, value: u64) -> Result<(Vec
 
     let amount = AleoAmount::from_bytes(value as i64);
     let state = StateTransition::new_coinbase(recipient, amount, noop, rng)?;
-    let authorization = dpc.authorize(&private_keys, state, None, rng)?;
-    let transaction = dpc.execute(&private_keys, authorization, executables, &temporary_ledger, rng)?;
+    let authorization = dpc.authorize(&vec![], &state, rng)?;
+    let transaction = dpc.execute(authorization, state.executables(), &temporary_ledger, rng)?;
 
     let transaction_bytes = transaction.to_bytes_le()?;
     println!("transaction size - {}\n", transaction_bytes.len());


### PR DESCRIPTION
## Motivation

Introduces `StateTransition` to `DPC` struct. This PR does not require resampling parameters.
- Updates `DPC::authorize` to reason over a state transition object
- Adds `ComputeKey` to the account model
- Updates `DPC::execute` to use compute keys for execution
- Updates `PrivateKey` to return `compute_key()` for execution
- Updates `genesis`, `testnet1_integration`, and `testnet2_integration` with state transition approach

## Test Plan

- Adds `snarkvm_dpc::state::Input` test for `new_noop`
- Adds `snarkvm_dpc::state::Output` test for `new_noop`
- Adds `snarkvm_dpc::state::StateTransition` test for `new_coinbase`
- Adds `snarkvm_dpc::state::StateBuilder` test for `add_noop_input` and `add_noop_output`