### PR TITLE
Parallel transaction verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,7 @@ dependencies = [
  "once_cell",
  "rand",
  "rand_chacha",
+ "rayon",
  "serde",
  "sha2",
  "snarkvm-algorithms",

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -112,6 +112,9 @@ version = "1.8.0"
 [dependencies.rand]
 version = "0.8"
 
+[dependencies.rayon]
+version = "1"
+
 [dependencies.serde]
 version = "1.0"
 features = [ "derive" ]

--- a/dpc/src/traits/dpc.rs
+++ b/dpc/src/traits/dpc.rs
@@ -61,7 +61,7 @@ pub trait DPCScheme<C: Parameters>: Sized {
     ) -> bool;
 
     /// Returns true iff all the transactions in the block are valid according to the ledger.
-    fn verify_transactions<L: RecordCommitmentTree<C> + RecordSerialNumberTree<C>>(
+    fn verify_transactions<L: RecordCommitmentTree<C> + RecordSerialNumberTree<C> + Sync>(
         &self,
         block: &[Self::Transaction],
         ledger: &L,


### PR DESCRIPTION
While investigating block import time spikes in snarkOS, profiling showed that `DPCScheme::verify_transactions` accounted for a significant part of that process; I was wondering if it could be improved and noticed that it was run sequentially, while it could be parallelized - it just required some tweaks to traits. I was being conservative and only added `Sync` (and sometimes `Send`) where the compiler required it.