### PR TITLE
Sanity check view key prior to decryption into plaintext

### DIFF
--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -65,7 +65,7 @@ fn dpc_testnet1_integration_test() {
         // Check that coinbase record can be decrypted from the transaction.
         let encrypted_record = coinbase_transaction.ciphertexts().next().unwrap();
         let view_key = ViewKey::from_private_key(recipient.private_key());
-        let decrypted_record = Record::from_account_view_key(&view_key, encrypted_record).unwrap();
+        let decrypted_record = Record::decrypt(&view_key.into(), encrypted_record).unwrap();
         assert_eq!(decrypted_record.owner(), recipient.address());
         assert_eq!(decrypted_record.value(), Block::<Testnet1>::block_reward(1));
     }

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -65,7 +65,7 @@ fn dpc_testnet2_integration_test() {
         // Check that coinbase record can be decrypted from the transaction.
         let encrypted_record = coinbase_transaction.ciphertexts().next().unwrap();
         let view_key = ViewKey::from_private_key(recipient.private_key());
-        let decrypted_record = Record::from_account_view_key(&view_key, encrypted_record).unwrap();
+        let decrypted_record = Record::decrypt(&view_key.into(), encrypted_record).unwrap();
         assert_eq!(decrypted_record.owner(), recipient.address());
         assert_eq!(decrypted_record.value(), Block::<Testnet2>::block_reward(1));
     }

--- a/dpc/src/record/decryption_key.rs
+++ b/dpc/src/record/decryption_key.rs
@@ -34,9 +34,15 @@ impl<N: Network> DecryptionKey<N> {
     }
 }
 
+impl<N: Network> From<ViewKey<N>> for DecryptionKey<N> {
+    fn from(account_view_key: ViewKey<N>) -> Self {
+        Self::AccountViewKey(account_view_key)
+    }
+}
+
 impl<N: Network> From<&ViewKey<N>> for DecryptionKey<N> {
     fn from(account_view_key: &ViewKey<N>) -> Self {
-        Self::AccountViewKey(account_view_key.clone())
+        Self::from(account_view_key.clone())
     }
 }
 

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -14,18 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    Address,
-    AleoAmount,
-    Bech32Locator,
-    Ciphertext,
-    ComputeKey,
-    DecryptionKey,
-    Network,
-    Payload,
-    RecordError,
-    ViewKey,
-};
+use crate::{Address, AleoAmount, Bech32Locator, Ciphertext, ComputeKey, DecryptionKey, Network, Payload, RecordError};
 use snarkvm_algorithms::traits::{EncryptionScheme, PRF};
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{to_bytes_le, FromBits, FromBytes, FromBytesDeserializer, ToBits, ToBytes, ToBytesSerializer};
@@ -122,53 +111,8 @@ impl<N: Network> Record<N> {
 
     /// Returns a record from the given decryption key and ciphertext.
     pub fn decrypt(decryption_key: &DecryptionKey<N>, ciphertext: &N::RecordCiphertext) -> Result<Self, RecordError> {
-        match decryption_key {
-            DecryptionKey::AccountViewKey(account_view_key) => {
-                Self::from_account_view_key(account_view_key, ciphertext)
-            }
-            DecryptionKey::RecordViewKey(record_view_key) => Self::from_record_view_key(record_view_key, ciphertext),
-        }
-    }
-
-    /// Returns a record from the given account view key and ciphertext.
-    pub fn from_account_view_key(
-        account_view_key: &ViewKey<N>,
-        ciphertext: &N::RecordCiphertext,
-    ) -> Result<Self, RecordError> {
-        // Compute the record view key.
-        let record_view_key = match N::account_encryption_scheme()
-            .generate_symmetric_key(&*account_view_key, *ciphertext.deref().randomizer())
-        {
-            Some(record_view_key) => record_view_key.into(),
-            None => return Err(anyhow!("Failed to compute record view key due to malformed account view key").into()),
-        };
-
         // Decrypt the record ciphertext.
-        let plaintext = ciphertext.deref().to_plaintext(&record_view_key)?;
-        let (owner, value, payload, program_id) = Self::decode_plaintext(&plaintext)?;
-
-        // Ensure the record owner matches.
-        let expected_owner = Address::from_view_key(account_view_key);
-        match owner == expected_owner {
-            true => Ok(Self {
-                owner,
-                value,
-                payload,
-                program_id,
-                record_view_key,
-                ciphertext: ciphertext.clone(),
-            }),
-            false => Err(anyhow!("Decoded incorrect record owner from ciphertext").into()),
-        }
-    }
-
-    /// Returns a record from the given record view key and ciphertext.
-    pub fn from_record_view_key(
-        record_view_key: &N::RecordViewKey,
-        ciphertext: &N::RecordCiphertext,
-    ) -> Result<Self, RecordError> {
-        // Decrypt the record ciphertext.
-        let plaintext = ciphertext.deref().to_plaintext(record_view_key)?;
+        let (plaintext, record_view_key) = (*ciphertext).to_plaintext(decryption_key)?;
         let (owner, value, payload, program_id) = Self::decode_plaintext(&plaintext)?;
 
         Ok(Self {
@@ -176,7 +120,7 @@ impl<N: Network> Record<N> {
             value,
             payload,
             program_id,
-            record_view_key: record_view_key.clone(),
+            record_view_key,
             ciphertext: ciphertext.clone(),
         })
     }
@@ -265,6 +209,12 @@ impl<N: Network> Record<N> {
             program_id  // 384 bits = 48 bytes
         ]?;
 
+        assert_eq!(
+            1 + N::ADDRESS_SIZE_IN_BYTES + 8 + N::RECORD_PAYLOAD_SIZE_IN_BYTES + N::ProgramID::data_size_in_bytes(),
+            plaintext.len(),
+            "Update me if the plaintext design changes."
+        );
+
         // Ensure the record bytes are within the permitted size.
         match plaintext.len() <= u16::MAX as usize {
             true => Ok(plaintext),
@@ -276,7 +226,8 @@ impl<N: Network> Record<N> {
     fn decode_plaintext(plaintext: &[u8]) -> Result<(Address<N>, AleoAmount, Payload<N>, N::ProgramID), RecordError> {
         assert_eq!(
             1 + N::ADDRESS_SIZE_IN_BYTES + 8 + N::RECORD_PAYLOAD_SIZE_IN_BYTES + N::ProgramID::data_size_in_bytes(),
-            plaintext.len()
+            plaintext.len(),
+            "Update me if the plaintext design changes."
         );
 
         // Decode the plaintext bytes.

--- a/dpc/src/record/tests.rs
+++ b/dpc/src/record/tests.rs
@@ -51,7 +51,7 @@ fn test_record_ciphertext() {
 
         // Decrypt the record.
         let account_view_key = ViewKey::from_private_key(account.private_key());
-        let candidate_record = Record::from_account_view_key(&account_view_key, record_ciphertext).unwrap();
+        let candidate_record = Record::decrypt(&account_view_key.into(), record_ciphertext).unwrap();
         assert_eq!(expected_record, candidate_record);
     }
 }

--- a/dpc/src/transition/transition.rs
+++ b/dpc/src/transition/transition.rs
@@ -219,7 +219,9 @@ impl<N: Network> Transition<N> {
             .iter()
             .filter_map(move |event| match event {
                 Event::RecordViewKey(i, record_view_key) => match ciphertexts.get(*i as usize) {
-                    Some(ciphertext) => Record::from_record_view_key(record_view_key, *ciphertext).ok(),
+                    Some(ciphertext) => {
+                        Record::decrypt(&DecryptionKey::from_record_view_key(record_view_key), *ciphertext).ok()
+                    }
                     None => None,
                 },
                 _ => None,


### PR DESCRIPTION
## Motivation

Sanity check view key prior to decryption into plaintext.

This PR removes `Record::from_account_view_key()` and `Record::from_record_view_key()` in place of `Record::decrypt()`. To switch over:
```rs
Record::from_account_view_key(&account_view_key, ciphertext)
-> Record::decrypt(&account_view_key.into(), ciphertext)
```
```rs
Record::from_record_view_key(&record_view_key, ciphertext)
-> Record::decrypt(&DecryptionKey::from_record_view_key(&record_view_key), ciphertext)
```