### PR TITLE
lint: address rust 1.61 clippy lints crate_in_macro_def and cast_abs_to_unsigned

### DIFF
--- a/algorithms/src/msm/variable_base/prefetch.rs
+++ b/algorithms/src/msm/variable_base/prefetch.rs
@@ -18,14 +18,14 @@
 macro_rules! prefetch_slice {
     ($curve: ident, $slice_1: ident, $slice_2: ident, $prefetch_iter: ident) => {
         if let Some((idp_1, idp_2)) = $prefetch_iter.next() {
-            crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_1[*idp_1 as usize]);
-            crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_2[*idp_2 as usize]);
+            $crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_1[*idp_1 as usize]);
+            $crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_2[*idp_2 as usize]);
         }
     };
 
     ($curve: ident, $slice_1: ident, $prefetch_iter: ident) => {
         if let Some((idp_1, _)) = $prefetch_iter.next() {
-            crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_1[*idp_1 as usize]);
+            $crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_1[*idp_1 as usize]);
         }
     };
 }
@@ -34,9 +34,9 @@ macro_rules! prefetch_slice {
 macro_rules! prefetch_slice_write {
     ($curve: ident, $slice_1: ident, $slice_2: ident, $prefetch_iter: ident) => {
         if let Some((idp_1, idp_2)) = $prefetch_iter.next() {
-            crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_1[*idp_1 as usize]);
+            $crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_1[*idp_1 as usize]);
             if *idp_2 != !0u32 {
-                crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_2[*idp_2 as usize]);
+                $crate::msm::variable_base::prefetch::prefetch::<$curve>(&$slice_2[*idp_2 as usize]);
             }
         }
     };

--- a/dpc/src/value_balance/value_balance_circuit.rs
+++ b/dpc/src/value_balance/value_balance_circuit.rs
@@ -176,7 +176,7 @@ mod tests {
             .unwrap();
 
         let value_balance_bytes =
-            UInt8::alloc_vec(cs.ns(|| "value_balance_bytes"), &(value_balance.0.abs() as u64).to_le_bytes()).unwrap();
+            UInt8::alloc_vec(cs.ns(|| "value_balance_bytes"), &(value_balance.0.unsigned_abs()).to_le_bytes()).unwrap();
 
         let is_negative =
             Boolean::alloc(&mut cs.ns(|| "value_balance_is_negative"), || Ok(value_balance.is_negative())).unwrap();

--- a/gadgets/src/integers/uint/macros.rs
+++ b/gadgets/src/integers/uint/macros.rs
@@ -23,7 +23,7 @@ macro_rules! cond_select_int_impl {
                 first: &Self,
                 second: &Self,
             ) -> Result<Self, SynthesisError> {
-                use crate::traits::integers::Integer;
+                use $crate::traits::integers::Integer;
 
                 if let Boolean::Constant(cond) = *cond {
                     if cond { Ok(first.clone()) } else { Ok(second.clone()) }
@@ -78,7 +78,7 @@ macro_rules! uint_impl_common {
             pub value: Option<$_type>,
         }
 
-        impl crate::traits::integers::Integer for $name {
+        impl $crate::traits::integers::Integer for $name {
             type IntegerType = $_type;
             type UnsignedGadget = $name;
             type UnsignedIntegerType = $_type;

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! checksum {
 #[macro_export]
 macro_rules! checksum_error {
     ($expected: expr, $candidate: expr) => {
-        Err(crate::errors::ParameterError::ChecksumMismatch($expected, $candidate))
+        Err($crate::errors::ParameterError::ChecksumMismatch($expected, $candidate))
     };
 }
 
@@ -35,7 +35,7 @@ macro_rules! impl_local {
         pub struct $name;
 
         impl $name {
-            pub fn load_bytes() -> Result<Vec<u8>, crate::errors::ParameterError> {
+            pub fn load_bytes() -> Result<Vec<u8>, $crate::errors::ParameterError> {
                 const METADATA: &'static str = include_str!(concat!($local_dir, $fname, ".metadata"));
 
                 let metadata: serde_json::Value =
@@ -49,7 +49,7 @@ macro_rules! impl_local {
 
                 // Ensure the size matches.
                 if expected_size != buffer.len() {
-                    return Err(crate::errors::ParameterError::SizeMismatch(expected_size, buffer.len()));
+                    return Err($crate::errors::ParameterError::SizeMismatch(expected_size, buffer.len()));
                 }
 
                 // Ensure the checksum matches.
@@ -79,7 +79,7 @@ macro_rules! impl_remote {
         pub struct $name;
 
         impl $name {
-            pub fn load_bytes() -> Result<Vec<u8>, crate::errors::ParameterError> {
+            pub fn load_bytes() -> Result<Vec<u8>, $crate::errors::ParameterError> {
                 const METADATA: &'static str = include_str!(concat!($local_dir, $fname, ".metadata"));
 
                 let metadata: serde_json::Value = serde_json::from_str(METADATA).expect("Metadata was not well-formatted");
@@ -160,14 +160,14 @@ macro_rules! impl_remote {
 
                             buffer
                         } else {
-                            return Err(crate::errors::ParameterError::RemoteFetchDisabled);
+                            return Err($crate::errors::ParameterError::RemoteFetchDisabled);
                         }
                     }
                 };
 
                  // Ensure the size matches.
                 if expected_size != buffer.len() {
-                    return Err(crate::errors::ParameterError::SizeMismatch(expected_size, buffer.len()));
+                    return Err($crate::errors::ParameterError::SizeMismatch(expected_size, buffer.len()));
                 }
 
                 // Ensure the checksum matches.
@@ -183,7 +183,7 @@ macro_rules! impl_remote {
             fn store_bytes(
                 buffer: &[u8],
                 file_path: &std::path::Path,
-            ) -> Result<(), crate::errors::ParameterError> {
+            ) -> Result<(), $crate::errors::ParameterError> {
                 use snarkvm_utilities::Write;
 
                 #[cfg(not(feature = "no_std_out"))]
@@ -203,7 +203,7 @@ macro_rules! impl_remote {
             }
 
             #[cfg(not(feature = "wasm"))]
-            fn remote_fetch(buffer: &mut Vec<u8>, url: &str) -> Result<(), crate::errors::ParameterError> {
+            fn remote_fetch(buffer: &mut Vec<u8>, url: &str) -> Result<(), $crate::errors::ParameterError> {
                 let mut easy = curl::easy::Easy::new();
                 easy.url(url)?;
                 #[cfg(not(feature = "no_std_out"))]
@@ -231,7 +231,7 @@ macro_rules! impl_remote {
             }
 
             #[cfg(feature = "wasm")]
-            fn remote_fetch(buffer: alloc::sync::Weak<parking_lot::RwLock<Vec<u8>>>, url: &'static str) -> Result<(), crate::errors::ParameterError> {
+            fn remote_fetch(buffer: alloc::sync::Weak<parking_lot::RwLock<Vec<u8>>>, url: &'static str) -> Result<(), $crate::errors::ParameterError> {
                 // NOTE(julesdesmit): We spawn a local thread here in order to be
                 // able to accommodate the async syntax from reqwest.
                 wasm_bindgen_futures::spawn_local(async move {


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Addresses a new clippy lint. PR #743 was failing CI due to [this clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#crate_in_macro_def) which was added in 1.61.0. 

Edit: Also addresses [this lint](https://rust-lang.github.io/rust-clippy/master/index.html#cast_abs_to_unsigned) which suggests using `unsigned_abs()`.