### PR TITLE
Improve BitIterator

### DIFF
--- a/utilities/src/bititerator.rs
+++ b/utilities/src/bititerator.rs
@@ -48,7 +48,7 @@ impl<Slice: AsRef<[u64]>> Iterator for BitIteratorBE<Slice> {
         } else {
             self.n -= 1;
             let part = self.n / 64;
-            let bit = self.n - (64 * part);
+            let bit = self.n & 63;
 
             Some(self.s.as_ref()[part] & (1 << bit) > 0)
         }
@@ -94,7 +94,7 @@ impl<Slice: AsRef<[u64]>> Iterator for BitIteratorLE<Slice> {
             None
         } else {
             let part = self.n / 64;
-            let bit = self.n - (64 * part);
+            let bit = self.n & 63;
             self.n += 1;
 
             Some(self.s.as_ref()[part] & (1 << bit) > 0)


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

`BitIterator` is used a lot in the calculation. However, each iteration will perform multiplying and  subtraction to do modulo.

This PR eliminates the usage of multiplication via bit-wise AND operation. It's a micro optimization, though.

`(n % 64) == (n & 63)`

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Tests already exist.

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->
None

