### PR TITLE
curves: add documentation directory for vendoring

### DIFF
--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [
   "zero-knowledge"
 ]
 categories = [ "cryptography::cryptocurrencies", "operating-systems" ]
-include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
+include = [ "Cargo.toml", "src", "README.md", "LICENSE.md", "documentation/" ]
 license = "GPL-3.0"
 edition = "2018"
 


### PR DESCRIPTION
## Motivation

Currently trying to vendor the snarkvm-curves crate will result in the following error

```
error: couldn't read /private/tmp/nix-build-snarkos-unstable-2021-01-14.drv-0/snarkos-unstable-2021-01-14-
vendor.tar.gz/snarkvm-curves/src/../documentation/the_aleo_curves/00_overview.md: No such file or director
y (os error 2)
  --> /private/tmp/nix-build-snarkos-unstable-2021-01-14.drv-0/snarkos-unstable-2021-01-14-vendor.tar.gz/s
narkvm-curves/src/lib.rs:22:10
   |
22 | #![doc = include_str!("../documentation/the_aleo_curves/00_overview.md")]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrac
e for more info)
```

this adds the documentation directory in the include of the cargo file

Just to give a bit of context, I'm trying to add snarkOS to the nixos distribution to make it easy to run it and share configurations.

closes https://github.com/AleoHQ/snarkVM/issues/587

(just as a heads up, I'll try go post about issues I run into as I go along adding snarkOS to nixos. Thank you again for making the software!)

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

(Link your related PRs here)
