### PR TITLE
Wrap pedersen parameters in Arcs

### DIFF
--- a/algorithms/src/crh/bowe_hopwood_pedersen_parameters.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen_parameters.rs
@@ -18,6 +18,8 @@ use snarkvm_curves::Group;
 
 use super::PedersenCRHParameters;
 
+use std::sync::Arc;
+
 pub const BOWE_HOPWOOD_CHUNK_SIZE: usize = 3;
 pub const BOWE_HOPWOOD_LOOKUP_SIZE: usize = 2usize.pow(BOWE_HOPWOOD_CHUNK_SIZE as u32);
 
@@ -26,7 +28,7 @@ use rayon::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BoweHopwoodPedersenCRHParameters<G: Group> {
-    base_lookup: Vec<Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>>,
+    base_lookup: Arc<Vec<Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>>>,
 }
 
 impl<G: Group> BoweHopwoodPedersenCRHParameters<G> {
@@ -57,7 +59,9 @@ impl<G: Group> BoweHopwoodPedersenCRHParameters<G> {
             })
             .collect();
 
-        Self { base_lookup }
+        Self {
+            base_lookup: Arc::new(base_lookup),
+        }
     }
 
     pub fn base_lookup(&self) -> &[Vec<[G; BOWE_HOPWOOD_LOOKUP_SIZE]>] {

--- a/algorithms/src/crh/pedersen.rs
+++ b/algorithms/src/crh/pedersen.rs
@@ -69,7 +69,7 @@ impl<G: Group, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH for Peder
         let bits = input.view_bits::<Lsb0>();
         let result = bits
             .chunks(WINDOW_SIZE)
-            .zip(&self.parameters.bases)
+            .zip(&*self.parameters.bases)
             .map(|(bits, powers)| {
                 let mut encoded = G::zero();
                 for (bit, base) in bits.iter().zip(powers.iter()) {


### PR DESCRIPTION
Another finding from snarkOS profiling: cloning operations related to `BoweHopwoodPedersenCompressedCRH::hash` are costly. Wrapping them in `Arc`s improves hashing performance.

Ideally, the `Arc` would not even be needed here (it's only used so that the type can be changed from `BoweHopwoodPedersenCompressedCRH` to `BoweHopwoodPedersenCRH` for the purposes of hashing), but it's the simplest solution that doesn't affect the existing APIs.