### PR TITLE
Update MAXIMUM_FUTURE_BLOCK_TIME to 90 seconds

### DIFF
--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -22,7 +22,8 @@ use chrono::Utc;
 use itertools::Itertools;
 use std::collections::HashMap;
 
-pub const TWO_HOURS_UNIX: i64 = 7200;
+/// The maximum future block time - 2 minutes.
+const MAX_FUTURE_BLOCK_TIME: i64 = 120;
 
 #[derive(Clone, Debug)]
 pub struct Blocks<N: Network> {
@@ -233,7 +234,7 @@ impl<N: Network> Blocks<N> {
 
         // Ensure the next block timestamp is within the declared time limit.
         let now = Utc::now().timestamp();
-        if block.timestamp() > (now + TWO_HOURS_UNIX) {
+        if block.timestamp() > (now + MAX_FUTURE_BLOCK_TIME) {
             return Err(anyhow!("The given block timestamp exceeds the time limit"));
         }
 

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -22,9 +22,6 @@ use chrono::Utc;
 use itertools::Itertools;
 use std::collections::HashMap;
 
-/// The maximum future block time - 2 minutes.
-const MAXIMUM_FUTURE_BLOCK_TIME: i64 = 120;
-
 #[derive(Clone, Debug)]
 pub struct Blocks<N: Network> {
     /// The current block height.
@@ -234,7 +231,7 @@ impl<N: Network> Blocks<N> {
 
         // Ensure the next block timestamp is within the declared time limit.
         let now = Utc::now().timestamp();
-        if block.timestamp() > (now + MAXIMUM_FUTURE_BLOCK_TIME) {
+        if block.timestamp() > (now + N::ALEO_FUTURE_TIME_LIMIT_IN_SECS) {
             return Err(anyhow!("The given block timestamp exceeds the time limit"));
         }
 

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use std::collections::HashMap;
 
 /// The maximum future block time - 2 minutes.
-const MAX_FUTURE_BLOCK_TIME: i64 = 120;
+const MAXIMUM_FUTURE_BLOCK_TIME: i64 = 120;
 
 #[derive(Clone, Debug)]
 pub struct Blocks<N: Network> {
@@ -234,7 +234,7 @@ impl<N: Network> Blocks<N> {
 
         // Ensure the next block timestamp is within the declared time limit.
         let now = Utc::now().timestamp();
-        if block.timestamp() > (now + MAX_FUTURE_BLOCK_TIME) {
+        if block.timestamp() > (now + MAXIMUM_FUTURE_BLOCK_TIME) {
             return Err(anyhow!("The given block timestamp exceeds the time limit"));
         }
 

--- a/dpc/src/ledger/ledger.rs
+++ b/dpc/src/ledger/ledger.rs
@@ -161,7 +161,10 @@ impl<N: Network> Ledger<N> {
         let previous_timestamp = self.latest_block_timestamp()?;
         let previous_difficulty_target = self.latest_block_difficulty_target()?;
         let previous_cumulative_weight = self.latest_cumulative_weight()?;
-        let block_timestamp = Utc::now().timestamp();
+
+        // Ensure that the new timestamp is ahead of the previous timestamp.
+        let block_timestamp = std::cmp::max(chrono::Utc::now().timestamp(), previous_timestamp.saturating_add(1));
+
         let difficulty_target =
             Blocks::<N>::compute_difficulty_target(previous_timestamp, previous_difficulty_target, block_timestamp);
         let cumulative_weight = previous_cumulative_weight.saturating_add((u64::MAX / difficulty_target) as u128);

--- a/dpc/src/ledger/ledger.rs
+++ b/dpc/src/ledger/ledger.rs
@@ -163,7 +163,7 @@ impl<N: Network> Ledger<N> {
         let previous_cumulative_weight = self.latest_cumulative_weight()?;
 
         // Ensure that the new timestamp is ahead of the previous timestamp.
-        let block_timestamp = std::cmp::max(chrono::Utc::now().timestamp(), previous_timestamp.saturating_add(1));
+        let block_timestamp = std::cmp::max(Utc::now().timestamp(), previous_timestamp.saturating_add(1));
 
         let difficulty_target =
             Blocks::<N>::compute_difficulty_target(previous_timestamp, previous_difficulty_target, block_timestamp);

--- a/dpc/src/network/testnet1.rs
+++ b/dpc/src/network/testnet1.rs
@@ -132,6 +132,7 @@ impl Network for Testnet1 {
 
     const ALEO_BLOCK_TIME_IN_SECS: i64 = 20i64;
     const ALEO_STARTING_SUPPLY_IN_CREDITS: i64 = 1_000_000_000;
+    const ALEO_FUTURE_TIME_LIMIT_IN_SECS: i64 = 90;
 
     type InnerCurve = Bls12_377;
     type InnerScalarField = <Self::InnerCurve as PairingEngine>::Fr;

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -138,6 +138,7 @@ impl Network for Testnet2 {
 
     const ALEO_BLOCK_TIME_IN_SECS: i64 = 20i64;
     const ALEO_STARTING_SUPPLY_IN_CREDITS: i64 = 1_000_000_000;
+    const ALEO_FUTURE_TIME_LIMIT_IN_SECS: i64 = 90;
 
     type InnerCurve = Bls12_377;
     type InnerScalarField = <Self::InnerCurve as PairingEngine>::Fr;

--- a/dpc/src/traits/network.rs
+++ b/dpc/src/traits/network.rs
@@ -152,6 +152,9 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     const ALEO_BLOCK_TIME_IN_SECS: i64;
     const ALEO_STARTING_SUPPLY_IN_CREDITS: i64;
 
+    /// The maximum future block time.
+    const ALEO_FUTURE_TIME_LIMIT_IN_SECS: i64;
+
     /// Inner curve type declarations.
     type InnerCurve: PairingEngine<Fr = Self::InnerScalarField, Fq = Self::OuterScalarField>;
     type InnerScalarField: PrimeField + PoseidonDefaultParametersField;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the `MAXIMUM_FUTURE_BLOCK_TIME` from 2 hours to 90 seconds. Meaning a new block's timestamp can be at most 90 seconds ahead of the node's current time.

Additionally, the miner now has an additional consideration, where the new block timestamp must be greater than the previous block timestamp.

Additional Notes:
Bitcoin mining protocol allows for 2 hour future block timestamps, however that is not an issue due to block difficulty adjustments every 2016 blocks.