### PR TITLE
Add additional memory pool functions

### DIFF
--- a/dpc/src/ledger/ledger.rs
+++ b/dpc/src/ledger/ledger.rs
@@ -182,7 +182,7 @@ impl<N: Network> Ledger<N> {
         self.add_next_block(&block)?;
 
         // On success, clear the memory pool of its transactions.
-        self.memory_pool.clear_transactions();
+        self.memory_pool.clear_all_transactions();
 
         Ok(())
     }

--- a/dpc/src/ledger/memory_pool.rs
+++ b/dpc/src/ledger/memory_pool.rs
@@ -132,6 +132,12 @@ impl<N: Network> MemoryPool<N> {
         Ok(())
     }
 
+    /// Removes a block from the memory pool.
+    pub fn remove_block(&mut self, block_hash: &N::BlockHash) -> Result<()> {
+        self.blocks.remove(block_hash);
+        Ok(())
+    }
+
     /// Clear a transaction (and associated state) from the memory pool.
     pub fn remove_transaction(&mut self, transaction: &Transaction<N>) {
         // This code section executes atomically.

--- a/dpc/src/ledger/memory_pool.rs
+++ b/dpc/src/ledger/memory_pool.rs
@@ -133,9 +133,8 @@ impl<N: Network> MemoryPool<N> {
     }
 
     /// Removes a block from the memory pool.
-    pub fn remove_block(&mut self, block_hash: &N::BlockHash) -> Result<()> {
+    pub fn remove_block(&mut self, block_hash: &N::BlockHash) {
         self.blocks.remove(block_hash);
-        Ok(())
     }
 
     /// Clear a transaction (and associated state) from the memory pool.

--- a/dpc/src/ledger/memory_pool.rs
+++ b/dpc/src/ledger/memory_pool.rs
@@ -133,7 +133,7 @@ impl<N: Network> MemoryPool<N> {
     }
 
     /// Clear a transaction (and associated state) from the memory pool.
-    pub fn clear_transaction(&mut self, transaction: &Transaction<N>) {
+    pub fn remove_transaction(&mut self, transaction: &Transaction<N>) {
         // This code section executes atomically.
 
         let mut memory_pool = self.clone();
@@ -150,7 +150,7 @@ impl<N: Network> MemoryPool<N> {
     }
 
     /// Clear a list of transactions (and associated state) from the memory pool.
-    pub fn clear_transactions(&mut self, transactions: &Vec<Transaction<N>>) {
+    pub fn remove_transactions(&mut self, transactions: &Vec<Transaction<N>>) {
         // This code section executes atomically.
 
         let mut memory_pool = self.clone();

--- a/dpc/src/ledger/memory_pool.rs
+++ b/dpc/src/ledger/memory_pool.rs
@@ -132,8 +132,44 @@ impl<N: Network> MemoryPool<N> {
         Ok(())
     }
 
+    /// Clear a transaction (and associated state) from the memory pool.
+    pub fn clear_transaction(&mut self, transaction: &Transaction<N>) {
+        // This code section executes atomically.
+
+        let mut memory_pool = self.clone();
+
+        memory_pool.transactions.remove(&transaction.transaction_id());
+        for serial_number in &transaction.serial_numbers() {
+            memory_pool.serial_numbers.remove(serial_number);
+        }
+        for commitment in &transaction.commitments() {
+            memory_pool.commitments.remove(commitment);
+        }
+
+        *self = memory_pool;
+    }
+
+    /// Clear a list of transactions (and associated state) from the memory pool.
+    pub fn clear_transactions(&mut self, transactions: &Vec<Transaction<N>>) {
+        // This code section executes atomically.
+
+        let mut memory_pool = self.clone();
+
+        for transaction in transactions {
+            memory_pool.transactions.remove(&transaction.transaction_id());
+            for serial_number in &transaction.serial_numbers() {
+                memory_pool.serial_numbers.remove(serial_number);
+            }
+            for commitment in &transaction.commitments() {
+                memory_pool.commitments.remove(commitment);
+            }
+        }
+
+        *self = memory_pool;
+    }
+
     /// Clears all transactions (and associated state) from the memory pool.
-    pub fn clear_transactions(&mut self) {
+    pub fn clear_all_transactions(&mut self) {
         self.transactions = Default::default();
         self.serial_numbers = Default::default();
         self.commitments = Default::default();

--- a/dpc/src/traits/network.rs
+++ b/dpc/src/traits/network.rs
@@ -44,7 +44,7 @@ use snarkvm_utilities::{
 use anyhow::Result;
 use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, Serialize};
-use std::{borrow::Borrow, cell::RefCell, ops::Deref, rc::Rc};
+use std::{borrow::Borrow, cell::RefCell, ops::Deref, rc::Rc, str::FromStr};
 
 pub trait Bech32Locator<F: Field>:
     From<F>
@@ -58,6 +58,7 @@ pub trait Bech32Locator<F: Field>:
     + Default
     + Debug
     + Display
+    + FromStr
     + ToBytes
     + FromBytes
     + Serialize


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR renames `clear_transactions` to `clear_all_transactions` and adds 3 additional functions to the `MemoryPool` - 
1. `remove_transaction`
2. `remove_transactions`
3. `remove_block`
