### PR TITLE
Initial improvements for `zip` safety

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -44,6 +44,9 @@ use std::fmt;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+#[cfg(not(feature = "parallel"))]
+use itertools::Itertools;
+
 /// Returns the ceiling of the base-2 logarithm of `x`.
 ///
 /// ```
@@ -280,7 +283,7 @@ impl<F: FftField> EvaluationDomain<F> {
             }
 
             batch_inversion(u.as_mut_slice());
-            cfg_iter_mut!(u).zip(ls).for_each(|(tau_minus_r, l)| {
+            cfg_iter_mut!(u).zip_eq(ls).for_each(|(tau_minus_r, l)| {
                 *tau_minus_r = l * *tau_minus_r;
             });
             u
@@ -344,10 +347,9 @@ impl<F: FftField> EvaluationDomain<F> {
     /// Returns the evaluations of the product over the domain.
     #[must_use]
     pub fn mul_polynomials_in_evaluation_domain(&self, self_evals: &[F], other_evals: &[F]) -> Vec<F> {
-        assert_eq!(self_evals.len(), other_evals.len());
-
         let mut result = self_evals.to_vec();
-        cfg_iter_mut!(result).zip(other_evals).for_each(|(a, b)| *a *= b);
+
+        cfg_iter_mut!(result).zip_eq(other_evals).for_each(|(a, b)| *a *= b);
 
         result
     }

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -17,8 +17,13 @@
 //! A polynomial represented in evaluations form.
 
 use crate::fft::{DensePolynomial, EvaluationDomain};
+#[cfg(not(feature = "parallel"))]
+use itertools::Itertools;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::serialize::*;
+use snarkvm_utilities::{cfg_iter_mut, serialize::*};
 
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
@@ -77,7 +82,7 @@ impl<'a, F: PrimeField> MulAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn mul_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations.iter_mut().zip(&other.evaluations).for_each(|(a, b)| *a *= b);
+        cfg_iter_mut!(self.evaluations).zip_eq(&other.evaluations).for_each(|(a, b)| *a *= b);
     }
 }
 
@@ -96,7 +101,7 @@ impl<'a, F: PrimeField> AddAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn add_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations.iter_mut().zip(&other.evaluations).for_each(|(a, b)| *a += b);
+        cfg_iter_mut!(self.evaluations).zip_eq(&other.evaluations).for_each(|(a, b)| *a += b);
     }
 }
 
@@ -115,7 +120,7 @@ impl<'a, F: PrimeField> SubAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn sub_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations.iter_mut().zip(&other.evaluations).for_each(|(a, b)| *a -= b);
+        cfg_iter_mut!(self.evaluations).zip_eq(&other.evaluations).for_each(|(a, b)| *a -= b);
     }
 }
 
@@ -134,6 +139,6 @@ impl<'a, F: PrimeField> DivAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn div_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations.iter_mut().zip(&other.evaluations).for_each(|(a, b)| *a /= b);
+        cfg_iter_mut!(self.evaluations).zip_eq(&other.evaluations).for_each(|(a, b)| *a /= b);
     }
 }

--- a/algorithms/src/polycommit/data_structures/polynomial.rs
+++ b/algorithms/src/polycommit/data_structures/polynomial.rs
@@ -183,6 +183,8 @@ impl<'a, F: PrimeField> LabeledPolynomialWithBasis<'a, F> {
                         match polynomial.as_ref() {
                             DPolynomial(p) => {
                                 if let Some(e) = dense_polys.get_mut(degree_bound) {
+                                    // Zip safety: `p` could be of smaller degree than `e` (or vice versa),
+                                    // so it's okay to just use `zip` here.
                                     cfg_iter_mut!(e).zip(&p.coeffs).for_each(|(e, f)| *e += *c * f)
                                 } else {
                                     let mut e: DensePolynomial<F> = p.to_owned().into_owned();
@@ -196,7 +198,7 @@ impl<'a, F: PrimeField> LabeledPolynomialWithBasis<'a, F> {
                     Lagrange { evaluations } => {
                         let domain = evaluations.domain().size();
                         if let Some(e) = lagrange_polys.get_mut(&domain) {
-                            cfg_iter_mut!(e).zip(&evaluations.evaluations).for_each(|(e, f)| *e += *c * f)
+                            cfg_iter_mut!(e).zip_eq(&evaluations.evaluations).for_each(|(e, f)| *e += *c * f)
                         } else {
                             let mut e = evaluations.to_owned().into_owned().evaluations;
                             cfg_iter_mut!(e).for_each(|e| *e *= c);
@@ -346,8 +348,8 @@ impl<'a, F: PrimeField> PolynomialWithBasis<'a, F> {
                 let mut denominators = cfg_iter!(powers).map(|pow| point - pow).collect::<Vec<_>>();
                 snarkvm_fields::batch_inversion(&mut denominators);
                 cfg_iter_mut!(denominators)
-                    .zip(powers)
-                    .zip(&evaluations.evaluations)
+                    .zip_eq(powers)
+                    .zip_eq(&evaluations.evaluations)
                     .map(|((denom, power), coeff)| *denom * power * coeff)
                     .sum::<F>()
                     * multiplier

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     msm::{FixedBaseMSM, VariableBaseMSM},
     polycommit::{PCError, PCRandomness},
 };
+use itertools::Itertools;
 use snarkvm_curves::traits::{AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve};
 use snarkvm_fields::{Field, One, PrimeField, Zero};
 use snarkvm_utilities::{cfg_iter, rand::UniformRand, BitIteratorBE};
@@ -189,7 +190,7 @@ impl<E: PairingEngine> KZG10<E> {
 
                 let affines = E::G2Projective::batch_normalization_into_affine(neg_powers_of_h);
 
-                for (i, affine) in list.iter().zip(affines.iter()) {
+                for (i, affine) in list.iter().zip_eq(affines.iter()) {
                     map.insert(*i, *affine);
                 }
 
@@ -475,7 +476,7 @@ impl<E: PairingEngine> KZG10<E> {
         // their coefficients and perform a final multiplication at the end.
         let mut g_multiplier = E::Fr::zero();
         let mut gamma_g_multiplier = E::Fr::zero();
-        for (((c, z), v), proof) in commitments.iter().zip(points).zip(values).zip(proofs) {
+        for (((c, z), v), proof) in commitments.iter().zip_eq(points).zip_eq(values).zip_eq(proofs) {
             let w = proof.w;
             let mut temp = w.mul(*z).into_projective();
             temp.add_assign_mixed(&c.0);

--- a/algorithms/src/polycommit/mod.rs
+++ b/algorithms/src/polycommit/mod.rs
@@ -44,6 +44,7 @@ pub use data_structures::*;
 /// Errors pertaining to query sets.
 pub mod error;
 pub use error::*;
+use itertools::Itertools;
 
 /// A random number generator that bypasses some limitations of the Rust borrow
 /// checker.
@@ -219,8 +220,8 @@ pub trait PolynomialCommitment<F: PrimeField, CF: PrimeField>: Sized + Clone + D
     {
         let poly_rand_comm: BTreeMap<_, _> = labeled_polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments.into_iter())
+            .zip_eq(rands)
+            .zip_eq(commitments.into_iter())
             .map(|((poly, r), comm)| (poly.label(), (poly, r, comm)))
             .collect();
 
@@ -307,7 +308,7 @@ pub trait PolynomialCommitment<F: PrimeField, CF: PrimeField>: Sized + Clone + D
         assert_eq!(proofs.len(), query_to_labels_map.len());
 
         let mut result = true;
-        for ((_point_name, (query, labels)), proof) in query_to_labels_map.into_iter().zip(proofs) {
+        for ((_point_name, (query, labels)), proof) in query_to_labels_map.into_iter().zip_eq(proofs) {
             let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::with_capacity(labels.len());
             let mut values = Vec::with_capacity(labels.len());
             for label in labels.into_iter() {
@@ -377,7 +378,7 @@ pub trait PolynomialCommitment<F: PrimeField, CF: PrimeField>: Sized + Clone + D
 
         let poly_query_set = lc_query_set_to_poly_query_set(lc_s.values().copied(), eqn_query_set);
         let poly_evals: Evaluations<_> =
-            poly_query_set.iter().map(|(_, point)| point).cloned().zip(evals.clone().unwrap()).collect();
+            poly_query_set.iter().map(|(_, point)| point).cloned().zip_eq(evals.clone().unwrap()).collect();
 
         for &(ref lc_label, (_, point)) in eqn_query_set {
             if let Some(lc) = lc_s.get(lc_label) {

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -33,6 +33,7 @@ use crate::{
         QuerySet,
     },
 };
+use itertools::Itertools;
 use snarkvm_curves::traits::{AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve};
 use snarkvm_fields::{One, Zero};
 use snarkvm_utilities::rand::UniformRand;
@@ -354,7 +355,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let mut combined_rand = kzg10::Randomness::empty();
         let mut curr_challenge = opening_challenge;
 
-        for (polynomial, rand) in labeled_polynomials.into_iter().zip(rands) {
+        for (polynomial, rand) in labeled_polynomials.into_iter().zip_eq(rands) {
             let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
             kzg10::KZG10::<E>::check_degrees_and_bounds(
@@ -439,7 +440,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let mut combined_witness: E::G1Projective = E::G1Projective::zero();
         let mut combined_adjusted_witness: E::G1Projective = E::G1Projective::zero();
 
-        for ((_query_name, (query, labels)), p) in query_to_labels_map.into_iter().zip(proof) {
+        for ((_query_name, (query, labels)), p) in query_to_labels_map.into_iter().zip_eq(proof) {
             let mut comms_to_combine: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values_to_combine = Vec::new();
             for label in labels.into_iter() {
@@ -489,8 +490,8 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
     {
         let label_map = polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments)
+            .zip_eq(rands)
+            .zip_eq(commitments)
             .map(|((p, r), c)| (p.label(), (p, r, c)))
             .collect::<BTreeMap<_, _>>();
 
@@ -542,7 +543,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
 
         let lc_commitments = lc_info
             .into_iter()
-            .zip(comms)
+            .zip_eq(comms)
             .map(|((label, d), c)| LabeledCommitment::new(label, c, d))
             .collect::<Vec<_>>();
 
@@ -615,7 +616,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let comms = E::G1Projective::batch_normalization_into_affine(lc_commitments).into_iter().map(kzg10::Commitment);
 
         let lc_commitments: Vec<_> =
-            lc_info.into_iter().zip(comms).map(|((label, d), c)| LabeledCommitment::new(label, c, d)).collect();
+            lc_info.into_iter().zip_eq(comms).map(|((label, d), c)| LabeledCommitment::new(label, c, d)).collect();
 
         Self::batch_check(vk, &lc_commitments, query_set, &evaluations, proof, opening_challenge, rng)
     }
@@ -638,8 +639,8 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
     {
         let label_map = polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments)
+            .zip_eq(rands)
+            .zip_eq(commitments)
             .map(|((p, r), c)| (p.label(), (p, r, c)))
             .collect::<BTreeMap<_, _>>();
 
@@ -685,7 +686,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let comms = Self::normalize_commitments(lc_commitments);
         let lc_commitments = lc_info
             .into_iter()
-            .zip(comms)
+            .zip_eq(comms)
             .map(|((label, d), c)| LabeledCommitment::new(label, c, d))
             .collect::<Vec<_>>();
 
@@ -761,7 +762,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let comms = Self::normalize_commitments(lc_commitments);
         let lc_commitments = lc_info
             .into_iter()
-            .zip(comms)
+            .zip_eq(comms)
             .map(|((label, d), c)| LabeledCommitment::new(label, c, d))
             .collect::<Vec<_>>();
         end_timer!(combined_comms_norm_time);
@@ -796,7 +797,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
         let mut combined_polynomial = DensePolynomial::zero();
         let mut combined_rand = kzg10::Randomness::empty();
 
-        for (opening_challenge_counter, (polynomial, rand)) in labeled_polynomials.into_iter().zip(rands).enumerate() {
+        for (opening_challenge_counter, (polynomial, rand)) in labeled_polynomials.into_iter().zip_eq(rands).enumerate()
+        {
             let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
             kzg10::KZG10::<E>::check_degrees_and_bounds(
@@ -836,8 +838,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
     {
         let poly_rand_comm: BTreeMap<_, _> = labeled_polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments.into_iter())
+            .zip_eq(rands)
+            .zip_eq(commitments.into_iter())
             .map(|((poly, r), comm)| (poly.label(), (poly, r, comm)))
             .collect();
 
@@ -956,7 +958,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
         assert_eq!(proofs.len(), query_to_labels_map.len());
 
         let mut result = true;
-        for ((_point_name, (point, labels)), proof) in query_to_labels_map.into_iter().zip(proofs) {
+        for ((_point_name, (point, labels)), proof) in query_to_labels_map.into_iter().zip_eq(proofs) {
             let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values = Vec::new();
             for label in labels {
@@ -1000,7 +1002,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
         let mut combined_values = E::Fr::zero();
 
         // Iterates through all of the commitments and accumulates common degree_bound elements in a BTreeMap
-        for (labeled_comm, value) in commitments.into_iter().zip(values) {
+        for (labeled_comm, value) in commitments.into_iter().zip_eq(values) {
             combined_values += &(value * curr_challenge);
 
             let comm = labeled_comm.commitment();
@@ -1053,7 +1055,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
         let mut combined_values = E::Fr::zero();
 
         // Iterates through all of the commitments and accumulates common degree_bound elements in a BTreeMap
-        for (opening_challenge_counter, (labeled_commitment, value)) in commitments.into_iter().zip(values).enumerate()
+        for (opening_challenge_counter, (labeled_commitment, value)) in
+            commitments.into_iter().zip_eq(values).enumerate()
         {
             let current_challenge = opening_challenges(opening_challenge_counter as u64);
             combined_values += &(value * current_challenge);
@@ -1122,7 +1125,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
             .map(|a| a.prepare())
             .collect::<Vec<_>>();
 
-        let g1_g2_prepared = g1_prepared_elems_iter.iter().zip(g2_prepared_elems.iter());
+        let g1_g2_prepared = g1_prepared_elems_iter.iter().zip_eq(g2_prepared_elems.iter());
         let is_one: bool = E::product_of_pairings(g1_g2_prepared).is_one();
         end_timer!(check_time);
         Ok(is_one)

--- a/algorithms/src/polycommit/test_templates.rs
+++ b/algorithms/src/polycommit/test_templates.rs
@@ -162,7 +162,7 @@ where
         // let mut point = F::one();
         for point_id in 0..num_points_in_query_set {
             let point = F::rand(rng);
-            for (polynomial, label) in polynomials.iter().zip(labels.iter()) {
+            for (polynomial, label) in polynomials.iter().zip_eq(labels.iter()) {
                 query_set.insert((label.clone(), (format!("rand_{}", point_id), point)));
                 let value = polynomial.evaluate(point);
                 values.insert((label.clone(), point), value);
@@ -282,7 +282,7 @@ where
         // let mut point = F::one();
         for point_id in 0..num_points_in_query_set {
             let point = F::rand(rng);
-            for (polynomial, label) in polynomials.iter().zip(labels.iter()) {
+            for (polynomial, label) in polynomials.iter().zip_eq(labels.iter()) {
                 query_set.insert((label.clone(), (format!("rand_{}", point_id), point)));
                 let value = polynomial.evaluate(point);
                 values.insert((label.clone(), point), value);

--- a/algorithms/src/snark/marlin/ahp/ahp.rs
+++ b/algorithms/src/snark/marlin/ahp/ahp.rs
@@ -405,12 +405,12 @@ impl<F: PrimeField> UnnormalizedBivariateLagrangePoly<F> for EvaluationDomain<F>
             snarkvm_fields::batch_inversion(&mut denoms);
             let ratio = domain.size() / self.size();
             let mut numerators = vec![vanish_x; domain.size()];
-            cfg_iter_mut!(numerators).zip(elements).enumerate().for_each(|(i, (n, e))| {
+            cfg_iter_mut!(numerators).zip_eq(elements).enumerate().for_each(|(i, (n, e))| {
                 if i % ratio != 0 {
                     *n -= self.evaluate_vanishing_polynomial(e);
                 }
             });
-            cfg_iter_mut!(denoms).zip(numerators).for_each(|(d, e)| *d *= e);
+            cfg_iter_mut!(denoms).zip_eq(numerators).for_each(|(d, e)| *d *= e);
         }
         denoms
     }

--- a/algorithms/src/snark/marlin/ahp/prover/prover.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/prover.rs
@@ -437,6 +437,8 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             #[cfg(feature = "parallel")]
             use rayon::iter::repeat;
 
+            // Zip safety: here `constraint_domain.size() + z_a_poly_det.coeffs.len()` could
+            // have size smaller than `z_c.coeffs`, so `zip_eq` would be incorrect.
             let zero = F::zero();
             repeat(&zero)
                 .take(constraint_domain.size())
@@ -451,6 +453,9 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
                     };
                     *z_c += t * r_b;
                 });
+
+            // Zip safety: here `constraint_domain.size() + z_b_poly_det.coeffs.len()` could
+            // have size smaller than `z_c.coeffs`, so `zip_eq` would be incorrect.
             repeat(&zero)
                 .take(constraint_domain.size())
                 .chain(&z_b_poly_det.coeffs)
@@ -509,6 +514,7 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
                 .interpolate();
         let w_poly = state.w_poly.as_ref().and_then(|p| p.polynomial().as_dense()).unwrap();
         let mut z_poly = w_poly.mul_by_vanishing_poly(state.input_domain);
+        // Zip safety: `x_poly` is smaller than `z_poly`.
         cfg_iter_mut!(z_poly.coeffs).zip(&x_poly.coeffs).for_each(|(z, x)| *z += x);
         assert!(z_poly.degree() < constraint_domain.size() + zk_bound);
 
@@ -674,8 +680,8 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             let alpha_beta = alpha * beta;
             let b_poly = {
                 let evals: Vec<F> = cfg_iter!(row_on_K.evaluations)
-                    .zip(&col_on_K.evaluations)
-                    .zip(&row_col_on_K.evaluations)
+                    .zip_eq(&col_on_K.evaluations)
+                    .zip_eq(&row_col_on_K.evaluations)
                     .map(|((r, c), r_c)| alpha_beta - alpha * r - beta * c + r_c)
                     .collect();
                 EvaluationsOnDomain::from_vec_and_domain(evals, non_zero_domain).interpolate()
@@ -686,11 +692,13 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         let [a_poly, b_poly]: [_; 2] = job_pool.execute_all().try_into().unwrap();
 
         let f_evals_time = start_timer!(|| "Computing f evals on K");
-        let mut inverses: Vec<_> =
-            cfg_iter!(row_on_K.evaluations).zip(&col_on_K.evaluations).map(|(r, c)| (beta - r) * (alpha - c)).collect();
+        let mut inverses: Vec<_> = cfg_iter!(row_on_K.evaluations)
+            .zip_eq(&col_on_K.evaluations)
+            .map(|(r, c)| (beta - r) * (alpha - c))
+            .collect();
         batch_inversion_and_mul(&mut inverses, &v_H_alpha_v_H_beta);
 
-        cfg_iter_mut!(inverses).zip(&arithmetization.evals_on_K.val.evaluations).for_each(|(inv, a)| *inv *= a);
+        cfg_iter_mut!(inverses).zip_eq(&arithmetization.evals_on_K.val.evaluations).for_each(|(inv, a)| *inv *= a);
         let f_evals_on_K = inverses;
         end_timer!(f_evals_time);
 

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -31,6 +31,7 @@ use crate::{
         UniversalSRS,
     },
 };
+use itertools::Itertools;
 use snarkvm_fields::{PrimeField, ToConstraintField};
 use snarkvm_r1cs::ConstraintSynthesizer;
 use snarkvm_utilities::{to_bytes_le, ToBytes};
@@ -317,7 +318,7 @@ impl<
             .circuit_verifying_key
             .iter()
             .cloned()
-            .zip(indexer_polynomials)
+            .zip_eq(indexer_polynomials)
             .map(|(c, l)| LabeledCommitment::new(l.to_string(), c, None))
             .chain(first_commitments.into_iter())
             .chain(second_commitments.into_iter())
@@ -526,8 +527,8 @@ impl<
             .chain(third_commitments)
             .chain(fourth_commitments)
             .cloned()
-            .zip(polynomial_labels)
-            .zip(degree_bounds)
+            .zip_eq(polynomial_labels)
+            .zip_eq(degree_bounds)
             .map(|((c, l), d)| LabeledCommitment::new(l, c, d))
             .collect();
 
@@ -547,7 +548,7 @@ impl<
             }
         }
         evaluation_labels.sort_by(|a, b| a.0.cmp(&b.0));
-        for (q, eval) in evaluation_labels.into_iter().zip(&proof.evaluations) {
+        for (q, eval) in evaluation_labels.into_iter().zip_eq(&proof.evaluations) {
             evaluations.insert(q, *eval);
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Change many uses of `zip` to `zip_eq`, which enforces that the lengths of the zipped iterators are equal. In the remaining usages of `zip`, provide justification for why `zip` is sufficient. 

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

(Link your related PRs here)
