### PR TITLE
Fix IndexMap extend order 

### DIFF
--- a/eval/src/setup/state.rs
+++ b/eval/src/setup/state.rs
@@ -82,8 +82,8 @@ impl<'a, F: PrimeField, G: GroupType<F>> FunctionEvaluator<'a, F, G> {
             .collect::<Result<Vec<_>, _>>()?;
 
         self.namespace_id_counter += 1;
-        let mut parent_variables = self.state_data.state.variables.clone();
-        parent_variables.extend(self.state_data.state.parent_variables.clone());
+        let mut parent_variables = self.state_data.state.parent_variables.clone();
+        parent_variables.extend(self.state_data.state.variables.clone());
         let mut state = EvaluatorState {
             program: self.state_data.state.program,
             variables: IndexMap::new(),
@@ -156,8 +156,8 @@ impl<'a, F: PrimeField, G: GroupType<F>> FunctionEvaluator<'a, F, G> {
         if condition_const_value {
             self.namespace_id_counter += 1;
 
-            let mut parent_variables = self.state_data.state.variables.clone();
-            parent_variables.extend(self.state_data.state.parent_variables.clone());
+            let mut parent_variables = self.state_data.state.parent_variables.clone();
+            parent_variables.extend(self.state_data.state.variables.clone());
             let state = EvaluatorState {
                 program: self.state_data.state.program,
                 variables: IndexMap::new(),
@@ -267,8 +267,8 @@ impl<'a, F: PrimeField, G: GroupType<F>> FunctionEvaluator<'a, F, G> {
         //todo: max loop count (DOS vector)
         for i in iter {
             self.namespace_id_counter += 1;
-            let mut parent_variables = self.state_data.state.variables.clone();
-            parent_variables.extend(self.state_data.state.parent_variables.clone());
+            let mut parent_variables = self.state_data.state.parent_variables.clone();
+            parent_variables.extend(self.state_data.state.variables.clone());
             let mut state = EvaluatorState {
                 program: self.state_data.state.program,
                 variables: IndexMap::new(),


### PR DESCRIPTION
## Motivation

Quick fix that follows #497. 
HashMap has different order in Union vs IndexMap, so bounded recursion tests started to fail on the Leo side. This PR addresses that problem and finalizes HashMap->IndexMap shift.

## Test plan

All tests pass on the Leo side.