### PR TITLE
Add `ZK` option to `MarlinMode`, and propagate everywhere

### DIFF
--- a/dpc/src/block/header.rs
+++ b/dpc/src/block/header.rs
@@ -467,7 +467,7 @@ mod tests {
     use super::*;
     use crate::{testnet1::Testnet1, testnet2::Testnet2, PoSWScheme};
     use snarkvm_algorithms::{SNARK, SRS};
-    use snarkvm_marlin::ahp::AHPForR1CS;
+    use snarkvm_marlin::{ahp::AHPForR1CS, marlin::MarlinTestnet1Mode};
 
     use rand::{rngs::ThreadRng, thread_rng};
 
@@ -551,8 +551,10 @@ mod tests {
     fn test_block_header_difficulty_target() {
         // Construct an instance of PoSW.
         let posw = {
-            let max_degree =
-                AHPForR1CS::<<Testnet2 as Network>::InnerScalarField>::max_degree(20000, 20000, 200000).unwrap();
+            let max_degree = AHPForR1CS::<<Testnet2 as Network>::InnerScalarField, MarlinTestnet1Mode>::max_degree(
+                20000, 20000, 200000,
+            )
+            .unwrap();
             let universal_srs =
                 <<Testnet2 as Network>::PoSWSNARK as SNARK>::universal_setup(&max_degree, &mut thread_rng()).unwrap();
             <<Testnet2 as Network>::PoSW as PoSWScheme<Testnet2>>::setup::<ThreadRng>(

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -162,7 +162,7 @@ impl Network for Testnet2 {
     type OuterProof = AleoObject<<Self::OuterSNARK as SNARK>::Proof, { Self::OUTER_PROOF_PREFIX }, { Self::OUTER_PROOF_SIZE_IN_BYTES }>;
 
     type ProgramSNARK = MarlinSNARK<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::OuterScalarField, PoseidonSponge<Self::OuterScalarField, 6, 1>>, MarlinTestnet2Mode, ProgramPublicVariables<Self>>;
-    type ProgramSNARKGadget = MarlinVerificationGadget<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, SonicKZG10Gadget<Self::InnerCurve, Self::OuterCurve, PairingGadget>>;
+    type ProgramSNARKGadget = MarlinVerificationGadget<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, SonicKZG10Gadget<Self::InnerCurve, Self::OuterCurve, PairingGadget>, MarlinTestnet2Mode>;
     type ProgramProvingKey = <Self::ProgramSNARK as SNARK>::ProvingKey;
     type ProgramVerifyingKey = <Self::ProgramSNARK as SNARK>::VerifyingKey;
     type ProgramProof = AleoObject<<Self::ProgramSNARK as SNARK>::Proof, { Self::PROGRAM_PROOF_PREFIX }, { Self::PROGRAM_PROOF_SIZE_IN_BYTES }>;

--- a/dpc/src/posw/circuit.rs
+++ b/dpc/src/posw/circuit.rs
@@ -142,6 +142,7 @@ impl<N: Network> ConstraintSynthesizer<N::InnerScalarField> for PoSWCircuit<N> {
 mod test {
     use super::*;
     use crate::{testnet1::Testnet1, testnet2::Testnet2};
+    use snarkvm_marlin::marlin::MarlinTestnet1Mode;
     use snarkvm_r1cs::TestConstraintSystem;
     use snarkvm_utilities::{FromBytes, ToBytes};
 
@@ -171,8 +172,10 @@ mod test {
     fn posw_proof_test<N: Network, R: Rng + CryptoRng>(rng: &mut R) {
         // Generate the proving and verifying key.
         let (proving_key, verifying_key) = {
-            let max_degree =
-                snarkvm_marlin::ahp::AHPForR1CS::<N::InnerScalarField>::max_degree(20000, 20000, 200000).unwrap();
+            let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<N::InnerScalarField, MarlinTestnet1Mode>::max_degree(
+                20000, 20000, 200000,
+            )
+            .unwrap();
             let universal_srs = <<N as Network>::PoSWSNARK as SNARK>::universal_setup(&max_degree, rng).unwrap();
 
             <<N as Network>::PoSWSNARK as SNARK>::setup::<_, R>(

--- a/dpc/src/posw/posw.rs
+++ b/dpc/src/posw/posw.rs
@@ -175,7 +175,7 @@ mod tests {
 
     use crate::{testnet2::Testnet2, Network, PoSWScheme};
     use snarkvm_algorithms::{SNARK, SRS};
-    use snarkvm_marlin::ahp::AHPForR1CS;
+    use snarkvm_marlin::{ahp::AHPForR1CS, marlin::MarlinTestnet1Mode};
     use snarkvm_utilities::ToBytes;
 
     use rand::{rngs::ThreadRng, thread_rng};
@@ -189,8 +189,10 @@ mod tests {
     fn test_posw_marlin() {
         // Construct an instance of PoSW.
         let posw = {
-            let max_degree =
-                AHPForR1CS::<<Testnet2 as Network>::InnerScalarField>::max_degree(20000, 20000, 200000).unwrap();
+            let max_degree = AHPForR1CS::<<Testnet2 as Network>::InnerScalarField, MarlinTestnet1Mode>::max_degree(
+                20000, 20000, 200000,
+            )
+            .unwrap();
             let universal_srs =
                 <<Testnet2 as Network>::PoSWSNARK as SNARK>::universal_setup(&max_degree, &mut thread_rng()).unwrap();
             <<Testnet2 as Network>::PoSW as PoSWScheme<Testnet2>>::setup::<ThreadRng>(

--- a/marlin/benches/marlin.rs
+++ b/marlin/benches/marlin.rs
@@ -43,7 +43,7 @@ type PCGadget = SonicKZG10Gadget<Bls12_377, BW6_761, Bls12_377PairingGadget>;
 
 type FS = FiatShamirAlgebraicSpongeRng<Fr, Fq, PoseidonSponge<Fq, 6, 1>>;
 type TestSNARK = MarlinSNARK<Fr, Fq, PC, FS, MarlinRecursiveMode, Vec<Fr>>;
-type TestSNARKGadget = MarlinVerificationGadget<Fr, Fq, PC, PCGadget>;
+type TestSNARKGadget = MarlinVerificationGadget<Fr, Fq, PC, PCGadget, MarlinRecursiveMode>;
 
 #[derive(Copy, Clone)]
 pub struct Benchmark<F: Field> {
@@ -85,7 +85,8 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for Benchmark<Constr
 
 fn snark_universal_setup(c: &mut Criterion) {
     let rng = &mut thread_rng();
-    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr>::max_degree(1000000, 1000000, 1000000).unwrap();
+    let max_degree =
+        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(1000000, 1000000, 1000000).unwrap();
 
     c.bench_function("snark_universal_setup", move |b| {
         b.iter(|| {
@@ -102,7 +103,8 @@ fn snark_circuit_setup(c: &mut Criterion) {
     let x = Fr::rand(rng);
     let y = Fr::rand(rng);
 
-    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr>::max_degree(100000, 100000, 100000).unwrap();
+    let max_degree =
+        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(100000, 100000, 100000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     c.bench_function("snark_circuit_setup", move |b| {
@@ -127,7 +129,7 @@ fn snark_prove(c: &mut Criterion) {
     let x = Fr::rand(rng);
     let y = Fr::rand(rng);
 
-    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr>::max_degree(1000, 1000, 1000).unwrap();
+    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(1000, 1000, 1000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     let circuit = Benchmark::<Fr> {
@@ -166,7 +168,8 @@ fn snark_verify(c: &mut Criterion) {
     let mut z = x;
     z.mul_assign(&y);
 
-    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr>::max_degree(1000000, 100000, 1000000).unwrap();
+    let max_degree =
+        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(1000000, 100000, 1000000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     let circuit = Benchmark::<Fr> {
@@ -208,7 +211,8 @@ fn snark_verify_gadget(c: &mut Criterion) {
     let mut z = x;
     z.mul_assign(&y);
 
-    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr>::max_degree(1000000, 100000, 1000000).unwrap();
+    let max_degree =
+        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(1000000, 100000, 1000000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     let circuit = Benchmark::<Fr> {

--- a/marlin/src/ahp/ahp.rs
+++ b/marlin/src/ahp/ahp.rs
@@ -16,6 +16,7 @@
 
 use crate::{
     ahp::{matrices, prover::ProverConstraintSystem, verifier, AHPError, CircuitInfo},
+    marlin::MarlinMode,
     String,
     ToString,
     Vec,
@@ -34,11 +35,12 @@ use rayon::prelude::*;
 /// The algebraic holographic proof defined in [CHMMVW19](https://eprint.iacr.org/2019/1047).
 /// Currently, this AHP only supports inputs of size one
 /// less than a power of 2 (i.e., of the form 2^n - 1).
-pub struct AHPForR1CS<F: Field> {
+pub struct AHPForR1CS<F: Field, MM: MarlinMode> {
     field: PhantomData<F>,
+    mode: PhantomData<MM>,
 }
 
-impl<F: PrimeField> AHPForR1CS<F> {
+impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     /// The labels for the polynomials output by the AHP indexer.
     #[rustfmt::skip]
     pub const INDEXER_POLYNOMIALS: [&'static str; 6] = [
@@ -58,24 +60,40 @@ impl<F: PrimeField> AHPForR1CS<F> {
     pub const LC_WITH_ZERO_EVAL: [&'static str; 2] = ["inner_sumcheck", "outer_sumcheck"];
     /// The labels for the polynomials output by the AHP prover.
     #[rustfmt::skip]
-    pub const PROVER_POLYNOMIALS: [&'static str; 9] = [
+    pub const PROVER_POLYNOMIALS_WITHOUT_ZK: [&'static str; 8] = [
+        // First sumcheck
+        "w", "z_a", "z_b", "t", "g_1", "h_1",
+        // Second sumcheck
+        "g_2", "h_2",
+    ];
+    /// The labels for the polynomials output by the AHP prover.
+    #[rustfmt::skip]
+    pub const PROVER_POLYNOMIALS_WITH_ZK: [&'static str; 9] = [
         // First sumcheck
         "w", "z_a", "z_b", "mask_poly", "t", "g_1", "h_1",
         // Second sumcheck
         "g_2", "h_2",
     ];
 
-    pub(crate) fn polynomial_labels() -> impl Iterator<Item = String> {
-        Self::INDEXER_POLYNOMIALS
-            .iter()
-            .chain(&Self::PROVER_POLYNOMIALS)
-            .map(|s| s.to_string())
+    pub(crate) fn indexer_polynomials() -> impl Iterator<Item = &'static str> {
+        if MM::RECURSION {
+            Self::INDEXER_POLYNOMIALS_WITH_VANISHING.as_ref().iter().copied()
+        } else {
+            Self::INDEXER_POLYNOMIALS.as_ref().iter().copied()
+        }
     }
 
-    pub(crate) fn polynomial_labels_with_vanishing() -> impl Iterator<Item = String> {
-        Self::INDEXER_POLYNOMIALS_WITH_VANISHING
-            .iter()
-            .chain(&Self::PROVER_POLYNOMIALS)
+    pub(crate) fn prover_polynomials() -> impl Iterator<Item = &'static str> {
+        if MM::ZK {
+            Self::PROVER_POLYNOMIALS_WITH_ZK.as_ref().iter().copied()
+        } else {
+            Self::PROVER_POLYNOMIALS_WITHOUT_ZK.as_ref().iter().copied()
+        }
+    }
+
+    pub(crate) fn polynomial_labels() -> impl Iterator<Item = String> {
+        Self::indexer_polynomials()
+            .chain(Self::prover_polynomials())
             .map(|s| s.to_string())
     }
 
@@ -103,7 +121,11 @@ impl<F: PrimeField> AHPForR1CS<F> {
 
         Ok(*[
             2 * domain_h_size + zk_bound - 2,
-            3 * domain_h_size + 2 * zk_bound - 3, //  mask_poly
+            if MM::ZK {
+                3 * domain_h_size + 2 * zk_bound - 3
+            } else {
+                0
+            }, //  mask_poly
             domain_h_size,
             domain_h_size,
             domain_k_size - 1,
@@ -133,8 +155,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     pub fn construct_linear_combinations<E: EvaluationsProvider<F>>(
         public_input: &[F],
         evals: &E,
-        state: &verifier::VerifierState<F>,
-        with_vanishing: bool,
+        state: &verifier::VerifierState<F, MM>,
     ) -> Result<Vec<LinearCombination<F>>, AHPError> {
         let domain_h = state.domain_h;
         let domain_k = state.domain_k;
@@ -179,21 +200,19 @@ impl<F: PrimeField> AHPForR1CS<F> {
             .fold(F::zero(), |x, y| x + y);
 
         #[rustfmt::skip]
-        let outer_sumcheck = LinearCombination::new(
-            "outer_sumcheck",
-            vec![
-                (F::one(), "mask_poly".into()),
-
-                (r_alpha_at_beta * (eta_a + (eta_c * z_b_at_beta)), "z_a".into()),
-                (r_alpha_at_beta * eta_b * z_b_at_beta, LCTerm::One),
-
-                (-t_at_beta * v_X_at_beta, "w".into()),
-                (-t_at_beta * x_at_beta, LCTerm::One),
-
-                (-v_H_at_beta, "h_1".into()),
-                (-beta * g_1_at_beta, LCTerm::One),
-            ],
-        );
+        let outer_sumcheck = {
+            let mut lc_terms = vec![];
+            if MM::ZK {
+                lc_terms.push((F::one(), "mask_poly".into()));
+            }
+            lc_terms.push((r_alpha_at_beta * (eta_a + (eta_c * z_b_at_beta)), "z_a".into()));
+            lc_terms.push((r_alpha_at_beta * eta_b * z_b_at_beta, LCTerm::One));
+            lc_terms.push((-t_at_beta * v_X_at_beta, "w".into()));
+            lc_terms.push((-t_at_beta * x_at_beta, LCTerm::One));
+            lc_terms.push((-v_H_at_beta, "h_1".into()));
+            lc_terms.push((-beta * g_1_at_beta, LCTerm::One));
+            LinearCombination::new("outer_sumcheck", lc_terms)
+        };
         debug_assert!(evals.get_lc_eval(&outer_sumcheck, beta)?.is_zero());
 
         linear_combinations.push(z_b);
@@ -229,7 +248,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
         linear_combinations.push(g_2);
         linear_combinations.push(inner_sumcheck);
 
-        if with_vanishing {
+        if MM::RECURSION {
             let vanishing_poly_h_alpha =
                 LinearCombination::new("vanishing_poly_h_alpha", vec![(F::one(), "vanishing_poly_h")]);
             let vanishing_poly_h_beta =

--- a/marlin/src/ahp/indexer/circuit.rs
+++ b/marlin/src/ahp/indexer/circuit.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{ahp::matrices::MatrixArithmetization, marlin::MarlinMode, CircuitInfo, Matrix};
 use snarkvm_fields::PrimeField;

--- a/marlin/src/ahp/indexer/circuit.rs
+++ b/marlin/src/ahp/indexer/circuit.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ahp::matrices::MatrixArithmetization, CircuitInfo, Matrix};
+use std::marker::PhantomData;
+
+use crate::{ahp::matrices::MatrixArithmetization, marlin::MarlinMode, CircuitInfo, Matrix};
 use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::LabeledPolynomial;
 use snarkvm_utilities::{errors::SerializationError, serialize::*};
@@ -31,7 +33,7 @@ use derivative::Derivative;
 /// 2) `{a,b,c}` are the matrices defining the R1CS instance
 /// 3) `{a,b,c}_star_arith` are structs containing information about A^*, B^*, and C^*,
 /// which are matrices defined as `M^*(i, j) = M(j, i) * u_H(j, j)`.
-pub struct Circuit<F: PrimeField> {
+pub struct Circuit<F: PrimeField, MM: MarlinMode> {
     /// Information about the indexed circuit.
     pub index_info: CircuitInfo<F>,
 
@@ -44,12 +46,14 @@ pub struct Circuit<F: PrimeField> {
 
     /// Joint arithmetization of the A*, B*, and C* matrices.
     pub joint_arith: MatrixArithmetization<F>,
+
+    pub(crate) mode: PhantomData<MM>,
 }
 
-impl<F: PrimeField> Circuit<F> {
+impl<F: PrimeField, MM: MarlinMode> Circuit<F, MM> {
     /// The maximum degree required to represent polynomials of this index.
     pub fn max_degree(&self) -> usize {
-        self.index_info.max_degree()
+        self.index_info.max_degree::<MM>()
     }
 
     /// Iterate over the indexed polynomials.

--- a/marlin/src/ahp/indexer/circuit_info.rs
+++ b/marlin/src/ahp/indexer/circuit_info.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ahp::AHPForR1CS, BTreeSet, Matrix, Vec};
+use crate::{ahp::AHPForR1CS, marlin::MarlinMode, BTreeSet, Matrix, Vec};
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{errors::SerializationError, serialize::*, ToBytes};
 
@@ -58,8 +58,8 @@ pub(crate) fn sum_matrices<F: PrimeField>(a: &Matrix<F>, b: &Matrix<F>, c: &Matr
 
 impl<F: PrimeField> CircuitInfo<F> {
     /// The maximum degree of polynomial required to represent this index in the AHP.
-    pub fn max_degree(&self) -> usize {
-        AHPForR1CS::<F>::max_degree(self.num_constraints, self.num_variables, self.num_non_zero).unwrap()
+    pub fn max_degree<MM: MarlinMode>(&self) -> usize {
+        AHPForR1CS::<F, MM>::max_degree(self.num_constraints, self.num_variables, self.num_non_zero).unwrap()
     }
 }
 

--- a/marlin/src/ahp/indexer/indexer.rs
+++ b/marlin/src/ahp/indexer/indexer.rs
@@ -14,11 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::ahp::{
-    indexer::{Circuit, CircuitInfo, IndexerConstraintSystem},
-    matrices::arithmetize_matrix,
-    AHPError,
-    AHPForR1CS,
+use crate::{
+    ahp::{
+        indexer::{Circuit, CircuitInfo, IndexerConstraintSystem},
+        matrices::arithmetize_matrix,
+        AHPError,
+        AHPForR1CS,
+    },
+    marlin::MarlinMode,
 };
 use snarkvm_algorithms::fft::EvaluationDomain;
 use snarkvm_fields::PrimeField;
@@ -32,9 +35,9 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "std"))]
 use snarkvm_utilities::println;
 
-impl<F: PrimeField> AHPForR1CS<F> {
+impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     /// Generate the index for this constraint system.
-    pub fn index<C: ConstraintSynthesizer<F>>(c: &C) -> Result<Circuit<F>, AHPError> {
+    pub fn index<C: ConstraintSynthesizer<F>>(c: &C) -> Result<Circuit<F, MM>, AHPError> {
         let index_time = start_timer!(|| "AHP::Index");
 
         let constraint_time = start_timer!(|| "Generating constraints");
@@ -105,6 +108,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
             c,
 
             joint_arith,
+            mode: PhantomData,
         })
     }
 }

--- a/marlin/src/ahp/prover/prover.rs
+++ b/marlin/src/ahp/prover/prover.rs
@@ -463,9 +463,9 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
 
         let hiding_bound = if MM::ZK { Some(1) } else { None };
         let oracles = ProverSecondOracles {
-                t: LabeledPolynomial::new("t".into(), t_poly, None, None),
-                g_1: LabeledPolynomial::new("g_1".into(), g_1, Some(domain_h.size() - 2), hiding_bound),
-                h_1: LabeledPolynomial::new("h_1".into(), h_1, None, None),
+            t: LabeledPolynomial::new("t".into(), t_poly, None, None),
+            g_1: LabeledPolynomial::new("g_1".into(), g_1, Some(domain_h.size() - 2), hiding_bound),
+            h_1: LabeledPolynomial::new("h_1".into(), h_1, None, None),
         };
 
         state.w_poly = None;

--- a/marlin/src/ahp/prover/state.rs
+++ b/marlin/src/ahp/prover/state.rs
@@ -16,6 +16,7 @@
 
 use crate::{
     ahp::{indexer::Circuit, prover::ProverConstraintSystem, verifier::VerifierFirstMessage},
+    marlin::MarlinMode,
     Vec,
 };
 use snarkvm_algorithms::fft::EvaluationDomain;
@@ -23,7 +24,7 @@ use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::LabeledPolynomial;
 
 /// State for the AHP prover.
-pub struct ProverState<'a, F: PrimeField> {
+pub struct ProverState<'a, F: PrimeField, MM: MarlinMode> {
     pub(super) padded_public_variables: Vec<F>,
     pub(super) private_variables: Vec<F>,
     /// Az
@@ -36,7 +37,7 @@ pub struct ProverState<'a, F: PrimeField> {
     pub(super) w_poly: Option<LabeledPolynomial<F>>,
     pub(super) mz_polys: Option<(LabeledPolynomial<F>, LabeledPolynomial<F>)>,
 
-    pub(super) index: &'a Circuit<F>,
+    pub(super) index: &'a Circuit<F, MM>,
 
     /// the random values sent by the verifier in the first round
     pub(super) verifier_first_message: Option<VerifierFirstMessage<F>>,
@@ -54,7 +55,7 @@ pub struct ProverState<'a, F: PrimeField> {
     pub(super) domain_k: EvaluationDomain<F>,
 }
 
-impl<'a, F: PrimeField> ProverState<'a, F> {
+impl<'a, F: PrimeField, MM: MarlinMode> ProverState<'a, F, MM> {
     /// Get the public input.
     pub fn public_input(&self) -> Vec<F> {
         ProverConstraintSystem::unformat_public_input(&self.padded_public_variables)

--- a/marlin/src/ahp/verifier/state.rs
+++ b/marlin/src/ahp/verifier/state.rs
@@ -14,13 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::ahp::verifier::{VerifierFirstMessage, VerifierSecondMessage};
+use std::marker::PhantomData;
+
+use crate::{
+    ahp::verifier::{VerifierFirstMessage, VerifierSecondMessage},
+    marlin::MarlinMode,
+};
 use snarkvm_algorithms::fft::EvaluationDomain;
 use snarkvm_fields::PrimeField;
 
 /// State of the AHP verifier.
 #[derive(Debug)]
-pub struct VerifierState<F: PrimeField> {
+pub struct VerifierState<F: PrimeField, MM: MarlinMode> {
     pub(crate) domain_h: EvaluationDomain<F>,
     pub(crate) domain_k: EvaluationDomain<F>,
 
@@ -28,4 +33,5 @@ pub struct VerifierState<F: PrimeField> {
     pub(crate) second_round_message: Option<VerifierSecondMessage<F>>,
 
     pub(crate) gamma: Option<F>,
+    pub(crate) mode: PhantomData<MM>,
 }

--- a/marlin/src/ahp/verifier/state.rs
+++ b/marlin/src/ahp/verifier/state.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     ahp::verifier::{VerifierFirstMessage, VerifierSecondMessage},

--- a/marlin/src/ahp/verifier/verifier.rs
+++ b/marlin/src/ahp/verifier/verifier.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     ahp::{

--- a/marlin/src/ahp/verifier/verifier.rs
+++ b/marlin/src/ahp/verifier/verifier.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::marker::PhantomData;
+
 use crate::{
     ahp::{
         indexer::CircuitInfo,
@@ -21,6 +23,7 @@ use crate::{
         AHPError,
         AHPForR1CS,
     },
+    marlin::MarlinMode,
     traits::FiatShamirRng,
 };
 use snarkvm_algorithms::fft::EvaluationDomain;
@@ -32,12 +35,12 @@ use snarkvm_polycommit::QuerySet;
 
 use rand_core::RngCore;
 
-impl<TargetField: PrimeField> AHPForR1CS<TargetField> {
+impl<TargetField: PrimeField, MM: MarlinMode> AHPForR1CS<TargetField, MM> {
     /// Output the first message and next round state.
     pub fn verifier_first_round<BaseField: PrimeField, R: FiatShamirRng<TargetField, BaseField>>(
         index_info: CircuitInfo<TargetField>,
         fs_rng: &mut R,
-    ) -> Result<(VerifierFirstMessage<TargetField>, VerifierState<TargetField>), AHPError> {
+    ) -> Result<(VerifierFirstMessage<TargetField>, VerifierState<TargetField, MM>), AHPError> {
         // Check that the R1CS is a square matrix.
         if index_info.num_constraints != index_info.num_variables {
             return Err(AHPError::NonSquareMatrix);
@@ -69,6 +72,7 @@ impl<TargetField: PrimeField> AHPForR1CS<TargetField> {
             first_round_message: Some(message),
             second_round_message: None,
             gamma: None,
+            mode: PhantomData,
         };
 
         Ok((message, new_state))
@@ -76,9 +80,9 @@ impl<TargetField: PrimeField> AHPForR1CS<TargetField> {
 
     /// Output the second message and next round state.
     pub fn verifier_second_round<BaseField: PrimeField, R: FiatShamirRng<TargetField, BaseField>>(
-        mut state: VerifierState<TargetField>,
+        mut state: VerifierState<TargetField, MM>,
         fs_rng: &mut R,
-    ) -> Result<(VerifierSecondMessage<TargetField>, VerifierState<TargetField>), AHPError> {
+    ) -> Result<(VerifierSecondMessage<TargetField>, VerifierState<TargetField, MM>), AHPError> {
         let elems = fs_rng.squeeze_nonnative_field_elements(1, OptimizationType::Weight)?;
         let beta = elems[0];
         assert!(!state.domain_h.evaluate_vanishing_polynomial(beta).is_zero());
@@ -91,9 +95,9 @@ impl<TargetField: PrimeField> AHPForR1CS<TargetField> {
 
     /// Output the third message and next round state.
     pub fn verifier_third_round<BaseField: PrimeField, R: FiatShamirRng<TargetField, BaseField>>(
-        mut state: VerifierState<TargetField>,
+        mut state: VerifierState<TargetField, MM>,
         fs_rng: &mut R,
-    ) -> Result<VerifierState<TargetField>, AHPError> {
+    ) -> Result<VerifierState<TargetField, MM>, AHPError> {
         let elems = fs_rng.squeeze_nonnative_field_elements(1, OptimizationType::Weight)?;
         let gamma = elems[0];
 
@@ -103,10 +107,10 @@ impl<TargetField: PrimeField> AHPForR1CS<TargetField> {
 
     /// Output the query state and next round state.
     pub fn verifier_query_set<'a, 'b, R: RngCore>(
-        state: VerifierState<TargetField>,
+        state: VerifierState<TargetField, MM>,
         _: &'a mut R,
-        with_vanishing: bool,
-    ) -> (QuerySet<'b, TargetField>, VerifierState<TargetField>) {
+    ) -> (QuerySet<'b, TargetField>, VerifierState<TargetField, MM>) {
+        let with_vanishing = MM::RECURSION;
         let alpha = state.first_round_message.unwrap().alpha;
         let beta = state.second_round_message.unwrap().beta;
         let gamma = state.gamma.unwrap();

--- a/marlin/src/constraints/verifier.rs
+++ b/marlin/src/constraints/verifier.rs
@@ -55,7 +55,8 @@ pub struct MarlinVerificationGadget<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
->(PhantomData<(TargetField, BaseField, PC, PCG)>);
+    MM: MarlinMode,
+>(PhantomData<(TargetField, BaseField, PC, PCG, MM)>);
 
 /// Fiat Shamir Algebraic Sponge RNG type
 pub type FSA<InnerField, OuterField> =
@@ -70,7 +71,7 @@ pub type FSG<InnerField, OuterField> = FiatShamirAlgebraicSpongeRngVar<
 >;
 
 impl<TargetField, BaseField, PC, PCG, FS, MM, V> SNARKVerifierGadget<MarlinSNARK<TargetField, BaseField, PC, FS, MM, V>>
-    for MarlinVerificationGadget<TargetField, BaseField, PC, PCG>
+    for MarlinVerificationGadget<TargetField, BaseField, PC, PCG, MM>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
@@ -88,9 +89,10 @@ where
         PCG,
         FSA<TargetField, BaseField>,
         FSG<TargetField, BaseField>,
+        MM,
     >;
     type ProofGadget = ProofVar<TargetField, BaseField, PC, PCG>;
-    type VerificationKeyGadget = CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>;
+    type VerificationKeyGadget = CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>;
 
     fn input_gadget_from_bytes<CS: ConstraintSystem<BaseField>>(
         mut cs: CS,
@@ -151,7 +153,7 @@ where
     }
 }
 
-impl<TargetField, BaseField, PC, PCG> MarlinVerificationGadget<TargetField, BaseField, PC, PCG>
+impl<TargetField, BaseField, PC, PCG, MM: MarlinMode> MarlinVerificationGadget<TargetField, BaseField, PC, PCG, MM>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
@@ -168,7 +170,7 @@ where
         R: FiatShamirRngVar<TargetField, BaseField, PR>,
     >(
         mut cs: CS,
-        prepared_verifying_key: &PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>,
+        prepared_verifying_key: &PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R, MM>,
         public_input: &[NonNativeFieldVar<TargetField, BaseField>],
         proof: &ProofVar<TargetField, BaseField, PC, PCG>,
     ) -> Result<Boolean, MarlinError> {
@@ -196,7 +198,7 @@ where
             OptimizationType::Weight,
         )?;
 
-        let (_, verifier_state) = AHPForR1CS::<TargetField, BaseField, PC, PCG>::verifier_first_round(
+        let (_, verifier_state) = AHPForR1CS::<TargetField, BaseField, PC, PCG, MM>::verifier_first_round(
             cs.ns(|| "verifier_first_round"),
             prepared_verifying_key.domain_h_size,
             prepared_verifying_key.domain_k_size,
@@ -205,7 +207,7 @@ where
             &proof.prover_messages[0].field_elements,
         )?;
 
-        let (_, verifier_state) = AHPForR1CS::<TargetField, BaseField, PC, PCG>::verifier_second_round(
+        let (_, verifier_state) = AHPForR1CS::<TargetField, BaseField, PC, PCG, MM>::verifier_second_round(
             cs.ns(|| "verifier_second_round"),
             verifier_state,
             &mut fs_rng,
@@ -213,7 +215,7 @@ where
             &proof.prover_messages[1].field_elements,
         )?;
 
-        let verifier_state = AHPForR1CS::<TargetField, BaseField, PC, PCG>::verifier_third_round(
+        let verifier_state = AHPForR1CS::<TargetField, BaseField, PC, PCG, MM>::verifier_third_round(
             cs.ns(|| "verifier_third_round"),
             verifier_state,
             &mut fs_rng,
@@ -221,7 +223,7 @@ where
             &proof.prover_messages[2].field_elements,
         )?;
 
-        let lc = AHPForR1CS::<TargetField, BaseField, PC, PCG>::verifier_decision(
+        let lc = AHPForR1CS::<TargetField, BaseField, PC, PCG, MM>::verifier_decision(
             cs.ns(|| "verifier_decision"),
             &padded_public_input,
             &proof.evaluations,
@@ -230,7 +232,7 @@ where
         )?;
 
         let (num_opening_challenges, num_batching_rands, comm, query_set, evaluations) =
-            AHPForR1CS::<TargetField, BaseField, PC, PCG>::verifier_comm_query_eval_set(
+            AHPForR1CS::<TargetField, BaseField, PC, PCG, MM>::verifier_comm_query_eval_set(
                 cs.ns(|| "verifier_comm_query_eval_set"),
                 &prepared_verifying_key,
                 &proof,
@@ -295,7 +297,7 @@ where
         R: FiatShamirRngVar<TargetField, BaseField, PR>,
     >(
         mut cs: CS,
-        verifying_key: &CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>,
+        verifying_key: &CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>,
         public_input: &[NonNativeFieldVar<TargetField, BaseField>],
         proof: &ProofVar<TargetField, BaseField, PC, PCG>,
     ) -> Result<Boolean, MarlinError> {
@@ -359,7 +361,7 @@ mod test {
     fn verifier_test() {
         let rng = &mut test_rng();
 
-        let max_degree = crate::ahp::AHPForR1CS::<Fr>::max_degree(10000, 25, 10000).unwrap();
+        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(10000, 25, 10000).unwrap();
         let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
         let num_constraints = 10000;
@@ -393,7 +395,7 @@ mod test {
         let mut cs = TestConstraintSystem::<Fq>::new();
 
         // BEGIN: ivk to ivk_gadget
-        let ivk_gadget: CircuitVerifyingKeyVar<Fr, Fq, PC, PCGadget> =
+        let ivk_gadget: CircuitVerifyingKeyVar<Fr, Fq, PC, PCGadget, MarlinRecursiveMode> =
             CircuitVerifyingKeyVar::alloc(cs.ns(|| "alloc_circuit_vk"), || Ok(circuit_vk)).unwrap();
         // END: ivk to ivk_gadget
 
@@ -487,7 +489,7 @@ mod test {
         };
         // END: proof to proof_gadget
 
-        MarlinVerificationGadget::<Fr, Fq, PC, PCGadget>::verify::<_, FS, FSG>(
+        MarlinVerificationGadget::<Fr, Fq, PC, PCGadget, MarlinRecursiveMode>::verify::<_, FS, FSG>(
             cs.ns(|| "marlin_verification"),
             &ivk_gadget,
             &public_input_gadget,

--- a/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
@@ -36,7 +36,7 @@ use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
 use crate::{
     constraints::{verifier::MarlinVerificationGadget, verifier_key::PreparedCircuitVerifyingKeyVar},
-    marlin::CircuitVerifyingKey,
+    marlin::{CircuitVerifyingKey, MarlinMode},
     FiatShamirRng,
     FiatShamirRngVar,
     PolynomialCommitment,
@@ -51,9 +51,10 @@ pub struct CircuitVerifyingKeyVar<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
+    MM: MarlinMode,
 > {
     /// The original key
-    pub origin_verifier_key: CircuitVerifyingKey<TargetField, BaseField, PC>,
+    pub origin_verifier_key: CircuitVerifyingKey<TargetField, BaseField, PC, MM>,
     /// The size of domain h
     pub domain_h_size: u64,
     /// The size of domain k
@@ -73,7 +74,8 @@ impl<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-> Clone for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+    MM: MarlinMode,
+> Clone for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 {
     fn clone(&self) -> Self {
         Self {
@@ -93,7 +95,8 @@ impl<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-> CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+    MM: MarlinMode,
+> CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 {
     /// Returns an iterator of the circuit commitments.
     pub fn iter(&self) -> impl Iterator<Item = &PCG::CommitmentVar> {
@@ -106,14 +109,15 @@ impl<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-> AllocGadget<CircuitVerifyingKey<TargetField, BaseField, PC>, BaseField>
-    for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+    MM: MarlinMode,
+> AllocGadget<CircuitVerifyingKey<TargetField, BaseField, PC, MM>, BaseField>
+    for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 {
     #[inline]
     fn alloc_constant<FN, T, CS: ConstraintSystem<BaseField>>(mut cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         let tmp = value_gen()?;
         let ivk = tmp.borrow();
@@ -156,7 +160,7 @@ impl<
     fn alloc<FN, T, CS: ConstraintSystem<BaseField>>(mut cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         let tmp = value_gen()?;
         let ivk = tmp.borrow();
@@ -200,7 +204,7 @@ impl<
     fn alloc_input<FN, T, CS: ConstraintSystem<BaseField>>(mut cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         let tmp = value_gen()?;
         let ivk = tmp.borrow();
@@ -248,7 +252,8 @@ impl<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-> ToConstraintFieldGadget<BaseField> for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+    MM: MarlinMode,
+> ToConstraintFieldGadget<BaseField> for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 {
     fn to_constraint_field<CS: ConstraintSystem<BaseField>>(
         &self,
@@ -280,7 +285,8 @@ impl<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-> ToMinimalBitsGadget<BaseField> for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+    MM: MarlinMode,
+> ToMinimalBitsGadget<BaseField> for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 {
     fn to_minimal_bits<CS: ConstraintSystem<BaseField>>(&self, mut cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         let mut domain_h_size_booleans = self.domain_h_size_gadget.to_bits_le(cs.ns(|| "domain_h_size"))?;
@@ -306,9 +312,9 @@ impl<
     }
 }
 
-impl<TargetField, BaseField, PC, PCG, PR, R>
-    PrepareGadget<PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>, BaseField>
-    for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+impl<TargetField, BaseField, PC, PCG, PR, R, MM>
+    PrepareGadget<PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R, MM>, BaseField>
+    for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
@@ -316,15 +322,16 @@ where
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
+    MM: MarlinMode,
 {
     /// Returns an instance of a `PreparedCircuitVerifyingKeyGadget`.
     fn prepare<CS: ConstraintSystem<BaseField>>(
         &self,
         mut cs: CS,
-    ) -> Result<PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>, SynthesisError> {
+    ) -> Result<PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R, MM>, SynthesisError> {
         let mut fs_rng = R::new(cs.ns(|| "Init rng"));
         let protocol_bytes =
-            UInt8::constant_vec(MarlinVerificationGadget::<TargetField, BaseField, PC, PCG>::PROTOCOL_NAME);
+            UInt8::constant_vec(MarlinVerificationGadget::<TargetField, BaseField, PC, PCG, MM>::PROTOCOL_NAME);
         fs_rng.absorb_bytes(cs.ns(|| "absorb protocol name"), &protocol_bytes)?;
 
         let comm_fe = self
@@ -346,18 +353,16 @@ where
         // instead of running the prepare algorithm, allocate the constant version.
         let prepared_verifier_key = self.verifier_key.prepare(cs.ns(|| "Prepare PC"))?;
 
-        Ok(
-            PreparedCircuitVerifyingKeyVar::<TargetField, BaseField, PC, PCG, PR, R> {
-                domain_h_size: self.domain_h_size,
-                domain_k_size: self.domain_k_size,
-                domain_h_size_gadget: self.domain_h_size_gadget.clone(),
-                domain_k_size_gadget: self.domain_k_size_gadget.clone(),
-                prepared_index_comms,
-                prepared_verifier_key,
-                fs_rng,
-                pr: PhantomData,
-            },
-        )
+        Ok(PreparedCircuitVerifyingKeyVar {
+            domain_h_size: self.domain_h_size,
+            domain_k_size: self.domain_k_size,
+            domain_h_size_gadget: self.domain_h_size_gadget.clone(),
+            domain_k_size_gadget: self.domain_k_size_gadget.clone(),
+            prepared_index_comms,
+            prepared_verifier_key,
+            fs_rng,
+            pr: PhantomData,
+        })
     }
 }
 
@@ -366,7 +371,8 @@ impl<
     BaseField: PrimeField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
-> ToBytesGadget<BaseField> for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+    MM: MarlinMode,
+> ToBytesGadget<BaseField> for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 {
     fn to_bytes<CS: ConstraintSystem<BaseField>>(&self, mut cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         let mut res = Vec::<UInt8>::new();
@@ -396,13 +402,14 @@ impl<
     }
 }
 
-impl<TargetField, BaseField, PC, PCG> AllocBytesGadget<Vec<u8>, BaseField>
-    for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG>
+impl<TargetField, BaseField, PC, PCG, MM> AllocBytesGadget<Vec<u8>, BaseField>
+    for CircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, MM>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
     PC: PolynomialCommitment<TargetField, BaseField>,
     PCG: PCCheckVar<TargetField, PC, BaseField>,
+    MM: MarlinMode,
 {
     #[inline]
     fn alloc_bytes<FN, T, CS: ConstraintSystem<BaseField>>(mut cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
@@ -411,10 +418,10 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let circuit_vk: CircuitVerifyingKey<TargetField, BaseField, PC> =
+            let circuit_vk: CircuitVerifyingKey<TargetField, BaseField, PC, MM> =
                 FromBytes::read_le(&vk_bytes.borrow()[..])?;
 
-            CircuitVerifyingKeyVar::<TargetField, BaseField, PC, PCG>::alloc(cs.ns(|| "unprepared_vk"), || {
+            CircuitVerifyingKeyVar::<TargetField, BaseField, PC, PCG, MM>::alloc(cs.ns(|| "unprepared_vk"), || {
                 Ok(circuit_vk)
             })
         })
@@ -430,12 +437,12 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let circuit_vk: CircuitVerifyingKey<TargetField, BaseField, PC> =
-                FromBytes::read_le(&vk_bytes.borrow()[..])?;
+            let circuit_vk: CircuitVerifyingKey<_, _, _, _> = FromBytes::read_le(&vk_bytes.borrow()[..])?;
 
-            CircuitVerifyingKeyVar::<TargetField, BaseField, PC, PCG>::alloc_input(cs.ns(|| "unprepared_vk"), || {
-                Ok(circuit_vk)
-            })
+            CircuitVerifyingKeyVar::<TargetField, BaseField, PC, PCG, MM>::alloc_input(
+                cs.ns(|| "unprepared_vk"),
+                || Ok(circuit_vk),
+            )
         })
     }
 }
@@ -477,7 +484,7 @@ mod test {
         let num_variables = 25;
 
         // Construct the circuit verifier key.
-        let max_degree = crate::ahp::AHPForR1CS::<Fr>::max_degree(100, 25, 100).unwrap();
+        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinTestnet1Mode>::max_degree(100, 25, 100).unwrap();
         let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
         let a = Fr::rand(rng);
@@ -498,7 +505,7 @@ mod test {
 
         // Allocate the circuit vk gadget.
         let circuit_vk_gadget =
-            CircuitVerifyingKeyVar::<_, _, _, MultiPCVar>::alloc(cs.ns(|| "alloc_vk"), || Ok(circuit_vk.clone()))
+            CircuitVerifyingKeyVar::<_, _, _, MultiPCVar, _>::alloc(cs.ns(|| "alloc_vk"), || Ok(circuit_vk.clone()))
                 .unwrap();
 
         // Enforce that the native vk and vk gadget elements are equivalent.

--- a/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/prepared_circuit_verifier_key.rs
@@ -25,7 +25,7 @@ use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use crate::{
     constraints::verifier::MarlinVerificationGadget,
-    marlin::{CircuitVerifyingKey, PreparedCircuitVerifyingKey},
+    marlin::{CircuitVerifyingKey, MarlinMode, PreparedCircuitVerifyingKey},
     FiatShamirRng,
     FiatShamirRngVar,
     PhantomData,
@@ -42,6 +42,7 @@ pub struct PreparedCircuitVerifyingKeyVar<
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
+    MM: MarlinMode,
 > {
     /// The size of domain h
     pub domain_h_size: u64,
@@ -58,7 +59,7 @@ pub struct PreparedCircuitVerifyingKeyVar<
     /// The Fiat-Shamir Rng
     pub fs_rng: R,
 
-    pub pr: PhantomData<PR>,
+    pub pr: PhantomData<(PR, MM)>,
 }
 
 impl<
@@ -68,7 +69,8 @@ impl<
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
-> Clone for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>
+    MM: MarlinMode,
+> Clone for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R, MM>
 {
     fn clone(&self) -> Self {
         PreparedCircuitVerifyingKeyVar {
@@ -84,9 +86,9 @@ impl<
     }
 }
 
-impl<TargetField, BaseField, PC, PCG, PR, R>
-    AllocGadget<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>, BaseField>
-    for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>
+impl<TargetField, BaseField, PC, PCG, PR, R, MM>
+    AllocGadget<PreparedCircuitVerifyingKey<TargetField, BaseField, PC, MM>, BaseField>
+    for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R, MM>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
@@ -94,12 +96,13 @@ where
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
+    MM: MarlinMode,
 {
     #[inline]
     fn alloc_constant<FN, T, CS: ConstraintSystem<BaseField>>(mut cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         let tmp = value_gen()?;
         let obj = tmp.borrow();
@@ -133,7 +136,7 @@ where
 
         let mut fs_rng_raw = PR::new();
         fs_rng_raw.absorb_bytes(&to_bytes_le![
-            &MarlinVerificationGadget::<TargetField, BaseField, PC, PCG>::PROTOCOL_NAME
+            &MarlinVerificationGadget::<TargetField, BaseField, PC, PCG, MM>::PROTOCOL_NAME
         ]?);
 
         let fs_rng = {
@@ -165,7 +168,7 @@ where
     fn alloc<FN, T, CS: ConstraintSystem<BaseField>>(_cs: CS, _value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         unimplemented!();
         // the overhead is not worthwhile
@@ -175,15 +178,16 @@ where
     fn alloc_input<FN, T, CS: ConstraintSystem<BaseField>>(_cs: CS, _value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<PreparedCircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         unimplemented!();
         // the overhead is not worthwhile
     }
 }
 
-impl<TargetField, BaseField, PC, PCG, PR, R> AllocGadget<CircuitVerifyingKey<TargetField, BaseField, PC>, BaseField>
-    for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R>
+impl<TargetField, BaseField, PC, PCG, PR, R, MM>
+    AllocGadget<CircuitVerifyingKey<TargetField, BaseField, PC, MM>, BaseField>
+    for PreparedCircuitVerifyingKeyVar<TargetField, BaseField, PC, PCG, PR, R, MM>
 where
     TargetField: PrimeField,
     BaseField: PrimeField + PoseidonDefaultParametersField,
@@ -191,12 +195,13 @@ where
     PCG: PCCheckVar<TargetField, PC, BaseField>,
     PR: FiatShamirRng<TargetField, BaseField>,
     R: FiatShamirRngVar<TargetField, BaseField, PR>,
+    MM: MarlinMode,
 {
     #[inline]
     fn alloc_constant<FN, T, CS: ConstraintSystem<BaseField>>(cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         let tmp = value_gen()?;
         let vk = tmp.borrow();
@@ -209,7 +214,7 @@ where
     fn alloc<FN, T, CS: ConstraintSystem<BaseField>>(cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         let tmp = value_gen()?;
         let vk = tmp.borrow();
@@ -222,7 +227,7 @@ where
     fn alloc_input<FN, T, CS: ConstraintSystem<BaseField>>(cs: CS, value_gen: FN) -> Result<Self, SynthesisError>
     where
         FN: FnOnce() -> Result<T, SynthesisError>,
-        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC>>,
+        T: Borrow<CircuitVerifyingKey<TargetField, BaseField, PC, MM>>,
     {
         let tmp = value_gen()?;
         let vk = tmp.borrow();
@@ -278,7 +283,7 @@ mod test {
         let num_variables = 25;
 
         // Construct the circuit verifier key.
-        let max_degree = crate::ahp::AHPForR1CS::<Fr>::max_degree(100, 25, 100).unwrap();
+        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinTestnet1Mode>::max_degree(100, 25, 100).unwrap();
         let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
         let a = Fr::rand(rng);
@@ -300,8 +305,8 @@ mod test {
         let prepared_circuit_vk = circuit_vk.prepare();
 
         // Allocate the circuit vk gadget.
-        let prepared_circuit_vk_gadget: PreparedCircuitVerifyingKeyVar<_, _, _, _, FS, FSG> =
-            CircuitVerifyingKeyVar::<_, _, _, MultiPCVar>::alloc(cs.ns(|| "alloc_vk"), || Ok(circuit_vk.clone()))
+        let prepared_circuit_vk_gadget: PreparedCircuitVerifyingKeyVar<_, _, _, _, FS, FSG, _> =
+            CircuitVerifyingKeyVar::<_, _, _, MultiPCVar, _>::alloc(cs.ns(|| "alloc_vk"), || Ok(circuit_vk.clone()))
                 .unwrap()
                 .prepare(cs.ns(|| "Prepare"))
                 .unwrap();

--- a/marlin/src/marlin/circuit_proving_key.rs
+++ b/marlin/src/marlin/circuit_proving_key.rs
@@ -22,22 +22,26 @@ use snarkvm_utilities::{serialize::*, FromBytes, ToBytes};
 use crate::{IoResult, Read, Write};
 use derivative::Derivative;
 
+use super::MarlinMode;
+
 /// Proving key for a specific circuit (i.e., R1CS matrices).
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""))]
 #[derive(Debug)]
-pub struct CircuitProvingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> {
+pub struct CircuitProvingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> {
     /// The circuit verifying key.
-    pub circuit_verifying_key: CircuitVerifyingKey<F, CF, PC>,
+    pub circuit_verifying_key: CircuitVerifyingKey<F, CF, PC, MM>,
     /// The randomness for the circuit polynomial commitments.
     pub circuit_commitment_randomness: Vec<PC::Randomness>,
     /// The circuit itself.
-    pub circuit: Circuit<F>,
+    pub circuit: Circuit<F, MM>,
     /// The committer key for this index, trimmed from the universal SRS.
     pub committer_key: PC::CommitterKey,
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToBytes for CircuitProvingKey<F, CF, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> ToBytes
+    for CircuitProvingKey<F, CF, PC, MM>
+{
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         CanonicalSerialize::serialize(&self.circuit_verifying_key, &mut writer)?;
         CanonicalSerialize::serialize(&self.circuit_commitment_randomness, &mut writer)?;
@@ -47,7 +51,9 @@ impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToBytes for
     }
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> FromBytes for CircuitProvingKey<F, CF, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> FromBytes
+    for CircuitProvingKey<F, CF, PC, MM>
+{
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let circuit_verifying_key = CanonicalDeserialize::deserialize(&mut reader)?;

--- a/marlin/src/marlin/circuit_verifying_key.rs
+++ b/marlin/src/marlin/circuit_verifying_key.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     ahp::indexer::*,

--- a/marlin/src/marlin/circuit_verifying_key.rs
+++ b/marlin/src/marlin/circuit_verifying_key.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::marker::PhantomData;
+
 use crate::{
     ahp::indexer::*,
     marlin::{CircuitProvingKey, PreparedCircuitVerifyingKey},
@@ -29,26 +31,34 @@ use derivative::Derivative;
 use snarkvm_algorithms::fft::EvaluationDomain;
 use snarkvm_r1cs::SynthesisError;
 
+use super::MarlinMode;
+
 /// Verification key for a specific index (i.e., R1CS matrices).
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""))]
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct CircuitVerifyingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> {
+pub struct CircuitVerifyingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> {
     /// Stores information about the size of the circuit, as well as its defined field.
     pub circuit_info: CircuitInfo<F>,
     /// Commitments to the indexed polynomials.
     pub circuit_commitments: Vec<PC::Commitment>,
     /// The verifier key for this index, trimmed from the universal SRS.
     pub verifier_key: PC::VerifierKey,
+    #[doc(hidden)]
+    pub mode: PhantomData<MM>,
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToBytes for CircuitVerifyingKey<F, CF, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> ToBytes
+    for CircuitVerifyingKey<F, CF, PC, MM>
+{
     fn write_le<W: Write>(&self, mut w: W) -> crate::io::Result<()> {
         CanonicalSerialize::serialize(self, &mut w).map_err(|_| error("could not serialize CircuitVerifyingKey"))
     }
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToMinimalBits for CircuitVerifyingKey<F, CF, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> ToMinimalBits
+    for CircuitVerifyingKey<F, CF, PC, MM>
+{
     fn to_minimal_bits(&self) -> Vec<bool> {
         let domain_h = EvaluationDomain::<F>::new(self.circuit_info.num_constraints)
             .ok_or(SynthesisError::PolynomialDegreeTooLarge)
@@ -80,43 +90,48 @@ impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> ToMinimalBi
     }
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> FromBytes for CircuitVerifyingKey<F, CF, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> FromBytes
+    for CircuitVerifyingKey<F, CF, PC, MM>
+{
     fn read_le<R: Read>(mut r: R) -> crate::io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut r).map_err(|_| error("could not deserialize CircuitVerifyingKey"))
     }
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> CircuitVerifyingKey<F, CF, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode>
+    CircuitVerifyingKey<F, CF, PC, MM>
+{
     /// Iterate over the commitments to indexed polynomials in `self`.
     pub fn iter(&self) -> impl Iterator<Item = &PC::Commitment> {
         self.circuit_commitments.iter()
     }
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> From<CircuitProvingKey<F, CF, PC>>
-    for CircuitVerifyingKey<F, CF, PC>
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode>
+    From<CircuitProvingKey<F, CF, PC, MM>> for CircuitVerifyingKey<F, CF, PC, MM>
 {
-    fn from(other: CircuitProvingKey<F, CF, PC>) -> Self {
+    fn from(other: CircuitProvingKey<F, CF, PC, MM>) -> Self {
         other.circuit_verifying_key
     }
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> From<PreparedCircuitVerifyingKey<F, CF, PC>>
-    for CircuitVerifyingKey<F, CF, PC>
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode>
+    From<PreparedCircuitVerifyingKey<F, CF, PC, MM>> for CircuitVerifyingKey<F, CF, PC, MM>
 {
-    fn from(other: PreparedCircuitVerifyingKey<F, CF, PC>) -> Self {
+    fn from(other: PreparedCircuitVerifyingKey<F, CF, PC, MM>) -> Self {
         other.orig_vk
     }
 }
 
-impl<F, CF, PC> Prepare<PreparedCircuitVerifyingKey<F, CF, PC>> for CircuitVerifyingKey<F, CF, PC>
+impl<F, CF, PC, MM> Prepare<PreparedCircuitVerifyingKey<F, CF, PC, MM>> for CircuitVerifyingKey<F, CF, PC, MM>
 where
     F: PrimeField,
     CF: PrimeField,
     PC: PolynomialCommitment<F, CF>,
+    MM: MarlinMode,
 {
     /// Prepare the circuit verifying key.
-    fn prepare(&self) -> PreparedCircuitVerifyingKey<F, CF, PC> {
+    fn prepare(&self) -> PreparedCircuitVerifyingKey<F, CF, PC, MM> {
         let mut prepared_index_comms = Vec::<PC::PreparedCommitment>::new();
         for (_, comm) in self.circuit_commitments.iter().enumerate() {
             prepared_index_comms.push(comm.prepare());
@@ -134,7 +149,7 @@ where
         let domain_h_size = domain_h.size();
         let domain_k_size = domain_k.size();
 
-        PreparedCircuitVerifyingKey::<F, CF, PC> {
+        PreparedCircuitVerifyingKey::<F, CF, PC, MM> {
             domain_h_size: domain_h_size as u64,
             domain_k_size: domain_k_size as u64,
             prepared_index_comms,
@@ -144,11 +159,12 @@ where
     }
 }
 
-impl<F, CF, PC> ToConstraintField<CF> for CircuitVerifyingKey<F, CF, PC>
+impl<F, CF, PC, MM> ToConstraintField<CF> for CircuitVerifyingKey<F, CF, PC, MM>
 where
     F: PrimeField,
     CF: PrimeField,
     PC: PolynomialCommitment<F, CF>,
+    MM: MarlinMode,
 {
     fn to_field_elements(&self) -> Result<Vec<CF>, ConstraintFieldError> {
         let domain_h = EvaluationDomain::<CF>::new(self.circuit_info.num_constraints)

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -36,7 +36,7 @@ use snarkvm_utilities::println;
 use crate::marlin::PreparedCircuitVerifyingKey;
 use core::{
     marker::PhantomData,
-    sync::atomic::{AtomicBool, Ordering}, num,
+    sync::atomic::{AtomicBool, Ordering},
 };
 use rand_core::RngCore;
 

--- a/marlin/src/marlin/mode.rs
+++ b/marlin/src/marlin/mode.rs
@@ -17,9 +17,11 @@
 use core::fmt::Debug;
 
 /// A trait to specify the Marlin mode.
-pub trait MarlinMode: Clone + Debug {
+pub trait MarlinMode: Clone + Debug + 'static + Sync + Send {
     /// Specifies whether this is for a recursive proof of at least depth-1.
     const RECURSION: bool;
+
+    const ZK: bool;
 }
 
 /// TODO (howardwu): Combine all of the testnet configurations into an environment struct higher up.
@@ -29,6 +31,7 @@ pub struct MarlinTestnet1Mode;
 
 impl MarlinMode for MarlinTestnet1Mode {
     const RECURSION: bool = false;
+    const ZK: bool = true;
 }
 
 /// The Marlin testnet2 mode does not assume recursive proofs of any depth.
@@ -37,6 +40,7 @@ pub struct MarlinTestnet2Mode;
 
 impl MarlinMode for MarlinTestnet2Mode {
     const RECURSION: bool = true;
+    const ZK: bool = true;
 }
 
 /// The Marlin default mode assumes a recursive proof of at least depth-1.
@@ -45,4 +49,14 @@ pub struct MarlinRecursiveMode;
 
 impl MarlinMode for MarlinRecursiveMode {
     const RECURSION: bool = true;
+    const ZK: bool = true;
+}
+
+/// The Marlin testnet2 mode does not assume recursive proofs of any depth.
+#[derive(Clone, Debug)]
+pub struct MarlinPoswMode;
+
+impl MarlinMode for MarlinPoswMode {
+    const RECURSION: bool = true;
+    const ZK: bool = false;
 }

--- a/marlin/src/marlin/mode.rs
+++ b/marlin/src/marlin/mode.rs
@@ -52,11 +52,11 @@ impl MarlinMode for MarlinRecursiveMode {
     const ZK: bool = true;
 }
 
-/// The Marlin testnet2 mode does not assume recursive proofs of any depth.
+/// The Marlin POSW mode does not assume recursive proofs of any depth.
 #[derive(Clone, Debug)]
 pub struct MarlinPoswMode;
 
 impl MarlinMode for MarlinPoswMode {
-    const RECURSION: bool = true;
+    const RECURSION: bool = false;
     const ZK: bool = false;
 }

--- a/marlin/src/marlin/prepared_circuit_verifying_key.rs
+++ b/marlin/src/marlin/prepared_circuit_verifying_key.rs
@@ -19,8 +19,10 @@ use crate::{marlin::CircuitVerifyingKey, Vec};
 use snarkvm_fields::PrimeField;
 use snarkvm_polycommit::PolynomialCommitment;
 
+use super::MarlinMode;
+
 /// Verification key, prepared (preprocessed) for use in pairings.
-pub struct PreparedCircuitVerifyingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> {
+pub struct PreparedCircuitVerifyingKey<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> {
     /// Size of the variable domain.
     pub domain_h_size: u64,
     /// Size of the matrix domain.
@@ -32,10 +34,12 @@ pub struct PreparedCircuitVerifyingKey<F: PrimeField, CF: PrimeField, PC: Polyno
     /// Non-prepared verification key, for use in native "prepared verify" (which
     /// is actually standard verify), as well as in absorbing the original vk into
     /// the Fiat-Shamir sponge.
-    pub orig_vk: CircuitVerifyingKey<F, CF, PC>,
+    pub orig_vk: CircuitVerifyingKey<F, CF, PC, MM>,
 }
 
-impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> Clone for PreparedCircuitVerifyingKey<F, CF, PC> {
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinMode> Clone
+    for PreparedCircuitVerifyingKey<F, CF, PC, MM>
+{
     fn clone(&self) -> Self {
         PreparedCircuitVerifyingKey {
             domain_h_size: self.domain_h_size,

--- a/marlin/src/marlin/tests.rs
+++ b/marlin/src/marlin/tests.rs
@@ -95,7 +95,8 @@ mod marlin {
                 pub(crate) fn test_circuit(num_constraints: usize, num_variables: usize) {
                     let rng = &mut test_rng();
 
-                    let max_degree = crate::ahp::AHPForR1CS::<Fr>::max_degree(100, 25, 300).unwrap();
+                    let max_degree =
+                        crate::ahp::AHPForR1CS::<Fr, MarlinTestnet1Mode>::max_degree(100, 25, 300).unwrap();
                     let universal_srs = $marlin_inst::universal_setup(max_degree, rng).unwrap();
 
                     for _ in 0..100 {
@@ -202,7 +203,7 @@ mod marlin_recursion {
     fn test_circuit(num_constraints: usize, num_variables: usize) {
         let rng = &mut test_rng();
 
-        let max_degree = crate::ahp::AHPForR1CS::<Fr>::max_degree(100, 25, 300).unwrap();
+        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(100, 25, 300).unwrap();
         let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
         for _ in 0..100 {

--- a/marlin/src/marlin/tests.rs
+++ b/marlin/src/marlin/tests.rs
@@ -73,7 +73,7 @@ mod marlin {
     use super::*;
     use crate::{
         fiat_shamir::FiatShamirChaChaRng,
-        marlin::{MarlinSNARK, MarlinTestnet1Mode, MarlinPoswMode},
+        marlin::{MarlinPoswMode, MarlinSNARK, MarlinTestnet1Mode},
     };
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
     use snarkvm_polycommit::{marlin_pc::MarlinKZG10, sonic_pc::SonicKZG10};
@@ -97,8 +97,7 @@ mod marlin {
                 pub(crate) fn test_circuit(num_constraints: usize, num_variables: usize) {
                     let rng = &mut test_rng();
 
-                    let max_degree =
-                        crate::ahp::AHPForR1CS::<Fr, $marlin_mode>::max_degree(100, 25, 300).unwrap();
+                    let max_degree = crate::ahp::AHPForR1CS::<Fr, $marlin_mode>::max_degree(100, 25, 300).unwrap();
                     let universal_srs = $marlin_inst::universal_setup(max_degree, rng).unwrap();
 
                     for _ in 0..100 {

--- a/marlin/src/marlin/tests.rs
+++ b/marlin/src/marlin/tests.rs
@@ -73,7 +73,7 @@ mod marlin {
     use super::*;
     use crate::{
         fiat_shamir::FiatShamirChaChaRng,
-        marlin::{MarlinSNARK, MarlinTestnet1Mode},
+        marlin::{MarlinSNARK, MarlinTestnet1Mode, MarlinPoswMode},
     };
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
     use snarkvm_polycommit::{marlin_pc::MarlinKZG10, sonic_pc::SonicKZG10};
@@ -88,15 +88,17 @@ mod marlin {
     type MultiPCSonic = SonicKZG10<Bls12_377>;
     type MarlinSonicInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode>;
 
+    type MarlinSonicPoswInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinPoswMode>;
+
     macro_rules! impl_marlin_test {
-        ($test_struct: ident, $marlin_inst: tt) => {
+        ($test_struct: ident, $marlin_inst: tt, $marlin_mode: tt) => {
             struct $test_struct {}
             impl $test_struct {
                 pub(crate) fn test_circuit(num_constraints: usize, num_variables: usize) {
                     let rng = &mut test_rng();
 
                     let max_degree =
-                        crate::ahp::AHPForR1CS::<Fr, MarlinTestnet1Mode>::max_degree(100, 25, 300).unwrap();
+                        crate::ahp::AHPForR1CS::<Fr, $marlin_mode>::max_degree(100, 25, 300).unwrap();
                     let universal_srs = $marlin_inst::universal_setup(max_degree, rng).unwrap();
 
                     for _ in 0..100 {
@@ -130,8 +132,9 @@ mod marlin {
         };
     }
 
-    impl_marlin_test!(MarlinPCTest, MarlinInst);
-    impl_marlin_test!(SonicPCTest, MarlinSonicInst);
+    impl_marlin_test!(MarlinPCTest, MarlinInst, MarlinTestnet1Mode);
+    impl_marlin_test!(SonicPCTest, MarlinSonicInst, MarlinTestnet1Mode);
+    impl_marlin_test!(SonicPCPoswTest, MarlinSonicPoswInst, MarlinPoswMode);
 
     #[test]
     fn prove_and_verify_with_tall_matrix_big() {
@@ -140,6 +143,7 @@ mod marlin {
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
         SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -149,6 +153,7 @@ mod marlin {
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
         SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -158,6 +163,7 @@ mod marlin {
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
         SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -167,6 +173,7 @@ mod marlin {
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
         SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables);
     }
 
     #[test]
@@ -176,6 +183,7 @@ mod marlin {
 
         MarlinPCTest::test_circuit(num_constraints, num_variables);
         SonicPCTest::test_circuit(num_constraints, num_variables);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables);
     }
 }
 

--- a/marlin/tests/test_verifier_constraints_on_groth16.rs
+++ b/marlin/tests/test_verifier_constraints_on_groth16.rs
@@ -250,7 +250,7 @@ impl ConstraintSynthesizer<Fr> for MulSquareCircuit {
 
 #[derive(Clone, Debug)]
 struct RecursiveCircuit {
-    pub vk: Option<CircuitVerifyingKey<Fr, Fq, PC>>,
+    pub vk: Option<CircuitVerifyingKey<Fr, Fq, PC, MarlinRecursiveMode>>,
     pub input: Option<Vec<Fr>>,
     pub proof: Option<Proof<Fr, Fq, PC>>,
 }
@@ -305,7 +305,7 @@ impl ConstraintSynthesizer<Fq> for RecursiveCircuit {
                     .collect()
             })
             .ok_or(SynthesisError::AssignmentMissing)?;
-        MarlinVerificationGadget::<Fr, Fq, PC, PCGadget>::verify::<_, FS, FSG>(
+        MarlinVerificationGadget::<Fr, Fq, PC, PCGadget, MarlinRecursiveMode>::verify::<_, FS, FSG>(
             cs.ns(|| "marlin_verification"),
             &vk,
             &input,
@@ -329,7 +329,7 @@ type MarlinInst = MarlinCore<Fr, Fq, PC, FS, MarlinRecursiveMode>;
 #[test]
 fn verifier_on_groth16() {
     let rng = &mut test_rng();
-    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr>::max_degree(10000, 25, 10000).unwrap();
+    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(10000, 25, 10000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     let (vk1, input1, proof1) = {

--- a/parameters/examples/setup.rs
+++ b/parameters/examples/setup.rs
@@ -28,7 +28,7 @@ use snarkvm_dpc::{
     ProgramPublicVariables,
     SynthesizedCircuit,
 };
-use snarkvm_marlin::ahp::AHPForR1CS;
+use snarkvm_marlin::{ahp::AHPForR1CS, marlin::MarlinTestnet1Mode};
 use snarkvm_utilities::{FromBytes, ToBytes, ToMinimalBits};
 
 use anyhow::Result;
@@ -77,7 +77,9 @@ pub fn universal_setup<N: Network>() -> Result<()> {
     const UNIVERSAL_METADATA: &str = "universal.metadata";
     const UNIVERSAL_SRS: &str = "universal.srs";
 
-    let max_degree = AHPForR1CS::<<N as Network>::InnerScalarField>::max_degree(2000000, 4000000, 8000000).unwrap();
+    let max_degree =
+        AHPForR1CS::<<N as Network>::InnerScalarField, MarlinTestnet1Mode>::max_degree(2000000, 4000000, 8000000)
+            .unwrap();
     let universal_srs = <<N as Network>::ProgramSNARK as SNARK>::universal_setup(&max_degree, &mut thread_rng())?;
     let universal_srs = universal_srs.to_bytes_le()?;
 
@@ -232,7 +234,8 @@ pub fn posw_setup<N: Network>() -> Result<()> {
     const POSW_VERIFYING_KEY: &str = "posw.verifying";
 
     // TODO: decide the size of the universal setup
-    let max_degree = AHPForR1CS::<<N as Network>::InnerScalarField>::max_degree(40000, 40000, 60000).unwrap();
+    let max_degree =
+        AHPForR1CS::<<N as Network>::InnerScalarField, MarlinTestnet1Mode>::max_degree(40000, 40000, 60000).unwrap();
     let universal_srs = <<N as Network>::PoSWSNARK as SNARK>::universal_setup(&max_degree, &mut thread_rng())?;
     let srs_bytes = universal_srs.to_bytes_le()?;
     println!("srs\n\tsize - {}", srs_bytes.len());

--- a/polycommit/src/data_structures.rs
+++ b/polycommit/src/data_structures.rs
@@ -76,7 +76,7 @@ pub trait PCCommitment: CanonicalDeserialize + CanonicalSerialize + Clone + Debu
 
 /// Defines the minimal interface of commitment randomness for any polynomial
 /// commitment scheme.
-pub trait PCRandomness: CanonicalSerialize + CanonicalDeserialize + Clone {
+pub trait PCRandomness: CanonicalSerialize + CanonicalDeserialize + Clone + Eq {
     /// Outputs empty randomness that does not hide the commitment.
     fn empty() -> Self;
 
@@ -89,7 +89,15 @@ pub trait PCRandomness: CanonicalSerialize + CanonicalDeserialize + Clone {
 
 /// Defines the minimal interface of evaluation proofs for any polynomial
 /// commitment scheme.
-pub trait PCProof: CanonicalSerialize + CanonicalDeserialize + Clone + ToBytes {}
+pub trait PCProof: CanonicalSerialize + CanonicalDeserialize + Clone + ToBytes {
+    fn is_hiding(&self) -> bool;
+}
+
+impl<P: PCProof> PCProof for Vec<P> {
+    fn is_hiding(&self) -> bool {
+        self.iter().any(|p| p.is_hiding())
+    }
+}
 
 /// A polynomial along with information about its degree bound (if any), and the
 /// maximum number of queries that will be made to it. This latter number determines

--- a/polycommit/src/kzg10/data_structures.rs
+++ b/polycommit/src/kzg10/data_structures.rs
@@ -480,4 +480,8 @@ pub struct Proof<E: PairingEngine> {
 }
 impl_bytes!(Proof);
 
-impl<E: PairingEngine> PCProof for Proof<E> {}
+impl<E: PairingEngine> PCProof for Proof<E> {
+    fn is_hiding(&self) -> bool {
+        self.random_v.is_some()
+    }
+}

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -139,6 +139,12 @@ pub struct BatchLCProof<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<
     pub evaluations: Option<Vec<F>>,
 }
 
+impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> PCProof for BatchLCProof<F, CF, PC> {
+    fn is_hiding(&self) -> bool {
+        self.proof.is_hiding()
+    }
+}
+
 impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>> FromBytes for BatchLCProof<F, CF, PC> {
     fn read_le<R: Read>(mut reader: R) -> io::Result<Self> {
         CanonicalDeserialize::deserialize(&mut reader).map_err(|_| error_fn("could not deserialize struct"))
@@ -187,6 +193,7 @@ pub trait PolynomialCommitment<F: PrimeField, CF: PrimeField>: Sized + Clone + D
     type BatchProof: CanonicalSerialize
         + CanonicalDeserialize
         + Clone
+        + PCProof
         + From<Vec<Self::Proof>>
         + Into<Vec<Self::Proof>>
         + PartialEq


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Adds a flag to make Marlin proofs optionally non-zero-knowledge.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

(Link your related PRs here)
