### PR TITLE
Enable WASM compilation for Marlin

### DIFF
--- a/marlin/src/ahp/errors.rs
+++ b/marlin/src/ahp/errors.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::String;
+
 /// Describes the failure modes of the AHP scheme.
 #[derive(Debug)]
 pub enum AHPError {

--- a/marlin/src/ahp/indexer/circuit_info.rs
+++ b/marlin/src/ahp/indexer/circuit_info.rs
@@ -14,14 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::ahp::AHPForR1CS;
+use crate::{ahp::AHPForR1CS, BTreeSet, Matrix, Vec};
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{errors::SerializationError, serialize::*, ToBytes};
 
-use crate::Matrix;
 use core::marker::PhantomData;
 use derivative::Derivative;
-use std::collections::BTreeSet;
 
 /// Information about the circuit, including the field of definition, the number of
 /// variables, the number of constraints, and the maximum number of non-zero
@@ -66,7 +64,7 @@ impl<F: PrimeField> CircuitInfo<F> {
 }
 
 impl<F: PrimeField> ToBytes for CircuitInfo<F> {
-    fn write_le<W: Write>(&self, mut w: W) -> Result<(), std::io::Error> {
+    fn write_le<W: Write>(&self, mut w: W) -> Result<(), crate::io::Error> {
         (self.num_variables as u64).write_le(&mut w)?;
         (self.num_constraints as u64).write_le(&mut w)?;
         (self.num_non_zero as u64).write_le(&mut w)

--- a/marlin/src/ahp/indexer/indexer.rs
+++ b/marlin/src/ahp/indexer/indexer.rs
@@ -29,6 +29,9 @@ use snarkvm_r1cs::{ConstraintSynthesizer, ConstraintSystem};
 use crate::{num_non_zero, sum_matrices};
 use core::marker::PhantomData;
 
+#[cfg(not(feature = "std"))]
+use snarkvm_utilities::println;
+
 impl<F: PrimeField> AHPForR1CS<F> {
     /// Generate the index for this constraint system.
     pub fn index<C: ConstraintSynthesizer<F>>(c: &C) -> Result<Circuit<F>, AHPError> {

--- a/marlin/src/ahp/indexer/mod.rs
+++ b/marlin/src/ahp/indexer/mod.rs
@@ -16,6 +16,8 @@
 
 #![allow(non_snake_case)]
 
+use crate::Vec;
+
 mod circuit;
 pub(crate) use circuit::*;
 

--- a/marlin/src/ahp/matrices.rs
+++ b/marlin/src/ahp/matrices.rs
@@ -30,6 +30,8 @@ use snarkvm_r1cs::{ConstraintSystem, Index as VarIndex};
 use snarkvm_utilities::{errors::SerializationError, serialize::*};
 
 use derivative::Derivative;
+
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 // This function converts a matrix output by Zexe's constraint infrastructure

--- a/marlin/src/ahp/prover/constraint_system.rs
+++ b/marlin/src/ahp/prover/constraint_system.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::ahp::matrices::make_matrices_square;
+use crate::{ahp::matrices::make_matrices_square, Vec};
 use snarkvm_fields::Field;
 use snarkvm_r1cs::errors::SynthesisError;
 

--- a/marlin/src/ahp/prover/prover.rs
+++ b/marlin/src/ahp/prover/prover.rs
@@ -41,6 +41,9 @@ use snarkvm_r1cs::ConstraintSynthesizer;
 
 use rand_core::RngCore;
 
+#[cfg(not(feature = "std"))]
+use snarkvm_utilities::println;
+
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use snarkvm_algorithms::fft::DensePolynomial;

--- a/marlin/src/constraints/ahp.rs
+++ b/marlin/src/constraints/ahp.rs
@@ -53,6 +53,9 @@ use crate::{
     FiatShamirRng,
     FiatShamirRngVar,
     PolynomialCommitment,
+    String,
+    ToString,
+    Vec,
 };
 
 /// The Marlin verifier round state gadget used to output the state of each round.

--- a/marlin/src/constraints/error.rs
+++ b/marlin/src/constraints/error.rs
@@ -14,10 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "std")]
 use crate::marlin::MarlinError;
+use crate::String;
 
 use core::fmt::Display;
+#[cfg(feature = "std")]
 use std::fmt::{Debug, Formatter};
+
+#[cfg(not(feature = "std"))]
+use core::fmt::{Debug, Formatter};
 
 /// Error handling for Marlin constraints.
 pub struct MarlinConstraintsError {
@@ -25,6 +31,7 @@ pub struct MarlinConstraintsError {
     pub error_msg: String,
 }
 
+#[cfg(feature = "std")]
 impl<E> From<MarlinError<E>> for MarlinConstraintsError
 where
     E: std::error::Error,

--- a/marlin/src/constraints/lagrange_interpolation.rs
+++ b/marlin/src/constraints/lagrange_interpolation.rs
@@ -21,7 +21,7 @@ use snarkvm_gadgets::{
 };
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
-use crate::constraints::polynomial::AlgebraForAHP;
+use crate::{constraints::polynomial::AlgebraForAHP, Vec};
 
 /// A helper struct for evaluating the vanishing polynomial.
 pub struct VanishingPolynomial<F: Field> {

--- a/marlin/src/constraints/polynomial.rs
+++ b/marlin/src/constraints/polynomial.rs
@@ -18,7 +18,7 @@ use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{nonnative::NonNativeFieldVar, traits::fields::FieldGadget};
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
-use std::marker::PhantomData;
+use crate::PhantomData;
 
 /// A struct with methods to compute vanishing polynomial equations.
 pub struct AlgebraForAHP<F: PrimeField, CF: PrimeField> {

--- a/marlin/src/constraints/proof.rs
+++ b/marlin/src/constraints/proof.rs
@@ -23,7 +23,7 @@ use snarkvm_gadgets::{nonnative::NonNativeFieldVar, traits::alloc::AllocGadget, 
 use snarkvm_polycommit::PCCheckVar;
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
-use crate::{marlin::Proof, PolynomialCommitment};
+use crate::{marlin::Proof, PolynomialCommitment, String, ToString, Vec};
 use snarkvm_utilities::FromBytes;
 
 /// The prover message gadget

--- a/marlin/src/constraints/snark.rs
+++ b/marlin/src/constraints/snark.rs
@@ -15,7 +15,6 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use rand::{CryptoRng, Rng};
-use std::marker::PhantomData;
 
 use crate::{
     constraints::UniversalSRS,
@@ -28,6 +27,7 @@ use crate::{
         PreparedCircuitVerifyingKey,
         Proof,
     },
+    PhantomData,
     PolynomialCommitment,
 };
 use snarkvm_algorithms::{crypto_hash::PoseidonDefaultParametersField, SNARKError, SNARK, SRS};

--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -31,6 +31,8 @@ use crate::{
     PolynomialCommitment,
     PoseidonSponge,
     PoseidonSpongeVar,
+    String,
+    Vec,
 };
 use snarkvm_algorithms::{crypto_hash::PoseidonDefaultParametersField, fft::EvaluationDomain};
 use snarkvm_fields::PrimeField;

--- a/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
@@ -40,6 +40,7 @@ use crate::{
     FiatShamirRng,
     FiatShamirRngVar,
     PolynomialCommitment,
+    Vec,
 };
 use snarkvm_algorithms::{crypto_hash::PoseidonDefaultParametersField, Prepare};
 use snarkvm_utilities::{marker::PhantomData, to_bytes_le, FromBytes, ToBytes};

--- a/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
@@ -15,7 +15,6 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use core::borrow::Borrow;
-use std::marker::PhantomData;
 
 use snarkvm_algorithms::Prepare;
 use snarkvm_fields::{PrimeField, ToConstraintField};
@@ -29,7 +28,9 @@ use crate::{
     marlin::{CircuitVerifyingKey, PreparedCircuitVerifyingKey},
     FiatShamirRng,
     FiatShamirRngVar,
+    PhantomData,
     PolynomialCommitment,
+    Vec,
 };
 use snarkvm_algorithms::crypto_hash::PoseidonDefaultParametersField;
 

--- a/marlin/src/fiat_shamir/errors.rs
+++ b/marlin/src/fiat_shamir/errors.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::fmt;
+use crate::ToString;
+use core::fmt;
 
 /// A `enum` specifying the possible failure modes of `FiatShamir`.
 #[derive(Debug)]

--- a/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge.rs
@@ -17,6 +17,7 @@
 use crate::{
     fiat_shamir::{AlgebraicSponge, FiatShamirError, FiatShamirRng},
     PhantomData,
+    Vec,
 };
 use snarkvm_fields::{FieldParameters, PrimeField, ToConstraintField};
 use snarkvm_gadgets::{

--- a/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge_gadget.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_algebraic_sponge_gadget.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::marker::PhantomData;
-
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     bits::{Boolean, ToBitsBEGadget},
@@ -36,6 +34,8 @@ use crate::fiat_shamir::{
     AlgebraicSponge,
     FiatShamirAlgebraicSpongeRng,
 };
+
+use crate::{PhantomData, Vec};
 
 /// Building the Fiat-Shamir sponge's gadget from any algebraic sponge's gadget.
 #[derive(Clone)]

--- a/marlin/src/fiat_shamir/fiat_shamir_chacha.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_chacha.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{fiat_shamir::FiatShamirRng, FiatShamirError, PhantomData};
+use crate::{fiat_shamir::FiatShamirRng, FiatShamirError, PhantomData, Vec};
 use snarkvm_fields::{PrimeField, ToConstraintField};
 use snarkvm_gadgets::nonnative::params::OptimizationType;
 

--- a/marlin/src/fiat_shamir/fiat_shamir_poseidon_sponge.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_poseidon_sponge.rs
@@ -21,7 +21,7 @@
 // ([COS20]: https://eprint.iacr.org/2019/1076) with small syntax changes.
 //
 
-use crate::fiat_shamir::AlgebraicSponge;
+use crate::{fiat_shamir::AlgebraicSponge, Vec};
 use snarkvm_algorithms::crypto_hash::{CryptographicSponge, PoseidonDefaultParametersField};
 use snarkvm_fields::PrimeField;
 

--- a/marlin/src/fiat_shamir/fiat_shamir_poseidon_sponge_gadget.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_poseidon_sponge_gadget.rs
@@ -32,6 +32,8 @@ use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 use crate::fiat_shamir::{fiat_shamir_poseidon_sponge::PoseidonSponge, traits::AlgebraicSpongeVar};
 use snarkvm_algorithms::crypto_hash::PoseidonDefaultParametersField;
 
+use crate::Vec;
+
 #[derive(Clone)]
 /// the gadget for Poseidon sponge
 pub struct PoseidonSpongeVar<F: PrimeField + PoseidonDefaultParametersField> {

--- a/marlin/src/fiat_shamir/traits/algebraic_sponge.rs
+++ b/marlin/src/fiat_shamir/traits/algebraic_sponge.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::Vec;
 use snarkvm_fields::PrimeField;
 
 /// Trait for an algebraic sponge.

--- a/marlin/src/fiat_shamir/traits/algebraic_sponge_gadget.rs
+++ b/marlin/src/fiat_shamir/traits/algebraic_sponge_gadget.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::traits::AlgebraicSponge;
+use crate::{traits::AlgebraicSponge, Vec};
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::fields::FpGadget;
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};

--- a/marlin/src/fiat_shamir/traits/fiat_shamir.rs
+++ b/marlin/src/fiat_shamir/traits/fiat_shamir.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::fiat_shamir::FiatShamirError;
+use crate::{fiat_shamir::FiatShamirError, Vec};
 use snarkvm_fields::{PrimeField, ToConstraintField};
 use snarkvm_gadgets::nonnative::params::OptimizationType;
 

--- a/marlin/src/fiat_shamir/traits/fiat_shamir_gadget.rs
+++ b/marlin/src/fiat_shamir/traits/fiat_shamir_gadget.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::traits::FiatShamirRng;
+use crate::{traits::FiatShamirRng, Vec};
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     bits::Boolean,

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -42,19 +42,30 @@ extern crate alloc;
 #[rustfmt::skip]
 #[cfg(not(feature = "std"))]
 use alloc::{
-    collections::BTreeMap,
-    marker::PhantomData,
+    collections::{BTreeSet, BTreeMap},
     string::{String, ToString},
     vec::Vec,
+};
+
+#[cfg(not(feature = "std"))]
+use core::marker::PhantomData;
+
+#[cfg(not(feature = "std"))]
+use snarkvm_utilities::io::{
+    Read,
+    Result as IoResult,
+    Write,
+    {self},
 };
 
 #[rustfmt::skip]
 #[cfg(feature = "std")]
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeSet, BTreeMap},
     marker::PhantomData,
     string::{String, ToString},
     vec::Vec,
+    io::{Read, Write, Result as IoResult, {self}},
 };
 use snarkvm_polycommit::PolynomialCommitment;
 

--- a/marlin/src/marlin/circuit_proving_key.rs
+++ b/marlin/src/marlin/circuit_proving_key.rs
@@ -19,8 +19,8 @@ use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::PolynomialCommitment;
 use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
+use crate::{IoResult, Read, Write};
 use derivative::Derivative;
-use std::io::{Read, Result as IoResult, Write};
 
 /// Proving key for a specific circuit (i.e., R1CS matrices).
 #[derive(Derivative)]

--- a/marlin/src/marlin/circuit_verifying_key.rs
+++ b/marlin/src/marlin/circuit_verifying_key.rs
@@ -25,14 +25,10 @@ use snarkvm_fields::{ConstraintFieldError, PrimeField, ToConstraintField};
 use snarkvm_polycommit::PolynomialCommitment;
 use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes, ToMinimalBits};
 
+use crate::{Read, Write};
 use derivative::Derivative;
 use snarkvm_algorithms::fft::EvaluationDomain;
 use snarkvm_r1cs::SynthesisError;
-use std::io::{
-    Read,
-    Write,
-    {self},
-};
 
 /// Verification key for a specific index (i.e., R1CS matrices).
 #[derive(Derivative)]
@@ -48,7 +44,7 @@ pub struct CircuitVerifyingKey<F: PrimeField, CF: PrimeField, PC: PolynomialComm
 }
 
 impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToBytes for CircuitVerifyingKey<F, CF, PC> {
-    fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut w: W) -> crate::io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("could not serialize CircuitVerifyingKey"))
     }
 }
@@ -86,7 +82,7 @@ impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToMinimalBi
 }
 
 impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> FromBytes for CircuitVerifyingKey<F, CF, PC> {
-    fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
+    fn read_le<R: Read>(mut r: R) -> crate::io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut r).map_err(|_| error("could not deserialize CircuitVerifyingKey"))
     }
 }

--- a/marlin/src/marlin/errors.rs
+++ b/marlin/src/marlin/errors.rs
@@ -16,7 +16,11 @@
 
 use snarkvm_algorithms::SNARKError;
 
+#[cfg(feature = "std")]
 use std::fmt::Debug;
+
+#[cfg(not(feature = "std"))]
+use core::fmt::Debug;
 
 /// A `enum` specifying the possible failure modes of `Marlin`.
 #[derive(Debug)]

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -18,6 +18,9 @@ use crate::{
     ahp::{AHPError, AHPForR1CS, EvaluationsProvider},
     fiat_shamir::traits::FiatShamirRng,
     marlin::{compute_vk_hash, CircuitProvingKey, CircuitVerifyingKey, MarlinError, MarlinMode, Proof, UniversalSRS},
+    String,
+    ToString,
+    Vec,
 };
 use snarkvm_algorithms::fft::EvaluationDomain;
 use snarkvm_fields::PrimeField;
@@ -25,6 +28,9 @@ use snarkvm_gadgets::nonnative::params::OptimizationType;
 use snarkvm_polycommit::{Evaluations, LabeledCommitment, LabeledPolynomial, PCUniversalParams, PolynomialCommitment};
 use snarkvm_r1cs::{ConstraintSynthesizer, SynthesisError};
 use snarkvm_utilities::{to_bytes_le, ToBytes};
+
+#[cfg(not(feature = "std"))]
+use snarkvm_utilities::println;
 
 use crate::marlin::PreparedCircuitVerifyingKey;
 use core::marker::PhantomData;

--- a/marlin/src/marlin/prepared_circuit_verifying_key.rs
+++ b/marlin/src/marlin/prepared_circuit_verifying_key.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::marlin::CircuitVerifyingKey;
+use crate::{marlin::CircuitVerifyingKey, Vec};
 
 use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::PolynomialCommitment;

--- a/marlin/src/marlin/proof.rs
+++ b/marlin/src/marlin/proof.rs
@@ -19,7 +19,7 @@ use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::{BatchLCProof, PCCommitment, PolynomialCommitment};
 use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes};
 
-use std::io::{Read, Write};
+use crate::{Read, Write};
 
 /// A zkSNARK proof.
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
@@ -112,13 +112,13 @@ impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> Proof<F, CF
 }
 
 impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToBytes for Proof<F, CF, PC> {
-    fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut w: W) -> crate::io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("could not serialize Proof"))
     }
 }
 
 impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> FromBytes for Proof<F, CF, PC> {
-    fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
+    fn read_le<R: Read>(mut r: R) -> crate::io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut r).map_err(|_| error("could not deserialize Proof"))
     }
 }


### PR DESCRIPTION
## Motivation

Enable WASM compilation of Marlin, so that the DPC package can be used for the Inner setup.
