### PR TITLE
Update AleoAmount denominations

### DIFF
--- a/dpc/src/block/block.rs
+++ b/dpc/src/block/block.rs
@@ -270,7 +270,7 @@ impl<N: Network> Block<N> {
         match height == 0 {
             true => {
                 // Output the starting supply as the genesis block reward.
-                AleoAmount::from_i64(N::ALEO_STARTING_SUPPLY_IN_CREDITS * AleoAmount::ONE_CREDIT.0)
+                AleoAmount::from_gate(N::ALEO_STARTING_SUPPLY_IN_CREDITS * AleoAmount::ONE_CREDIT.0)
             }
             false => {
                 // The initial blocks that aren't taken into account with the halving calculation.
@@ -288,7 +288,7 @@ impl<N: Network> Block<N> {
                 let num_halves = u32::min(height.saturating_sub(1) / block_segments, 2);
                 let reward = initial_reward / (2_u64.pow(num_halves)) as i64;
 
-                AleoAmount::from_i64(reward)
+                AleoAmount::from_gate(reward)
             }
         }
     }
@@ -454,22 +454,22 @@ mod tests {
 
         assert_eq!(
             Block::<Testnet2>::block_reward(0),
-            AleoAmount::from_i64(Testnet2::ALEO_STARTING_SUPPLY_IN_CREDITS * AleoAmount::ONE_CREDIT.0)
+            AleoAmount::from_gate(Testnet2::ALEO_STARTING_SUPPLY_IN_CREDITS * AleoAmount::ONE_CREDIT.0)
         );
 
         let mut supply = AleoAmount::ZERO;
 
         // Phase 1 - 100 credits per block.
-        let phase_1_sum = AleoAmount::from_i64(
+        let phase_1_sum = AleoAmount::from_gate(
             (0..=first_halving).into_par_iter().map(|i| Block::<Testnet2>::block_reward(i).0).sum::<i64>(),
         );
 
         supply = supply.add(phase_1_sum);
 
-        assert_eq!(supply, AleoAmount::from_i64(supply_at_first_halving * AleoAmount::ONE_CREDIT.0));
+        assert_eq!(supply, AleoAmount::from_gate(supply_at_first_halving * AleoAmount::ONE_CREDIT.0));
 
         // Phase 2 - 50 credits per block.
-        let phase_2_sum = AleoAmount::from_i64(
+        let phase_2_sum = AleoAmount::from_gate(
             ((first_halving + 1)..=second_halving)
                 .into_par_iter()
                 .map(|i| Block::<Testnet2>::block_reward(i).0)
@@ -478,7 +478,7 @@ mod tests {
 
         supply = supply.add(phase_2_sum);
 
-        assert_eq!(supply, AleoAmount::from_i64(supply_at_second_halving * AleoAmount::ONE_CREDIT.0));
+        assert_eq!(supply, AleoAmount::from_gate(supply_at_second_halving * AleoAmount::ONE_CREDIT.0));
     }
 
     #[test]

--- a/dpc/src/circuits/tests.rs
+++ b/dpc/src/circuits/tests.rs
@@ -25,7 +25,7 @@ fn dpc_execute_circuits_test<N: Network>(expected_inner_num_constraints: usize) 
     let rng = &mut thread_rng();
 
     let recipient = Account::new(rng);
-    let amount = AleoAmount::from_i64(10);
+    let amount = AleoAmount::from_gate(10);
     let request = Request::new_coinbase(recipient.address(), amount, false, rng).unwrap();
     let response = ResponseBuilder::new()
         .add_request(request.clone())

--- a/dpc/src/record/record.rs
+++ b/dpc/src/record/record.rs
@@ -359,7 +359,7 @@ mod tests {
         rng.fill(&mut payload);
         let expected_record = Record::new(
             address,
-            AleoAmount::from_i64(1234),
+            AleoAmount::from_gate(1234),
             Payload::from_bytes_le(&payload).unwrap(),
             *Testnet2::noop_program_id(),
             rng,
@@ -403,7 +403,7 @@ mod tests {
         rng.fill(&mut payload);
         let expected_record = Record::new(
             address,
-            AleoAmount::from_i64(1234),
+            AleoAmount::from_gate(1234),
             Payload::from_bytes_le(&payload).unwrap(),
             *Testnet2::noop_program_id(),
             rng,

--- a/dpc/src/record/tests.rs
+++ b/dpc/src/record/tests.rs
@@ -35,7 +35,7 @@ fn test_record_ciphertext() {
 
         let expected_record = Record::new(
             account.address(),
-            AleoAmount::from_i64(value),
+            AleoAmount::from_gate(value),
             Payload::from_bytes_le(&payload).unwrap(),
             *Testnet2::noop_program_id(),
             rng,

--- a/dpc/src/virtual_machine/amount.rs
+++ b/dpc/src/virtual_machine/amount.rs
@@ -180,6 +180,11 @@ mod tests {
         ];
 
         #[test]
+        fn test_gate_conversion() {
+            TEST_AMOUNTS.iter().for_each(|amounts| test_from_i64(amounts.gate, AleoAmount(amounts.gate)));
+        }
+
+        #[test]
         fn test_aleo_conversion() {
             TEST_AMOUNTS.iter().for_each(|amounts| test_from_aleo(amounts.aleo, AleoAmount(amounts.gate)));
         }

--- a/dpc/src/virtual_machine/amount.rs
+++ b/dpc/src/virtual_machine/amount.rs
@@ -62,25 +62,25 @@ impl AleoAmount {
     pub const ZERO: AleoAmount = AleoAmount(0i64);
 
     /// Create an `AleoAmount` given a number of gates.
-    pub fn from_i64(bytes: i64) -> Self {
-        Self(bytes)
+    pub fn from_gate(gates: i64) -> Self {
+        Self(gates)
     }
 
     /// Create an `AleoAmount` given a number of credits.
     pub fn from_aleo(aleo_value: i64) -> Self {
-        Self::from_i64(aleo_value * 10_i64.pow(Denomination::CREDIT.precision()))
+        Self::from_gate(aleo_value * 10_i64.pow(Denomination::CREDIT.precision()))
     }
 
     /// Add the values of two `AleoAmount`s
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, b: Self) -> Self {
-        Self::from_i64(self.0 + b.0)
+        Self::from_gate(self.0 + b.0)
     }
 
     /// Subtract the value of two `AleoAmounts`
     #[allow(clippy::should_implement_trait)]
     pub fn sub(self, b: AleoAmount) -> Self {
-        Self::from_i64(self.0 - b.0)
+        Self::from_gate(self.0 - b.0)
     }
 
     /// Returns `true` the amount is positive and `false` if the amount is zero or
@@ -137,8 +137,8 @@ impl fmt::Display for AleoAmount {
 mod tests {
     use super::*;
 
-    fn test_from_i64(gate_value: i64, expected_amount: AleoAmount) {
-        let amount = AleoAmount::from_i64(gate_value);
+    fn test_from_gate(gate_value: i64, expected_amount: AleoAmount) {
+        let amount = AleoAmount::from_gate(gate_value);
         assert_eq!(expected_amount, amount)
     }
 
@@ -148,17 +148,17 @@ mod tests {
     }
 
     fn test_addition(a: &i64, b: &i64, result: &i64) {
-        let a = AleoAmount::from_i64(*a);
-        let b = AleoAmount::from_i64(*b);
-        let result = AleoAmount::from_i64(*result);
+        let a = AleoAmount::from_gate(*a);
+        let b = AleoAmount::from_gate(*b);
+        let result = AleoAmount::from_gate(*result);
 
         assert_eq!(result, a.add(b));
     }
 
     fn test_subtraction(a: &i64, b: &i64, result: &i64) {
-        let a = AleoAmount::from_i64(*a);
-        let b = AleoAmount::from_i64(*b);
-        let result = AleoAmount::from_i64(*result);
+        let a = AleoAmount::from_gate(*a);
+        let b = AleoAmount::from_gate(*b);
+        let result = AleoAmount::from_gate(*result);
 
         assert_eq!(result, a.sub(b));
     }
@@ -181,7 +181,7 @@ mod tests {
 
         #[test]
         fn test_gate_conversion() {
-            TEST_AMOUNTS.iter().for_each(|amounts| test_from_i64(amounts.gate, AleoAmount(amounts.gate)));
+            TEST_AMOUNTS.iter().for_each(|amounts| test_from_gate(amounts.gate, AleoAmount(amounts.gate)));
         }
 
         #[test]
@@ -226,6 +226,12 @@ mod tests {
                 AmountDenominationTestCase { gate: 1234567, aleo: 1 },
                 AmountDenominationTestCase { gate: 1_000_000_000_000_000_000, aleo: 999_999_999_999 },
             ];
+
+            #[should_panic]
+            #[test]
+            fn test_invalid_gate_conversion() {
+                INVALID_TEST_AMOUNTS.iter().for_each(|amounts| test_from_gate(amounts.aleo, AleoAmount(amounts.gate)));
+            }
 
             #[should_panic]
             #[test]

--- a/dpc/src/virtual_machine/output.rs
+++ b/dpc/src/virtual_machine/output.rs
@@ -40,7 +40,7 @@ impl<N: Network> Output<N> {
         let noop_private_key = PrivateKey::new(rng);
         let noop_address = noop_private_key.try_into()?;
 
-        Self::new(noop_address, AleoAmount::from_i64(0), Payload::default(), None)
+        Self::new(noop_address, AleoAmount::from_gate(0), Payload::default(), None)
     }
 
     /// Initializes a new instance of `Output`.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes the Aleo `byte` denomination and updates `gate` to the base unit.

## Test Plan

Tests have been updated to reflect this change.
