### PR TITLE
Implements a macro to automatically derive ToBytes and FromBytes for enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,7 @@ dependencies = [
  "snarkvm-algorithms",
  "snarkvm-circuits-environment",
  "snarkvm-circuits-types",
+ "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
 ]

--- a/bytecode/src/instructions/mod.rs
+++ b/bytecode/src/instructions/mod.rs
@@ -96,3 +96,53 @@ impl<M: Memory> fmt::Display for Instruction<M> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Stack;
+
+    use snarkvm_circuits::Circuit;
+    use snarkvm_utilities::{FromBytes, ToBytes};
+
+    #[test]
+    fn test_instruction_to_bytes() {
+        type M = Stack<Circuit>;
+        // Test serialization for the `Add` instruction. Check that the first two bytes are 0u16.
+        let instruction = Instruction::<M>::parse("add r0 r2 r1;", M::default()).unwrap().1;
+        let bytes = instruction.to_bytes_le().unwrap();
+        assert_eq!(u16::from_bytes_le(&bytes[0..2]).unwrap(), 0u16);
+
+        // Test serialization for the `Store` instruction. Check that the first two bytes are 1u16.
+        let instruction = Instruction::<M>::parse("store r0 r2;", M::default()).unwrap().1;
+        let bytes = instruction.to_bytes_le().unwrap();
+        assert_eq!(u16::from_bytes_le(&bytes[0..2]).unwrap(), 1u16);
+
+        // Test serialization for the `Sub` instruction. Check that the first two bytes are 2u16.
+        let instruction = Instruction::<M>::parse("sub r0 r2 r1;", M::default()).unwrap().1;
+        let bytes = instruction.to_bytes_le().unwrap();
+        assert_eq!(u16::from_bytes_le(&bytes[0..2]).unwrap(), 2u16);
+    }
+
+    #[test]
+    fn test_instruction_to_and_from_bytes() {
+        type M = Stack<Circuit>;
+        // Test serialization for the `Add` instruction. Check that to_bytes and from_bytes are symmetric in the enum variant.
+        let instruction = Instruction::<M>::parse("add r0 r2 r1;", M::default()).unwrap().1;
+        let bytes = instruction.to_bytes_le().unwrap();
+        let recovered_instruction = Instruction::<M>::from_bytes_le(&bytes).unwrap();
+        assert_eq!(std::mem::discriminant(&instruction), std::mem::discriminant(&recovered_instruction));
+
+        // Test serialization for the `Store` instruction. Check that to_bytes and from_bytes are symmetric in the enum variant.
+        let instruction = Instruction::<M>::parse("store r0 r2;", M::default()).unwrap().1;
+        let bytes = instruction.to_bytes_le().unwrap();
+        let recovered_instruction = Instruction::<M>::from_bytes_le(&bytes).unwrap();
+        assert_eq!(std::mem::discriminant(&instruction), std::mem::discriminant(&recovered_instruction));
+
+        // Test serialization for the `Sub` instruction. Check that to_bytes and from_bytes are symmetric in the enum variant.
+        let instruction = Instruction::<M>::parse("sub r0 r2 r1;", M::default()).unwrap().1;
+        let bytes = instruction.to_bytes_le().unwrap();
+        let recovered_instruction = Instruction::<M>::from_bytes_le(&bytes).unwrap();
+        assert_eq!(std::mem::discriminant(&instruction), std::mem::discriminant(&recovered_instruction));
+    }
+}

--- a/circuits/src/literal.rs
+++ b/circuits/src/literal.rs
@@ -32,6 +32,7 @@ use snarkvm_utilities::{
 
 use enum_index::EnumIndex;
 
+// TODO: Consider deriving EnumToBytes and EnumFromBytes for Literal. Nontrivial refactor required.
 #[derive(Clone, EnumIndex)]
 pub enum Literal<E: Environment> {
     /// The Aleo address type.

--- a/circuits/src/type_.rs
+++ b/circuits/src/type_.rs
@@ -23,7 +23,7 @@ use snarkvm_utilities::{
 };
 
 use enum_index::EnumIndex;
-
+// TODO: Consider deriving EnumToBytes and EnumFromBytes for Literal. Requires additional functionality to ignore certain fields in the proc macro.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, EnumIndex)]
 pub enum Type<E: Environment> {
     /// The Aleo address type.

--- a/utilities/derives/Cargo.toml
+++ b/utilities/derives/Cargo.toml
@@ -20,17 +20,19 @@ edition = "2021"
 [lib]
 proc-macro = true
 
-[dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
+[dependencies.proc-macro2]
+version = "1.0"
 
-  [dependencies.proc-macro-crate]
-  version = "0.1"
+[dependencies.proc-macro-crate]
+version = "0.1"
 
-  [dependencies.proc-macro-error]
-  version = "1"
-  default-features = false
+[dependencies.proc-macro-error]
+version = "1"
+default-features = false
 
-  [dependencies.syn]
-  version = "1.0"
-  features = [ "full" ]
+[dependencies.quote]
+version= "1.0"
+
+[dependencies.syn]
+version = "1.0"
+features = [ "full" ]

--- a/utilities/derives/src/canonical_deserialize.rs
+++ b/utilities/derives/src/canonical_deserialize.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, Type};
+
+/// Returns two TokenStreams, one for the compressed deserialize, one for the
+/// uncompressed.
+fn impl_deserialize_field(ty: &Type) -> (TokenStream, TokenStream) {
+    // Check if type is a tuple.
+    match ty {
+        Type::Tuple(tuple) => {
+            let (compressed_fields, uncompressed_fields): (Vec<_>, Vec<_>) =
+                tuple.elems.iter().map(impl_deserialize_field).unzip();
+            (quote! { (#(#compressed_fields)*), }, quote! { (#(#uncompressed_fields)*), })
+        }
+        _ => (
+            quote! { CanonicalDeserialize::deserialize(reader)?, },
+            quote! { CanonicalDeserialize::deserialize_uncompressed(reader)?, },
+        ),
+    }
+}
+
+pub(crate) fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let deserialize_body;
+    let deserialize_uncompressed_body;
+
+    match ast.data {
+        Data::Struct(ref data_struct) => {
+            let mut tuple = false;
+            let mut compressed_field_cases = Vec::<TokenStream>::with_capacity(data_struct.fields.len());
+            let mut uncompressed_field_cases = Vec::<TokenStream>::with_capacity(data_struct.fields.len());
+            for field in data_struct.fields.iter() {
+                match &field.ident {
+                    None => {
+                        tuple = true;
+                        let (compressed, uncompressed) = impl_deserialize_field(&field.ty);
+                        compressed_field_cases.push(compressed);
+                        uncompressed_field_cases.push(uncompressed);
+                    }
+                    // struct field without len_type
+                    Some(ident) => {
+                        let (compressed_field, uncompressed_field) = impl_deserialize_field(&field.ty);
+                        compressed_field_cases.push(quote! { #ident: #compressed_field });
+                        uncompressed_field_cases.push(quote! { #ident: #uncompressed_field });
+                    }
+                }
+            }
+
+            if tuple {
+                deserialize_body = quote!({
+                    Ok(#name (
+                        #(#compressed_field_cases)*
+                    ))
+                });
+                deserialize_uncompressed_body = quote!({
+                    Ok(#name (
+                        #(#uncompressed_field_cases)*
+                    ))
+                });
+            } else {
+                deserialize_body = quote!({
+                    Ok(#name {
+                        #(#compressed_field_cases)*
+                    })
+                });
+                deserialize_uncompressed_body = quote!({
+                    Ok(#name {
+                        #(#uncompressed_field_cases)*
+                    })
+                });
+            }
+        }
+        _ => panic!("Deserialize can only be derived for structs, {} is not a Struct", name),
+    };
+
+    let gen = quote! {
+        impl #impl_generics CanonicalDeserialize for #name #ty_generics #where_clause {
+            #[allow(unused_mut,unused_variables)]
+            fn deserialize<R: snarkvm_utilities::Read>(reader: &mut R) -> Result<Self, snarkvm_utilities::SerializationError> {
+                #deserialize_body
+            }
+            #[allow(unused_mut,unused_variables)]
+            fn deserialize_uncompressed<R: snarkvm_utilities::Read>(reader: &mut R) -> Result<Self, snarkvm_utilities::SerializationError> {
+                #deserialize_uncompressed_body
+            }
+        }
+    };
+    gen
+}

--- a/utilities/derives/src/canonical_serialize.rs
+++ b/utilities/derives/src/canonical_serialize.rs
@@ -1,0 +1,143 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{Data, Index, Type};
+
+enum IdentOrIndex {
+    Ident(proc_macro2::Ident),
+    Index(Index),
+}
+
+impl ToTokens for IdentOrIndex {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Ident(ident) => ident.to_tokens(tokens),
+            Self::Index(index) => index.to_tokens(tokens),
+        }
+    }
+}
+
+fn impl_serialize_field(
+    serialize_body: &mut Vec<TokenStream>,
+    serialized_size_body: &mut Vec<TokenStream>,
+    serialize_uncompressed_body: &mut Vec<TokenStream>,
+    uncompressed_size_body: &mut Vec<TokenStream>,
+    idents: &mut Vec<IdentOrIndex>,
+    ty: &Type,
+) {
+    // Check if type is a tuple.
+    match ty {
+        Type::Tuple(tuple) => {
+            for (i, elem_ty) in tuple.elems.iter().enumerate() {
+                let index = Index::from(i);
+                idents.push(IdentOrIndex::Index(index));
+                impl_serialize_field(
+                    serialize_body,
+                    serialized_size_body,
+                    serialize_uncompressed_body,
+                    uncompressed_size_body,
+                    idents,
+                    elem_ty,
+                );
+                idents.pop();
+            }
+        }
+        _ => {
+            serialize_body.push(quote! { CanonicalSerialize::serialize(&self.#(#idents).*, writer)?; });
+            serialized_size_body.push(quote! { size += CanonicalSerialize::serialized_size(&self.#(#idents).*); });
+            serialize_uncompressed_body
+                .push(quote! { CanonicalSerialize::serialize_uncompressed(&self.#(#idents).*, writer)?; });
+            uncompressed_size_body.push(quote! { size += CanonicalSerialize::uncompressed_size(&self.#(#idents).*); });
+        }
+    }
+}
+
+pub(crate) fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let len = if let Data::Struct(ref data_struct) = ast.data {
+        data_struct.fields.len()
+    } else {
+        panic!("Serialize can only be derived for structs, {} is not a struct", name);
+    };
+
+    let mut serialize_body = Vec::<TokenStream>::with_capacity(len);
+    let mut serialized_size_body = Vec::<TokenStream>::with_capacity(len);
+    let mut serialize_uncompressed_body = Vec::<TokenStream>::with_capacity(len);
+    let mut uncompressed_size_body = Vec::<TokenStream>::with_capacity(len);
+
+    match ast.data {
+        Data::Struct(ref data_struct) => {
+            let mut idents = Vec::<IdentOrIndex>::new();
+
+            for (i, field) in data_struct.fields.iter().enumerate() {
+                match field.ident {
+                    None => {
+                        let index = Index::from(i);
+                        idents.push(IdentOrIndex::Index(index));
+                    }
+                    Some(ref ident) => {
+                        idents.push(IdentOrIndex::Ident(ident.clone()));
+                    }
+                }
+
+                impl_serialize_field(
+                    &mut serialize_body,
+                    &mut serialized_size_body,
+                    &mut serialize_uncompressed_body,
+                    &mut uncompressed_size_body,
+                    &mut idents,
+                    &field.ty,
+                );
+
+                idents.clear();
+            }
+        }
+        _ => panic!("Serialize can only be derived for structs, {} is not a struct", name),
+    };
+
+    let gen = quote! {
+        impl #impl_generics CanonicalSerialize for #name #ty_generics #where_clause {
+            #[allow(unused_mut, unused_variables)]
+            fn serialize<W: snarkvm_utilities::Write>(&self, writer: &mut W) -> Result<(), snarkvm_utilities::SerializationError> {
+                #(#serialize_body)*
+                Ok(())
+            }
+            #[allow(unused_mut, unused_variables)]
+            fn serialized_size(&self) -> usize {
+                let mut size = 0;
+                #(#serialized_size_body)*
+                size
+            }
+            #[allow(unused_mut, unused_variables)]
+            fn serialize_uncompressed<W: snarkvm_utilities::Write>(&self, writer: &mut W) -> Result<(), snarkvm_utilities::SerializationError> {
+                #(#serialize_uncompressed_body)*
+                Ok(())
+            }
+            #[allow(unused_mut, unused_variables)]
+            fn uncompressed_size(&self) -> usize {
+                let mut size = 0;
+                #(#uncompressed_size_body)*
+                size
+            }
+        }
+    };
+    gen
+}

--- a/utilities/derives/src/enum_from_bytes.rs
+++ b/utilities/derives/src/enum_from_bytes.rs
@@ -14,101 +14,81 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::enum_validate_input::validate_input_ast;
+
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
-use syn::{parse::Parse, Data, Fields, Type};
+use syn::{Fields, Type};
 
 pub(crate) fn impl_from_bytes(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
 
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-    // Parse attributes and check that tag is a primitive integer type.
-    // TODO: Allow only one tag attribute.
-    let attribute = ast
-        .attrs
-        .iter()
-        .find(|attr| attr.path.is_ident("tag"))
-        .expect("`tag` attribute is required for deriving `EnumFromBytes`");
-    let tag_type = attribute.parse_args_with(Type::parse).expect("`tag` attribute must be a type");
-    match tag_type {
-        Type::Path(ref tp) => match tp.path.segments.last() {
-            Some(segment) => match segment.ident.to_string().as_str() {
-                "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {}
-                _ => panic!("`tag` attribute must be a primitive integer type"),
-            },
-            None => panic!("Type path must have at least one segment."),
-        },
-        _ => panic!("`tag` attribute must be a primitive integer type for deriving `EnumFromBytes`"),
-    }
+    let (data_enum, tag_type) = validate_input_ast(ast);
 
-    match ast.data {
-        Data::Enum(ref data_enum) => {
-            let mut match_cases = Vec::<TokenStream>::with_capacity(data_enum.variants.len());
+    let mut match_cases = Vec::<TokenStream>::with_capacity(data_enum.variants.len());
 
-            for (i, variant) in data_enum.variants.iter().enumerate() {
-                let variant_name = &variant.ident;
-                let variant_index = Literal::usize_unsuffixed(i);
-                let match_arm = match &variant.fields {
-                    Fields::Named(fields) => {
-                        let mut field_reads = Vec::<TokenStream>::with_capacity(fields.named.len());
+    for (i, variant) in data_enum.variants.iter().enumerate() {
+        let variant_name = &variant.ident;
+        let variant_index = Literal::usize_unsuffixed(i);
+        let match_arm = match &variant.fields {
+            Fields::Named(fields) => {
+                let mut field_reads = Vec::<TokenStream>::with_capacity(fields.named.len());
 
-                        for field in fields.named.iter() {
-                            let ty = &field.ty;
-                            field_reads.push(quote! {
-                                #ty::read_le(&mut reader)?
-                            });
-                        }
-
-                        quote! {
-                            Ok(#variant_index) => Ok(Self::#variant_name(#(#field_reads),*))
-                        }
-                    }
-                    Fields::Unnamed(fields) => {
-                        let mut field_reads = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
-
-                        for field in fields.unnamed.iter() {
-                            let ty = match &field.ty {
-                                Type::Path(tp) => tp
-                                    .path
-                                    .segments
-                                    .last()
-                                    .expect("Expected path to contain at least one segment")
-                                    .ident
-                                    .clone(),
-                                _ => panic!("Expected field type to be a path."),
-                            };
-                            field_reads.push(quote! {
-                                #ty::read_le(&mut reader)?
-                            });
-                        }
-
-                        quote! {
-                            Ok(#variant_index) => Ok(Self::#variant_name(#(#field_reads),*))
-                        }
-                    }
-                    Fields::Unit => {
-                        quote! {
-                            Ok(#variant_index) => Ok(Self::#variant_name)
-                        }
-                    }
-                };
-                match_cases.push(match_arm);
-            }
-
-            let gen = quote! {
-                impl #impl_generics snarkvm_utilities::bytes::FromBytes for #name #ty_generics #where_clause {
-                    fn read_le<R: std::io::Read>(mut reader: R) -> std::io::Result<Self> {
-                        match #tag_type::read_le(&mut reader) {
-                            #(#match_cases),*,
-                            Ok(code) => Err(snarkvm_utilities::error(format!("Unrecognized variant number {} for {}", code, stringify!(#name)))),
-                            Err(err) => Err(err),
-                        }
-                    }
+                for field in fields.named.iter() {
+                    let ty = &field.ty;
+                    field_reads.push(quote! {
+                        #ty::read_le(&mut reader)?
+                    });
                 }
-            };
-            gen
-        }
-        _ => panic!("EnumFromBytes can only be derived for enums, {} is not an enum", name),
+
+                quote! {
+                    Ok(#variant_index) => Ok(Self::#variant_name(#(#field_reads),*))
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let mut field_reads = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
+
+                for field in fields.unnamed.iter() {
+                    let ty = match &field.ty {
+                        Type::Path(tp) => tp
+                            .path
+                            .segments
+                            .last()
+                            .expect("Expected path to contain at least one segment")
+                            .ident
+                            .clone(),
+                        _ => panic!("Expected field type to be a path."),
+                    };
+                    field_reads.push(quote! {
+                        #ty::read_le(&mut reader)?
+                    });
+                }
+
+                quote! {
+                    Ok(#variant_index) => Ok(Self::#variant_name(#(#field_reads),*))
+                }
+            }
+            Fields::Unit => {
+                quote! {
+                    Ok(#variant_index) => Ok(Self::#variant_name)
+                }
+            }
+        };
+        match_cases.push(match_arm);
     }
+
+    let gen = quote! {
+        impl #impl_generics snarkvm_utilities::bytes::FromBytes for #name #ty_generics #where_clause {
+            fn read_le<R: std::io::Read>(mut reader: R) -> std::io::Result<Self> {
+                match #tag_type::read_le(&mut reader) {
+                    #(#match_cases),*,
+                    Ok(code) => Err(snarkvm_utilities::error(format!("Unrecognized variant number {} for {}", code, stringify!(#name)))),
+                    Err(err) => Err(err),
+                }
+            }
+        }
+    };
+    gen
 }

--- a/utilities/derives/src/enum_from_bytes.rs
+++ b/utilities/derives/src/enum_from_bytes.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use proc_macro2::{Ident, Literal, Span, TokenStream};
+use quote::quote;
+use syn::{parse::Parse, Data, Fields, Type};
+
+pub(crate) fn impl_from_bytes(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    // Parse attributes and check that tag is a primitive integer type.
+    // TODO: Allow only one tag attribute.
+    let attribute = ast
+        .attrs
+        .iter()
+        .find(|attr| attr.path.is_ident("tag"))
+        .expect("`tag` attribute is required for deriving `EnumFromBytes`");
+    let tag_type = attribute.parse_args_with(Type::parse).expect("`tag` attribute must be a type");
+    match tag_type {
+        Type::Path(ref tp) => match tp.path.segments.last() {
+            Some(segment) => match segment.ident.to_string().as_str() {
+                "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {}
+                _ => panic!("`tag` attribute must be a primitive integer type"),
+            },
+            None => panic!("Type path must have at least one segment."),
+        },
+        _ => panic!("`tag` attribute must be a primitive integer type for deriving `EnumFromBytes`"),
+    }
+
+    match ast.data {
+        Data::Enum(ref data_enum) => {
+            let mut match_cases = Vec::<TokenStream>::with_capacity(data_enum.variants.len());
+
+            for (i, variant) in data_enum.variants.iter().enumerate() {
+                let variant_name = &variant.ident;
+                let variant_index = Literal::usize_unsuffixed(i);
+                let match_arm = match &variant.fields {
+                    Fields::Named(fields) => {
+                        let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.named.len());
+                        let mut field_reads = Vec::<TokenStream>::with_capacity(fields.named.len());
+
+                        for field in fields.named.iter() {
+                            let ty = &field.ty;
+                            field_reads.push(quote! {
+                                #ty::read_le(&mut reader)?
+                            });
+                        }
+
+                        quote! {
+                            Ok(#variant_index) => Ok(Self::#variant_name(#(#field_reads),*))
+                        }
+                    }
+                    Fields::Unnamed(fields) => {
+                        let mut field_reads = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
+
+                        for field in fields.unnamed.iter() {
+                            let ty = match &field.ty {
+                                Type::Path(tp) => tp
+                                    .path
+                                    .segments
+                                    .last()
+                                    .expect("Expected path to contain at least one segment")
+                                    .ident
+                                    .clone(),
+                                _ => panic!("Expected field type to be a path."),
+                            };
+                            field_reads.push(quote! {
+                                #ty::read_le(&mut reader)?
+                            });
+                        }
+
+                        quote! {
+                            Ok(#variant_index) => Ok(Self::#variant_name(#(#field_reads),*))
+                        }
+                    }
+                    Fields::Unit => {
+                        quote! {
+                            Ok(#variant_index) => Ok(Self::#variant_name)
+                        }
+                    }
+                };
+                match_cases.push(match_arm);
+            }
+
+            let gen = quote! {
+                impl #impl_generics snarkvm_utilities::bytes::FromBytes for #name #ty_generics #where_clause {
+                    fn read_le<R: std::io::Read>(mut reader: R) -> std::io::Result<Self> {
+                        match #tag_type::read_le(&mut reader) {
+                            #(#match_cases),*,
+                            Ok(code) => Err(snarkvm_utilities::error(format!("Unrecognized variant number {} for {}", code, stringify!(#name)))),
+                            Err(err) => Err(err),
+                        }
+                    }
+                }
+            };
+            gen
+        }
+        _ => panic!("EnumFromBytes can only be derived for enums, {} is not an enum", name),
+    }
+}

--- a/utilities/derives/src/enum_from_bytes.rs
+++ b/utilities/derives/src/enum_from_bytes.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use proc_macro2::{Ident, Literal, Span, TokenStream};
+use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use syn::{parse::Parse, Data, Fields, Type};
 
@@ -51,7 +51,6 @@ pub(crate) fn impl_from_bytes(ast: &syn::DeriveInput) -> TokenStream {
                 let variant_index = Literal::usize_unsuffixed(i);
                 let match_arm = match &variant.fields {
                     Fields::Named(fields) => {
-                        let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.named.len());
                         let mut field_reads = Vec::<TokenStream>::with_capacity(fields.named.len());
 
                         for field in fields.named.iter() {

--- a/utilities/derives/src/enum_to_bytes.rs
+++ b/utilities/derives/src/enum_to_bytes.rs
@@ -1,0 +1,130 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::{parse::Parse, Data, Fields, Type};
+
+pub(crate) fn impl_to_bytes(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    // Parse attributes and check that tag is a primitive integer type.
+    // TODO: Allow only one tag attribute.
+    let attribute = ast
+        .attrs
+        .iter()
+        .find(|attr| attr.path.is_ident("tag"))
+        .expect("`tag` attribute is required for deriving `EnumToBytes`");
+    let tag_type = attribute.parse_args_with(Type::parse).expect("`tag` attribute must be a type");
+    match tag_type {
+        Type::Path(ref tp) => match tp.path.segments.last() {
+            Some(segment) => match segment.ident.to_string().as_str() {
+                "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {}
+                _ => panic!("`tag` attribute must be a primitive integer type"),
+            },
+            None => panic!("Type path must have at least one segment."),
+        },
+        _ => panic!("`tag` attribute must be a primitive integer type for deriving `EnumToBytes`"),
+    }
+
+    match ast.data {
+        Data::Enum(ref data_enum) => {
+            let mut match_cases = Vec::<TokenStream>::with_capacity(data_enum.variants.len());
+
+            for (variant_index, variant) in data_enum.variants.iter().enumerate() {
+                let variant_name = &variant.ident;
+                let match_arm = match &variant.fields {
+                    Fields::Named(fields) => {
+                        let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.named.len());
+                        let mut field_writes = Vec::<TokenStream>::with_capacity(fields.named.len());
+
+                        for (i, field) in fields.named.iter().enumerate() {
+                            let pattern = field.ident.as_ref().unwrap();
+                            field_patterns.push(quote! {
+                                #pattern
+                            });
+                            if i == fields.named.len() - 1 {
+                                field_writes.push(quote! {
+                                    #pattern.write_le(&mut writer)
+                                });
+                            } else {
+                                field_writes.push(quote! {
+                                    #pattern.write_le(&mut writer)?;
+                                });
+                            }
+                        }
+
+                        quote! {
+                            #variant_name{#(#field_patterns),*} => {
+                                (#variant_index as #tag_type).write_le(&mut writer)?;
+                                #(#field_writes)*
+                            }
+                        }
+                    }
+                    Fields::Unnamed(fields) => {
+                        let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
+                        let mut field_writes = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
+
+                        for (i, _) in fields.unnamed.iter().enumerate() {
+                            let pattern = Ident::new(&format!("field_{}", i), Span::call_site());
+                            field_patterns.push(quote! {
+                                #pattern
+                            });
+                            if i == fields.unnamed.len() - 1 {
+                                field_writes.push(quote! {
+                                    #pattern.write_le(&mut writer)
+                                });
+                            } else {
+                                field_writes.push(quote! {
+                                    #pattern.write_le(&mut writer)?;
+                                });
+                            }
+                        }
+
+                        quote! {
+                            #name::#variant_name(#(#field_patterns),*) => {
+                                (#variant_index as #tag_type).write_le(&mut writer)?;
+                                #(#field_writes)*
+                            }
+                        }
+                    }
+                    Fields::Unit => {
+                        quote! {
+                            #name::#variant_name => {
+                                (#variant_index as #tag_type).write_le(&mut writer)
+                            }
+                        }
+                    }
+                };
+                match_cases.push(match_arm);
+            }
+
+            let gen = quote! {
+                impl #impl_generics snarkvm_utilities::bytes::ToBytes for #name #ty_generics #where_clause {
+                    fn write_le<W: std::io::Write>(&self, mut writer: W) -> std::io::Result<()> {
+                        match self {
+                            #(#match_cases)*
+                        }
+                    }
+                }
+            };
+            gen
+        }
+        _ => panic!("EnumToBytes can only be derived for enums, {} is not an enum", name),
+    }
+}

--- a/utilities/derives/src/enum_to_bytes.rs
+++ b/utilities/derives/src/enum_to_bytes.rs
@@ -14,117 +14,95 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::enum_validate_input::validate_input_ast;
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use syn::{parse::Parse, Data, Fields, Type};
+use syn::Fields;
 
 pub(crate) fn impl_to_bytes(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
-
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-    // Parse attributes and check that tag is a primitive integer type.
-    // TODO: Allow only one tag attribute.
-    let attribute = ast
-        .attrs
-        .iter()
-        .find(|attr| attr.path.is_ident("tag"))
-        .expect("`tag` attribute is required for deriving `EnumToBytes`");
-    let tag_type = attribute.parse_args_with(Type::parse).expect("`tag` attribute must be a type");
-    match tag_type {
-        Type::Path(ref tp) => match tp.path.segments.last() {
-            Some(segment) => match segment.ident.to_string().as_str() {
-                "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {}
-                _ => panic!("`tag` attribute must be a primitive integer type"),
-            },
-            None => panic!("Type path must have at least one segment."),
-        },
-        _ => panic!("`tag` attribute must be a primitive integer type for deriving `EnumToBytes`"),
-    }
+    let (data_enum, tag_type) = validate_input_ast(ast);
+    let mut match_cases = Vec::<TokenStream>::with_capacity(data_enum.variants.len());
 
-    match ast.data {
-        Data::Enum(ref data_enum) => {
-            let mut match_cases = Vec::<TokenStream>::with_capacity(data_enum.variants.len());
+    for (variant_index, variant) in data_enum.variants.iter().enumerate() {
+        let variant_name = &variant.ident;
+        let match_arm = match &variant.fields {
+            Fields::Named(fields) => {
+                let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.named.len());
+                let mut field_writes = Vec::<TokenStream>::with_capacity(fields.named.len());
 
-            for (variant_index, variant) in data_enum.variants.iter().enumerate() {
-                let variant_name = &variant.ident;
-                let match_arm = match &variant.fields {
-                    Fields::Named(fields) => {
-                        let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.named.len());
-                        let mut field_writes = Vec::<TokenStream>::with_capacity(fields.named.len());
-
-                        for (i, field) in fields.named.iter().enumerate() {
-                            let pattern = field.ident.as_ref().unwrap();
-                            field_patterns.push(quote! {
-                                #pattern
-                            });
-                            if i == fields.named.len() - 1 {
-                                field_writes.push(quote! {
-                                    #pattern.write_le(&mut writer)
-                                });
-                            } else {
-                                field_writes.push(quote! {
-                                    #pattern.write_le(&mut writer)?;
-                                });
-                            }
-                        }
-
-                        quote! {
-                            #variant_name{#(#field_patterns),*} => {
-                                (#variant_index as #tag_type).write_le(&mut writer)?;
-                                #(#field_writes)*
-                            }
-                        }
-                    }
-                    Fields::Unnamed(fields) => {
-                        let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
-                        let mut field_writes = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
-
-                        for (i, _) in fields.unnamed.iter().enumerate() {
-                            let pattern = Ident::new(&format!("field_{}", i), Span::call_site());
-                            field_patterns.push(quote! {
-                                #pattern
-                            });
-                            if i == fields.unnamed.len() - 1 {
-                                field_writes.push(quote! {
-                                    #pattern.write_le(&mut writer)
-                                });
-                            } else {
-                                field_writes.push(quote! {
-                                    #pattern.write_le(&mut writer)?;
-                                });
-                            }
-                        }
-
-                        quote! {
-                            #name::#variant_name(#(#field_patterns),*) => {
-                                (#variant_index as #tag_type).write_le(&mut writer)?;
-                                #(#field_writes)*
-                            }
-                        }
-                    }
-                    Fields::Unit => {
-                        quote! {
-                            #name::#variant_name => {
-                                (#variant_index as #tag_type).write_le(&mut writer)
-                            }
-                        }
-                    }
-                };
-                match_cases.push(match_arm);
-            }
-
-            let gen = quote! {
-                impl #impl_generics snarkvm_utilities::bytes::ToBytes for #name #ty_generics #where_clause {
-                    fn write_le<W: std::io::Write>(&self, mut writer: W) -> std::io::Result<()> {
-                        match self {
-                            #(#match_cases)*
-                        }
+                for (i, field) in fields.named.iter().enumerate() {
+                    let pattern = field.ident.as_ref().unwrap();
+                    field_patterns.push(quote! {
+                        #pattern
+                    });
+                    if i == fields.named.len() - 1 {
+                        field_writes.push(quote! {
+                            #pattern.write_le(&mut writer)
+                        });
+                    } else {
+                        field_writes.push(quote! {
+                            #pattern.write_le(&mut writer)?;
+                        });
                     }
                 }
-            };
-            gen
-        }
-        _ => panic!("EnumToBytes can only be derived for enums, {} is not an enum", name),
+
+                quote! {
+                    #variant_name{#(#field_patterns),*} => {
+                        (#variant_index as #tag_type).write_le(&mut writer)?;
+                        #(#field_writes)*
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let mut field_patterns = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
+                let mut field_writes = Vec::<TokenStream>::with_capacity(fields.unnamed.len());
+
+                for (i, _) in fields.unnamed.iter().enumerate() {
+                    let pattern = Ident::new(&format!("field_{}", i), Span::call_site());
+                    field_patterns.push(quote! {
+                        #pattern
+                    });
+                    if i == fields.unnamed.len() - 1 {
+                        field_writes.push(quote! {
+                            #pattern.write_le(&mut writer)
+                        });
+                    } else {
+                        field_writes.push(quote! {
+                            #pattern.write_le(&mut writer)?;
+                        });
+                    }
+                }
+
+                quote! {
+                    #name::#variant_name(#(#field_patterns),*) => {
+                        (#variant_index as #tag_type).write_le(&mut writer)?;
+                        #(#field_writes)*
+                    }
+                }
+            }
+            Fields::Unit => {
+                quote! {
+                    #name::#variant_name => {
+                        (#variant_index as #tag_type).write_le(&mut writer)
+                    }
+                }
+            }
+        };
+        match_cases.push(match_arm);
     }
+
+    let gen = quote! {
+        impl #impl_generics snarkvm_utilities::bytes::ToBytes for #name #ty_generics #where_clause {
+            fn write_le<W: std::io::Write>(&self, mut writer: W) -> std::io::Result<()> {
+                match self {
+                    #(#match_cases)*
+                }
+            }
+        }
+    };
+    gen
 }

--- a/utilities/derives/src/enum_validate_input.rs
+++ b/utilities/derives/src/enum_validate_input.rs
@@ -1,0 +1,44 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use syn::{parse::Parse, Data, DataEnum, Type};
+
+// Validates the AST provided to the derive macro.
+pub(crate) fn validate_input_ast(ast: &syn::DeriveInput) -> (&DataEnum, Type) {
+    // Parse attributes and checks that tag is a primitive integer type.
+    // Note that only the first `tag` is used.
+    let attribute = ast
+        .attrs
+        .iter()
+        .find(|attr| attr.path.is_ident("tag"))
+        .expect("`tag` attribute is required for deriving `EnumToBytes`");
+    let tag_type = attribute.parse_args_with(Type::parse).expect("`tag` attribute must be a type");
+    match tag_type {
+        Type::Path(ref tp) => match tp.path.segments.last() {
+            Some(segment) => match segment.ident.to_string().as_str() {
+                "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {}
+                _ => panic!("`tag` attribute must be a primitive integer type"),
+            },
+            None => panic!("Type path must have at least one segment."),
+        },
+        _ => panic!("`tag` attribute must be a primitive integer type for deriving `EnumToBytes`"),
+    }
+
+    match ast.data {
+        Data::Enum(ref data_enum) => (data_enum, tag_type),
+        _ => panic!("EnumToBytes can only be derived for enums, {} is not an enum", ast.ident),
+    }
+}

--- a/utilities/derives/src/lib.rs
+++ b/utilities/derives/src/lib.rs
@@ -18,6 +18,10 @@ mod canonical_deserialize;
 
 mod canonical_serialize;
 
+mod enum_from_bytes;
+
+mod enum_to_bytes;
+
 mod test_with_metrics;
 
 use proc_macro_error::{abort_call_site, proc_macro_error};
@@ -33,6 +37,18 @@ pub fn derive_canonical_serialize(input: proc_macro::TokenStream) -> proc_macro:
 pub fn derive_canonical_deserialize(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     proc_macro::TokenStream::from(canonical_deserialize::impl_canonical_deserialize(&ast))
+}
+
+#[proc_macro_derive(EnumFromBytes, attributes(tag))]
+pub fn derive_enum_from_bytes(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    proc_macro::TokenStream::from(enum_from_bytes::impl_from_bytes(&ast))
+}
+
+#[proc_macro_derive(EnumToBytes, attributes(tag))]
+pub fn derive_enum_to_bytes(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    proc_macro::TokenStream::from(enum_to_bytes::impl_to_bytes(&ast))
 }
 
 #[proc_macro_error]

--- a/utilities/derives/src/lib.rs
+++ b/utilities/derives/src/lib.rs
@@ -14,268 +14,32 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use proc_macro2::{Ident, Span, TokenStream};
-use proc_macro_crate::crate_name;
+mod canonical_deserialize;
+
+mod canonical_serialize;
+
+mod test_with_metrics;
+
 use proc_macro_error::{abort_call_site, proc_macro_error};
 use syn::*;
-
-use quote::{quote, ToTokens};
 
 #[proc_macro_derive(CanonicalSerialize)]
 pub fn derive_canonical_serialize(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
-    proc_macro::TokenStream::from(impl_canonical_serialize(&ast))
-}
-
-enum IdentOrIndex {
-    Ident(proc_macro2::Ident),
-    Index(Index),
-}
-
-impl ToTokens for IdentOrIndex {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            Self::Ident(ident) => ident.to_tokens(tokens),
-            Self::Index(index) => index.to_tokens(tokens),
-        }
-    }
-}
-
-fn impl_serialize_field(
-    serialize_body: &mut Vec<TokenStream>,
-    serialized_size_body: &mut Vec<TokenStream>,
-    serialize_uncompressed_body: &mut Vec<TokenStream>,
-    uncompressed_size_body: &mut Vec<TokenStream>,
-    idents: &mut Vec<IdentOrIndex>,
-    ty: &Type,
-) {
-    // Check if type is a tuple.
-    match ty {
-        Type::Tuple(tuple) => {
-            for (i, elem_ty) in tuple.elems.iter().enumerate() {
-                let index = Index::from(i);
-                idents.push(IdentOrIndex::Index(index));
-                impl_serialize_field(
-                    serialize_body,
-                    serialized_size_body,
-                    serialize_uncompressed_body,
-                    uncompressed_size_body,
-                    idents,
-                    elem_ty,
-                );
-                idents.pop();
-            }
-        }
-        _ => {
-            serialize_body.push(quote! { CanonicalSerialize::serialize(&self.#(#idents).*, writer)?; });
-            serialized_size_body.push(quote! { size += CanonicalSerialize::serialized_size(&self.#(#idents).*); });
-            serialize_uncompressed_body
-                .push(quote! { CanonicalSerialize::serialize_uncompressed(&self.#(#idents).*, writer)?; });
-            uncompressed_size_body.push(quote! { size += CanonicalSerialize::uncompressed_size(&self.#(#idents).*); });
-        }
-    }
-}
-
-fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
-    let name = &ast.ident;
-
-    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-
-    let len = if let Data::Struct(ref data_struct) = ast.data {
-        data_struct.fields.len()
-    } else {
-        panic!("Serialize can only be derived for structs, {} is not a struct", name);
-    };
-
-    let mut serialize_body = Vec::<TokenStream>::with_capacity(len);
-    let mut serialized_size_body = Vec::<TokenStream>::with_capacity(len);
-    let mut serialize_uncompressed_body = Vec::<TokenStream>::with_capacity(len);
-    let mut uncompressed_size_body = Vec::<TokenStream>::with_capacity(len);
-
-    match ast.data {
-        Data::Struct(ref data_struct) => {
-            let mut idents = Vec::<IdentOrIndex>::new();
-
-            for (i, field) in data_struct.fields.iter().enumerate() {
-                match field.ident {
-                    None => {
-                        let index = Index::from(i);
-                        idents.push(IdentOrIndex::Index(index));
-                    }
-                    Some(ref ident) => {
-                        idents.push(IdentOrIndex::Ident(ident.clone()));
-                    }
-                }
-
-                impl_serialize_field(
-                    &mut serialize_body,
-                    &mut serialized_size_body,
-                    &mut serialize_uncompressed_body,
-                    &mut uncompressed_size_body,
-                    &mut idents,
-                    &field.ty,
-                );
-
-                idents.clear();
-            }
-        }
-        _ => panic!("Serialize can only be derived for structs, {} is not a struct", name),
-    };
-
-    let gen = quote! {
-        impl #impl_generics CanonicalSerialize for #name #ty_generics #where_clause {
-            #[allow(unused_mut, unused_variables)]
-            fn serialize<W: snarkvm_utilities::Write>(&self, writer: &mut W) -> Result<(), snarkvm_utilities::SerializationError> {
-                #(#serialize_body)*
-                Ok(())
-            }
-            #[allow(unused_mut, unused_variables)]
-            fn serialized_size(&self) -> usize {
-                let mut size = 0;
-                #(#serialized_size_body)*
-                size
-            }
-            #[allow(unused_mut, unused_variables)]
-            fn serialize_uncompressed<W: snarkvm_utilities::Write>(&self, writer: &mut W) -> Result<(), snarkvm_utilities::SerializationError> {
-                #(#serialize_uncompressed_body)*
-                Ok(())
-            }
-            #[allow(unused_mut, unused_variables)]
-            fn uncompressed_size(&self) -> usize {
-                let mut size = 0;
-                #(#uncompressed_size_body)*
-                size
-            }
-        }
-    };
-    gen
+    proc_macro::TokenStream::from(canonical_serialize::impl_canonical_serialize(&ast))
 }
 
 #[proc_macro_derive(CanonicalDeserialize)]
 pub fn derive_canonical_deserialize(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
-    proc_macro::TokenStream::from(impl_canonical_deserialize(&ast))
-}
-
-/// Returns two TokenStreams, one for the compressed deserialize, one for the
-/// uncompressed.
-fn impl_deserialize_field(ty: &Type) -> (TokenStream, TokenStream) {
-    // Check if type is a tuple.
-    match ty {
-        Type::Tuple(tuple) => {
-            let (compressed_fields, uncompressed_fields): (Vec<_>, Vec<_>) =
-                tuple.elems.iter().map(impl_deserialize_field).unzip();
-            (quote! { (#(#compressed_fields)*), }, quote! { (#(#uncompressed_fields)*), })
-        }
-        _ => (
-            quote! { CanonicalDeserialize::deserialize(reader)?, },
-            quote! { CanonicalDeserialize::deserialize_uncompressed(reader)?, },
-        ),
-    }
-}
-
-fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
-    let name = &ast.ident;
-
-    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-
-    let deserialize_body;
-    let deserialize_uncompressed_body;
-
-    match ast.data {
-        Data::Struct(ref data_struct) => {
-            let mut tuple = false;
-            let mut compressed_field_cases = Vec::<TokenStream>::with_capacity(data_struct.fields.len());
-            let mut uncompressed_field_cases = Vec::<TokenStream>::with_capacity(data_struct.fields.len());
-            for field in data_struct.fields.iter() {
-                match &field.ident {
-                    None => {
-                        tuple = true;
-                        let (compressed, uncompressed) = impl_deserialize_field(&field.ty);
-                        compressed_field_cases.push(compressed);
-                        uncompressed_field_cases.push(uncompressed);
-                    }
-                    // struct field without len_type
-                    Some(ident) => {
-                        let (compressed_field, uncompressed_field) = impl_deserialize_field(&field.ty);
-                        compressed_field_cases.push(quote! { #ident: #compressed_field });
-                        uncompressed_field_cases.push(quote! { #ident: #uncompressed_field });
-                    }
-                }
-            }
-
-            if tuple {
-                deserialize_body = quote!({
-                    Ok(#name (
-                        #(#compressed_field_cases)*
-                    ))
-                });
-                deserialize_uncompressed_body = quote!({
-                    Ok(#name (
-                        #(#uncompressed_field_cases)*
-                    ))
-                });
-            } else {
-                deserialize_body = quote!({
-                    Ok(#name {
-                        #(#compressed_field_cases)*
-                    })
-                });
-                deserialize_uncompressed_body = quote!({
-                    Ok(#name {
-                        #(#uncompressed_field_cases)*
-                    })
-                });
-            }
-        }
-        _ => panic!("Deserialize can only be derived for structs, {} is not a Struct", name),
-    };
-
-    let gen = quote! {
-        impl #impl_generics CanonicalDeserialize for #name #ty_generics #where_clause {
-            #[allow(unused_mut,unused_variables)]
-            fn deserialize<R: snarkvm_utilities::Read>(reader: &mut R) -> Result<Self, snarkvm_utilities::SerializationError> {
-                #deserialize_body
-            }
-            #[allow(unused_mut,unused_variables)]
-            fn deserialize_uncompressed<R: snarkvm_utilities::Read>(reader: &mut R) -> Result<Self, snarkvm_utilities::SerializationError> {
-                #deserialize_uncompressed_body
-            }
-        }
-    };
-    gen
+    proc_macro::TokenStream::from(canonical_deserialize::impl_canonical_deserialize(&ast))
 }
 
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn test_with_metrics(_: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match parse::<ItemFn>(item.clone()) {
-        Ok(function) => {
-            fn generate_test_function(function: ItemFn, crate_name: Ident) -> proc_macro::TokenStream {
-                let name = &function.sig.ident;
-                let statements = function.block.stmts;
-                (quote! {
-                    // Generates a new test with Prometheus registry checks, and enforces
-                    // that the test runs serially with other tests that use metrics.
-                    #[test]
-                    #[serial]
-                    fn #name() {
-                        // Initialize Prometheus once in the test environment.
-                        #crate_name::testing::initialize_prometheus_for_testing();
-                        // Check that all metrics are 0 or empty.
-                        assert_eq!(0, #crate_name::Metrics::get_connected_peers());
-                        // Run the test logic.
-                        #(#statements)*
-                        // Check that all metrics are reset to 0 or empty (for next test).
-                        assert_eq!(0, Metrics::get_connected_peers());
-                    }
-                })
-                .into()
-            }
-            let name = crate_name("snarkos-metrics").unwrap_or_else(|_| "crate".to_string());
-            let crate_name = Ident::new(&name, Span::call_site());
-            generate_test_function(function, crate_name)
-        }
+        Ok(function) => test_with_metrics::generate_test_function(function),
         _ => abort_call_site!("test_with_metrics only works on functions"),
     }
 }

--- a/utilities/derives/src/lib.rs
+++ b/utilities/derives/src/lib.rs
@@ -15,12 +15,11 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 mod canonical_deserialize;
-
 mod canonical_serialize;
 
 mod enum_from_bytes;
-
 mod enum_to_bytes;
+mod enum_validate_input;
 
 mod test_with_metrics;
 
@@ -39,12 +38,20 @@ pub fn derive_canonical_deserialize(input: proc_macro::TokenStream) -> proc_macr
     proc_macro::TokenStream::from(canonical_deserialize::impl_canonical_deserialize(&ast))
 }
 
+/// This macro is used to derive `FromBytes` for an enum.
+/// This macro requires that the fields of tuple and struct enum variants also implement `FromBytes`.
+/// Users must define a `tag` attribute on the enum, which must be a primitive integer type.
+/// The `tag` attribute determines the size of the enum tag.
 #[proc_macro_derive(EnumFromBytes, attributes(tag))]
 pub fn derive_enum_from_bytes(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     proc_macro::TokenStream::from(enum_from_bytes::impl_from_bytes(&ast))
 }
 
+/// This macro is used to derive `ToBytes` for an enum.
+/// This macro requires that the fields of tuple and struct enum variants also implement `ToBytes`.
+/// Users must define a `tag` attribute on the enum, which must be a primitive integer type.
+/// The `tag` attribute determines the size of the enum tag.
 #[proc_macro_derive(EnumToBytes, attributes(tag))]
 pub fn derive_enum_to_bytes(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/utilities/derives/src/test_with_metrics.rs
+++ b/utilities/derives/src/test_with_metrics.rs
@@ -1,0 +1,44 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use proc_macro2::{Ident, Span};
+use proc_macro_crate::crate_name;
+use quote::quote;
+use syn::ItemFn;
+
+pub(crate) fn generate_test_function(function: ItemFn) -> proc_macro::TokenStream {
+    let name = &function.sig.ident;
+    let crate_name =
+        Ident::new(&crate_name("snarkos-metrics").unwrap_or_else(|_| "crate".to_string()), Span::call_site());
+    let statements = function.block.stmts;
+    (quote! {
+        // Generates a new test with Prometheus registry checks, and enforces
+        // that the test runs serially with other tests that use metrics.
+        #[test]
+        #[serial]
+        fn #name() {
+            // Initialize Prometheus once in the test environment.
+            #crate_name::testing::initialize_prometheus_for_testing();
+            // Check that all metrics are 0 or empty.
+            assert_eq!(0, #crate_name::Metrics::get_connected_peers());
+            // Run the test logic.
+            #(#statements)*
+            // Check that all metrics are reset to 0 or empty (for next test).
+            assert_eq!(0, Metrics::get_connected_peers());
+        }
+    })
+    .into()
+}


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Implementing `ToBytes` and `FromBytes` for enums requires hard-coded constants for enum tags.
This is hard to maintain as enum variants are introduced or removed.
This PR introduces two proc macros that derive the implementations for enums.

## Test Plan

Tests in `bytecode` verifying that instructions are given the correct tags.
