### PR TITLE
Further groth16-related perf improvements

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -36,7 +36,7 @@ use crate::{
 use snarkvm_fields::{batch_inversion, FftField, FftParameters, Field};
 #[cfg(feature = "parallel")]
 use snarkvm_utilities::max_available_threads;
-use snarkvm_utilities::{errors::SerializationError, execute_with_max_available_threads, serialize::*};
+use snarkvm_utilities::{errors::SerializationError, serialize::*};
 
 use rand::Rng;
 use std::fmt;
@@ -167,10 +167,8 @@ impl<F: FftField> EvaluationDomain<F> {
 
     /// Compute an FFT, modifying the vector in place.
     pub fn fft_in_place<T: DomainCoeff<F>>(&self, coeffs: &mut Vec<T>) {
-        execute_with_max_available_threads(|| {
-            coeffs.resize(self.size(), T::zero());
-            self.in_order_fft_in_place(&mut *coeffs);
-        });
+        coeffs.resize(self.size(), T::zero());
+        self.in_order_fft_in_place(&mut *coeffs);
     }
 
     /// Compute an IFFT.
@@ -183,10 +181,8 @@ impl<F: FftField> EvaluationDomain<F> {
     /// Compute an IFFT, modifying the vector in place.
     #[inline]
     pub fn ifft_in_place<T: DomainCoeff<F>>(&self, evals: &mut Vec<T>) {
-        execute_with_max_available_threads(|| {
-            evals.resize(self.size(), T::zero());
-            self.in_order_ifft_in_place(&mut *evals);
-        });
+        evals.resize(self.size(), T::zero());
+        self.in_order_ifft_in_place(&mut *evals);
     }
 
     /// Compute an FFT over a coset of the domain.
@@ -199,10 +195,8 @@ impl<F: FftField> EvaluationDomain<F> {
     /// Compute an FFT over a coset of the domain, modifying the input vector
     /// in place.
     pub fn coset_fft_in_place<T: DomainCoeff<F>>(&self, coeffs: &mut Vec<T>) {
-        execute_with_max_available_threads(|| {
-            Self::distribute_powers(coeffs, F::multiplicative_generator());
-            self.fft_in_place(coeffs);
-        });
+        Self::distribute_powers(coeffs, F::multiplicative_generator());
+        self.fft_in_place(coeffs);
     }
 
     /// Compute an IFFT over a coset of the domain.
@@ -214,10 +208,8 @@ impl<F: FftField> EvaluationDomain<F> {
 
     /// Compute an IFFT over a coset of the domain, modifying the input vector in place.
     pub fn coset_ifft_in_place<T: DomainCoeff<F>>(&self, evals: &mut Vec<T>) {
-        execute_with_max_available_threads(|| {
-            evals.resize(self.size(), T::zero());
-            self.in_order_coset_ifft_in_place(&mut *evals);
-        });
+        evals.resize(self.size(), T::zero());
+        self.in_order_coset_ifft_in_place(&mut *evals);
     }
 
     /// Multiply the `i`-th element of `coeffs` with `g^i`.

--- a/algorithms/src/snark/groth16/r1cs_to_qap.rs
+++ b/algorithms/src/snark/groth16/r1cs_to_qap.rs
@@ -71,9 +71,8 @@ impl R1CStoQAP {
         let mut b = vec![E::Fr::zero(); qap_num_variables + 1];
         let mut c = vec![E::Fr::zero(); qap_num_variables + 1];
 
-        for i in 0..assembly.num_public_variables {
-            a[i] = u[assembly.num_constraints() + i];
-        }
+        a[..assembly.num_public_variables]
+            .copy_from_slice(&u[assembly.num_constraints()..][..assembly.num_public_variables]);
 
         for (i, x) in u.iter().enumerate().take(assembly.num_constraints()) {
             for &(ref coeff, index) in assembly.at[i].iter() {


### PR DESCRIPTION
This PR started out with adjustments to the R1CStoQAP functions, which brought ~1% and ~4% wins to the `snark_setup` and `snark_prove` benchmarks respectively, but down the road, a few tweaks to parallelism provided great wins to `snark_prove` and most of the `fft` benchmarks (I compressed the `fft` results to stay within the GitHub PR size limit):
```
snark_prove             time:   [11.746 ms 11.781 ms 11.820 ms]
                        change: [-46.215% -45.892% -45.564%] (p = 0.00 < 0.05)

"BLS12-377 - radix-2" - subgroup_fft_in_place/32768
                        change: [-28.014% -27.247% -26.505%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_fft_in_place/65536
                        change: [-19.821% -19.050% -18.239%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_fft_in_place/131072
                        change: [-15.467% -14.690% -13.928%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_fft_in_place/262144
                        change: [-10.944% -10.279% -9.5915%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_fft_in_place/524288
                        change: [-4.9244% -4.2994% -3.6753%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_fft_in_place/1048576
                        change: [-3.7367% -2.6856% -1.6455%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_fft_in_place/2097152
                        change: [-6.2193% -5.5771% -4.9651%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_fft_in_place/4194304
                        change: [-4.0883% -3.8467% -3.6178%] (p = 0.00 < 0.05)

"BLS12-377 - radix-2" - subgroup_ifft_in_place/32768
                        change: [-23.822% -23.138% -22.439%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_ifft_in_place/65536
                        change: [-17.412% -16.717% -16.030%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_ifft_in_place/131072
                        change: [-14.700% -13.917% -13.137%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_ifft_in_place/262144
                        change: [-12.296% -11.604% -10.875%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_ifft_in_place/524288
                        change: [-6.3742% -5.7661% -5.1375%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_ifft_in_place/1048576 
                        change: [+0.6192% +1.9120% +3.1686%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_ifft_in_place/2097152
                        change: [-5.4650% -5.0034% -4.5735%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - subgroup_ifft_in_place/4194304
                        change: [-3.6662% -3.4340% -3.1888%] (p = 0.00 < 0.05)

"BLS12-377 - radix-2" - coset_fft_in_place/32768
                        change: [-53.670% -52.992% -52.300%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_fft_in_place/65536
                        change: [-43.497% -42.679% -41.879%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_fft_in_place/131072
                        change: [-34.556% -33.697% -32.837%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_fft_in_place/262144
                        change: [-25.909% -25.085% -24.292%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_fft_in_place/524288
                        change: [-14.433% -13.520% -12.605%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_fft_in_place/1048576
                        change: [+0.2455% +1.3769% +2.4041%] (p = 0.01 < 0.05)
"BLS12-377 - radix-2" - coset_fft_in_place/2097152
                        change: [-7.4416% -6.9670% -6.5165%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_fft_in_place/4194304
                        change: [-6.7545% -6.3000% -5.8669%] (p = 0.00 < 0.05)

"BLS12-377 - radix-2" - coset_ifft_in_place/32768
                        change: [-26.328% -25.074% -23.927%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_ifft_in_place/65536
                        change: [-17.721% -16.796% -15.863%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_ifft_in_place/131072
                        change: [-14.494% -13.778% -13.046%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_ifft_in_place/262144
                        change: [-13.132% -12.431% -11.733%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_ifft_in_place/524288
                        change: [-9.4738% -8.3335% -7.2746%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_ifft_in_place/1048576
                        change: [+1.6902% +2.9363% +4.1596%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_ifft_in_place/2097152
                        change: [-5.0769% -4.5573% -4.0022%] (p = 0.00 < 0.05)
"BLS12-377 - radix-2" - coset_ifft_in_place/4194304
                        change: [-4.8327% -4.5138% -4.2051%] (p = 0.00 < 0.05)