### PR TITLE
Record view key decryption

### DIFF
--- a/algorithms/src/encryption/ecies_poseidon.rs
+++ b/algorithms/src/encryption/ecies_poseidon.rs
@@ -17,16 +17,29 @@
 use crate::{
     crypto_hash::{CryptographicSponge, PoseidonDefaultParametersField, PoseidonParameters, PoseidonSponge},
     hash_to_curve::hash_to_curve,
-    EncryptionError, EncryptionScheme,
+    EncryptionError,
+    EncryptionScheme,
 };
 use rand::{CryptoRng, Rng};
 use snarkvm_curves::{
-    templates::twisted_edwards_extended::Affine as TEAffine, AffineCurve, ProjectiveCurve, TwistedEdwardsParameters,
+    templates::twisted_edwards_extended::Affine as TEAffine,
+    AffineCurve,
+    ProjectiveCurve,
+    TwistedEdwardsParameters,
 };
 use snarkvm_fields::{ConstraintFieldError, FieldParameters, PrimeField, ToConstraintField, Zero};
 use snarkvm_utilities::{
-    io::Result as IoResult, ops::Mul, serialize::*, FromBits, FromBytes, Read, SerializationError, ToBits, ToBytes,
-    UniformRand, Write,
+    io::Result as IoResult,
+    ops::Mul,
+    serialize::*,
+    FromBits,
+    FromBytes,
+    Read,
+    SerializationError,
+    ToBits,
+    ToBytes,
+    UniformRand,
+    Write,
 };
 
 use itertools::Itertools;
@@ -100,9 +113,9 @@ where
 {
     type Parameters = TEAffine<TE>;
     type PrivateKey = TE::ScalarField;
-    type SharedSecret = TE::BaseField;
     type PublicKey = TEAffine<TE>;
     type Randomness = TE::ScalarField;
+    type SharedSecret = TE::BaseField;
 
     fn setup(message: &str) -> Self {
         let (generator, _, _) = hash_to_curve::<TEAffine<TE>>(message);

--- a/algorithms/src/traits/encryption.rs
+++ b/algorithms/src/traits/encryption.rs
@@ -25,6 +25,7 @@ pub trait EncryptionScheme:
 {
     type Parameters: Clone + Debug + Eq;
     type PrivateKey: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + ToBits + UniformRand;
+    type SharedSecret: Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + ToBits + UniformRand;
     type PublicKey: Copy + Clone + Debug + Default + Eq + ToBytes + FromBytes;
     type Randomness: Copy + Clone + Debug + Default + Eq + Hash + ToBytes + FromBytes + UniformRand;
 
@@ -39,6 +40,11 @@ pub trait EncryptionScheme:
 
     fn generate_randomness<R: Rng + CryptoRng>(&self, rng: &mut R) -> Self::Randomness;
 
+    fn to_shared_secret(
+        public_key: &<Self as EncryptionScheme>::PublicKey,
+        randomness: &Self::Randomness,
+    ) -> <Self as EncryptionScheme>::SharedSecret;
+
     fn encrypt(
         &self,
         public_key: &<Self as EncryptionScheme>::PublicKey,
@@ -49,6 +55,13 @@ pub trait EncryptionScheme:
     fn decrypt(
         &self,
         private_key: &<Self as EncryptionScheme>::PrivateKey,
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, EncryptionError>;
+
+    fn decrypt_with_shared_secret(
+        &self,
+        shared_secret: &<Self as EncryptionScheme>::SharedSecret,
+        public_key: &<Self as EncryptionScheme>::PublicKey,
         ciphertext: &[u8],
     ) -> Result<Vec<u8>, EncryptionError>;
 

--- a/dpc/src/account/address.rs
+++ b/dpc/src/account/address.rs
@@ -60,6 +60,13 @@ impl<N: Network> Address<N> {
         Self(N::account_encryption_scheme().generate_public_key(&*view_key))
     }
 
+    /// Derives the account address from a record ciphertext encryption public key.
+    pub(crate) fn from_record_encryption_public_key(
+        public_key: <N::RecordCiphertextScheme as EncryptionScheme>::PublicKey,
+    ) -> Self {
+        Self(public_key)
+    }
+
     /// Verifies a signature on a message signed by the account view key.
     /// Returns `true` if the signature is valid. Otherwise, returns `false`.
     pub fn verify_signature(&self, message: &[u8], signature: &N::AccountSignature) -> Result<bool, AccountError> {

--- a/dpc/src/record/mod.rs
+++ b/dpc/src/record/mod.rs
@@ -23,6 +23,9 @@ pub use payload::*;
 pub mod record;
 pub use record::*;
 
+pub mod record_view_key;
+pub use record_view_key::*;
+
 pub mod record_proof;
 pub use record_proof::*;
 

--- a/dpc/src/record/record_view_key.rs
+++ b/dpc/src/record/record_view_key.rs
@@ -1,0 +1,51 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::Network;
+use snarkvm_algorithms::traits::EncryptionScheme;
+
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "N: Network"),
+    Debug(bound = "N: Network"),
+    PartialEq(bound = "N: Network"),
+    Eq(bound = "N: Network"),
+    Hash(bound = "N: Network")
+)]
+pub struct RecordViewKey<N: Network> {
+    shared_secret: <N::RecordCiphertextScheme as EncryptionScheme>::SharedSecret,
+    public_key: <N::RecordCiphertextScheme as EncryptionScheme>::PublicKey,
+}
+
+impl<N: Network> RecordViewKey<N> {
+    pub fn new(
+        shared_secret: <N::RecordCiphertextScheme as EncryptionScheme>::SharedSecret,
+        public_key: <N::RecordCiphertextScheme as EncryptionScheme>::PublicKey,
+    ) -> Self {
+        Self {
+            shared_secret,
+            public_key,
+        }
+    }
+
+    pub fn shared_secret(&self) -> &<N::RecordCiphertextScheme as EncryptionScheme>::SharedSecret {
+        &self.shared_secret
+    }
+
+    pub fn public_key(&self) -> &<N::RecordCiphertextScheme as EncryptionScheme>::PublicKey {
+        &self.public_key
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR introduces a record view key that can be used to decrypt a record ciphertext.