### PR TITLE
implement account from_private_key

### DIFF
--- a/dpc/src/account/account.rs
+++ b/dpc/src/account/account.rs
@@ -36,6 +36,12 @@ impl<C: Parameters> AccountScheme for Account<C> {
     /// Creates a new account.
     fn new<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, AccountError> {
         let private_key = PrivateKey::new(rng);
+
+        Self::from_private_key(private_key)
+    }
+
+    /// Creates an account from a private key.
+    fn from_private_key(private_key: PrivateKey<C>) -> Result<Self, AccountError> {
         let view_key = ViewKey::try_from(&private_key)?;
         let address = Address::try_from(&view_key)?;
 

--- a/dpc/src/account/tests.rs
+++ b/dpc/src/account/tests.rs
@@ -21,7 +21,10 @@ mod testnet1 {
 
     use rand::{thread_rng, SeedableRng};
     use rand_chacha::ChaChaRng;
-    use std::{convert::TryInto, str::FromStr};
+    use std::{
+        convert::{TryFrom, TryInto},
+        str::FromStr,
+    };
 
     const ALEO_TESTNET1_PRIVATE_KEY: &str = "APrivateKey1y9jeNQybT9Mxk1AssbFmSXcFu9dG7sWkfYEsBUZrMin816z";
     const ALEO_TESTNET1_VIEW_KEY: &str = "AViewKey1hNsfjkmrfiYWqMKtpKUW9LfGw93Pzz82UmmMn7pHHqZc";
@@ -48,7 +51,7 @@ mod testnet1 {
     #[test]
     fn test_from_private_key() {
         let private_key = PrivateKey::<Testnet1Parameters>::from_str(ALEO_TESTNET1_PRIVATE_KEY).unwrap();
-        let account = Account::<Testnet1Parameters>::from_private_key(private_key).unwrap();
+        let account = Account::<Testnet1Parameters>::try_from(private_key).unwrap();
 
         assert_eq!(ALEO_TESTNET1_PRIVATE_KEY, account.private_key().to_string());
         assert_eq!(ALEO_TESTNET1_VIEW_KEY, account.view_key.to_string());
@@ -184,7 +187,10 @@ mod testnet2 {
 
     use rand::{thread_rng, SeedableRng};
     use rand_chacha::ChaChaRng;
-    use std::{convert::TryInto, str::FromStr};
+    use std::{
+        convert::{TryFrom, TryInto},
+        str::FromStr,
+    };
 
     const ALEO_TESTNET2_PRIVATE_KEY: &str = "APrivateKey1y9jeNQybT9Mxk1AssbFmSXcFu9dG7sWkfYEsBUZrMin816z";
     const ALEO_TESTNET2_VIEW_KEY: &str = "AViewKey1hNsfjkmrfiYWqMKtpKUW9LfGw93Pzz82UmmMn7pHHqZc";
@@ -211,7 +217,7 @@ mod testnet2 {
     #[test]
     fn test_from_private_key() {
         let private_key = PrivateKey::<Testnet2Parameters>::from_str(ALEO_TESTNET2_PRIVATE_KEY).unwrap();
-        let account = Account::<Testnet2Parameters>::from_private_key(private_key).unwrap();
+        let account = Account::<Testnet2Parameters>::try_from(private_key).unwrap();
 
         assert_eq!(ALEO_TESTNET2_PRIVATE_KEY, account.private_key().to_string());
         assert_eq!(ALEO_TESTNET2_VIEW_KEY, account.view_key.to_string());

--- a/dpc/src/account/tests.rs
+++ b/dpc/src/account/tests.rs
@@ -48,7 +48,6 @@ mod testnet1 {
     #[test]
     fn test_from_private_key() {
         let private_key = PrivateKey::<Testnet1Parameters>::from_str(ALEO_TESTNET1_PRIVATE_KEY).unwrap();
-
         let account = Account::<Testnet1Parameters>::from_private_key(private_key).unwrap();
 
         assert_eq!(ALEO_TESTNET1_PRIVATE_KEY, account.private_key().to_string());
@@ -207,6 +206,16 @@ mod testnet2 {
         for _ in 0..ITERATIONS {
             assert!(Account::<Testnet2Parameters>::new(&mut rng).is_ok());
         }
+    }
+
+    #[test]
+    fn test_from_private_key() {
+        let private_key = PrivateKey::<Testnet2Parameters>::from_str(ALEO_TESTNET2_PRIVATE_KEY).unwrap();
+        let account = Account::<Testnet2Parameters>::from_private_key(private_key).unwrap();
+
+        assert_eq!(ALEO_TESTNET2_PRIVATE_KEY, account.private_key().to_string());
+        assert_eq!(ALEO_TESTNET2_VIEW_KEY, account.view_key.to_string());
+        assert_eq!(ALEO_TESTNET2_ADDRESS, account.address.to_string());
     }
 
     #[test]

--- a/dpc/src/account/tests.rs
+++ b/dpc/src/account/tests.rs
@@ -46,6 +46,17 @@ mod testnet1 {
     }
 
     #[test]
+    fn test_from_private_key() {
+        let private_key = PrivateKey::<Testnet1Parameters>::from_str(ALEO_TESTNET1_PRIVATE_KEY).unwrap();
+
+        let account = Account::<Testnet1Parameters>::from_private_key(private_key).unwrap();
+
+        assert_eq!(ALEO_TESTNET1_PRIVATE_KEY, account.private_key().to_string());
+        assert_eq!(ALEO_TESTNET1_VIEW_KEY, account.view_key.to_string());
+        assert_eq!(ALEO_TESTNET1_ADDRESS, account.address.to_string());
+    }
+
+    #[test]
     fn test_account_derivation() {
         let private_key = PrivateKey::<Testnet1Parameters>::from_str(ALEO_TESTNET1_PRIVATE_KEY).unwrap();
         let view_key = ViewKey::<Testnet1Parameters>::from_private_key(&private_key).unwrap();

--- a/dpc/src/traits/account.rs
+++ b/dpc/src/traits/account.rs
@@ -27,9 +27,6 @@ pub trait AccountScheme: Sized {
     /// Creates a new account.
     fn new<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, AccountError>;
 
-    /// Creates an account from a private key.
-    fn from_private_key(private_key: Self::PrivateKey) -> Result<Self, AccountError>;
-
     /// Returns a reference to the private key.
     fn private_key(&self) -> &Self::PrivateKey;
 

--- a/dpc/src/traits/account.rs
+++ b/dpc/src/traits/account.rs
@@ -27,6 +27,9 @@ pub trait AccountScheme: Sized {
     /// Creates a new account.
     fn new<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self, AccountError>;
 
+    /// Creates an account from a private key.
+    fn from_private_key(private_key: Self::PrivateKey) -> Result<Self, AccountError>;
+
     /// Returns a reference to the private key.
     fn private_key(&self) -> &Self::PrivateKey;
 


### PR DESCRIPTION
## Motivation

I am currently refactoring the aleo sdk to be compatible with the testnet2 branch of snarkVM.  
One desired feature of the sdk is to import an account from a private key - example: `Account::from_private_key()`.  
The sdk uses the `Account<C: Parameters>` struct in snarkVM which does not provide this functionality.  
Rather than re-implement the `Account` struct in aleo sdk this PR adds the desired method in snarkVM.

## Changes
* add `Account::from_private_key()` method to `AccountScheme` trait.
* implement `Account::from_private_key()` method for generic `Account<C: Parameters>` struct.
* add test for `Account::from_private_key()` in account tests.

