### PR TITLE
[Tracking] Testnet2 security updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ dependencies = [
  "derivative",
  "digest 0.9.0",
  "hashbrown",
+ "itertools",
  "rand",
  "rand_chacha",
  "rand_core",

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -295,8 +295,8 @@ impl<F: FftField> EvaluationDomain<F> {
 
     /// Return the sparse vanishing polynomial.
     pub fn vanishing_polynomial(&self) -> SparsePolynomial<F> {
-        let coeffs = vec![(0, -F::one()), (self.size(), F::one())];
-        SparsePolynomial::from_coefficients_vec(coeffs)
+        let coeffs = [(0, -F::one()), (self.size(), F::one())];
+        SparsePolynomial::from_coefficients(coeffs)
     }
 
     /// This evaluates the vanishing polynomial for this domain at tau.

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -44,6 +44,9 @@ use std::fmt;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+#[cfg(not(feature = "parallel"))]
+use itertools::Itertools;
+
 /// Returns the ceiling of the base-2 logarithm of `x`.
 ///
 /// ```
@@ -286,7 +289,7 @@ impl<F: FftField> EvaluationDomain<F> {
             }
 
             batch_inversion(u.as_mut_slice());
-            cfg_iter_mut!(u).zip(ls).for_each(|(tau_minus_r, l)| {
+            cfg_iter_mut!(u).zip_eq(ls).for_each(|(tau_minus_r, l)| {
                 *tau_minus_r = l * *tau_minus_r;
             });
             u
@@ -357,10 +360,8 @@ impl<F: FftField> EvaluationDomain<F> {
     /// Returns the evaluations of the product over the domain.
     #[must_use]
     pub fn mul_polynomials_in_evaluation_domain(&self, self_evals: &[F], other_evals: &[F]) -> Vec<F> {
-        assert_eq!(self_evals.len(), other_evals.len());
-
         let mut result = self_evals.to_vec();
-        cfg_iter_mut!(result).zip(other_evals).for_each(|(a, b)| *a *= b);
+        cfg_iter_mut!(result).zip_eq(other_evals).for_each(|(a, b)| *a *= b);
 
         result
     }

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -18,9 +18,15 @@
 
 use crate::fft::{DensePolynomial, EvaluationDomain};
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{errors::SerializationError, serialize::*};
+use snarkvm_utilities::{cfg_iter_mut, errors::SerializationError, serialize::*};
 
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+#[cfg(not(feature = "parallel"))]
+use itertools::Itertools;
 
 /// Stores a polynomial in evaluation form.
 #[derive(Clone, PartialEq, Eq, Hash, Debug, CanonicalSerialize, CanonicalDeserialize)]
@@ -76,9 +82,8 @@ impl<'a, F: PrimeField> MulAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn mul_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations
-            .iter_mut()
-            .zip(&other.evaluations)
+        cfg_iter_mut!(self.evaluations)
+            .zip_eq(&other.evaluations)
             .for_each(|(a, b)| *a *= b);
     }
 }
@@ -98,9 +103,8 @@ impl<'a, F: PrimeField> AddAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn add_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations
-            .iter_mut()
-            .zip(&other.evaluations)
+        cfg_iter_mut!(self.evaluations)
+            .zip_eq(&other.evaluations)
             .for_each(|(a, b)| *a += b);
     }
 }
@@ -120,9 +124,8 @@ impl<'a, F: PrimeField> SubAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn sub_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations
-            .iter_mut()
-            .zip(&other.evaluations)
+        cfg_iter_mut!(self.evaluations)
+            .zip_eq(&other.evaluations)
             .for_each(|(a, b)| *a -= b);
     }
 }
@@ -142,9 +145,8 @@ impl<'a, F: PrimeField> DivAssign<&'a Evaluations<F>> for Evaluations<F> {
     #[inline]
     fn div_assign(&mut self, other: &'a Evaluations<F>) {
         assert_eq!(self.domain, other.domain, "domains are unequal");
-        self.evaluations
-            .iter_mut()
-            .zip(&other.evaluations)
+        cfg_iter_mut!(self.evaluations)
+            .zip_eq(&other.evaluations)
             .for_each(|(a, b)| *a /= b);
     }
 }

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -256,6 +256,16 @@ impl<F: PrimeField> DensePolynomial<F> {
     }
 }
 
+impl<F: Field> From<super::SparsePolynomial<F>> for DensePolynomial<F> {
+    fn from(other: super::SparsePolynomial<F>) -> Self {
+        let mut result = vec![F::zero(); other.degree() + 1];
+        for (i, coeff) in other.coeffs() {
+            result[*i] = *coeff;
+        }
+        DensePolynomial::from_coefficients_vec(result)
+    }
+}
+
 impl<F: Field> Neg for DensePolynomial<F> {
     type Output = DensePolynomial<F>;
 
@@ -339,7 +349,7 @@ impl<'a, F: Field> AddAssign<&'a super::SparsePolynomial<F>> for DensePolynomial
         if self.degree() < other.degree() {
             self.coeffs.resize(other.degree() + 1, F::zero());
         }
-        for (i, b) in &other.coeffs {
+        for (i, b) in other.coeffs() {
             self.coeffs[*i] += b;
         }
         // If the leading coefficient ends up being zero, pop it off.
@@ -357,7 +367,7 @@ impl<'a, F: Field> Sub<&'a super::SparsePolynomial<F>> for DensePolynomial<F> {
         if self.degree() < other.degree() {
             self.coeffs.resize(other.degree() + 1, F::zero());
         }
-        for (i, b) in &other.coeffs {
+        for (i, b) in other.coeffs() {
             self.coeffs[*i] -= b;
         }
         // If the leading coefficient ends up being zero, pop it off.

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -18,7 +18,7 @@
 
 use crate::fft::{DenseOrSparsePolynomial, EvaluationDomain, Evaluations};
 use snarkvm_fields::{Field, PrimeField};
-use snarkvm_utilities::{errors::SerializationError, serialize::*};
+use snarkvm_utilities::{cfg_iter_mut, errors::SerializationError, serialize::*};
 
 use rand::Rng;
 use std::{
@@ -28,6 +28,9 @@ use std::{
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
+
+#[cfg(not(feature = "parallel"))]
+use itertools::Itertools;
 
 /// Stores a polynomial in coefficient form.
 #[derive(Clone, PartialEq, Eq, Hash, Default, CanonicalSerialize, CanonicalDeserialize)]
@@ -102,10 +105,9 @@ impl<F: Field> DensePolynomial<F> {
             powers_of_point.push(cur);
             cur *= point;
         }
-        assert_eq!(powers_of_point.len(), self.coeffs.len());
         let zero = F::zero();
         let mapping = crate::cfg_into_iter!(powers_of_point)
-            .zip(&self.coeffs)
+            .zip_eq(&self.coeffs)
             .map(|(power, coeff)| power * coeff);
         crate::cfg_reduce!(mapping, || zero, |a, b| a + b)
     }
@@ -144,8 +146,8 @@ impl<F: PrimeField> DensePolynomial<F> {
     pub fn mul_by_vanishing_poly(&self, domain: EvaluationDomain<F>) -> DensePolynomial<F> {
         let mut shifted = vec![F::zero(); domain.size()];
         shifted.extend_from_slice(&self.coeffs);
-        crate::cfg_iter_mut!(shifted)
-            .zip(&self.coeffs)
+        crate::cfg_iter_mut!(shifted[..self.coeffs.len()])
+            .zip_eq(&self.coeffs)
             .for_each(|(s, c)| *s -= c);
         DensePolynomial::from_coefficients_vec(shifted)
     }
@@ -172,15 +174,18 @@ impl<'a, 'b, F: Field> Add<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
             self.clone()
         } else if self.degree() >= other.degree() {
             let mut result = self.clone();
-            for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
-                *a += b
-            }
+            // Zip safety: `result` and `other` could have different lengths.
+            cfg_iter_mut!(result.coeffs)
+                .zip(&other.coeffs)
+                .for_each(|(a, b)| *a += b);
+
             result
         } else {
             let mut result = other.clone();
-            for (a, b) in result.coeffs.iter_mut().zip(&self.coeffs) {
-                *a += b
-            }
+            // Zip safety: `result` and `other` could have different lengths.
+            cfg_iter_mut!(result.coeffs)
+                .zip(&self.coeffs)
+                .for_each(|(a, b)| *a += b);
             // If the leading coefficient ends up being zero, pop it off.
             while result.coeffs.last().unwrap().is_zero() {
                 result.coeffs.pop();
@@ -198,15 +203,13 @@ impl<'a, 'b, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
         } else if other.is_zero() {
             // return
         } else if self.degree() >= other.degree() {
-            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                *a += b
-            }
+            // Zip safety: `self` and `other` could have different lengths.
+            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a += b);
         } else {
             // Add the necessary number of zero coefficients.
             self.coeffs.resize(other.coeffs.len(), F::zero());
-            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                *a += b
-            }
+            // Zip safety: `self` and `other` have the same length.
+            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a += b);
             // If the leading coefficient ends up being zero, pop it off.
             while self.coeffs.last().unwrap().is_zero() {
                 self.coeffs.pop();
@@ -225,15 +228,17 @@ impl<'a, 'b, F: Field> AddAssign<(F, &'a DensePolynomial<F>)> for DensePolynomia
         } else if other.is_zero() {
             // return
         } else if self.degree() >= other.degree() {
-            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+            // Zip safety: `self` and `other` could have different lengths.
+            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| {
                 *a += f * b;
-            }
+            });
         } else {
             // Add the necessary number of zero coefficients.
             self.coeffs.resize(other.coeffs.len(), F::zero());
-            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+            // Zip safety: `self` and `other` have the same length after the resize.
+            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| {
                 *a += f * b;
-            }
+            });
             // If the leading coefficient ends up being zero, pop it off.
             while self.coeffs.last().unwrap().is_zero() {
                 self.coeffs.pop();
@@ -283,16 +288,20 @@ impl<'a, 'b, F: Field> Sub<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
             self.clone()
         } else if self.degree() >= other.degree() {
             let mut result = self.clone();
-            for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
-                *a -= b
-            }
+            // Zip safety: `result` and `other` could have different degrees.
+            cfg_iter_mut!(result.coeffs)
+                .zip(&other.coeffs)
+                .for_each(|(a, b)| *a -= b);
+
             result
         } else {
             let mut result = self.clone();
             result.coeffs.resize(other.coeffs.len(), F::zero());
-            for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
+            // Zip safety: `result` and `other` have the same length after the resize.
+            cfg_iter_mut!(result.coeffs).zip(&other.coeffs).for_each(|(a, b)| {
                 *a -= b;
-            }
+            });
+
             if !result.is_zero() {
                 // If the leading coefficient ends up being zero, pop it off.
                 while result.coeffs.last().unwrap().is_zero() {
@@ -316,15 +325,13 @@ impl<'a, 'b, F: Field> SubAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
         } else if other.is_zero() {
             // return
         } else if self.degree() >= other.degree() {
-            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                *a -= b
-            }
+            // Zip safety: self and other could have different lengths.
+            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a -= b);
         } else {
             // Add the necessary number of zero coefficients.
             self.coeffs.resize(other.coeffs.len(), F::zero());
-            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                *a -= b
-            }
+            // Zip safety: self and other have the same length after the resize.
+            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a -= b);
             // If the leading coefficient ends up being zero, pop it off.
             while self.coeffs.last().unwrap().is_zero() {
                 self.coeffs.pop();

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -494,6 +494,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrow)]
     fn divide_polynomials_random() {
         let rng = &mut thread_rng();
 

--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -103,7 +103,7 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
     #[inline]
     fn leading_coefficient(&self) -> Option<&F> {
         match self {
-            SPolynomial(p) => p.coeffs.last().map(|(_, c)| c),
+            SPolynomial(p) => p.coeffs().last().map(|(_, c)| c),
             DPolynomial(p) => p.last(),
         }
     }
@@ -128,7 +128,7 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
                 quotient[cur_q_degree] = cur_q_coeff;
 
                 if let SPolynomial(p) = divisor {
-                    for (i, div_coeff) in &p.coeffs {
+                    for (i, div_coeff) in p.coeffs() {
                         remainder[cur_q_degree + i] -= &(cur_q_coeff * div_coeff);
                     }
                 } else if let DPolynomial(p) = divisor {

--- a/algorithms/src/merkle_tree/merkle_path.rs
+++ b/algorithms/src/merkle_tree/merkle_path.rs
@@ -39,7 +39,7 @@ pub struct MerklePath<P: MerkleParameters> {
 impl<P: MerkleParameters> MerklePath<P> {
     pub fn verify<L: ToBytes>(&self, root_hash: &MerkleTreeDigest<P>, leaf: &L) -> Result<bool, MerkleError> {
         // Check that the given leaf matches the leaf in the membership proof.
-        if self.path.len() != P::DEPTH - 1 {
+        if self.path.len() == P::DEPTH {
             let claimed_leaf_hash = self.parameters.hash_leaf::<L>(leaf)?;
 
             let mut index = self.leaf_index;

--- a/algorithms/src/merkle_tree/merkle_path.rs
+++ b/algorithms/src/merkle_tree/merkle_path.rs
@@ -39,7 +39,7 @@ pub struct MerklePath<P: MerkleParameters> {
 impl<P: MerkleParameters> MerklePath<P> {
     pub fn verify<L: ToBytes>(&self, root_hash: &MerkleTreeDigest<P>, leaf: &L) -> Result<bool, MerkleError> {
         // Check that the given leaf matches the leaf in the membership proof.
-        if !self.path.is_empty() {
+        if self.path.len() != P::DEPTH - 1 {
             let claimed_leaf_hash = self.parameters.hash_leaf::<L>(leaf)?;
 
             let mut index = self.leaf_index;

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -265,7 +265,7 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
         let leaf_hash = self.parameters.hash_leaf(leaf)?;
 
         let tree_depth = tree_depth(self.tree.len());
-        let tree_index = convert_index_to_last_level(index, tree_depth);
+        let tree_index = convert_index_to_last_level(index, tree_depth)?;
 
         // Check that the given index corresponds to the correct leaf.
         if tree_index >= self.tree.len() || leaf_hash != self.tree[tree_index] {
@@ -375,8 +375,11 @@ fn parent(index: usize) -> Option<usize> {
 }
 
 #[inline]
-fn convert_index_to_last_level(index: usize, tree_depth: usize) -> usize {
-    index + (1 << tree_depth) - 1
+fn convert_index_to_last_level(index: usize, tree_depth: usize) -> Result<usize, MerkleError> {
+    let shifted = 1u32
+        .checked_shl(tree_depth as u32)
+        .ok_or(MerkleError::IncorrectLeafIndex(index))?;
+    Ok(index.saturating_add(shifted as usize).saturating_sub(1))
 }
 
 pub struct Ancestors(usize);

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -294,9 +294,8 @@ mod pedersen_compressed_crh_on_projective {
         };
 
         // Ensure that the proof is invalid because the path length is not P::DEPTH - 1.
-        assert_eq!(
-            false,
-            invalid_proof
+        assert!(
+            !invalid_proof
                 .verify(merkle_tree_root, &to_bytes_le![leaf1, leaf2].unwrap())
                 .unwrap()
         );

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -193,6 +193,7 @@ mod pedersen_crh_on_projective {
 
 mod pedersen_compressed_crh_on_projective {
     use super::*;
+    use crate::merkle_tree::MerklePath;
     use snarkvm_curves::edwards_bls12::EdwardsProjective as Edwards;
 
     const NUM_WINDOWS: usize = 256;
@@ -249,5 +250,55 @@ mod pedersen_compressed_crh_on_projective {
 
         assert_eq!(tree.root(), new_tree_1.root());
         assert_eq!(tree.root(), new_tree_2.root());
+    }
+
+    #[test]
+    fn merkle_tree_invalid_path_test() {
+        type MTParameters = MerkleTreeParameters<PedersenCompressedCRH<Edwards, NUM_WINDOWS, WINDOW_SIZE>, 2>;
+        let leaves = generate_random_leaves!(4, 64);
+
+        let parameters = &MTParameters::setup("merkle_tree_test");
+        let crh = parameters.crh();
+
+        // Evaluate the Merkle tree root.
+        let merkle_tree = generate_merkle_tree(&leaves, parameters);
+        let merkle_tree_root = merkle_tree.root();
+        // real proof
+        let proof = merkle_tree.generate_proof(0, &leaves[0]).unwrap();
+        assert!(proof.verify(merkle_tree_root, &leaves[0].to_vec()).unwrap());
+
+        // Manually construct the merkle tree.
+
+        // Construct the leaf nodes.
+        let leaf1 = crh.hash(&leaves[0]).unwrap();
+        let leaf2 = crh.hash(&leaves[1]).unwrap();
+        let leaf3 = crh.hash(&leaves[2]).unwrap();
+        let leaf4 = crh.hash(&leaves[3]).unwrap();
+
+        // Construct the inner nodes.
+        let left = crh.hash(&to_bytes_le![leaf1, leaf2].unwrap()).unwrap();
+        let right = crh.hash(&to_bytes_le![leaf3, leaf4].unwrap()).unwrap();
+
+        // Construct the root.
+        let expected_root = {
+            // depth 0
+            crh.hash(&to_bytes_le![left, right].unwrap()).unwrap()
+        };
+        assert_eq!(merkle_tree_root, &expected_root);
+
+        // Manually construct a proof of the inner node
+        let invalid_proof = MerklePath {
+            parameters: Arc::new(parameters.clone()),
+            path: vec![right],
+            leaf_index: 0,
+        };
+
+        // Ensure that the proof is invalid because the path length is not P::DEPTH - 1.
+        assert_eq!(
+            false,
+            invalid_proof
+                .verify(merkle_tree_root, &to_bytes_le![leaf1, leaf2].unwrap())
+                .unwrap()
+        );
     }
 }

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -299,6 +299,7 @@ mod pedersen_compressed_crh_on_projective {
                 .verify(merkle_tree_root, &to_bytes_le![leaf1, leaf2].unwrap())
                 .unwrap()
         );
+    }
 
     #[should_panic]
     #[test]

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -250,4 +250,24 @@ mod pedersen_compressed_crh_on_projective {
         assert_eq!(tree.root(), new_tree_1.root());
         assert_eq!(tree.root(), new_tree_2.root());
     }
+
+    #[should_panic]
+    #[test]
+    fn merkle_tree_overflow_protection_test() {
+        type MTParameters = MerkleTreeParameters<PedersenCompressedCRH<Edwards, NUM_WINDOWS, WINDOW_SIZE>, 32>;
+        let leaves = generate_random_leaves!(4, 8);
+
+        let parameters = &MTParameters::setup("merkle_tree_test");
+        let tree = MerkleTree::<MTParameters>::new(Arc::new(parameters.clone()), &leaves[..]).unwrap();
+
+        let _proof = tree.generate_proof(0, &leaves[0]).unwrap();
+        _proof.verify(tree.root(), &leaves[0]).unwrap();
+
+        let leaf1 = parameters.crh().hash(&leaves[0]).unwrap();
+        let leaf2 = parameters.crh().hash(&leaves[1]).unwrap();
+
+        // proof for non-leaf node
+        let raw_nodes = to_bytes_le![leaf1, leaf2].unwrap();
+        let _proof = tree.generate_proof(18446744073709551614, &raw_nodes).unwrap();
+    }
 }

--- a/algorithms/src/msm/variable_base/cuda.rs
+++ b/algorithms/src/msm/variable_base/cuda.rs
@@ -345,6 +345,7 @@ lazy_static::lazy_static! {
     };
 }
 
+#[allow(clippy::transmute_undefined_repr)]
 pub(super) fn msm_cuda<G: AffineCurve>(
     mut bases: &[G],
     mut scalars: &[<G::ScalarField as PrimeField>::BigInteger],

--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -231,14 +231,21 @@ where
     });
     let results: Vec<_> = pool.execute_all();
 
-    let g1_b = if r != E::Fr::zero() {
-        results[0].into_g1()
+    let (g1_b, g2_b, h_acc, l_aux_acc) = if r != E::Fr::zero() {
+        (
+            results[0].into_g1(),
+            results[1].into_g2(),
+            results[2].into_g1(),
+            results[3].into_g1(),
+        )
     } else {
-        E::G1Projective::zero()
+        (
+            E::G1Projective::zero(),
+            results[0].into_g2(),
+            results[1].into_g1(),
+            results[2].into_g1(),
+        )
     };
-    let g2_b = results[1].into_g2();
-    let h_acc = results[2].into_g1();
-    let l_aux_acc = results[3].into_g1();
 
     let s_g_a = g_a.mul(s);
     let r_g1_b = g1_b.mul(r);

--- a/dpc/src/ledger/ledger_tree.rs
+++ b/dpc/src/ledger/ledger_tree.rs
@@ -58,7 +58,9 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
         self.block_hashes.insert(*block_hash, self.current_index);
 
         let current_index = self.current_index;
-        self.current_index = current_index.checked_add(1).ok_or(anyhow!("Integer overflow."))?;
+        self.current_index = current_index
+            .checked_add(1)
+            .ok_or(anyhow!("The index exceeds the maximum number of allowed block hashes."))?;
 
         Ok(current_index)
     }
@@ -85,7 +87,9 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
 
         // Ensure that the number of block hashes does not exceed the u32 bounds of `self.current_index`.
         if (self.current_index as usize).saturating_add(num_block_hashes) > u32::MAX as usize {
-            return Err(anyhow!("Integer overflow."));
+            return Err(anyhow!(
+                "The list of given block hashes exceeds the maximum number of allowed block hashes."
+            ));
         }
 
         // Add the block hashes to the tree. Start the tree from scratch if the tree is currently empty.
@@ -107,7 +111,7 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
         self.current_index = self
             .current_index
             .checked_add(num_block_hashes as u32)
-            .ok_or(anyhow!("Integer overflow."))?;
+            .ok_or(anyhow!("The index exceeds the maximum number of allowed block hashes."))?;
         let end_index = self.current_index.checked_sub(1).ok_or(anyhow!("Integer underflow."))?;
 
         Ok((start_index, end_index))

--- a/dpc/src/ledger/ledger_tree.rs
+++ b/dpc/src/ledger/ledger_tree.rs
@@ -47,7 +47,6 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
         })
     }
 
-    /// TODO (howardwu): Add safety checks for u32 (max 2^32).
     /// Adds the given block hash to the tree, returning its index in the tree.
     fn add(&mut self, block_hash: &N::BlockHash) -> Result<u32> {
         // Ensure the block_hash does not already exist in the tree.
@@ -57,12 +56,13 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
 
         self.tree = Arc::new(self.tree.rebuild(self.current_index as usize, &[block_hash])?);
         self.block_hashes.insert(*block_hash, self.current_index);
-        self.current_index += 1;
 
-        Ok(self.current_index - 1)
+        let current_index = self.current_index;
+        self.current_index = current_index.checked_add(1).ok_or(anyhow!("Integer overflow."))?;
+
+        Ok(current_index)
     }
 
-    /// TODO (howardwu): Add safety checks for u32 (max 2^32).
     /// Adds all given block hashes to the tree, returning the start and ending index in the tree.
     fn add_all(&mut self, block_hashes: &[N::BlockHash]) -> Result<(u32, u32)> {
         // Ensure the list of given block hashes is non-empty.
@@ -83,6 +83,11 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
         let start_index = self.current_index;
         let num_block_hashes = block_hashes.len();
 
+        // Ensure that the number of block hashes does not exceed the u32 bounds of `self.current_index`.
+        if (self.current_index as usize).saturating_add(num_block_hashes) > u32::MAX as usize {
+            return Err(anyhow!("Integer overflow."));
+        }
+
         // Add the block hashes to the tree. Start the tree from scratch if the tree is currently empty.
         self.tree = match self.current_index {
             0 => Arc::new(MerkleTree::<N::LedgerRootParameters>::new::<N::BlockHash>(
@@ -98,8 +103,12 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
                 .enumerate()
                 .map(|(index, block_hash)| (*block_hash, start_index + index as u32)),
         );
-        self.current_index += num_block_hashes as u32;
-        let end_index = self.current_index - 1;
+
+        self.current_index = self
+            .current_index
+            .checked_add(num_block_hashes as u32)
+            .ok_or(anyhow!("Integer overflow."))?;
+        let end_index = self.current_index.checked_sub(1).ok_or(anyhow!("Integer underflow."))?;
 
         Ok((start_index, end_index))
     }

--- a/dpc/src/ledger/ledger_tree.rs
+++ b/dpc/src/ledger/ledger_tree.rs
@@ -87,9 +87,7 @@ impl<N: Network> LedgerTreeScheme<N> for LedgerTree<N> {
 
         // Ensure that the number of block hashes does not exceed the u32 bounds of `self.current_index`.
         if (self.current_index as usize).saturating_add(num_block_hashes) > u32::MAX as usize {
-            return Err(anyhow!(
-                "The list of given block hashes exceeds the maximum number of allowed block hashes."
-            ));
+            return Err(anyhow!("The ledger tree will reach its maximum size."));
         }
 
         // Add the block hashes to the tree. Start the tree from scratch if the tree is currently empty.

--- a/dpc/src/transaction/transitions.rs
+++ b/dpc/src/transaction/transitions.rs
@@ -62,16 +62,19 @@ impl<N: Network> Transitions<N> {
         self.tree = Arc::new(self.tree.rebuild(self.current_index as usize, &[transition_id])?);
         self.transitions
             .insert(transition_id, (self.current_index, transition.clone()));
-        self.current_index += 1;
+        let current_index = self.current_index;
+        self.current_index = current_index
+            .checked_add(1)
+            .ok_or(anyhow!("The index exceeds the maximum number of allowed transitions."))?;
 
-        Ok(self.current_index - 1)
+        Ok(current_index)
     }
 
     /// Adds all given transitions to the tree, returning the start and ending index in the tree.
     pub(crate) fn add_all(&mut self, transitions: &[Transition<N>]) -> Result<(u8, u8)> {
         // Ensure the current index has not reached the maximum number of transitions permitted in software.
         if self.current_index >= N::NUM_TRANSITIONS
-            || self.current_index + transitions.len() as u8 >= N::NUM_TRANSITIONS
+            || (self.current_index as usize).saturating_add(transitions.len()) >= N::NUM_TRANSITIONS as usize
         {
             return Err(anyhow!("The transitions tree has reached its maximum size"));
         }
@@ -97,8 +100,11 @@ impl<N: Network> Transitions<N> {
                 .enumerate()
                 .map(|(index, transition)| (transition.transition_id(), (start_index + index as u8, transition))),
         );
-        self.current_index += transition_ids.len() as u8;
-        let end_index = self.current_index - 1;
+        self.current_index = self
+            .current_index
+            .checked_add(transition_ids.len() as u8)
+            .ok_or(anyhow!("The index exceeds the maximum number of allowed transitions."))?;
+        let end_index = self.current_index.checked_sub(1).ok_or(anyhow!("Integer underflow."))?;
 
         Ok((start_index, end_index))
     }

--- a/dpc/src/virtual_machine/event.rs
+++ b/dpc/src/virtual_machine/event.rs
@@ -153,7 +153,7 @@ impl<'de, N: Network> Deserialize<'de> for Event<N> {
                     2 => Ok(Self::Operation(
                         serde_json::from_value(event["operation"].clone()).map_err(de::Error::custom)?,
                     )),
-                    _ => unreachable!(format!("Invalid event id {}", event_id)),
+                    _ => unreachable!("Invalid event id {}", event_id),
                 }
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "event"),

--- a/dpc/src/virtual_machine/operation.rs
+++ b/dpc/src/virtual_machine/operation.rs
@@ -176,7 +176,7 @@ impl<N: Network> FromStr for Operation<N> {
                 let function_inputs = serde_json::from_value(operation["function_inputs"].clone())?;
                 Ok(Self::Evaluate(function_id, function_type, function_inputs))
             }
-            _ => unreachable!(format!("Invalid operation id {}", operation_id)),
+            _ => unreachable!("Invalid operation id {}", operation_id),
         }
     }
 }

--- a/dpc/src/virtual_machine/program.rs
+++ b/dpc/src/virtual_machine/program.rs
@@ -149,9 +149,7 @@ impl<N: Network> Program<N> {
 
         // Ensure that the number of functions does not exceed the u8 bounds of `self.last_function_index`.
         if (self.last_function_index as usize).saturating_add(num_functions) > u8::MAX as usize {
-            return Err(anyhow!(
-                "The list of given functions exceeds the maximum number of allowed functions."
-            ));
+            return Err(anyhow!("The program tree will reach its maximum size."));
         }
 
         self.functions.extend(

--- a/dpc/src/virtual_machine/program.rs
+++ b/dpc/src/virtual_machine/program.rs
@@ -99,7 +99,6 @@ impl<N: Network> Program<N> {
 }
 
 impl<N: Network> Program<N> {
-    /// TODO (howardwu): Add safety checks for u8 (max 255 functions).
     /// Adds the given function to the tree, returning its function index in the tree.
     fn add(&mut self, function: Arc<dyn Function<N>>) -> Result<u8> {
         // Ensure the function does not already exist in the tree.
@@ -114,8 +113,12 @@ impl<N: Network> Program<N> {
         self.functions
             .insert(function.function_id(), (self.last_function_index, function));
 
-        self.last_function_index += 1;
-        Ok(self.last_function_index - 1)
+        let last_function_index = self.last_function_index;
+        self.last_function_index = last_function_index
+            .checked_add(1)
+            .ok_or(anyhow!("The index exceeds the maximum number of functions."))?;
+
+        Ok(last_function_index)
     }
 
     /// TODO (howardwu): Add safety checks for u8 (max 255 functions).
@@ -144,6 +147,13 @@ impl<N: Network> Program<N> {
         let start_index = self.last_function_index;
         let num_functions = functions.len();
 
+        // Ensure that the number of functions does not exceed the u8 bounds of `self.last_function_index`.
+        if (self.last_function_index as usize).saturating_add(num_functions) > u8::MAX as usize {
+            return Err(anyhow!(
+                "The list of given functions exceeds the maximum number of allowed functions."
+            ));
+        }
+
         self.functions.extend(
             functions
                 .into_iter()
@@ -151,8 +161,14 @@ impl<N: Network> Program<N> {
                 .map(|(index, function)| (function.function_id(), (start_index + index as u8, function))),
         );
 
-        self.last_function_index += num_functions as u8;
-        let end_index = self.last_function_index - 1;
+        self.last_function_index = self
+            .last_function_index
+            .checked_add(num_functions as u8)
+            .ok_or(anyhow!("The index exceeds the maximum number of allowed functions."))?;
+        let end_index = self
+            .last_function_index
+            .checked_sub(1)
+            .ok_or(anyhow!("Integer underflow."))?;
 
         Ok((start_index, end_index))
     }

--- a/marlin/Cargo.toml
+++ b/marlin/Cargo.toml
@@ -86,6 +86,9 @@ version = "0.9"
 [dependencies.hashbrown]
 version = "0.11.2"
 
+[dependencies.itertools]
+version = "0.10.3"
+
 [dependencies.rand]
 version = "0.8"
 

--- a/marlin/src/marlin/marlin.rs
+++ b/marlin/src/marlin/marlin.rs
@@ -17,7 +17,15 @@
 use crate::{
     ahp::{AHPError, AHPForR1CS, EvaluationsProvider},
     fiat_shamir::traits::FiatShamirRng,
-    marlin::{CircuitProvingKey, CircuitVerifyingKey, MarlinError, MarlinMode, Proof, UniversalSRS},
+    marlin::{
+        CircuitProvingKey,
+        CircuitVerifyingKey,
+        MarlinError,
+        MarlinMode,
+        PreparedCircuitVerifyingKey,
+        Proof,
+        UniversalSRS,
+    },
     prover::ProverConstraintSystem,
     String,
     ToString,
@@ -41,11 +49,11 @@ use snarkvm_utilities::{to_bytes_le, ToBytes};
 #[cfg(not(feature = "std"))]
 use snarkvm_utilities::println;
 
-use crate::marlin::PreparedCircuitVerifyingKey;
 use core::{
     marker::PhantomData,
     sync::atomic::{AtomicBool, Ordering},
 };
+use itertools::Itertools;
 use rand_core::RngCore;
 
 /// The Marlin proof system.
@@ -465,7 +473,7 @@ impl<
             .circuit_verifying_key
             .iter()
             .cloned()
-            .zip(indexer_polynomials)
+            .zip_eq(indexer_polynomials)
             .map(|(c, l)| LabeledCommitment::new(l.to_string(), c, None))
             .chain(first_commitments.into_iter())
             .chain(second_commitments.into_iter())
@@ -709,8 +717,8 @@ impl<
             .chain(second_commitments)
             .chain(third_commitments)
             .cloned()
-            .zip(polynomial_labels)
-            .zip(degree_bounds)
+            .zip_eq(polynomial_labels)
+            .zip_eq(degree_bounds)
             .map(|((c, l), d)| LabeledCommitment::new(l, c, d))
             .collect();
 
@@ -734,7 +742,7 @@ impl<
             }
         }
         evaluation_labels.sort_by(|a, b| a.0.cmp(&b.0));
-        for (q, eval) in evaluation_labels.into_iter().zip(&proof.evaluations) {
+        for (q, eval) in evaluation_labels.into_iter().zip_eq(&proof.evaluations) {
             evaluations.insert(q, *eval);
         }
 

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -35,6 +35,7 @@ use core::{
     ops::Mul,
     sync::atomic::{AtomicBool, Ordering},
 };
+use itertools::Itertools;
 use rand_core::RngCore;
 
 #[cfg(feature = "parallel")]
@@ -191,7 +192,7 @@ impl<E: PairingEngine> KZG10<E> {
 
                 let affines = E::G2Projective::batch_normalization_into_affine(neg_powers_of_h);
 
-                for (i, affine) in list.iter().zip(affines.iter()) {
+                for (i, affine) in list.iter().zip_eq(affines.iter()) {
                     map.insert(*i, *affine);
                 }
 
@@ -407,7 +408,7 @@ impl<E: PairingEngine> KZG10<E> {
         // their coefficients and perform a final multiplication at the end.
         let mut g_multiplier = E::Fr::zero();
         let mut gamma_g_multiplier = E::Fr::zero();
-        for (((c, z), v), proof) in commitments.iter().zip(points).zip(values).zip(proofs) {
+        for (((c, z), v), proof) in commitments.iter().zip_eq(points).zip_eq(values).zip_eq(proofs) {
             let w = proof.w;
             let mut temp = w.mul(*z).into_projective();
             temp.add_assign_mixed(&c.0);

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -39,6 +39,7 @@ use snarkvm_utilities::{
 };
 
 use core::{fmt::Debug, sync::atomic::AtomicBool};
+use itertools::Itertools;
 use rand_core::RngCore;
 
 #[cfg(not(feature = "std"))]
@@ -271,8 +272,8 @@ pub trait PolynomialCommitment<F: PrimeField, CF: PrimeField>: Sized + Clone + D
     {
         let poly_rand_comm: BTreeMap<_, _> = labeled_polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments.into_iter())
+            .zip_eq(rands)
+            .zip_eq(commitments.into_iter())
             .map(|((poly, r), comm)| (poly.label(), (poly, r, comm)))
             .collect();
 
@@ -372,7 +373,7 @@ pub trait PolynomialCommitment<F: PrimeField, CF: PrimeField>: Sized + Clone + D
         assert_eq!(proofs.len(), query_to_labels_map.len());
 
         let mut result = true;
-        for ((_point_name, (query, labels)), proof) in query_to_labels_map.into_iter().zip(proofs) {
+        for ((_point_name, (query, labels)), proof) in query_to_labels_map.into_iter().zip_eq(proofs) {
             let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::with_capacity(labels.len());
             let mut values = Vec::with_capacity(labels.len());
             for label in labels.into_iter() {
@@ -462,7 +463,7 @@ pub trait PolynomialCommitment<F: PrimeField, CF: PrimeField>: Sized + Clone + D
             .iter()
             .map(|(_, point)| point)
             .cloned()
-            .zip(evals.clone().unwrap())
+            .zip_eq(evals.clone().unwrap())
             .collect();
 
         for &(ref lc_label, (_, point)) in eqn_query_set {
@@ -754,7 +755,7 @@ pub mod tests {
             // let mut point = F::one();
             for point_id in 0..num_points_in_query_set {
                 let point = F::rand(rng);
-                for (polynomial, label) in polynomials.iter().zip(labels.iter()) {
+                for (polynomial, label) in polynomials.iter().zip_eq(labels.iter()) {
                     query_set.insert((label.clone(), (format!("rand_{}", point_id), point)));
                     let value = polynomial.evaluate(point);
                     values.insert((label.clone(), point), value);

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -45,6 +45,7 @@ use core::{
     ops::Mul,
     sync::atomic::{AtomicBool, Ordering},
 };
+use itertools::Itertools;
 use rand_core::{RngCore, SeedableRng};
 
 mod data_structures;
@@ -325,7 +326,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let mut combined_rand = kzg10::Randomness::empty();
         let mut curr_challenge = opening_challenge;
 
-        for (polynomial, rand) in labeled_polynomials.into_iter().zip(rands) {
+        for (polynomial, rand) in labeled_polynomials.into_iter().zip_eq(rands) {
             let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
             kzg10::KZG10::<E>::check_degrees_and_bounds(
@@ -412,7 +413,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let mut combined_witness: E::G1Projective = E::G1Projective::zero();
         let mut combined_adjusted_witness: E::G1Projective = E::G1Projective::zero();
 
-        for ((_query_name, (query, labels)), p) in query_to_labels_map.into_iter().zip(proof) {
+        for ((_query_name, (query, labels)), p) in query_to_labels_map.into_iter().zip_eq(proof) {
             let mut comms_to_combine: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values_to_combine = Vec::new();
             for label in labels.into_iter() {
@@ -463,8 +464,8 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
     {
         let label_map = polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments)
+            .zip_eq(rands)
+            .zip_eq(commitments)
             .map(|((p, r), c)| (p.label(), (p, r, c)))
             .collect::<BTreeMap<_, _>>();
 
@@ -517,7 +518,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
 
         let lc_commitments = lc_info
             .into_iter()
-            .zip(comms)
+            .zip_eq(comms)
             .map(|((label, d), c)| LabeledCommitment::new(label, c, d))
             .collect::<Vec<_>>();
 
@@ -600,7 +601,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
 
         let lc_commitments: Vec<_> = lc_info
             .into_iter()
-            .zip(comms)
+            .zip_eq(comms)
             .map(|((label, d), c)| LabeledCommitment::new(label, c, d))
             .collect();
 
@@ -633,8 +634,8 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
     {
         let label_map = polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments)
+            .zip_eq(rands)
+            .zip_eq(commitments)
             .map(|((p, r), c)| (p.label(), (p, r, c)))
             .collect::<BTreeMap<_, _>>();
 
@@ -681,7 +682,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let comms = Self::normalize_commitments(lc_commitments);
         let lc_commitments = lc_info
             .into_iter()
-            .zip(comms)
+            .zip_eq(comms)
             .map(|((label, d), c)| LabeledCommitment::new(label, c, d))
             .collect::<Vec<_>>();
 
@@ -764,7 +765,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr, E::Fq> for SonicKZG10<E> {
         let comms = Self::normalize_commitments(lc_commitments);
         let lc_commitments = lc_info
             .into_iter()
-            .zip(comms)
+            .zip_eq(comms)
             .map(|((label, d), c)| LabeledCommitment::new(label, c, d))
             .collect::<Vec<_>>();
         end_timer!(combined_comms_norm_time);
@@ -799,7 +800,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
         let mut combined_polynomial = Polynomial::zero();
         let mut combined_rand = kzg10::Randomness::empty();
 
-        for (opening_challenge_counter, (polynomial, rand)) in labeled_polynomials.into_iter().zip(rands).enumerate() {
+        for (opening_challenge_counter, (polynomial, rand)) in labeled_polynomials.into_iter().zip_eq(rands).enumerate()
+        {
             let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
             kzg10::KZG10::<E>::check_degrees_and_bounds(
@@ -839,8 +841,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
     {
         let poly_rand_comm: BTreeMap<_, _> = labeled_polynomials
             .into_iter()
-            .zip(rands)
-            .zip(commitments.into_iter())
+            .zip_eq(rands)
+            .zip_eq(commitments.into_iter())
             .map(|((poly, r), comm)| (poly.label(), (poly, r, comm)))
             .collect();
 
@@ -964,7 +966,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
         assert_eq!(proofs.len(), query_to_labels_map.len());
 
         let mut result = true;
-        for ((_point_name, (point, labels)), proof) in query_to_labels_map.into_iter().zip(proofs) {
+        for ((_point_name, (point, labels)), proof) in query_to_labels_map.into_iter().zip_eq(proofs) {
             let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values = Vec::new();
             for label in labels {
@@ -1011,7 +1013,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
         let mut combined_values = E::Fr::zero();
 
         // Iterates through all of the commitments and accumulates common degree_bound elements in a BTreeMap
-        for (labeled_comm, value) in commitments.into_iter().zip(values) {
+        for (labeled_comm, value) in commitments.into_iter().zip_eq(values) {
             combined_values += &(value * curr_challenge);
 
             let comm = labeled_comm.commitment();
@@ -1064,7 +1066,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
         let mut combined_values = E::Fr::zero();
 
         // Iterates through all of the commitments and accumulates common degree_bound elements in a BTreeMap
-        for (opening_challenge_counter, (labeled_commitment, value)) in commitments.into_iter().zip(values).enumerate()
+        for (opening_challenge_counter, (labeled_commitment, value)) in
+            commitments.into_iter().zip_eq(values).enumerate()
         {
             let current_challenge = opening_challenges(opening_challenge_counter as u64);
             combined_values += &(value * current_challenge);
@@ -1134,7 +1137,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
             .map(|a| a.prepare())
             .collect::<Vec<_>>();
 
-        let g1_g2_prepared = g1_prepared_elems_iter.iter().zip(g2_prepared_elems.iter());
+        let g1_g2_prepared = g1_prepared_elems_iter.iter().zip_eq(g2_prepared_elems.iter());
         let is_one: bool = E::product_of_pairings(g1_g2_prepared).is_one();
         end_timer!(check_time);
         Ok(is_one)


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR will track all the in progress and completed security related PRs. 

The initial plan is to merge all the security fixes into `testnet2-audit` before migrating them into the `testnet3` branch of snarkVM.

Tracker:
- [x] Sparse polynomial sorting - #682
     - `testnet3` variant #660
- [x] Zip safety - #683
     - `testnet3` variant #661
- [x] Coefficient to biginteger out of bounds - 
     - Merged into `testnet3` in: #655 https://github.com/AleoHQ/snarkVM/pull/655/files#diff-65c324b0c9a766e87a9021bb7110133f9c423fa069bf34c2ac2fbff03167940fR561-R571
- [x] Groth16 prover panics when r equals zero - #680
- [x] Merkle tree overflow protection - #684
- [x] Merkle path length enforcement - #685
- [x] Integer overflow protection - #688