### PR TITLE
Algorithms: refactor the `blake2xs` module 

### DIFF
--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -59,7 +59,7 @@ version = "0.8"
 version = "1.3.1"
 
 [dependencies.blake2]
-version = "0.9"
+version = "0.10"
 
 [dependencies.chrono]
 version = "0.4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,13 +160,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+checksum = "b94ba84325db59637ffc528bbe8c7f86c02c57cff5c0e2b9b00f9a851f42f309"
 dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest 0.10.0",
 ]
 
 [[package]]
@@ -484,16 +482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array 0.14.4",
- "subtle",
-]
-
-[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,15 +573,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8549e6bfdecd113b7e221fe60b433087f6957387a20f8118ebca9b12af19143d"
@@ -601,6 +580,7 @@ dependencies = [
  "block-buffer 0.10.0",
  "crypto-common",
  "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1239,12 +1219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "opencl3"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,7 +1839,7 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug 0.2.3",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1918,13 +1892,11 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "blake2",
  "blake2s_simd",
  "criterion",
  "crossbeam-channel",
  "csv",
  "derivative",
- "digest 0.9.0",
  "expect-test",
  "getrandom",
  "hex",
@@ -1955,10 +1927,9 @@ name = "snarkvm-circuits"
 version = "0.7.5"
 dependencies = [
  "anyhow",
- "blake2",
  "criterion",
  "derivative",
- "digest 0.9.0",
+ "digest 0.10.0",
  "itertools",
  "num-bigint",
  "num-integer",
@@ -2060,7 +2031,7 @@ dependencies = [
  "blake2",
  "criterion",
  "derivative",
- "digest 0.9.0",
+ "digest 0.10.0",
  "itertools",
  "num-bigint",
  "num-integer",
@@ -2111,7 +2082,7 @@ dependencies = [
  "blake2",
  "criterion",
  "derivative",
- "digest 0.9.0",
+ "digest 0.10.0",
  "hashbrown",
  "rand",
  "rand_chacha",
@@ -2158,9 +2129,8 @@ dependencies = [
 name = "snarkvm-polycommit"
 version = "0.7.5"
 dependencies = [
- "blake2",
  "derivative",
- "digest 0.9.0",
+ "digest 0.10.0",
  "hashbrown",
  "itertools",
  "rand",

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -107,10 +107,6 @@ version = "0.1.8"
 [dependencies.anyhow]
 version = "1.0"
 
-[dependencies.blake2]
-version = "0.10"
-optional = true
-
 [dependencies.blake2s_simd]
 version = "1.0"
 
@@ -119,9 +115,6 @@ version = "0.5"
 
 [dependencies.derivative]
 version = "2"
-
-[dependencies.digest]
-version = "0.10"
 
 [dependencies.hex]
 version = "0.4.3"
@@ -242,7 +235,7 @@ wasm = [
 ]
 commitment = [ "crh" ]
 crh = [ ]
-crypto_hash = [ "blake2" ]
+crypto_hash = [ ]
 encryption = [ "signature" ]
 fft = [ ]
 hash_to_curve = [ ]

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -109,6 +109,7 @@ version = "1.0"
 
 [dependencies.blake2s_simd]
 version = "1.0"
+optional = true
 
 [dependencies.crossbeam-channel]
 version = "0.5"
@@ -235,10 +236,10 @@ wasm = [
 ]
 commitment = [ "crh" ]
 crh = [ ]
-crypto_hash = [ ]
+crypto_hash = [ "blake2s_simd" ]
 encryption = [ "signature" ]
 fft = [ ]
-hash_to_curve = [ ]
+hash_to_curve = [ "crypto_hash" ]
 merkle_tree = [ ]
 msm = [ ]
 prf = [ ]

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -108,7 +108,7 @@ version = "0.1.8"
 version = "1.0"
 
 [dependencies.blake2]
-version = "0.9"
+version = "0.10"
 optional = true
 
 [dependencies.blake2s_simd]
@@ -121,7 +121,7 @@ version = "0.5"
 version = "2"
 
 [dependencies.digest]
-version = "0.9"
+version = "0.10"
 
 [dependencies.hex]
 version = "0.4.3"

--- a/algorithms/src/crypto_hash/blake2xs.rs
+++ b/algorithms/src/crypto_hash/blake2xs.rs
@@ -129,4 +129,20 @@ mod tests {
             assert_eq!(output, case.output);
         }
     }
+
+    #[test]
+    fn test_blake2s() {
+        // Run test vector cases for blake2s as a sanity check for the underlying impl.
+        let vectors: Vec<Case> = serde_json::from_str(include_str!("./resources/blake2-kat.json")).unwrap();
+        for case in vectors.iter().filter(|v| &v.hash == "blake2s" && v.key.is_empty()) {
+            let input = hex::decode(case.input.as_bytes()).unwrap();
+            let output = hex::encode(
+                blake2s_simd::Params::new()
+                    .personal(&0u64.to_le_bytes())
+                    .hash(&input)
+                    .as_bytes(),
+            );
+            assert_eq!(output, case.output);
+        }
+    }
 }

--- a/algorithms/src/crypto_hash/blake2xs.rs
+++ b/algorithms/src/crypto_hash/blake2xs.rs
@@ -20,8 +20,8 @@
 ///! This implementation is based on the BLAKE2Xs specification in Section 2 of:
 ///! https://www.blake2.net/blake2x.pdf
 ///!
-use blake2::VarBlake2s;
-use digest::{Update, VariableOutput};
+use blake2::Blake2sVar;
+use digest::VariableOutput;
 
 #[rustfmt::skip]
 #[macro_export]
@@ -51,7 +51,6 @@ impl Blake2Xs {
     ///  - `input` is an input message as a slice of bytes,
     ///  - `XOF_DIGEST_LENGTH` is a `u16` set to the length of the final output digest in bytes,
     ///  - `PERSONALIZATION` is a `u64` representing a UTF-8 string of 8 characters.
-    #[rustfmt::skip]
     pub fn evaluate(input: &[u8], xof_digest_length: u16, persona: &[u8]) -> Vec<u8> {
         debug_assert!(xof_digest_length > 0, "Output digest must be of non-zero length");
         debug_assert!(persona.len() <= 8, "Personalization may be at most 8 characters");
@@ -70,106 +69,28 @@ impl Blake2Xs {
         for node_offset in 0..num_rounds {
             // Calculate the digest length for this round.
             let is_final_round = node_offset == num_rounds - 1;
-            let has_remainder =  xof_digest_length % 32 != 0;
+            let has_remainder = xof_digest_length % 32 != 0;
             let digest_length = match is_final_round && has_remainder {
                 true => (xof_digest_length % 32) as usize,
-                false => 32
+                false => 32,
             };
 
             // Compute the next part of the output digest.
-            output.extend_from_slice(blake2s_simd::Params::new()
-                .hash_length(digest_length)
-                .fanout(0)
-                .max_depth(0)
-                .max_leaf_length(32)
-                .node_offset(xof_digest_length_node_offset | (node_offset as u64))
-                .inner_hash_length(32)
-                .personal(persona)
-                .hash(input_digest.as_bytes())
-                .as_bytes());
+            output.extend_from_slice(
+                blake2s_simd::Params::new()
+                    .hash_length(digest_length)
+                    .fanout(0)
+                    .max_depth(0)
+                    .max_leaf_length(32)
+                    .node_offset(xof_digest_length_node_offset | (node_offset as u64))
+                    .inner_hash_length(32)
+                    .personal(persona)
+                    .hash(input_digest.as_bytes())
+                    .as_bytes(),
+            );
         }
 
         output
-    }
-
-    #[rustfmt::skip]
-    pub fn evaluate_blake2s(input: &[u8], persona: u64) -> [u8; 32] {
-        let mut h = VarBlake2s::with_parameter_block(&Self::blake2s_parameter_block(persona));
-        let mut output = [0u8; 32];
-        h.update(input);
-        h.finalize_variable(|buffer| output.copy_from_slice(buffer));
-        output
-    }
-
-    /// Returns the parameter block for BLAKE2Xs where:
-    ///  - `DIGEST_LENGTH` is a `u8` set to the expected output length of this evaluation of Blake2Xs,
-    ///  - `NODE_OFFSET` is a `u32` representing the current multiple of the digest length (starting from 0),
-    ///  - `XOF_DIGEST_LENGTH` is a `u16` set to the length of the final output digest in bytes,
-    ///  - `PERSONALIZATION` is a `u64` representing a UTF-8 string of 8 characters.
-    #[rustfmt::skip]
-    pub fn blake2xs_parameter_block(digest_length: u8, node_offset: u32, xof_digest_length: u16, persona: u64) -> [u32; 8] {
-        // • “Key length” is set to 0 (even if the root hash was keyed)
-        const KEY_LENGTH: u8 = 0u8;
-        // • “Fanout” is set to 0 (unlimited)
-        const FANOUT: u8 = 0u8;
-        // • “Maximal depth” is set to 0
-        const DEPTH: u8 = 0u8;
-        // • “Leaf maximal byte length” is set to 32 for BLAKE2Xs, and 64 for BLAKE2Xb
-        const LEAF_LENGTH: u32 = 32u32;
-        // • “Node depth” is set to 0 (leaves)
-        const NODE_DEPTH: u8 = 0u8;
-        // • “Inner hash byte length” is set to 32 for BLAKE2Xs and 64 for BLAKE2Xb
-        const INNER_LENGTH: u8 = 32u8;
-        // • Other fields are left to the same values as in the underlying BLAKE2 instance
-        const SALT: u64 = 0u64;
-
-        Self::parameter_block::<KEY_LENGTH, FANOUT, DEPTH, LEAF_LENGTH, NODE_DEPTH, INNER_LENGTH, SALT>(
-            digest_length,
-            node_offset,
-            xof_digest_length,
-            persona,
-        )
-    }
-
-    /// Returns the parameter block for BLAKE2s.
-    #[rustfmt::skip]
-    pub const fn blake2s_parameter_block(persona: u64) -> [u32; 8] {
-        Self::parameter_block::<0u8, 1u8, 1u8, 0u32, 0u8, 0u8, 0u64>(32u8, 0u32, 0u16, persona)
-    }
-
-    /// Returns the parameter block for BLAKE2 where:
-    ///  - `DIGEST_LENGTH` is a `u8` set to the expected output length of this evaluation,
-    ///  - `NODE_OFFSET` is a `u32` representing the current multiple of the digest length (starting from 0),
-    ///  - `XOF_DIGEST_LENGTH` is a `u16` set to the length of the final output digest in bytes,
-    ///  - `PERSONALIZATION` is a `u64` representing a UTF-8 string of 8 characters.
-    #[rustfmt::skip]
-    pub const fn parameter_block<
-        const KEY_LENGTH: u8,
-        const FANOUT: u8,
-        const DEPTH: u8,
-        const LEAF_LENGTH: u32,
-        const NODE_DEPTH: u8,
-        const INNER_LENGTH: u8,
-        const SALT: u64,
-    >(digest_length: u8, node_offset: u32, xof_digest_length: u16, persona: u64) -> [u32; 8] {
-        [
-            // Offset 0 - Digest length || Key length || Fanout || Depth
-            u32::from_le_bytes([digest_length, KEY_LENGTH, FANOUT, DEPTH]),
-            // Offset 4 - Leaf length
-            LEAF_LENGTH,
-            // Offset 8 - Node offset
-            node_offset,
-            // Offset 12 - XOF digest length || Node depth || Inner length
-            u32::from_le_bytes([xof_digest_length as u8, (xof_digest_length >> 8) as u8, NODE_DEPTH, INNER_LENGTH]),
-            // Offset 16 - Salt
-            u32::from_le_bytes([SALT as u8, (SALT >> 8) as u8, (SALT >> 16) as u8, (SALT >> 24) as u8]),
-            // Offset 20 - Salt (continued)
-            u32::from_le_bytes([(SALT >> 32) as u8, (SALT >> 40) as u8, (SALT >> 48) as u8, (SALT >> 56) as u8]),
-            // Offset 24 - Personalization
-            u32::from_le_bytes([persona as u8, (persona >> 8) as u8, (persona >> 16) as u8, (persona >> 24) as u8]),
-            // Offset 24 - Personalization (continued)
-            u32::from_le_bytes([(persona >> 32) as u8, (persona >> 40) as u8, (persona >> 48) as u8, (persona >> 56) as u8]),
-        ]
     }
 }
 
@@ -177,7 +98,7 @@ impl Blake2Xs {
 mod tests {
     use crate::crypto_hash::Blake2Xs;
 
-    use blake2::{Blake2s, VarBlake2s};
+    use blake2::{Blake2s, Blake2sVar};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaChaRng;
     use serde::Deserialize;
@@ -217,118 +138,14 @@ mod tests {
         }
     }
 
-    #[rustfmt::skip]
     #[test]
     fn test_blake2s() {
         // Run test vector cases.
         let vectors: Vec<Case> = serde_json::from_str(include_str!("./resources/blake2-kat.json")).unwrap();
-        for case in vectors.iter().filter(|v| &v.hash == "blake2s" && v.key.is_empty()) {            
+        for case in vectors.iter().filter(|v| &v.hash == "blake2s" && v.key.is_empty()) {
             let input = hex::decode(case.input.as_bytes()).unwrap();
             let output = hex::encode(Blake2Xs::evaluate_blake2s(&input, 0u64));
             assert_eq!(output, case.output);
-        }
-    }
-
-    #[rustfmt::skip]
-    #[test]
-    fn test_blake2s_parameter_block_correctness() {
-        use digest::generic_array::typenum::{Unsigned, U32};
-
-        fn evaluate_blake2s(mut h: Blake2s, input: [u8; 32]) -> Vec<u8> {
-            use digest::Digest;
-
-            h.update(input.as_ref());
-
-            let mut output = [0u8; 32];
-            output.copy_from_slice(&h.finalize());
-            output.to_vec()
-        }
-
-        fn evaluate_varblake2s(mut h: VarBlake2s, input: [u8; 32]) -> Vec<u8> {
-            use digest::{Update, VariableOutput};
-
-            h.update(input.as_ref());
-
-            let mut output = vec![0u8; digest::VariableOutput::output_size(&h)];
-            h.finalize_variable(|buffer| output.copy_from_slice(buffer));
-            assert_eq!(32, output.len());
-            output
-        }
-
-        fn u32_params_to_parameter_block(key: &[u8], salt: &[u8], persona: &[u8]) -> [u32; 8] {
-            use digest::generic_array::{typenum::{U4, Unsigned}, GenericArray};
-            use core::{convert::TryInto, ops::Div};
-
-            let kk = key.len();
-            assert!(kk <= U32::to_usize());
-            assert!(32 <= U32::to_usize());
-
-            // The number of bytes needed to express two words.
-            let length = U32::to_usize()/4;
-            assert!(salt.len() <= length);
-            assert!(persona.len() <= length);
-
-            // Build a parameter block
-            let mut p = [0u32; 8];
-            p[0] = 0x0101_0000 ^ ((kk as u32) << 8) ^ 32u32;
-
-            // salt is two words long
-            if salt.len() < length {
-                let mut padded_salt = GenericArray::<u8, <U32 as Div<U4>>::Output>::default();
-                for i in 0..salt.len() {
-                    padded_salt[i] = salt[i];
-                }
-                p[4] = u32::from_le_bytes(padded_salt[0 .. length/2].try_into().unwrap());
-                p[5] = u32::from_le_bytes(padded_salt[length/2 .. padded_salt.len()].try_into().unwrap());
-            } else {
-                p[4] = u32::from_le_bytes(salt[0 .. salt.len()/2].try_into().unwrap());
-                p[5] = u32::from_le_bytes(salt[salt.len()/2 .. salt.len()].try_into().unwrap());
-            }
-
-            // persona is also two words long
-            if persona.len() < length {
-                let mut padded_persona = GenericArray::<u8, <U32 as Div<U4>>::Output>::default();
-                for i in 0..persona.len() {
-                    padded_persona[i] = persona[i];
-                }
-                p[6] = u32::from_le_bytes(padded_persona[0 .. length/2].try_into().unwrap());
-                p[7] = u32::from_le_bytes(padded_persona[length/2 .. padded_persona.len()].try_into().unwrap());
-            } else {
-                p[6] = u32::from_le_bytes(persona[0 .. length/2].try_into().unwrap());
-                p[7] = u32::from_le_bytes(persona[length/2 .. persona.len()].try_into().unwrap());
-            }
-            p
-        }
-
-        // Initialize a random number generator.
-        let rng = &mut ChaChaRng::seed_from_u64(123456789u64);
-        
-        // Initialize the reference salt and persona.
-        const REFERENCE_SALT: [u8; 8] = [0u8; 8];
-        const REFERENCE_PERSONA: [u8; 8] = 0u64.to_le_bytes();
-        
-        // Run evaluations and enforce equality.
-        for _ in 0..ITERATIONS {
-            
-            // Initialize a reference implementation of Blake2s.
-            let reference_a = Blake2s::with_params(&[], &REFERENCE_SALT, &REFERENCE_PERSONA);
-
-            // Initialize a reference implementation of VarBlake2s.
-            let reference_b = VarBlake2s::with_params(&[], &REFERENCE_SALT, &REFERENCE_PERSONA, U32::to_usize());
-
-            // Initialize a reference implementation of VarBlake2s from a parameter block.
-            let reference_c = VarBlake2s::with_parameter_block(&u32_params_to_parameter_block(&[], &REFERENCE_SALT, &REFERENCE_PERSONA));
-
-            // Initialize a candidate implementation of Blake2s from the parameter block.
-            let candidate = VarBlake2s::with_parameter_block(&Blake2Xs::blake2s_parameter_block(0u64));
-            
-            // Sample a new input.
-            let input: [u8; 32] = rng.gen();
-            
-            // Compare the evaluation of the implementations.
-            assert_eq!(evaluate_blake2s(reference_a, input), evaluate_varblake2s(reference_b.clone(), input));
-            assert_eq!(evaluate_varblake2s(reference_b, input), evaluate_varblake2s(reference_c.clone(), input));
-            assert_eq!(evaluate_varblake2s(reference_c, input), evaluate_varblake2s(candidate, input));
         }
     }
 }

--- a/algorithms/src/crypto_hash/blake2xs.rs
+++ b/algorithms/src/crypto_hash/blake2xs.rs
@@ -20,8 +20,6 @@
 ///! This implementation is based on the BLAKE2Xs specification in Section 2 of:
 ///! https://www.blake2.net/blake2x.pdf
 ///!
-use blake2::Blake2sVar;
-use digest::VariableOutput;
 
 #[rustfmt::skip]
 #[macro_export]
@@ -97,13 +95,7 @@ impl Blake2Xs {
 #[cfg(test)]
 mod tests {
     use crate::crypto_hash::Blake2Xs;
-
-    use blake2::{Blake2s, Blake2sVar};
-    use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaChaRng;
     use serde::Deserialize;
-
-    const ITERATIONS: usize = 10_000;
 
     #[derive(Deserialize)]
     struct Case {
@@ -134,17 +126,6 @@ mod tests {
             let input = hex::decode(case.input.as_bytes()).unwrap();
             let xof_digest_length = case.output.len() as u16 / 2;
             let output = hex::encode(Blake2Xs::evaluate(&input, xof_digest_length, "".as_bytes()));
-            assert_eq!(output, case.output);
-        }
-    }
-
-    #[test]
-    fn test_blake2s() {
-        // Run test vector cases.
-        let vectors: Vec<Case> = serde_json::from_str(include_str!("./resources/blake2-kat.json")).unwrap();
-        for case in vectors.iter().filter(|v| &v.hash == "blake2s" && v.key.is_empty()) {
-            let input = hex::decode(case.input.as_bytes()).unwrap();
-            let output = hex::encode(Blake2Xs::evaluate_blake2s(&input, 0u64));
             assert_eq!(output, case.output);
         }
     }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -54,7 +54,7 @@ version = "1.0.53"
 version = "2"
 
 [dependencies.digest]
-version = "0.9"
+version = "0.10"
 
 [dependencies.itertools]
 version = "0.10.1"

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -91,9 +91,6 @@ version = "0.7.5"
 path = "../polycommit"
 version = "0.7.5"
 
-[dev-dependencies.blake2]
-version = "0.9"
-
 [dev-dependencies.criterion]
 version = "0.3"
 

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -105,7 +105,7 @@ version = "0.8"
 version = "1.3"
 
 [dependencies.blake2]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [dependencies.chrono]

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -28,7 +28,7 @@ use crate::{
     Program,
     ProgramPublicVariables,
 };
-use blake2::Blake2s;
+use blake2::Blake2s256;
 use snarkvm_algorithms::{
     crh::{PedersenCompressedCRH, PoseidonCRH, BHPCRH},
     encryption::ECIESPoseidonEncryption,
@@ -87,7 +87,7 @@ pub type DeprecatedPoSWSNARK<N> = MarlinSNARK<
     <N as Network>::InnerScalarField,
     <N as Network>::OuterScalarField,
     SonicKZG10<<N as Network>::InnerCurve>,
-    FiatShamirChaChaRng<<N as Network>::InnerScalarField, <N as Network>::OuterScalarField, Blake2s>,
+    FiatShamirChaChaRng<<N as Network>::InnerScalarField, <N as Network>::OuterScalarField, Blake2s256>,
     snarkvm_marlin::marlin::MarlinTestnet1Mode,
     Vec<<N as Network>::InnerScalarField>,
 >;
@@ -183,7 +183,7 @@ impl Network for Testnet2 {
     type ProgramVerifyingKey = <Self::ProgramSNARK as SNARK>::VerifyingKey;
     type ProgramProof = AleoObject<<Self::ProgramSNARK as SNARK>::Proof, { Self::PROGRAM_PROOF_PREFIX }, { Self::PROGRAM_PROOF_SIZE_IN_BYTES }>;
 
-    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, FiatShamirChaChaRng<Self::InnerScalarField, Self::OuterScalarField, Blake2s>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
+    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, FiatShamirChaChaRng<Self::InnerScalarField, Self::OuterScalarField, Blake2s256>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
     type PoSWProof = AleoObject<<Self::PoSWSNARK as SNARK>::Proof, { Self::HEADER_PROOF_PREFIX }, { Self::HEADER_PROOF_SIZE_IN_BYTES }>;
     type PoSW = PoSW<Self>;
 

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -54,7 +54,7 @@ version = "1.0.53"
 version = "2"
 
 [dependencies.digest]
-version = "0.9"
+version = "0.10"
 
 [dependencies.itertools]
 version = "0.10.3"
@@ -78,7 +78,7 @@ optional = true
 version = "1.0"
 
 [dev-dependencies.blake2]
-version = "0.9"
+version = "0.10"
 
 [dev-dependencies.criterion]
 version = "0.3"

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -53,9 +53,6 @@ version = "1.0.53"
 [dependencies.derivative]
 version = "2"
 
-[dependencies.digest]
-version = "0.10"
-
 [dependencies.itertools]
 version = "0.10.3"
 
@@ -82,6 +79,9 @@ version = "0.10"
 
 [dev-dependencies.criterion]
 version = "0.3"
+
+[dev-dependencies.digest]
+version = "0.10"
 
 [dev-dependencies.paste]
 version = "1.0"

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use blake2::{digest::Digest, Blake2s};
+use blake2::{digest::Digest, Blake2s256};
 use rand::{thread_rng, Rng};
 
 use snarkvm_algorithms::{
@@ -138,7 +138,7 @@ fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: Mas
     let mut root_bytes = [0u8; 32];
     root.write_le(&mut root_bytes[..]).unwrap();
 
-    let mut h = Blake2s::new();
+    let mut h = Blake2s256::new();
     h.update(nonce.as_ref());
     h.update(&root_bytes);
     let mask = h.finalize().to_vec();

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -72,10 +72,6 @@ default-features = false
 [dependencies.bincode]
 version = "1.3"
 
-[dependencies.blake2]
-version = "0.10"
-default-features = false
-
 [dependencies.derivative]
 version = "2"
 features = [ "use_core" ]
@@ -109,6 +105,10 @@ features = [ "derive" ]
 version = "1.8"
 default-features = false
 features = [ "const_generics", "const_new" ]
+
+[dev-dependencies.blake2]
+version = "0.10"
+default-features = false
 
 [dev-dependencies.criterion]
 version = "0.3.5"

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -73,7 +73,7 @@ default-features = false
 version = "1.3"
 
 [dependencies.blake2]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [dependencies.derivative]
@@ -81,7 +81,7 @@ version = "2"
 features = [ "use_core" ]
 
 [dependencies.digest]
-version = "0.9"
+version = "0.10"
 
 [dependencies.hashbrown]
 version = "0.11.2"

--- a/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
+++ b/marlin/src/constraints/verifier_key/circuit_verifier_key.rs
@@ -451,7 +451,7 @@ where
 mod test {
     use core::ops::MulAssign;
 
-    use blake2::Blake2s;
+    use blake2::Blake2s256;
 
     use snarkvm_curves::{
         bls12_377::{Bls12_377, Fq, Fr},
@@ -470,7 +470,7 @@ mod test {
     use super::*;
 
     type MultiPC = SonicKZG10<Bls12_377>;
-    type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode>;
+    type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinTestnet1Mode>;
 
     type MultiPCVar = SonicKZG10Gadget<Bls12_377, BW6_761, Bls12_377PairingGadget>;
 

--- a/marlin/src/fiat_shamir/fiat_shamir_chacha.rs
+++ b/marlin/src/fiat_shamir/fiat_shamir_chacha.rs
@@ -188,7 +188,7 @@ mod tests {
     use snarkvm_curves::bls12_377::{Fq, Fr};
     use snarkvm_utilities::rand::UniformRand;
 
-    use blake2::Blake2s;
+    use blake2::Blake2s256;
     use rand_chacha::ChaChaRng;
 
     const NUM_ABSORBED_RAND_FIELD_ELEMS: usize = 10;
@@ -212,7 +212,7 @@ mod tests {
             absorbed_rand_byte_elems.push((0..SIZE_ABSORBED_BYTE_ELEM).map(|_| u8::rand(&mut rng)).collect());
         }
 
-        let mut fs_rng = FiatShamirChaChaRng::<Fr, Fq, Blake2s>::new();
+        let mut fs_rng = FiatShamirChaChaRng::<Fr, Fq, Blake2s256>::new();
         fs_rng.absorb_nonnative_field_elements(&absorbed_rand_field_elems, OptimizationType::Weight);
         for absorbed_rand_byte_elem in absorbed_rand_byte_elems {
             fs_rng.absorb_bytes(&absorbed_rand_byte_elem);

--- a/marlin/src/marlin/tests.rs
+++ b/marlin/src/marlin/tests.rs
@@ -79,16 +79,16 @@ mod marlin {
     use snarkvm_polycommit::{marlin_pc::MarlinKZG10, sonic_pc::SonicKZG10};
     use snarkvm_utilities::rand::{test_rng, UniformRand};
 
-    use blake2::Blake2s;
+    use blake2::Blake2s256;
     use core::ops::MulAssign;
 
     type MultiPC = MarlinKZG10<Bls12_377>;
-    type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode>;
+    type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinTestnet1Mode>;
 
     type MultiPCSonic = SonicKZG10<Bls12_377>;
-    type MarlinSonicInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode>;
+    type MarlinSonicInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinTestnet1Mode>;
 
-    type MarlinSonicPoswInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinPoswMode>;
+    type MarlinSonicPoswInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinPoswMode>;
 
     macro_rules! impl_marlin_test {
         ($test_struct: ident, $marlin_inst: tt, $marlin_mode: tt) => {

--- a/marlin/src/marlin/tests.rs
+++ b/marlin/src/marlin/tests.rs
@@ -86,9 +86,11 @@ mod marlin {
     type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinTestnet1Mode>;
 
     type MultiPCSonic = SonicKZG10<Bls12_377>;
-    type MarlinSonicInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinTestnet1Mode>;
+    type MarlinSonicInst =
+        MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinTestnet1Mode>;
 
-    type MarlinSonicPoswInst = MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinPoswMode>;
+    type MarlinSonicPoswInst =
+        MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s256>, MarlinPoswMode>;
 
     macro_rules! impl_marlin_test {
         ($test_struct: ident, $marlin_inst: tt, $marlin_mode: tt) => {

--- a/polycommit/Cargo.toml
+++ b/polycommit/Cargo.toml
@@ -72,7 +72,7 @@ version = "2"
 features = [ "use_core" ]
 
 [dependencies.digest]
-version = "0.9"
+version = "0.10"
 
 [dependencies.hashbrown]
 version = "0.11.2"

--- a/polycommit/Cargo.toml
+++ b/polycommit/Cargo.toml
@@ -93,10 +93,6 @@ features = [ "std_rng" ]
 version = "1"
 optional = true
 
-[dev-dependencies.blake2]
-version = "0.9"
-default-features = false
-
 [dev-dependencies.snarkvm-marlin]
 path = "../marlin"
 


### PR DESCRIPTION
This PR removes the dead code from the `blake2xs` module. This includes the now unnecessary parameter-block helpers and some obsolete tests. In addition, `blake2s_simd` was turned into an optional dependency and `blake2` was removed from the `algorithms` crate entirely. 

After the bump to `v0.10`, `blake2` remains a dependency (`Blake2s256`) on `FiatShamirChaChaRng` and is also bounded by `Digest` which the `simd` implementation is not.

Obviates #574 and #527. 