### PR TITLE
test: add test for address parser

### DIFF
--- a/circuits/types/address/src/lib.rs
+++ b/circuits/types/address/src/lib.rs
@@ -148,3 +148,18 @@ impl<E: Environment> Display for Address<E> {
         write!(f, "{}.{}", address, self.eject_mode())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_circuits_environment::Circuit;
+
+    #[test]
+    fn test_address_parse() -> Result<(), String> {
+        let address = "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.public";
+        match Address::<Circuit>::parse(address) {
+            Ok(_) => Ok(()),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Fix a bug in the address parsing found in testing the bytecode. The test named `test_address_parse` in [circuits/types/address/src/lib.rs](https://github.com/AleoHQ/snarkVM/compare/fix/circuits-address-parser?expand=1#diff-9d4558b41c6b04863e754cfc85fcb82f7a5eb4401eeabab6d42447f2a0cec3f5) will fail until the bug is addressed.