### PR TITLE
Introduce a mine_once_unchecked for PoSW

### DIFF
--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -55,20 +55,26 @@ pub struct Block<N: Network> {
 
 impl<N: Network> Block<N> {
     /// Initializes a new block.
-    pub fn mine<R: Rng + CryptoRng>(template: BlockTemplate<N>, terminator: &AtomicBool, rng: &mut R) -> Result<Self> {
+    pub fn new(template: BlockTemplate<N>, header: BlockHeader<N>) -> Result<Self> {
         assert!(
             !(*template.transactions()).is_empty(),
             "Cannot create block with no transactions"
         );
 
-        // Prepare the block variables.
+        // Prepare the variables.
         let previous_block_hash = template.previous_block_hash();
         let transactions = template.transactions().clone();
 
-        // Compute the block header.
-        let header = BlockHeader::mine(&template, terminator, rng)?;
-
         Ok(Self::from(previous_block_hash, header, transactions)?)
+    }
+
+    /// Initializes a new block.
+    pub fn mine<R: Rng + CryptoRng>(template: BlockTemplate<N>, terminator: &AtomicBool, rng: &mut R) -> Result<Self> {
+        assert!(
+            !(*template.transactions()).is_empty(),
+            "Cannot create block with no transactions"
+        );
+        Ok(Self::new(template, BlockHeader::mine(&template, terminator, rng)?)?)
     }
 
     /// Initializes a new genesis block with one coinbase transaction.

--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -55,7 +55,7 @@ pub struct Block<N: Network> {
 
 impl<N: Network> Block<N> {
     /// Initializes a new block.
-    pub fn new(template: BlockTemplate<N>, header: BlockHeader<N>) -> Result<Self> {
+    pub fn new(template: &BlockTemplate<N>, header: BlockHeader<N>) -> Result<Self> {
         assert!(
             !(*template.transactions()).is_empty(),
             "Cannot create block with no transactions"
@@ -78,7 +78,7 @@ impl<N: Network> Block<N> {
         // Compute the block header.
         let header = BlockHeader::mine(&template, terminator, rng)?;
 
-        Ok(Self::new(template, header)?)
+        Ok(Self::new(&template, header)?)
     }
 
     /// Initializes a new genesis block with one coinbase transaction.

--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -74,7 +74,11 @@ impl<N: Network> Block<N> {
             !(*template.transactions()).is_empty(),
             "Cannot create block with no transactions"
         );
-        Ok(Self::new(template, BlockHeader::mine(&template, terminator, rng)?)?)
+
+        // Compute the block header.
+        let header = BlockHeader::mine(&template, terminator, rng)?;
+
+        Ok(Self::new(template, header)?)
     }
 
     /// Initializes a new genesis block with one coinbase transaction.

--- a/dpc/src/block/header.rs
+++ b/dpc/src/block/header.rs
@@ -68,6 +68,19 @@ pub struct BlockHeaderMetadata {
 }
 
 impl BlockHeaderMetadata {
+    /// Initializes a new instance of a block header metadata.
+    pub fn new<N: Network>(template: &BlockTemplate<N>) -> Self {
+        match template.block_height() == 0 {
+            true => Self::genesis(),
+            false => Self {
+                height: template.block_height(),
+                timestamp: template.block_timestamp(),
+                difficulty_target: template.difficulty_target(),
+                cumulative_weight: template.cumulative_weight(),
+            },
+        }
+    }
+
     /// Initializes a new instance of a genesis block header metadata.
     pub fn genesis() -> Self {
         Self {
@@ -135,22 +148,11 @@ impl<N: Network> BlockHeader<N> {
 
     /// Mines a new instance of a block header.
     pub fn mine<R: Rng + CryptoRng>(template: &BlockTemplate<N>, terminator: &AtomicBool, rng: &mut R) -> Result<Self> {
-        // Construct the candidate block metadata.
-        let metadata = match template.block_height() == 0 {
-            true => BlockHeaderMetadata::genesis(),
-            false => BlockHeaderMetadata {
-                height: template.block_height(),
-                timestamp: template.block_timestamp(),
-                difficulty_target: template.difficulty_target(),
-                cumulative_weight: template.cumulative_weight(),
-            },
-        };
-
         // Construct a candidate block header.
         let mut block_header = Self {
             previous_ledger_root: template.previous_ledger_root(),
             transactions_root: template.transactions().transactions_root(),
-            metadata,
+            metadata: BlockHeaderMetadata::new(template),
             nonce: Default::default(),
             proof: None,
         };
@@ -167,6 +169,35 @@ impl<N: Network> BlockHeader<N> {
             true => Ok(block_header),
             false => Err(anyhow!("Failed to initialize a block header")),
         }
+    }
+
+    ///
+    /// Mines a new unchecked instance of a block header.
+    /// WARNING - This method does *not* enforce the block header is valid.
+    ///
+    pub fn mine_once_unchecked<R: Rng + CryptoRng>(
+        template: &BlockTemplate<N>,
+        terminator: &AtomicBool,
+        rng: &mut R,
+    ) -> Result<Self> {
+        // Construct a candidate block header.
+        let mut block_header = Self {
+            previous_ledger_root: template.previous_ledger_root(),
+            transactions_root: template.transactions().transactions_root(),
+            metadata: BlockHeaderMetadata::new(template),
+            nonce: Default::default(),
+            proof: None,
+        };
+        debug_assert!(
+            !block_header.is_valid(),
+            "Block header with a missing nonce and proof is invalid"
+        );
+
+        // Run one iteration of PoSW.
+        // Warning: this operation is unchecked.
+        N::posw().mine_once_unchecked(&mut block_header, terminator, rng)?;
+
+        Ok(block_header)
     }
 
     /// Returns `true` if the block header is well-formed.

--- a/dpc/src/block/template.rs
+++ b/dpc/src/block/template.rs
@@ -99,11 +99,6 @@ impl<N: Network> BlockTemplate<N> {
     pub fn transactions(&self) -> &Transactions<N> {
         &self.transactions
     }
-
-    /// Sets the difficulty target to the given difficulty target.
-    pub fn set_difficulty_target(&mut self, difficulty_target: u64) {
-        self.difficulty_target = difficulty_target;
-    }
 }
 
 impl<N: Network> FromBytes for BlockTemplate<N> {

--- a/dpc/src/traits/posw.rs
+++ b/dpc/src/traits/posw.rs
@@ -37,9 +37,20 @@ pub trait PoSWScheme<N: Network>: Clone + Send + Sync {
     /// Returns a reference to the PoSW circuit verifying key.
     fn verifying_key(&self) -> &<N::PoSWSNARK as SNARK>::VerifyingKey;
 
-    /// Given the leaves of the block header, it will calculate a PoSW and nonce
+    /// Given the block header, compute a PoSW proof and nonce
     /// such that they are under the difficulty target.
     fn mine<R: Rng + CryptoRng>(
+        &self,
+        block_header: &mut BlockHeader<N>,
+        terminator: &AtomicBool,
+        rng: &mut R,
+    ) -> Result<(), PoswError>;
+
+    ///
+    /// Given the block header, compute a PoSW proof.
+    /// WARNING - This method does *not* ensure the resulting proof satisfies the difficulty target.
+    ///
+    fn mine_once_unchecked<R: Rng + CryptoRng>(
         &self,
         block_header: &mut BlockHeader<N>,
         terminator: &AtomicBool,


### PR DESCRIPTION
## Motivation

Introduces a `mine_once_unchecked` for PoSW.

This unchecked method is necessary for pool operations with provers and operators, as implemented in https://github.com/AleoHQ/snarkOS/pull/1427.