### PR TITLE
fixed SNARK parameters to stored in the local place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,6 +1942,7 @@ dependencies = [
  "snarkvm-posw",
  "snarkvm-utilities",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -37,6 +37,9 @@ version = "0.4.3"
 [dependencies.thiserror]
 version = "1.0"
 
+[dependencies.tracing]
+version = "0.1.26"
+
 [dev-dependencies.snarkvm-curves]
 path = "../curves"
 default-features = false

--- a/parameters/src/check_parameters.rs
+++ b/parameters/src/check_parameters.rs
@@ -1,57 +1,74 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::errors::ParameterError;
+
 use std::path::{Path, PathBuf};
 use std::fs::create_dir_all;
 use std::io::{Read, Write};
 
-pub struct ParamCheck {
+pub struct CheckParameters {
     checksum: String,
     url: String,
-    fname: String,
+    filename: String,
 }
 
-impl ParamCheck {
-    pub fn new(fname: &str, url: &str, checksum: &str) -> Self {
+impl CheckParameters {
+    pub fn new(filename: &str, url: &str, checksum: &str) -> Self {
         Self {
             checksum: checksum.to_string(),
             url: url.to_string(),
-            fname: fname.to_string(),
+            filename: filename.to_string(),
         }
     }
 
-    fn para_path_from_env() -> Result<PathBuf, ParameterError> {
-        let p = option_env!("ALEO_PROOFS_PARAMETER_CACHE").map(|p| Path::new(p).to_path_buf())
+    fn parameters_path_from_env() -> Result<PathBuf, ParameterError> {
+        let path = option_env!("ALEO_PROOFS_PARAMETER_CACHE").map(|name| Path::new(name).to_path_buf())
             .unwrap_or_else(|| std::env::temp_dir().join("aleo-proof-parameters"));
-        if !p.exists() || !p.is_dir() {
-            create_dir_all(p.clone()).map(|_| p.to_path_buf()).map_err(|e| ParameterError::Message(format!("{}", e)))
+        if !path.exists() || !path.is_dir() {
+            create_dir_all(path.clone()).map(|_| path.to_path_buf()).map_err(|err| ParameterError::Message(format!("{}", err)))
         } else {
-            Ok(p.to_path_buf())
+            Ok(path.to_path_buf())
         }
     }
 
-    fn checksum(msg: &[u8]) -> String {
-        hex::encode(snarkvm_algorithms::crh::sha256::sha256(msg))
+    fn checksum(message: &[u8]) -> String {
+        hex::encode(snarkvm_algorithms::crh::sha256::sha256(message))
     }
 
     pub fn load_bytes(&self) -> Result<Vec<u8>, ParameterError> {
-        let para_path = Self::para_path_from_env()?;
-        let para_file = para_path.join(self.versioned_filename());
-        let content = std::fs::File::open(para_file.clone()).map(|mut x| {
-            let mut buf = Vec::new();
-            x.read_to_end(&mut buf).unwrap_or(0);
-            buf
+        let parameters_path = Self::parameters_path_from_env()?;
+        let parameters_file = parameters_path.join(self.versioned_filename());
+        let content = std::fs::File::open(parameters_file.clone()).map(|mut file| {
+            let mut buffer = Vec::new();
+            file.read_to_end(&mut buffer).unwrap_or(0);
+            buffer
         }).unwrap_or(Vec::new());
 
         if Self::checksum(content.as_ref()) != self.checksum {
-            let buf = self.load_remote()?;
-            match std::fs::File::create(para_file).map(|mut f| {
-                f.write_all(buf.as_ref()).unwrap_or(())
+            let buffer = self.load_remote()?;
+            match std::fs::File::create(parameters_file).map(|mut file| {
+                file.write_all(buffer.as_ref()).unwrap_or(())
             }) {
                 Ok(_) => {},
                 Err(e) => {
                     tracing::error!("Cannot store the data of {} caused by the {}", self.versioned_filename(), format!("{:?}", e));
                 },
             }
-            Ok(buf)
+            Ok(buffer)
         } else {
             Ok(content)
         }
@@ -72,15 +89,15 @@ impl ParamCheck {
     }
 
     fn versioned_filename(&self) -> String {
-        self.checksum.get(0..7).map(|x| format!("{}-{}.params", self.fname, x))
-            .unwrap_or(self.fname.to_string() + ".params")
+        self.checksum.get(0..7).map(|x| format!("{}-{}.params", self.filename, x))
+            .unwrap_or(self.filename.to_string() + ".params")
     }
 
     fn remote_url(&self) -> String {
         format!("{}/{}", self.url, self.versioned_filename())
     }
 
-    fn remote_fetch(&self, buf: &mut Vec<u8>) -> Result<(), ParameterError> {
+    fn remote_fetch(&self, buffer: &mut Vec<u8>) -> Result<(), ParameterError> {
         let mut easy = curl::easy::Easy::new();
         easy.url(self.remote_url().as_str())?;
         easy.progress(true)?;
@@ -98,7 +115,7 @@ impl ParamCheck {
 
         let mut transfer = easy.transfer();
         transfer.write_function(|data| {
-            buf.extend_from_slice(data);
+            buffer.extend_from_slice(data);
             Ok(data.len())
         })?;
         Ok(transfer.perform()?)
@@ -107,14 +124,14 @@ impl ParamCheck {
 
 #[cfg(test)]
 mod tests {
-    use super::ParamCheck;
+    use super::CheckParameters;
 
     #[test]
     fn test_posw_snark_param() {
         let checksum = include_str!(concat!("./testnet1/", "posw_snark_pk", ".checksum"));
         let filename = "posw_snark_pk";
         let url = "https://snarkos-testnet.s3-us-west-2.amazonaws.com";
-        let para = ParamCheck::new(filename, url, checksum);
+        let para = CheckParameters::new(filename, url, checksum);
 
         assert!(para.load_bytes().is_ok());
     }

--- a/parameters/src/lib.rs
+++ b/parameters/src/lib.rs
@@ -22,6 +22,8 @@ extern crate thiserror;
 #[macro_use]
 pub mod macros;
 
+pub mod param_check;
+
 pub mod errors;
 pub use errors::*;
 

--- a/parameters/src/lib.rs
+++ b/parameters/src/lib.rs
@@ -22,7 +22,7 @@ extern crate thiserror;
 #[macro_use]
 pub mod macros;
 
-pub mod param_check;
+pub mod check_parameters;
 
 pub mod errors;
 pub use errors::*;

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -63,7 +63,6 @@ macro_rules! impl_params_local {
 #[macro_export]
 macro_rules! impl_params_remote {
     ($name: ident, $test_name: ident, $remote_url: tt, $local_dir: expr, $fname: tt, $size: tt) => {
-
         pub struct $name;
 
         impl crate::traits::Parameter for $name {
@@ -71,136 +70,8 @@ macro_rules! impl_params_remote {
             const SIZE: u64 = $size;
 
             fn load_bytes() -> Result<Vec<u8>, crate::errors::ParameterError> {
-                // Compose the correct file path for the parameter file.
-                let filename = Self::versioned_filename();
-                let mut file_path = std::path::PathBuf::from(file!());
-                file_path.pop();
-                file_path.push($local_dir);
-                file_path.push(&filename);
-
-                // Compute the relative path.
-                let relative_path = if file_path.strip_prefix("parameters").is_ok() {
-                    file_path.strip_prefix("parameters")?
-                } else {
-                    &file_path
-                };
-
-                // Compute the absolute path.
-                let mut absolute_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                absolute_path.push(&relative_path);
-
-                let buffer = if relative_path.exists() {
-                    // Attempts to load the parameter file locally with a relative path.
-                    std::fs::read(relative_path)?
-                } else if absolute_path.exists() {
-                    // Attempts to load the parameter file locally with an absolute path.
-                    std::fs::read(absolute_path)?
-                } else {
-                    // Downloads the missing parameters and stores it in the local directory for use.
-                    eprintln!(
-                        "\nWARNING - \"{}\" does not exist, downloading this file remotely and storing it locally. Please ensure \"{}\" is stored in {:?}.\n",
-                        filename, filename, file_path
-                    );
-                    let output = Self::load_remote()?;
-                    match Self::store_bytes(&output, &relative_path, &absolute_path, &file_path) {
-                        Ok(()) => output,
-                        Err(_) => {
-                            eprintln!(
-                                "\nWARNING - Failed to store \"{}\" locally. Please download this file manually and ensure it is stored in {:?}.\n",
-                                filename, file_path
-                            );
-                            output
-                        }
-                    }
-                };
-
-                let checksum = checksum!(&buffer);
-                match Self::CHECKSUM == checksum {
-                    true => Ok(buffer),
-                    false => checksum_error!(Self::CHECKSUM.into(), checksum),
-                }
-            }
-        }
-
-        impl $name {
-            #[cfg(any(test, feature = "remote"))]
-            pub fn load_remote() -> Result<Vec<u8>, crate::errors::ParameterError> {
-                use crate::traits::Parameter;
-
-                println!("{} - Downloading parameters...", module_path!());
-                let mut buffer = vec![];
-                let url = Self::remote_url();
-                Self::remote_fetch(&mut buffer, &url)?;
-                println!("\n{} - Download complete", module_path!());
-
-                // Verify the checksum of the remote data before returning
-                let checksum = checksum!(&buffer);
-                match Self::CHECKSUM == checksum {
-                    true => Ok(buffer),
-                    false => checksum_error!(Self::CHECKSUM.into(), checksum),
-                }
-            }
-
-            #[cfg(not(any(test, feature = "remote")))]
-            pub fn load_remote() -> Result<Vec<u8>, crate::errors::ParameterError> {
-                Err(crate::errors::ParameterError::RemoteFetchDisabled)
-            }
-
-            fn versioned_filename() -> String {
-                use crate::traits::Parameter;
-
-                match Self::CHECKSUM.get(0..7) {
-                    Some(sum) => format!("{}-{}.params", $fname, sum),
-                    _ => concat!($fname, ".params",).to_string()
-                }
-            }
-
-            #[cfg(any(test, feature = "remote"))]
-            fn remote_url() -> String {
-                format!("{}/{}", $remote_url, Self::versioned_filename())
-            }
-
-            fn store_bytes(
-                buffer: &[u8],
-                relative_path: &std::path::Path,
-                absolute_path: &std::path::Path,
-                file_path: &std::path::Path,
-            ) -> Result<(), crate::errors::ParameterError> {
-                use snarkvm_utilities::Write;
-
-                println!("{} - Storing parameters ({:?})", module_path!(), file_path);
-                // Attempt to write the parameter buffer to a file.
-                if let Ok(mut file) = std::fs::File::create(relative_path) {
-                    file.write_all(&buffer)?;
-                } else if let Ok(mut file) = std::fs::File::create(absolute_path) {
-                    file.write_all(&buffer)?;
-                }
-                Ok(())
-            }
-
-            #[cfg(any(test, feature = "remote"))]
-            fn remote_fetch(buffer: &mut Vec<u8>, url: &str) -> Result<(), crate::errors::ParameterError> {
-                let mut easy = curl::easy::Easy::new();
-                easy.url(url)?;
-                easy.progress(true)?;
-                easy.progress_function(|total_download, current_download, _, _| {
-                    let percent = (current_download / total_download) * 100.0;
-                    let size_in_megabytes = total_download as u64 / 1_048_576;
-                    print!(
-                        "\r{} - {:.2}% complete ({:#} MB total)",
-                        module_path!(),
-                        percent,
-                        size_in_megabytes
-                    );
-                    true
-                })?;
-
-                let mut transfer = easy.transfer();
-                transfer.write_function(|data| {
-                    buffer.extend_from_slice(data);
-                    Ok(data.len())
-                })?;
-                Ok(transfer.perform()?)
+                let para = crate::param_check::ParamCheck::new($fname, $remote_url, Self::CHECKSUM);
+                para.load_bytes()
             }
         }
 
@@ -214,3 +85,4 @@ macro_rules! impl_params_remote {
         }
     }
 }
+

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -83,6 +83,5 @@ macro_rules! impl_params_remote {
             let parameters = $name::load_bytes().expect("failed to load parameters");
             assert_eq!($name::SIZE, parameters.len() as u64);
         }
-    }
+    };
 }
-

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -62,16 +62,16 @@ macro_rules! impl_params_local {
 
 #[macro_export]
 macro_rules! impl_params_remote {
-    ($name: ident, $test_name: ident, $remote_url: tt, $local_dir: expr, $fname: tt, $size: tt) => {
+    ($name: ident, $test_name: ident, $remote_url: tt, $local_dir: expr, $filename: tt, $size: tt) => {
         pub struct $name;
 
         impl crate::traits::Parameter for $name {
-            const CHECKSUM: &'static str = include_str!(concat!($local_dir, $fname, ".checksum"));
+            const CHECKSUM: &'static str = include_str!(concat!($local_dir, $filename, ".checksum"));
             const SIZE: u64 = $size;
 
             fn load_bytes() -> Result<Vec<u8>, crate::errors::ParameterError> {
-                let para = crate::param_check::ParamCheck::new($fname, $remote_url, Self::CHECKSUM);
-                para.load_bytes()
+                let parameters = crate::check_parameters::CheckParameters::new($filename, $remote_url, Self::CHECKSUM);
+                parameters.load_bytes()
             }
         }
 

--- a/parameters/src/param_check.rs
+++ b/parameters/src/param_check.rs
@@ -1,0 +1,121 @@
+use crate::errors::ParameterError;
+use std::path::{Path, PathBuf};
+use std::fs::create_dir_all;
+use std::io::{Read, Write};
+
+pub struct ParamCheck {
+    checksum: String,
+    url: String,
+    fname: String,
+}
+
+impl ParamCheck {
+    pub fn new(fname: &str, url: &str, checksum: &str) -> Self {
+        Self {
+            checksum: checksum.to_string(),
+            url: url.to_string(),
+            fname: fname.to_string(),
+        }
+    }
+
+    fn para_path_from_env() -> Result<PathBuf, ParameterError> {
+        let p = option_env!("ALEO_PROOFS_PARAMETER_CACHE").map(|p| Path::new(p).to_path_buf())
+            .unwrap_or_else(|| std::env::temp_dir().join("aleo-proof-parameters"));
+        if !p.exists() || !p.is_dir() {
+            create_dir_all(p.clone()).map(|_| p.to_path_buf()).map_err(|e| ParameterError::Message(format!("{}", e)))
+        } else {
+            Ok(p.to_path_buf())
+        }
+    }
+
+    fn checksum(msg: &[u8]) -> String {
+        hex::encode(snarkvm_algorithms::crh::sha256::sha256(msg))
+    }
+
+    pub fn load_bytes(&self) -> Result<Vec<u8>, ParameterError> {
+        let para_path = Self::para_path_from_env()?;
+        let para_file = para_path.join(self.versioned_filename());
+        let content = std::fs::File::open(para_file.clone()).map(|mut x| {
+            let mut buf = Vec::new();
+            x.read_to_end(&mut buf).unwrap_or(0);
+            buf
+        }).unwrap_or(Vec::new());
+
+        if Self::checksum(content.as_ref()) != self.checksum {
+            let buf = self.load_remote()?;
+            match std::fs::File::create(para_file).map(|mut f| {
+                f.write_all(buf.as_ref()).unwrap_or(())
+            }) {
+                Ok(_) => {},
+                Err(e) => {
+                    tracing::error!("Cannot store the data of {} caused by the {}", self.versioned_filename(), format!("{:?}", e));
+                },
+            }
+            Ok(buf)
+        } else {
+            Ok(content)
+        }
+    }
+
+    fn load_remote(&self) ->  Result<Vec<u8>, ParameterError> {
+        println!("{} - Downloading parameters...", self.remote_url());
+        let mut buffer = Vec::new();
+        self.remote_fetch(&mut buffer)?;
+        println!("{} - Download complete", self.remote_url());
+
+        // Verify the checksum of the remote data before returning
+        let checksum = Self::checksum(buffer.as_slice());
+        match self.checksum == checksum {
+            true => Ok(buffer),
+            false => Err(ParameterError::ChecksumMismatch(self.checksum.clone(), checksum.clone()))
+        }
+    }
+
+    fn versioned_filename(&self) -> String {
+        self.checksum.get(0..7).map(|x| format!("{}-{}.params", self.fname, x))
+            .unwrap_or(self.fname.to_string() + ".params")
+    }
+
+    fn remote_url(&self) -> String {
+        format!("{}/{}", self.url, self.versioned_filename())
+    }
+
+    fn remote_fetch(&self, buf: &mut Vec<u8>) -> Result<(), ParameterError> {
+        let mut easy = curl::easy::Easy::new();
+        easy.url(self.remote_url().as_str())?;
+        easy.progress(true)?;
+        easy.progress_function(|total_download, current_download, _, _| {
+            let percent = (current_download / total_download) * 100.0;
+            let size_in_megabytes = total_download as u64 / 1_048_576;
+            print!(
+                "\r{} - {:.2}% complete ({:#} MB total)",
+                module_path!(),
+                percent,
+                size_in_megabytes
+            );
+            true
+        })?;
+
+        let mut transfer = easy.transfer();
+        transfer.write_function(|data| {
+            buf.extend_from_slice(data);
+            Ok(data.len())
+        })?;
+        Ok(transfer.perform()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParamCheck;
+
+    #[test]
+    fn test_posw_snark_param() {
+        let checksum = include_str!(concat!("./testnet1/", "posw_snark_pk", ".checksum"));
+        let filename = "posw_snark_pk";
+        let url = "https://snarkos-testnet.s3-us-west-2.amazonaws.com";
+        let para = ParamCheck::new(filename, url, checksum);
+
+        assert!(para.load_bytes().is_ok());
+    }
+}


### PR DESCRIPTION
## 🐛 Bug Report

./snarkVM/parameters/src/macros.rs

```rust
macro_rules! impl_params_remote {
    ($name: ident, $remote_url: tt, $local_dir: expr, $fname: tt, $size: tt) => {

        pub struct $name;

        impl crate::traits::Parameter for $name {
            const CHECKSUM: &'static str = include_str!(concat!($local_dir, $fname, ".checksum"));
            const SIZE: u64 = $size;

            fn load_bytes() -> Result<Vec<u8>, crate::errors::ParameterError> {
                // Compose the correct file path for the parameter file.
                let filename = Self::versioned_filename();
                let mut file_path = std::path::PathBuf::from(file!());
                file_path.pop();
                file_path.push($local_dir);
                file_path.push(&filename);

                // Compute the relative path.
                let relative_path = if file_path.strip_prefix("parameters").is_ok() {
                    file_path.strip_prefix("parameters")?
                } else {
                    &file_path
                };
       .....
```

`let mut file_path = std::path::PathBuf::from(file!());` the macro `file!()` will expand in the compile time, so this always the file path of *macros.rs*. when compiled the snarkos, and copy it to a another computer running that have not the path of *macros.rs*, will lead to always download parameter from the remote url;

examples:

i'm compile the snarkos in the local computer A, the file_path will be `/home/lzj/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-7a04d2510079875b/snarkvm-parameters-0.4.0/src/params/`

and copy the snarkos to a another computer B that have not the path `/home/lzj`, this will lead to download the parameter from remote url:

```txt
WARNING - "inner_snark_pk-68eebd0.params" does not exist, downloading this file remotely and storing it locally. Please ensure "inner_snark_pk-68eebd0.params" is stored in "/home/lzj/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-7a04d2510079875b/snarkvm-parameters-0.7.9/src/testnet1/./inner_snark_pk-68eebd0.params".

snarkvm_parameters::testnet1 - Downloading parameters...
snarkvm_parameters::testnet1 - 1.66% complete (238 MB total)Oct 29 09:15:51.438  INFO Syncer lent machines: LentC: {[(127.0.0.1:27778, 0x151e516807e8a9af, 0xb42e99211847)]}
Oct 29 09:15:51.553  INFO Syncer add machines: [LentMachine: {socket: 127.0.0.1:27778, cipher: 0x151e516807e8a9af, finger: 0xb42e99211847, lent_time: 1800s, lent_at_time: Instant { tv_sec: 3684706, tv_nsec: 189117951 }}]
snarkvm_parameters::testnet1 - 100.00% complete (238 MB total)
snarkvm_parameters::testnet1 - Download complete
snarkvm_parameters::testnet1 - Storing parameters ("/home/lzj/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-7a04d2510079875b/snarkvm-parameters-0.7.9/src/testnet1/./inner_snark_pk-68eebd0.params")

WARNING - "outer_snark_pk-12b0f50.params" does not exist, downloading this file remotely and storing it locally. Please ensure "outer_snark_pk-12b0f50.params" is stored in "/home/lzj/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-7a04d2510079875b/snarkvm-parameters-0.7.9/src/testnet1/./outer_snark_pk-12b0f50.params".
```

This modify will store the parameters in the `std::env::tmp_dir().join('aleo-proof-parameters')` when the environment `ALEO_PROOFS_PARAMETER_CACHE` not specified.