### PR TITLE
Adds a block header size constant in `Network` trait

### DIFF
--- a/dpc/src/network/testnet1.rs
+++ b/dpc/src/network/testnet1.rs
@@ -130,7 +130,7 @@ impl Network for Testnet1 {
     const TRANSITION_TREE_DEPTH: usize = 3;
     const TRANSACTION_TREE_DEPTH: usize = 7;
 
-    const ALEO_BLOCK_TIME_IN_SECS: i64 = 15i64;
+    const ALEO_BLOCK_TIME_IN_SECS: i64 = 20i64;
     const ALEO_MAXIMUM_FORK_DEPTH: u32 = 1024;
     const ALEO_STARTING_SUPPLY_IN_CREDITS: i64 = 500_000;
 

--- a/dpc/src/network/testnet1.rs
+++ b/dpc/src/network/testnet1.rs
@@ -112,6 +112,7 @@ impl Network for Testnet1 {
     const SIGNATURE_PREFIX: u32 = hrp4!("sign");
 
     const ADDRESS_SIZE_IN_BYTES: usize = 32;
+    const HEADER_SIZE_IN_BYTES: usize = 887;
     const HEADER_PROOF_SIZE_IN_BYTES: usize = 771;
     const INNER_PROOF_SIZE_IN_BYTES: usize = 193;
     const OUTER_PROOF_SIZE_IN_BYTES: usize = 289;

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -118,6 +118,7 @@ impl Network for Testnet2 {
     const SIGNATURE_PREFIX: u32 = hrp4!("sign");
 
     const ADDRESS_SIZE_IN_BYTES: usize = 32;
+    const HEADER_SIZE_IN_BYTES: usize = 887;
     const HEADER_PROOF_SIZE_IN_BYTES: usize = 771;
     const INNER_PROOF_SIZE_IN_BYTES: usize = 193;
     const OUTER_PROOF_SIZE_IN_BYTES: usize = 289;

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -136,7 +136,7 @@ impl Network for Testnet2 {
     const TRANSITION_TREE_DEPTH: usize = 3;
     const TRANSACTION_TREE_DEPTH: usize = 7;
 
-    const ALEO_BLOCK_TIME_IN_SECS: i64 = 15i64;
+    const ALEO_BLOCK_TIME_IN_SECS: i64 = 20i64;
     const ALEO_MAXIMUM_FORK_DEPTH: u32 = 1024;
     const ALEO_STARTING_SUPPLY_IN_CREDITS: i64 = 500_000;
 

--- a/dpc/src/traits/network.rs
+++ b/dpc/src/traits/network.rs
@@ -128,6 +128,7 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     const SIGNATURE_PREFIX: u32;
 
     const ADDRESS_SIZE_IN_BYTES: usize;
+    const HEADER_SIZE_IN_BYTES: usize;
     const HEADER_PROOF_SIZE_IN_BYTES: usize;
     const INNER_PROOF_SIZE_IN_BYTES: usize;
     const OUTER_PROOF_SIZE_IN_BYTES: usize;


### PR DESCRIPTION
## Motivation

Adds a block header size constant in `Network` trait

## Test Plan

Adds a test for block header size constant in `dpc/src/block/header.rs`.

