### PR TITLE
Add gencode flag for Ampere/RTX cards in blst_377_cuda

### DIFF
--- a/algorithms/src/msm/variable_base/blst_377_cuda/build.sh
+++ b/algorithms/src/msm/variable_base/blst_377_cuda/build.sh
@@ -10,7 +10,7 @@ nvcc ./msm.cu --device-debug -ptx -rdc=true -o ./msm.debug.ptx
 nvcc ./tests.cu --device-debug -ptx -rdc=true -o ./tests.debug.ptx
 
 # Build msm.fatbin
-nvcc ./asm_cuda.cu ./blst_377_ops.cu ./msm.cu -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_75,code=compute_75 -dlink -fatbin -o ./msm.fatbin
+nvcc ./asm_cuda.cu ./blst_377_ops.cu ./msm.cu -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_75,code=compute_75 -gencode=arch=compute_86,code=sm_86 -dlink -fatbin -o ./msm.fatbin
 
 # Build test.fatbin
-nvcc ./asm_cuda.cu ./blst_377_ops.cu ./tests.cu ./msm.cu -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_75,code=compute_75 --device-debug -dlink -fatbin -o ./test.fatbin
+nvcc ./asm_cuda.cu ./blst_377_ops.cu ./tests.cu ./msm.cu -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_75,code=compute_75 -gencode=arch=compute_86,code=sm_86 --device-debug -dlink -fatbin -o ./test.fatbin


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Due to missing gencode flag for newer cards, owners of such cards will have this error:

```
snarkos.sh: DEBUG Loaded CUDA devices: [Device { vendor: Nvidia, name: "NVIDIA RTX A4000", memory: 16900227072, pci_id: PciId(256), uuid: Some(288ac7cd-0ca8-5b10-cdb1-42ba3bbb6fe9), device: Device { device: 0 }, context: UnownedContext { inner: 0x7f3378125f60 } }]
snarkos.sh: DEBUG loaded devices: [Device { vendor: Nvidia, name: "NVIDIA RTX A4000", memory: 16900227072, pci_id: PciId(256), uuid: Some(288ac7cd-0ca8-5b10-cdb1-42ba3bbb6fe9), cuda: Some(Device { vendor: Nvidia, name: "NVIDIA RTX A4000", memory: 16900227072, pci_id: PciId(256), uuid: Some(288ac7cd-0ca8-5b10-cdb1-42ba3bbb6fe9), device: Device { device: 0 }, context: UnownedContext { inner: 0x7f3378125f60 } }), opencl: Some(Device { vendor: Nvidia, name: "NVIDIA RTX A4000", memory: 16900227072, pci_id: PciId(256), uuid: Some(288ac7cd-0ca8-5b10-cdb1-42ba3bbb6fe9), device: Device { id: 139859033435904 } }) }]
snarkos.sh: Using 'NVIDIA RTX A4000' as CUDA device with 16900227072 bytes of memory

snarkos.sh: thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Cuda(NoBinaryForGpu)', /home/ubuntu/.cargo/git/checkouts/snarkvm-f1160780ffe17de8/48c59e9/algorithms/src/msm/variable_base/cuda.rs:183:39
snarkos.sh: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After additional binary code generated, NVIDIA RTX A4000 works just fine.

**This requires nvcc from CUDA 11.1 or later.**

## Test Plan

After fix is merged, `build.sh` also must be run and new bincode has to be committed. To test the change, one should run bench on any Ampere/RTX GPU:

```bash
cd snarkVM/dpc
cargo bench --bench posw --features "snarkvm-algorithms/cuda"
```


## Notes

According to this [reference](https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/), this flag adds compatibility for the whole RTX set of cards, based on Ampere architecture: Tesla GA10x cards, RTX Ampere – RTX 3080, GA102 – RTX 3090, RTX A2000, A3000, A4000, A5000, A6000, NVIDIA A40, GA106 – RTX 3060, GA104 – RTX 3070, GA107 – RTX 3050, Quadro A10, Quadro A16, Quadro A40, A2 Tensor Core GPU