### PR TITLE
Allow modification of the difficulty target

### DIFF
--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -263,6 +263,14 @@ impl<N: Network> Block<N> {
         self.header.difficulty_target()
     }
 
+    /// Sets the block difficulty target.
+    /// Used purely for pool purposes - as workers need to set their header difficulty to a share
+    /// difficulty provided by the pool, and the pool needs to reset the difficulty back to normal when
+    /// checking if it is an actual solution.
+    pub fn set_difficulty_target(&mut self, target: u64) {
+        self.header.set_difficulty_target(target);
+    }
+
     /// Returns the cumulative weight up to this block (inclusive).
     pub fn cumulative_weight(&self) -> u128 {
         self.header.cumulative_weight()

--- a/dpc/src/block/header.rs
+++ b/dpc/src/block/header.rs
@@ -323,6 +323,13 @@ impl<N: Network> BlockHeader<N> {
     pub(crate) fn set_proof(&mut self, proof: N::PoSWProof) {
         self.proof = Some(proof);
     }
+
+    /// Sets the block header target difficulty to the given target difficulty.
+    /// This method is used by pool operators in order to restore a proposed block header
+    /// to it's original state.
+    pub(crate) fn set_difficulty_target(&mut self, target: u64) {
+        self.metadata.difficulty_target = target;
+    }
 }
 
 impl<N: Network> FromBytes for BlockHeader<N> {


### PR DESCRIPTION
## Motivation

This method is necessary for pool operators in order
to restore proposed blocks to their original form, so they can be
properly checked and broadcast in case they are a valid solution.

## Related PRs

https://github.com/AleoHQ/snarkOS/pull/1427
