### PR TITLE
A few deserialization improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
   integration-testnet1:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -63,7 +63,7 @@ jobs:
 
   integration-testnet2:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -78,7 +78,7 @@ jobs:
 
   algorithms:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -93,7 +93,7 @@ jobs:
 
   curves:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -108,7 +108,7 @@ jobs:
 
   derives:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -123,7 +123,7 @@ jobs:
 
   dpc:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -138,7 +138,7 @@ jobs:
 
   fields:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -153,7 +153,7 @@ jobs:
 
   gadgets:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -168,7 +168,7 @@ jobs:
 
   marlin:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -183,7 +183,7 @@ jobs:
 
   parameters:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -198,7 +198,7 @@ jobs:
 
   polycommit:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -213,7 +213,7 @@ jobs:
 
   profiler:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -228,7 +228,7 @@ jobs:
 
   r1cs:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout
@@ -243,7 +243,7 @@ jobs:
 
   utilities:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.58
     resource_class: 2xlarge
     steps:
       - checkout

--- a/dpc/src/record/payload.rs
+++ b/dpc/src/record/payload.rs
@@ -40,9 +40,7 @@ impl<N: Network> Payload<N> {
     }
 
     pub fn is_empty(&self) -> bool {
-        let mut payload = vec![0u8; N::RECORD_PAYLOAD_SIZE_IN_BYTES];
-        payload.copy_from_slice(&self.0);
-        payload == vec![0u8; N::RECORD_PAYLOAD_SIZE_IN_BYTES]
+        self.0.len() == N::RECORD_PAYLOAD_SIZE_IN_BYTES && self.0.iter().all(|byte| *byte == 0)
     }
 
     pub fn size() -> usize {

--- a/dpc/src/record/payload.rs
+++ b/dpc/src/record/payload.rs
@@ -106,7 +106,7 @@ impl<'de, N: Network> Deserialize<'de> for Payload<N> {
 
 impl<N: Network> Default for Payload<N> {
     fn default() -> Self {
-        Self::from(vec![])
+        Self::from(vec![0u8; N::RECORD_CIPHERTEXT_SIZE_IN_BYTES])
     }
 }
 


### PR DESCRIPTION
This PR does 3 things:
- removes some deserialization-related allocations (`Ciphertext`, `Payload`)
- returns an error when `CanonicalDeserialize::deserialize` tries to allocate more than the OS can provide
- bumps the CircleCI Rust images to 1.58 (the highest currently available stable version) in order to be able to use `Vec::try_reserve`

Supersedes https://github.com/AleoHQ/snarkVM/pull/592.