### PR TITLE
Fix bug in GPU blst_377_cuda

### DIFF
--- a/algorithms/src/msm/variable_base/blst_377_cuda/blst_377_ops.cu
+++ b/algorithms/src/msm/variable_base/blst_377_cuda/blst_377_ops.cu
@@ -417,6 +417,12 @@ __device__ void blst_p1_add_projective_to_projective(blst_p1 *out, const blst_p1
     blst_fp_mul(s2, p2->Y, p1->Z);
     blst_fp_mul(s2, s2, z1z1);
 
+    if (is_blst_fp_eq(u1, u2) && is_blst_fp_eq(s1, s2)){
+        // The two points are equal, so we double
+        blst_p1_double(out, p1);
+        return;
+    }
+
     // H = U2-U1
     blst_fp h;
     blst_fp_sub(h, u2, u1);


### PR DESCRIPTION
## Motivation
bug in blst_p1_add_projective_to_projective function, The two points are equal, so is double,is not zero.

## Test Plan
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/45553901/167789982-07da16df-0fd8-4e00-ac12-db4aa7681156.png">
The array has two items and their values are the same. The test result is wrong. The PR result is correct

## Related PRs
(Link your related PRs here)
