### PR TITLE
Consistently map terminated MarlinError::Terminated into SnarkError::Terminated

### DIFF
--- a/marlin/src/marlin/errors.rs
+++ b/marlin/src/marlin/errors.rs
@@ -61,6 +61,15 @@ impl From<snarkvm_polycommit::Error> for MarlinError {
     }
 }
 
+impl MarlinError {
+    pub fn into_snark_error(&self, prefix: &str) -> SNARKError {
+        match self {
+            MarlinError::Terminated => SNARKError::Terminated,
+            err => SNARKError::Crate("marlin", format!("{} - {:?}", prefix, err)),
+        }
+    }
+}
+
 impl From<MarlinError> for SNARKError {
     fn from(error: MarlinError) -> Self {
         match error {

--- a/marlin/src/parameters.rs
+++ b/marlin/src/parameters.rs
@@ -61,7 +61,7 @@ where
     /// Creates an instance of `Parameters` from a given universal SRS.
     pub fn new<C: ConstraintSynthesizer<E::Fr>>(circuit: &C, universal_srs: &SRS<E>) -> Result<Self, SNARKError> {
         let (proving_key, verifying_key) = MarlinTestnet1::<E>::circuit_setup(universal_srs, circuit)
-            .map_err(|error| SNARKError::Crate("marlin", format!("could not index - {:?}", error)))?;
+            .map_err(|error| error.into_snark_error("could not index"))?;
         Ok(Self {
             proving_key,
             verifying_key,

--- a/marlin/src/snark.rs
+++ b/marlin/src/snark.rs
@@ -114,7 +114,7 @@ where
         let proving_time = start_timer!(|| "{Marlin}::Proving");
         let proof =
             MarlinTestnet1::<E>::prove_with_terminator(&proving_key.proving_key, input_and_witness, terminator, rng)
-                .map_err(|error| SNARKError::Crate("marlin", format!("Failed to generate proof - {:?}", error)))?;
+                .map_err(|error| error.into_snark_error("Failed to generate proof"))?;
         end_timer!(proving_time);
         Ok(proof)
     }
@@ -126,7 +126,7 @@ where
     ) -> Result<bool, SNARKError> {
         let verification_time = start_timer!(|| "{Marlin}::Verifying");
         let res = MarlinTestnet1::<E>::verify(&verifying_key, &input.to_field_elements()?, &proof)
-            .map_err(|_| SNARKError::Crate("marlin", "Could not verify proof".to_owned()))?;
+            .map_err(|error| error.into_snark_error("Could not verify proof"))?;
         end_timer!(verification_time);
 
         Ok(res)


### PR DESCRIPTION
Fixes inconsistency caused by some manual mappings.