### PR TITLE
Use bitvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +746,12 @@ name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1464,6 +1482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +1917,7 @@ version = "0.7.5"
 dependencies = [
  "anyhow",
  "bincode",
+ "bitvec",
  "blake2",
  "blake2s_simd",
  "criterion",
@@ -1929,6 +1954,7 @@ name = "snarkvm-circuits"
 version = "0.7.5"
 dependencies = [
  "anyhow",
+ "bitvec",
  "blake2",
  "criterion",
  "derivative",
@@ -1958,6 +1984,7 @@ name = "snarkvm-curves"
 version = "0.7.5"
 dependencies = [
  "bincode",
+ "bitvec",
  "criterion",
  "derivative",
  "rand",
@@ -2018,6 +2045,7 @@ name = "snarkvm-fields"
 version = "0.7.5"
 dependencies = [
  "anyhow",
+ "bitvec",
  "derivative",
  "rand",
  "rayon",
@@ -2031,6 +2059,7 @@ name = "snarkvm-gadgets"
 version = "0.7.5"
 dependencies = [
  "anyhow",
+ "bitvec",
  "blake2",
  "criterion",
  "derivative",
@@ -2082,6 +2111,7 @@ name = "snarkvm-marlin"
 version = "0.7.5"
 dependencies = [
  "bincode",
+ "bitvec",
  "blake2",
  "criterion",
  "derivative",
@@ -2132,6 +2162,7 @@ dependencies = [
 name = "snarkvm-polycommit"
 version = "0.7.5"
 dependencies = [
+ "bitvec",
  "blake2",
  "derivative",
  "digest 0.9.0",
@@ -2179,6 +2210,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
+ "bitvec",
  "itertools",
  "num-bigint",
  "num_cpus",
@@ -2279,6 +2311,12 @@ dependencies = [
  "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2687,4 +2725,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
 ]

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -104,6 +104,11 @@ default-features = false
 [dependencies.anyhow]
 version = "1.0"
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.blake2]
 version = "0.9"
 optional = true

--- a/algorithms/src/crh/bhp.rs
+++ b/algorithms/src/crh/bhp.rs
@@ -88,9 +88,7 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH
     }
 
     fn hash_bits(&self, input: &BitSlice) -> Result<Self::Output, CRHError> {
-        let affine = self
-            .hash_bits_inner(input.iter().map(|bit| *bit), input.len())?
-            .into_affine();
+        let affine = self.hash_bits_inner(input.iter().by_vals(), input.len())?.into_affine();
         debug_assert!(affine.is_in_correct_subgroup_assuming_on_curve());
         Ok(affine.to_x_coordinate())
     }

--- a/algorithms/src/crh/pedersen.rs
+++ b/algorithms/src/crh/pedersen.rs
@@ -19,6 +19,7 @@ use snarkvm_curves::{AffineCurve, ProjectiveCurve};
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
+use bitvec::prelude::*;
 use std::{
     borrow::Cow,
     fmt::Debug,
@@ -40,7 +41,7 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH
         Self::bases(message).into()
     }
 
-    fn hash_bits(&self, input: &[bool]) -> Result<Self::Output, CRHError> {
+    fn hash_bits(&self, input: &BitSlice) -> Result<Self::Output, CRHError> {
         if input.len() > WINDOW_SIZE * NUM_WINDOWS {
             return Err(CRHError::IncorrectInputLength(input.len(), WINDOW_SIZE, NUM_WINDOWS));
         }

--- a/algorithms/src/crh/pedersen_compressed.rs
+++ b/algorithms/src/crh/pedersen_compressed.rs
@@ -19,6 +19,7 @@ use snarkvm_curves::{AffineCurve, ProjectiveCurve};
 use snarkvm_fields::{ConstraintFieldError, Field, ToConstraintField};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
+use bitvec::prelude::*;
 use std::{
     fmt::Debug,
     io::{Read, Result as IoResult, Write},
@@ -40,7 +41,7 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CRH
     }
 
     /// Returns the affine x-coordinate as the collision-resistant hash output.
-    fn hash_bits(&self, input: &[bool]) -> Result<Self::Output, CRHError> {
+    fn hash_bits(&self, input: &BitSlice) -> Result<Self::Output, CRHError> {
         let affine = self.crh.hash_bits(input)?;
         debug_assert!(affine.is_in_correct_subgroup_assuming_on_curve());
         Ok(affine.to_x_coordinate())

--- a/algorithms/src/crh/poseidon.rs
+++ b/algorithms/src/crh/poseidon.rs
@@ -22,6 +22,7 @@ use crate::{
 use snarkvm_fields::{ConstraintFieldError, FieldParameters, PrimeField, ToConstraintField};
 use snarkvm_utilities::{any::TypeId, FromBytes, ToBytes};
 
+use bitvec::prelude::*;
 use std::{
     borrow::Cow,
     fmt::Debug,
@@ -42,7 +43,7 @@ impl<F: PrimeField + PoseidonDefaultParametersField, const INPUT_SIZE_FE: usize>
         Self(PoseidonCryptoHash::<F, 4, false>::setup())
     }
 
-    fn hash_bits(&self, input: &[bool]) -> Result<Self::Output, CRHError> {
+    fn hash_bits(&self, input: &BitSlice) -> Result<Self::Output, CRHError> {
         // Pad the input if necessary.
         let input = {
             let input_size_bits: usize = INPUT_SIZE_FE * <F as PrimeField>::Parameters::CAPACITY as usize;

--- a/algorithms/src/crypto_hash/grain_lfsr.rs
+++ b/algorithms/src/crypto_hash/grain_lfsr.rs
@@ -16,6 +16,7 @@
 
 #![allow(dead_code)]
 
+use bitvec::prelude::*;
 use snarkvm_fields::{FieldParameters, PrimeField};
 use snarkvm_utilities::{cmp::Ordering, vec::Vec, FromBits};
 
@@ -99,8 +100,8 @@ impl PoseidonGrainLFSR {
         res
     }
 
-    pub fn get_bits(&mut self, num_bits: usize) -> Vec<bool> {
-        let mut res = Vec::with_capacity(num_bits);
+    pub fn get_bits(&mut self, num_bits: usize) -> BitVec<usize, Msb0> {
+        let mut res = BitVec::with_capacity(num_bits);
 
         for _ in 0..num_bits {
             // Obtain the first bit
@@ -132,7 +133,7 @@ impl PoseidonGrainLFSR {
                 let bits = self.get_bits(self.prime_num_bits as usize);
 
                 // Construct the number
-                let bigint = F::BigInteger::from_bits_be(&bits);
+                let bigint = F::BigInteger::from_bits_be(bits.as_bitslice());
 
                 if bigint.cmp(&F::Parameters::MODULUS) == Ordering::Less {
                     res.push(F::from_repr(bigint).unwrap());

--- a/algorithms/src/encryption/ecies_poseidon.rs
+++ b/algorithms/src/encryption/ecies_poseidon.rs
@@ -43,6 +43,7 @@ use snarkvm_utilities::{
     Write,
 };
 
+use bitvec::prelude::*;
 use itertools::Itertools;
 use rand::{CryptoRng, Rng};
 use std::sync::Arc;
@@ -235,7 +236,7 @@ where
         sponge.absorb(&[self.symmetric_encryption_domain, *symmetric_key]);
 
         // Convert the message into bits.
-        let mut plaintext_bits = Vec::<bool>::with_capacity(message.len() * 8 + 1);
+        let mut plaintext_bits = BitVec::with_capacity(message.len() * 8 + 1);
         for byte in message.iter() {
             let mut byte = *byte;
             for _ in 0..8 {
@@ -311,10 +312,10 @@ where
 
         let capacity = <<TE::BaseField as PrimeField>::Parameters as FieldParameters>::CAPACITY as usize;
 
-        let mut bits = Vec::<bool>::with_capacity(plaintext_elements.len() * capacity);
+        let mut bits: BitVec<usize, Lsb0> = BitVec::with_capacity(plaintext_elements.len() * capacity);
         for elem in plaintext_elements.iter() {
             let elem_bits = elem.to_repr().to_bits_le();
-            bits.extend_from_slice(&elem_bits[..capacity]); // only keep `capacity` bits, discarding the highest bit.
+            bits.extend_from_bitslice(&elem_bits[..capacity]); // only keep `capacity` bits, discarding the highest bit.
         }
 
         // Drop all the ending zeros and the last "1" bit.

--- a/algorithms/src/signature/aleo.rs
+++ b/algorithms/src/signature/aleo.rs
@@ -344,10 +344,7 @@ where
         self.g_bases
             .iter()
             .zip_eq(&scalar.to_bits_le())
-            .filter_map(|(base, bit)| match *bit {
-                true => Some(base),
-                false => None,
-            })
+            .filter_map(|(base, bit)| bit.then(|| base))
             .sum::<TEProjective<TE>>()
             .into_affine()
     }

--- a/algorithms/src/signature/aleo.rs
+++ b/algorithms/src/signature/aleo.rs
@@ -344,7 +344,7 @@ where
         self.g_bases
             .iter()
             .zip_eq(&scalar.to_bits_le())
-            .filter_map(|(base, bit)| match bit {
+            .filter_map(|(base, bit)| match *bit {
                 true => Some(base),
                 false => None,
             })

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -33,6 +33,7 @@ use snarkvm_utilities::{
     ToMinimalBits,
 };
 
+use bitvec::prelude::*;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::io::{
     Read,
@@ -256,21 +257,21 @@ impl<E: PairingEngine> ToBytes for VerifyingKey<E> {
 }
 
 impl<E: PairingEngine> ToMinimalBits for VerifyingKey<E> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> BitVec {
         let alpha_g1_bits = self.alpha_g1.to_minimal_bits();
         let beta_g2_bits = self.beta_g2.to_minimal_bits();
         let gamma_g2_bits = self.gamma_g2.to_minimal_bits();
         let delta_g2_bits = self.delta_g2.to_minimal_bits();
         let gamma_abc_g1_bits = self.gamma_abc_g1.to_minimal_bits();
 
-        [
-            alpha_g1_bits,
-            beta_g2_bits,
-            gamma_g2_bits,
-            delta_g2_bits,
-            gamma_abc_g1_bits,
-        ]
-        .concat()
+        let mut ret = BitVec::new();
+        ret.extend_from_bitslice(&alpha_g1_bits);
+        ret.extend_from_bitslice(&beta_g2_bits);
+        ret.extend_from_bitslice(&gamma_g2_bits);
+        ret.extend_from_bitslice(&delta_g2_bits);
+        ret.extend_from_bitslice(&gamma_abc_g1_bits);
+
+        ret
     }
 }
 

--- a/algorithms/src/traits/crh.rs
+++ b/algorithms/src/traits/crh.rs
@@ -17,6 +17,7 @@
 use crate::errors::CRHError;
 use snarkvm_utilities::{FromBytes, ToBytes};
 
+use bitvec::prelude::*;
 use snarkvm_fields::PrimeField;
 use std::{
     fmt::{Debug, Display},
@@ -33,11 +34,11 @@ pub trait CRH: Clone + Debug + ToBytes + FromBytes + Send + Sync + From<<Self as
         let bits = input
             .iter()
             .flat_map(|&byte| (0..8).map(move |i| (byte >> i) & 1u8 == 1u8))
-            .collect::<Vec<bool>>();
-        self.hash_bits(&bits)
+            .collect::<BitVec>();
+        self.hash_bits(bits.as_bitslice())
     }
 
-    fn hash_bits(&self, input_bits: &[bool]) -> Result<Self::Output, CRHError>;
+    fn hash_bits(&self, input_bits: &BitSlice) -> Result<Self::Output, CRHError>;
 
     fn hash_field_elements<F: PrimeField>(&self, input: &[F]) -> Result<Self::Output, CRHError> {
         let mut input_bytes = vec![];

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -50,6 +50,11 @@ default-features = false
 [dependencies.anyhow]
 version = "1.0.43"
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.derivative]
 version = "2"
 

--- a/circuits/src/fields/scalar/mod.rs
+++ b/circuits/src/fields/scalar/mod.rs
@@ -33,6 +33,7 @@ use crate::{traits::*, Boolean, Environment, Mode};
 use snarkvm_fields::{One as O, PrimeField, Zero as Z};
 use snarkvm_utilities::{FromBits as FBits, ToBits as TBits};
 
+use bitvec::prelude::*;
 use std::fmt;
 
 #[derive(Clone)]
@@ -63,7 +64,7 @@ impl<E: Environment> ScalarField<E> {
     /// Ejects the scalar field as a constant scalar field value.
     ///
     pub fn eject_value(&self) -> E::ScalarField {
-        let bits = self.0.iter().map(Boolean::eject_value).collect::<Vec<_>>();
+        let bits = self.0.iter().map(Boolean::eject_value).collect::<BitVec>();
         let biginteger = <E::ScalarField as PrimeField>::BigInteger::from_bits_le(&bits[..]);
         let scalar = <E::ScalarField as PrimeField>::from_repr(biginteger);
         match scalar {

--- a/circuits/src/fields/scalar/to_bits.rs
+++ b/circuits/src/fields/scalar/to_bits.rs
@@ -58,7 +58,7 @@ mod tests {
 
     fn check_to_bits_le(
         name: &str,
-        expected: &[bool],
+        expected: &BitSlice<usize, Lsb0>,
         candidate: &ScalarField<Circuit>,
         num_constants: usize,
         num_public: usize,
@@ -84,7 +84,7 @@ mod tests {
 
     fn check_to_bits_be(
         name: &str,
-        expected: &[bool],
+        expected: &BitSlice<usize, Msb0>,
         candidate: ScalarField<Circuit>,
         num_constants: usize,
         num_public: usize,

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -32,6 +32,11 @@ path = "../utilities"
 version = "0.7.5"
 default-features = false
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.derivative]
 version = "2"
 

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -30,6 +30,7 @@ use snarkvm_utilities::{
     ToMinimalBits,
 };
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -189,7 +190,7 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> BitVec {
         let mut res_bits = self.x.to_bits_le();
         res_bits.push(*self.y.to_bits_le().first().unwrap());
         res_bits.push(self.infinity);

--- a/curves/src/templates/short_weierstrass_projective/affine.rs
+++ b/curves/src/templates/short_weierstrass_projective/affine.rs
@@ -30,6 +30,7 @@ use snarkvm_utilities::{
     ToMinimalBits,
 };
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -176,7 +177,7 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> BitVec {
         let mut res_bits = self.x.to_bits_le();
         res_bits.push(*self.y.to_bits_le().first().unwrap());
         res_bits.push(self.infinity);

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -30,6 +30,7 @@ use snarkvm_utilities::{
     ToMinimalBits,
 };
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -218,7 +219,7 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> BitVec {
         self.x.to_bits_le()
     }
 }

--- a/dpc/src/circuits/outer_public_variables.rs
+++ b/dpc/src/circuits/outer_public_variables.rs
@@ -92,7 +92,7 @@ impl<N: Network> ToConstraintField<N::OuterScalarField> for OuterPublicVariables
         // Alloc the original inputs as bits, then pack them into the new field, in little-endian format.
         for inner_snark_fe in &self.inner_public_variables.to_field_elements()? {
             v.extend_from_slice(&ToConstraintField::<N::OuterScalarField>::to_field_elements(
-                inner_snark_fe.to_bits_le().as_slice(),
+                inner_snark_fe.to_bits_le().as_bitslice(),
             )?);
         }
 

--- a/fields/Cargo.toml
+++ b/fields/Cargo.toml
@@ -25,6 +25,11 @@ default-features = false
 [dependencies.anyhow]
 version = "1.0"
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.derivative]
 version = "2"
 

--- a/fields/src/fp12_2over3over2.rs
+++ b/fields/src/fp12_2over3over2.rs
@@ -25,6 +25,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -482,17 +483,17 @@ impl<P: Fp12Parameters> From<u8> for Fp12<P> {
 }
 
 impl<P: Fp12Parameters> ToBits for Fp12<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_le());
-        res.extend_from_slice(&self.c1.to_bits_le());
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
+        let mut res = bitvec![];
+        res.extend_from_bitslice(&self.c0.to_bits_le());
+        res.extend_from_bitslice(&self.c1.to_bits_le());
         res
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_be());
-        res.extend_from_slice(&self.c1.to_bits_be());
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        let mut res = BitVec::new();
+        res.extend_from_bitslice(&self.c0.to_bits_be());
+        res.extend_from_bitslice(&self.c1.to_bits_be());
         res
     }
 }

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -17,6 +17,7 @@
 use crate::{Field, LegendreSymbol, One, PrimeField, SquareRootField, Zero};
 use snarkvm_utilities::{errors::SerializationError, rand::UniformRand, serialize::*, FromBytes, ToBits, ToBytes};
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -284,17 +285,17 @@ impl<P: Fp2Parameters> From<u8> for Fp2<P> {
 }
 
 impl<P: Fp2Parameters> ToBits for Fp2<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_le());
-        res.extend_from_slice(&self.c1.to_bits_le());
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
+        let mut res = bitvec![];
+        res.extend_from_bitslice(&self.c0.to_bits_le());
+        res.extend_from_bitslice(&self.c1.to_bits_le());
         res
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_be());
-        res.extend_from_slice(&self.c1.to_bits_be());
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        let mut res = BitVec::new();
+        res.extend_from_bitslice(&self.c0.to_bits_be());
+        res.extend_from_bitslice(&self.c1.to_bits_be());
         res
     }
 }

--- a/fields/src/fp3.rs
+++ b/fields/src/fp3.rs
@@ -17,6 +17,7 @@
 use crate::{Field, LegendreSymbol, One, PrimeField, SquareRootField, Zero};
 use snarkvm_utilities::{errors::SerializationError, rand::UniformRand, serialize::*, FromBytes, ToBits, ToBytes};
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -329,19 +330,19 @@ impl<P: Fp3Parameters> From<u8> for Fp3<P> {
 }
 
 impl<P: Fp3Parameters> ToBits for Fp3<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_le());
-        res.extend_from_slice(&self.c1.to_bits_le());
-        res.extend_from_slice(&self.c2.to_bits_le());
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
+        let mut res = bitvec![];
+        res.extend_from_bitslice(&self.c0.to_bits_le());
+        res.extend_from_bitslice(&self.c1.to_bits_le());
+        res.extend_from_bitslice(&self.c2.to_bits_le());
         res
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_be());
-        res.extend_from_slice(&self.c1.to_bits_be());
-        res.extend_from_slice(&self.c2.to_bits_be());
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        let mut res = BitVec::new();
+        res.extend_from_bitslice(&self.c0.to_bits_be());
+        res.extend_from_bitslice(&self.c1.to_bits_be());
+        res.extend_from_bitslice(&self.c2.to_bits_be());
         res
     }
 }

--- a/fields/src/fp6_2over3.rs
+++ b/fields/src/fp6_2over3.rs
@@ -25,6 +25,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -345,17 +346,17 @@ impl<P: Fp6Parameters> From<u8> for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> ToBits for Fp6<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_le());
-        res.extend_from_slice(&self.c1.to_bits_le());
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
+        let mut res = bitvec![];
+        res.extend_from_bitslice(&self.c0.to_bits_le());
+        res.extend_from_bitslice(&self.c1.to_bits_le());
         res
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_be());
-        res.extend_from_slice(&self.c1.to_bits_be());
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        let mut res = BitVec::new();
+        res.extend_from_bitslice(&self.c0.to_bits_be());
+        res.extend_from_bitslice(&self.c1.to_bits_be());
         res
     }
 }

--- a/fields/src/fp6_3over2.rs
+++ b/fields/src/fp6_3over2.rs
@@ -17,6 +17,7 @@
 use crate::{Field, Fp2, Fp2Parameters, One, Zero};
 use snarkvm_utilities::{errors::SerializationError, rand::UniformRand, serialize::*, FromBytes, ToBits, ToBytes};
 
+use bitvec::prelude::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -464,19 +465,19 @@ impl<P: Fp6Parameters> From<u8> for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> ToBits for Fp6<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_le());
-        res.extend_from_slice(&self.c1.to_bits_le());
-        res.extend_from_slice(&self.c2.to_bits_le());
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
+        let mut res = bitvec![];
+        res.extend_from_bitslice(&self.c0.to_bits_le());
+        res.extend_from_bitslice(&self.c1.to_bits_le());
+        res.extend_from_bitslice(&self.c2.to_bits_le());
         res
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut res = vec![];
-        res.extend_from_slice(&self.c0.to_bits_be());
-        res.extend_from_slice(&self.c1.to_bits_be());
-        res.extend_from_slice(&self.c2.to_bits_be());
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        let mut res = BitVec::new();
+        res.extend_from_bitslice(&self.c0.to_bits_be());
+        res.extend_from_bitslice(&self.c1.to_bits_be());
+        res.extend_from_bitslice(&self.c2.to_bits_be());
         res
     }
 }

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -35,6 +35,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
+use bitvec::prelude::*;
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -398,18 +399,15 @@ impl_add_sub_from_field_ref!(Fp256, Fp256Parameters);
 impl_mul_div_from_field_ref!(Fp256, Fp256Parameters);
 
 impl<P: Fp256Parameters> ToBits for Fp256<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
         let mut bits_vec = self.to_repr().to_bits_le();
         bits_vec.truncate(P::MODULUS_BITS as usize);
 
         bits_vec
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut bits_vec = self.to_bits_le();
-        bits_vec.reverse();
-
-        bits_vec
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        self.to_bits_le().into_iter().rev().collect()
     }
 }
 

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -35,6 +35,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
+use bitvec::prelude::*;
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -473,18 +474,15 @@ impl_add_sub_from_field_ref!(Fp384, Fp384Parameters);
 impl_mul_div_from_field_ref!(Fp384, Fp384Parameters);
 
 impl<P: Fp384Parameters> ToBits for Fp384<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
         let mut bits_vec = self.to_repr().to_bits_le();
         bits_vec.truncate(P::MODULUS_BITS as usize);
 
         bits_vec
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut bits_vec = self.to_bits_le();
-        bits_vec.reverse();
-
-        bits_vec
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        self.to_bits_le().into_iter().rev().collect()
     }
 }
 

--- a/fields/src/fp_768.rs
+++ b/fields/src/fp_768.rs
@@ -35,6 +35,7 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
+use bitvec::prelude::*;
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -808,18 +809,15 @@ impl_add_sub_from_field_ref!(Fp768, Fp768Parameters);
 impl_mul_div_from_field_ref!(Fp768, Fp768Parameters);
 
 impl<P: Fp768Parameters> ToBits for Fp768<P> {
-    fn to_bits_le(&self) -> Vec<bool> {
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0> {
         let mut bits_vec = self.to_repr().to_bits_le();
         bits_vec.truncate(P::MODULUS_BITS as usize);
 
         bits_vec
     }
 
-    fn to_bits_be(&self) -> Vec<bool> {
-        let mut bits_vec = self.to_bits_le();
-        bits_vec.reverse();
-
-        bits_vec
+    fn to_bits_be(&self) -> BitVec<usize, Msb0> {
+        self.to_bits_le().into_iter().rev().collect()
     }
 }
 

--- a/fields/src/to_field_vec.rs
+++ b/fields/src/to_field_vec.rs
@@ -15,6 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{ConstraintFieldError, Field, FieldParameters, Fp2, Fp2Parameters, PrimeField, ToConstraintField};
+use bitvec::prelude::*;
 use snarkvm_utilities::FromBits;
 
 impl<F: PrimeField> ToConstraintField<F> for F {
@@ -56,20 +57,13 @@ impl<P: Fp2Parameters> ToConstraintField<P::Fp> for Fp2<P> {
     }
 }
 
-impl<F: PrimeField> ToConstraintField<F> for [bool] {
+impl<F: PrimeField> ToConstraintField<F> for BitSlice {
     #[inline]
     fn to_field_elements(&self) -> Result<Vec<F>, ConstraintFieldError> {
         Ok(self
             .chunks(<F as PrimeField>::Parameters::CAPACITY as usize)
             .map(|chunk| F::from_repr(F::BigInteger::from_bits_le(chunk)).unwrap())
             .collect::<Vec<F>>())
-    }
-}
-
-impl<F: PrimeField, const NUM_BITS: usize> ToConstraintField<F> for [bool; NUM_BITS] {
-    #[inline]
-    fn to_field_elements(&self) -> Result<Vec<F>, ConstraintFieldError> {
-        self.as_ref().to_field_elements()
     }
 }
 

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -50,6 +50,11 @@ default-features = false
 [dependencies.anyhow]
 version = "1.0.52"
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.derivative]
 version = "2"
 

--- a/gadgets/src/bits/boolean_input.rs
+++ b/gadgets/src/bits/boolean_input.rs
@@ -16,6 +16,7 @@
 
 use std::{borrow::Borrow, marker::PhantomData};
 
+use bitvec::prelude::*;
 use snarkvm_fields::{FieldParameters, PrimeField};
 use snarkvm_r1cs::{ConstraintSystem, LinearCombination, SynthesisError};
 use snarkvm_utilities::{FromBits, ToBits};
@@ -96,11 +97,11 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
         let obj = value_gen()?;
 
         // Step 1: obtain the bits of the F field elements
-        let mut src_bits = Vec::<bool>::new();
+        let mut src_bits = BitVec::new();
         for elem in obj.borrow().iter() {
             let mut bits = elem.to_repr().to_bits_le();
             bits.truncate(F::size_in_bits());
-            bits.extend_from_slice(&vec![false; F::size_in_bits() - bits.len()]);
+            bits.extend_from_bitslice(&bitvec![usize, Lsb0; 0; F::size_in_bits() - bits.len()]);
 
             src_bits.append(&mut bits);
         }
@@ -119,7 +120,7 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
             let mut coeff = CF::one();
 
             for (j, bit) in chunk.iter().enumerate() {
-                let boolean = Boolean::alloc(cs.ns(|| format!("alloc_bits_{}_{}", i, j)), || Ok(bit))?;
+                let boolean = Boolean::alloc(cs.ns(|| format!("alloc_bits_{}_{}", i, j)), || Ok(*bit))?;
 
                 lc = &lc + boolean.lc(CS::one(), CF::one()) * coeff;
                 coeff.double_in_place();
@@ -151,11 +152,11 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
         let obj = value_gen()?;
 
         // Step 1: obtain the bits of the F field elements
-        let mut src_bits = Vec::<bool>::new();
+        let mut src_bits = BitVec::new();
         for elem in obj.borrow().iter() {
             let mut bits = elem.to_repr().to_bits_le();
             bits.truncate(F::size_in_bits());
-            bits.extend_from_slice(&vec![false; F::size_in_bits() - bits.len()]);
+            bits.extend_from_bitslice(&bitvec![usize, Lsb0; 0; F::size_in_bits() - bits.len()]);
 
             src_bits.append(&mut bits);
         }
@@ -174,7 +175,7 @@ impl<F: PrimeField, CF: PrimeField> AllocGadget<Vec<F>, CF> for BooleanInputGadg
             let mut coeff = CF::one();
 
             for (j, bit) in chunk.iter().enumerate() {
-                let boolean = Boolean::alloc(cs.ns(|| format!("alloc_bits_{}_{}", i, j)), || Ok(bit))?;
+                let boolean = Boolean::alloc(cs.ns(|| format!("alloc_bits_{}_{}", i, j)), || Ok(*bit))?;
 
                 lc = &lc + boolean.lc(CS::one(), CF::one()) * coeff;
                 coeff.double_in_place();

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -72,6 +72,11 @@ default-features = false
 [dependencies.bincode]
 version = "1.3"
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.blake2]
 version = "0.9"
 default-features = false

--- a/marlin/src/marlin/circuit_verifying_key.rs
+++ b/marlin/src/marlin/circuit_verifying_key.rs
@@ -87,7 +87,8 @@ impl<F: PrimeField, CF: PrimeField, PC: PolynomialCommitment<F, CF>, MM: MarlinM
 
         let circuit_commitments_bits = self.circuit_commitments.to_minimal_bits();
 
-        let mut ret = BitVec::new();
+        let mut ret =
+            BitVec::with_capacity(domain_h_size_bits.len() + domain_k_size_bits.len() + circuit_commitments_bits.len());
         ret.extend_from_bitslice(&domain_h_size_bits);
         ret.extend_from_bitslice(&domain_k_size_bits);
         ret.extend_from_bitslice(&circuit_commitments_bits);

--- a/polycommit/Cargo.toml
+++ b/polycommit/Cargo.toml
@@ -67,6 +67,11 @@ path = "../utilities"
 version = "0.7.5"
 default-features = false
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.derivative]
 version = "2"
 features = [ "use_core" ]

--- a/polycommit/src/kzg10/data_structures.rs
+++ b/polycommit/src/kzg10/data_structures.rs
@@ -15,6 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{impl_bytes, BTreeMap, *};
+use bitvec::prelude::*;
 use core::ops::{Add, AddAssign};
 use snarkvm_curves::{
     traits::{AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve},
@@ -311,7 +312,7 @@ pub struct Commitment<E: PairingEngine>(
 impl_bytes!(Commitment);
 
 impl<E: PairingEngine> ToMinimalBits for Commitment<E> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> BitVec {
         self.0.to_minimal_bits()
     }
 }

--- a/polycommit/src/marlin_pc/data_structures.rs
+++ b/polycommit/src/marlin_pc/data_structures.rs
@@ -19,6 +19,7 @@ use snarkvm_curves::{traits::PairingEngine, Group};
 use snarkvm_fields::{ConstraintFieldError, PrimeField, ToConstraintField};
 use snarkvm_utilities::{error, errors::SerializationError, serialize::*, FromBytes, ToBytes, ToMinimalBits};
 
+use bitvec::prelude::*;
 use core::ops::{Add, AddAssign};
 use rand_core::RngCore;
 
@@ -235,11 +236,15 @@ pub struct Commitment<E: PairingEngine> {
 impl_bytes!(Commitment);
 
 impl<E: PairingEngine> ToMinimalBits for Commitment<E> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> BitVec {
         let comm_bits = self.comm.to_minimal_bits();
 
         if let Some(shifted_comm) = &self.shifted_comm {
-            [comm_bits, shifted_comm.to_minimal_bits()].concat()
+            let mut ret = BitVec::new();
+            ret.extend_from_bitslice(&comm_bits);
+            ret.extend_from_bitslice(&shifted_comm.to_minimal_bits());
+
+            ret
         } else {
             comm_bits
         }

--- a/polycommit/src/marlin_pc/data_structures.rs
+++ b/polycommit/src/marlin_pc/data_structures.rs
@@ -240,8 +240,7 @@ impl<E: PairingEngine> ToMinimalBits for Commitment<E> {
         let comm_bits = self.comm.to_minimal_bits();
 
         if let Some(shifted_comm) = &self.shifted_comm {
-            let mut ret = BitVec::new();
-            ret.extend_from_bitslice(&comm_bits);
+            let mut ret = comm_bits;
             ret.extend_from_bitslice(&shifted_comm.to_minimal_bits());
 
             ret

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -32,6 +32,11 @@ version = "1.0"
 [dependencies.bincode]
 version = "1.3.3"
 
+[dependencies.bitvec]
+version = "1"
+default-features = false
+features = ["alloc"]
+
 [dependencies.itertools]
 version = "0.10.3"
 

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -196,20 +196,20 @@ macro_rules! biginteger {
 
         impl ToBits for $name {
             /// Returns `self` as a boolean array in little-endian order, with trailing zeros.
-            fn to_bits_le(&self) -> Vec<bool> {
-                BitIteratorLE::new(self).collect::<Vec<_>>()
+            fn to_bits_le(&self) -> bitvec::prelude::BitVec<usize, bitvec::prelude::Lsb0> {
+                BitIteratorLE::new(self).collect()
             }
 
             /// Returns `self` as a boolean array in big-endian order, with leading zeros.
-            fn to_bits_be(&self) -> Vec<bool> {
-                BitIteratorBE::new(self).collect::<Vec<_>>()
+            fn to_bits_be(&self) -> bitvec::prelude::BitVec<usize, bitvec::prelude::Msb0> {
+                BitIteratorBE::new(self).collect()
             }
         }
 
         impl FromBits for $name {
             /// Returns a `BigInteger` by parsing a slice of bits in little-endian format
             /// and transforms it into a slice of little-endian u64 elements.
-            fn from_bits_le(bits: &[bool]) -> Self {
+            fn from_bits_le(bits: &bitvec::prelude::BitSlice<usize, bitvec::prelude::Lsb0>) -> Self {
                 let mut res = Self::default();
 
                 for (i, bits64) in bits.chunks(64).enumerate() {
@@ -225,11 +225,10 @@ macro_rules! biginteger {
 
             /// Returns a `BigInteger` by parsing a slice of bits in big-endian format
             /// and transforms it into a slice of little-endian u64 elements.
-            fn from_bits_be(bits: &[bool]) -> Self {
-                let mut bits_reversed = bits.to_vec();
-                bits_reversed.reverse();
+            fn from_bits_be(bits: &bitvec::prelude::BitSlice<usize, bitvec::prelude::Msb0>) -> Self {
+                let bits_reversed: bitvec::prelude::BitVec<usize, bitvec::prelude::Lsb0> = bits.iter().rev().collect();
 
-                Self::from_bits_le(&bits_reversed)
+                Self::from_bits_le(bits_reversed.as_bitslice())
             }
         }
 

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -16,27 +16,6 @@
 
 use crate::Vec;
 
-/// Takes as input a sequence of structs, and converts them to a series of little-endian bits.
-/// All traits that implement `ToBits` can be automatically converted to bits in this manner.
-#[macro_export]
-macro_rules! to_bits_le {
-    ($($x:expr),*) => ({
-        let mut buffer = $crate::vec![];
-        {$crate::push_bits_to_vec!(buffer, $($x),*)}.map(|_| buffer)
-    });
-}
-
-#[macro_export]
-macro_rules! push_bits_to_vec {
-    ($buffer:expr, $y:expr, $($x:expr),*) => ({
-        {ToBits::write_le(&$y, &mut $buffer)}.and({$crate::push_bits_to_vec!($buffer, $($x),*)})
-    });
-
-    ($buffer:expr, $x:expr) => ({
-        ToBits::write_le(&$x, &mut $buffer)
-    })
-}
-
 pub trait ToBits: Sized {
     /// Returns `self` as a boolean array in little-endian order.
     fn to_bits_le(&self) -> Vec<bool>;

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -15,31 +15,32 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::Vec;
+use bitvec::prelude::*;
 
 pub trait ToBits: Sized {
     /// Returns `self` as a boolean array in little-endian order.
-    fn to_bits_le(&self) -> Vec<bool>;
+    fn to_bits_le(&self) -> BitVec<usize, Lsb0>;
 
     /// Returns `self` as a boolean array in big-endian order.
-    fn to_bits_be(&self) -> Vec<bool>;
+    fn to_bits_be(&self) -> BitVec<usize, Msb0>;
 }
 
 pub trait FromBits: Sized {
     /// Reads `Self` from a boolean array in little-endian order.
-    fn from_bits_le(bits: &[bool]) -> Self;
+    fn from_bits_le(bits: &BitSlice<usize, Lsb0>) -> Self;
 
     /// Reads `Self` from a boolean array in big-endian order.
-    fn from_bits_be(bits: &[bool]) -> Self;
+    fn from_bits_be(bits: &BitSlice<usize, Msb0>) -> Self;
 }
 
 pub trait ToMinimalBits: Sized {
     /// Returns `self` as a minimal boolean array.
-    fn to_minimal_bits(&self) -> Vec<bool>;
+    fn to_minimal_bits(&self) -> BitVec;
 }
 
 impl<T: ToMinimalBits> ToMinimalBits for Vec<T> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
-        let mut res_bits = vec![];
+    fn to_minimal_bits(&self) -> BitVec {
+        let mut res_bits = BitVec::new();
         for elem in self.iter() {
             res_bits.extend(elem.to_minimal_bits());
         }


### PR DESCRIPTION
This PR proposes the use of `bitvec` to handle vectors and slices of `bool` in order to reduce related memory use to an **eighth** of the current values and to be able to distinguish LE and BE collections (due to `BitVec` being generic over the [bit order](https://docs.rs/bitvec/latest/bitvec/slice/struct.BitSlice.html#o-bitorder)).

I've run all the available benchmarks, but many results are inconclusive, due to them being volatile even between vanilla `testnet2` runs; below are the ones I consider likely to be significant (i.e. showing a change between `testnet` -> `testnet2_bitvec`, no difference in a `testnet2` -> `testnet2` run, and with few outliers):
```
Aleo Encryption Setup   time:   [4.1425 ms 4.1525 ms 4.1638 ms]
                        change: [+37.195% +37.370% +37.557%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe

Aleo Encryption Generate symmetric Key
                        time:   [194.30 us 194.90 us 195.53 us]
                        change: [-33.477% -33.325% -33.186%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 20 measurements (10.00%)
  1 (5.00%) high mild
  1 (5.00%) high severe

Aleo Encryption Decrypt time:   [37.161 us 37.345 us 37.490 us]
                        change: [+14.219% +14.585% +14.979%] (p = 0.00 < 0.05)
                        Performance has regressed.

try_hash_to_g1_on_bls12_377
                        time:   [111.43 us 111.49 us 111.59 us]
                        change: [-37.883% -37.814% -37.749%] (p = 0.00 < 0.05)
                        Performance has improved.

PoseidonPRF PRF evaluation
                        time:   [4.1996 ms 4.2070 ms 4.2147 ms]
                        change: [+38.326% +38.545% +38.767%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) high mild

Aleo Signature Setup    time:   [4.1354 ms 4.1434 ms 4.1538 ms]
                        change: [+33.016% +34.299% +35.693%] (p = 0.00 < 0.05)
                        Performance has regressed.

account_private_key     time:   [13.169 ms 13.191 ms 13.209 ms]
                        change: [+37.422% +38.474% +39.494%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild

account_address         time:   [152.55 us 154.29 us 155.93 us]
                        change: [+2.6857% +4.6644% +6.5416%] (p = 0.00 < 0.05)
                        Performance has regressed.

NoopProgram::load       time:   [220.61 ps 220.89 ps 221.26 ps]
                        change: [-5.8387% -4.2721% -2.6520%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

integer_arithmetic::u8_addmany
                        time:   [18.025 us 18.304 us 18.884 us]
                        change: [-12.521% -9.3300% -7.0447%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

integer_arithmetic::u64_addmany
                        time:   [146.52 us 149.23 us 152.36 us]
                        change: [+14.391% +16.381% +18.404%] (p = 0.00 < 0.05)
                        Performance has regressed.

integer_arithmetic::u16_pow
                        time:   [17.547 ms 17.594 ms 17.651 ms]
                        change: [-8.2566% -7.6579% -7.0771%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

snark_universal_setup   time:   [10.168 s 10.228 s 10.295 s]
                        change: [+7.6839% +8.9766% +10.132%] (p = 0.00 < 0.05)
                        Performance has regressed.

snark_verify            time:   [22.321 ms 22.341 ms 22.367 ms]
                        change: [+13.105% +13.460% +13.828%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```

A small performance penalty (in speed, but still providing a large reduction in memory use) is expected, but it's possible that some of my changes aren't optimal; I'll try to improve them, so I'm marking this PR as a draft for now.