### PR TITLE
Add parallelism to snarkvm-marlin CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,7 @@ jobs:
     docker:
       - image: cimg/rust:1.58
     resource_class: 2xlarge
+    parallelism: 10
     steps:
       - checkout
       - setup_environment:
@@ -177,7 +178,14 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd marlin && RUST_MIN_STACK=67108864 cargo test
+          command: |
+            cd marlin
+            cargo test -- --list --format terse | sed 's/: test//' > test_names.txt
+            TEST_NAMES=$(circleci tests split test_names.txt)
+            for i in $(echo $TEST_NAMES | sed "s/ / /g")
+            do
+                RUST_MIN_STACK=67108864 cargo test $i
+            done
       - clear_environment:
           cache_key: snarkvm-marlin-cache
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds parallelism to the `snarkvm-marlin` CI, which reduces the runtime by approximately 40%.
