### PR TITLE
feat: impl bytecode instructions And, Equal, Not, Or, XOR, NAND, NEQ, NOR 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,6 +2033,7 @@ dependencies = [
  "indexmap",
  "nom",
  "once_cell",
+ "paste",
  "snarkvm-algorithms",
  "snarkvm-circuits",
  "snarkvm-curves",

--- a/bytecode/Cargo.toml
+++ b/bytecode/Cargo.toml
@@ -30,6 +30,9 @@ version = "7.1"
 [dependencies.once_cell]
 version = "1.8.0"
 
+[dependencies.paste]
+version = "1.0.7"
+
 [dev-dependencies.snarkvm-algorithms]
 path = "../algorithms"
 version = "0.7.5"

--- a/bytecode/src/function/instructions/and.rs
+++ b/bytecode/src/function/instructions/and.rs
@@ -135,7 +135,6 @@ mod tests {
         ["public", "constant", "constant"],
         ["public", "private", "private"],
         ["private", "public", "private"],
-        // Why does this pass?? Feels like private & constant should yield a private
         ["private", "constant", "constant"],
         ["private", "private", "private"],
         ["constant", "public", "public"],

--- a/bytecode/src/function/instructions/and.rs
+++ b/bytecode/src/function/instructions/and.rs
@@ -155,6 +155,12 @@ mod tests {
         ["constant", "private", "private"],
     ];
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("and r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::And(_)));
+    }
+
     test_modes!(boolean, And, "true", "false", "false", SIGNED_INTEGER_MODE_TESTS);
     test_modes!(i8, And, "1i8", "0i8", "0i8", SIGNED_INTEGER_MODE_TESTS);
     test_modes!(i16, And, "1i16", "0i16", "0i16", SIGNED_INTEGER_MODE_TESTS);

--- a/bytecode/src/function/instructions/and.rs
+++ b/bytecode/src/function/instructions/and.rs
@@ -1,0 +1,181 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Literal, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::io::{Read, Result as IoResult, Write};
+
+/// Performs a bitwise And on `first` and `second`, storing the outcome in `destination`.
+pub struct And<P: Program> {
+    operation: BinaryOperation<P>,
+}
+
+impl<P: Program> And<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for And<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "and"
+    }
+}
+
+impl<P: Program> Operation<P> for And<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+        let second = match registers.load(self.operation.second()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match (first, second) {
+            (Literal::Boolean(a), Literal::Boolean(b)) => Literal::Boolean(a & b),
+            (Literal::I8(a), Literal::I8(b)) => Literal::I8(a & b),
+            (Literal::I16(a), Literal::I16(b)) => Literal::I16(a & b),
+            (Literal::I32(a), Literal::I32(b)) => Literal::I32(a & b),
+            (Literal::I64(a), Literal::I64(b)) => Literal::I64(a & b),
+            (Literal::I128(a), Literal::I128(b)) => Literal::I128(a & b),
+            (Literal::U8(a), Literal::U8(b)) => Literal::U8(a & b),
+            (Literal::U16(a), Literal::U16(b)) => Literal::U16(a & b),
+            (Literal::U32(a), Literal::U32(b)) => Literal::U32(a & b),
+            (Literal::U64(a), Literal::U64(b)) => Literal::U64(a & b),
+            (Literal::U128(a), Literal::U128(b)) => Literal::U128(a & b),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for And<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into an 'and' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        let (string, operation) = map(BinaryOperation::parse, |operation| Self { operation })(string)?;
+        // Return the operation.
+        Ok((string, operation))
+    }
+}
+
+impl<P: Program> fmt::Display for And<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for And<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: BinaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for And<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for And<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::And(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_instruction_halts, test_modes};
+
+    const SIGNED_INTEGER_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "constant"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        // Why does this pass?? Feels like private & constant should yield a private
+        ["private", "constant", "constant"],
+        ["private", "private", "private"],
+        ["constant", "public", "public"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "private"],
+    ];
+
+    const UNSIGNED_INTEGER_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "public"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        ["private", "constant", "private"],
+        ["private", "private", "private"],
+        ["constant", "public", "public"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "private"],
+    ];
+
+    test_modes!(boolean, And, "true", "false", "false", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i8, And, "1i8", "0i8", "0i8", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i16, And, "1i16", "0i16", "0i16", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i32, And, "1i32", "0i32", "0i32", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i64, And, "1i64", "0i64", "0i64", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i128, And, "1i128", "0i128", "0i128", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u8, And, "3u8", "2u8", "2u8", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u16, And, "3u16", "2u16", "2u16", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u32, And, "3u32", "2u32", "2u32", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u64, And, "3u64", "2u64", "2u64", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u128, And, "3u128", "2u128", "2u128", UNSIGNED_INTEGER_MODE_TESTS);
+
+    test_instruction_halts!(
+        address_halts,
+        And,
+        "Invalid 'and' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(string_halts, And, "Invalid 'and' instruction", "\"hello\".constant", "\"world\".constant");
+    test_instruction_halts!(field_halts, And, "Invalid 'and' instruction", "1field.constant", "1field.constant");
+    test_instruction_halts!(group_halts, And, "Invalid 'and' instruction", "2group.constant", "2group.constant");
+    test_instruction_halts!(scalar_halts, And, "Invalid 'and' instruction", "1scalar.constant", "1scalar.constant");
+}

--- a/bytecode/src/function/instructions/div.rs
+++ b/bytecode/src/function/instructions/div.rs
@@ -170,85 +170,19 @@ mod tests {
 
     type P = Process;
 
-    // Testing this manually since the constant x public mode yields a public,
-    // but the test_modes! macro expects a private.
-    // test_modes!(field, Div, "2field", "1field", "2field");
-    mod field {
-        use super::Div;
-        use crate::binary_instruction_test;
-        binary_instruction_test!(
-            test_public_and_public_yields_private,
-            Div,
-            "2field.public",
-            "1field.public",
-            "2field.private"
-        );
+    const FIELD_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "public"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        ["private", "constant", "private"],
+        ["private", "private", "private"],
+        ["constant", "public", "private"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "private"],
+    ];
 
-        binary_instruction_test!(
-            test_public_and_constant_yields_public,
-            Div,
-            "2field.public",
-            "1field.constant",
-            "2field.public"
-        );
-
-        binary_instruction_test!(
-            test_public_and_private_yields_private,
-            Div,
-            "2field.public",
-            "1field.private",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_private_and_constant_yields_private,
-            Div,
-            "2field.private",
-            "1field.constant",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_private_and_public_yields_private,
-            Div,
-            "2field.private",
-            "1field.public",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_private_and_private_yields_private,
-            Div,
-            "2field.private",
-            "1field.private",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_constant_and_private_yields_private,
-            Div,
-            "2field.constant",
-            "1field.private",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_constant_and_public_yields_private,
-            Div,
-            "2field.constant",
-            "1field.public",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_constant_and_constant_yields_constant,
-            Div,
-            "2field.constant",
-            "1field.constant",
-            "2field.constant"
-        );
-    }
-
+    test_modes!(field, Div, "2field", "1field", "2field", FIELD_MODE_TESTS);
     test_modes!(i8, Div, "-4i8", "2i8", "-2i8");
     test_modes!(i16, Div, "-4i16", "2i16", "-2i16");
     test_modes!(i32, Div, "-4i32", "2i32", "-2i32");

--- a/bytecode/src/function/instructions/div_wrapped.rs
+++ b/bytecode/src/function/instructions/div_wrapped.rs
@@ -186,28 +186,28 @@ mod tests {
 
     test_instruction_halts!(i8_underflow_halts, DivWrapped, "Division by zero error", "1i8.constant", "0i8.constant");
     test_instruction_halts!(
-        i16_underflow_halts,
+        i16_division_by_zero_halts,
         DivWrapped,
         "Division by zero error",
         "1i16.constant",
         "0i16.constant"
     );
     test_instruction_halts!(
-        i32_underflow_halts,
+        i32_division_by_zero_halts,
         DivWrapped,
         "Division by zero error",
         "1i32.constant",
         "0i32.constant"
     );
     test_instruction_halts!(
-        i64_underflow_halts,
+        i64_division_by_zero_halts,
         DivWrapped,
         "Division by zero error",
         "1i64.constant",
         "0i64.constant"
     );
     test_instruction_halts!(
-        i128_underflow_halts,
+        i128_division_by_zero_halts,
         DivWrapped,
         "Division by zero error",
         "1i128.constant",

--- a/bytecode/src/function/instructions/equal.rs
+++ b/bytecode/src/function/instructions/equal.rs
@@ -81,8 +81,21 @@ impl<P: Program> Operation<P> for Equal<P> {
 
         // Perform the operation.
         let result = match (first, second) {
+            (Literal::Address(a), Literal::Address(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::Boolean(a), Literal::Boolean(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::Field(a), Literal::Field(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::Group(a), Literal::Group(b)) => Literal::Boolean(a.is_equal(&b)),
             (Literal::I8(a), Literal::I8(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::I16(a), Literal::I16(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::I32(a), Literal::I32(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::I64(a), Literal::I64(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::I128(a), Literal::I128(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::Scalar(a), Literal::Scalar(b)) => Literal::Boolean(a.is_equal(&b)),
             (Literal::U8(a), Literal::U8(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::U16(a), Literal::U16(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::U32(a), Literal::U32(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::U64(a), Literal::U64(b)) => Literal::Boolean(a.is_equal(&b)),
+            (Literal::U128(a), Literal::U128(b)) => Literal::Boolean(a.is_equal(&b)),
             _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
         };
 
@@ -159,12 +172,56 @@ impl<P: Program> Into<Instruction<P>> for Equal<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Process, Register};
+    use crate::{test_instruction_halts, test_modes, Identifier, Process, Register};
 
     type P = Process;
 
-    fn check_is_eq(first: Value<P>, second: Value<P>, expected: Value<P>) {
-        let registers = Registers::<P>::default();
+    const BOOLEAN_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "public"],
+        ["public", "private", "private"],
+        ["private", "constant", "private"],
+        ["private", "public", "private"],
+        ["private", "private", "private"],
+        ["constant", "private", "private"],
+        ["constant", "public", "public"],
+        ["constant", "constant", "constant"],
+    ];
+
+    test_modes!(
+        address,
+        Equal,
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah",
+        "true"
+    );
+    test_modes!(boolean, Equal, "true", "true", "true", BOOLEAN_MODE_TESTS);
+    test_modes!(field, Equal, "1field", "1field", "true");
+    test_modes!(group, Equal, "2group", "2group", "true");
+    test_modes!(i8, Equal, "1i8", "1i8", "true");
+    test_modes!(i16, Equal, "1i16", "1i16", "true");
+    test_modes!(i32, Equal, "1i32", "1i32", "true");
+    test_modes!(i64, Equal, "1i64", "1i64", "true");
+    test_modes!(i128, Equal, "1i128", "1i128", "true");
+    test_modes!(scalar, Equal, "1scalar", "1scalar", "true");
+    test_modes!(u8, Equal, "1u8", "1u8", "true");
+    test_modes!(u16, Equal, "1u16", "1u16", "true");
+    test_modes!(u32, Equal, "1u32", "1u32", "true");
+    test_modes!(u64, Equal, "1u64", "1u64", "true");
+    test_modes!(u128, Equal, "1u128", "1u128", "true");
+
+    test_instruction_halts!(string_halts, Equal, "Invalid 'eq' instruction", "\"hello\"", "\"hello\"");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<Process>::default();
         registers.define(&Register::from_str("r0"));
         registers.define(&Register::from_str("r1"));
         registers.define(&Register::from_str("r2"));
@@ -172,23 +229,5 @@ mod tests {
         registers.assign(&Register::from_str("r1"), second);
 
         Equal::from_str("r0 r1 into r2").evaluate(&registers);
-        let candidate = registers.load(&Register::from_str("r2"));
-        assert_eq!(expected, candidate);
-    }
-
-    #[test]
-    fn test_is_eq_i8() {
-        let first = Value::<P>::from_str("1i8.public");
-        let second = Value::<P>::from_str("2i8.private");
-        let expected = Value::<P>::from_str("false.private");
-        check_is_eq(first, second, expected);
-    }
-
-    #[test]
-    fn test_is_eq_u8() {
-        let first = Value::<P>::from_str("2u8.public");
-        let second = Value::<P>::from_str("2u8.private");
-        let expected = Value::<P>::from_str("true.private");
-        check_is_eq(first, second, expected);
     }
 }

--- a/bytecode/src/function/instructions/equal.rs
+++ b/bytecode/src/function/instructions/equal.rs
@@ -174,8 +174,6 @@ mod tests {
     use super::*;
     use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process, Register};
 
-    type P = Process;
-
     const BOOLEAN_MODE_TESTS: [[&str; 3]; 9] = [
         ["public", "public", "private"],
         ["public", "constant", "public"],

--- a/bytecode/src/function/instructions/equal.rs
+++ b/bytecode/src/function/instructions/equal.rs
@@ -188,6 +188,12 @@ mod tests {
         ["constant", "constant", "constant"],
     ];
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("eq r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Equal(_)));
+    }
+
     test_modes!(
         address,
         Equal,

--- a/bytecode/src/function/instructions/equal.rs
+++ b/bytecode/src/function/instructions/equal.rs
@@ -172,7 +172,7 @@ impl<P: Program> Into<Instruction<P>> for Equal<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_instruction_halts, test_modes, Identifier, Process, Register};
+    use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process, Register};
 
     type P = Process;
 
@@ -195,20 +195,55 @@ mod tests {
         "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah",
         "true"
     );
+    binary_instruction_test!(
+        address_ne,
+        Equal,
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.public",
+        "aleo1t9r2aalldn3al4346l3pdplj8prrz5svvahsrl64gp4023342sxsrhs2yg.public",
+        "false.private"
+    );
+
     test_modes!(boolean, Equal, "true", "true", "true", BOOLEAN_MODE_TESTS);
+    binary_instruction_test!(boolean_ne, Equal, "true.public", "false.public", "false.private");
+
     test_modes!(field, Equal, "1field", "1field", "true");
+    binary_instruction_test!(field_ne, Equal, "1field.public", "2field.public", "false.private");
+
     test_modes!(group, Equal, "2group", "2group", "true");
+    binary_instruction_test!(group_ne, Equal, "2group.public", "0group.public", "false.private");
+
     test_modes!(i8, Equal, "1i8", "1i8", "true");
+    binary_instruction_test!(i8_ne, Equal, "1i8.public", "2i8.public", "false.private");
+
     test_modes!(i16, Equal, "1i16", "1i16", "true");
+    binary_instruction_test!(i16_ne, Equal, "1i16.public", "2i16.public", "false.private");
+
     test_modes!(i32, Equal, "1i32", "1i32", "true");
+    binary_instruction_test!(i32_ne, Equal, "1i32.public", "2i32.public", "false.private");
+
     test_modes!(i64, Equal, "1i64", "1i64", "true");
+    binary_instruction_test!(i64_ne, Equal, "1i64.public", "2i64.public", "false.private");
+
     test_modes!(i128, Equal, "1i128", "1i128", "true");
+    binary_instruction_test!(i128_ne, Equal, "1i128.public", "2i128.public", "false.private");
+
     test_modes!(scalar, Equal, "1scalar", "1scalar", "true");
+    binary_instruction_test!(scalar_ne, Equal, "1scalar.public", "2scalar.public", "false.private");
+
     test_modes!(u8, Equal, "1u8", "1u8", "true");
+    binary_instruction_test!(u8_ne, Equal, "1u8.public", "2u8.public", "false.private");
+
     test_modes!(u16, Equal, "1u16", "1u16", "true");
+    binary_instruction_test!(u16_ne, Equal, "1u16.public", "2u16.public", "false.private");
+
     test_modes!(u32, Equal, "1u32", "1u32", "true");
+    binary_instruction_test!(u32_ne, Equal, "1u32.public", "2u32.public", "false.private");
+
     test_modes!(u64, Equal, "1u64", "1u64", "true");
+    binary_instruction_test!(u64_ne, Equal, "1u64.public", "2u64.public", "false.private");
+
     test_modes!(u128, Equal, "1u128", "1u128", "true");
+    binary_instruction_test!(u128_ne, Equal, "1u128.public", "2u128.public", "false.private");
 
     test_instruction_halts!(string_halts, Equal, "Invalid 'eq' instruction", "\"hello\"", "\"hello\"");
 

--- a/bytecode/src/function/instructions/mod.rs
+++ b/bytecode/src/function/instructions/mod.rs
@@ -355,23 +355,23 @@ impl<P: Program> ToBytes for Instruction<P> {
                 instruction.write_le(&mut writer)
             }
             Self::Not(instruction) => {
-                u16::write_le(&1u16, &mut writer)?;
-                instruction.write_le(&mut writer)
-            }
-            Self::Or(instruction) => {
-                u16::write_le(&1u16, &mut writer)?;
-                instruction.write_le(&mut writer)
-            }
-            Self::Sub(instruction) => {
                 u16::write_le(&9u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
-            Self::SubWrapped(instruction) => {
+            Self::Or(instruction) => {
                 u16::write_le(&10u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
+            Self::Sub(instruction) => {
+                u16::write_le(&11u16, &mut writer)?;
+                instruction.write_le(&mut writer)
+            }
+            Self::SubWrapped(instruction) => {
+                u16::write_le(&12u16, &mut writer)?;
+                instruction.write_le(&mut writer)
+            }
             Self::Xor(instruction) => {
-                u16::write_le(&1u16, &mut writer)?;
+                u16::write_le(&13u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
         }

--- a/bytecode/src/function/instructions/mod.rs
+++ b/bytecode/src/function/instructions/mod.rs
@@ -295,35 +295,35 @@ impl<P: Program> ToBytes for Instruction<P> {
                 instruction.write_le(&mut writer)
             }
             Self::Div(instruction) => {
-                u16::write_le(&2u16, &mut writer)?;
-                instruction.write_le(&mut writer)
-            }
-            Self::DivWrapped(instruction) => {
                 u16::write_le(&3u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
-            Self::Equal(instruction) => {
+            Self::DivWrapped(instruction) => {
                 u16::write_le(&4u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
-            Self::Mul(instruction) => {
+            Self::Equal(instruction) => {
                 u16::write_le(&5u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
-            Self::MulWrapped(instruction) => {
+            Self::Mul(instruction) => {
                 u16::write_le(&6u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
-            Self::Neg(instruction) => {
+            Self::MulWrapped(instruction) => {
                 u16::write_le(&7u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
-            Self::Sub(instruction) => {
+            Self::Neg(instruction) => {
                 u16::write_le(&8u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
-            Self::SubWrapped(instruction) => {
+            Self::Sub(instruction) => {
                 u16::write_le(&9u16, &mut writer)?;
+                instruction.write_le(&mut writer)
+            }
+            Self::SubWrapped(instruction) => {
+                u16::write_le(&10u16, &mut writer)?;
                 instruction.write_le(&mut writer)
             }
         }

--- a/bytecode/src/function/instructions/mul.rs
+++ b/bytecode/src/function/instructions/mul.rs
@@ -176,91 +176,25 @@ mod tests {
 
     type P = Process;
 
+    const FIELD_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "public"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        ["private", "constant", "private"],
+        ["private", "private", "private"],
+        ["constant", "public", "private"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "private"],
+    ];
+
     #[test]
     fn test_parse() {
         let (_, instruction) = Instruction::<Process>::parse("mul r0 r1 into r2;").unwrap();
         assert!(matches!(instruction, Instruction::Mul(_)));
     }
 
-    // Testing this manually since the constant x public mode yields a public,
-    // but the test_modes! macro expects a private.
-    // test_modes!(field, Mul, "1field", "2field", "2field");
-    mod field {
-        use super::Mul;
-        use crate::binary_instruction_test;
-        binary_instruction_test!(
-            test_public_and_public_yields_private,
-            Mul,
-            "1field.public",
-            "2field.public",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_public_and_constant_yields_private,
-            Mul,
-            "1field.public",
-            "2field.constant",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_public_and_private_yields_private,
-            Mul,
-            "1field.public",
-            "2field.private",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_private_and_constant_yields_private,
-            Mul,
-            "1field.private",
-            "2field.constant",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_private_and_public_yields_private,
-            Mul,
-            "1field.private",
-            "2field.public",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_private_and_private_yields_private,
-            Mul,
-            "1field.private",
-            "2field.private",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_constant_and_private_yields_private,
-            Mul,
-            "1field.constant",
-            "2field.private",
-            "2field.private"
-        );
-
-        binary_instruction_test!(
-            test_constant_and_public_yields_public,
-            Mul,
-            "1field.constant",
-            "2field.public",
-            "2field.public"
-        );
-
-        binary_instruction_test!(
-            test_constant_and_constant_yields_constant,
-            Mul,
-            "1field.constant",
-            "2field.constant",
-            "2field.constant"
-        );
-    }
-
+    test_modes!(field, Mul, "2field", "1field", "2field", FIELD_MODE_TESTS);
     test_modes!(group, Mul, "2group", "1scalar", "2group");
     test_modes!(scalar, Mul, "1scalar", "2group", "2group");
     test_modes!(i8, Mul, "1i8", "2i8", "2i8");

--- a/bytecode/src/function/instructions/nand.rs
+++ b/bytecode/src/function/instructions/nand.rs
@@ -120,6 +120,12 @@ mod tests {
     use super::*;
     use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process};
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("nand r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Nand(_)));
+    }
+
     test_modes!(boolean, Nand, "true", "true", "false");
     binary_instruction_test!(boolean_nand_true_and_false, Nand, "true.public", "false.public", "true.private");
     binary_instruction_test!(boolean_nand_false_and_true, Nand, "false.public", "true.public", "true.private");

--- a/bytecode/src/function/instructions/nand.rs
+++ b/bytecode/src/function/instructions/nand.rs
@@ -1,0 +1,174 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Literal, Nand as NandCircuit, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::io::{Read, Result as IoResult, Write};
+
+/// Returns false only if `first` and `second` are true, storing the outcome in `destination`.
+pub struct Nand<P: Program> {
+    operation: BinaryOperation<P>,
+}
+
+impl<P: Program> Nand<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for Nand<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "nand"
+    }
+}
+
+impl<P: Program> Operation<P> for Nand<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+        let second = match registers.load(self.operation.second()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match (first, second) {
+            (Literal::Boolean(a), Literal::Boolean(b)) => Literal::Boolean(a.nand(&b)),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for Nand<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into an 'nand' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        let (string, operation) = map(BinaryOperation::parse, |operation| Self { operation })(string)?;
+        // Return the operation.
+        Ok((string, operation))
+    }
+}
+
+impl<P: Program> fmt::Display for Nand<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for Nand<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: BinaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for Nand<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for Nand<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::Nand(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process};
+
+    test_modes!(boolean, Nand, "true", "true", "false");
+    binary_instruction_test!(boolean_nand_true_and_false, Nand, "true.public", "false.public", "true.private");
+    binary_instruction_test!(boolean_nand_false_and_true, Nand, "false.public", "true.public", "true.private");
+    binary_instruction_test!(boolean_nand_false_and_false, Nand, "false.public", "false.public", "true.private");
+
+    test_instruction_halts!(
+        address_halts,
+        Nand,
+        "Invalid 'nand' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(i8, Nand, "Invalid 'nand' instruction", "1i8.constant", "0i8.constant");
+    test_instruction_halts!(i16, Nand, "Invalid 'nand' instruction", "1i16.constant", "0i16.constant");
+    test_instruction_halts!(i32, Nand, "Invalid 'nand' instruction", "1i32.constant", "0i32.constant");
+    test_instruction_halts!(i64, Nand, "Invalid 'nand' instruction", "1i64.constant", "0i64.constant");
+    test_instruction_halts!(i128, Nand, "Invalid 'nand' instruction", "1i128.constant", "0i128.constant");
+    test_instruction_halts!(u8, Nand, "Invalid 'nand' instruction", "1u8.constant", "2u8.constant");
+    test_instruction_halts!(u16, Nand, "Invalid 'nand' instruction", "1u16.constant", "2u16.constant");
+    test_instruction_halts!(u32, Nand, "Invalid 'nand' instruction", "1u32.constant", "2u32.constant");
+    test_instruction_halts!(u64, Nand, "Invalid 'nand' instruction", "1u64.constant", "2u64.constant");
+    test_instruction_halts!(u128, Nand, "Invalid 'nand' instruction", "1u128.constant", "2u128.constant");
+    test_instruction_halts!(
+        string_halts,
+        Nand,
+        "Invalid 'nand' instruction",
+        "\"hello\".constant",
+        "\"world\".constant"
+    );
+    test_instruction_halts!(field_halts, Nand, "Invalid 'nand' instruction", "1field.constant", "1field.constant");
+    test_instruction_halts!(group_halts, Nand, "Invalid 'nand' instruction", "2group.constant", "2group.constant");
+    test_instruction_halts!(scalar_halts, Nand, "Invalid 'nand' instruction", "1scalar.constant", "1scalar.constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.define(&Register::from_str("r2"));
+        registers.assign(&Register::from_str("r0"), first);
+        registers.assign(&Register::from_str("r1"), second);
+
+        Nand::from_str("r0 r1 into r2").evaluate(&registers);
+    }
+}

--- a/bytecode/src/function/instructions/nand.rs
+++ b/bytecode/src/function/instructions/nand.rs
@@ -79,7 +79,7 @@ impl<P: Program> Operation<P> for Nand<P> {
 impl<P: Program> Parser for Nand<P> {
     type Environment = P::Environment;
 
-    /// Parses a string into an 'nand' operation.
+    /// Parses a string into a 'nand' operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the operation from the string.

--- a/bytecode/src/function/instructions/neg.rs
+++ b/bytecode/src/function/instructions/neg.rs
@@ -116,7 +116,7 @@ impl<P: Program> Metrics<Self> for Neg<P> {
 impl<P: Program> Parser for Neg<P> {
     type Environment = P::Environment;
 
-    /// Parses a string into an 'neg' operation.
+    /// Parses a string into a 'neg' operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the operation from the string.

--- a/bytecode/src/function/instructions/neg.rs
+++ b/bytecode/src/function/instructions/neg.rs
@@ -153,7 +153,7 @@ impl<P: Program> Into<Instruction<P>> for Neg<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_instruction_halts, test_modes, Process};
+    use crate::{test_instruction_halts, test_modes, Identifier, Process};
 
     #[test]
     fn test_parse() {
@@ -213,4 +213,20 @@ mod tests {
     );
     test_instruction_halts!(boolean_neg_halts, Neg, "Invalid 'neg' instruction", "true.constant");
     test_instruction_halts!(string_neg_halts, Neg, "Invalid 'neg' instruction", "\"hello\".constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.assign(&Register::from_str("r0"), first);
+
+        Neg::from_str("r0 into r1").evaluate(&registers);
+    }
 }

--- a/bytecode/src/function/instructions/nor.rs
+++ b/bytecode/src/function/instructions/nor.rs
@@ -1,0 +1,166 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Literal, Nor as NorCircuit, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::io::{Read, Result as IoResult, Write};
+
+/// Returns true when neither `first` nor `second` is true, storing the outcome in `destination`.
+pub struct Nor<P: Program> {
+    operation: BinaryOperation<P>,
+}
+
+impl<P: Program> Nor<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for Nor<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "nor"
+    }
+}
+
+impl<P: Program> Operation<P> for Nor<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+        let second = match registers.load(self.operation.second()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match (first, second) {
+            (Literal::Boolean(a), Literal::Boolean(b)) => Literal::Boolean(a.nor(&b)),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for Nor<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into an 'nor' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        let (string, operation) = map(BinaryOperation::parse, |operation| Self { operation })(string)?;
+        // Return the operation.
+        Ok((string, operation))
+    }
+}
+
+impl<P: Program> fmt::Display for Nor<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for Nor<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: BinaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for Nor<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for Nor<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::Nor(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process};
+
+    test_modes!(boolean, Nor, "false", "false", "true");
+    binary_instruction_test!(boolean_nor, Nor, "true.public", "false.public", "false.private");
+
+    test_instruction_halts!(
+        address_halts,
+        Nor,
+        "Invalid 'nor' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(i8, Nor, "Invalid 'nor' instruction", "1i8.constant", "0i8.constant");
+    test_instruction_halts!(i16, Nor, "Invalid 'nor' instruction", "1i16.constant", "0i16.constant");
+    test_instruction_halts!(i32, Nor, "Invalid 'nor' instruction", "1i32.constant", "0i32.constant");
+    test_instruction_halts!(i64, Nor, "Invalid 'nor' instruction", "1i64.constant", "0i64.constant");
+    test_instruction_halts!(i128, Nor, "Invalid 'nor' instruction", "1i128.constant", "0i128.constant");
+    test_instruction_halts!(u8, Nor, "Invalid 'nor' instruction", "1u8.constant", "2u8.constant");
+    test_instruction_halts!(u16, Nor, "Invalid 'nor' instruction", "1u16.constant", "2u16.constant");
+    test_instruction_halts!(u32, Nor, "Invalid 'nor' instruction", "1u32.constant", "2u32.constant");
+    test_instruction_halts!(u64, Nor, "Invalid 'nor' instruction", "1u64.constant", "2u64.constant");
+    test_instruction_halts!(u128, Nor, "Invalid 'nor' instruction", "1u128.constant", "2u128.constant");
+    test_instruction_halts!(string_halts, Nor, "Invalid 'nor' instruction", "\"hello\".constant", "\"world\".constant");
+    test_instruction_halts!(field_halts, Nor, "Invalid 'nor' instruction", "1field.constant", "1field.constant");
+    test_instruction_halts!(group_halts, Nor, "Invalid 'nor' instruction", "2group.constant", "2group.constant");
+    test_instruction_halts!(scalar_halts, Nor, "Invalid 'nor' instruction", "1scalar.constant", "1scalar.constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.define(&Register::from_str("r2"));
+        registers.assign(&Register::from_str("r0"), first);
+        registers.assign(&Register::from_str("r1"), second);
+
+        Nor::from_str("r0 r1 into r2").evaluate(&registers);
+    }
+}

--- a/bytecode/src/function/instructions/nor.rs
+++ b/bytecode/src/function/instructions/nor.rs
@@ -120,6 +120,12 @@ mod tests {
     use super::*;
     use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process};
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("nor r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Nor(_)));
+    }
+
     test_modes!(boolean, Nor, "false", "false", "true");
     binary_instruction_test!(boolean_nor, Nor, "true.public", "false.public", "false.private");
 

--- a/bytecode/src/function/instructions/nor.rs
+++ b/bytecode/src/function/instructions/nor.rs
@@ -79,7 +79,7 @@ impl<P: Program> Operation<P> for Nor<P> {
 impl<P: Program> Parser for Nor<P> {
     type Environment = P::Environment;
 
-    /// Parses a string into an 'nor' operation.
+    /// Parses a string into a 'nor' operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the operation from the string.

--- a/bytecode/src/function/instructions/not.rs
+++ b/bytecode/src/function/instructions/not.rs
@@ -124,6 +124,12 @@ mod tests {
     use super::*;
     use crate::{test_instruction_halts, test_modes, Identifier, Process};
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("not r0 into r1;").unwrap();
+        assert!(matches!(instruction, Instruction::Not(_)));
+    }
+
     test_modes!(boolean, Not, "true", "false");
     test_modes!(i8, Not, "0i8", "-1i8");
     test_modes!(i16, Not, "0i16", "-1i16");

--- a/bytecode/src/function/instructions/not.rs
+++ b/bytecode/src/function/instructions/not.rs
@@ -1,0 +1,165 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Literal, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::io::{Read, Result as IoResult, Write};
+
+/// Flips each bit in the representation of `first`, storing the outcome in `destination`.
+pub struct Not<P: Program> {
+    operation: UnaryOperation<P>,
+}
+
+impl<P: Program> Not<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for Not<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "not"
+    }
+}
+
+impl<P: Program> Operation<P> for Not<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match first {
+            Literal::Boolean(a) => Literal::Boolean(!a),
+            Literal::I8(a) => Literal::I8(!a),
+            Literal::I16(a) => Literal::I16(!a),
+            Literal::I32(a) => Literal::I32(!a),
+            Literal::I64(a) => Literal::I64(!a),
+            Literal::I128(a) => Literal::I128(!a),
+            Literal::U8(a) => Literal::U8(!a),
+            Literal::U16(a) => Literal::U16(!a),
+            Literal::U32(a) => Literal::U32(!a),
+            Literal::U64(a) => Literal::U64(!a),
+            Literal::U128(a) => Literal::U128(!a),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for Not<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into an 'not' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        map(UnaryOperation::parse, |operation| Self { operation })(string)
+    }
+}
+
+impl<P: Program> fmt::Display for Not<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for Not<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: UnaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for Not<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for Not<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::Not(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_instruction_halts, test_modes, Identifier, Process};
+
+    test_modes!(boolean, Not, "true", "false");
+    test_modes!(i8, Not, "0i8", "-1i8");
+    test_modes!(i16, Not, "0i16", "-1i16");
+    test_modes!(i32, Not, "0i32", "-1i32");
+    test_modes!(i64, Not, "0i64", "-1i64");
+    test_modes!(i128, Not, "0i128", "-1i128");
+    test_modes!(u8, Not, "0u8", &format!("{}u8", u8::MAX));
+    test_modes!(u16, Not, "0u16", &format!("{}u16", u16::MAX));
+    test_modes!(u32, Not, "0u32", &format!("{}u32", u32::MAX));
+    test_modes!(u64, Not, "0u64", &format!("{}u64", u64::MAX));
+    test_modes!(u128, Not, "0u128", &format!("{}u128", u128::MAX));
+
+    test_instruction_halts!(
+        address_not_halts,
+        Not,
+        "Invalid 'not' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(field_not_halts, Not, "Invalid 'not' instruction", "1field.constant");
+    test_instruction_halts!(group_not_halts, Not, "Invalid 'not' instruction", "2group.constant");
+    test_instruction_halts!(scalar_not_halts, Not, "Invalid 'not' instruction", "1scalar.constant");
+    test_instruction_halts!(string_not_halts, Not, "Invalid 'not' instruction", "\"hello\".constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.assign(&Register::from_str("r0"), first);
+
+        Not::from_str("r0 into r1").evaluate(&registers);
+    }
+}

--- a/bytecode/src/function/instructions/not.rs
+++ b/bytecode/src/function/instructions/not.rs
@@ -85,7 +85,7 @@ impl<P: Program> Operation<P> for Not<P> {
 impl<P: Program> Parser for Not<P> {
     type Environment = P::Environment;
 
-    /// Parses a string into an 'not' operation.
+    /// Parses a string into a 'not' operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the operation from the string.

--- a/bytecode/src/function/instructions/not_equal.rs
+++ b/bytecode/src/function/instructions/not_equal.rs
@@ -1,0 +1,214 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Equal, Literal, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::io::{Read, Result as IoResult, Write};
+
+/// Returns true if `first` is not equal to `second`, storing the result in `destination`.
+pub struct NotEqual<P: Program> {
+    operation: BinaryOperation<P>,
+}
+
+impl<P: Program> NotEqual<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for NotEqual<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "neq"
+    }
+}
+
+impl<P: Program> Operation<P> for NotEqual<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+        let second = match registers.load(self.operation.second()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match (first, second) {
+            (Literal::Address(a), Literal::Address(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::Boolean(a), Literal::Boolean(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::Field(a), Literal::Field(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::Group(a), Literal::Group(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::I8(a), Literal::I8(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::I16(a), Literal::I16(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::I32(a), Literal::I32(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::I64(a), Literal::I64(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::I128(a), Literal::I128(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::Scalar(a), Literal::Scalar(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::U8(a), Literal::U8(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::U16(a), Literal::U16(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::U32(a), Literal::U32(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::U64(a), Literal::U64(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            (Literal::U128(a), Literal::U128(b)) => Literal::Boolean(a.is_not_equal(&b)),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for NotEqual<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into an 'eq' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        let (string, operation) = map(BinaryOperation::parse, |operation| Self { operation })(string)?;
+        // Return the operation.
+        Ok((string, operation))
+    }
+}
+
+impl<P: Program> fmt::Display for NotEqual<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for NotEqual<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: BinaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for NotEqual<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for NotEqual<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::NotEqual(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process};
+
+    test_modes!(
+        address,
+        NotEqual,
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah",
+        "false"
+    );
+    binary_instruction_test!(
+        address_ne,
+        NotEqual,
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.public",
+        "aleo1t9r2aalldn3al4346l3pdplj8prrz5svvahsrl64gp4023342sxsrhs2yg.public",
+        "true.private"
+    );
+
+    test_modes!(boolean, NotEqual, "true", "true", "false");
+    binary_instruction_test!(boolean_ne, NotEqual, "true.public", "false.public", "true.private");
+
+    test_modes!(field, NotEqual, "1field", "1field", "false");
+    binary_instruction_test!(field_ne, NotEqual, "1field.public", "2field.public", "true.private");
+
+    test_modes!(group, NotEqual, "2group", "2group", "false");
+    binary_instruction_test!(group_ne, NotEqual, "2group.public", "0group.public", "true.private");
+
+    test_modes!(i8, NotEqual, "1i8", "1i8", "false");
+    binary_instruction_test!(i8_ne, NotEqual, "1i8.public", "-1i8.public", "true.private");
+
+    test_modes!(i16, NotEqual, "1i16", "1i16", "false");
+    binary_instruction_test!(i16_ne, NotEqual, "1i16.public", "-1i16.public", "true.private");
+
+    test_modes!(i32, NotEqual, "1i32", "1i32", "false");
+    binary_instruction_test!(i32_ne, NotEqual, "1i32.public", "-1i32.public", "true.private");
+
+    test_modes!(i64, NotEqual, "1i64", "1i64", "false");
+    binary_instruction_test!(i64_ne, NotEqual, "1i64.public", "-1i64.public", "true.private");
+
+    test_modes!(i128, NotEqual, "1i128", "1i128", "false");
+    binary_instruction_test!(i128_ne, NotEqual, "1i128.public", "-1i128.public", "true.private");
+
+    test_modes!(scalar, NotEqual, "1scalar", "1scalar", "false");
+    binary_instruction_test!(scalar_ne, NotEqual, "1scalar.public", "-1scalar.public", "true.private");
+
+    test_modes!(u8, NotEqual, "1u8", "1u8", "false");
+    binary_instruction_test!(u8_ne, NotEqual, "1u8.public", "2u8.public", "true.private");
+
+    test_modes!(u16, NotEqual, "1u16", "1u16", "false");
+    binary_instruction_test!(u16_ne, NotEqual, "1u16.public", "2u16.public", "true.private");
+
+    test_modes!(u32, NotEqual, "1u32", "1u32", "false");
+    binary_instruction_test!(u32_ne, NotEqual, "1u32.public", "2u32.public", "true.private");
+
+    test_modes!(u64, NotEqual, "1u64", "1u64", "false");
+    binary_instruction_test!(u64_ne, NotEqual, "1u64.public", "2u64.public", "true.private");
+
+    test_modes!(u128, NotEqual, "1u128", "1u128", "false");
+    binary_instruction_test!(u128_ne, NotEqual, "1u128.public", "2u128.public", "true.private");
+
+    test_instruction_halts!(string_halts, NotEqual, "Invalid 'neq' instruction", "\"hello\"", "\"hello\"");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.define(&Register::from_str("r2"));
+        registers.assign(&Register::from_str("r0"), first);
+        registers.assign(&Register::from_str("r1"), second);
+
+        NotEqual::from_str("r0 r1 into r2").evaluate(&registers);
+    }
+}

--- a/bytecode/src/function/instructions/not_equal.rs
+++ b/bytecode/src/function/instructions/not_equal.rs
@@ -134,6 +134,12 @@ mod tests {
     use super::*;
     use crate::{binary_instruction_test, test_instruction_halts, test_modes, Identifier, Process};
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("neq r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::NotEqual(_)));
+    }
+
     test_modes!(
         address,
         NotEqual,

--- a/bytecode/src/function/instructions/or.rs
+++ b/bytecode/src/function/instructions/or.rs
@@ -154,6 +154,12 @@ mod tests {
         ["constant", "private", "private"],
     ];
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("or r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Or(_)));
+    }
+
     test_modes!(boolean, Or, "true", "false", "true", BOOLEAN_MODE_TESTS);
     test_modes!(i8, Or, "1i8", "0i8", "1i8", INTEGER_MODE_TESTS);
     test_modes!(i16, Or, "1i16", "0i16", "1i16", INTEGER_MODE_TESTS);

--- a/bytecode/src/function/instructions/or.rs
+++ b/bytecode/src/function/instructions/or.rs
@@ -1,0 +1,199 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Literal, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::io::{Read, Result as IoResult, Write};
+
+/// Performs a bitwise Or on `first` and `second`, storing the outcome in `destination`.
+pub struct Or<P: Program> {
+    operation: BinaryOperation<P>,
+}
+
+impl<P: Program> Or<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for Or<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "or"
+    }
+}
+
+impl<P: Program> Operation<P> for Or<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+        let second = match registers.load(self.operation.second()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match (first, second) {
+            (Literal::Boolean(a), Literal::Boolean(b)) => Literal::Boolean(a | b),
+            (Literal::I8(a), Literal::I8(b)) => Literal::I8(a | b),
+            (Literal::I16(a), Literal::I16(b)) => Literal::I16(a | b),
+            (Literal::I32(a), Literal::I32(b)) => Literal::I32(a | b),
+            (Literal::I64(a), Literal::I64(b)) => Literal::I64(a | b),
+            (Literal::I128(a), Literal::I128(b)) => Literal::I128(a | b),
+            (Literal::U8(a), Literal::U8(b)) => Literal::U8(a | b),
+            (Literal::U16(a), Literal::U16(b)) => Literal::U16(a | b),
+            (Literal::U32(a), Literal::U32(b)) => Literal::U32(a | b),
+            (Literal::U64(a), Literal::U64(b)) => Literal::U64(a | b),
+            (Literal::U128(a), Literal::U128(b)) => Literal::U128(a | b),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for Or<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into an 'or' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        let (string, operation) = map(BinaryOperation::parse, |operation| Self { operation })(string)?;
+        // Return the operation.
+        Ok((string, operation))
+    }
+}
+
+impl<P: Program> fmt::Display for Or<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for Or<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: BinaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for Or<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for Or<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::Or(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_instruction_halts, test_modes, Identifier, Process};
+
+    const BOOLEAN_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "public"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        ["private", "constant", "private"],
+        ["private", "private", "private"],
+        ["constant", "public", "constant"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "constant"],
+    ];
+
+    const INTEGER_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "public"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        ["private", "constant", "private"],
+        ["private", "private", "private"],
+        ["constant", "public", "public"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "private"],
+    ];
+
+    test_modes!(boolean, Or, "true", "false", "true", BOOLEAN_MODE_TESTS);
+    test_modes!(i8, Or, "1i8", "0i8", "1i8", INTEGER_MODE_TESTS);
+    test_modes!(i16, Or, "1i16", "0i16", "1i16", INTEGER_MODE_TESTS);
+    test_modes!(i32, Or, "1i32", "0i32", "1i32", INTEGER_MODE_TESTS);
+    test_modes!(i64, Or, "1i64", "0i64", "1i64", INTEGER_MODE_TESTS);
+    test_modes!(i128, Or, "1i128", "0i128", "1i128", INTEGER_MODE_TESTS);
+    test_modes!(u8, Or, "1u8", "2u8", "3u8", INTEGER_MODE_TESTS);
+    test_modes!(u16, Or, "1u16", "2u16", "3u16", INTEGER_MODE_TESTS);
+    test_modes!(u32, Or, "1u32", "2u32", "3u32", INTEGER_MODE_TESTS);
+    test_modes!(u64, Or, "1u64", "2u64", "3u64", INTEGER_MODE_TESTS);
+    test_modes!(u128, Or, "1u128", "2u128", "3u128", INTEGER_MODE_TESTS);
+
+    test_instruction_halts!(
+        address_halts,
+        Or,
+        "Invalid 'or' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(string_halts, Or, "Invalid 'or' instruction", "\"hello\".constant", "\"world\".constant");
+    test_instruction_halts!(field_halts, Or, "Invalid 'or' instruction", "1field.constant", "1field.constant");
+    test_instruction_halts!(group_halts, Or, "Invalid 'or' instruction", "2group.constant", "2group.constant");
+    test_instruction_halts!(scalar_halts, Or, "Invalid 'or' instruction", "1scalar.constant", "1scalar.constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.define(&Register::from_str("r2"));
+        registers.assign(&Register::from_str("r0"), first);
+        registers.assign(&Register::from_str("r1"), second);
+
+        Or::from_str("r0 r1 into r2").evaluate(&registers);
+    }
+}

--- a/bytecode/src/function/instructions/sub.rs
+++ b/bytecode/src/function/instructions/sub.rs
@@ -133,7 +133,7 @@ impl<P: Program> Metrics<Self> for Sub<P> {
 impl<P: Program> Parser for Sub<P> {
     type Environment = P::Environment;
 
-    /// Parses a string into an 'sub' operation.
+    /// Parses a string into a 'sub' operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the operation from the string.

--- a/bytecode/src/function/instructions/sub.rs
+++ b/bytecode/src/function/instructions/sub.rs
@@ -49,7 +49,7 @@ use core::{fmt, ops::Sub as SubCircuit};
 use nom::combinator::map;
 use std::io::{Read, Result as IoResult, Write};
 
-/// Subtracts `second` from `first`, storing the outcome in `destination`.
+/// Computes `first - second`, storing the outcome in `destination`.
 pub struct Sub<P: Program> {
     operation: BinaryOperation<P>,
 }

--- a/bytecode/src/function/instructions/sub.rs
+++ b/bytecode/src/function/instructions/sub.rs
@@ -172,7 +172,7 @@ impl<P: Program> Into<Instruction<P>> for Sub<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_instruction_halts, test_modes, Process};
+    use crate::{test_instruction_halts, test_modes, Identifier, Process};
 
     #[test]
     fn test_parse() {
@@ -273,4 +273,23 @@ mod tests {
     );
     test_instruction_halts!(boolean_halts, Sub, "Invalid 'sub' instruction", "true.constant", "true.constant");
     test_instruction_halts!(string_halts, Sub, "Invalid 'sub' instruction", "\"hello\".constant", "\"world\".constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.define(&Register::from_str("r2"));
+        registers.assign(&Register::from_str("r0"), first);
+        registers.assign(&Register::from_str("r1"), second);
+
+        Sub::from_str("r0 r1 into r2").evaluate(&registers);
+    }
 }

--- a/bytecode/src/function/instructions/sub_wrapped.rs
+++ b/bytecode/src/function/instructions/sub_wrapped.rs
@@ -46,7 +46,7 @@ use core::fmt;
 use nom::combinator::map;
 use std::io::{Read, Result as IoResult, Write};
 
-/// Subtracts `second` from `first`, wrapping around at the boundary of the type, and storing the outcome in `destination`.
+/// Computes `first - second`, wrapping around at the boundary of the type, and storing the outcome in `destination`.
 pub struct SubWrapped<P: Program> {
     operation: BinaryOperation<P>,
 }

--- a/bytecode/src/function/instructions/xor.rs
+++ b/bytecode/src/function/instructions/xor.rs
@@ -154,6 +154,12 @@ mod tests {
         ["constant", "private", "private"],
     ];
 
+    #[test]
+    fn test_parse() {
+        let (_, instruction) = Instruction::<Process>::parse("xor r0 r1 into r2;").unwrap();
+        assert!(matches!(instruction, Instruction::Xor(_)));
+    }
+
     // Boolean happens to produce the same modes as signed integers for Xor.
     test_modes!(boolean, Xor, "true", "false", "true", SIGNED_INTEGER_MODE_TESTS);
     test_modes!(i8, Xor, "1i8", "0i8", "1i8", SIGNED_INTEGER_MODE_TESTS);

--- a/bytecode/src/function/instructions/xor.rs
+++ b/bytecode/src/function/instructions/xor.rs
@@ -1,0 +1,200 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    function::{parsers::*, Instruction, Opcode, Operation, Registers},
+    helpers::Register,
+    Program,
+    Value,
+};
+use snarkvm_circuits::{Literal, Parser, ParserResult};
+use snarkvm_utilities::{FromBytes, ToBytes};
+
+use core::fmt;
+use nom::combinator::map;
+use std::io::{Read, Result as IoResult, Write};
+
+/// Performs a bitwise Xor on `first` and `second`, storing the outcome in `destination`.
+pub struct Xor<P: Program> {
+    operation: BinaryOperation<P>,
+}
+
+impl<P: Program> Xor<P> {
+    /// Returns the operands of the instruction.
+    pub fn operands(&self) -> Vec<Operand<P>> {
+        self.operation.operands()
+    }
+
+    /// Returns the destination register of the instruction.
+    pub fn destination(&self) -> &Register<P> {
+        self.operation.destination()
+    }
+}
+
+impl<P: Program> Opcode for Xor<P> {
+    /// Returns the opcode as a string.
+    #[inline]
+    fn opcode() -> &'static str {
+        "xor"
+    }
+}
+
+impl<P: Program> Operation<P> for Xor<P> {
+    /// Evaluates the operation.
+    #[inline]
+    fn evaluate(&self, registers: &Registers<P>) {
+        // Load the values for the first and second operands.
+        let first = match registers.load(self.operation.first()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+        let second = match registers.load(self.operation.second()) {
+            Value::Literal(literal) => literal,
+            Value::Composite(name, ..) => P::halt(format!("{name} is not a literal")),
+        };
+
+        // Perform the operation.
+        let result = match (first, second) {
+            (Literal::Boolean(a), Literal::Boolean(b)) => Literal::Boolean(a ^ b),
+            (Literal::I8(a), Literal::I8(b)) => Literal::I8(a ^ b),
+            (Literal::I16(a), Literal::I16(b)) => Literal::I16(a ^ b),
+            (Literal::I32(a), Literal::I32(b)) => Literal::I32(a ^ b),
+            (Literal::I64(a), Literal::I64(b)) => Literal::I64(a ^ b),
+            (Literal::I128(a), Literal::I128(b)) => Literal::I128(a ^ b),
+            (Literal::U8(a), Literal::U8(b)) => Literal::U8(a ^ b),
+            (Literal::U16(a), Literal::U16(b)) => Literal::U16(a ^ b),
+            (Literal::U32(a), Literal::U32(b)) => Literal::U32(a ^ b),
+            (Literal::U64(a), Literal::U64(b)) => Literal::U64(a ^ b),
+            (Literal::U128(a), Literal::U128(b)) => Literal::U128(a ^ b),
+            _ => P::halt(format!("Invalid '{}' instruction", Self::opcode())),
+        };
+
+        registers.assign(self.operation.destination(), result);
+    }
+}
+
+impl<P: Program> Parser for Xor<P> {
+    type Environment = P::Environment;
+
+    /// Parses a string into an 'xor' operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the operation from the string.
+        let (string, operation) = map(BinaryOperation::parse, |operation| Self { operation })(string)?;
+        // Return the operation.
+        Ok((string, operation))
+    }
+}
+
+impl<P: Program> fmt::Display for Xor<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.operation)
+    }
+}
+
+impl<P: Program> FromBytes for Xor<P> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Self { operation: BinaryOperation::read_le(&mut reader)? })
+    }
+}
+
+impl<P: Program> ToBytes for Xor<P> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operation.write_le(&mut writer)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<P: Program> Into<Instruction<P>> for Xor<P> {
+    /// Converts the operation into an instruction.
+    fn into(self) -> Instruction<P> {
+        Instruction::Xor(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_instruction_halts, test_modes, Identifier, Process};
+
+    const SIGNED_INTEGER_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "public"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        ["private", "constant", "private"],
+        ["private", "private", "private"],
+        ["constant", "public", "private"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "private"],
+    ];
+
+    const UNSIGNED_INTEGER_MODE_TESTS: [[&str; 3]; 9] = [
+        ["public", "public", "private"],
+        ["public", "constant", "private"],
+        ["public", "private", "private"],
+        ["private", "public", "private"],
+        ["private", "constant", "private"],
+        ["private", "private", "private"],
+        ["constant", "public", "private"],
+        ["constant", "constant", "constant"],
+        ["constant", "private", "private"],
+    ];
+
+    // Boolean happens to produce the same modes as signed integers for Xor.
+    test_modes!(boolean, Xor, "true", "false", "true", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i8, Xor, "1i8", "0i8", "1i8", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i16, Xor, "1i16", "0i16", "1i16", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i32, Xor, "1i32", "0i32", "1i32", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i64, Xor, "1i64", "0i64", "1i64", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(i128, Xor, "1i128", "0i128", "1i128", SIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u8, Xor, "1u8", "2u8", "3u8", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u16, Xor, "1u16", "2u16", "3u16", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u32, Xor, "1u32", "2u32", "3u32", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u64, Xor, "1u64", "2u64", "3u64", UNSIGNED_INTEGER_MODE_TESTS);
+    test_modes!(u128, Xor, "1u128", "2u128", "3u128", UNSIGNED_INTEGER_MODE_TESTS);
+
+    test_instruction_halts!(
+        address_halts,
+        Xor,
+        "Invalid 'xor' instruction",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant",
+        "aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.constant"
+    );
+    test_instruction_halts!(string_halts, Xor, "Invalid 'xor' instruction", "\"hello\".constant", "\"world\".constant");
+    test_instruction_halts!(field_halts, Xor, "Invalid 'xor' instruction", "1field.constant", "1field.constant");
+    test_instruction_halts!(group_halts, Xor, "Invalid 'xor' instruction", "2group.constant", "2group.constant");
+    test_instruction_halts!(scalar_halts, Xor, "Invalid 'xor' instruction", "1scalar.constant", "1scalar.constant");
+
+    #[test]
+    #[should_panic(expected = "message is not a literal")]
+    fn test_composite_halts() {
+        let first = Value::<Process>::Composite(Identifier::from_str("message"), vec![
+            Literal::from_str("2group.public"),
+            Literal::from_str("10field.private"),
+        ]);
+        let second = first.clone();
+
+        let registers = Registers::<Process>::default();
+        registers.define(&Register::from_str("r0"));
+        registers.define(&Register::from_str("r1"));
+        registers.define(&Register::from_str("r2"));
+        registers.assign(&Register::from_str("r0"), first);
+        registers.assign(&Register::from_str("r1"), second);
+
+        Xor::from_str("r0 r1 into r2").evaluate(&registers);
+    }
+}

--- a/bytecode/src/function/instructions/xor.rs
+++ b/bytecode/src/function/instructions/xor.rs
@@ -160,7 +160,6 @@ mod tests {
         assert!(matches!(instruction, Instruction::Xor(_)));
     }
 
-    // Boolean happens to produce the same modes as signed integers for Xor.
     test_modes!(boolean, Xor, "true", "false", "true", SIGNED_INTEGER_MODE_TESTS);
     test_modes!(i8, Xor, "1i8", "0i8", "1i8", SIGNED_INTEGER_MODE_TESTS);
     test_modes!(i16, Xor, "1i16", "0i16", "1i16", SIGNED_INTEGER_MODE_TESTS);

--- a/bytecode/src/helpers/identifier.rs
+++ b/bytecode/src/helpers/identifier.rs
@@ -48,7 +48,24 @@ const KEYWORDS: &[&str] = &[
     // Boolean
     "true",
     "false",
-    // TODO (howardwu): Add the instruction opcodes.
+    // Opcodes
+    "add",
+    "add.w",
+    "and",
+    "div",
+    "div.w",
+    "eq",
+    "mul",
+    "mul.w",
+    "nand",
+    "neg",
+    "neq",
+    "nor",
+    "not",
+    "or",
+    "sub",
+    "sub.w",
+    "xor",
     // Statements
     "input",
     "output",

--- a/bytecode/src/helpers/identifier.rs
+++ b/bytecode/src/helpers/identifier.rs
@@ -191,6 +191,8 @@ mod tests {
         assert!(Identifier::<P>::parse("r0").is_err());
         assert!(Identifier::<P>::parse("r123").is_err());
         assert!(Identifier::<P>::parse("r0.owner").is_err());
+        // Must not be an opcode.
+        assert!(Identifier::<P>::parse("add").is_err());
     }
 
     #[test]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Implement bytecode instructions for And,Equal, Not, Or, XOR, NAND, NEQ, NOR.

Add opcodes to reserved keywords list in `identifiers.rs`.

Refactored testing macro implementations to cut down on duplication and increase clarity. Generated tests also have clearer names. For example,`test_modes!(boolean, or, "true", "false", "false")` would produce a test named `test_or_boolean_modes`.
