### PR TITLE
Add to_decrypted_records fn for Transaction

### DIFF
--- a/dpc/src/transaction/transaction.rs
+++ b/dpc/src/transaction/transaction.rs
@@ -219,7 +219,8 @@ impl<N: Network> Transaction<N> {
             .map(|e| Ok(e.to_hash()?))
             .collect::<Result<Vec<_>>>()?)
     }
-/// Returns the records that can be decrypted with the given account view key.
+
+    /// Returns the records that can be decrypted with the given account view key.
     pub fn to_decrypted_records(&self, account_view_key: &ViewKey<N>) -> Option<Vec<Record<N>>> {
         self.encrypted_records
             .iter()


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

The `to_decrypted_records` function reduces the amount of code users will need to write to decrypt records in a Transaction.
