### PR TITLE
Extend BlockHeaderMetadata with LedgerRoot and TransactionsRoot

### DIFF
--- a/dpc/src/block/template.rs
+++ b/dpc/src/block/template.rs
@@ -110,11 +110,7 @@ impl<N: Network> BlockTemplate<N> {
 
     /// Returns an instance of the block header tree.
     pub fn to_header_tree(&self) -> Result<MerkleTree<N::BlockHeaderRootParameters>> {
-        Self::compute_block_header_tree(
-            self.previous_ledger_root,
-            self.transactions.transactions_root(),
-            &BlockHeaderMetadata::new(self),
-        )
+        Self::compute_block_header_tree(&BlockHeaderMetadata::new(self))
     }
 
     /// Returns the block header root.
@@ -124,14 +120,12 @@ impl<N: Network> BlockTemplate<N> {
 
     /// Returns an instance of the block header tree.
     pub fn compute_block_header_tree(
-        previous_ledger_root: N::LedgerRoot,
-        transactions_root: N::TransactionsRoot,
-        metadata: &BlockHeaderMetadata,
+        metadata: &BlockHeaderMetadata<N>,
     ) -> Result<MerkleTree<N::BlockHeaderRootParameters>> {
-        let previous_ledger_root = previous_ledger_root.to_bytes_le()?;
+        let previous_ledger_root = metadata.previous_ledger_root().to_bytes_le()?;
         assert_eq!(previous_ledger_root.len(), 32);
 
-        let transactions_root = transactions_root.to_bytes_le()?;
+        let transactions_root = metadata.transactions_root().to_bytes_le()?;
         assert_eq!(transactions_root.len(), 32);
 
         let metadata = metadata.to_bytes_le()?;

--- a/dpc/src/posw/posw.rs
+++ b/dpc/src/posw/posw.rs
@@ -113,13 +113,7 @@ impl<N: Network> PoSWScheme<N> for PoSW<N> {
             // Check if the updated block header is valid.
             if self.verify(block_template.difficulty_target(), &circuit.to_public_inputs(), &proof) {
                 // Construct a block header.
-                return Ok(BlockHeader::from(
-                    block_template.previous_ledger_root(),
-                    block_template.transactions().transactions_root(),
-                    BlockHeaderMetadata::new(block_template),
-                    circuit.nonce(),
-                    proof,
-                )?);
+                return Ok(BlockHeader::from(BlockHeaderMetadata::new(block_template), circuit.nonce(), proof)?);
             }
 
             // Increment the iteration by one.


### PR DESCRIPTION
This PR proposes that `LedgerRoot` and `TransactionsRoot` are inserted into `BlockHeaderMetadata` as opposed to being right before it in the `BlockHeader`. This will allow us to do 2 things with great snarkOS performance implications:
- use `BlockHeaderMetadata` (as opposed to the full `BlockHeader`) in `BlockLocators`, making their deserialization a lot faster, fixing issues like https://github.com/AleoHQ/snarkOS/issues/1632
- introduce a `DataMap<N::BlockHash, BlockHeaderMetadata<N>>` (in addition to the existing `DataMap<N::BlockHash, BlockHeader<N>>`) storage map that would allow us to perform all header-related storage operations that don't require the proof orders of magnitude faster, without any data duplication or low-level deserialization

This is a pure refactoring and shouldn't introduce any functional changes.

note: alternatives like splitting `BlockProof` (that would contain the nonce and the proof) out from the `BlockHeader` or any other variation where we can deserialize the current header partially into an object / objects without the proof would work; this PR just does that in the simplest way I could think of.