### PR TITLE
Removes unused Network traits and unifies MarlinMode

### DIFF
--- a/circuits/src/models/constraint_converter.rs
+++ b/circuits/src/models/constraint_converter.rs
@@ -232,7 +232,7 @@ mod tests {
             use snarkvm_curves::bls12_377::{Bls12_377, Fq};
             use snarkvm_marlin::{
                 fiat_shamir::{FiatShamirAlgebraicSpongeRng, PoseidonSponge},
-                marlin::{MarlinRecursiveMode, MarlinSNARK},
+                marlin::{MarlinHidingMode, MarlinSNARK},
             };
             use snarkvm_polycommit::sonic_pc::SonicKZG10;
             use snarkvm_utilities::rand::test_rng;
@@ -243,14 +243,14 @@ mod tests {
                 Fq,
                 MultiPC,
                 FiatShamirAlgebraicSpongeRng<Fr, Fq, PoseidonSponge<Fq, 6, 1>>,
-                MarlinRecursiveMode,
+                MarlinHidingMode,
                 Vec<Fr>,
             >;
 
             let rng = &mut test_rng();
 
             let max_degree =
-                snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(200, 200, 300).unwrap();
+                snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(200, 200, 300).unwrap();
             let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
             let (index_pk, index_vk) = MarlinInst::circuit_setup(&universal_srs, &*Circuit::cs().cs.borrow()).unwrap();

--- a/dpc/src/network/testnet1.rs
+++ b/dpc/src/network/testnet1.rs
@@ -128,10 +128,9 @@ impl Network for Testnet1 {
 
     type InnerCurve = Bls12_377;
     type InnerScalarField = <Self::InnerCurve as PairingEngine>::Fr;
-    
+    type InnerBaseField = <Self::OuterCurve as PairingEngine>::Fr;
+
     type OuterCurve = BW6_761;
-    type OuterBaseField = <Self::OuterCurve as PairingEngine>::Fq;
-    type OuterScalarField = <Self::OuterCurve as PairingEngine>::Fr;
 
     type ProgramAffineCurve = EdwardsBls12Affine;
     type ProgramAffineCurveGadget = EdwardsBls12Gadget;
@@ -148,7 +147,7 @@ impl Network for Testnet1 {
     type ProgramVerifyingKey = <Self::ProgramSNARK as SNARK>::VerifyingKey;
     type ProgramProof = AleoObject<<Self::ProgramSNARK as SNARK>::Proof, { Self::PROGRAM_PROOF_PREFIX }, { Self::PROGRAM_PROOF_SIZE_IN_BYTES }>;
 
-    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::OuterScalarField, PoseidonSponge<Self::OuterScalarField, 6, 1>>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
+    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::InnerBaseField, PoseidonSponge<Self::InnerBaseField, 6, 1>>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
     type PoSWProof = AleoObject<<Self::PoSWSNARK as SNARK>::Proof, { Self::HEADER_PROOF_PREFIX }, { Self::HEADER_PROOF_SIZE_IN_BYTES }>;
     type PoSW = PoSW<Self>;
 
@@ -176,8 +175,8 @@ impl Network for Testnet1 {
     type CommitmentGadget = BHPCRHGadget<Self::ProgramProjectiveCurve, Self::InnerScalarField, Self::ProgramAffineCurveGadget, 41, 63>;
     type Commitment = AleoLocator<<Self::CommitmentScheme as CRH>::Output, { Self::COMMITMENT_PREFIX }>;
 
-    type FunctionIDCRH = PoseidonCRH<Self::OuterScalarField, 34>;
-    type FunctionIDCRHGadget = PoseidonCRHGadget<Self::OuterScalarField, 34>;
+    type FunctionIDCRH = PoseidonCRH<Self::InnerBaseField, 34>;
+    type FunctionIDCRHGadget = PoseidonCRHGadget<Self::InnerBaseField, 34>;
     type FunctionID = AleoLocator<<Self::FunctionIDCRH as CRH>::Output, { Self::FUNCTION_ID_PREFIX }>;
 
     type FunctionInputsCRH = PoseidonCRH<Self::InnerScalarField, 128>;
@@ -185,7 +184,7 @@ impl Network for Testnet1 {
     type FunctionInputsHash = AleoLocator<<Self::FunctionInputsCRH as CRH>::Output, { Self::FUNCTION_INPUTS_HASH_PREFIX }>;
 
     type InnerCircuitIDCRH = BHPCRH<EdwardsBW6, 85, 63>;
-    type InnerCircuitIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::OuterScalarField, EdwardsBW6Gadget, 85, 63>;
+    type InnerCircuitIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 85, 63>;
     type InnerCircuitID = AleoLocator<<Self::InnerCircuitIDCRH as CRH>::Output, { Self::INNER_CIRCUIT_ID_PREFIX }>;
 
     type LedgerRootCRH = BHPCRH<Self::ProgramProjectiveCurve, 16, 32>;
@@ -198,7 +197,7 @@ impl Network for Testnet1 {
     type PoSWNonce = AleoLocator<Self::InnerScalarField, { Self::HEADER_NONCE_PREFIX }>;
 
     type ProgramIDCRH = BHPCRH<EdwardsBW6, 16, 48>;
-    type ProgramIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::OuterScalarField, EdwardsBW6Gadget, 16, 48>;
+    type ProgramIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 16, 48>;
     type ProgramIDParameters = MerkleTreeParameters<Self::ProgramIDCRH, { Self::PROGRAM_TREE_DEPTH }>;
     type ProgramID = AleoLocator<<Self::ProgramIDCRH as CRH>::Output, { Self::PROGRAM_ID_PREFIX }>;
 

--- a/dpc/src/network/testnet1.rs
+++ b/dpc/src/network/testnet1.rs
@@ -53,7 +53,7 @@ use snarkvm_gadgets::{
         prf::PoseidonPRFGadget,
         signature::AleoSignatureSchemeGadget,
     },
-    curves::{edwards_bls12::EdwardsBls12Gadget, edwards_bw6::EdwardsBW6Gadget},
+    curves::edwards_bls12::EdwardsBls12Gadget,
 };
 use snarkvm_marlin::{marlin::MarlinPoswMode, FiatShamirAlgebraicSpongeRng, MarlinSNARK, PoseidonSponge};
 use snarkvm_parameters::{testnet1::*, Genesis};
@@ -181,7 +181,6 @@ impl Network for Testnet1 {
     type FunctionInputsHash = AleoLocator<<Self::FunctionInputsCRH as CRH>::Output, { Self::FUNCTION_INPUTS_HASH_PREFIX }>;
 
     type InnerCircuitIDCRH = BHPCRH<EdwardsBW6, 85, 63>;
-    type InnerCircuitIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 85, 63>;
     type InnerCircuitID = AleoLocator<<Self::InnerCircuitIDCRH as CRH>::Output, { Self::INNER_CIRCUIT_ID_PREFIX }>;
 
     type LedgerRootCRH = BHPCRH<Self::ProgramProjectiveCurve, 16, 32>;
@@ -194,7 +193,6 @@ impl Network for Testnet1 {
     type PoSWNonce = AleoLocator<Self::InnerScalarField, { Self::HEADER_NONCE_PREFIX }>;
 
     type ProgramIDCRH = BHPCRH<EdwardsBW6, 16, 48>;
-    type ProgramIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 16, 48>;
     type ProgramIDParameters = MerkleTreeParameters<Self::ProgramIDCRH, { Self::PROGRAM_TREE_DEPTH }>;
     type ProgramID = AleoLocator<<Self::ProgramIDCRH as CRH>::Output, { Self::PROGRAM_ID_PREFIX }>;
 

--- a/dpc/src/network/testnet1.rs
+++ b/dpc/src/network/testnet1.rs
@@ -38,7 +38,6 @@ use snarkvm_algorithms::{
 };
 use snarkvm_curves::{
     bls12_377::Bls12_377,
-    bw6_761::BW6_761,
     edwards_bls12::{
         EdwardsAffine as EdwardsBls12Affine,
         EdwardsParameters,
@@ -128,9 +127,7 @@ impl Network for Testnet1 {
 
     type InnerCurve = Bls12_377;
     type InnerScalarField = <Self::InnerCurve as PairingEngine>::Fr;
-    type InnerBaseField = <Self::OuterCurve as PairingEngine>::Fr;
-
-    type OuterCurve = BW6_761;
+    type InnerBaseField = <Self::InnerCurve as PairingEngine>::Fq;
 
     type ProgramAffineCurve = EdwardsBls12Affine;
     type ProgramAffineCurveGadget = EdwardsBls12Gadget;

--- a/dpc/src/network/testnet1.rs
+++ b/dpc/src/network/testnet1.rs
@@ -55,7 +55,7 @@ use snarkvm_gadgets::{
     },
     curves::edwards_bls12::EdwardsBls12Gadget,
 };
-use snarkvm_marlin::{marlin::MarlinPoswMode, FiatShamirAlgebraicSpongeRng, MarlinSNARK, PoseidonSponge};
+use snarkvm_marlin::{marlin::MarlinNonHidingMode, FiatShamirAlgebraicSpongeRng, MarlinSNARK, PoseidonSponge};
 use snarkvm_parameters::{testnet1::*, Genesis};
 use snarkvm_polycommit::sonic_pc::SonicKZG10;
 use snarkvm_utilities::{FromBytes, ToMinimalBits};
@@ -144,7 +144,7 @@ impl Network for Testnet1 {
     type ProgramVerifyingKey = <Self::ProgramSNARK as SNARK>::VerifyingKey;
     type ProgramProof = AleoObject<<Self::ProgramSNARK as SNARK>::Proof, { Self::PROGRAM_PROOF_PREFIX }, { Self::PROGRAM_PROOF_SIZE_IN_BYTES }>;
 
-    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::InnerBaseField, PoseidonSponge<Self::InnerBaseField, 6, 1>>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
+    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::InnerBaseField, PoseidonSponge<Self::InnerBaseField, 6, 1>>, MarlinNonHidingMode, Vec<Self::InnerScalarField>>;
     type PoSWProof = AleoObject<<Self::PoSWSNARK as SNARK>::Proof, { Self::HEADER_PROOF_PREFIX }, { Self::HEADER_PROOF_SIZE_IN_BYTES }>;
     type PoSW = PoSW<Self>;
 

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -57,7 +57,7 @@ use snarkvm_gadgets::{
     curves::edwards_bls12::EdwardsBls12Gadget,
 };
 use snarkvm_marlin::{
-    marlin::{MarlinPoswMode, MarlinSNARK, MarlinTestnet2Mode},
+    marlin::{MarlinHidingMode, MarlinNonHidingMode, MarlinSNARK},
     FiatShamirAlgebraicSpongeRng,
     FiatShamirChaChaRng,
     PoseidonSponge,
@@ -146,12 +146,12 @@ impl Network for Testnet2 {
     type InnerSNARK = Groth16<Self::InnerCurve, InnerPublicVariables<Testnet2>>;
     type InnerProof = AleoObject<<Self::InnerSNARK as SNARK>::Proof, { Self::INNER_PROOF_PREFIX }, { Self::INNER_PROOF_SIZE_IN_BYTES }>;
 
-    type ProgramSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::InnerBaseField, PoseidonSponge<Self::InnerBaseField, 6, 1>>, MarlinTestnet2Mode, ProgramPublicVariables<Self>>;
+    type ProgramSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::InnerBaseField, PoseidonSponge<Self::InnerBaseField, 6, 1>>, MarlinHidingMode, ProgramPublicVariables<Self>>;
     type ProgramProvingKey = <Self::ProgramSNARK as SNARK>::ProvingKey;
     type ProgramVerifyingKey = <Self::ProgramSNARK as SNARK>::VerifyingKey;
     type ProgramProof = AleoObject<<Self::ProgramSNARK as SNARK>::Proof, { Self::PROGRAM_PROOF_PREFIX }, { Self::PROGRAM_PROOF_SIZE_IN_BYTES }>;
 
-    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirChaChaRng<Self::InnerScalarField, Self::InnerBaseField, Blake2s>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
+    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirChaChaRng<Self::InnerScalarField, Self::InnerBaseField, Blake2s>, MarlinNonHidingMode, Vec<Self::InnerScalarField>>;
     type PoSWProof = AleoObject<<Self::PoSWSNARK as SNARK>::Proof, { Self::HEADER_PROOF_PREFIX }, { Self::HEADER_PROOF_SIZE_IN_BYTES }>;
     type PoSW = PoSW<Self>;
 

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -135,10 +135,9 @@ impl Network for Testnet2 {
 
     type InnerCurve = Bls12_377;
     type InnerScalarField = <Self::InnerCurve as PairingEngine>::Fr;
-    
+    type InnerBaseField = <Self::OuterCurve as PairingEngine>::Fr;
+
     type OuterCurve = BW6_761;
-    type OuterBaseField = <Self::OuterCurve as PairingEngine>::Fq;
-    type OuterScalarField = <Self::OuterCurve as PairingEngine>::Fr;
 
     type ProgramAffineCurve = EdwardsBls12Affine;
     type ProgramAffineCurveGadget = EdwardsBls12Gadget;
@@ -150,12 +149,12 @@ impl Network for Testnet2 {
     type InnerSNARK = Groth16<Self::InnerCurve, InnerPublicVariables<Testnet2>>;
     type InnerProof = AleoObject<<Self::InnerSNARK as SNARK>::Proof, { Self::INNER_PROOF_PREFIX }, { Self::INNER_PROOF_SIZE_IN_BYTES }>;
 
-    type ProgramSNARK = MarlinSNARK<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::OuterScalarField, PoseidonSponge<Self::OuterScalarField, 6, 1>>, MarlinTestnet2Mode, ProgramPublicVariables<Self>>;
+    type ProgramSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirAlgebraicSpongeRng<Self::InnerScalarField, Self::InnerBaseField, PoseidonSponge<Self::InnerBaseField, 6, 1>>, MarlinTestnet2Mode, ProgramPublicVariables<Self>>;
     type ProgramProvingKey = <Self::ProgramSNARK as SNARK>::ProvingKey;
     type ProgramVerifyingKey = <Self::ProgramSNARK as SNARK>::VerifyingKey;
     type ProgramProof = AleoObject<<Self::ProgramSNARK as SNARK>::Proof, { Self::PROGRAM_PROOF_PREFIX }, { Self::PROGRAM_PROOF_SIZE_IN_BYTES }>;
 
-    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::OuterScalarField, SonicKZG10<Self::InnerCurve>, FiatShamirChaChaRng<Self::InnerScalarField, Self::OuterScalarField, Blake2s>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
+    type PoSWSNARK = MarlinSNARK<Self::InnerScalarField, Self::InnerBaseField, SonicKZG10<Self::InnerCurve>, FiatShamirChaChaRng<Self::InnerScalarField, Self::InnerBaseField, Blake2s>, MarlinPoswMode, Vec<Self::InnerScalarField>>;
     type PoSWProof = AleoObject<<Self::PoSWSNARK as SNARK>::Proof, { Self::HEADER_PROOF_PREFIX }, { Self::HEADER_PROOF_SIZE_IN_BYTES }>;
     type PoSW = PoSW<Self>;
 
@@ -183,8 +182,8 @@ impl Network for Testnet2 {
     type CommitmentGadget = BHPCRHGadget<Self::ProgramProjectiveCurve, Self::InnerScalarField, Self::ProgramAffineCurveGadget, 41, 63>;
     type Commitment = AleoLocator<<Self::CommitmentScheme as CRH>::Output, { Self::COMMITMENT_PREFIX }>;
 
-    type FunctionIDCRH = PoseidonCRH<Self::OuterScalarField, 34>;
-    type FunctionIDCRHGadget = PoseidonCRHGadget<Self::OuterScalarField, 34>;
+    type FunctionIDCRH = PoseidonCRH<Self::InnerBaseField, 34>;
+    type FunctionIDCRHGadget = PoseidonCRHGadget<Self::InnerBaseField, 34>;
     type FunctionID = AleoLocator<<Self::FunctionIDCRH as CRH>::Output, { Self::FUNCTION_ID_PREFIX }>;
 
     type FunctionInputsCRH = PoseidonCRH<Self::InnerScalarField, 128>;
@@ -192,7 +191,7 @@ impl Network for Testnet2 {
     type FunctionInputsHash = AleoLocator<<Self::FunctionInputsCRH as CRH>::Output, { Self::FUNCTION_INPUTS_HASH_PREFIX }>;
 
     type InnerCircuitIDCRH = BHPCRH<EdwardsBW6, 85, 63>;
-    type InnerCircuitIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::OuterScalarField, EdwardsBW6Gadget, 85, 63>;
+    type InnerCircuitIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 85, 63>;
     type InnerCircuitID = AleoLocator<<Self::InnerCircuitIDCRH as CRH>::Output, { Self::INNER_CIRCUIT_ID_PREFIX }>;
 
     type LedgerRootCRH = BHPCRH<Self::ProgramProjectiveCurve, 16, 32>;
@@ -205,7 +204,7 @@ impl Network for Testnet2 {
     type PoSWNonce = AleoLocator<Self::InnerScalarField, { Self::HEADER_NONCE_PREFIX }>;
 
     type ProgramIDCRH = BHPCRH<EdwardsBW6, 16, 48>;
-    type ProgramIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::OuterScalarField, EdwardsBW6Gadget, 16, 48>;
+    type ProgramIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 16, 48>;
     type ProgramIDParameters = MerkleTreeParameters<Self::ProgramIDCRH, { Self::PROGRAM_TREE_DEPTH }>;
     type ProgramID = AleoLocator<<Self::ProgramIDCRH as CRH>::Output, { Self::PROGRAM_ID_PREFIX }>;
 

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -39,7 +39,6 @@ use snarkvm_algorithms::{
 };
 use snarkvm_curves::{
     bls12_377::Bls12_377,
-    bw6_761::BW6_761,
     edwards_bls12::{
         EdwardsAffine as EdwardsBls12Affine,
         EdwardsParameters,
@@ -135,9 +134,7 @@ impl Network for Testnet2 {
 
     type InnerCurve = Bls12_377;
     type InnerScalarField = <Self::InnerCurve as PairingEngine>::Fr;
-    type InnerBaseField = <Self::OuterCurve as PairingEngine>::Fr;
-
-    type OuterCurve = BW6_761;
+    type InnerBaseField = <Self::InnerCurve as PairingEngine>::Fq;
 
     type ProgramAffineCurve = EdwardsBls12Affine;
     type ProgramAffineCurveGadget = EdwardsBls12Gadget;

--- a/dpc/src/network/testnet2.rs
+++ b/dpc/src/network/testnet2.rs
@@ -54,7 +54,7 @@ use snarkvm_gadgets::{
         prf::PoseidonPRFGadget,
         signature::AleoSignatureSchemeGadget,
     },
-    curves::{edwards_bls12::EdwardsBls12Gadget, edwards_bw6::EdwardsBW6Gadget},
+    curves::edwards_bls12::EdwardsBls12Gadget,
 };
 use snarkvm_marlin::{
     marlin::{MarlinPoswMode, MarlinSNARK, MarlinTestnet2Mode},
@@ -188,7 +188,6 @@ impl Network for Testnet2 {
     type FunctionInputsHash = AleoLocator<<Self::FunctionInputsCRH as CRH>::Output, { Self::FUNCTION_INPUTS_HASH_PREFIX }>;
 
     type InnerCircuitIDCRH = BHPCRH<EdwardsBW6, 85, 63>;
-    type InnerCircuitIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 85, 63>;
     type InnerCircuitID = AleoLocator<<Self::InnerCircuitIDCRH as CRH>::Output, { Self::INNER_CIRCUIT_ID_PREFIX }>;
 
     type LedgerRootCRH = BHPCRH<Self::ProgramProjectiveCurve, 16, 32>;
@@ -201,7 +200,6 @@ impl Network for Testnet2 {
     type PoSWNonce = AleoLocator<Self::InnerScalarField, { Self::HEADER_NONCE_PREFIX }>;
 
     type ProgramIDCRH = BHPCRH<EdwardsBW6, 16, 48>;
-    type ProgramIDCRHGadget = BHPCRHGadget<EdwardsBW6, Self::InnerBaseField, EdwardsBW6Gadget, 16, 48>;
     type ProgramIDParameters = MerkleTreeParameters<Self::ProgramIDCRH, { Self::PROGRAM_TREE_DEPTH }>;
     type ProgramID = AleoLocator<<Self::ProgramIDCRH as CRH>::Output, { Self::PROGRAM_ID_PREFIX }>;
 

--- a/dpc/src/posw/circuit.rs
+++ b/dpc/src/posw/circuit.rs
@@ -152,7 +152,7 @@ impl<N: Network> ConstraintSynthesizer<N::InnerScalarField> for PoSWCircuit<N> {
 mod test {
     use super::*;
     use crate::{testnet1::Testnet1, testnet2::Testnet2, PoSWProof};
-    use snarkvm_marlin::marlin::MarlinTestnet1Mode;
+    use snarkvm_marlin::marlin::MarlinHidingMode;
     use snarkvm_r1cs::TestConstraintSystem;
     use snarkvm_utilities::{FromBytes, ToBytes, UniformRand};
 
@@ -179,7 +179,7 @@ mod test {
     fn posw_proof_test<N: Network, R: Rng + CryptoRng>(rng: &mut R) {
         // Generate the proving and verifying key.
         let (proving_key, verifying_key) = {
-            let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<N::InnerScalarField, MarlinTestnet1Mode>::max_degree(
+            let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<N::InnerScalarField, MarlinHidingMode>::max_degree(
                 20000, 20000, 200000,
             )
             .unwrap();

--- a/dpc/src/traits/network.rs
+++ b/dpc/src/traits/network.rs
@@ -153,9 +153,6 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     type InnerScalarField: PrimeField + PoseidonDefaultParametersField;
     type InnerBaseField: PrimeField + PoseidonDefaultParametersField;
 
-    /// Outer curve type declarations.
-    type OuterCurve: PairingEngine;
-
     /// Program curve type declarations.
     type ProgramAffineCurve: AffineCurve<BaseField = Self::ProgramBaseField>;
     type ProgramAffineCurveGadget: GroupGadget<Self::ProgramAffineCurve, Self::InnerScalarField>;

--- a/dpc/src/traits/network.rs
+++ b/dpc/src/traits/network.rs
@@ -219,7 +219,6 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
 
     /// CRH for hash of the `Self::InnerSNARK` verifying keys. Invoked only over `Self::OuterScalarField`.
     type InnerCircuitIDCRH: CRH<Output = Self::InnerBaseField>;
-    type InnerCircuitIDCRHGadget: CRHGadget<Self::InnerCircuitIDCRH, Self::InnerBaseField>;
     type InnerCircuitID: Bech32Locator<<Self::InnerCircuitIDCRH as CRH>::Output>;
 
     /// Merkle scheme for computing the ledger root. Invoked only over `Self::InnerScalarField`.
@@ -235,7 +234,6 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
 
     /// CRH for deriving program IDs. Invoked only over `Self::OuterScalarField`.
     type ProgramIDCRH: CRH<Output = Self::InnerBaseField>;
-    type ProgramIDCRHGadget: CRHGadget<Self::ProgramIDCRH, Self::InnerBaseField>;
     type ProgramIDParameters: MerkleParameters<H = Self::ProgramIDCRH>;
     type ProgramID: Bech32Locator<<Self::ProgramIDCRH as CRH>::Output>;
 

--- a/dpc/src/traits/network.rs
+++ b/dpc/src/traits/network.rs
@@ -149,13 +149,12 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     const ALEO_MAXIMUM_FORK_DEPTH: u32;
 
     /// Inner curve type declarations.
-    type InnerCurve: PairingEngine<Fr = Self::InnerScalarField, Fq = Self::OuterScalarField>;
+    type InnerCurve: PairingEngine<Fr = Self::InnerScalarField, Fq = Self::InnerBaseField>;
     type InnerScalarField: PrimeField + PoseidonDefaultParametersField;
+    type InnerBaseField: PrimeField + PoseidonDefaultParametersField;
 
     /// Outer curve type declarations.
     type OuterCurve: PairingEngine;
-    type OuterBaseField: PrimeField;
-    type OuterScalarField: PrimeField + PoseidonDefaultParametersField;
 
     /// Program curve type declarations.
     type ProgramAffineCurve: AffineCurve<BaseField = Self::ProgramBaseField>;
@@ -166,17 +165,17 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     type ProgramScalarField: PrimeField;
 
     /// SNARK for inner circuit proof generation.
-    type InnerSNARK: SNARK<ScalarField = Self::InnerScalarField, BaseField = Self::OuterScalarField, VerifierInput = InnerPublicVariables<Self>>;
+    type InnerSNARK: SNARK<ScalarField = Self::InnerScalarField, BaseField = Self::InnerBaseField, VerifierInput = InnerPublicVariables<Self>>;
     type InnerProof: Bech32Object<<Self::InnerSNARK as SNARK>::Proof>;
 
     /// SNARK for Aleo program functions.
-    type ProgramSNARK: SNARK<ScalarField = Self::InnerScalarField, BaseField = Self::OuterScalarField, VerifierInput = ProgramPublicVariables<Self>, ProvingKey = Self::ProgramProvingKey, VerifyingKey = Self::ProgramVerifyingKey, UniversalSetupConfig = usize>;
+    type ProgramSNARK: SNARK<ScalarField = Self::InnerScalarField, BaseField = Self::InnerBaseField, VerifierInput = ProgramPublicVariables<Self>, ProvingKey = Self::ProgramProvingKey, VerifyingKey = Self::ProgramVerifyingKey, UniversalSetupConfig = usize>;
     type ProgramProvingKey: Clone + ToBytes + FromBytes + Send + Sync;
-    type ProgramVerifyingKey: ToConstraintField<Self::OuterScalarField> + Clone + PartialEq + Eq + ToBytes + FromBytes + Serialize + DeserializeOwned + ToMinimalBits + Send + Sync;
+    type ProgramVerifyingKey: ToConstraintField<Self::InnerBaseField> + Clone + PartialEq + Eq + ToBytes + FromBytes + Serialize + DeserializeOwned + ToMinimalBits + Send + Sync;
     type ProgramProof: Bech32Object<<Self::ProgramSNARK as SNARK>::Proof>;
 
     /// SNARK for PoSW.
-    type PoSWSNARK: SNARK<ScalarField = Self::InnerScalarField, BaseField = Self::OuterScalarField, VerifierInput = Vec<Self::InnerScalarField>, UniversalSetupConfig = usize>;
+    type PoSWSNARK: SNARK<ScalarField = Self::InnerScalarField, BaseField = Self::InnerBaseField, VerifierInput = Vec<Self::InnerScalarField>, UniversalSetupConfig = usize>;
     type PoSWProof: Bech32Object<<Self::PoSWSNARK as SNARK>::Proof>;
     type PoSW: PoSWScheme<Self>;
 
@@ -212,8 +211,8 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     type Commitment: Bech32Locator<<Self::CommitmentScheme as CRH>::Output>;
 
     /// CRH for deriving function IDs. Invoked only over `Self::OuterScalarField`.
-    type FunctionIDCRH: CRH<Output = Self::OuterScalarField>;
-    type FunctionIDCRHGadget: CRHGadget<Self::FunctionIDCRH, Self::OuterScalarField>;
+    type FunctionIDCRH: CRH<Output = Self::InnerBaseField>;
+    type FunctionIDCRHGadget: CRHGadget<Self::FunctionIDCRH, Self::InnerBaseField>;
     type FunctionID: Bech32Locator<<Self::FunctionIDCRH as CRH>::Output>;
 
     /// Crypto hash for deriving the function inputs hash. Invoked only over `Self::InnerScalarField`.
@@ -222,8 +221,8 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     type FunctionInputsHash: Bech32Locator<<Self::FunctionInputsCRH as CRH>::Output>;
 
     /// CRH for hash of the `Self::InnerSNARK` verifying keys. Invoked only over `Self::OuterScalarField`.
-    type InnerCircuitIDCRH: CRH<Output = Self::OuterScalarField>;
-    type InnerCircuitIDCRHGadget: CRHGadget<Self::InnerCircuitIDCRH, Self::OuterScalarField>;
+    type InnerCircuitIDCRH: CRH<Output = Self::InnerBaseField>;
+    type InnerCircuitIDCRHGadget: CRHGadget<Self::InnerCircuitIDCRH, Self::InnerBaseField>;
     type InnerCircuitID: Bech32Locator<<Self::InnerCircuitIDCRH as CRH>::Output>;
 
     /// Merkle scheme for computing the ledger root. Invoked only over `Self::InnerScalarField`.
@@ -238,8 +237,8 @@ pub trait Network: 'static + Copy + Clone + Debug + Default + PartialEq + Eq + S
     type PoSWNonce: Bech32Locator<Self::InnerScalarField>;
 
     /// CRH for deriving program IDs. Invoked only over `Self::OuterScalarField`.
-    type ProgramIDCRH: CRH<Output = Self::OuterScalarField>;
-    type ProgramIDCRHGadget: CRHGadget<Self::ProgramIDCRH, Self::OuterScalarField>;
+    type ProgramIDCRH: CRH<Output = Self::InnerBaseField>;
+    type ProgramIDCRHGadget: CRHGadget<Self::ProgramIDCRH, Self::InnerBaseField>;
     type ProgramIDParameters: MerkleParameters<H = Self::ProgramIDCRH>;
     type ProgramID: Bech32Locator<<Self::ProgramIDCRH as CRH>::Output>;
 

--- a/dpc/tests/mod.rs
+++ b/dpc/tests/mod.rs
@@ -25,7 +25,7 @@ use std::{
 use snarkvm_algorithms::{SNARKError, SRS};
 use snarkvm_curves::bls12_377::Fr;
 use snarkvm_dpc::{testnet2::Testnet2, BlockTemplate, Network, PoSWError, PoSWScheme};
-use snarkvm_marlin::marlin::{CircuitProvingKey, MarlinPoswMode, MarlinTestnet1Mode};
+use snarkvm_marlin::marlin::{CircuitProvingKey, MarlinHidingMode, MarlinNonHidingMode};
 
 use rand::{rngs::ThreadRng, thread_rng};
 
@@ -89,7 +89,7 @@ fn test_posw_setup_vs_load_weak_sanity_check() {
         // Load the PoSW Marlin parameters.
         let rng = &mut thread_rng();
         // Run the universal setup.
-        let max_degree = snarkvm_marlin::AHPForR1CS::<Fr, MarlinTestnet1Mode>::max_degree(40000, 40000, 60000).unwrap();
+        let max_degree = snarkvm_marlin::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(40000, 40000, 60000).unwrap();
         let universal_srs = <Testnet2 as Network>::PoSWSNARK::universal_setup(max_degree, rng).unwrap();
         // Run the circuit setup.
         <<Testnet2 as Network>::PoSW as PoSWScheme<Testnet2>>::setup::<ThreadRng>(&mut SRS::<ThreadRng, _>::Universal(
@@ -99,9 +99,10 @@ fn test_posw_setup_vs_load_weak_sanity_check() {
     };
     let loaded_posw = Testnet2::posw().clone();
 
-    let generated_proving_key: &CircuitProvingKey<Fr, _, _, MarlinPoswMode> =
+    let generated_proving_key: &CircuitProvingKey<Fr, _, _, MarlinNonHidingMode> =
         generated_posw.proving_key().as_ref().unwrap();
-    let loaded_proving_key: &CircuitProvingKey<Fr, _, _, MarlinPoswMode> = loaded_posw.proving_key().as_ref().unwrap();
+    let loaded_proving_key: &CircuitProvingKey<Fr, _, _, MarlinNonHidingMode> =
+        loaded_posw.proving_key().as_ref().unwrap();
 
     let a = generated_proving_key.committer_key.max_degree;
     let b = loaded_proving_key.committer_key.max_degree;
@@ -142,8 +143,8 @@ fn test_posw_setup_vs_load_weak_sanity_check() {
     println!("{:?} == {:?}? {}", a, b, a == b);
     assert_eq!(a, b);
 
-    let a = generated_proving_key.circuit.index_info.max_degree::<MarlinTestnet1Mode>();
-    let b = loaded_proving_key.circuit.index_info.max_degree::<MarlinTestnet1Mode>();
+    let a = generated_proving_key.circuit.index_info.max_degree::<MarlinHidingMode>();
+    let b = loaded_proving_key.circuit.index_info.max_degree::<MarlinHidingMode>();
     println!("{:?} == {:?}? {}", a, b, a == b);
     assert_eq!(a, b);
 

--- a/marlin/benches/marlin.rs
+++ b/marlin/benches/marlin.rs
@@ -20,7 +20,7 @@ extern crate criterion;
 use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
 use snarkvm_fields::Field;
 use snarkvm_marlin::{
-    marlin::{MarlinRecursiveMode, MarlinSNARK},
+    marlin::{MarlinHidingMode, MarlinSNARK},
     FiatShamirAlgebraicSpongeRng,
     PoseidonSponge,
 };
@@ -31,7 +31,7 @@ use snarkvm_utilities::{ops::MulAssign, UniformRand};
 use criterion::Criterion;
 use rand::{self, thread_rng};
 
-type MarlinInst = MarlinSNARK<Fr, Fq, PC, FS, MarlinRecursiveMode, Vec<Fr>>;
+type MarlinInst = MarlinSNARK<Fr, Fq, PC, FS, MarlinHidingMode, Vec<Fr>>;
 
 type PC = SonicKZG10<Bls12_377>;
 type FS = FiatShamirAlgebraicSpongeRng<Fr, Fq, PoseidonSponge<Fq, 6, 1>>;
@@ -74,7 +74,7 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for Benchmark<Constr
 fn snark_universal_setup(c: &mut Criterion) {
     let rng = &mut thread_rng();
     let max_degree =
-        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(1000000, 1000000, 1000000).unwrap();
+        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(1000000, 1000000, 1000000).unwrap();
 
     c.bench_function("snark_universal_setup", move |b| {
         b.iter(|| {
@@ -92,7 +92,7 @@ fn snark_circuit_setup(c: &mut Criterion) {
     let y = Fr::rand(rng);
 
     let max_degree =
-        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(100000, 100000, 100000).unwrap();
+        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(100000, 100000, 100000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     c.bench_function("snark_circuit_setup", move |b| {
@@ -112,7 +112,7 @@ fn snark_prove(c: &mut Criterion) {
     let x = Fr::rand(rng);
     let y = Fr::rand(rng);
 
-    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(1000, 1000, 1000).unwrap();
+    let max_degree = snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(1000, 1000, 1000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     let circuit = Benchmark::<Fr> { a: Some(x), b: Some(y), num_constraints, num_variables };
@@ -138,7 +138,7 @@ fn snark_verify(c: &mut Criterion) {
     z.mul_assign(&y);
 
     let max_degree =
-        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(1000000, 100000, 1000000).unwrap();
+        snarkvm_marlin::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(1000000, 100000, 1000000).unwrap();
     let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
     let circuit = Benchmark::<Fr> { a: Some(x), b: Some(y), num_constraints, num_variables };

--- a/marlin/src/marlin/mode.rs
+++ b/marlin/src/marlin/mode.rs
@@ -21,35 +21,18 @@ pub trait MarlinMode: Clone + Debug + 'static + Sync + Send {
     const ZK: bool;
 }
 
-/// TODO (howardwu): Combine all of the testnet configurations into an environment struct higher up.
-/// The Marlin testnet1 mode does not assume recursive proofs of any depth.
+/// The Marlin hiding mode produces a hiding Marlin proof.
 #[derive(Clone, Debug)]
-pub struct MarlinTestnet1Mode;
+pub struct MarlinHidingMode;
 
-impl MarlinMode for MarlinTestnet1Mode {
+impl MarlinMode for MarlinHidingMode {
     const ZK: bool = true;
 }
 
-/// The Marlin testnet2 mode does not assume recursive proofs of any depth.
+/// The Marlin non-hiding mode produces a non-hiding Marlin proof.
 #[derive(Clone, Debug)]
-pub struct MarlinTestnet2Mode;
+pub struct MarlinNonHidingMode;
 
-impl MarlinMode for MarlinTestnet2Mode {
-    const ZK: bool = true;
-}
-
-/// The Marlin default mode assumes a recursive proof of at least depth-1.
-#[derive(Clone, Debug)]
-pub struct MarlinRecursiveMode;
-
-impl MarlinMode for MarlinRecursiveMode {
-    const ZK: bool = true;
-}
-
-/// The Marlin POSW mode does not assume recursive proofs of any depth.
-#[derive(Clone, Debug)]
-pub struct MarlinPoswMode;
-
-impl MarlinMode for MarlinPoswMode {
+impl MarlinMode for MarlinNonHidingMode {
     const ZK: bool = false;
 }

--- a/marlin/src/marlin/snark.rs
+++ b/marlin/src/marlin/snark.rs
@@ -93,7 +93,7 @@ pub mod test {
     use super::*;
     use crate::{
         fiat_shamir::{FiatShamirAlgebraicSpongeRng, PoseidonSponge},
-        marlin::{MarlinRecursiveMode, MarlinSNARK},
+        marlin::{MarlinHidingMode, MarlinSNARK},
     };
     use snarkvm_algorithms::SRS;
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
@@ -141,7 +141,7 @@ pub mod test {
 
     type PC = SonicKZG10<Bls12_377>;
     type FS = FiatShamirAlgebraicSpongeRng<Fr, Fq, PoseidonSponge<Fq, 6, 1>>;
-    type TestSNARK = MarlinSNARK<Fr, Fq, PC, FS, MarlinRecursiveMode, Vec<Fr>>;
+    type TestSNARK = MarlinSNARK<Fr, Fq, PC, FS, MarlinHidingMode, Vec<Fr>>;
 
     #[test]
     fn marlin_snark_test() {

--- a/marlin/src/marlin/tests.rs
+++ b/marlin/src/marlin/tests.rs
@@ -70,7 +70,7 @@ mod marlin {
     use super::*;
     use crate::{
         fiat_shamir::FiatShamirChaChaRng,
-        marlin::{MarlinPoswMode, MarlinSNARK, MarlinTestnet1Mode},
+        marlin::{MarlinHidingMode, MarlinNonHidingMode, MarlinSNARK},
     };
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
     use snarkvm_polycommit::{marlin_pc::MarlinKZG10, sonic_pc::SonicKZG10};
@@ -80,14 +80,14 @@ mod marlin {
     use core::ops::MulAssign;
 
     type MultiPC = MarlinKZG10<Bls12_377>;
-    type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode, Vec<Fr>>;
+    type MarlinInst = MarlinSNARK<Fr, Fq, MultiPC, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinHidingMode, Vec<Fr>>;
 
     type MultiPCSonic = SonicKZG10<Bls12_377>;
     type MarlinSonicInst =
-        MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinTestnet1Mode, Vec<Fr>>;
+        MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinHidingMode, Vec<Fr>>;
 
     type MarlinSonicPoswInst =
-        MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinPoswMode, Vec<Fr>>;
+        MarlinSNARK<Fr, Fq, MultiPCSonic, FiatShamirChaChaRng<Fr, Fq, Blake2s>, MarlinNonHidingMode, Vec<Fr>>;
 
     macro_rules! impl_marlin_test {
         ($test_struct: ident, $marlin_inst: tt, $marlin_mode: tt) => {
@@ -177,9 +177,9 @@ mod marlin {
         };
     }
 
-    impl_marlin_test!(MarlinPCTest, MarlinInst, MarlinTestnet1Mode);
-    impl_marlin_test!(SonicPCTest, MarlinSonicInst, MarlinTestnet1Mode);
-    impl_marlin_test!(SonicPCPoswTest, MarlinSonicPoswInst, MarlinPoswMode);
+    impl_marlin_test!(MarlinPCTest, MarlinInst, MarlinHidingMode);
+    impl_marlin_test!(SonicPCTest, MarlinSonicInst, MarlinHidingMode);
+    impl_marlin_test!(SonicPCPoswTest, MarlinSonicPoswInst, MarlinNonHidingMode);
 
     #[test]
     fn prove_and_verify_with_tall_matrix_big() {
@@ -276,7 +276,7 @@ mod marlin_recursion {
     use super::*;
     use crate::{
         fiat_shamir::{FiatShamirAlgebraicSpongeRng, PoseidonSponge},
-        marlin::{CircuitVerifyingKey, MarlinRecursiveMode, MarlinSNARK},
+        marlin::{CircuitVerifyingKey, MarlinHidingMode, MarlinSNARK},
     };
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
     use snarkvm_polycommit::sonic_pc::SonicKZG10;
@@ -295,14 +295,14 @@ mod marlin_recursion {
         Fq,
         MultiPC,
         FiatShamirAlgebraicSpongeRng<Fr, Fq, PoseidonSponge<Fq, 6, 1>>,
-        MarlinRecursiveMode,
+        MarlinHidingMode,
         Vec<Fr>,
     >;
 
     fn test_circuit(num_constraints: usize, num_variables: usize) {
         let rng = &mut test_rng();
 
-        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(100, 25, 300).unwrap();
+        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(100, 25, 300).unwrap();
         let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
         for _ in 0..100 {
@@ -331,7 +331,7 @@ mod marlin_recursion {
     fn test_serde_json(num_constraints: usize, num_variables: usize) {
         let rng = &mut test_rng();
 
-        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(100, 25, 300).unwrap();
+        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(100, 25, 300).unwrap();
         let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
         let circuit = Circuit { a: Some(Fr::rand(rng)), b: Some(Fr::rand(rng)), num_constraints, num_variables };
@@ -352,7 +352,7 @@ mod marlin_recursion {
     fn test_bincode(num_constraints: usize, num_variables: usize) {
         let rng = &mut test_rng();
 
-        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinRecursiveMode>::max_degree(100, 25, 300).unwrap();
+        let max_degree = crate::ahp::AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(100, 25, 300).unwrap();
         let universal_srs = MarlinInst::universal_setup(max_degree, rng).unwrap();
 
         let circuit = Circuit { a: Some(Fr::rand(rng)), b: Some(Fr::rand(rng)), num_constraints, num_variables };

--- a/parameters/examples/setup.rs
+++ b/parameters/examples/setup.rs
@@ -16,7 +16,7 @@
 
 use snarkvm_algorithms::{crh::sha256::sha256, CRH, SNARK, SRS};
 use snarkvm_dpc::{InnerCircuit, Network, PoSWScheme, SynthesizedCircuit};
-use snarkvm_marlin::{ahp::AHPForR1CS, marlin::MarlinTestnet1Mode};
+use snarkvm_marlin::{ahp::AHPForR1CS, marlin::MarlinHidingMode};
 use snarkvm_utilities::{FromBytes, ToBytes, ToMinimalBits};
 
 use anyhow::Result;
@@ -66,7 +66,7 @@ pub fn universal_setup<N: Network>() -> Result<()> {
     const UNIVERSAL_SRS: &str = "universal.srs";
 
     let max_degree =
-        AHPForR1CS::<<N as Network>::InnerScalarField, MarlinTestnet1Mode>::max_degree(2000000, 4000000, 8000000)
+        AHPForR1CS::<<N as Network>::InnerScalarField, MarlinHidingMode>::max_degree(2000000, 4000000, 8000000)
             .unwrap();
     let universal_srs = <<N as Network>::ProgramSNARK as SNARK>::universal_setup(&max_degree, &mut thread_rng())?;
     let universal_srs = universal_srs.to_bytes_le()?;
@@ -154,7 +154,7 @@ pub fn posw_setup<N: Network>() -> Result<()> {
 
     // TODO: decide the size of the universal setup
     let max_degree =
-        AHPForR1CS::<<N as Network>::InnerScalarField, MarlinTestnet1Mode>::max_degree(40000, 40000, 60000).unwrap();
+        AHPForR1CS::<<N as Network>::InnerScalarField, MarlinHidingMode>::max_degree(40000, 40000, 60000).unwrap();
     let universal_srs = <<N as Network>::PoSWSNARK as SNARK>::universal_setup(&max_degree, &mut thread_rng())?;
     let srs_bytes = universal_srs.to_bytes_le()?;
     println!("srs\n\tsize - {}", srs_bytes.len());


### PR DESCRIPTION
## Motivation

- Removes the following types from `Network`:
    - `OuterCurve`
    - `OuterBaseField`
    - `InnerCircuitIDCRHGadget`
    - `ProgramIDCRHGadget`

- Unifies `MarlinMode` variants into `MarlinHidingMode` and `MarlinNonHidingMode`
