### PR TITLE
Replace `chrono` with `time` (RUSTSEC-2020-0159)

### DIFF
--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -61,11 +61,6 @@ version = "1.3.1"
 [dependencies.blake2]
 version = "0.9"
 
-[dependencies.chrono]
-version = "0.4"
-default-features = false
-features = [ "clock", "serde" ]
-
 [dependencies.derivative]
 version = "2"
 
@@ -86,6 +81,9 @@ version = "0.3"
 
 [dependencies.thiserror]
 version = "1.0"
+
+[dependencies.time]
+version = "0.3.7"
 
 [features]
 print-trace = [ "snarkvm-profiler/print-trace" ]

--- a/.integration/tests/dpc_testnet1.rs
+++ b/.integration/tests/dpc_testnet1.rs
@@ -19,9 +19,9 @@ use std::sync::atomic::AtomicBool;
 use snarkvm_dpc::{prelude::*, testnet1::*};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
-use chrono::Utc;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
+use time::OffsetDateTime;
 
 #[test]
 fn test_testnet1_inner_circuit_id_sanity_check() {
@@ -72,7 +72,7 @@ fn dpc_testnet1_integration_test() {
     let transactions = Transactions::from(&[coinbase_transaction]).unwrap();
 
     let previous_ledger_root = ledger.latest_ledger_root();
-    let timestamp = Utc::now().timestamp();
+    let timestamp = OffsetDateTime::now_utc().unix_timestamp();
     let difficulty_target =
         Blocks::<Testnet1>::compute_difficulty_target(previous_block.header(), timestamp, block_height);
     let cumulative_weight = previous_block.cumulative_weight().saturating_add((u64::MAX / difficulty_target) as u128);

--- a/.integration/tests/dpc_testnet2.rs
+++ b/.integration/tests/dpc_testnet2.rs
@@ -19,9 +19,9 @@ use std::sync::atomic::AtomicBool;
 use snarkvm_dpc::{prelude::*, testnet2::*};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
-use chrono::Utc;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
+use time::OffsetDateTime;
 
 #[test]
 fn test_testnet2_inner_circuit_id_sanity_check() {
@@ -72,7 +72,7 @@ fn dpc_testnet2_integration_test() {
     let transactions = Transactions::from(&[coinbase_transaction]).unwrap();
 
     let previous_ledger_root = ledger.latest_ledger_root();
-    let timestamp = Utc::now().timestamp();
+    let timestamp = OffsetDateTime::now_utc().unix_timestamp();
     let difficulty_target =
         Blocks::<Testnet2>::compute_difficulty_target(previous_block.header(), timestamp, block_height);
     let cumulative_weight = previous_block.cumulative_weight().saturating_add((u64::MAX / difficulty_target) as u128);

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,19 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "winapi",
-]
-
-[[package]]
 name = "ci_info"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,7 +2025,6 @@ dependencies = [
  "bech32",
  "bincode",
  "blake2",
- "chrono",
  "criterion",
  "derivative",
  "hex",
@@ -2051,6 +2046,7 @@ dependencies = [
  "snarkvm-r1cs",
  "snarkvm-utilities",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -2100,7 +2096,6 @@ dependencies = [
  "bech32",
  "bincode",
  "blake2",
- "chrono",
  "derivative",
  "hex",
  "itertools",
@@ -2115,6 +2110,7 @@ dependencies = [
  "snarkvm-r1cs",
  "snarkvm-utilities",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -2382,6 +2378,16 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
  "syn 1.0.86",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "libc",
+ "num_threads",
 ]
 
 [[package]]

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -108,11 +108,6 @@ version = "1.3"
 version = "0.9"
 default-features = false
 
-[dependencies.chrono]
-version = "0.4"
-default-features = false
-features = [ "clock", "serde" ]
-
 [dependencies.derivative]
 version = "2"
 
@@ -140,6 +135,9 @@ version = "1.0"
 
 [dependencies.thiserror]
 version = "1.0"
+
+[dependencies.time]
+version = "0.3.7"
 
 [dev-dependencies.criterion]
 version = "0.3.5"

--- a/dpc/src/ledger/blocks.rs
+++ b/dpc/src/ledger/blocks.rs
@@ -18,9 +18,9 @@ use crate::prelude::*;
 use snarkvm_algorithms::merkle_tree::*;
 
 use anyhow::{anyhow, Result};
-use chrono::Utc;
 use itertools::Itertools;
 use std::collections::HashMap;
+use time::OffsetDateTime;
 
 #[derive(Clone, Debug)]
 pub struct Blocks<N: Network> {
@@ -221,7 +221,7 @@ impl<N: Network> Blocks<N> {
         }
 
         // Ensure the next block timestamp is within the declared time limit.
-        let now = Utc::now().timestamp();
+        let now = OffsetDateTime::now_utc().unix_timestamp();
         if block.timestamp() > (now + N::ALEO_FUTURE_TIME_LIMIT_IN_SECS) {
             return Err(anyhow!("The given block timestamp exceeds the time limit"));
         }

--- a/dpc/src/ledger/ledger.rs
+++ b/dpc/src/ledger/ledger.rs
@@ -17,9 +17,9 @@
 use crate::prelude::*;
 
 use anyhow::{anyhow, Result};
-use chrono::Utc;
 use rand::{CryptoRng, Rng};
 use std::{collections::HashMap, sync::atomic::AtomicBool};
+use time::OffsetDateTime;
 
 #[derive(Clone, Debug)]
 pub struct Ledger<N: Network> {
@@ -154,7 +154,8 @@ impl<N: Network> Ledger<N> {
         let block_height = self.latest_block_height() + 1;
 
         // Ensure that the new timestamp is ahead of the previous timestamp.
-        let block_timestamp = std::cmp::max(Utc::now().timestamp(), self.latest_block_timestamp()?.saturating_add(1));
+        let block_timestamp =
+            std::cmp::max(OffsetDateTime::now_utc().unix_timestamp(), self.latest_block_timestamp()?.saturating_add(1));
 
         // Compute the block difficulty target.
         let difficulty_target =

--- a/dpc/src/posw/posw.rs
+++ b/dpc/src/posw/posw.rs
@@ -29,9 +29,9 @@ use crate::{
 use snarkvm_algorithms::{traits::SNARK, SRS};
 use snarkvm_utilities::UniformRand;
 
-use chrono::Utc;
 use core::sync::atomic::AtomicBool;
 use rand::{CryptoRng, Rng};
+use time::OffsetDateTime;
 
 /// A Proof of Succinct Work miner and verifier.
 #[derive(Clone)]
@@ -101,7 +101,8 @@ impl<N: Network> PoSWScheme<N> for PoSW<N> {
         loop {
             // Every 100 iterations, check that the miner is still within the allowed mining duration.
             if iteration % 100 == 0
-                && Utc::now().timestamp() >= block_template.block_timestamp() + MAXIMUM_MINING_DURATION
+                && OffsetDateTime::now_utc().unix_timestamp()
+                    >= block_template.block_timestamp() + MAXIMUM_MINING_DURATION
             {
                 return Err(PoSWError::Message("Failed mine block in the allowed mining duration".to_string()));
             }


### PR DESCRIPTION
Unfortunately, `chrono` still hasn't seen the release of a new version dealing with its outdated `time` dependency and isn't currently well-maintained. The remaining audit warnings are of little cause for concern and should get resolved on their own once the relevant dependencies release new versions. 

Advisory: [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159.html).
