### PR TITLE
Reduce the number of allocations in some hot functions

### DIFF
--- a/algorithms/src/merkle_tree/merkle_path.rs
+++ b/algorithms/src/merkle_tree/merkle_path.rs
@@ -44,7 +44,6 @@ impl<P: MerkleParameters> MerklePath<P> {
             let mut index = self.leaf_index;
 
             let mut curr_path_node = claimed_leaf_hash;
-            let mut buffer = vec![0u8; hash_input_size_in_bytes];
 
             // Check levels between leaf level and root.
             for level in 0..self.path.len() {

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -152,7 +152,7 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
         }
 
         // Track the indices of newly added leaves.
-        let new_indices = (start_index..start_index + new_leaves.len()).collect::<Vec<_>>();
+        let new_indices = || start_index..start_index + new_leaves.len();
 
         // Compute and store the hash values for each leaf.
         let hash_input_size_in_bytes = P::H::INPUT_SIZE_BITS / 8;
@@ -180,12 +180,10 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
                 let right_index = right_child(current_index);
 
                 // Hash only the tree paths that are altered by the addition of new leaves or are brand new.
-                if new_indices.contains(&current_index)
+                if new_indices().contains(&current_index)
                     || self.tree.get(left_index) != tree.get(left_index)
                     || self.tree.get(right_index) != tree.get(right_index)
-                    || new_indices
-                        .iter()
-                        .any(|&idx| Ancestors(idx).into_iter().find(|&i| i == current_index).is_some())
+                    || new_indices().any(|idx| Ancestors(idx).into_iter().find(|&i| i == current_index).is_some())
                 {
                     // Compute Hash(left || right).
                     tree[current_index] =

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -145,7 +145,7 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
 
         // Compute the starting index (on the left) for each level of the tree.
         let mut index = 0;
-        let mut level_indices = Vec::with_capacity(tree_depth);
+        let mut level_indices = Vec::with_capacity(tree_depth + 1);
         for _ in 0..=tree_depth {
             level_indices.push(index);
             index = left_child(index);

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -135,19 +135,19 @@ impl<E: PairingEngine> Proof<E> {
 
     /// Deserialize a proof from compressed or uncompressed bytes.
     pub fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        // Construct the compressed reader.
         let compressed_proof_size = Self::compressed_proof_size()?;
-        let mut proof_reader = vec![0u8; compressed_proof_size];
-        reader.read_exact(&mut proof_reader)?;
+        let uncompressed_proof_size = Self::uncompressed_proof_size()?;
+
+        // Construct the compressed reader.
+        let mut proof_reader = vec![0u8; uncompressed_proof_size];
+        reader.read_exact(&mut proof_reader[..compressed_proof_size])?;
 
         // Attempt to read the compressed proof.
-        if let Ok(proof) = Self::read_compressed(&proof_reader[..]) {
+        if let Ok(proof) = Self::read_compressed(&proof_reader[..compressed_proof_size]) {
             return Ok(proof);
         }
 
         // Construct the uncompressed reader.
-        let uncompressed_proof_size = Self::uncompressed_proof_size()?;
-        proof_reader.resize(uncompressed_proof_size, 0);
         reader.read_exact(&mut proof_reader[compressed_proof_size..])?;
 
         // Attempt to read the uncompressed proof.

--- a/fields/src/to_field_vec.rs
+++ b/fields/src/to_field_vec.rs
@@ -84,9 +84,9 @@ impl<F: PrimeField> ToConstraintField<F> for [u8] {
             .chunks(floored_field_size_in_bytes)
             .map(|chunk| {
                 // Before packing, pad the chunk to the next power of two.
-                let mut chunk = chunk.to_vec();
-                chunk.resize(floored_field_size_in_bytes.next_power_of_two(), 0u8);
-                F::read_le(chunk.as_slice())
+                let mut chunk_vec = vec![0u8; floored_field_size_in_bytes.next_power_of_two()];
+                chunk_vec[..chunk.len()].copy_from_slice(chunk);
+                F::read_le(&*chunk_vec)
             })
             .collect::<Result<Vec<_>, _>>()?)
     }

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -30,22 +30,30 @@ pub fn from_bytes_le_to_bits_le(bytes: &[u8]) -> impl Iterator<Item = bool> + Do
 
 #[inline]
 pub fn from_bits_le_to_bytes_le(bits: &[bool]) -> Vec<u8> {
-    // Pad the bits if it not a correct size
-    let mut bits = std::borrow::Cow::from(bits);
-    if bits.len() % 8 != 0 {
-        let current_length = bits.len();
-        bits.to_mut().resize(current_length + 8 - (current_length % 8), false);
-    }
+    let desired_size = if bits.len() % 8 == 0 {
+        bits.len() / 8
+    } else {
+        bits.len() / 8 + 1
+    };
 
-    let mut bytes = Vec::with_capacity(bits.len() / 8);
+    let mut bytes = Vec::with_capacity(desired_size);
     for bits in bits.chunks(8) {
         let mut result = 0u8;
         for (i, bit) in bits.iter().enumerate() {
             let bit_value = *bit as u8;
             result += bit_value << i as u8;
         }
+
+        // Pad the bits if their number doesn't correspond to full bytes
+        if bits.len() < 8 {
+            for i in bits.len()..8 {
+                let bit_value = false as u8;
+                result += bit_value << i as u8;
+            }
+        }
         bytes.push(result);
     }
+
     bytes
 }
 


### PR DESCRIPTION
snarkOS profiling results indicate that allocations are non-negligible, especially while fast-forwarding blocks; this PR targets allocations in some hot functions.