### PR TITLE
[Testnet2] Prevent merkle tree leaf selection overflows

### DIFF
--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -265,7 +265,7 @@ impl<P: MerkleParameters + Send + Sync> MerkleTree<P> {
         let leaf_hash = self.parameters.hash_leaf(leaf)?;
 
         let tree_depth = tree_depth(self.tree.len());
-        let tree_index = convert_index_to_last_level(index, tree_depth);
+        let tree_index = convert_index_to_last_level(index, tree_depth)?;
 
         // Check that the given index corresponds to the correct leaf.
         if tree_index >= self.tree.len() || leaf_hash != self.tree[tree_index] {
@@ -375,8 +375,11 @@ fn parent(index: usize) -> Option<usize> {
 }
 
 #[inline]
-fn convert_index_to_last_level(index: usize, tree_depth: usize) -> usize {
-    index + (1 << tree_depth) - 1
+fn convert_index_to_last_level(index: usize, tree_depth: usize) -> Result<usize, MerkleError> {
+    let shifted = 1u32
+        .checked_shl(tree_depth as u32)
+        .ok_or(MerkleError::IncorrectLeafIndex(index))?;
+    Ok(index.saturating_add(shifted as usize).saturating_sub(1))
 }
 
 pub struct Ancestors(usize);

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -250,4 +250,24 @@ mod pedersen_compressed_crh_on_projective {
         assert_eq!(tree.root(), new_tree_1.root());
         assert_eq!(tree.root(), new_tree_2.root());
     }
+
+    #[should_panic]
+    #[test]
+    fn merkle_tree_overflow_protection_test() {
+        type MTParameters = MerkleTreeParameters<PedersenCompressedCRH<Edwards, NUM_WINDOWS, WINDOW_SIZE>, 32>;
+        let leaves = generate_random_leaves!(4, 8);
+
+        let parameters = &MTParameters::setup("merkle_tree_test");
+        let tree = MerkleTree::<MTParameters>::new(Arc::new(parameters.clone()), &leaves[..]).unwrap();
+
+        let _proof = tree.generate_proof(0, &leaves[0]).unwrap();
+        _proof.verify(tree.root(), &leaves[0]).unwrap();
+
+        let leaf1 = parameters.crh().hash(&leaves[0]).unwrap();
+        let leaf2 = parameters.crh().hash(&leaves[1]).unwrap();
+
+        // proof for non-leaf node
+        let raw_nodes = to_bytes_le![leaf1, leaf2].unwrap();
+        let _proof = tree.generate_proof(18446744073709551614, &raw_nodes).unwrap();
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Ensures that generating a proof with an arbitrary index will be protected from overflows, namely in the `convert_index_to_last_level` function.

Tracking PR: #679 

## Test Plan

A test for potential overflows has been added.
