### PR TITLE
Merkle tree perf tweaks

### DIFF
--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -168,8 +168,7 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
 
         // Compute the hash values for every node in the tree.
         let mut upper_bound = last_level_index;
-        level_indices.reverse();
-        for &start_index in &level_indices {
+        for start_index in level_indices.into_iter().rev() {
             // Iterate over the current level.
             for current_index in start_index..upper_bound {
                 let left_index = left_child(current_index);


### PR DESCRIPTION
I had a feeling that hashing done on each level of the Merkle tree could be done in parallel, and it seems that it does work and brings a nice performance boost - with this change, my snarkOS ledger loads in 33s instead of 208s, which is a **84%** decrease.