### PR TITLE
[Testnet2] Fix indexing error for create_proof_no_zk

### DIFF
--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -231,14 +231,21 @@ where
     });
     let results: Vec<_> = pool.execute_all();
 
-    let g1_b = if r != E::Fr::zero() {
-        results[0].into_g1()
+    let (g1_b, g2_b, h_acc, l_aux_acc) = if r != E::Fr::zero() {
+        (
+            results[0].into_g1(),
+            results[1].into_g2(),
+            results[2].into_g1(),
+            results[3].into_g1(),
+        )
     } else {
-        E::G1Projective::zero()
+        (
+            E::G1Projective::zero(),
+            results[0].into_g2(),
+            results[1].into_g1(),
+            results[2].into_g1(),
+        )
     };
-    let g2_b = results[1].into_g2();
-    let h_acc = results[2].into_g1();
-    let l_aux_acc = results[3].into_g1();
 
     let s_g_a = g_a.mul(s);
     let r_g1_b = g1_b.mul(r);


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Ensures that if a Groth16 proof is being constructed without zk or with an `r` value of 0, then the indexing of the execution pool results are correct.

Tracking PR: #679 

## Test Plan

A test for `create_proof_no_zk` has been added.
