### PR TITLE
Add an unchecked initialization function for blocks

### DIFF
--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -142,6 +142,29 @@ impl<N: Network> Block<N> {
         }
     }
 
+    /// Initializes a new block from a given previous hash, header, and transactions list,
+    /// without checking if the block is necessarily valid. Should only be used by pool
+    /// operators in order to do some preliminary validity checks that do not include
+    /// checking if the network difficulty was satisfied.
+    pub fn from_unchecked(
+        previous_block_hash: N::BlockHash,
+        header: BlockHeader<N>,
+        transactions: Transactions<N>,
+    ) -> Result<Self, BlockError> {
+        // Compute the block hash.
+        let block_hash = N::block_hash_crh()
+            .hash(&to_bytes_le![previous_block_hash, header.to_header_root()?]?)?
+            .into();
+
+        // Construct the block.
+        Ok(Self {
+            block_hash,
+            previous_block_hash,
+            header,
+            transactions,
+        })
+    }
+
     /// Returns `true` if the block is well-formed.
     pub fn is_valid(&self) -> bool {
         // Ensure the previous block hash is well-formed.


### PR DESCRIPTION
The function requires a user to deconstruct the block template
manually, which should hopefully give some indication that this shouldnt be
used lightly.

## Motivation

Needed for pool operators in order to check work properly.

## Related PRs

https://github.com/AleoHQ/snarkOS/pull/1427
