### PR TITLE
fix anyhow result issues by direct imports

### DIFF
--- a/eval/src/setup/instruction/core/common/unwrap_args.rs
+++ b/eval/src/setup/instruction/core/common/unwrap_args.rs
@@ -19,7 +19,7 @@ use crate::{ConstrainedValue, GroupType, Integer};
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{bits::Boolean, integers::uint::UInt8};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 
 macro_rules! unwrap_constrained_array {
     ($function_name:ident, $return_type:ty, $call:expr) => {

--- a/eval/src/setup/instruction/mod.rs
+++ b/eval/src/setup/instruction/mod.rs
@@ -47,7 +47,7 @@ use crate::{
     Integer,
 };
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 
 use super::EvaluatorState;
 

--- a/eval/src/setup/mod.rs
+++ b/eval/src/setup/mod.rs
@@ -16,7 +16,7 @@
 
 use std::{borrow::Cow, marker::PhantomData};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use indexmap::IndexMap;
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{Boolean, CondSelectGadget};

--- a/eval/tests/test.rs
+++ b/eval/tests/test.rs
@@ -16,7 +16,7 @@
 
 use std::{collections::BTreeMap, fs, path::Path};
 
-use anyhow::*;
+use anyhow::Result;
 use snarkvm_curves::bls12_377::Fr;
 use snarkvm_eval::{edwards_bls12::EdwardsGroupType, ConstrainedValue, Evaluator, SetupEvaluator};
 use snarkvm_ir::{InputData, Program, SnarkVMVersion};

--- a/ir/src/function.rs
+++ b/ir/src/function.rs
@@ -16,7 +16,7 @@
 
 use crate::{ir, Instruction};
 
-use anyhow::*;
+use anyhow::Result;
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/ir/src/header.rs
+++ b/ir/src/header.rs
@@ -16,7 +16,7 @@
 
 use crate::{ir, Input};
 
-use anyhow::*;
+use anyhow::Result;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]

--- a/ir/src/input.rs
+++ b/ir/src/input.rs
@@ -16,7 +16,7 @@
 
 use crate::{ir, Type, Value};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use indexmap::IndexMap;
 use prost::Message;
 use serde::Serialize;

--- a/ir/src/instruction/array.rs
+++ b/ir/src/instruction/array.rs
@@ -16,7 +16,7 @@
 
 use std::fmt;
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
 
 use crate::{ir, Value};

--- a/ir/src/instruction/call.rs
+++ b/ir/src/instruction/call.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use crate::{ir, Value};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
 
 use super::{decode_control_string, decode_control_u32};

--- a/ir/src/instruction/complex.rs
+++ b/ir/src/instruction/complex.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use crate::{ir, Value};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use num_enum::TryFromPrimitive;
 use serde::Serialize;
 

--- a/ir/src/instruction/mod.rs
+++ b/ir/src/instruction/mod.rs
@@ -32,7 +32,7 @@ use op::InstructionOp;
 
 mod code;
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use num_enum::TryFromPrimitive;
 use serde::Serialize;
 

--- a/ir/src/instruction/predicate.rs
+++ b/ir/src/instruction/predicate.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use crate::{ir, Value};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/ir/src/instruction/query.rs
+++ b/ir/src/instruction/query.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use crate::{ir, Value};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
 
 use super::decode_control_u32;

--- a/ir/src/program.rs
+++ b/ir/src/program.rs
@@ -20,7 +20,7 @@ use prost::Message;
 
 use crate::{ir, Function, Header, Instruction, MaskData, RepeatData};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/ir/src/types.rs
+++ b/ir/src/types.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use crate::ir;
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]

--- a/ir/src/values/group.rs
+++ b/ir/src/values/group.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use crate::{ir, Field};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]

--- a/ir/src/values/mod.rs
+++ b/ir/src/values/mod.rs
@@ -18,7 +18,7 @@ use std::{convert::TryFrom, fmt};
 
 use crate::{ir, Type};
 
-use anyhow::*;
+use anyhow::{anyhow, Result};
 use bech32::ToBase32;
 use serde::Serialize;
 


### PR DESCRIPTION
Some anyhow update or change made it so `use anyhow::*;` was importing an anyhow Ok.