### PR TITLE
fix: reduce magic numbers to prevent stack overflow in wasm call to bhp

### DIFF
--- a/algorithms/src/crh/bhp.rs
+++ b/algorithms/src/crh/bhp.rs
@@ -31,7 +31,7 @@ use rayon::prelude::*;
 // The stack is currently allocated with the following size
 // because we cannot specify them using the trait consts.
 const MAX_WINDOW_SIZE: usize = 256;
-const MAX_NUM_WINDOWS: usize = 4096;
+const MAX_NUM_WINDOWS: usize = 2048;
 
 pub const BOWE_HOPWOOD_CHUNK_SIZE: usize = 3;
 pub const BOWE_HOPWOOD_LOOKUP_SIZE: usize = 2usize.pow(BOWE_HOPWOOD_CHUNK_SIZE as u32);

--- a/marlin/src/constraints/error.rs
+++ b/marlin/src/constraints/error.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ahp::AHPError, marlin::MarlinError, String};
+use crate::{ahp::AHPError, marlin::MarlinError, String, ToString};
 
 use core::fmt::{Debug, Display, Formatter};
 

--- a/marlin/src/fiat_shamir/fiat_shamir_poseidon_sponge.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_poseidon_sponge.rs
@@ -25,7 +25,7 @@ use crate::{fiat_shamir::AlgebraicSponge, Vec};
 use snarkvm_algorithms::crypto_hash::{CryptographicSponge, PoseidonDefaultParametersField};
 use snarkvm_fields::PrimeField;
 
-use std::sync::Arc;
+use snarkvm_utilities::sync::Arc;
 
 /// The sponge for Poseidon
 #[derive(Clone, Debug)]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -56,6 +56,7 @@ default-features = false
 path = "../marlin"
 version = "0.7.5"
 optional = true
+default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-polycommit]


### PR DESCRIPTION
BHP commit makes an absolutely insane stack allocation that needed to be trimmed down for it to work properly in wasm.