### PR TITLE
Improve the quality of randomness in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
   gadgets:
     docker:
       - image: cimg/rust:1.58
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - checkout
       - setup_environment:

--- a/algorithms/src/msm/tests.rs
+++ b/algorithms/src/msm/tests.rs
@@ -20,10 +20,10 @@ use snarkvm_curves::{
     traits::{AffineCurve, ProjectiveCurve},
 };
 use snarkvm_fields::{PrimeField, Zero};
-use snarkvm_utilities::{rand::UniformRand, BitIteratorBE};
-
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
+use snarkvm_utilities::{
+    rand::{test_rng, UniformRand},
+    BitIteratorBE,
+};
 
 fn naive_variable_base_msm<G: AffineCurve>(
     bases: &[G],
@@ -41,7 +41,7 @@ fn naive_variable_base_msm<G: AffineCurve>(
 fn variable_base_test_with_bls12() {
     const SAMPLES: usize = 1 << 10;
 
-    let mut rng = XorShiftRng::seed_from_u64(234872845u64);
+    let mut rng = test_rng();
 
     let v = (0..SAMPLES).map(|_| Fr::rand(&mut rng).to_repr()).collect::<Vec<_>>();
     let g = (0..SAMPLES).map(|_| G1Projective::rand(&mut rng).into_affine()).collect::<Vec<_>>();
@@ -56,7 +56,7 @@ fn variable_base_test_with_bls12() {
 fn variable_base_test_with_bls12_unequal_numbers() {
     const SAMPLES: usize = 1 << 10;
 
-    let mut rng = XorShiftRng::seed_from_u64(234872845u64);
+    let mut rng = test_rng();
 
     let v = (0..SAMPLES - 1).map(|_| Fr::rand(&mut rng).to_repr()).collect::<Vec<_>>();
     let g = (0..SAMPLES).map(|_| G1Projective::rand(&mut rng).into_affine()).collect::<Vec<_>>();

--- a/algorithms/src/msm/variable_base/cuda.rs
+++ b/algorithms/src/msm/variable_base/cuda.rs
@@ -356,10 +356,8 @@ mod tests {
     use super::*;
     use snarkvm_curves::{bls12_377::Fq, ProjectiveCurve};
     use snarkvm_fields::{Field, One, PrimeField};
-    use snarkvm_utilities::UniformRand;
+    use snarkvm_utilities::rand::{test_rng, UniformRand};
 
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
     use serial_test::serial;
 
     #[repr(C)]
@@ -424,7 +422,7 @@ mod tests {
     }
 
     fn make_tests(count: usize, cardinality: usize) -> Vec<Vec<Fq>> {
-        let mut rng = XorShiftRng::seed_from_u64(234832847u64);
+        let mut rng = test_rng();
         let mut inputs = vec![];
         for _ in 0..count {
             let mut out = vec![];
@@ -437,7 +435,7 @@ mod tests {
     }
 
     fn make_projective_tests(count: usize, cardinality: usize) -> Vec<Vec<G1Projective>> {
-        let mut rng = XorShiftRng::seed_from_u64(234832847u64);
+        let mut rng = test_rng();
         let mut inputs = vec![];
         for _ in 0..count {
             let mut out = vec![];
@@ -450,7 +448,7 @@ mod tests {
     }
 
     fn make_affine_tests(count: usize, cardinality: usize) -> Vec<Vec<CudaAffine>> {
-        let mut rng = XorShiftRng::seed_from_u64(23483281023u64);
+        let mut rng = test_rng();
         let mut inputs = vec![];
         for _ in 0..count {
             let mut out = vec![];

--- a/algorithms/src/snark/marlin/snark.rs
+++ b/algorithms/src/snark/marlin/snark.rs
@@ -108,7 +108,7 @@ pub mod test {
     use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
     use snarkvm_fields::Field;
     use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
-    use snarkvm_utilities::{test_rng, UniformRand};
+    use snarkvm_utilities::{test_crypto_rng, UniformRand};
 
     use core::ops::MulAssign;
 
@@ -155,7 +155,7 @@ pub mod test {
 
     #[test]
     fn marlin_snark_test() {
-        let mut rng = test_rng();
+        let mut rng = test_crypto_rng();
 
         for _ in 0..ITERATIONS {
             // Construct the circuit.

--- a/curves/src/bls12_377/fq6.rs
+++ b/curves/src/bls12_377/fq6.rs
@@ -255,17 +255,14 @@ impl Fp6Parameters for Fq6Parameters {
 
 #[cfg(test)]
 mod test {
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
-
     use snarkvm_fields::{One, Zero};
-    use snarkvm_utilities::rand::UniformRand;
+    use snarkvm_utilities::rand::{test_rng, UniformRand};
 
     use super::*;
 
     #[test]
     fn test_fq2_mul_nonresidue() {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = test_rng();
 
         let nqr = Fq2::new(Fq::zero(), Fq::one());
         println!("One: {:?}", Fq::one());

--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -59,10 +59,10 @@ use snarkvm_fields::{
 };
 use snarkvm_utilities::{
     biginteger::{BigInteger, BigInteger384},
-    rand::UniformRand,
+    rand::{test_rng, UniformRand},
 };
 
-use rand::SeedableRng;
+use rand::{thread_rng, Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use std::{
     cmp::Ordering,
@@ -169,7 +169,7 @@ fn test_fq_repr_num_bits() {
 fn test_fq_add_assign() {
     // Test associativity
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Generate a, b, c and ensure (a + b) + c == a + (b + c).
@@ -193,7 +193,7 @@ fn test_fq_add_assign() {
 
 #[test]
 fn test_fq_sub_assign() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Ensure that (a - b) + (b - a) = 0.
@@ -213,7 +213,7 @@ fn test_fq_sub_assign() {
 
 #[test]
 fn test_fq_mul_assign() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * b) * c = a * (b * c)
@@ -258,7 +258,7 @@ fn test_fq_mul_assign() {
 
 #[test]
 fn test_fq_squaring() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * a) = a^2
@@ -278,7 +278,7 @@ fn test_fq_squaring() {
 fn test_fq_inverse() {
     assert!(Fq::zero().inverse().is_none());
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let one = Fq::one();
 
@@ -293,7 +293,7 @@ fn test_fq_inverse() {
 
 #[test]
 fn test_fq_double_in_place() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Ensure doubling a is equivalent to adding a to itself.
@@ -313,7 +313,7 @@ fn test_fq_negate() {
         assert!(a.is_zero());
     }
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Ensure (a - (-a)) = 0.
@@ -327,7 +327,7 @@ fn test_fq_negate() {
 
 #[test]
 fn test_fq_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for i in 0..1000 {
         // Exponentiate by various small numbers and ensure it consists with repeated
@@ -351,7 +351,7 @@ fn test_fq_pow() {
 
 #[test]
 fn test_fq_sqrt() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     assert_eq!(Fq::zero().sqrt().unwrap(), Fq::zero());
 
@@ -461,7 +461,7 @@ fn test_fq2_legendre() {
 
 #[test]
 fn test_fq2_mul_nonresidue() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let nqr = Fq2::new(Fq::zero(), Fq::one());
 
@@ -478,7 +478,7 @@ fn test_fq2_mul_nonresidue() {
 
 #[test]
 fn test_fq6_mul_by_1() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c1 = Fq2::rand(&mut rng);
@@ -494,7 +494,7 @@ fn test_fq6_mul_by_1() {
 
 #[test]
 fn test_fq6_mul_by_01() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);
@@ -511,7 +511,7 @@ fn test_fq6_mul_by_01() {
 
 #[test]
 fn test_fq12_mul_by_014() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);
@@ -529,7 +529,7 @@ fn test_fq12_mul_by_014() {
 
 #[test]
 fn test_fq12_mul_by_034() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);

--- a/curves/src/templates/short_weierstrass_jacobian/tests.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/tests.rs
@@ -22,12 +22,9 @@ use crate::traits::{
 use snarkvm_fields::Zero;
 use snarkvm_utilities::{
     io::Cursor,
-    rand::UniformRand,
+    rand::{test_rng, UniformRand},
     serialize::{CanonicalDeserialize, CanonicalSerialize},
 };
-
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 
 pub const ITERATIONS: usize = 10;
 
@@ -39,7 +36,7 @@ pub fn sw_tests<P: ShortWeierstrassParameters>() {
 pub fn sw_curve_serialization_test<P: ShortWeierstrassParameters>() {
     let buf_size = Affine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let a = Projective::<P>::rand(&mut rng);
@@ -122,7 +119,7 @@ pub fn sw_curve_serialization_test<P: ShortWeierstrassParameters>() {
 pub fn sw_from_random_bytes<P: ShortWeierstrassParameters>() {
     let buf_size = Affine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let a = Projective::<P>::rand(&mut rng);

--- a/curves/src/templates/twisted_edwards_extended/tests.rs
+++ b/curves/src/templates/twisted_edwards_extended/tests.rs
@@ -18,7 +18,7 @@ use super::{Affine, Projective};
 
 use snarkvm_utilities::{
     io::Cursor,
-    rand::UniformRand,
+    rand::{test_rng, UniformRand},
     serialize::{CanonicalDeserialize, CanonicalSerialize},
     to_bytes_le,
     ToBytes,
@@ -30,9 +30,6 @@ use crate::traits::{
     TwistedEdwardsParameters,
 };
 use snarkvm_fields::{Field, One, PrimeField, Zero};
-
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 
 pub const ITERATIONS: usize = 10;
 
@@ -61,7 +58,7 @@ where
 pub fn edwards_curve_serialization_test<P: TwistedEdwardsParameters>() {
     let buf_size = Affine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let a = Projective::<P>::rand(&mut rng);
@@ -127,7 +124,7 @@ where
 {
     let buf_size = Affine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let a = Projective::<P>::rand(&mut rng);
@@ -160,7 +157,7 @@ pub fn edwards_from_x_and_y_coordinates<P: TwistedEdwardsParameters>()
 where
     P::BaseField: PrimeField,
 {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let a = Projective::<P>::rand(&mut rng);

--- a/curves/src/traits/tests_curve.rs
+++ b/curves/src/traits/tests_curve.rs
@@ -16,16 +16,14 @@
 
 use crate::traits::{AffineCurve, ProjectiveCurve};
 use snarkvm_fields::Zero;
-use snarkvm_utilities::rand::UniformRand;
+use snarkvm_utilities::rand::{test_rng, UniformRand};
 
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, Mul};
 
 pub const ITERATIONS: usize = 5;
 
 fn random_addition_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let a = G::rand(&mut rng);
@@ -100,7 +98,7 @@ fn random_addition_test<G: ProjectiveCurve>() {
 }
 
 fn random_multiplication_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let mut a = G::rand(&mut rng);
@@ -132,7 +130,7 @@ fn random_multiplication_test<G: ProjectiveCurve>() {
 }
 
 fn random_doubling_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let mut a = G::rand(&mut rng);
@@ -159,7 +157,7 @@ fn random_doubling_test<G: ProjectiveCurve>() {
 }
 
 fn random_negation_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let r = G::rand(&mut rng);
@@ -189,7 +187,7 @@ fn random_negation_test<G: ProjectiveCurve>() {
 }
 
 fn random_transformation_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let g = G::rand(&mut rng);
@@ -229,7 +227,7 @@ fn random_transformation_test<G: ProjectiveCurve>() {
 }
 
 pub fn curve_tests<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     // Negation edge case with zero.
     {

--- a/curves/src/traits/tests_field.rs
+++ b/curves/src/traits/tests_field.rs
@@ -17,11 +17,11 @@
 use snarkvm_fields::{traits::FftParameters, FftField, Field, LegendreSymbol, PrimeField, SquareRootField};
 use snarkvm_utilities::{
     io::Cursor,
+    rand::test_rng,
     serialize::{CanonicalDeserialize, CanonicalSerialize, Flags, SWFlags},
 };
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 pub const ITERATIONS: u32 = 10;
 
@@ -172,7 +172,7 @@ fn random_expansion_tests<F: Field, R: Rng>(rng: &mut R) {
 }
 
 fn random_string_tests<F: PrimeField>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     {
         let a = "84395729384759238745923745892374598234705297301958723458712394587103249587213984572934750213947582345792304758273458972349582734958273495872304598234";
@@ -212,7 +212,7 @@ fn random_string_tests<F: PrimeField>() {
 }
 
 fn random_sqrt_tests<F: SquareRootField>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let a = F::rand(&mut rng);
@@ -302,7 +302,7 @@ pub fn field_test<F: Field>(a: F, b: F) {
     // (a - b)^2 = (-(b - a))^2
     assert_eq!((a - b).square(), (-(b - a)).square());
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
     random_negation_tests::<F, _>(&mut rng);
     random_addition_tests::<F, _>(&mut rng);
     random_subtraction_tests::<F, _>(&mut rng);
@@ -388,7 +388,7 @@ pub fn sqrt_field_test<F: SquareRootField>(elem: F) {
 }
 
 pub fn frobenius_test<F: Field, C: AsRef<[u64]>>(characteristic: C, maxpower: usize) {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..ITERATIONS {
         let a = F::rand(&mut rng);

--- a/curves/src/traits/tests_group.rs
+++ b/curves/src/traits/tests_group.rs
@@ -16,14 +16,12 @@
 
 use crate::traits::Group;
 use snarkvm_fields::{One, Zero};
-use snarkvm_utilities::rand::UniformRand;
-
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
+use snarkvm_utilities::rand::{test_rng, UniformRand};
 
 #[allow(clippy::eq_op)]
 pub fn group_test<G: Group>(a: G, mut b: G) {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
+
     let zero = G::zero();
     let fr_zero = G::ScalarField::zero();
     let fr_one = G::ScalarField::one();

--- a/gadgets/src/bits/boolean.rs
+++ b/gadgets/src/bits/boolean.rs
@@ -944,12 +944,12 @@ impl<F: PrimeField> ToConstraintFieldGadget<F> for Vec<Boolean> {
 mod test {
     use std::str::FromStr;
 
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
-
     use snarkvm_fields::{Field, One, PrimeField, Zero};
     use snarkvm_r1cs::{Fr, TestConstraintSystem};
-    use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand};
+    use snarkvm_utilities::{
+        bititerator::BitIteratorBE,
+        rand::{test_rng, UniformRand},
+    };
 
     use super::*;
 
@@ -1643,7 +1643,7 @@ mod test {
             assert!(!cs.is_satisfied());
         }
 
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = test_rng();
 
         for _ in 0..1000 {
             let r = Fr::rand(&mut rng);

--- a/gadgets/src/curves/bls12_377.rs
+++ b/gadgets/src/curves/bls12_377.rs
@@ -56,14 +56,12 @@ mod test {
     };
     use snarkvm_fields::PrimeField;
     use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-    use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand};
+    use snarkvm_utilities::{
+        bititerator::BitIteratorBE,
+        rand::{test_rng, UniformRand},
+    };
 
     use core::ops::Mul;
-    use rand::{
-        SeedableRng,
-        {self},
-    };
-    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn bls12_g1_constraint_costs() {
@@ -111,7 +109,7 @@ mod test {
 
     #[test]
     fn bls12_g1_gadget_test() {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = test_rng();
 
         let mut cs = TestConstraintSystem::<Fq>::new();
 

--- a/gadgets/src/curves/tests_field.rs
+++ b/gadgets/src/curves/tests_field.rs
@@ -14,16 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{
-    thread_rng,
-    SeedableRng,
-    {self},
-};
-use rand_xorshift::XorShiftRng;
+use rand::thread_rng;
 
 use snarkvm_fields::Field;
 use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
-use snarkvm_utilities::{bititerator::BitIteratorBE, rand::UniformRand};
+use snarkvm_utilities::{
+    bititerator::BitIteratorBE,
+    rand::{test_rng, UniformRand},
+};
 
 use crate::{
     bits::Boolean,
@@ -174,7 +172,8 @@ fn random_frobenius_tests<NativeF: Field, F: Field, FG: FieldGadget<NativeF, F>,
     mut cs: CS,
     maxpower: usize,
 ) {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
+
     for i in 0..(maxpower + 1) {
         let mut a = NativeF::rand(&mut rng);
         let mut a_gadget = FG::alloc(cs.ns(|| format!("a_gadget_{:?}", i)), || Ok(a)).unwrap();
@@ -192,7 +191,7 @@ fn bls12_377_field_gadgets_test() {
 
     let mut cs = TestConstraintSystem::<Fq>::new();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let a = FqGadget::alloc(&mut cs.ns(|| "generate_a"), || Ok(Fq::rand(&mut rng))).unwrap();
     let b = FqGadget::alloc(&mut cs.ns(|| "generate_b"), || Ok(Fq::rand(&mut rng))).unwrap();

--- a/gadgets/src/integers/int/bytes/to_bytes.rs
+++ b/gadgets/src/integers/int/bytes/to_bytes.rs
@@ -60,9 +60,10 @@ mod tests {
     use super::*;
     use snarkvm_curves::bls12_377::Fr;
     use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
+    use snarkvm_utilities::rand::test_rng;
 
     use num_traits::PrimInt;
-    use rand::{thread_rng, Rng};
+    use rand::Rng;
 
     const ITERATIONS: usize = 100_000;
 
@@ -84,25 +85,27 @@ mod tests {
             }
         }
 
+        let mut rng = test_rng();
+
         for _ in 0..ITERATIONS {
             // 8-bit signed integer
-            let expected: i8 = thread_rng().gen();
+            let expected: i8 = rng.gen();
             int_to_bytes_test::<Fr, i8, Int8>(expected, &expected.to_le_bytes());
 
             // 16-bit signed integer
-            let expected: i16 = thread_rng().gen();
+            let expected: i16 = rng.gen();
             int_to_bytes_test::<Fr, i16, Int16>(expected, &expected.to_le_bytes());
 
             // 32-bit signed integer
-            let expected: i32 = thread_rng().gen();
+            let expected: i32 = rng.gen();
             int_to_bytes_test::<Fr, i32, Int32>(expected, &expected.to_le_bytes());
 
             // 64-bit signed integer
-            let expected: i64 = thread_rng().gen();
+            let expected: i64 = rng.gen();
             int_to_bytes_test::<Fr, i64, Int64>(expected, &expected.to_le_bytes());
 
             // 128-bit signed integer
-            let expected: i128 = thread_rng().gen();
+            let expected: i128 = rng.gen();
             int_to_bytes_test::<Fr, i128, Int128>(expected, &expected.to_le_bytes());
         }
     }

--- a/gadgets/src/integers/int/tests/int128.rs
+++ b/gadgets/src/integers/int/tests/int128.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintChecker, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -65,7 +65,7 @@ fn check_all_allocated_bits(expected: i128, actual: Int128) {
 
 #[test]
 fn test_int128_constant_and_alloc() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -89,7 +89,7 @@ fn test_int128_constant_and_alloc() {
 
 #[test]
 fn test_int128_add_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -115,7 +115,7 @@ fn test_int128_add_constants() {
 
 #[test]
 fn test_int128_add() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -152,7 +152,7 @@ fn test_int128_add() {
 
 #[test]
 fn test_int128_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -183,7 +183,7 @@ fn test_int128_sub_constants() {
 
 #[test]
 fn test_int128_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -225,7 +225,7 @@ fn test_int128_sub() {
 
 #[test]
 fn test_int128_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..3 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -254,7 +254,7 @@ fn test_int128_mul_constants() {
 
 #[test]
 fn test_int128_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..2 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -294,7 +294,7 @@ fn test_int128_mul() {
 
 #[test]
 fn test_int128_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..3 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -324,7 +324,7 @@ fn test_int128_div_constants() {
 
 #[test]
 fn test_int128_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..2 {
         let mut cs = TestConstraintChecker::<Fr>::new();

--- a/gadgets/src/integers/int/tests/int16.rs
+++ b/gadgets/src/integers/int/tests/int16.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -65,7 +65,7 @@ fn check_all_allocated_bits(expected: i16, actual: Int16) {
 
 #[test]
 fn test_int16_constant_and_alloc() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -89,7 +89,7 @@ fn test_int16_constant_and_alloc() {
 
 #[test]
 fn test_int16_add_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -115,7 +115,7 @@ fn test_int16_add_constants() {
 
 #[test]
 fn test_int16_add() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -152,7 +152,7 @@ fn test_int16_add() {
 
 #[test]
 fn test_int16_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -183,7 +183,7 @@ fn test_int16_sub_constants() {
 
 #[test]
 fn test_int16_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -225,7 +225,7 @@ fn test_int16_sub() {
 
 #[test]
 fn test_int16_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -254,7 +254,7 @@ fn test_int16_mul_constants() {
 
 #[test]
 fn test_int16_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..50 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -294,7 +294,7 @@ fn test_int16_mul() {
 
 #[test]
 fn test_int16_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -324,7 +324,7 @@ fn test_int16_div_constants() {
 
 #[test]
 fn test_int16_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -356,7 +356,7 @@ fn test_int16_div() {
 
 #[test]
 fn test_int16_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -382,7 +382,7 @@ fn test_int16_pow_constants() {
 
 #[test]
 fn test_int16_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..3 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/gadgets/src/integers/int/tests/int32.rs
+++ b/gadgets/src/integers/int/tests/int32.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -65,7 +65,7 @@ fn check_all_allocated_bits(expected: i32, actual: Int32) {
 
 #[test]
 fn test_int32_constant_and_alloc() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -89,7 +89,7 @@ fn test_int32_constant_and_alloc() {
 
 #[test]
 fn test_int32_add_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -115,7 +115,7 @@ fn test_int32_add_constants() {
 
 #[test]
 fn test_int32_add() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -152,7 +152,7 @@ fn test_int32_add() {
 
 #[test]
 fn test_int32_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -183,7 +183,7 @@ fn test_int32_sub_constants() {
 
 #[test]
 fn test_int32_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -225,7 +225,7 @@ fn test_int32_sub() {
 
 #[test]
 fn test_int32_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -254,7 +254,7 @@ fn test_int32_mul_constants() {
 
 #[test]
 fn test_int32_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -294,7 +294,7 @@ fn test_int32_mul() {
 
 #[test]
 fn test_int32_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -324,7 +324,7 @@ fn test_int32_div_constants() {
 
 #[test]
 fn test_int32_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -356,7 +356,7 @@ fn test_int32_div() {
 
 #[test]
 fn test_int32_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -382,7 +382,7 @@ fn test_int32_pow_constants() {
 
 #[test]
 fn test_int32_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/gadgets/src/integers/int/tests/int64.rs
+++ b/gadgets/src/integers/int/tests/int64.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -65,7 +65,7 @@ fn check_all_allocated_bits(expected: i64, actual: Int64) {
 
 #[test]
 fn test_int64_constant_and_alloc() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -96,7 +96,7 @@ fn test_int64_constant_and_alloc() {
 
 #[test]
 fn test_int64_add_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -122,7 +122,7 @@ fn test_int64_add_constants() {
 
 #[test]
 fn test_int64_add() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -159,7 +159,7 @@ fn test_int64_add() {
 
 #[test]
 fn test_int64_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -190,7 +190,7 @@ fn test_int64_sub_constants() {
 
 #[test]
 fn test_int64_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -232,7 +232,7 @@ fn test_int64_sub() {
 
 #[test]
 fn test_int64_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..5 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -261,7 +261,7 @@ fn test_int64_mul_constants() {
 
 #[test]
 fn test_int64_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..5 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -301,7 +301,7 @@ fn test_int64_mul() {
 
 #[test]
 fn test_int64_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..3 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -331,7 +331,7 @@ fn test_int64_div_constants() {
 
 #[test]
 fn test_int64_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..3 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -363,7 +363,7 @@ fn test_int64_div() {
 
 #[test]
 fn test_int64_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..5 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -389,7 +389,7 @@ fn test_int64_pow_constants() {
 
 #[test]
 fn test_int64_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..5 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/gadgets/src/integers/int/tests/int8.rs
+++ b/gadgets/src/integers/int/tests/int8.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -67,7 +67,7 @@ fn check_all_allocated_bits(expected: i8, actual: Int8) {
 
 #[test]
 fn test_int8_constant_and_alloc() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -91,7 +91,7 @@ fn test_int8_constant_and_alloc() {
 
 #[test]
 fn test_int8_add_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -117,7 +117,7 @@ fn test_int8_add_constants() {
 
 #[test]
 fn test_int8_add() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -154,7 +154,7 @@ fn test_int8_add() {
 
 #[test]
 fn test_int8_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -185,7 +185,7 @@ fn test_int8_sub_constants() {
 
 #[test]
 fn test_int8_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -227,7 +227,7 @@ fn test_int8_sub() {
 
 #[test]
 fn test_int8_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -253,7 +253,7 @@ fn test_int8_mul_constants() {
 
 #[test]
 fn test_int8_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -290,7 +290,7 @@ fn test_int8_mul() {
 
 #[test]
 fn test_int8_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -320,7 +320,7 @@ fn test_int8_div_constants() {
 
 #[test]
 fn test_int8_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -407,7 +407,7 @@ fn test_int8_div_setup_mode() {
 
 #[test]
 fn test_int8_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -433,7 +433,7 @@ fn test_int8_pow_constants() {
 
 #[test]
 fn test_int8_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/gadgets/src/integers/uint/bytes/to_bytes.rs
+++ b/gadgets/src/integers/uint/bytes/to_bytes.rs
@@ -56,9 +56,10 @@ mod tests {
     use super::*;
     use snarkvm_curves::bls12_377::Fr;
     use snarkvm_r1cs::{ConstraintSystem, TestConstraintSystem};
+    use snarkvm_utilities::rand::test_rng;
 
     use num_traits::PrimInt;
-    use rand::{thread_rng, Rng};
+    use rand::Rng;
 
     const ITERATIONS: usize = 100_000;
 
@@ -80,25 +81,27 @@ mod tests {
             }
         }
 
+        let mut rng = test_rng();
+
         for _ in 0..ITERATIONS {
             // 8-bit unsigned integer
-            let expected: u8 = thread_rng().gen();
+            let expected: u8 = rng.gen();
             uint_to_bytes_test::<Fr, u8, UInt8>(expected, &expected.to_le_bytes());
 
             // 16-bit unsigned integer
-            let expected: u16 = thread_rng().gen();
+            let expected: u16 = rng.gen();
             uint_to_bytes_test::<Fr, u16, UInt16>(expected, &expected.to_le_bytes());
 
             // 32-bit unsigned integer
-            let expected: u32 = thread_rng().gen();
+            let expected: u32 = rng.gen();
             uint_to_bytes_test::<Fr, u32, UInt32>(expected, &expected.to_le_bytes());
 
             // 64-bit unsigned integer
-            let expected: u64 = thread_rng().gen();
+            let expected: u64 = rng.gen();
             uint_to_bytes_test::<Fr, u64, UInt64>(expected, &expected.to_le_bytes());
 
             // 128-bit unsigned integer
-            let expected: u128 = thread_rng().gen();
+            let expected: u128 = rng.gen();
             uint_to_bytes_test::<Fr, u128, UInt128>(expected, &expected.to_le_bytes());
         }
     }

--- a/gadgets/src/integers/uint/tests/uint128.rs
+++ b/gadgets/src/integers/uint/tests/uint128.rs
@@ -16,11 +16,11 @@
 
 use std::convert::TryInto;
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintChecker, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -61,7 +61,7 @@ fn check_all_allocated_bits(mut expected: u128, actual: UInt128) {
 
 #[test]
 fn test_uint128_from_bits() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let v = (0..128).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
@@ -91,7 +91,7 @@ fn test_uint128_from_bits() {
 
 #[test]
 fn test_uint128_rotr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let mut num = rng.gen();
 
@@ -120,7 +120,7 @@ fn test_uint128_rotr() {
 
 #[test]
 fn test_uint128_xor() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -162,7 +162,7 @@ fn test_uint128_xor() {
 
 #[test]
 fn test_uint128_addmany_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -187,7 +187,7 @@ fn test_uint128_addmany_constants() {
 
 #[test]
 fn test_uint128_addmany() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -221,7 +221,7 @@ fn test_uint128_addmany() {
 
 #[test]
 fn test_uint128_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -244,7 +244,7 @@ fn test_uint128_sub_constants() {
 
 #[test]
 fn test_uint128_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -279,7 +279,7 @@ fn test_uint128_sub() {
 
 #[test]
 fn test_uint128_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -302,7 +302,7 @@ fn test_uint128_mul_constants() {
 
 #[test]
 fn test_uint128_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -339,7 +339,7 @@ fn test_uint128_mul() {
 
 #[test]
 fn test_uint128_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -362,7 +362,7 @@ fn test_uint128_div_constants() {
 
 #[test]
 fn test_uint128_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..2 {
         let mut cs = TestConstraintChecker::<Fr>::new();
@@ -402,7 +402,7 @@ fn test_uint128_div() {
 
 #[test]
 fn test_uint128_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -425,7 +425,7 @@ fn test_uint128_pow_constants() {
 
 #[test]
 fn test_uint128_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let mut cs = TestConstraintChecker::<Fr>::new();
 

--- a/gadgets/src/integers/uint/tests/uint16.rs
+++ b/gadgets/src/integers/uint/tests/uint16.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -58,7 +58,7 @@ fn check_all_allocated_bits(mut expected: u16, actual: UInt16) {
 
 #[test]
 fn test_uint16_from_bits() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let v = (0..16).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
@@ -88,7 +88,7 @@ fn test_uint16_from_bits() {
 
 #[test]
 fn test_uint16_rotr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let mut num = rng.gen();
 
@@ -117,7 +117,7 @@ fn test_uint16_rotr() {
 
 #[test]
 fn test_uint16_xor() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -159,7 +159,7 @@ fn test_uint16_xor() {
 
 #[test]
 fn test_uint16_addmany_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -185,7 +185,7 @@ fn test_uint16_addmany_constants() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn test_uint16_addmany() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -224,7 +224,7 @@ fn test_uint16_addmany() {
 
 #[test]
 fn test_uint16_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -247,7 +247,7 @@ fn test_uint16_sub_constants() {
 
 #[test]
 fn test_uint16_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -282,7 +282,7 @@ fn test_uint16_sub() {
 
 #[test]
 fn test_uint16_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -305,7 +305,7 @@ fn test_uint16_mul_constants() {
 
 #[test]
 fn test_uint16_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -340,7 +340,7 @@ fn test_uint16_mul() {
 
 #[test]
 fn test_uint16_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -363,7 +363,7 @@ fn test_uint16_div_constants() {
 
 #[test]
 fn test_uint16_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -398,7 +398,7 @@ fn test_uint16_div() {
 
 #[test]
 fn test_uint16_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -421,7 +421,7 @@ fn test_uint16_pow_constants() {
 
 #[test]
 fn test_uint16_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/gadgets/src/integers/uint/tests/uint32.rs
+++ b/gadgets/src/integers/uint/tests/uint32.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -58,7 +58,7 @@ fn check_all_allocated_bits(mut expected: u32, actual: UInt32) {
 
 #[test]
 fn test_uint32_from_bits() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let v = (0..32).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
@@ -88,7 +88,7 @@ fn test_uint32_from_bits() {
 
 #[test]
 fn test_uint32_rotr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let mut num = rng.gen();
 
@@ -117,7 +117,7 @@ fn test_uint32_rotr() {
 
 #[test]
 fn test_uint32_xor() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -159,7 +159,7 @@ fn test_uint32_xor() {
 
 #[test]
 fn test_uint32_addmany_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -185,7 +185,7 @@ fn test_uint32_addmany_constants() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn test_uint32_addmany() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -224,7 +224,7 @@ fn test_uint32_addmany() {
 
 #[test]
 fn test_uint32_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -247,7 +247,7 @@ fn test_uint32_sub_constants() {
 
 #[test]
 fn test_uint32_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -282,7 +282,7 @@ fn test_uint32_sub() {
 
 #[test]
 fn test_uint32_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -305,7 +305,7 @@ fn test_uint32_mul_constants() {
 
 #[test]
 fn test_uint32_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -340,7 +340,7 @@ fn test_uint32_mul() {
 
 #[test]
 fn test_uint32_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -363,7 +363,7 @@ fn test_uint32_div_constants() {
 
 #[test]
 fn test_uint32_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -398,7 +398,7 @@ fn test_uint32_div() {
 
 #[test]
 fn test_uint32_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -421,7 +421,7 @@ fn test_uint32_pow_constants() {
 
 #[test]
 fn test_uint32_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..10 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/gadgets/src/integers/uint/tests/uint64.rs
+++ b/gadgets/src/integers/uint/tests/uint64.rs
@@ -16,11 +16,11 @@
 
 use std::convert::TryInto;
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -60,7 +60,7 @@ fn check_all_allocated_bits(mut expected: u64, actual: UInt64) {
 
 #[test]
 fn test_uint64_from_bits() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let v = (0..64).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
@@ -90,7 +90,7 @@ fn test_uint64_from_bits() {
 
 #[test]
 fn test_uint64_rotr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let mut num = rng.gen();
 
@@ -119,7 +119,7 @@ fn test_uint64_rotr() {
 
 #[test]
 fn test_uint64_xor() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -161,7 +161,7 @@ fn test_uint64_xor() {
 
 #[test]
 fn test_uint64_addmany_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -187,7 +187,7 @@ fn test_uint64_addmany_constants() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn test_uint64_addmany() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -226,7 +226,7 @@ fn test_uint64_addmany() {
 
 #[test]
 fn test_uint64_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -249,7 +249,7 @@ fn test_uint64_sub_constants() {
 
 #[test]
 fn test_uint64_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -284,7 +284,7 @@ fn test_uint64_sub() {
 
 #[test]
 fn test_uint64_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -307,7 +307,7 @@ fn test_uint64_mul_constants() {
 
 #[test]
 fn test_uint64_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -342,7 +342,7 @@ fn test_uint64_mul() {
 
 #[test]
 fn test_uint64_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -365,7 +365,7 @@ fn test_uint64_div_constants() {
 
 #[test]
 fn test_uint64_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -400,7 +400,7 @@ fn test_uint64_div() {
 
 #[test]
 fn test_uint64_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -423,7 +423,7 @@ fn test_uint64_pow_constants() {
 
 #[test]
 fn test_uint64_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..4 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/gadgets/src/integers/uint/tests/uint8.rs
+++ b/gadgets/src/integers/uint/tests/uint8.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use rand::Rng;
 
 use snarkvm_fields::{One, Zero};
 use snarkvm_r1cs::{ConstraintSystem, Fr, TestConstraintSystem};
+use snarkvm_utilities::rand::test_rng;
 
 use crate::{
     bits::Boolean,
@@ -82,7 +82,7 @@ fn test_uint8_alloc_input_vec() {
 
 #[test]
 fn test_uint8_from_bits() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let v = (0..8).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
@@ -112,7 +112,7 @@ fn test_uint8_from_bits() {
 
 #[test]
 fn test_uint8_rotr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let mut num = rng.gen();
 
@@ -141,7 +141,7 @@ fn test_uint8_rotr() {
 
 #[test]
 fn test_uint8_xor() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -183,7 +183,7 @@ fn test_uint8_xor() {
 
 #[test]
 fn test_uint8_addmany_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -209,7 +209,7 @@ fn test_uint8_addmany_constants() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn test_uint8_addmany() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -248,7 +248,7 @@ fn test_uint8_addmany() {
 
 #[test]
 fn test_uint8_sub_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -271,7 +271,7 @@ fn test_uint8_sub_constants() {
 
 #[test]
 fn test_uint8_sub() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -306,7 +306,7 @@ fn test_uint8_sub() {
 
 #[test]
 fn test_uint8_mul_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -329,7 +329,7 @@ fn test_uint8_mul_constants() {
 
 #[test]
 fn test_uint8_mul() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -364,7 +364,7 @@ fn test_uint8_mul() {
 
 #[test]
 fn test_uint8_div_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -387,7 +387,7 @@ fn test_uint8_div_constants() {
 
 #[test]
 fn test_uint8_div() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -422,7 +422,7 @@ fn test_uint8_div() {
 
 #[test]
 fn test_uint8_pow_constants() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
@@ -445,7 +445,7 @@ fn test_uint8_pow_constants() {
 
 #[test]
 fn test_uint8_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.4"
 [dependencies.rand]
 version = "0.8"
 default-features = false
-features = [ "std_rng" ]
+features = [ "getrandom", "std_rng" ]
 
 [dependencies.rayon]
 version = "1"
@@ -55,7 +55,7 @@ default-features = false
 [dependencies.thiserror]
 version = "1.0"
 
-[dev-dependencies.rand_xorshift]
+[dependencies.rand_xorshift]
 version = "0.3"
 default-features = false
 

--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -16,8 +16,11 @@
 
 use rand::{
     distributions::{Distribution, Standard},
+    rngs::StdRng,
     Rng,
+    SeedableRng,
 };
+use rand_xorshift::XorShiftRng;
 
 pub trait UniformRand: Sized {
     fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self;
@@ -33,11 +36,16 @@ where
     }
 }
 
-/// Should be used only for tests, not for any real world usage.
-pub fn test_rng() -> rand::rngs::StdRng {
-    use rand::SeedableRng;
+/// A fast Rng which should be used only in tests or benchmarks, but not for any real world purposes.
+pub fn test_rng() -> XorShiftRng {
+    // Obtain the initial seed using entropy provided by the OS.
+    let seed = StdRng::from_entropy().gen();
 
-    // arbitrary seed
-    let seed = [1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-    rand::rngs::StdRng::from_seed(seed)
+    // Use the seed to initialize a fast, non-cryptographic Rng.
+    XorShiftRng::seed_from_u64(seed)
+}
+
+/// An Rng which can be used in tests or benchmarks requiring a CryptoRng.
+pub fn test_crypto_rng() -> StdRng {
+    StdRng::from_entropy()
 }


### PR DESCRIPTION
Instead of using hard-coded seeds, obtain them once using the `getrandom` feature and then seed the fast `XorShiftRandom` with them in order to have more random inputs in the related tests.
Note: this change is not possible everywhere, as some of the tests require a `CryptoRng`; in those cases, `StdRng` is used instead, and it's also seeded from the entropy provided by the OS.