### PR TITLE
Additional cuda error handling

### DIFF
--- a/algorithms/src/msm/variable_base/cuda.rs
+++ b/algorithms/src/msm/variable_base/cuda.rs
@@ -191,6 +191,7 @@ fn initialize_cuda_request_handler(input: crossbeam_channel::Receiver<CudaReques
                 program,
             };
 
+            // Handle each cuda request received from the channel.
             while let Ok(request) = input.recv() {
                 let out = handle_cuda_request(&mut context, &request);
 
@@ -198,10 +199,9 @@ fn initialize_cuda_request_handler(input: crossbeam_channel::Receiver<CudaReques
             }
         }
         Err(err) => {
-            eprintln!("Error loading cuda program: {:?}", err);
-            // Always return an error
-            while let Ok(request) = input.recv() {
-                request.response.send(Err(GPUError::DeviceNotFound)).ok();
+            // If the cuda program fails to load, notify the cuda request dispatcher.
+            if let Ok(request) = input.recv() {
+                request.response.send(Err(err)).ok();
             }
         }
     }

--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -56,7 +56,7 @@ impl VariableBaseMSM {
                         Ok(x) => return x,
                         Err(e) => {
                             HAS_CUDA_FAILED.store(true, Ordering::SeqCst);
-                            eprintln!("CUDA failed, moving to next msm method: {:?}", e);
+                            eprintln!("CUDA failed {:?}, moving to next msm method.", e);
                         }
                     }
                 }

--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -56,7 +56,7 @@ impl VariableBaseMSM {
                         Ok(x) => return x,
                         Err(e) => {
                             HAS_CUDA_FAILED.store(true, Ordering::SeqCst);
-                            eprintln!("CUDA failed {:?}, moving to next msm method.", e);
+                            eprintln!("CUDA failed, moving to next msm method. Error: {:?}", e);
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes an issue where failing CUDA compatibility would cause threads to panic and mining to hang. Now, the implementation will default to the native MSM implementation when CUDA fails.