### PR TITLE
Fix merkle tree rebuilds

### DIFF
--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -302,15 +302,14 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
         parameters: &P,
         leaves: &[L],
     ) -> Result<Vec<Vec<<<P as MerkleParameters>::H as CRH>::Output>>, MerkleError> {
-        cfg_chunks!(leaves, 500) // arbitrary, experimentally derived
-            .map(|chunk| -> Result<Vec<_>, MerkleError> {
-                let mut out = Vec::with_capacity(chunk.len());
-                for leaf in chunk.into_iter() {
-                    out.push(parameters.hash_leaf(&leaf)?);
-                }
-                Ok(out)
-            })
-            .collect::<Result<Vec<_>, MerkleError>>()
+        match leaves.len() {
+            0 => Ok(vec![]),
+            _ => Ok(vec![
+                cfg_iter!(leaves)
+                    .map(|leaf| parameters.hash_leaf(&leaf).unwrap())
+                    .collect::<Vec<_>>(),
+            ]),
+        }
     }
 }
 

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -230,7 +230,7 @@ mod pedersen_compressed_crh_on_projective {
     }
 
     #[test]
-    fn test_rebuild() {
+    fn merkle_tree_rebuild_test() {
         type MTParameters = MerkleTreeParameters<PedersenCompressedCRH<Edwards, NUM_WINDOWS, WINDOW_SIZE>, 32>;
         let leaves = generate_random_leaves!(1000, 32);
 

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -228,4 +228,26 @@ mod pedersen_compressed_crh_on_projective {
         type MTParameters = MerkleTreeParameters<PedersenCompressedCRH<Edwards, NUM_WINDOWS, WINDOW_SIZE>, 3>;
         padded_merkle_tree_test::<MTParameters>();
     }
+
+    #[test]
+    fn test_rebuild() {
+        type MTParameters = MerkleTreeParameters<PedersenCompressedCRH<Edwards, NUM_WINDOWS, WINDOW_SIZE>, 32>;
+        let leaves = generate_random_leaves!(1000, 32);
+
+        let parameters = &MTParameters::setup("merkle_tree_test");
+        let tree = MerkleTree::<MTParameters>::new(Arc::new(parameters.clone()), &leaves[..]).unwrap();
+
+        let mut new_tree_1 =
+            MerkleTree::<MTParameters>::new(Arc::new(parameters.clone()), &Vec::<[u8; 32]>::new()).unwrap();
+        for (i, leaf) in leaves.iter().enumerate() {
+            new_tree_1 = new_tree_1.rebuild(i, &vec![leaf]).unwrap();
+        }
+
+        let mut new_tree_2 =
+            MerkleTree::<MTParameters>::new(Arc::new(parameters.clone()), &Vec::<[u8; 32]>::new()).unwrap();
+        new_tree_2 = new_tree_2.rebuild(0, &leaves[..]).unwrap();
+
+        assert_eq!(tree.root(), new_tree_1.root());
+        assert_eq!(tree.root(), new_tree_2.root());
+    }
 }

--- a/dpc/src/block/header.rs
+++ b/dpc/src/block/header.rs
@@ -149,7 +149,6 @@ impl<N: Network> BlockHeader<N> {
 
     /// Returns `true` if the block header is well-formed.
     pub fn is_valid(&self) -> bool {
-        println!("11");
         // Ensure the ledger root is nonzero.
         if self.previous_ledger_root == Default::default() {
             eprintln!("Invalid ledger root in block header");
@@ -316,8 +315,6 @@ impl<N: Network> FromBytes for BlockHeader<N> {
             metadata,
             proof: Some(proof),
         };
-
-        println!("aa");
 
         // Ensure the block header is well-formed.
         match block_header.is_valid() {
@@ -499,14 +496,9 @@ mod tests {
     fn test_block_header_serialization_bincode() {
         let block_header = Testnet2::genesis_block().header().clone();
 
-        println!("start");
         let serialized = &bincode::serialize(&block_header).unwrap();
 
-        println!("start 1");
-
         let deserialized: BlockHeader<Testnet2> = bincode::deserialize(&serialized[..]).unwrap();
-
-        println!("start 2");
 
         assert_eq!(deserialized, block_header);
     }

--- a/dpc/src/block/header.rs
+++ b/dpc/src/block/header.rs
@@ -149,6 +149,7 @@ impl<N: Network> BlockHeader<N> {
 
     /// Returns `true` if the block header is well-formed.
     pub fn is_valid(&self) -> bool {
+        println!("11");
         // Ensure the ledger root is nonzero.
         if self.previous_ledger_root == Default::default() {
             eprintln!("Invalid ledger root in block header");
@@ -315,6 +316,8 @@ impl<N: Network> FromBytes for BlockHeader<N> {
             metadata,
             proof: Some(proof),
         };
+
+        println!("aa");
 
         // Ensure the block header is well-formed.
         match block_header.is_valid() {
@@ -489,6 +492,22 @@ mod tests {
         assert_eq!(&serialized[..], &bincode::serialize(&block_header).unwrap()[..]);
 
         let deserialized = BlockHeader::read_le(&serialized[..]).unwrap();
+        assert_eq!(deserialized, block_header);
+    }
+
+    #[test]
+    fn test_block_header_serialization_bincode() {
+        let block_header = Testnet2::genesis_block().header().clone();
+
+        println!("start");
+        let serialized = &bincode::serialize(&block_header).unwrap();
+
+        println!("start 1");
+
+        let deserialized: BlockHeader<Testnet2> = bincode::deserialize(&serialized[..]).unwrap();
+
+        println!("start 2");
+
         assert_eq!(deserialized, block_header);
     }
 

--- a/dpc/src/ledger/ledger_tree.rs
+++ b/dpc/src/ledger/ledger_tree.rs
@@ -83,7 +83,16 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
 
         let start_index = self.current_index;
         let num_block_hashes = block_hashes.len();
-        self.tree = Arc::new(self.tree.rebuild(self.current_index as usize, &block_hashes)?);
+
+        // Add the block hashes to the tree. Start the tree from scratch if the tree is currently empty.
+        self.tree = match self.current_index {
+            0 => Arc::new(MerkleTree::<N::LedgerRootParameters>::new::<N::BlockHash>(
+                Arc::new(N::ledger_root_parameters().clone()),
+                &block_hashes,
+            )?),
+            _ => Arc::new(self.tree.rebuild(self.current_index as usize, &block_hashes)?),
+        };
+
         self.block_hashes.extend(
             block_hashes
                 .into_iter()

--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -137,7 +137,7 @@ where
         let mut fs_rng = prepared_verifying_key.fs_rng.clone();
 
         if cfg!(debug_assertions) {
-            println!("before AHP: constraints: {}", cs.num_constraints());
+            eprintln!("before AHP: constraints: {}", cs.num_constraints());
         }
 
         let padded_public_input = {
@@ -228,7 +228,7 @@ where
         )?;
 
         if cfg!(debug_assertions) {
-            println!("before PC checks: constraints: {}", cs.num_constraints());
+            eprintln!("before PC checks: constraints: {}", cs.num_constraints());
         }
 
         let rand_data = PCCheckRandomDataVar::<TargetField, BaseField> {

--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -136,7 +136,7 @@ where
     ) -> Result<Boolean, MarlinError> {
         let mut fs_rng = prepared_verifying_key.fs_rng.clone();
 
-        eprintln!("before AHP: constraints: {}", cs.num_constraints());
+        // eprintln!("before AHP: constraints: {}", cs.num_constraints());
 
         let padded_public_input = {
             let mut new_input = vec![NonNativeFieldVar::<TargetField, BaseField>::one(&mut cs.ns(|| "one"))?];

--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -136,7 +136,9 @@ where
     ) -> Result<Boolean, MarlinError> {
         let mut fs_rng = prepared_verifying_key.fs_rng.clone();
 
-        // eprintln!("before AHP: constraints: {}", cs.num_constraints());
+        if cfg!(debug_assertions) {
+            println!("before AHP: constraints: {}", cs.num_constraints());
+        }
 
         let padded_public_input = {
             let mut new_input = vec![NonNativeFieldVar::<TargetField, BaseField>::one(&mut cs.ns(|| "one"))?];
@@ -225,7 +227,9 @@ where
             num_batching_rands,
         )?;
 
-        // eprintln!("before PC checks: constraints: {}", cs.num_constraints());
+        if cfg!(debug_assertions) {
+            println!("before PC checks: constraints: {}", cs.num_constraints());
+        }
 
         let rand_data = PCCheckRandomDataVar::<TargetField, BaseField> {
             opening_challenges,

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -591,7 +591,7 @@ impl<
         let public_input = ProverConstraintSystem::unformat_public_input(&padded_public_input);
 
         if cfg!(debug_assertions) {
-            println!("Number of padded public variables: {}", padded_public_input.len());
+            eprintln!("Number of padded public variables: {}", padded_public_input.len());
         }
 
         let is_recursion = MM::RECURSION;

--- a/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
+++ b/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
@@ -153,7 +153,7 @@ where
             labels.1.insert(label);
         }
 
-        eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
+        // eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
 
         let zero = PG::G1Gadget::zero(cs.ns(|| format!("g1_zero")))?;
 
@@ -354,7 +354,7 @@ where
             combined_evals.push(combined_eval_reduced);
         }
 
-        eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
+        // eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
 
         // Perform the batch check.
         {
@@ -528,7 +528,7 @@ where
                 &[prepared_beta_h, prepared_h],
             )?;
 
-            eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
+            // eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
 
             let rhs = &PG::GTGadget::one(cs.ns(|| "rhs"))?;
             lhs.is_eq(cs.ns(|| "lhs_is_eq_rhs"), &rhs)

--- a/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
+++ b/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
@@ -153,7 +153,9 @@ where
             labels.1.insert(label);
         }
 
-        // eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
+        if cfg!(debug_assertions) {
+            println!("before PC combining commitments: constraints: {}", cs.num_constraints());
+        }
 
         let zero = PG::G1Gadget::zero(cs.ns(|| format!("g1_zero")))?;
 
@@ -354,7 +356,9 @@ where
             combined_evals.push(combined_eval_reduced);
         }
 
-        // eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
+        if cfg!(debug_assertions) {
+            println!("before PC batch check: constraints: {}", cs.num_constraints());
+        }
 
         // Perform the batch check.
         {
@@ -528,7 +532,9 @@ where
                 &[prepared_beta_h, prepared_h],
             )?;
 
-            // eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
+            if cfg!(debug_assertions) {
+                println!("after PC batch check: constraints: {}", cs.num_constraints());
+            }
 
             let rhs = &PG::GTGadget::one(cs.ns(|| "rhs"))?;
             lhs.is_eq(cs.ns(|| "lhs_is_eq_rhs"), &rhs)

--- a/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
+++ b/polycommit/src/marlin_pc/gadgets/marlin_kzg10.rs
@@ -154,7 +154,7 @@ where
         }
 
         if cfg!(debug_assertions) {
-            println!("before PC combining commitments: constraints: {}", cs.num_constraints());
+            eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
         }
 
         let zero = PG::G1Gadget::zero(cs.ns(|| format!("g1_zero")))?;
@@ -357,7 +357,7 @@ where
         }
 
         if cfg!(debug_assertions) {
-            println!("before PC batch check: constraints: {}", cs.num_constraints());
+            eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
         }
 
         // Perform the batch check.
@@ -533,7 +533,7 @@ where
             )?;
 
             if cfg!(debug_assertions) {
-                println!("after PC batch check: constraints: {}", cs.num_constraints());
+                eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
             }
 
             let rhs = &PG::GTGadget::one(cs.ns(|| "rhs"))?;

--- a/polycommit/src/sonic_pc/gadgets/sonic_kzg10.rs
+++ b/polycommit/src/sonic_pc/gadgets/sonic_kzg10.rs
@@ -180,7 +180,7 @@ where
         }
 
         if cfg!(debug_assertions) {
-            println!("before PC combining commitments: constraints: {}", cs.num_constraints());
+            eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
         }
 
         let zero = PG::G1Gadget::zero(cs.ns(|| format!("g1_zero")))?;
@@ -347,7 +347,7 @@ where
         }
 
         if cfg!(debug_assertions) {
-            println!("before PC batch check: constraints: {}", cs.num_constraints());
+            eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
         }
 
         // Perform the batch check.
@@ -554,7 +554,7 @@ where
             )?;
 
             if cfg!(debug_assertions) {
-                println!("after PC batch check: constraints: {}", cs.num_constraints());
+                eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
             }
 
             let rhs = &PG::GTGadget::one(cs.ns(|| "rhs"))?;

--- a/polycommit/src/sonic_pc/gadgets/sonic_kzg10.rs
+++ b/polycommit/src/sonic_pc/gadgets/sonic_kzg10.rs
@@ -179,7 +179,9 @@ where
             labels.1.insert(label);
         }
 
-        // eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
+        if cfg!(debug_assertions) {
+            println!("before PC combining commitments: constraints: {}", cs.num_constraints());
+        }
 
         let zero = PG::G1Gadget::zero(cs.ns(|| format!("g1_zero")))?;
 
@@ -344,7 +346,9 @@ where
             combined_degree_bound_shift_powers.push(shift_powers);
         }
 
-        // eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
+        if cfg!(debug_assertions) {
+            println!("before PC batch check: constraints: {}", cs.num_constraints());
+        }
 
         // Perform the batch check.
         {
@@ -549,7 +553,9 @@ where
                 pairing_right.as_slice(),
             )?;
 
-            // eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
+            if cfg!(debug_assertions) {
+                println!("after PC batch check: constraints: {}", cs.num_constraints());
+            }
 
             let rhs = &PG::GTGadget::one(cs.ns(|| "rhs"))?;
             lhs.is_eq(cs.ns(|| "lhs_is_eq_rhs"), &rhs)

--- a/polycommit/src/sonic_pc/gadgets/sonic_kzg10.rs
+++ b/polycommit/src/sonic_pc/gadgets/sonic_kzg10.rs
@@ -179,7 +179,7 @@ where
             labels.1.insert(label);
         }
 
-        eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
+        // eprintln!("before PC combining commitments: constraints: {}", cs.num_constraints());
 
         let zero = PG::G1Gadget::zero(cs.ns(|| format!("g1_zero")))?;
 
@@ -344,7 +344,7 @@ where
             combined_degree_bound_shift_powers.push(shift_powers);
         }
 
-        eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
+        // eprintln!("before PC batch check: constraints: {}", cs.num_constraints());
 
         // Perform the batch check.
         {
@@ -549,7 +549,7 @@ where
                 pairing_right.as_slice(),
             )?;
 
-            eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
+            // eprintln!("after PC batch check: constraints: {}", cs.num_constraints());
 
             let rhs = &PG::GTGadget::one(cs.ns(|| "rhs"))?;
             lhs.is_eq(cs.ns(|| "lhs_is_eq_rhs"), &rhs)


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes merkle tree rebuilds and updates updates the parallelization of leaf hashing. Additionally an optimization has been added to `LedgerTree`.

## Test Plan

A rebuild test has been added to ensure that the tree is being rebuilt correctly.

## Additional Notes

Quick benchmark of the merkle tree implementations

**Old:**
- 1000 leaves:
    - new() - 500 ms
    - rebuild() - 508 ms
- 10000 leaves:
    - new() - 5768 ms
    - rebuild() - 5791 ms
- 100000 leaves:
    - new() - 52099 ms (52 seconds)
    - rebuild() - 52115 ms (52 seconds)
    
**New:**
- 1000 leaves:
    - new() - 33 ms
    - rebuild() - 280 ms
- 10000 leaves:
    - new() - 199 ms
    - rebuild() - 3667 ms
- 100000 leaves:
    - new() - 1724 ms
    - rebuild() - 31108 ms (31 seconds)

