### PR TITLE
MSM tweaks

### DIFF
--- a/algorithms/src/msm/fixed_base.rs
+++ b/algorithms/src/msm/fixed_base.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_curves::traits::ProjectiveCurve;
 use snarkvm_fields::{FieldParameters, PrimeField};
-use snarkvm_utilities::{cfg_into_iter, ToBits};
+use snarkvm_utilities::{cfg_into_iter, cfg_iter_mut, ToBits};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -40,17 +40,27 @@ impl FixedBaseMSM {
         let mut multiples_of_g = vec![vec![T::zero(); in_window]; outerc];
 
         let mut g_outer = g;
-        for (outer, m) in multiples_of_g.iter_mut().enumerate() {
-            let mut g_inner = T::zero();
-            let cur_in_window = if outer == outerc - 1 { last_in_window } else { in_window };
-            for x in m.iter_mut().take(cur_in_window) {
-                *x = g_inner;
-                g_inner += g_outer;
-            }
+        let mut g_outers = Vec::with_capacity(outerc);
+        for _ in 0..outerc {
+            g_outers.push(g_outer);
             for _ in 0..window {
                 g_outer.double_in_place();
             }
         }
+
+        cfg_iter_mut!(multiples_of_g)
+            .enumerate()
+            .take(outerc)
+            .zip(g_outers)
+            .for_each(|((outer, multiples_of_g), g_outer)| {
+                let cur_in_window = if outer == outerc - 1 { last_in_window } else { in_window };
+
+                let mut g_inner = T::zero();
+                for inner in multiples_of_g.iter_mut().take(cur_in_window) {
+                    *inner = g_inner;
+                    g_inner += &g_outer;
+                }
+            });
         multiples_of_g
     }
 

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -21,6 +21,67 @@ use snarkvm_utilities::BigInteger;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+fn update_buckets<G: AffineCurve>(
+    base: &G,
+    mut scalar: <G::ScalarField as PrimeField>::BigInteger,
+    w_start: usize,
+    c: usize,
+    buckets: &mut [G::Projective],
+) {
+    // We right-shift by w_start, thus getting rid of the
+    // lower bits.
+    scalar.divn(w_start as u32);
+
+    // We mod the remaining bits by the window size.
+    let scalar = scalar.as_ref()[0] % (1 << c);
+
+    // If the scalar is non-zero, we update the corresponding
+    // bucket.
+    // (Recall that `buckets` doesn't have a zero bucket.)
+    if scalar != 0 {
+        buckets[(scalar - 1) as usize].add_assign_mixed(base);
+    }
+}
+
+fn process_window<G: AffineCurve>(
+    bases: &[G],
+    scalars: &[<G::ScalarField as PrimeField>::BigInteger],
+    w_start: usize,
+    c: usize,
+) -> G::Projective {
+    let mut res = G::Projective::zero();
+    let fr_one = G::ScalarField::one().to_repr();
+
+    // We only process unit scalars once in the first window.
+    if w_start == 0 {
+        scalars
+            .iter()
+            .zip(bases)
+            .filter(|(&s, _)| s == fr_one)
+            .for_each(|(_, base)| {
+                res.add_assign_mixed(base);
+            });
+    }
+
+    // We don't need the "zero" bucket, so we only have 2^c - 1 buckets
+    let mut buckets = vec![G::Projective::zero(); (1 << c) - 1];
+    scalars
+        .iter()
+        .zip(bases)
+        .filter(|(&s, _)| s > fr_one)
+        .for_each(|(&scalar, base)| update_buckets(base, scalar, w_start, c, &mut buckets));
+    // G::Projective::batch_normalization(&mut buckets);
+
+    for running_sum in buckets.into_iter().rev().scan(G::Projective::zero(), |sum, b| {
+        *sum += b;
+        Some(*sum)
+    }) {
+        res += running_sum;
+    }
+
+    res
+}
+
 pub fn msm_standard<G: AffineCurve>(
     bases: &[G],
     scalars: &[<G::ScalarField as PrimeField>::BigInteger],
@@ -32,9 +93,6 @@ pub fn msm_standard<G: AffineCurve>(
     };
 
     let num_bits = <G::ScalarField as PrimeField>::Parameters::MODULUS_BITS as usize;
-    let fr_one = G::ScalarField::one().to_repr();
-
-    let zero = G::zero().into_projective();
 
     // Each window is of size `c`.
     // We divide up the bits 0..num_bits into windows of size `c`, and
@@ -42,60 +100,22 @@ pub fn msm_standard<G: AffineCurve>(
     // window_starts.into_iter() //
     let window_sums: Vec<_> = crate::cfg_into_iter!(0..num_bits)
         .step_by(c)
-        .map(|w_start| {
-            let mut res = zero;
-            // We don't need the "zero" bucket, so we only have 2^c - 1 buckets
-            let mut buckets = vec![zero; (1 << c) - 1];
-            scalars
-                .iter()
-                .zip(bases)
-                .filter(|(s, _)| !s.is_zero())
-                .for_each(|(&scalar, base)| {
-                    if scalar == fr_one {
-                        // We only process unit scalars once in the first window.
-                        if w_start == 0 {
-                            res.add_assign_mixed(base);
-                        }
-                    } else {
-                        let mut scalar = scalar;
-
-                        // We right-shift by w_start, thus getting rid of the
-                        // lower bits.
-                        scalar.divn(w_start as u32);
-
-                        // We mod the remaining bits by the window size.
-                        let scalar = scalar.as_ref()[0] % (1 << c);
-
-                        // If the scalar is non-zero, we update the corresponding
-                        // bucket.
-                        // (Recall that `buckets` doesn't have a zero bucket.)
-                        if scalar != 0 {
-                            buckets[(scalar - 1) as usize].add_assign_mixed(base);
-                        }
-                    }
-                });
-            // G::Projective::batch_normalization(&mut buckets);
-
-            let mut running_sum = G::Projective::zero();
-            for b in buckets.into_iter().rev() {
-                running_sum += b;
-                // running_sum.add_assign_mixed(&b);
-                res += running_sum;
-            }
-
-            res
-        })
+        .map(|w_start| process_window(bases, scalars, w_start, c))
         .collect();
 
     // We store the sum for the lowest window.
-    let lowest = window_sums.first().unwrap();
+    let (lowest, window_sums) = window_sums.split_first().unwrap();
 
     // We're traversing windows from high to low.
-    window_sums[1..].iter().rev().fold(zero, |mut total, sum_i| {
-        total += sum_i;
-        for _ in 0..c {
-            total.double_in_place();
-        }
-        total
-    }) + lowest
+    window_sums
+        .iter()
+        .rev()
+        .fold(G::Projective::zero(), |mut total, sum_i| {
+            total += sum_i;
+            for _ in 0..c {
+                total.double_in_place();
+            }
+            total
+        })
+        + lowest
 }

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -35,13 +35,13 @@ pub fn msm_standard<G: AffineCurve>(
     let fr_one = G::ScalarField::one().to_repr();
 
     let zero = G::zero().into_projective();
-    let window_starts: Vec<_> = (0..num_bits).step_by(c).collect();
 
     // Each window is of size `c`.
     // We divide up the bits 0..num_bits into windows of size `c`, and
     // in parallel process each such window.
     // window_starts.into_iter() //
-    let window_sums: Vec<_> = crate::cfg_into_iter!(window_starts)
+    let window_sums: Vec<_> = crate::cfg_into_iter!(0..num_bits)
+        .step_by(c)
         .map(|w_start| {
             let mut res = zero;
             // We don't need the "zero" bucket, so we only have 2^c - 1 buckets

--- a/curves/src/traits/group.rs
+++ b/curves/src/traits/group.rs
@@ -20,6 +20,7 @@ use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBytes};
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
+    iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
@@ -47,6 +48,7 @@ pub trait Group:
     + AddAssign<Self>
     + SubAssign<Self>
     + MulAssign<Self::ScalarField>
+    + Sum
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>

--- a/curves/src/traits/group.rs
+++ b/curves/src/traits/group.rs
@@ -20,7 +20,6 @@ use snarkvm_utilities::{rand::UniformRand, FromBytes, ToBytes};
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
-    iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
@@ -48,7 +47,6 @@ pub trait Group:
     + AddAssign<Self>
     + SubAssign<Self>
     + MulAssign<Self::ScalarField>
-    + Sum
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>

--- a/curves/src/traits/pairing_engine.rs
+++ b/curves/src/traits/pairing_engine.rs
@@ -106,6 +106,7 @@ pub trait ProjectiveCurve:
     + CanonicalSerialize
     + ConstantSerializedSize
     + CanonicalDeserialize
+    + iter::Sum
     + From<<Self as ProjectiveCurve>::Affine>
 {
     type BaseField: Field;


### PR DESCRIPTION
I've been looking at the MSM impls, and have the following proposals for improvements:
- parallelize `FixedBaseMSM::windowed_mul`
- refactor `VariableBaseMSM::msm_standard` into 3 functions for greater readability; I initially did it hoping to be able to find performance improvements, but since there wasn't any room for them in the end, the last commit can be dropped if the original shape is more desirable