### PR TITLE
Fix BHP commitment setup

### DIFF
--- a/algorithms/src/commitment/bhp.rs
+++ b/algorithms/src/commitment/bhp.rs
@@ -19,7 +19,6 @@ use snarkvm_curves::{AffineCurve, ProjectiveCurve};
 use snarkvm_fields::{ConstraintFieldError, Field, PrimeField, ToConstraintField};
 use snarkvm_utilities::{BitIteratorLE, FromBytes, ToBytes};
 
-use itertools::Itertools;
 use std::{
     fmt::Debug,
     io::{Read, Result as IoResult, Write},
@@ -54,6 +53,7 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Com
             random_base.push(base);
             base.double_in_place();
         }
+        assert_eq!(random_base.len(), num_scalar_bits);
 
         Self { bhp_crh: bhp, random_base }
     }
@@ -72,7 +72,8 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Com
 
         // Compute h^r.
         let scalar_bits = BitIteratorLE::new(randomness.to_repr());
-        for (bit, power) in scalar_bits.into_iter().zip_eq(&self.random_base) {
+        // This is left as `zip` because the `scalar_bits` is byte denominated (by 8) and the trailing bits will always be 0.
+        for (bit, power) in scalar_bits.into_iter().zip(&self.random_base) {
             if bit {
                 output += power
             }

--- a/algorithms/src/commitment/bhp.rs
+++ b/algorithms/src/commitment/bhp.rs
@@ -19,6 +19,7 @@ use snarkvm_curves::{AffineCurve, ProjectiveCurve};
 use snarkvm_fields::{ConstraintFieldError, Field, PrimeField, ToConstraintField};
 use snarkvm_utilities::{BitIteratorLE, FromBytes, ToBytes};
 
+use itertools::Itertools;
 use std::{
     fmt::Debug,
     io::{Read, Result as IoResult, Write},
@@ -72,8 +73,7 @@ impl<G: ProjectiveCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Com
 
         // Compute h^r.
         let scalar_bits = BitIteratorLE::new(randomness.to_repr());
-        // This is left as `zip` because the `scalar_bits` is byte denominated (by 8) and the trailing bits will always be 0.
-        for (bit, power) in scalar_bits.into_iter().zip(&self.random_base) {
+        for (bit, power) in scalar_bits.take(G::ScalarField::size_in_bits()).zip_eq(&self.random_base) {
             if bit {
                 output += power
             }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the number of `random_bases` from `WINDOW_SIZE` to `NUM_SCALAR_BITS` in order to sufficiently randomize the commitment. 

Previously, if the window size was set to less than the number of bits in the scalar element, there wouldn't be enough random bases to randomize the output.