### PR TITLE
Add Merkle tree benchmarks

### DIFF
--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -23,7 +23,7 @@ path = "benches/msm/variable_base.rs"
 harness = false
 
 [[bench]]
-name = "commitment-bhp"
+name = "commitment_bhp"
 path = "benches/commitment/bhp.rs"
 harness = false
 
@@ -40,6 +40,11 @@ harness = false
 [[bench]]
 name = "hash_to_curve"
 path = "benches/crypto_hash/hash_to_curve.rs"
+harness = false
+
+[[bench]]
+name = "merkle_tree_bhp"
+path = "benches/merkle_tree/merkle_tree.rs"
 harness = false
 
 [[bench]]

--- a/algorithms/benches/merkle_tree/merkle_tree.rs
+++ b/algorithms/benches/merkle_tree/merkle_tree.rs
@@ -1,0 +1,97 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate criterion;
+
+use snarkvm_algorithms::{
+    crh::BHPCRH,
+    merkle_tree::{MerkleTree, MerkleTreeParameters},
+    traits::MerkleParameters,
+};
+use snarkvm_curves::edwards_bls12::EdwardsProjective;
+
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+
+use criterion::Criterion;
+
+const SETUP_MESSAGE: &str = "bhp_merkle_tree_benchmark";
+
+const NUM_WINDOWS: usize = 3;
+const WINDOW_SIZE: usize = 57;
+const TREE_DEPTH: usize = 32;
+
+type H = BHPCRH<EdwardsProjective, NUM_WINDOWS, WINDOW_SIZE>;
+type P = MerkleTreeParameters<H, TREE_DEPTH>;
+
+const NUM_ENTRIES: &[usize] = &[10, 100, 1000, 10000];
+const LEAF_SIZE: usize = 32;
+
+/// Generates the specified number of random Merkle tree leaves.
+macro_rules! generate_random_leaves {
+    ($num_leaves:expr, $leaf_size:expr) => {{
+        let mut rng = thread_rng();
+
+        let mut vec = Vec::with_capacity($num_leaves);
+        for _ in 0..$num_leaves {
+            let mut id = [0u8; $leaf_size];
+            rng.fill(&mut id);
+            vec.push(id);
+        }
+        vec
+    }};
+}
+
+fn new(c: &mut Criterion) {
+    let parameters = P::setup(SETUP_MESSAGE);
+
+    for entries in NUM_ENTRIES {
+        let leaves = generate_random_leaves!(*entries, LEAF_SIZE);
+        let mut merkle_tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), &[[0u8; LEAF_SIZE]]).unwrap();
+
+        c.bench_function(&format!("New Merkle Tree ({} entries)", entries), move |b| {
+            b.iter(|| {
+                merkle_tree = merkle_tree.rebuild(1, &leaves).unwrap();
+            })
+        });
+    }
+}
+
+fn insert(c: &mut Criterion) {
+    let parameters = P::setup(SETUP_MESSAGE);
+
+    for entries in NUM_ENTRIES {
+        let leaves = generate_random_leaves!(*entries, LEAF_SIZE);
+        let mut merkle_tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), &[[0u8; LEAF_SIZE]]).unwrap();
+
+        c.bench_function(&format!("Insert Merkle Tree ({} entries)", entries), move |b| {
+            b.iter(|| {
+                for (i, leaf) in leaves.iter().enumerate() {
+                    merkle_tree = merkle_tree.rebuild(i + 1, &[leaf]).unwrap();
+                }
+            })
+        });
+    }
+}
+
+criterion_group! {
+    name = merkle_tree_bhp;
+    config = Criterion::default().sample_size(10);
+    targets = new, insert
+}
+
+criterion_main!(merkle_tree_bhp);

--- a/algorithms/benches/merkle_tree/merkle_tree.rs
+++ b/algorithms/benches/merkle_tree/merkle_tree.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use criterion::Criterion;
 
-const SETUP_MESSAGE: &str = "bhp_merkle_tree_benchmark";
+const SETUP_MESSAGE: &str = "merkle_tree_bhp_benchmark";
 
 const NUM_WINDOWS: usize = 3;
 const WINDOW_SIZE: usize = 57;

--- a/algorithms/benches/merkle_tree/merkle_tree.rs
+++ b/algorithms/benches/merkle_tree/merkle_tree.rs
@@ -38,7 +38,7 @@ const TREE_DEPTH: usize = 32;
 type H = BHPCRH<EdwardsProjective, NUM_WINDOWS, WINDOW_SIZE>;
 type P = MerkleTreeParameters<H, TREE_DEPTH>;
 
-const NUM_ENTRIES: &[usize] = &[10, 100, 1000, 10000];
+const NUM_ENTRIES: &[usize] = &[100000];
 const LEAF_SIZE: usize = 32;
 
 /// Generates the specified number of random Merkle tree leaves.
@@ -58,23 +58,23 @@ macro_rules! generate_random_leaves {
 
 fn new(c: &mut Criterion) {
     for entries in NUM_ENTRIES {
-        let parameters = P::setup(SETUP_MESSAGE);
+        let parameters = Arc::new(P::setup(SETUP_MESSAGE));
         let leaves = generate_random_leaves!(*entries, LEAF_SIZE);
 
         c.bench_function(&format!("New Merkle Tree ({} entries)", entries), move |b| {
             b.iter(|| {
-                MerkleTree::<P>::new(Arc::new(parameters.clone()), &leaves).unwrap();
+                MerkleTree::<P>::new(parameters.clone(), &leaves).unwrap();
             })
         });
     }
 }
 
 fn insert(c: &mut Criterion) {
-    let parameters = P::setup(SETUP_MESSAGE);
+    let parameters = Arc::new(P::setup(SETUP_MESSAGE));
 
     for entries in NUM_ENTRIES {
         let leaves = generate_random_leaves!(*entries, LEAF_SIZE);
-        let mut merkle_tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), &[[0u8; LEAF_SIZE]]).unwrap();
+        let mut merkle_tree = MerkleTree::<P>::new(parameters.clone(), &[[0u8; LEAF_SIZE]]).unwrap();
 
         c.bench_function(&format!("Insert Merkle Tree ({} entries)", entries), move |b| {
             b.iter(|| {

--- a/algorithms/benches/merkle_tree/merkle_tree.rs
+++ b/algorithms/benches/merkle_tree/merkle_tree.rs
@@ -57,15 +57,13 @@ macro_rules! generate_random_leaves {
 }
 
 fn new(c: &mut Criterion) {
-    let parameters = P::setup(SETUP_MESSAGE);
-
     for entries in NUM_ENTRIES {
+        let parameters = P::setup(SETUP_MESSAGE);
         let leaves = generate_random_leaves!(*entries, LEAF_SIZE);
-        let mut merkle_tree = MerkleTree::<P>::new(Arc::new(parameters.clone()), &[[0u8; LEAF_SIZE]]).unwrap();
 
         c.bench_function(&format!("New Merkle Tree ({} entries)", entries), move |b| {
             b.iter(|| {
-                merkle_tree = merkle_tree.rebuild(1, &leaves).unwrap();
+                MerkleTree::<P>::new(Arc::new(parameters.clone()), &leaves).unwrap();
             })
         });
     }

--- a/algorithms/benches/merkle_tree/merkle_tree.rs
+++ b/algorithms/benches/merkle_tree/merkle_tree.rs
@@ -38,7 +38,7 @@ const TREE_DEPTH: usize = 32;
 type H = BHPCRH<EdwardsProjective, NUM_WINDOWS, WINDOW_SIZE>;
 type P = MerkleTreeParameters<H, TREE_DEPTH>;
 
-const NUM_ENTRIES: &[usize] = &[100000];
+const NUM_ENTRIES: &[usize] = &[10, 100, 1000, 10000];
 const LEAF_SIZE: usize = 32;
 
 /// Generates the specified number of random Merkle tree leaves.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR introduces benchmarks for Merkle tree operations:
- `new` - Create a Merkle tree from the provided leaves.
- `insert` - Create a Merkle tree from the provided leaves by inserting the leaves one by one.

The benchmarks measures each operation with the following number of leaves - 10, 100, 1000, 10000.

### Tree specifications:
Tree depth: 32
Hash function: BHP(EdwardsProjective, 3, 57)

## Results

| Operation | Number of Entries |    Time   | Estimated Time per Leaf |
|:---------:|:-----------------:|:---------:|:-----------------------:|
|    new    |         10        | 2.4541 ms |         245.4 μs        |
|    new    |        100        | 3.1672 ms |         31.6 μs         |
|    new    |        1000       | 5.2399 ms |          5.2 μs         |
|    new    |       10000       | 39.345 ms |          3.9 μs         |
|   insert  |         10        | 19.268 ms |          1.9 ms         |
|   insert  |        100        | 260.53 ms |          2.6 ms         |
|   insert  |        1000       |  2.9324 s |          2.9 ms         |
|   insert  |       10000       |  29.735 s |          2.9 ms         |

Machine Specs: 
```
AMD® Ryzen threadripper 3960x 24-core processor × 48 thread
Ubuntu 20.04.2 LTS
64 GB DDR4 RAM
```