### PR TITLE
Use physical number of threads for FFT parallelization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
+ "num_cpus",
  "once_cell",
  "rand",
  "rand_chacha",

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -141,6 +141,10 @@ optional = true
 features = [ "js" ]
 default-features = false
 
+[dependencies.num_cpus]
+version = "1"
+optional = true
+
 [dependencies.rand_chacha]
 version = "0.3"
 default-features = false
@@ -240,6 +244,6 @@ msm = [ ]
 prf = [ ]
 signature = [ "encryption", "crypto_hash" ]
 snark = [ "fft", "msm" ]
-parallel = [ ]
+parallel = [ "num_cpus" ]
 print-trace = [ "snarkvm-profiler/print-trace" ]
 cuda = [ "rust-gpu-tools" ]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Changes the new FFT implementation to use the physical number of threads, instead of logical threads.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

(Link your related PRs here)
