### PR TITLE
Arced system parameters

### DIFF
--- a/dpc/src/testnet1/inner_circuit/inner_circuit.rs
+++ b/dpc/src/testnet1/inner_circuit/inner_circuit.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 #[derivative(Clone(bound = "C: Testnet1Components"))]
 pub struct InnerCircuit<C: Testnet1Components> {
     // Parameters
-    system_parameters: SystemParameters<C>,
+    system_parameters: Arc<SystemParameters<C>>,
     ledger_parameters: Arc<C::MerkleParameters>,
 
     ledger_digest: MerkleTreeDigest<C::MerkleParameters>,
@@ -71,7 +71,7 @@ pub struct InnerCircuit<C: Testnet1Components> {
 }
 
 impl<C: Testnet1Components> InnerCircuit<C> {
-    pub fn blank(system_parameters: &SystemParameters<C>, ledger_parameters: &Arc<C::MerkleParameters>) -> Self {
+    pub fn blank(system_parameters: &Arc<SystemParameters<C>>, ledger_parameters: &Arc<C::MerkleParameters>) -> Self {
         let num_input_records = C::NUM_INPUT_RECORDS;
         let num_output_records = C::NUM_OUTPUT_RECORDS;
         let digest = MerkleTreeDigest::<C::MerkleParameters>::default();
@@ -146,7 +146,7 @@ impl<C: Testnet1Components> InnerCircuit<C> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         // Parameters
-        system_parameters: SystemParameters<C>,
+        system_parameters: Arc<SystemParameters<C>>,
         ledger_parameters: Arc<C::MerkleParameters>,
 
         // Digest

--- a/dpc/src/testnet1/inner_circuit/inner_circuit_verifier_input.rs
+++ b/dpc/src/testnet1/inner_circuit/inner_circuit_verifier_input.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 #[derivative(Clone(bound = "C: Testnet1Components"))]
 pub struct InnerCircuitVerifierInput<C: Testnet1Components> {
     // Commitment, CRH, and signature parameters
-    pub system_parameters: SystemParameters<C>,
+    pub system_parameters: Arc<SystemParameters<C>>,
 
     // Ledger parameters and digest
     pub ledger_parameters: Arc<C::MerkleParameters>,

--- a/dpc/src/testnet1/mod.rs
+++ b/dpc/src/testnet1/mod.rs
@@ -106,7 +106,7 @@ pub trait Testnet1Components: DPCComponents {
 ///////////////////////////////////////////////////////////////////////////////
 
 pub struct DPC<C: Testnet1Components> {
-    pub system_parameters: SystemParameters<C>,
+    pub system_parameters: Arc<SystemParameters<C>>,
     pub noop_program: NoopProgram<C>,
     pub inner_snark_parameters: (
         Option<<C::InnerSNARK as SNARK>::ProvingKey>,
@@ -139,7 +139,7 @@ where
 
     fn setup<R: Rng + CryptoRng>(ledger_parameters: &Arc<C::MerkleParameters>, rng: &mut R) -> anyhow::Result<Self> {
         let setup_time = start_timer!(|| "DPC::setup");
-        let system_parameters = Self::SystemParameters::setup(rng)?;
+        let system_parameters = Arc::new(Self::SystemParameters::setup(rng)?);
 
         let noop_program_timer = start_timer!(|| "Noop program SNARK setup");
         let noop_program = NoopProgram::setup(
@@ -182,7 +182,7 @@ where
 
     fn load(verify_only: bool) -> anyhow::Result<Self> {
         let timer = start_timer!(|| "DPC::load");
-        let system_parameters = Self::SystemParameters::load()?;
+        let system_parameters = Arc::new(Self::SystemParameters::load()?);
         let noop_program = NoopProgram::load(
             &system_parameters.local_data_commitment,
             &system_parameters.program_verification_key_crh,

--- a/dpc/src/testnet1/outer_circuit/outer_circuit.rs
+++ b/dpc/src/testnet1/outer_circuit/outer_circuit.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Testnet1Components"))]
 pub struct OuterCircuit<C: Testnet1Components> {
-    system_parameters: SystemParameters<C>,
+    system_parameters: Arc<SystemParameters<C>>,
 
     // Inner snark verifier public inputs
     ledger_parameters: Arc<C::MerkleParameters>,
@@ -61,7 +61,7 @@ pub struct OuterCircuit<C: Testnet1Components> {
 
 impl<C: Testnet1Components> OuterCircuit<C> {
     pub fn blank(
-        system_parameters: SystemParameters<C>,
+        system_parameters: Arc<SystemParameters<C>>,
         ledger_parameters: Arc<C::MerkleParameters>,
         inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey,
         inner_snark_proof: <C::InnerSNARK as SNARK>::Proof,
@@ -106,7 +106,7 @@ impl<C: Testnet1Components> OuterCircuit<C> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        system_parameters: SystemParameters<C>,
+        system_parameters: Arc<SystemParameters<C>>,
 
         // Inner SNARK public inputs
         ledger_parameters: Arc<C::MerkleParameters>,

--- a/dpc/src/testnet2/inner_circuit/inner_circuit.rs
+++ b/dpc/src/testnet2/inner_circuit/inner_circuit.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 #[derivative(Clone(bound = "C: Testnet2Components"))]
 pub struct InnerCircuit<C: Testnet2Components> {
     // Parameters
-    system_parameters: SystemParameters<C>,
+    system_parameters: Arc<SystemParameters<C>>,
     ledger_parameters: Arc<C::MerkleParameters>,
 
     ledger_digest: MerkleTreeDigest<C::MerkleParameters>,
@@ -71,7 +71,7 @@ pub struct InnerCircuit<C: Testnet2Components> {
 }
 
 impl<C: Testnet2Components> InnerCircuit<C> {
-    pub fn blank(system_parameters: &SystemParameters<C>, ledger_parameters: &Arc<C::MerkleParameters>) -> Self {
+    pub fn blank(system_parameters: &Arc<SystemParameters<C>>, ledger_parameters: &Arc<C::MerkleParameters>) -> Self {
         let num_input_records = C::NUM_INPUT_RECORDS;
         let num_output_records = C::NUM_OUTPUT_RECORDS;
         let digest = MerkleTreeDigest::<C::MerkleParameters>::default();
@@ -146,7 +146,7 @@ impl<C: Testnet2Components> InnerCircuit<C> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         // Parameters
-        system_parameters: SystemParameters<C>,
+        system_parameters: Arc<SystemParameters<C>>,
         ledger_parameters: Arc<C::MerkleParameters>,
 
         // Digest

--- a/dpc/src/testnet2/inner_circuit/inner_circuit_verifier_input.rs
+++ b/dpc/src/testnet2/inner_circuit/inner_circuit_verifier_input.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 #[derivative(Clone(bound = "C: Testnet2Components"))]
 pub struct InnerCircuitVerifierInput<C: Testnet2Components> {
     // Commitment, CRH, and signature parameters
-    pub system_parameters: SystemParameters<C>,
+    pub system_parameters: Arc<SystemParameters<C>>,
 
     // Ledger parameters and digest
     pub ledger_parameters: Arc<C::MerkleParameters>,

--- a/dpc/src/testnet2/mod.rs
+++ b/dpc/src/testnet2/mod.rs
@@ -129,7 +129,7 @@ pub trait Testnet2Components: DPCComponents {
 ///////////////////////////////////////////////////////////////////////////////
 
 pub struct DPC<C: Testnet2Components> {
-    pub system_parameters: SystemParameters<C>,
+    pub system_parameters: Arc<SystemParameters<C>>,
     pub noop_program: NoopProgram<C>,
     pub inner_snark_parameters: (
         Option<<C::InnerSNARK as SNARK>::ProvingKey>,
@@ -166,7 +166,7 @@ where
 
     fn setup<R: Rng + CryptoRng>(ledger_parameters: &Arc<C::MerkleParameters>, rng: &mut R) -> anyhow::Result<Self> {
         let setup_time = start_timer!(|| "DPC::setup");
-        let system_parameters = Self::SystemParameters::setup(rng)?;
+        let system_parameters = Arc::new(Self::SystemParameters::setup(rng)?);
 
         let noop_program_timer = start_timer!(|| "Noop program SNARK setup");
         let noop_program = NoopProgram::setup(
@@ -209,7 +209,7 @@ where
 
     fn load(verify_only: bool) -> anyhow::Result<Self> {
         let timer = start_timer!(|| "DPC::load");
-        let system_parameters = Self::SystemParameters::load()?;
+        let system_parameters = Arc::new(Self::SystemParameters::load()?);
         let noop_program = NoopProgram::load(
             &system_parameters.local_data_commitment,
             &system_parameters.program_verification_key_crh,

--- a/dpc/src/testnet2/outer_circuit/outer_circuit.rs
+++ b/dpc/src/testnet2/outer_circuit/outer_circuit.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: Testnet2Components"))]
 pub struct OuterCircuit<C: Testnet2Components> {
-    system_parameters: SystemParameters<C>,
+    system_parameters: Arc<SystemParameters<C>>,
 
     // Inner snark verifier public inputs
     ledger_parameters: Arc<C::MerkleParameters>,
@@ -61,7 +61,7 @@ pub struct OuterCircuit<C: Testnet2Components> {
 
 impl<C: Testnet2Components> OuterCircuit<C> {
     pub fn blank(
-        system_parameters: SystemParameters<C>,
+        system_parameters: Arc<SystemParameters<C>>,
         ledger_parameters: Arc<C::MerkleParameters>,
         inner_snark_vk: <C::InnerSNARK as SNARK>::VerifyingKey,
         inner_snark_proof: <C::InnerSNARK as SNARK>::Proof,
@@ -106,7 +106,7 @@ impl<C: Testnet2Components> OuterCircuit<C> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        system_parameters: SystemParameters<C>,
+        system_parameters: Arc<SystemParameters<C>>,
 
         // Inner SNARK public inputs
         ledger_parameters: Arc<C::MerkleParameters>,

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -44,7 +44,7 @@ pub fn setup<C: Testnet1Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
-    let system_parameters = SystemParameters::<C>::load()?;
+    let system_parameters = Arc::new(SystemParameters::<C>::load()?);
     let inner_snark_parameters = C::InnerSNARK::setup(
         &InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
         rng,

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -45,7 +45,7 @@ use utils::store;
 
 pub fn setup<C: Testnet1Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let rng = &mut thread_rng();
-    let system_parameters = SystemParameters::<C>::load()?;
+    let system_parameters = Arc::new(SystemParameters::<C>::load()?);
 
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
         From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);

--- a/parameters/examples/testnet2_inner_snark.rs
+++ b/parameters/examples/testnet2_inner_snark.rs
@@ -44,7 +44,7 @@ pub fn setup<C: Testnet2Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
     let ledger_merkle_tree_parameters = Arc::new(From::from(merkle_tree_hash_parameters));
 
-    let system_parameters = SystemParameters::<C>::load()?;
+    let system_parameters = Arc::new(SystemParameters::<C>::load()?);
     let inner_snark_parameters = C::InnerSNARK::setup(
         &InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
         rng,

--- a/parameters/examples/testnet2_outer_snark.rs
+++ b/parameters/examples/testnet2_outer_snark.rs
@@ -45,7 +45,7 @@ use utils::store;
 
 pub fn setup<C: Testnet2Components>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let rng = &mut thread_rng();
-    let system_parameters = SystemParameters::<C>::load()?;
+    let system_parameters = Arc::new(SystemParameters::<C>::load()?);
 
     let merkle_tree_hash_parameters: <C::MerkleParameters as MerkleParameters>::H =
         From::from(FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?);


### PR DESCRIPTION
This PR is a result of profiling done in snarkOS - the `SystemParameters` object is relatively expensive to clone, so wrapping it in an `Arc` can result in a noticeable performance improvement.