### PR TITLE
 feat: impl Add, Mul, Neg, Sub instructions

### DIFF
--- a/bytecode/src/function/instructions/add.rs
+++ b/bytecode/src/function/instructions/add.rs
@@ -147,70 +147,70 @@ mod tests {
     test_modes!(scalar, Add, "1scalar", "2scalar", "3scalar");
 
     test_instruction_halts!(
-        i8_overflow,
+        i8_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}i8.constant", i8::MAX),
         "1i8.constant"
     );
     test_instruction_halts!(
-        i16_overflow,
+        i16_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}i16.constant", i16::MAX),
         "1i16.constant"
     );
     test_instruction_halts!(
-        i32_overflow,
+        i32_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}i32.constant", i32::MAX),
         "1i32.constant"
     );
     test_instruction_halts!(
-        i64_overflow,
+        i64_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}i64.constant", i64::MAX),
         "1i64.constant"
     );
     test_instruction_halts!(
-        i128_overflow,
+        i128_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}i128.constant", i128::MAX),
         "1i128.constant"
     );
     test_instruction_halts!(
-        u8_overflow,
+        u8_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}u8.constant", u8::MAX),
         "1u8.constant"
     );
     test_instruction_halts!(
-        u16_overflow,
+        u16_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}u16.constant", u16::MAX),
         "1u16.constant"
     );
     test_instruction_halts!(
-        u32_overflow,
+        u32_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}u32.constant", u32::MAX),
         "1u32.constant"
     );
     test_instruction_halts!(
-        u64_overflow,
+        u64_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}u64.constant", u64::MAX),
         "1u64.constant"
     );
     test_instruction_halts!(
-        u128_overflow,
+        u128_overflow_halts,
         Add,
         "Integer overflow on addition of two constants",
         &format!("{}u128.constant", u128::MAX),
@@ -218,18 +218,18 @@ mod tests {
     );
 
     test_instruction_halts!(
-        address,
+        address_halts,
         Add,
         "Invalid 'add' instruction",
         "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
         "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
     );
-    test_instruction_halts!(boolean, Add, "Invalid 'add' instruction", "true.constant", "true.constant");
-    test_instruction_halts!(string, Add, "Invalid 'add' instruction", "\"hello\".constant", "\"world\".constant");
+    test_instruction_halts!(boolean_halts, Add, "Invalid 'add' instruction", "true.constant", "true.constant");
+    test_instruction_halts!(string_halts, Add, "Invalid 'add' instruction", "\"hello\".constant", "\"world\".constant");
 
     #[test]
     #[should_panic(expected = "message is not a literal")]
-    fn test_halts_on_composite() {
+    fn test_composite_halts() {
         let first = Value::<P>::Composite(Identifier::from_str("message"), vec![
             Literal::from_str("2group.public"),
             Literal::from_str("10field.private"),

--- a/bytecode/src/function/instructions/add.rs
+++ b/bytecode/src/function/instructions/add.rs
@@ -169,6 +169,176 @@ mod tests {
     }
 
     #[test]
+    fn test_add_i8() {
+        let negative_one = Value::<P>::from_str("-1i8.public");
+        let two = Value::<P>::from_str("2i8.private");
+        let one = Value::<P>::from_str("1i8.private");
+        check_add_test(negative_one, two, one);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_i8_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}i8.constant", i8::MAX));
+        let one = Value::<P>::from_str("1i8.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_i16() {
+        let negative_one = Value::<P>::from_str("-1i16.public");
+        let two = Value::<P>::from_str("2i16.private");
+        let one = Value::<P>::from_str("1i16.private");
+        check_add_test(negative_one, two, one);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_i16_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}i16.constant", i16::MAX));
+        let one = Value::<P>::from_str("1i16.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_i32() {
+        let negative_one = Value::<P>::from_str("-1i32.public");
+        let two = Value::<P>::from_str("2i32.private");
+        let one = Value::<P>::from_str("1i32.private");
+        check_add_test(negative_one, two, one);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_i32_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}i32.constant", i32::MAX));
+        let one = Value::<P>::from_str("1i32.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_i64() {
+        let negative_one = Value::<P>::from_str("-1i64.public");
+        let two = Value::<P>::from_str("2i64.private");
+        let one = Value::<P>::from_str("1i64.private");
+        check_add_test(negative_one, two, one);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_i64_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}i64.constant", i64::MAX));
+        let one = Value::<P>::from_str("1i64.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_i128() {
+        let negative_one = Value::<P>::from_str("-1i128.public");
+        let two = Value::<P>::from_str("2i128.private");
+        let one = Value::<P>::from_str("1i128.private");
+        check_add_test(negative_one, two, one);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_i128_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}i128.constant", i128::MAX));
+        let one = Value::<P>::from_str("1i128.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_u8() {
+        let one = Value::<P>::from_str("1u8.public");
+        let two = Value::<P>::from_str("2u8.private");
+        let three = Value::<P>::from_str("3u8.private");
+        check_add_test(one, two, three);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_u8_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}u8.constant", u8::MAX));
+        let one = Value::<P>::from_str("1u8.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_u16() {
+        let one = Value::<P>::from_str("1u16.public");
+        let two = Value::<P>::from_str("2u16.private");
+        let three = Value::<P>::from_str("3u16.private");
+        check_add_test(one, two, three);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_u16_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}u16.constant", u16::MAX));
+        let one = Value::<P>::from_str("1u16.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_u32() {
+        let one = Value::<P>::from_str("1u32.public");
+        let two = Value::<P>::from_str("2u32.private");
+        let three = Value::<P>::from_str("3u32.private");
+        check_add_test(one, two, three);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_u32_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}u32.constant", u32::MAX));
+        let one = Value::<P>::from_str("1u32.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_u64() {
+        let one = Value::<P>::from_str("1u64.public");
+        let two = Value::<P>::from_str("2u64.private");
+        let three = Value::<P>::from_str("3u64.private");
+        check_add_test(one, two, three);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_u64_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}u64.constant", u64::MAX));
+        let one = Value::<P>::from_str("1u64.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
+    fn test_add_u128() {
+        let one = Value::<P>::from_str("1u128.public");
+        let two = Value::<P>::from_str("2u128.private");
+        let three = Value::<P>::from_str("3u128.private");
+        check_add_test(one, two, three);
+    }
+
+    #[test]
+    #[should_panic(expected = "Integer overflow on addition of two constants")]
+    fn test_add_u128_constant_overflow_halts() {
+        let max = Value::<P>::from_str(&format!("{}u128.constant", u128::MAX));
+        let one = Value::<P>::from_str("1u128.constant");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
+        check_add_test(max, one, unreachable);
+    }
+
+    #[test]
     #[should_panic(expected = "message is not a literal")]
     fn test_halts_on_composite() {
         let composite = Value::<P>::Composite(Identifier::from_str("message"), vec![
@@ -176,8 +346,9 @@ mod tests {
             Literal::from_str("10field.private"),
         ]);
         let second = Value::<P>::from_str("4scalar.public");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(composite, second, Value::<P>::from_str("\"Unreachable\".private"));
+        check_add_test(composite, second, unreachable);
     }
 
     #[test]
@@ -185,8 +356,9 @@ mod tests {
     fn test_halts_on_string_operand() {
         let invalid_add_literal = Value::<P>::from_str("\"hello world\".public");
         let second = Value::<P>::from_str("4scalar.public");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(invalid_add_literal, second, Value::<P>::from_str("\"Unreachable\".private"));
+        check_add_test(invalid_add_literal, second, unreachable);
     }
 
     #[test]
@@ -195,8 +367,9 @@ mod tests {
         let invalid_add_literal =
             Value::<P>::from_str("aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.public");
         let second = Value::<P>::from_str("4scalar.public");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(invalid_add_literal, second, Value::<P>::from_str("\"Unreachable\".private"));
+        check_add_test(invalid_add_literal, second, unreachable);
     }
 
     #[test]
@@ -204,7 +377,8 @@ mod tests {
     fn test_halts_on_boolean_operand() {
         let invalid_add_literal = Value::<P>::from_str("true.public");
         let second = Value::<P>::from_str("4scalar.public");
+        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(invalid_add_literal, second, Value::<P>::from_str("\"Unreachable\".private"));
+        check_add_test(invalid_add_literal, second, unreachable);
     }
 }

--- a/bytecode/src/function/instructions/add.rs
+++ b/bytecode/src/function/instructions/add.rs
@@ -135,8 +135,8 @@ mod tests {
     mod modes {
         use super::*;
 
-        macro_rules! add_test {
-            ($test_name: ident, $a: expr, $b: expr, $c: expr, $assert_equal: expr) => {
+        macro_rules! binary_instruction_test {
+            ($test_name: ident, $instruction: ident, $a: expr, $b: expr, $c: expr, $assert_equal: expr) => {
                 #[test]
                 fn $test_name() {
                     let a = Value::<P>::from_str($a);
@@ -150,7 +150,7 @@ mod tests {
                     registers.assign(&Register::from_str("r0"), a);
                     registers.assign(&Register::from_str("r1"), b);
 
-                    Add::from_str("r0 r1 into r2").evaluate(&registers);
+                    $instruction::from_str("r0 r1 into r2").evaluate(&registers);
                     let candidate = registers.load(&Register::from_str("r2"));
                     if $assert_equal {
                         assert_eq!(expected, candidate);
@@ -163,68 +163,76 @@ mod tests {
         }
 
         macro_rules! test_modes {
-            ($type: ident, $a: expr, $b: expr, $expected: expr) => {
+            ($type: ident, $instruction: ident, $a: expr, $b: expr, $expected: expr) => {
                 mod $type {
                     use super::*;
 
-                    add_test!(
-                        test_public_add_public_is_not_public,
+                    binary_instruction_test!(
+                        test_public_and_public_is_not_public,
+                        $instruction,
                         concat!($a, ".public"),
                         concat!($b, ".public"),
                         concat!($expected, ".public"),
                         false
                     );
 
-                    add_test!(
-                        test_public_add_public_is_private,
+                    binary_instruction_test!(
+                        test_public_and_public_is_private,
+                        $instruction,
                         concat!($a, ".public"),
                         concat!($b, ".public"),
                         concat!($expected, ".private"),
                         true
                     );
 
-                    add_test!(
-                        test_public_add_private_is_not_public,
+                    binary_instruction_test!(
+                        test_public_and_private_is_not_public,
+                        $instruction,
                         concat!($a, ".public"),
                         concat!($b, ".private"),
                         concat!($expected, ".public"),
                         false
                     );
 
-                    add_test!(
-                        test_public_add_private_is_private,
+                    binary_instruction_test!(
+                        test_public_and_private_is_private,
+                        $instruction,
                         concat!($a, ".public"),
                         concat!($b, ".private"),
                         concat!($expected, ".private"),
                         true
                     );
 
-                    add_test!(
-                        test_private_add_public_is_not_public,
+                    binary_instruction_test!(
+                        test_private_and_public_is_not_public,
+                        $instruction,
                         concat!($a, ".private"),
                         concat!($b, ".public"),
                         concat!($expected, ".public"),
                         false
                     );
 
-                    add_test!(
-                        test_private_add_public_is_private,
+                    binary_instruction_test!(
+                        test_private_and_public_is_private,
+                        $instruction,
                         concat!($a, ".private"),
                         concat!($b, ".public"),
                         concat!($expected, ".private"),
                         true
                     );
 
-                    add_test!(
-                        test_private_add_private_is_not_public,
+                    binary_instruction_test!(
+                        test_private_and_private_is_not_public,
+                        $instruction,
                         concat!($a, ".private"),
                         concat!($b, ".private"),
                         concat!($expected, ".public"),
                         false
                     );
 
-                    add_test!(
-                        test_private_add_private_is_private,
+                    binary_instruction_test!(
+                        test_private_and_private_is_private,
+                        $instruction,
                         concat!($a, ".private"),
                         concat!($b, ".private"),
                         concat!($expected, ".private"),
@@ -234,22 +242,22 @@ mod tests {
             };
         }
 
-        test_modes!(field, "1field", "2field", "3field");
-        test_modes!(group, "2group", "0group", "2group");
-        test_modes!(i8, "-1i8", "2i8", "1i8");
-        test_modes!(i16, "-1i16", "2i16", "1i16");
-        test_modes!(i32, "-1i32", "2i32", "1i32");
-        test_modes!(i64, "-1i64", "2i64", "1i64");
-        test_modes!(i128, "-1i128", "2i128", "1i128");
-        test_modes!(u8, "1u8", "2u8", "3u8");
-        test_modes!(u16, "1u16", "2u16", "3u16");
-        test_modes!(u32, "1u32", "2u32", "3u32");
-        test_modes!(u64, "1u64", "2u64", "3u64");
-        test_modes!(u128, "1u128", "2u128", "3u128");
-        test_modes!(scalar, "1scalar", "2scalar", "3scalar");
+        test_modes!(field, Add, "1field", "2field", "3field");
+        test_modes!(group, Add, "2group", "0group", "2group");
+        test_modes!(i8, Add, "-1i8", "2i8", "1i8");
+        test_modes!(i16, Add, "-1i16", "2i16", "1i16");
+        test_modes!(i32, Add, "-1i32", "2i32", "1i32");
+        test_modes!(i64, Add, "-1i64", "2i64", "1i64");
+        test_modes!(i128, Add, "-1i128", "2i128", "1i128");
+        test_modes!(u8, Add, "1u8", "2u8", "3u8");
+        test_modes!(u16, Add, "1u16", "2u16", "3u16");
+        test_modes!(u32, Add, "1u32", "2u32", "3u32");
+        test_modes!(u64, Add, "1u64", "2u64", "3u64");
+        test_modes!(u128, Add, "1u128", "2u128", "3u128");
+        test_modes!(scalar, Add, "1scalar", "2scalar", "3scalar");
     }
 
-    fn check_add_test(first: Value<P>, second: Value<P>, expected: Value<P>) {
+    fn check_binary_instruction_test(first: Value<P>, second: Value<P>, expected: Value<P>) {
         let registers = Registers::<P>::default();
         registers.define(&Register::from_str("r0"));
         registers.define(&Register::from_str("r1"));
@@ -267,14 +275,14 @@ mod tests {
         let one = Value::<P>::from_str("1field.public");
         let two = Value::<P>::from_str("2field.private");
         let three = Value::<P>::from_str("3field.private");
-        check_add_test(one, two, three);
+        check_binary_instruction_test(one, two, three);
     }
 
     #[test]
     fn test_add_group() {
         let two = Value::<P>::from_str("2group.private");
         let zero = Value::<P>::from_str("0group.private");
-        check_add_test(two.clone(), zero, two);
+        check_binary_instruction_test(two.clone(), zero, two);
     }
 
     #[test]
@@ -282,7 +290,7 @@ mod tests {
         let one = Value::<P>::from_str("1scalar.public");
         let two = Value::<P>::from_str("2scalar.private");
         let three = Value::<P>::from_str("3scalar.private");
-        check_add_test(one, two, three);
+        check_binary_instruction_test(one, two, three);
     }
 
     #[test]
@@ -290,7 +298,7 @@ mod tests {
         let negative_one = Value::<P>::from_str("-1i8.public");
         let two = Value::<P>::from_str("2i8.private");
         let one = Value::<P>::from_str("1i8.private");
-        check_add_test(negative_one, two, one);
+        check_binary_instruction_test(negative_one, two, one);
     }
 
     #[test]
@@ -299,7 +307,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}i8.constant", i8::MAX));
         let one = Value::<P>::from_str("1i8.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -307,7 +315,7 @@ mod tests {
         let negative_one = Value::<P>::from_str("-1i16.public");
         let two = Value::<P>::from_str("2i16.private");
         let one = Value::<P>::from_str("1i16.private");
-        check_add_test(negative_one, two, one);
+        check_binary_instruction_test(negative_one, two, one);
     }
 
     #[test]
@@ -316,7 +324,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}i16.constant", i16::MAX));
         let one = Value::<P>::from_str("1i16.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -324,7 +332,7 @@ mod tests {
         let negative_one = Value::<P>::from_str("-1i32.public");
         let two = Value::<P>::from_str("2i32.private");
         let one = Value::<P>::from_str("1i32.private");
-        check_add_test(negative_one, two, one);
+        check_binary_instruction_test(negative_one, two, one);
     }
 
     #[test]
@@ -333,7 +341,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}i32.constant", i32::MAX));
         let one = Value::<P>::from_str("1i32.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -341,7 +349,7 @@ mod tests {
         let negative_one = Value::<P>::from_str("-1i64.public");
         let two = Value::<P>::from_str("2i64.private");
         let one = Value::<P>::from_str("1i64.private");
-        check_add_test(negative_one, two, one);
+        check_binary_instruction_test(negative_one, two, one);
     }
 
     #[test]
@@ -350,7 +358,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}i64.constant", i64::MAX));
         let one = Value::<P>::from_str("1i64.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -358,7 +366,7 @@ mod tests {
         let negative_one = Value::<P>::from_str("-1i128.public");
         let two = Value::<P>::from_str("2i128.private");
         let one = Value::<P>::from_str("1i128.private");
-        check_add_test(negative_one, two, one);
+        check_binary_instruction_test(negative_one, two, one);
     }
 
     #[test]
@@ -367,7 +375,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}i128.constant", i128::MAX));
         let one = Value::<P>::from_str("1i128.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -375,7 +383,7 @@ mod tests {
         let one = Value::<P>::from_str("1u8.public");
         let two = Value::<P>::from_str("2u8.private");
         let three = Value::<P>::from_str("3u8.private");
-        check_add_test(one, two, three);
+        check_binary_instruction_test(one, two, three);
     }
 
     #[test]
@@ -384,7 +392,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}u8.constant", u8::MAX));
         let one = Value::<P>::from_str("1u8.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -392,7 +400,7 @@ mod tests {
         let one = Value::<P>::from_str("1u16.public");
         let two = Value::<P>::from_str("2u16.private");
         let three = Value::<P>::from_str("3u16.private");
-        check_add_test(one, two, three);
+        check_binary_instruction_test(one, two, three);
     }
 
     #[test]
@@ -401,7 +409,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}u16.constant", u16::MAX));
         let one = Value::<P>::from_str("1u16.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -409,7 +417,7 @@ mod tests {
         let one = Value::<P>::from_str("1u32.public");
         let two = Value::<P>::from_str("2u32.private");
         let three = Value::<P>::from_str("3u32.private");
-        check_add_test(one, two, three);
+        check_binary_instruction_test(one, two, three);
     }
 
     #[test]
@@ -418,7 +426,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}u32.constant", u32::MAX));
         let one = Value::<P>::from_str("1u32.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -426,7 +434,7 @@ mod tests {
         let one = Value::<P>::from_str("1u64.public");
         let two = Value::<P>::from_str("2u64.private");
         let three = Value::<P>::from_str("3u64.private");
-        check_add_test(one, two, three);
+        check_binary_instruction_test(one, two, three);
     }
 
     #[test]
@@ -435,7 +443,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}u64.constant", u64::MAX));
         let one = Value::<P>::from_str("1u64.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -443,7 +451,7 @@ mod tests {
         let one = Value::<P>::from_str("1u128.public");
         let two = Value::<P>::from_str("2u128.private");
         let three = Value::<P>::from_str("3u128.private");
-        check_add_test(one, two, three);
+        check_binary_instruction_test(one, two, three);
     }
 
     #[test]
@@ -452,7 +460,7 @@ mod tests {
         let max = Value::<P>::from_str(&format!("{}u128.constant", u128::MAX));
         let one = Value::<P>::from_str("1u128.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
+        check_binary_instruction_test(max, one, unreachable);
     }
 
     #[test]
@@ -465,7 +473,7 @@ mod tests {
         let second = Value::<P>::from_str("4scalar.public");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(composite, second, unreachable);
+        check_binary_instruction_test(composite, second, unreachable);
     }
 
     #[test]
@@ -475,7 +483,7 @@ mod tests {
         let second = Value::<P>::from_str("4scalar.public");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(invalid_add_literal, second, unreachable);
+        check_binary_instruction_test(invalid_add_literal, second, unreachable);
     }
 
     #[test]
@@ -486,7 +494,7 @@ mod tests {
         let second = Value::<P>::from_str("4scalar.public");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(invalid_add_literal, second, unreachable);
+        check_binary_instruction_test(invalid_add_literal, second, unreachable);
     }
 
     #[test]
@@ -496,6 +504,6 @@ mod tests {
         let second = Value::<P>::from_str("4scalar.public");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
 
-        check_add_test(invalid_add_literal, second, unreachable);
+        check_binary_instruction_test(invalid_add_literal, second, unreachable);
     }
 }

--- a/bytecode/src/function/instructions/add.rs
+++ b/bytecode/src/function/instructions/add.rs
@@ -128,28 +128,23 @@ impl<P: Program> Into<Instruction<P>> for Add<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Identifier, Process, Register};
+    use crate::{test_modes, Identifier, Process, Register};
 
     type P = Process;
 
-    mod modes {
-        use super::Add;
-        use crate::test_modes;
-
-        test_modes!(field, Add, "1field", "2field", "3field");
-        test_modes!(group, Add, "2group", "0group", "2group");
-        test_modes!(i8, Add, "-1i8", "2i8", "1i8");
-        test_modes!(i16, Add, "-1i16", "2i16", "1i16");
-        test_modes!(i32, Add, "-1i32", "2i32", "1i32");
-        test_modes!(i64, Add, "-1i64", "2i64", "1i64");
-        test_modes!(i128, Add, "-1i128", "2i128", "1i128");
-        test_modes!(u8, Add, "1u8", "2u8", "3u8");
-        test_modes!(u16, Add, "1u16", "2u16", "3u16");
-        test_modes!(u32, Add, "1u32", "2u32", "3u32");
-        test_modes!(u64, Add, "1u64", "2u64", "3u64");
-        test_modes!(u128, Add, "1u128", "2u128", "3u128");
-        test_modes!(scalar, Add, "1scalar", "2scalar", "3scalar");
-    }
+    test_modes!(field, Add, "1field", "2field", "3field");
+    test_modes!(group, Add, "2group", "0group", "2group");
+    test_modes!(i8, Add, "-1i8", "2i8", "1i8");
+    test_modes!(i16, Add, "-1i16", "2i16", "1i16");
+    test_modes!(i32, Add, "-1i32", "2i32", "1i32");
+    test_modes!(i64, Add, "-1i64", "2i64", "1i64");
+    test_modes!(i128, Add, "-1i128", "2i128", "1i128");
+    test_modes!(u8, Add, "1u8", "2u8", "3u8");
+    test_modes!(u16, Add, "1u16", "2u16", "3u16");
+    test_modes!(u32, Add, "1u32", "2u32", "3u32");
+    test_modes!(u64, Add, "1u64", "2u64", "3u64");
+    test_modes!(u128, Add, "1u128", "2u128", "3u128");
+    test_modes!(scalar, Add, "1scalar", "2scalar", "3scalar");
 
     fn check_add_test(first: Value<P>, second: Value<P>, expected: Value<P>) {
         let registers = Registers::<P>::default();
@@ -165,51 +160,12 @@ mod tests {
     }
 
     #[test]
-    fn test_add_field() {
-        let one = Value::<P>::from_str("1field.public");
-        let two = Value::<P>::from_str("2field.private");
-        let three = Value::<P>::from_str("3field.private");
-        check_add_test(one, two, three);
-    }
-
-    #[test]
-    fn test_add_group() {
-        let two = Value::<P>::from_str("2group.private");
-        let zero = Value::<P>::from_str("0group.private");
-        check_add_test(two.clone(), zero, two);
-    }
-
-    #[test]
-    fn test_add_scalar() {
-        let one = Value::<P>::from_str("1scalar.public");
-        let two = Value::<P>::from_str("2scalar.private");
-        let three = Value::<P>::from_str("3scalar.private");
-        check_add_test(one, two, three);
-    }
-
-    #[test]
-    fn test_add_i8() {
-        let negative_one = Value::<P>::from_str("-1i8.public");
-        let two = Value::<P>::from_str("2i8.private");
-        let one = Value::<P>::from_str("1i8.private");
-        check_add_test(negative_one, two, one);
-    }
-
-    #[test]
     #[should_panic(expected = "Integer overflow on addition of two constants")]
     fn test_add_i8_constant_overflow_halts() {
         let max = Value::<P>::from_str(&format!("{}i8.constant", i8::MAX));
         let one = Value::<P>::from_str("1i8.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
         check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    fn test_add_i16() {
-        let negative_one = Value::<P>::from_str("-1i16.public");
-        let two = Value::<P>::from_str("2i16.private");
-        let one = Value::<P>::from_str("1i16.private");
-        check_add_test(negative_one, two, one);
     }
 
     #[test]
@@ -222,28 +178,12 @@ mod tests {
     }
 
     #[test]
-    fn test_add_i32() {
-        let negative_one = Value::<P>::from_str("-1i32.public");
-        let two = Value::<P>::from_str("2i32.private");
-        let one = Value::<P>::from_str("1i32.private");
-        check_add_test(negative_one, two, one);
-    }
-
-    #[test]
     #[should_panic(expected = "Integer overflow on addition of two constants")]
     fn test_add_i32_constant_overflow_halts() {
         let max = Value::<P>::from_str(&format!("{}i32.constant", i32::MAX));
         let one = Value::<P>::from_str("1i32.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
         check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    fn test_add_i64() {
-        let negative_one = Value::<P>::from_str("-1i64.public");
-        let two = Value::<P>::from_str("2i64.private");
-        let one = Value::<P>::from_str("1i64.private");
-        check_add_test(negative_one, two, one);
     }
 
     #[test]
@@ -256,28 +196,12 @@ mod tests {
     }
 
     #[test]
-    fn test_add_i128() {
-        let negative_one = Value::<P>::from_str("-1i128.public");
-        let two = Value::<P>::from_str("2i128.private");
-        let one = Value::<P>::from_str("1i128.private");
-        check_add_test(negative_one, two, one);
-    }
-
-    #[test]
     #[should_panic(expected = "Integer overflow on addition of two constants")]
     fn test_add_i128_constant_overflow_halts() {
         let max = Value::<P>::from_str(&format!("{}i128.constant", i128::MAX));
         let one = Value::<P>::from_str("1i128.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
         check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    fn test_add_u8() {
-        let one = Value::<P>::from_str("1u8.public");
-        let two = Value::<P>::from_str("2u8.private");
-        let three = Value::<P>::from_str("3u8.private");
-        check_add_test(one, two, three);
     }
 
     #[test]
@@ -290,28 +214,12 @@ mod tests {
     }
 
     #[test]
-    fn test_add_u16() {
-        let one = Value::<P>::from_str("1u16.public");
-        let two = Value::<P>::from_str("2u16.private");
-        let three = Value::<P>::from_str("3u16.private");
-        check_add_test(one, two, three);
-    }
-
-    #[test]
     #[should_panic(expected = "Integer overflow on addition of two constants")]
     fn test_add_u16_constant_overflow_halts() {
         let max = Value::<P>::from_str(&format!("{}u16.constant", u16::MAX));
         let one = Value::<P>::from_str("1u16.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
         check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    fn test_add_u32() {
-        let one = Value::<P>::from_str("1u32.public");
-        let two = Value::<P>::from_str("2u32.private");
-        let three = Value::<P>::from_str("3u32.private");
-        check_add_test(one, two, three);
     }
 
     #[test]
@@ -324,28 +232,12 @@ mod tests {
     }
 
     #[test]
-    fn test_add_u64() {
-        let one = Value::<P>::from_str("1u64.public");
-        let two = Value::<P>::from_str("2u64.private");
-        let three = Value::<P>::from_str("3u64.private");
-        check_add_test(one, two, three);
-    }
-
-    #[test]
     #[should_panic(expected = "Integer overflow on addition of two constants")]
     fn test_add_u64_constant_overflow_halts() {
         let max = Value::<P>::from_str(&format!("{}u64.constant", u64::MAX));
         let one = Value::<P>::from_str("1u64.constant");
         let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
         check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    fn test_add_u128() {
-        let one = Value::<P>::from_str("1u128.public");
-        let two = Value::<P>::from_str("2u128.private");
-        let three = Value::<P>::from_str("3u128.private");
-        check_add_test(one, two, three);
     }
 
     #[test]

--- a/bytecode/src/function/instructions/add.rs
+++ b/bytecode/src/function/instructions/add.rs
@@ -128,7 +128,7 @@ impl<P: Program> Into<Instruction<P>> for Add<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_modes, Identifier, Process, Register};
+    use crate::{test_instruction_halts, test_modes, Identifier, Process, Register};
 
     type P = Process;
 
@@ -146,7 +146,96 @@ mod tests {
     test_modes!(u128, Add, "1u128", "2u128", "3u128");
     test_modes!(scalar, Add, "1scalar", "2scalar", "3scalar");
 
-    fn check_add_test(first: Value<P>, second: Value<P>, expected: Value<P>) {
+    test_instruction_halts!(
+        i8_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}i8.constant", i8::MAX),
+        "1i8.constant"
+    );
+    test_instruction_halts!(
+        i16_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}i16.constant", i16::MAX),
+        "1i16.constant"
+    );
+    test_instruction_halts!(
+        i32_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}i32.constant", i32::MAX),
+        "1i32.constant"
+    );
+    test_instruction_halts!(
+        i64_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}i64.constant", i64::MAX),
+        "1i64.constant"
+    );
+    test_instruction_halts!(
+        i128_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}i128.constant", i128::MAX),
+        "1i128.constant"
+    );
+    test_instruction_halts!(
+        u8_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}u8.constant", u8::MAX),
+        "1u8.constant"
+    );
+    test_instruction_halts!(
+        u16_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}u16.constant", u16::MAX),
+        "1u16.constant"
+    );
+    test_instruction_halts!(
+        u32_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}u32.constant", u32::MAX),
+        "1u32.constant"
+    );
+    test_instruction_halts!(
+        u64_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}u64.constant", u64::MAX),
+        "1u64.constant"
+    );
+    test_instruction_halts!(
+        u128_overflow,
+        Add,
+        "Integer overflow on addition of two constants",
+        &format!("{}u128.constant", u128::MAX),
+        "1u128.constant"
+    );
+
+    test_instruction_halts!(
+        address,
+        Add,
+        "Invalid 'add' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(boolean, Add, "Invalid 'add' instruction", "true.constant", "true.constant");
+    test_instruction_halts!(string, Add, "Invalid 'add' instruction", "\"hello\".constant", "\"world\".constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_halts_on_composite() {
+        let first = Value::<P>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
         let registers = Registers::<P>::default();
         registers.define(&Register::from_str("r0"));
         registers.define(&Register::from_str("r1"));
@@ -155,141 +244,5 @@ mod tests {
         registers.assign(&Register::from_str("r1"), second);
 
         Add::from_str("r0 r1 into r2").evaluate(&registers);
-        let candidate = registers.load(&Register::from_str("r2"));
-        assert_eq!(expected, candidate);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_i8_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}i8.constant", i8::MAX));
-        let one = Value::<P>::from_str("1i8.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_i16_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}i16.constant", i16::MAX));
-        let one = Value::<P>::from_str("1i16.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_i32_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}i32.constant", i32::MAX));
-        let one = Value::<P>::from_str("1i32.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_i64_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}i64.constant", i64::MAX));
-        let one = Value::<P>::from_str("1i64.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_i128_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}i128.constant", i128::MAX));
-        let one = Value::<P>::from_str("1i128.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_u8_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}u8.constant", u8::MAX));
-        let one = Value::<P>::from_str("1u8.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_u16_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}u16.constant", u16::MAX));
-        let one = Value::<P>::from_str("1u16.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_u32_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}u32.constant", u32::MAX));
-        let one = Value::<P>::from_str("1u32.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_u64_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}u64.constant", u64::MAX));
-        let one = Value::<P>::from_str("1u64.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Integer overflow on addition of two constants")]
-    fn test_add_u128_constant_overflow_halts() {
-        let max = Value::<P>::from_str(&format!("{}u128.constant", u128::MAX));
-        let one = Value::<P>::from_str("1u128.constant");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-        check_add_test(max, one, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "message is not a literal")]
-    fn test_halts_on_composite() {
-        let composite = Value::<P>::Composite(Identifier::from_str("message"), vec![
-            Literal::from_str("2group.public"),
-            Literal::from_str("10field.private"),
-        ]);
-        let second = Value::<P>::from_str("4scalar.public");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-
-        check_add_test(composite, second, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Invalid 'add' instruction")]
-    fn test_halts_on_string_operand() {
-        let invalid_add_literal = Value::<P>::from_str("\"hello world\".public");
-        let second = Value::<P>::from_str("4scalar.public");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-
-        check_add_test(invalid_add_literal, second, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Invalid 'add' instruction")]
-    fn test_halts_on_address_operand() {
-        let invalid_add_literal =
-            Value::<P>::from_str("aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.public");
-        let second = Value::<P>::from_str("4scalar.public");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-
-        check_add_test(invalid_add_literal, second, unreachable);
-    }
-
-    #[test]
-    #[should_panic(expected = "Invalid 'add' instruction")]
-    fn test_halts_on_boolean_operand() {
-        let invalid_add_literal = Value::<P>::from_str("true.public");
-        let second = Value::<P>::from_str("4scalar.public");
-        let unreachable = Value::<P>::from_str("\"Unreachable\".constant");
-
-        check_add_test(invalid_add_literal, second, unreachable);
     }
 }

--- a/bytecode/src/function/instructions/add.rs
+++ b/bytecode/src/function/instructions/add.rs
@@ -132,6 +132,119 @@ mod tests {
 
     type P = Process;
 
+    macro_rules! impl_add_test {
+        ($test_name: ident, $a: expr, $b: expr, $c: expr, $assert_equal: expr) => {
+            #[test]
+            fn $test_name() {
+                let a = Value::<P>::from_str($a);
+                let b = Value::<P>::from_str($b);
+                let expected = Value::<P>::from_str($c);
+
+                let registers = Registers::<P>::default();
+                registers.define(&Register::from_str("r0"));
+                registers.define(&Register::from_str("r1"));
+                registers.define(&Register::from_str("r2"));
+                registers.assign(&Register::from_str("r0"), a);
+                registers.assign(&Register::from_str("r1"), b);
+
+                Add::from_str("r0 r1 into r2").evaluate(&registers);
+                let candidate = registers.load(&Register::from_str("r2"));
+                if $assert_equal {
+                    assert_eq!(expected, candidate);
+                } else {
+                    // The equality check should fail due to mismatched Modes.
+                    assert_ne!(expected, candidate);
+                }
+            }
+        };
+    }
+
+    macro_rules! test_modes {
+        ($type: ident, $a: expr, $b: expr, $expected: expr) => {
+            mod $type {
+                use super::*;
+
+                impl_add_test!(
+                    test_0,
+                    concat!($a, ".public"),
+                    concat!($b, ".public"),
+                    concat!($expected, ".public"),
+                    false
+                );
+
+                impl_add_test!(
+                    test_1,
+                    concat!($a, ".public"),
+                    concat!($b, ".public"),
+                    concat!($expected, ".private"),
+                    true
+                );
+
+                impl_add_test!(
+                    test_2,
+                    concat!($a, ".public"),
+                    concat!($b, ".private"),
+                    concat!($expected, ".public"),
+                    false
+                );
+
+                impl_add_test!(
+                    test_3,
+                    concat!($a, ".public"),
+                    concat!($b, ".private"),
+                    concat!($expected, ".private"),
+                    true
+                );
+
+                impl_add_test!(
+                    test_4,
+                    concat!($a, ".private"),
+                    concat!($b, ".public"),
+                    concat!($expected, ".public"),
+                    false
+                );
+
+                impl_add_test!(
+                    test_5,
+                    concat!($a, ".private"),
+                    concat!($b, ".public"),
+                    concat!($expected, ".private"),
+                    true
+                );
+
+                impl_add_test!(
+                    test_6,
+                    concat!($a, ".private"),
+                    concat!($b, ".private"),
+                    concat!($expected, ".public"),
+                    false
+                );
+
+                impl_add_test!(
+                    test_7,
+                    concat!($a, ".private"),
+                    concat!($b, ".private"),
+                    concat!($expected, ".private"),
+                    true
+                );
+            }
+        };
+    }
+
+    test_modes!(field, "1field", "2field", "3field");
+    test_modes!(group, "2group", "0group", "2group");
+    test_modes!(i8, "-1i8", "2i8", "1i8");
+    test_modes!(i16, "-1i16", "2i16", "1i16");
+    test_modes!(i32, "-1i32", "2i32", "1i32");
+    test_modes!(i64, "-1i64", "2i64", "1i64");
+    test_modes!(i128, "-1i128", "2i128", "1i128");
+    test_modes!(u8, "1u8", "2u8", "3u8");
+    test_modes!(u16, "1u16", "2u16", "3u16");
+    test_modes!(u32, "1u32", "2u32", "3u32");
+    test_modes!(u64, "1u64", "2u64", "3u64");
+    test_modes!(u128, "1u128", "2u128", "3u128");
+    test_modes!(scalar, "1scalar", "2scalar", "3scalar");
+
     fn check_add_test(first: Value<P>, second: Value<P>, expected: Value<P>) {
         let registers = Registers::<P>::default();
         registers.define(&Register::from_str("r0"));

--- a/bytecode/src/function/instructions/add.rs
+++ b/bytecode/src/function/instructions/add.rs
@@ -132,6 +132,12 @@ mod tests {
 
     type P = Process;
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("add r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Add(_)));
+    }
+
     test_modes!(field, Add, "1field", "2field", "3field");
     test_modes!(group, Add, "2group", "0group", "2group");
     test_modes!(i8, Add, "-1i8", "2i8", "1i8");

--- a/bytecode/src/function/instructions/mod.rs
+++ b/bytecode/src/function/instructions/mod.rs
@@ -127,6 +127,7 @@ impl<P: Program> Parser for Instruction<P> {
         let (string, instruction) = alt((
             // Note that order of the individual parsers matters.
             preceded(pair(tag(Add::<P>::opcode()), tag(" ")), map(Add::parse, Into::into)),
+            preceded(pair(tag(Mul::<P>::opcode()), tag(" ")), map(Mul::parse, Into::into)),
             preceded(pair(tag(Neg::<P>::opcode()), tag(" ")), map(Neg::parse, Into::into)),
             preceded(pair(tag(Sub::<P>::opcode()), tag(" ")), map(Sub::parse, Into::into)),
         ))(string)?;

--- a/bytecode/src/function/instructions/mod.rs
+++ b/bytecode/src/function/instructions/mod.rs
@@ -215,6 +215,30 @@ mod tests {
                 $instruction::from_str("r0 r1 into r2").evaluate(&registers);
             }
         };
+
+        ($test_name:ident, $instruction: ident, $reason: expr, $input: expr) => {
+            #[test]
+            #[should_panic(expected = $reason)]
+            fn $test_name() {
+                use $crate::{
+                    function::{Operation, Registers},
+                    Parser,
+                    Process,
+                    Register,
+                    Value,
+                };
+                type P = Process;
+
+                let input = Value::<P>::from_str($input);
+
+                let registers = Registers::<P>::default();
+                registers.define(&Register::from_str("r0"));
+                registers.define(&Register::from_str("r1"));
+                registers.assign(&Register::from_str("r0"), input);
+
+                $instruction::from_str("r0 into r1").evaluate(&registers);
+            }
+        };
     }
 
     #[macro_export]

--- a/bytecode/src/function/instructions/mod.rs
+++ b/bytecode/src/function/instructions/mod.rs
@@ -174,11 +174,11 @@ impl<P: Program> ToBytes for Instruction<P> {
                 instruction.write_le(&mut writer)
             }
             Self::Neg(instruction) => {
-                u16::write_le(&1u16, &mut writer)?;
+                u16::write_le(&2u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
             Self::Sub(instruction) => {
-                u16::write_le(&2u16, &mut writer)?;
+                u16::write_le(&3u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
         }

--- a/bytecode/src/function/instructions/mod.rs
+++ b/bytecode/src/function/instructions/mod.rs
@@ -172,6 +172,36 @@ impl<P: Program> ToBytes for Instruction<P> {
 #[cfg(test)]
 mod tests {
     #[macro_export]
+    macro_rules! test_instruction_halts {
+        ($test_name:ident, $instruction: ident, $reason: expr, $a: expr, $b: expr) => {
+            #[test]
+            #[should_panic(expected = $reason)]
+            fn $test_name() {
+                use $crate::{
+                    function::{Operation, Registers},
+                    Parser,
+                    Process,
+                    Register,
+                    Value,
+                };
+                type P = Process;
+
+                let a = Value::<P>::from_str($a);
+                let b = Value::<P>::from_str($b);
+
+                let registers = Registers::<P>::default();
+                registers.define(&Register::from_str("r0"));
+                registers.define(&Register::from_str("r1"));
+                registers.define(&Register::from_str("r2"));
+                registers.assign(&Register::from_str("r0"), a);
+                registers.assign(&Register::from_str("r1"), b);
+
+                $instruction::from_str("r0 r1 into r2").evaluate(&registers);
+            }
+        };
+    }
+
+    #[macro_export]
     macro_rules! unary_instruction_test {
         ($test_name: ident, $instruction: ident, $input: expr, $expected: expr) => {
             #[test]

--- a/bytecode/src/function/instructions/mod.rs
+++ b/bytecode/src/function/instructions/mod.rs
@@ -65,7 +65,7 @@ pub enum Instruction<P: Program> {
     Mul(Mul<P>),
     /// Negates `first`, storing the outcome in `destination`.
     Neg(Neg<P>),
-    /// Subtracts `first` from `second`, storing the outcome in `destination`.
+    /// Subtracts `second` from `first`, storing the outcome in `destination`.
     Sub(Sub<P>),
 }
 

--- a/bytecode/src/function/instructions/mul.rs
+++ b/bytecode/src/function/instructions/mul.rs
@@ -137,6 +137,12 @@ mod tests {
 
     type P = Process;
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("mul r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Mul(_)));
+    }
+
     // Testing this manually since the constant x public mode yields a public,
     // but the test_modes! macro expects a private.
     // test_modes!(field, Mul, "1field", "2field", "2field");

--- a/bytecode/src/function/instructions/mul.rs
+++ b/bytecode/src/function/instructions/mul.rs
@@ -200,7 +200,7 @@ mod tests {
         );
 
         binary_instruction_test!(
-            test_constant_and_public_yields_private,
+            test_constant_and_public_yields_public,
             Mul,
             "1field.constant",
             "2field.public",

--- a/bytecode/src/function/instructions/mul.rs
+++ b/bytecode/src/function/instructions/mul.rs
@@ -1,0 +1,253 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Literal, MulChecked, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::{
+    io::{Read, Result as IoResult, Write},
+    ops::Mul as NativeMul,
+};
+
+/// Multiplies `first` and `second`, storing the outcome in `destination`.
+pub struct Mul<P: Program> {
+    operation: BinaryOperation<P>,
+}
+
+impl<P: Program> Mul<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for Mul<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "mul"
+    }
+}
+
+impl<P: Program> Operation<P> for Mul<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+        let second = match registers.load(self.operation.second()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match (first, second) {
+            (Literal::Field(a), Literal::Field(b)) => Literal::Field(a.mul(b)),
+            (Literal::Group(a), Literal::Scalar(b)) => Literal::Group(a.mul(b)),
+            (Literal::Scalar(a), Literal::Group(b)) => Literal::Group(a.mul(b)),
+            (Literal::I8(a), Literal::I8(b)) => Literal::I8(a.mul_checked(&b)),
+            (Literal::I16(a), Literal::I16(b)) => Literal::I16(a.mul_checked(&b)),
+            (Literal::I32(a), Literal::I32(b)) => Literal::I32(a.mul_checked(&b)),
+            (Literal::I64(a), Literal::I64(b)) => Literal::I64(a.mul_checked(&b)),
+            (Literal::I128(a), Literal::I128(b)) => Literal::I128(a.mul_checked(&b)),
+            (Literal::U8(a), Literal::U8(b)) => Literal::U8(a.mul_checked(&b)),
+            (Literal::U16(a), Literal::U16(b)) => Literal::U16(a.mul_checked(&b)),
+            (Literal::U32(a), Literal::U32(b)) => Literal::U32(a.mul_checked(&b)),
+            (Literal::U64(a), Literal::U64(b)) => Literal::U64(a.mul_checked(&b)),
+            (Literal::U128(a), Literal::U128(b)) => Literal::U128(a.mul_checked(&b)),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for Mul<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into a 'mul' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        let (string, operation) = map(BinaryOperation::parse, |operation| Self { operation })(string)?;
+        // Return the operation.
+        Ok((string, operation))
+    }
+}
+
+impl<P: Program> fmt::Display for Mul<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for Mul<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: BinaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for Mul<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for Mul<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::Mul(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_instruction_halts, test_modes, Identifier, Process, Register};
+
+    type P = Process;
+
+    test_modes!(field, Mul, "1field", "2field", "2field");
+    test_modes!(group, Mul, "2group", "1scalar", "2group");
+    test_modes!(scalar, Mul, "1scalar", "2group", "2group");
+    test_modes!(i8, Mul, "1i8", "2i8", "2i8");
+    test_modes!(i16, Mul, "1i16", "2i16", "2i16");
+    test_modes!(i32, Mul, "1i32", "2i32", "2i32");
+    test_modes!(i64, Mul, "1i64", "2i64", "2i64");
+    test_modes!(i128, Mul, "1i128", "2i128", "2i128");
+    test_modes!(u8, Mul, "1u8", "2u8", "2u8");
+    test_modes!(u16, Mul, "1u16", "2u16", "2u16");
+    test_modes!(u32, Mul, "1u32", "2u32", "2u32");
+    test_modes!(u64, Mul, "1u64", "2u64", "2u64");
+    test_modes!(u128, Mul, "1u128", "2u128", "2u128");
+
+    test_instruction_halts!(
+        i8_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}i8.constant", i8::MAX),
+        "2i8.constant"
+    );
+    test_instruction_halts!(
+        i16_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}i16.constant", i16::MAX),
+        "2i16.constant"
+    );
+    test_instruction_halts!(
+        i32_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}i32.constant", i32::MAX),
+        "2i32.constant"
+    );
+    test_instruction_halts!(
+        i64_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}i64.constant", i64::MAX),
+        "2i64.constant"
+    );
+    test_instruction_halts!(
+        i128_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}i128.constant", i128::MAX),
+        "2i128.constant"
+    );
+    test_instruction_halts!(
+        u8_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}u8.constant", u8::MAX),
+        "2u8.constant"
+    );
+    test_instruction_halts!(
+        u16_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}u16.constant", u16::MAX),
+        "2u16.constant"
+    );
+    test_instruction_halts!(
+        u32_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}u32.constant", u32::MAX),
+        "2u32.constant"
+    );
+    test_instruction_halts!(
+        u64_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}u64.constant", u64::MAX),
+        "2u64.constant"
+    );
+    test_instruction_halts!(
+        u128_overflow_halts,
+        Mul,
+        "Integer overflow on multiplication of two constants",
+        &format!("{}u128.constant", u128::MAX),
+        "2u128.constant"
+    );
+
+    test_instruction_halts!(
+        address_halts,
+        Mul,
+        "Invalid 'mul' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(boolean_halts, Mul, "Invalid 'mul' instruction", "true.constant", "true.constant");
+    test_instruction_halts!(string_halts, Mul, "Invalid 'mul' instruction", "\"hello\".constant", "\"world\".constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<P>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<P>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.define(&Register::from_str("r2"));
+        registers.assign(&Register::from_str("r0"), first);
+        registers.assign(&Register::from_str("r1"), second);
+
+        Mul::from_str("r0 r1 into r2").evaluate(&registers);
+    }
+}

--- a/bytecode/src/function/instructions/mul.rs
+++ b/bytecode/src/function/instructions/mul.rs
@@ -137,7 +137,85 @@ mod tests {
 
     type P = Process;
 
-    test_modes!(field, Mul, "1field", "2field", "2field");
+    // Testing this manually since the constant x public mode yields a public,
+    // but the test_modes! macro expects a private.
+    // test_modes!(field, Mul, "1field", "2field", "2field");
+    mod field {
+        use super::Mul;
+        use crate::binary_instruction_test;
+        binary_instruction_test!(
+            test_public_and_public_yields_private,
+            Mul,
+            "1field.public",
+            "2field.public",
+            "2field.private"
+        );
+
+        binary_instruction_test!(
+            test_public_and_constant_yields_private,
+            Mul,
+            "1field.public",
+            "2field.constant",
+            "2field.private"
+        );
+
+        binary_instruction_test!(
+            test_public_and_private_yields_private,
+            Mul,
+            "1field.public",
+            "2field.private",
+            "2field.private"
+        );
+
+        binary_instruction_test!(
+            test_private_and_constant_yields_private,
+            Mul,
+            "1field.private",
+            "2field.constant",
+            "2field.private"
+        );
+
+        binary_instruction_test!(
+            test_private_and_public_yields_private,
+            Mul,
+            "1field.private",
+            "2field.public",
+            "2field.private"
+        );
+
+        binary_instruction_test!(
+            test_private_and_private_yields_private,
+            Mul,
+            "1field.private",
+            "2field.private",
+            "2field.private"
+        );
+
+        binary_instruction_test!(
+            test_constant_and_private_yields_private,
+            Mul,
+            "1field.constant",
+            "2field.private",
+            "2field.private"
+        );
+
+        binary_instruction_test!(
+            test_constant_and_public_yields_private,
+            Mul,
+            "1field.constant",
+            "2field.public",
+            "2field.public"
+        );
+
+        binary_instruction_test!(
+            test_constant_and_constant_yields_constant,
+            Mul,
+            "1field.constant",
+            "2field.constant",
+            "2field.constant"
+        );
+    }
+
     test_modes!(group, Mul, "2group", "1scalar", "2group");
     test_modes!(scalar, Mul, "1scalar", "2group", "2group");
     test_modes!(i8, Mul, "1i8", "2i8", "2i8");

--- a/bytecode/src/function/instructions/neg.rs
+++ b/bytecode/src/function/instructions/neg.rs
@@ -118,26 +118,13 @@ impl<P: Program> Into<Instruction<P>> for Neg<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::unary_instruction_test;
+    use crate::test_modes;
 
-    mod modes {
-        use super::Neg;
-        use crate::test_modes;
-
-        test_modes!(field, Neg, "1field", "-1field");
-        test_modes!(group, Neg, "2group", "-2group");
-        test_modes!(i8, Neg, "1i8", "-1i8");
-        test_modes!(i16, Neg, "1i16", "-1i16");
-        test_modes!(i32, Neg, "1i32", "-1i32");
-        test_modes!(i64, Neg, "1i64", "-1i64");
-        test_modes!(i128, Neg, "1i128", "-1i128");
-    }
-
-    unary_instruction_test!(field, Neg, "1field.private", "-1field.private");
-    unary_instruction_test!(group, Neg, "2group.private", "-2group.private");
-    unary_instruction_test!(i8, Neg, "1i8.private", "-1i8.private");
-    unary_instruction_test!(i16, Neg, "1i16.private", "-1i16.private");
-    unary_instruction_test!(i32, Neg, "1i32.private", "-1i32.private");
-    unary_instruction_test!(i64, Neg, "1i64.private", "-1i64.private");
-    unary_instruction_test!(i128, Neg, "1i128.private", "-1i128.private");
+    test_modes!(field, Neg, "1field", "-1field");
+    test_modes!(group, Neg, "2group", "-2group");
+    test_modes!(i8, Neg, "1i8", "-1i8");
+    test_modes!(i16, Neg, "1i16", "-1i16");
+    test_modes!(i32, Neg, "1i32", "-1i32");
+    test_modes!(i64, Neg, "1i64", "-1i64");
+    test_modes!(i128, Neg, "1i128", "-1i128");
 }

--- a/bytecode/src/function/instructions/neg.rs
+++ b/bytecode/src/function/instructions/neg.rs
@@ -118,7 +118,7 @@ impl<P: Program> Into<Instruction<P>> for Neg<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_modes;
+    use crate::{test_instruction_halts, test_modes};
 
     test_modes!(field, Neg, "1field", "-1field");
     test_modes!(group, Neg, "2group", "-2group");
@@ -127,4 +127,49 @@ mod tests {
     test_modes!(i32, Neg, "1i32", "-1i32");
     test_modes!(i64, Neg, "1i64", "-1i64");
     test_modes!(i128, Neg, "1i128", "-1i128");
+
+    test_instruction_halts!(
+        i8_min_neg_halts,
+        Neg,
+        "Integer overflow on addition of two constants",
+        &format!("{}i8", i8::MIN)
+    );
+    test_instruction_halts!(
+        i16_min_neg_halts,
+        Neg,
+        "Integer overflow on addition of two constants",
+        &format!("{}i16", i16::MIN)
+    );
+    test_instruction_halts!(
+        i32_min_neg_halts,
+        Neg,
+        "Integer overflow on addition of two constants",
+        &format!("{}i32", i32::MIN)
+    );
+    test_instruction_halts!(
+        i64_min_neg_halts,
+        Neg,
+        "Integer overflow on addition of two constants",
+        &format!("{}i64", i64::MIN)
+    );
+    test_instruction_halts!(
+        i128_min_neg_halts,
+        Neg,
+        "Integer overflow on addition of two constants",
+        &format!("{}i128", i128::MIN)
+    );
+    test_instruction_halts!(u8_neg_halts, Neg, "Invalid 'neg' instruction", "1u8");
+    test_instruction_halts!(u16_neg_halts, Neg, "Invalid 'neg' instruction", "1u16");
+    test_instruction_halts!(u32_neg_halts, Neg, "Invalid 'neg' instruction", "1u32");
+    test_instruction_halts!(u64_neg_halts, Neg, "Invalid 'neg' instruction", "1u64");
+    test_instruction_halts!(u128_neg_halts, Neg, "Invalid 'neg' instruction", "1u128");
+    test_instruction_halts!(scalar_neg_halts, Neg, "Invalid 'neg' instruction", "1scalar.constant");
+    test_instruction_halts!(
+        address_neg_halts,
+        Neg,
+        "Invalid 'neg' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(boolean_neg_halts, Neg, "Invalid 'neg' instruction", "true.constant");
+    test_instruction_halts!(string_neg_halts, Neg, "Invalid 'neg' instruction", "\"hello\".constant");
 }

--- a/bytecode/src/function/instructions/neg.rs
+++ b/bytecode/src/function/instructions/neg.rs
@@ -119,6 +119,13 @@ mod tests {
 
     type P = Process;
 
+    mod modes {
+        use super::Neg;
+        use crate::test_modes;
+
+        test_modes!(field, Neg, "1field", "-1field");
+    }
+
     fn check_neg(first: Value<P>, expected: Value<P>) {
         let registers = Registers::<P>::default();
         registers.define(&Register::from_str("r0"));

--- a/bytecode/src/function/instructions/neg.rs
+++ b/bytecode/src/function/instructions/neg.rs
@@ -67,7 +67,10 @@ impl<P: Program> Operation<P> for Neg<P> {
             Literal::Field(a) => Literal::Field(-a),
             Literal::Group(a) => Literal::Group(-a),
             Literal::I8(a) => Literal::I8(-a),
-            Literal::U8(a) => Literal::U8(-a),
+            Literal::I16(a) => Literal::I16(-a),
+            Literal::I32(a) => Literal::I32(-a),
+            Literal::I64(a) => Literal::I64(-a),
+            Literal::I128(a) => Literal::I128(-a),
             _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
         };
 
@@ -115,39 +118,26 @@ impl<P: Program> Into<Instruction<P>> for Neg<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Process, Register};
-
-    type P = Process;
+    use crate::unary_instruction_test;
 
     mod modes {
         use super::Neg;
         use crate::test_modes;
 
         test_modes!(field, Neg, "1field", "-1field");
+        test_modes!(group, Neg, "2group", "-2group");
+        test_modes!(i8, Neg, "1i8", "-1i8");
+        test_modes!(i16, Neg, "1i16", "-1i16");
+        test_modes!(i32, Neg, "1i32", "-1i32");
+        test_modes!(i64, Neg, "1i64", "-1i64");
+        test_modes!(i128, Neg, "1i128", "-1i128");
     }
 
-    fn check_neg(first: Value<P>, expected: Value<P>) {
-        let registers = Registers::<P>::default();
-        registers.define(&Register::from_str("r0"));
-        registers.define(&Register::from_str("r1"));
-        registers.assign(&Register::from_str("r0"), first);
-
-        Neg::from_str("r0 into r1").evaluate(&registers);
-        let candidate = registers.load(&Register::from_str("r1"));
-        assert_eq!(expected, candidate);
-    }
-
-    #[test]
-    fn test_neg_field() {
-        let first = Value::<P>::from_str("1field.public");
-        let expected = Value::<P>::from_str("-1field.private");
-        check_neg(first, expected);
-    }
-
-    #[test]
-    fn test_neg_group() {
-        let first = Value::<P>::from_str("2group.public");
-        let expected = Value::<P>::from_str("-2group.private");
-        check_neg(first, expected);
-    }
+    unary_instruction_test!(field, Neg, "1field.private", "-1field.private");
+    unary_instruction_test!(group, Neg, "2group.private", "-2group.private");
+    unary_instruction_test!(i8, Neg, "1i8.private", "-1i8.private");
+    unary_instruction_test!(i16, Neg, "1i16.private", "-1i16.private");
+    unary_instruction_test!(i32, Neg, "1i32.private", "-1i32.private");
+    unary_instruction_test!(i64, Neg, "1i64.private", "-1i64.private");
+    unary_instruction_test!(i128, Neg, "1i128.private", "-1i128.private");
 }

--- a/bytecode/src/function/instructions/neg.rs
+++ b/bytecode/src/function/instructions/neg.rs
@@ -118,7 +118,13 @@ impl<P: Program> Into<Instruction<P>> for Neg<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_instruction_halts, test_modes};
+    use crate::{test_instruction_halts, test_modes, Process};
+
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("neg r0 into r1;").unwrap();
+        assert!(matches!(instruction, Instruction::Neg(_)));
+    }
 
     test_modes!(field, Neg, "1field", "-1field");
     test_modes!(group, Neg, "2group", "-2group");

--- a/bytecode/src/function/instructions/sub.rs
+++ b/bytecode/src/function/instructions/sub.rs
@@ -20,7 +20,7 @@ use crate::{
     Program,
     Value,
 };
-use snarkvm_circuits::{Literal, Parser, ParserResult};
+use snarkvm_circuits::{Literal, Parser, ParserResult, SubChecked};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
 use core::fmt;
@@ -70,6 +70,16 @@ impl<P: Program> Operation<P> for Sub<P> {
         let result = match (first, second) {
             (Literal::Field(a), Literal::Field(b)) => Literal::Field(a - b),
             (Literal::Group(a), Literal::Group(b)) => Literal::Group(a - b),
+            (Literal::I8(a), Literal::I8(b)) => Literal::I8(a.sub_checked(&b)),
+            (Literal::I16(a), Literal::I16(b)) => Literal::I16(a.sub_checked(&b)),
+            (Literal::I32(a), Literal::I32(b)) => Literal::I32(a.sub_checked(&b)),
+            (Literal::I64(a), Literal::I64(b)) => Literal::I64(a.sub_checked(&b)),
+            (Literal::I128(a), Literal::I128(b)) => Literal::I128(a.sub_checked(&b)),
+            (Literal::U8(a), Literal::U8(b)) => Literal::U8(a.sub_checked(&b)),
+            (Literal::U16(a), Literal::U16(b)) => Literal::U16(a.sub_checked(&b)),
+            (Literal::U32(a), Literal::U32(b)) => Literal::U32(a.sub_checked(&b)),
+            (Literal::U64(a), Literal::U64(b)) => Literal::U64(a.sub_checked(&b)),
+            (Literal::U128(a), Literal::U128(b)) => Literal::U128(a.sub_checked(&b)),
             _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
         };
 
@@ -119,36 +129,18 @@ impl<P: Program> Into<Instruction<P>> for Sub<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Process, Register};
+    use crate::test_modes;
 
-    type P = Process;
-
-    fn check_sub(first: Value<P>, second: Value<P>, expected: Value<P>) {
-        let registers = Registers::<P>::default();
-        registers.define(&Register::from_str("r0"));
-        registers.define(&Register::from_str("r1"));
-        registers.define(&Register::from_str("r2"));
-        registers.assign(&Register::from_str("r0"), first);
-        registers.assign(&Register::from_str("r1"), second);
-
-        Sub::from_str("r0 r1 into r2").evaluate(&registers);
-        let candidate = registers.load(&Register::from_str("r2"));
-        assert_eq!(expected, candidate);
-    }
-
-    #[test]
-    fn test_sub_field() {
-        let first = Value::<P>::from_str("3field.public");
-        let second = Value::<P>::from_str("2field.private");
-        let expected = Value::<P>::from_str("1field.private");
-        check_sub(first, second, expected);
-    }
-
-    #[test]
-    fn test_sub_group() {
-        let first = Value::<P>::from_str("2group.public");
-        let second = Value::<P>::from_str("0group.private");
-        let expected = Value::<P>::from_str("2group.private");
-        check_sub(first, second, expected);
-    }
+    test_modes!(field, Sub, "3field", "2field", "1field");
+    test_modes!(group, Sub, "2group", "0group", "2group");
+    test_modes!(i8, Sub, "1i8", "2i8", "-1i8");
+    test_modes!(i16, Sub, "1i16", "2i16", "-1i16");
+    test_modes!(i32, Sub, "1i32", "2i32", "-1i32");
+    test_modes!(i64, Sub, "1i64", "2i64", "-1i64");
+    test_modes!(i128, Sub, "1i128", "2i128", "-1i128");
+    test_modes!(u8, Sub, "3u8", "2u8", "1u8");
+    test_modes!(u16, Sub, "3u16", "2u16", "1u16");
+    test_modes!(u32, Sub, "3u32", "2u32", "1u32");
+    test_modes!(u64, Sub, "3u64", "2u64", "1u64");
+    test_modes!(u128, Sub, "3u128", "2u128", "1u128");
 }

--- a/bytecode/src/function/instructions/sub.rs
+++ b/bytecode/src/function/instructions/sub.rs
@@ -129,7 +129,7 @@ impl<P: Program> Into<Instruction<P>> for Sub<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_modes;
+    use crate::{test_instruction_halts, test_modes};
 
     test_modes!(field, Sub, "3field", "2field", "1field");
     test_modes!(group, Sub, "2group", "0group", "2group");
@@ -143,4 +143,85 @@ mod tests {
     test_modes!(u32, Sub, "3u32", "2u32", "1u32");
     test_modes!(u64, Sub, "3u64", "2u64", "1u64");
     test_modes!(u128, Sub, "3u128", "2u128", "1u128");
+
+    test_instruction_halts!(
+        i8_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}i8.constant", i8::MIN),
+        "1i8.constant"
+    );
+    test_instruction_halts!(
+        i16_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}i16.constant", i16::MIN),
+        "1i16.constant"
+    );
+    test_instruction_halts!(
+        i32_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}i32.constant", i32::MIN),
+        "1i32.constant"
+    );
+    test_instruction_halts!(
+        i64_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}i64.constant", i64::MIN),
+        "1i64.constant"
+    );
+    test_instruction_halts!(
+        i128_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}i128.constant", i128::MIN),
+        "1i128.constant"
+    );
+    test_instruction_halts!(
+        u8_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}u8.constant", u8::MIN),
+        "1u8.constant"
+    );
+    test_instruction_halts!(
+        u16_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}u16.constant", u16::MIN),
+        "1u16.constant"
+    );
+    test_instruction_halts!(
+        u32_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}u32.constant", u32::MIN),
+        "1u32.constant"
+    );
+    test_instruction_halts!(
+        u64_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}u64.constant", u64::MIN),
+        "1u64.constant"
+    );
+    test_instruction_halts!(
+        u128_underflow_halts,
+        Sub,
+        "Integer underflow on subtraction of two constants",
+        &format!("{}u128.constant", u128::MIN),
+        "1u128.constant"
+    );
+
+    test_instruction_halts!(
+        address_halts,
+        Sub,
+        "Invalid 'sub' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(boolean_halts, Sub, "Invalid 'sub' instruction", "true.constant", "true.constant");
+    test_instruction_halts!(string_halts, Sub, "Invalid 'sub' instruction", "\"hello\".constant", "\"world\".constant");
 }

--- a/bytecode/src/function/instructions/sub.rs
+++ b/bytecode/src/function/instructions/sub.rs
@@ -129,7 +129,13 @@ impl<P: Program> Into<Instruction<P>> for Sub<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_instruction_halts, test_modes};
+    use crate::{test_instruction_halts, test_modes, Process};
+
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("sub r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Sub(_)));
+    }
 
     test_modes!(field, Sub, "3field", "2field", "1field");
     test_modes!(group, Sub, "2group", "0group", "2group");

--- a/bytecode/src/function/instructions/sub.rs
+++ b/bytecode/src/function/instructions/sub.rs
@@ -27,7 +27,7 @@ use core::fmt;
 use nom::combinator::map;
 use std::io::{Read, Result as IoResult, Write};
 
-/// Subtracts `first` from `second`, storing the outcome in `destination`.
+/// Subtracts `second` from `first`, storing the outcome in `destination`.
 pub struct Sub<P: Program> {
     operation: BinaryOperation<P>,
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Impl Add, Mul, Neg, Sub instructions for bytecode. 

## Test Plan

- Added `test_modes` macro to test valid operation usage with different modes.
- Added `test_instruction_halts` macro to test invalid operands and other cases halt when expected

### Modes

The `test_modes` macro generates tests for all the following modes using the given operands.

~~These cases won't hold for all operations. Ex: Field mul(constant, public) -> public. For this case, I've manually written the tests and updated the expected output instead of using the `test_modes` macro. If more exceptions will appear, we should reconsider this approach.~~
Edit: In later work, I have modified the test_modes macro to optionally take a slice of mode test cases. This should handle operations whose modes don't conform to the common cases listed below.

#### Binary Modes

| Input    | Input    | Output   |
|----------|----------|----------|
| public   | public   | private  |
| public   | constant | private  |
| public   | private  | private  |
| private  | public   | private  |
| private  | private  | private  |
| private  | constant | private  |
| constant | public   | private  |
| constant | private  | private  |
| constant | constant | constant |

#### Unary Modes

| Input    | Output   |
|----------|----------|
| public   | private  |
| private  | private  |
| constant | constant |