### PR TITLE
Change backing storage of `SparsePolynomial` to `BTreeMap`

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -289,8 +289,8 @@ impl<F: FftField> EvaluationDomain<F> {
 
     /// Return the sparse vanishing polynomial.
     pub fn vanishing_polynomial(&self) -> SparsePolynomial<F> {
-        let coeffs = vec![(0, -F::one()), (self.size(), F::one())];
-        SparsePolynomial::from_coefficients_vec(coeffs)
+        let coeffs = [(0, -F::one()), (self.size(), F::one())];
+        SparsePolynomial::from_coefficients(coeffs)
     }
 
     /// This evaluates the vanishing polynomial for this domain at tau.

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -274,8 +274,8 @@ impl<F: PrimeField> DensePolynomial<F> {
 impl<F: Field> From<super::SparsePolynomial<F>> for DensePolynomial<F> {
     fn from(other: super::SparsePolynomial<F>) -> Self {
         let mut result = vec![F::zero(); other.degree() + 1];
-        for (i, coeff) in other.coeffs {
-            result[i] = coeff;
+        for (i, coeff) in other.coeffs() {
+            result[*i] = *coeff;
         }
         DensePolynomial::from_coefficients_vec(result)
     }
@@ -364,7 +364,7 @@ impl<'a, F: Field> AddAssign<&'a super::SparsePolynomial<F>> for DensePolynomial
         if self.degree() < other.degree() {
             self.coeffs.resize(other.degree() + 1, F::zero());
         }
-        for (i, b) in &other.coeffs {
+        for (i, b) in other.coeffs() {
             self.coeffs[*i] += b;
         }
         // If the leading coefficient ends up being zero, pop it off.
@@ -382,7 +382,7 @@ impl<'a, F: Field> Sub<&'a super::SparsePolynomial<F>> for DensePolynomial<F> {
         if self.degree() < other.degree() {
             self.coeffs.resize(other.degree() + 1, F::zero());
         }
-        for (i, b) in &other.coeffs {
+        for (i, b) in other.coeffs() {
             self.coeffs[*i] -= b;
         }
         // If the leading coefficient ends up being zero, pop it off.

--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -152,7 +152,7 @@ impl<'a, F: Field> DenseOrSparsePolynomial<'a, F> {
     #[inline]
     pub fn leading_coefficient(&self) -> Option<&F> {
         match self {
-            SPolynomial(p) => p.coeffs.last().map(|(_, c)| c),
+            SPolynomial(p) => p.coeffs().last().map(|(_, c)| c),
             DPolynomial(p) => p.last(),
         }
     }
@@ -188,7 +188,7 @@ impl<'a, F: Field> DenseOrSparsePolynomial<'a, F> {
 
     pub fn coeffs(&'a self) -> Box<dyn Iterator<Item = (usize, &'a F)> + 'a> {
         match self {
-            SPolynomial(p) => Box::new(p.coeffs.iter().map(|(c, f)| (*c, f))),
+            SPolynomial(p) => Box::new(p.coeffs().map(|(c, f)| (*c, f))),
             DPolynomial(p) => Box::new(p.coeffs.iter().enumerate()),
         }
     }
@@ -213,7 +213,7 @@ impl<'a, F: Field> DenseOrSparsePolynomial<'a, F> {
                 quotient[cur_q_degree] = cur_q_coeff;
 
                 if let SPolynomial(p) = divisor {
-                    for (i, div_coeff) in &p.coeffs {
+                    for (i, div_coeff) in p.coeffs() {
                         remainder[cur_q_degree + i] -= &(cur_q_coeff * div_coeff);
                     }
                 } else if let DPolynomial(p) = divisor {

--- a/algorithms/src/fft/polynomial/sparse.rs
+++ b/algorithms/src/fft/polynomial/sparse.rs
@@ -129,8 +129,12 @@ impl<F: PrimeField> SparsePolynomial<F> {
 }
 impl<F: PrimeField> core::ops::MulAssign<F> for SparsePolynomial<F> {
     fn mul_assign(&mut self, other: F) {
-        for (_, coeff) in &mut self.coeffs {
-            *coeff *= other;
+        if other.is_zero() {
+            *self = Self::zero()
+        } else {
+            for coeff in self.coeffs.values_mut() {
+                *coeff *= other;
+            }
         }
     }
 }

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -249,8 +249,7 @@ impl<E: PairingEngine> KZG10<E> {
                 commitment
             }
             DenseOrSparsePolynomial::SPolynomial(polynomial) => polynomial
-                .coeffs
-                .iter()
+                .coeffs()
                 .map(|(i, coeff)| {
                     powers.powers_of_beta_g[*i].mul_bits(BitIteratorBE::new_without_leading_zeros(coeff.to_repr()))
                 })

--- a/algorithms/src/snark/marlin/ahp/prover/prover.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/prover.rs
@@ -299,14 +299,14 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             let mask_poly_time = start_timer!(|| "Computing mask polynomial");
             // We'll use the masking technique from Lunar (https://eprint.iacr.org/2020/1069.pdf, pgs 20-22).
             let h_1_mask = DensePolynomial::rand(3, rng).coeffs; // selected arbitrarily.
-            let h_1_mask = SparsePolynomial::from_coefficients_vec(h_1_mask.into_iter().enumerate().collect())
+            let h_1_mask = SparsePolynomial::from_coefficients(h_1_mask.into_iter().enumerate())
                 .mul(&constraint_domain.vanishing_polynomial());
             assert_eq!(h_1_mask.degree(), constraint_domain.size() + 3);
             // multiply g_1_mask by X
             let mut g_1_mask = DensePolynomial::rand(5, rng);
             g_1_mask.coeffs[0] = F::zero();
-            let g_1_mask = SparsePolynomial::from_coefficients_vec(
-                g_1_mask.iter().enumerate().filter_map(|(i, coeff)| (!coeff.is_zero()).then(|| (i, *coeff))).collect(),
+            let g_1_mask = SparsePolynomial::from_coefficients(
+                g_1_mask.coeffs.into_iter().enumerate().filter(|(_, coeff)| !coeff.is_zero()),
             );
 
             let mut mask_poly = h_1_mask;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Ensures that coefficients are always sorted in the appropriate order.

Also makes the `coeffs` field private to ensure that no outside code can change this invariant. An immutable accessor is provided to support existing users of this field.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

(Link your related PRs here)
