### PR TITLE
fix dpc wasm compatibility

### DIFF
--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -130,6 +130,7 @@ version = "0.8"
 
 [dependencies.rayon]
 version = "1"
+optional = true
 
 [dependencies.serde]
 version = "1.0"
@@ -168,6 +169,7 @@ wasm = [
   "snarkvm-parameters/wasm"
 ]
 parallel = [
+  "rayon",
   "snarkvm-algorithms/parallel",
   "snarkvm-fields/parallel",
   "snarkvm-marlin/parallel",

--- a/dpc/src/block/transactions.rs
+++ b/dpc/src/block/transactions.rs
@@ -84,7 +84,7 @@ impl<N: Network> Transactions<N> {
         }
 
         // Ensure each transaction is well-formed.
-        if !cfg_iter!(self.transactions.as_slice()).all(Transaction::is_valid) {
+        if !cfg_iter!(self.transactions).all(Transaction::is_valid) {
             eprintln!("Invalid transaction found in the transactions list");
             return false;
         }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

### snarkvm-dpc wasm compatibility
- put rayon import in dpc behind a parallel feature flag
- switched a use of par_iter to cfg_iter! in dpc
- made rayon an optional dependency, included under the parallel feature