### PR TITLE
Reduce max future block time to `80s`

### DIFF
--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -22,7 +22,8 @@ use chrono::Utc;
 use itertools::Itertools;
 use std::collections::HashMap;
 
-pub const TWO_HOURS_UNIX: i64 = 7200;
+/// The maximum future block time in seconds.
+const MAXIMUM_FUTURE_BLOCK_TIME: i64 = 80;
 
 #[derive(Clone, Debug)]
 pub struct Blocks<N: Network> {
@@ -233,7 +234,7 @@ impl<N: Network> Blocks<N> {
 
         // Ensure the next block timestamp is within the declared time limit.
         let now = Utc::now().timestamp();
-        if block.timestamp() > (now + TWO_HOURS_UNIX) {
+        if block.timestamp() > (now + MAXIMUM_FUTURE_BLOCK_TIME) {
             return Err(anyhow!("The given block timestamp exceeds the time limit"));
         }
 

--- a/dpc/src/ledger/ledger.rs
+++ b/dpc/src/ledger/ledger.rs
@@ -161,7 +161,10 @@ impl<N: Network> Ledger<N> {
         let previous_timestamp = self.latest_block_timestamp()?;
         let previous_difficulty_target = self.latest_block_difficulty_target()?;
         let previous_cumulative_weight = self.latest_cumulative_weight()?;
-        let block_timestamp = Utc::now().timestamp();
+
+        // Ensure that the new timestamp is ahead of the previous timestamp.
+        let block_timestamp = std::cmp::max(Utc::now().timestamp(), previous_timestamp.saturating_add(1));
+
         let difficulty_target =
             Blocks::<N>::compute_difficulty_target(previous_timestamp, previous_difficulty_target, block_timestamp);
         let cumulative_weight = previous_cumulative_weight.saturating_add((u64::MAX / difficulty_target) as u128);


### PR DESCRIPTION
Reflects the changes made in https://github.com/AleoHQ/snarkOS/pull/1383 and https://github.com/AleoHQ/snarkOS/pull/1423. 
