### PR TITLE
Disable the oldtime feature in chrono

### DIFF
--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -63,7 +63,8 @@ version = "0.9"
 
 [dependencies.chrono]
 version = "0.4"
-features = [ "serde" ]
+default-features = false
+features = [ "clock", "serde" ]
 
 [dependencies.derivative]
 version = "2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
  "winapi",
 ]
 
@@ -1997,16 +1996,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -93,7 +93,8 @@ version = "0.8"
 
 [dependencies.chrono]
 version = "0.4"
-features = [ "serde" ]
+default-features = false
+features = [ "clock", "serde" ]
 
 [dependencies.derivative]
 version = "2"


### PR DESCRIPTION
Just like [its counterpart in snarkOS](https://github.com/AleoHQ/snarkOS/pull/1233), this PR removes the dependency on old `time` in order to avoid [CVE-2020-26235](https://nvd.nist.gov/vuln/detail/CVE-2020-26235) and its related warning when running `cargo audit`.

note: the problematic `localtime_r` is still used directly in "vanilla" `chrono`, but snarkOS (and snarkVM) should be fine due to not using local time (UTC is always used). Nevertheless, we might later want to switch to current `time` regardless, as `chrono` appears to be unmaintained.

Cc https://github.com/AleoHQ/snarkOS/issues/1223.