### PR TITLE
Implements an exponential difficulty target algorithm

### DIFF
--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -527,7 +527,7 @@ impl<N: Network> Blocks<N> {
             // Calculate the new difficulty.
             // Shift the target to multiply by 2^(integer) / RADIX.
             let shifts = integral - RBITS as i128;
-            let candidate_difficulty_target = if shifts < 0 {
+            let mut candidate_difficulty_target = if shifts < 0 {
                 match candidate_difficulty_target.checked_shr((-shifts) as u32) {
                     Some(target) => core::cmp::max(target, 1),
                     None => 1,
@@ -538,6 +538,9 @@ impl<N: Network> Blocks<N> {
                     None => u64::MAX as u128,
                 }
             };
+
+            // Cap the difficulty target at `u64::MAX` if it has overflowed.
+            candidate_difficulty_target = core::cmp::min(candidate_difficulty_target, u64::MAX as u128);
 
             // Cast the new difficulty target down from a u128 to a u64.
             // Ensure that the leading 64 bits are zeros.

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -633,7 +633,7 @@ mod tests {
                     block_time_elapsed,
                     Testnet2::ALEO_BLOCK_TIME_IN_SECS
                 );
-                // If the block was found slower than expected, the difficulty should decrease.
+                // If the block was found within the expected time, the difficulty should stay unchanged.
                 assert_eq!(new_target, anchor_difficulty_target as u128);
             } else if block_time_elapsed > Testnet2::ALEO_BLOCK_TIME_IN_SECS {
                 println!(

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -481,16 +481,19 @@ impl<N: Network> Blocks<N> {
             assert_eq!(anchor_difficulty_target.checked_shr(64), Some(0));
 
             // Determine the block time elapsed (in seconds) since the anchor block.
+            // Note: This operation includes a safety check for a repeat timestamp.
             let block_time_elapsed = core::cmp::max(block_timestamp.saturating_sub(anchor_timestamp), 1);
 
             // Determine the number of blocks since the anchor.
+            // Note: This operation includes a safety check for a repeat block height.
             let number_of_blocks_elapsed = core::cmp::max(block_height.saturating_sub(anchor_block_height), 1);
 
             // Determine the expected block time elapsed (in seconds) since the anchor block.
             let expected_block_time_elapsed = target_block_time.saturating_mul(number_of_blocks_elapsed as i64);
 
             // Determine the difference in block time elapsed (in seconds).
-            let difference_in_block_time_elapsed = block_time_elapsed.saturating_sub(expected_block_time_elapsed);
+            // Note: This operation must be *standard subtraction* to account for faster blocks.
+            let difference_in_block_time_elapsed = block_time_elapsed - expected_block_time_elapsed;
 
             // Compute the exponent factor.
             let exponent = RADIX.saturating_mul(difference_in_block_time_elapsed) / TAU;

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -737,7 +737,7 @@ mod tests {
 
             // Simulate a random block time.
             let simulated_block_time = rng.gen_range(1..Testnet2::ALEO_BLOCK_TIME_IN_SECS + 100);
-            let simulated_block_height = anchor_block_height + 1;
+            let simulated_block_height = anchor_block_height.saturating_add(rng.gen_range(1..10_000_u32));
 
             let expected_time_elapsed =
                 (simulated_block_height - anchor_block_height) as i64 * Testnet2::ALEO_BLOCK_TIME_IN_SECS;

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -484,7 +484,7 @@ impl<N: Network> Blocks<N> {
             let block_time_elapsed = core::cmp::max(block_timestamp.saturating_sub(anchor_timestamp), 1);
 
             // Determine the number of blocks since the anchor.
-            let number_of_blocks_elapsed = block_height.saturating_sub(anchor_block_height);
+            let number_of_blocks_elapsed = core::cmp::max(block_height.saturating_sub(anchor_block_height), 1);
 
             // Determine the expected block time elapsed (in seconds) since the anchor block.
             let expected_block_time_elapsed = target_block_time.saturating_mul(number_of_blocks_elapsed as i64);

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -403,159 +403,144 @@ impl<N: Network> Blocks<N> {
     }
 
     /// Returns the expected difficulty target given the previous block and expected next block details.
-    pub fn compute_difficulty_target(previous_timestamp: i64, previous_difficulty_target: u64, timestamp: i64) -> u64 {
-        const NUM_BLOCKS_PER_RETARGET: i64 = 1i64;
-
-        /// Bitcoin difficulty retarget algorithm.
-        ///     T_{i+1} = T_i * (S / (M * B)).
-        ///     M = Number of blocks per retarget.
-        ///     B = Expected time per block.
-        ///     S = Time elapsed between the last M blocks.
-        fn bitcoin_retarget(
-            previous_timestamp: i64,
-            previous_difficulty: u64,
-            block_timestamp: i64,
-            target_block_time: i64,
-        ) -> u64 {
-            let time_elapsed = block_timestamp.saturating_sub(previous_timestamp);
-            let time_elapsed = match time_elapsed > 0 {
-                true => time_elapsed,
-                false => 1,
-            };
-
-            let difficulty_factor = time_elapsed as f64 / (NUM_BLOCKS_PER_RETARGET * target_block_time) as f64;
-
-            let new_difficulty = (previous_difficulty as f64) * difficulty_factor;
-
-            match new_difficulty.is_finite() {
-                true => new_difficulty as u64,
-                false => u64::MAX,
-            }
-        }
-
-        bitcoin_retarget(
+    pub fn compute_difficulty_target(
+        previous_timestamp: i64,
+        previous_difficulty_target: u64,
+        block_timestamp: i64,
+    ) -> u64 {
+        Self::bitcoin_retarget(
             previous_timestamp,
             previous_difficulty_target,
-            timestamp,
+            block_timestamp,
             N::ALEO_BLOCK_TIME_IN_SECS,
         )
     }
 
-    // TODO (raychu86): THIS IS A WIP.
-    /// Returns the expected difficulty target under an EMA given the anchor block and expected next block details.
-    pub fn compute_asert_difficulty_target(
+    /// Bitcoin difficulty retarget algorithm.
+    ///     T_{i+1} = T_i * (S / (M * B)).
+    ///     M = Number of blocks per retarget.
+    ///     B = Expected time per block.
+    ///     S = Time elapsed between the last M blocks.
+    fn bitcoin_retarget(
+        previous_timestamp: i64,
+        previous_difficulty: u64,
+        block_timestamp: i64,
+        target_block_time: i64,
+    ) -> u64 {
+        const NUM_BLOCKS_PER_RETARGET: i64 = 1i64;
+
+        let time_elapsed = block_timestamp.saturating_sub(previous_timestamp);
+        let time_elapsed = match time_elapsed > 0 {
+            true => time_elapsed,
+            false => 1,
+        };
+
+        let difficulty_factor = time_elapsed as f64 / (NUM_BLOCKS_PER_RETARGET * target_block_time) as f64;
+
+        let new_difficulty = (previous_difficulty as f64) * difficulty_factor;
+
+        match new_difficulty.is_finite() {
+            true => new_difficulty as u64,
+            false => u64::MAX,
+        }
+    }
+
+    /// ASERT difficulty retarget algorithm based on https://www.reference.cash/protocol/forks/2020-11-15-asert.
+    ///     T_{i+1} = T_anchor * 2^((S - B * N) / tau).
+    ///     T_anchor = Anchor target of a specific block height
+    ///     B = Expected time per block.
+    ///     S = Time elapsed since the anchor.
+    ///     N = Number of blocks since the anchor.
+    ///     tau = The halflife of the algorithm. For every `tau` seconds ahead of
+    ///           schedule a block’s timestamp becomes, the difficulty doubles.
+    /// To avoid use of floating points, we use fixed-point arithmetic.
+    fn asert_retarget(
         anchor_timestamp: i64,
         anchor_difficulty_target: u64,
         anchor_block_height: u32,
         block_timestamp: i64,
         block_height: u32,
+        target_block_time: i64,
     ) -> u64 {
-        /// ASERT difficulty retarget algorithm based on https://www.reference.cash/protocol/forks/2020-11-15-asert.
-        ///     T_{i+1} = T_anchor * 2^((S - B * N) / tau).
-        ///     T_anchor = Anchor target of a specific block height
-        ///     B = Expected time per block.
-        ///     S = Time elapsed since the anchor.
-        ///     N = Number of blocks since the anchor.
-        ///     tau = The halflife of the algorithm. For every `tau` seconds ahead of
-        ///           schedule a block’s timestamp becomes, the difficulty doubles.
-        /// To avoid use of floating points, we use fixed-point arithmetic.
-        fn asert_retarget(
-            anchor_timestamp: i64,
-            anchor_difficulty_target: u64,
-            anchor_block_height: u32,
-            block_timestamp: i64,
-            block_height: u32,
-            target_block_time: i64,
-        ) -> u64 {
-            // Ensure that arithmetic shift is supported.
-            assert_eq!(-1_i64 >> 1, -1_i64);
+        // Ensure that arithmetic shift is supported.
+        assert_eq!(-1_i64 >> 1, -1_i64);
 
-            // Compute the difference in block time elapsed, defined as:
-            // (block_timestamp - anchor_timestamp) - target_block_time * number_of_blocks_elapsed.
-            let drift = {
-                // Determine the block time elapsed (in seconds) since the anchor block.
-                // Note: This operation includes a safety check for a repeat timestamp.
-                let block_time_elapsed = core::cmp::max(block_timestamp.saturating_sub(anchor_timestamp), 1);
+        // Compute the difference in block time elapsed, defined as:
+        // (block_timestamp - anchor_timestamp) - target_block_time * number_of_blocks_elapsed.
+        let drift = {
+            // Determine the block time elapsed (in seconds) since the anchor block.
+            // Note: This operation includes a safety check for a repeat timestamp.
+            let block_time_elapsed = core::cmp::max(block_timestamp.saturating_sub(anchor_timestamp), 1);
 
-                // Determine the number of blocks since the anchor.
-                // Note: This operation includes a safety check for a repeat block height.
-                let number_of_blocks_elapsed = core::cmp::max(block_height.saturating_sub(anchor_block_height), 1);
+            // Determine the number of blocks since the anchor.
+            // Note: This operation includes a safety check for a repeat block height.
+            let number_of_blocks_elapsed = core::cmp::max(block_height.saturating_sub(anchor_block_height), 1);
 
-                // Determine the expected block time elapsed (in seconds) since the anchor block.
-                let expected_block_time_elapsed = target_block_time.saturating_mul(number_of_blocks_elapsed as i64);
+            // Determine the expected block time elapsed (in seconds) since the anchor block.
+            let expected_block_time_elapsed = target_block_time.saturating_mul(number_of_blocks_elapsed as i64);
 
-                // Determine the difference in block time elapsed (in seconds).
-                // Note: This operation must be *standard subtraction* to account for faster blocks.
-                block_time_elapsed - expected_block_time_elapsed
-            };
+            // Determine the difference in block time elapsed (in seconds).
+            // Note: This operation must be *standard subtraction* to account for faster blocks.
+            block_time_elapsed - expected_block_time_elapsed
+        };
 
-            // Constants used for fixed point arithmetic.
-            const RBITS: u32 = 16;
-            const RADIX: u128 = 1 << RBITS;
+        // Constants used for fixed point arithmetic.
+        const RBITS: u32 = 16;
+        const RADIX: u128 = 1 << RBITS;
 
-            // The half life for the expected duration in doubling the difficulty target.
-            const TAU: u128 = 43_200; // 43,200 seconds = 12 hours
+        // The half life for the expected duration in doubling the difficulty target.
+        const TAU: u128 = 43_200; // 43,200 seconds = 12 hours
 
-            // Compute the exponent factor, and decompose it into integral & fractional parts for fixed point arithmetic.
-            let (integral, fractional) = {
-                // Calculate the exponent factor.
-                let exponent = (RADIX as i128).saturating_mul(drift as i128) / (TAU as i128);
+        // Compute the exponent factor, and decompose it into integral & fractional parts for fixed point arithmetic.
+        let (integral, fractional) = {
+            // Calculate the exponent factor.
+            let exponent = (RADIX as i128).saturating_mul(drift as i128) / (TAU as i128);
 
-                // Decompose into the integral and fractional parts.
-                let integral = exponent >> RBITS;
-                let fractional = (exponent - (integral << RBITS)) as u128;
-                assert!(fractional < RADIX, "Ensure fractional part is within fixed point size");
-                assert_eq!(exponent, integral * (RADIX as i128) + fractional as i128);
+            // Decompose into the integral and fractional parts.
+            let integral = exponent >> RBITS;
+            let fractional = (exponent - (integral << RBITS)) as u128;
+            assert!(fractional < RADIX, "Ensure fractional part is within fixed point size");
+            assert_eq!(exponent, integral * (RADIX as i128) + fractional as i128);
 
-                (integral, fractional)
-            };
+            (integral, fractional)
+        };
 
-            // Approximate the fractional multiplier as 2^RBITS * 2^fractional, where:
-            // 2^x ~= (1 + 0.695502049*x + 0.2262698*x**2 + 0.0782318*x**3)
-            let fractional_multiplier = RADIX
-                + ((195_766_423_245_049_u128 * fractional
-                    + 971_821_376_u128 * fractional.pow(2)
-                    + 5_127_u128 * fractional.pow(3)
-                    + 2_u128.pow(RBITS * 3 - 1))
-                    >> (RBITS * 3));
+        // Approximate the fractional multiplier as 2^RBITS * 2^fractional, where:
+        // 2^x ~= (1 + 0.695502049*x + 0.2262698*x**2 + 0.0782318*x**3)
+        let fractional_multiplier = RADIX
+            + ((195_766_423_245_049_u128 * fractional
+                + 971_821_376_u128 * fractional.pow(2)
+                + 5_127_u128 * fractional.pow(3)
+                + 2_u128.pow(RBITS * 3 - 1))
+                >> (RBITS * 3));
 
-            // Cast the anchor difficulty target from a u64 to a u128.
-            // The difficulty target must allow for leading zeros to account for overflows;
-            // an additional 64-bits for the leading zeros suffices.
-            let candidate_difficulty_target = (anchor_difficulty_target as u128).saturating_mul(fractional_multiplier);
+        // Cast the anchor difficulty target from a u64 to a u128.
+        // The difficulty target must allow for leading zeros to account for overflows;
+        // an additional 64-bits for the leading zeros suffices.
+        let candidate_difficulty_target = (anchor_difficulty_target as u128).saturating_mul(fractional_multiplier);
 
-            // Calculate the new difficulty.
-            // Shift the target to multiply by 2^(integer) / RADIX.
-            let shifts = integral - RBITS as i128;
-            let mut candidate_difficulty_target = if shifts < 0 {
-                match candidate_difficulty_target.checked_shr((-shifts) as u32) {
-                    Some(target) => core::cmp::max(target, 1),
-                    None => 1,
-                }
-            } else {
-                match candidate_difficulty_target.checked_shl(shifts as u32) {
-                    Some(target) => core::cmp::max(target, 1),
-                    None => u64::MAX as u128,
-                }
-            };
+        // Calculate the new difficulty.
+        // Shift the target to multiply by 2^(integer) / RADIX.
+        let shifts = integral - RBITS as i128;
+        let mut candidate_difficulty_target = if shifts < 0 {
+            match candidate_difficulty_target.checked_shr((-shifts) as u32) {
+                Some(target) => core::cmp::max(target, 1),
+                None => 1,
+            }
+        } else {
+            match candidate_difficulty_target.checked_shl(shifts as u32) {
+                Some(target) => core::cmp::max(target, 1),
+                None => u64::MAX as u128,
+            }
+        };
 
-            // Cap the difficulty target at `u64::MAX` if it has overflowed.
-            candidate_difficulty_target = core::cmp::min(candidate_difficulty_target, u64::MAX as u128);
+        // Cap the difficulty target at `u64::MAX` if it has overflowed.
+        candidate_difficulty_target = core::cmp::min(candidate_difficulty_target, u64::MAX as u128);
 
-            // Cast the new difficulty target down from a u128 to a u64.
-            // Ensure that the leading 64 bits are zeros.
-            assert_eq!(candidate_difficulty_target.checked_shr(64), Some(0));
-            candidate_difficulty_target as u64
-        }
-
-        asert_retarget(
-            anchor_timestamp,
-            anchor_difficulty_target,
-            anchor_block_height,
-            block_timestamp,
-            block_height,
-            N::ALEO_BLOCK_TIME_IN_SECS,
-        )
+        // Cast the new difficulty target down from a u128 to a u64.
+        // Ensure that the leading 64 bits are zeros.
+        assert_eq!(candidate_difficulty_target.checked_shr(64), Some(0));
+        candidate_difficulty_target as u64
     }
 }
 
@@ -567,7 +552,7 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     #[test]
-    fn test_retargeting_algorithm_increased() {
+    fn test_bitcoin_difficulty_target() {
         let rng = &mut thread_rng();
 
         let mut block_difficulty_target = u64::MAX;
@@ -599,7 +584,7 @@ mod tests {
     }
 
     #[test]
-    fn test_asert_retargeting_algorithm_simple() {
+    fn test_asert_difficulty_target_simple() {
         let anchor_timestamp = 1640179531i64;
         let anchor_block_height = 72154u32;
         let anchor_difficulty_target = 101336179232188u64;
@@ -617,12 +602,13 @@ mod tests {
                 (simulated_block_height - anchor_block_height) as i64 * Testnet2::ALEO_BLOCK_TIME_IN_SECS;
             let simulated_time_elapsed = (simulated_block_height - anchor_block_height) as i64 * simulated_block_time;
             let simulated_timestamp = anchor_timestamp.saturating_add(simulated_time_elapsed);
-            let candidate_difficulty_target = Blocks::<Testnet2>::compute_asert_difficulty_target(
+            let candidate_difficulty_target = Blocks::<Testnet2>::asert_retarget(
                 anchor_timestamp,
                 anchor_difficulty_target,
                 anchor_block_height,
                 simulated_timestamp,
                 simulated_block_height,
+                Testnet2::ALEO_BLOCK_TIME_IN_SECS,
             );
 
             println!(
@@ -657,12 +643,12 @@ mod tests {
     }
 
     #[test]
-    fn test_asert_retargeting_algorithm_anchored() {
+    fn test_asert_difficulty_target_anchored() {
         let anchor_timestamp = 1640179531i64;
         let anchor_block_height = 72154u32;
         let anchor_difficulty_target = 101336179232188u64;
 
-        for num_blocks_since_anchor in 1..1_000_000 {
+        for num_blocks_since_anchor in 1..500_000 {
             //
             // Simulate block times from T-10 to T+10 seconds,
             // where T := anchor_timestamp + ALEO_BLOCK_TIME_IN_SECS.
@@ -677,12 +663,13 @@ mod tests {
                 let simulated_time_elapsed =
                     (simulated_block_height - anchor_block_height) as i64 * simulated_block_time;
                 let simulated_timestamp = anchor_timestamp.saturating_add(simulated_time_elapsed);
-                let candidate_difficulty_target = Blocks::<Testnet2>::compute_asert_difficulty_target(
+                let candidate_difficulty_target = Blocks::<Testnet2>::asert_retarget(
                     anchor_timestamp,
                     anchor_difficulty_target,
                     anchor_block_height,
                     simulated_timestamp,
                     simulated_block_height,
+                    Testnet2::ALEO_BLOCK_TIME_IN_SECS,
                 );
 
                 println!(

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -585,8 +585,8 @@ mod tests {
     #[test]
     fn test_asert_retargeting_algorithm_simple() {
         let anchor_timestamp = 1640179531i64;
-        let anchor_block_height = 72154;
-        let anchor_difficulty_target = 101336179232188;
+        let anchor_block_height = 72154u32;
+        let anchor_difficulty_target = 101336179232188u64;
 
         //
         // Simulate block times from T-10 to T+10 seconds,


### PR DESCRIPTION
## Motivation

Implements an exponential difficulty target algorithm.

This PR implements the ASERT difficulty retarget algorithm based on https://www.reference.cash/protocol/forks/2020-11-15-asert.
```
 T_{i+1} = T_anchor * 2^((S - B * N) / tau)
```
where:
```
 T_anchor = Anchor target of a specific block height
 B = Expected time per block.
 S = Time elapsed since the anchor.
 N = Number of blocks since the anchor.
 tau = The half life of the algorithm. For every `tau` seconds ahead of
       schedule a block’s timestamp becomes, the difficulty doubles.
```

To avoid use of floating points, we use fixed-point arithmetic.

## Test Plan

Adds tests for algorithm based on the previous block and anchored block cases.