### PR TITLE
Fix indexing error for `create_proof_no_zk`

### DIFF
--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -219,10 +219,11 @@ where
     });
     let results: Vec<_> = pool.execute_all();
 
-    let g1_b = if r != E::Fr::zero() { results[0].into_g1() } else { E::G1Projective::zero() };
-    let g2_b = results[1].into_g2();
-    let h_acc = results[2].into_g1();
-    let l_aux_acc = results[3].into_g1();
+    let (g1_b, g2_b, h_acc, l_aux_acc) = if r != E::Fr::zero() {
+        (results[0].into_g1(), results[1].into_g2(), results[2].into_g1(), results[3].into_g1())
+    } else {
+        (E::G1Projective::zero(), results[0].into_g2(), results[1].into_g1(), results[2].into_g1())
+    };
 
     let s_g_a = g_a.mul(s);
     let r_g1_b = g1_b.mul(r);

--- a/algorithms/src/snark/groth16/tests.rs
+++ b/algorithms/src/snark/groth16/tests.rs
@@ -51,6 +51,7 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<C
 mod bls12_377 {
     use super::*;
     use crate::snark::groth16::{
+        create_proof_no_zk,
         create_random_proof,
         generate_random_parameters,
         prepare_verifying_key,
@@ -74,6 +75,24 @@ mod bls12_377 {
             let c = a * b;
 
             let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
+            let pvk = prepare_verifying_key::<Bls12_377>(parameters.vk.clone());
+
+            assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
+            assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_prove_no_zk() {
+        let rng = &mut thread_rng();
+        let parameters =
+            generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
+
+        for _ in 0..100 {
+            let (a, b) = (Fr::rand(rng), Fr::rand(rng));
+            let c = a * b;
+
+            let proof = create_proof_no_zk(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters).unwrap();
             let pvk = prepare_verifying_key::<Bls12_377>(parameters.vk.clone());
 
             assert!(verify_proof(&pvk, &proof, &[c]).unwrap());


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Ensures that if a Groth16 proof is being constructed without zk or with an `r` value of 0, then the indexing of the execution pool results are correct.

## Test Plan

A test for `create_proof_no_zk` has been added.
