### PR TITLE
Fix logic for Boolean::not

### DIFF
--- a/circuits/types/boolean/src/and.rs
+++ b/circuits/types/boolean/src/and.rs
@@ -179,6 +179,33 @@ mod tests {
     }
 
     #[test]
+    fn test_constant_and_private() {
+        // false AND false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_and("false AND false", expected, a, b, 0, 0, 0, 0);
+
+        // false AND true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_and("false AND true", expected, a, b, 0, 0, 0, 0);
+
+        // true AND false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_and("true AND false", expected, a, b, 0, 0, 0, 0);
+
+        // true AND true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_and("true AND true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
     fn test_public_and_constant() {
         // false AND false
         let expected = false;
@@ -234,6 +261,60 @@ mod tests {
 
     #[test]
     fn test_public_and_private() {
+        // false AND false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Public, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_and("false AND false", expected, a, b, 0, 0, 1, 1);
+
+        // false AND true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Public, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_and("false AND true", expected, a, b, 0, 0, 1, 1);
+
+        // true AND false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Public, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_and("true AND false", expected, a, b, 0, 0, 1, 1);
+
+        // true AND true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Public, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_and("true AND true", expected, a, b, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_private_and_constant() {
+        // false AND false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_and("false AND false", expected, a, b, 0, 0, 0, 0);
+
+        // false AND true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_and("false AND true", expected, a, b, 0, 0, 0, 0);
+
+        // true AND false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_and("true AND false", expected, a, b, 0, 0, 0, 0);
+
+        // true AND true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_and("true AND true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn test_private_and_public() {
         // false AND false
         let expected = false;
         let a = Boolean::<Circuit>::new(Mode::Public, false);

--- a/circuits/types/boolean/src/equal.rs
+++ b/circuits/types/boolean/src/equal.rs
@@ -107,6 +107,33 @@ mod tests {
     }
 
     #[test]
+    fn test_constant_equal_private() {
+        // false == false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_is_equal("false == false", expected, a, b, 0, 0, 0, 0);
+
+        // false == true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_is_equal("false == true", expected, a, b, 0, 0, 0, 0);
+
+        // true == false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_is_equal("true == false", expected, a, b, 0, 0, 0, 0);
+
+        // true == true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_is_equal("true == true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
     fn test_public_equals_constant() {
         // false == false
         let expected = true;
@@ -184,6 +211,60 @@ mod tests {
         let expected = true;
         let a = Boolean::<Circuit>::new(Mode::Public, true);
         let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_is_equal("true == true", expected, a, b, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_private_equals_constant() {
+        // false == false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_is_equal("false == false", expected, a, b, 0, 0, 0, 0);
+
+        // false == true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_is_equal("false == true", expected, a, b, 0, 0, 0, 0);
+
+        // true == false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_is_equal("true == false", expected, a, b, 0, 0, 0, 0);
+
+        // true == true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_is_equal("true == true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn test_private_equal_public() {
+        // false == false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_is_equal("false == false", expected, a, b, 0, 0, 1, 1);
+
+        // false == true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
+        check_is_equal("false == true", expected, a, b, 0, 0, 1, 1);
+
+        // true == false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_is_equal("true == false", expected, a, b, 0, 0, 1, 1);
+
+        // true == true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
         check_is_equal("true == true", expected, a, b, 0, 0, 1, 1);
     }
 

--- a/circuits/types/boolean/src/nand.rs
+++ b/circuits/types/boolean/src/nand.rs
@@ -134,6 +134,33 @@ mod tests {
     }
 
     #[test]
+    fn test_constant_nand_private() {
+        // false NAND false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_nand("false NAND false", expected, a, b, 0, 0, 0, 0);
+
+        // false NAND true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_nand("false NAND true", expected, a, b, 0, 0, 0, 0);
+
+        // true NAND false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_nand("true NAND false", expected, a, b, 0, 0, 0, 0);
+
+        // true NAND true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_nand("true NAND true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
     fn test_public_nand_constant() {
         // false NAND false
         let expected = true;
@@ -211,6 +238,60 @@ mod tests {
         let expected = false;
         let a = Boolean::<Circuit>::new(Mode::Public, true);
         let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_nand("true NAND true", expected, a, b, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_private_nand_constant() {
+        // false NAND false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_nand("false NAND false", expected, a, b, 0, 0, 0, 0);
+
+        // false NAND true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_nand("false NAND true", expected, a, b, 0, 0, 0, 0);
+
+        // true NAND false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_nand("true NAND false", expected, a, b, 0, 0, 0, 0);
+
+        // true NAND true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_nand("true NAND true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn test_private_nand_public() {
+        // false NAND false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_nand("false NAND false", expected, a, b, 0, 0, 1, 1);
+
+        // false NAND true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
+        check_nand("false NAND true", expected, a, b, 0, 0, 1, 1);
+
+        // true NAND false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_nand("true NAND false", expected, a, b, 0, 0, 1, 1);
+
+        // true NAND true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
         check_nand("true NAND true", expected, a, b, 0, 0, 1, 1);
     }
 

--- a/circuits/types/boolean/src/nor.rs
+++ b/circuits/types/boolean/src/nor.rs
@@ -74,14 +74,14 @@ impl<E: Environment> OutputMode<dyn Nor<Boolean<E>, Output = Boolean<E>>> for Bo
     fn output_mode(case: &Self::Case) -> Mode {
         match (case.0.mode(), case.1.mode()) {
             (Mode::Constant, Mode::Constant) => Mode::Constant,
-            (Mode::Public, Mode::Constant) => match &case.1 {
+            (_, Mode::Constant) => match &case.1 {
                 CircuitType::Constant(constant) => match constant.eject_value() {
                     true => Mode::Constant,
                     false => Mode::Private,
                 },
                 _ => E::halt("The constant is required to determine the output mode of Public NOR Constant"),
             },
-            (Mode::Constant, Mode::Public) => match &case.0 {
+            (Mode::Constant, _) => match &case.0 {
                 CircuitType::Constant(constant) => match constant.eject_value() {
                     true => Mode::Constant,
                     false => Mode::Private,
@@ -163,6 +163,33 @@ mod tests {
     }
 
     #[test]
+    fn test_constant_nor_private() {
+        // false NOR false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_nor("false NOR false", expected, a, b);
+
+        // false NOR true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_nor("false NOR true", expected, a, b);
+
+        // true NOR false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_nor("true NOR false", expected, a, b);
+
+        // true NOR true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_nor("true NOR true", expected, a, b);
+    }
+
+    #[test]
     fn test_public_nor_constant() {
         // false NOR false
         let expected = true;
@@ -240,6 +267,60 @@ mod tests {
         let expected = false;
         let a = Boolean::<Circuit>::new(Mode::Public, true);
         let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_nor("true NOR true", expected, a, b);
+    }
+
+    #[test]
+    fn test_private_nor_constant() {
+        // false NOR false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_nor("false NOR false", expected, a, b);
+
+        // false NOR true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_nor("false NOR true", expected, a, b);
+
+        // true NOR false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_nor("true NOR false", expected, a, b);
+
+        // true NOR true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_nor("true NOR true", expected, a, b);
+    }
+
+    #[test]
+    fn test_private_nor_public() {
+        // false NOR false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_nor("false NOR false", expected, a, b);
+
+        // false NOR true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
+        check_nor("false NOR true", expected, a, b);
+
+        // true NOR false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_nor("true NOR false", expected, a, b);
+
+        // true NOR true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
         check_nor("true NOR true", expected, a, b);
     }
 

--- a/circuits/types/boolean/src/not.rs
+++ b/circuits/types/boolean/src/not.rs
@@ -31,6 +31,8 @@ impl<E: Environment> Not for &Boolean<E> {
 
     /// Returns `(NOT a)`.
     fn not(self) -> Self::Output {
+        // Suppose that `self is `0`. Then `1 - self` is `1`.
+        // Suppose that `self is `1`. Then `1 - self` is `0`.
         match self.is_constant() {
             // Constant case.
             true => Boolean(E::one() - &self.0),

--- a/circuits/types/boolean/src/not.rs
+++ b/circuits/types/boolean/src/not.rs
@@ -31,8 +31,9 @@ impl<E: Environment> Not for &Boolean<E> {
 
     /// Returns `(NOT a)`.
     fn not(self) -> Self::Output {
-        // Suppose that `self is `0`. Then `1 - self` is `1`.
-        // Suppose that `self is `1`. Then `1 - self` is `0`.
+        // The `NOT` operation behaves as follows:
+        //     Case 1: If `(self == 0)`, then `(1 - self) == 1`.
+        //     Case 2: If `(self == 1)`, then `(1 - self) == 0`.
         match self.is_constant() {
             // Constant case.
             true => Boolean(E::one() - &self.0),

--- a/circuits/types/boolean/src/not.rs
+++ b/circuits/types/boolean/src/not.rs
@@ -31,19 +31,11 @@ impl<E: Environment> Not for &Boolean<E> {
 
     /// Returns `(NOT a)`.
     fn not(self) -> Self::Output {
-        // Constant case
-        if self.is_constant() {
-            match self.eject_value() {
-                true => Boolean(&self.0 - E::one()),
-                false => Boolean(&self.0 + E::one()),
-            }
-        }
-        // Public and private cases
-        else {
-            match self.eject_value() {
-                true => Boolean(&self.0 - Variable::Public(0, Rc::new(E::BaseField::one()))),
-                false => Boolean(&self.0 + Variable::Public(0, Rc::new(E::BaseField::one()))),
-            }
+        match self.is_constant() {
+            // Constant case.
+            true => Boolean(E::one() - &self.0),
+            // Public and private cases.
+            false => Boolean(Variable::Public(0, Rc::new(E::BaseField::one())) - &self.0),
         }
     }
 }

--- a/circuits/types/boolean/src/or.rs
+++ b/circuits/types/boolean/src/or.rs
@@ -180,6 +180,33 @@ mod tests {
     }
 
     #[test]
+    fn test_constant_or_private() {
+        // false OR false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_or("false OR false", expected, a, b, 0, 0, 0, 0);
+
+        // false OR true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_or("false OR true", expected, a, b, 0, 0, 0, 0);
+
+        // true OR false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_or("true OR false", expected, a, b, 0, 0, 0, 0);
+
+        // true OR true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_or("true OR true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
     fn test_public_or_constant() {
         // false OR false
         let expected = false;
@@ -257,6 +284,60 @@ mod tests {
         let expected = true;
         let a = Boolean::<Circuit>::new(Mode::Public, true);
         let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_or("true OR true", expected, a, b, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_private_or_constant() {
+        // false OR false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_or("false OR false", expected, a, b, 0, 0, 0, 0);
+
+        // false OR true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_or("false OR true", expected, a, b, 0, 0, 0, 0);
+
+        // true OR false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_or("true OR false", expected, a, b, 0, 0, 0, 0);
+
+        // true OR true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_or("true OR true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn test_private_or_public() {
+        // false OR false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_or("false OR false", expected, a, b, 0, 0, 1, 1);
+
+        // false OR true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
+        check_or("false OR true", expected, a, b, 0, 0, 1, 1);
+
+        // true OR false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_or("true OR false", expected, a, b, 0, 0, 1, 1);
+
+        // true OR true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
         check_or("true OR true", expected, a, b, 0, 0, 1, 1);
     }
 

--- a/circuits/types/boolean/src/ternary.rs
+++ b/circuits/types/boolean/src/ternary.rs
@@ -102,298 +102,171 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_constant_condition() {
-        // false ? Constant : Constant
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, false);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("false ? Constant : Constant", expected, condition, a, b, 0, 0, 0, 0);
+    fn run_test(
+        mode_condition: Mode,
+        mode_a: Mode,
+        mode_b: Mode,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+    ) {
+        for flag in [true, false] {
+            for first in [true, false] {
+                for second in [true, false] {
+                    let condition = Boolean::<Circuit>::new(mode_condition, flag);
+                    let a = Boolean::<Circuit>::new(mode_a, first);
+                    let b = Boolean::<Circuit>::new(mode_b, second);
 
-        // false ? Constant : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, false);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Constant : Public", expected, condition, a, b, 0, 0, 0, 0);
-
-        // false ? Public : Constant
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("false ? Public : Constant", expected, condition, a, b, 0, 0, 0, 0);
-
-        // false ? Public : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Public : Public", expected, condition, a, b, 0, 0, 0, 0);
-
-        // false ? Public : Private
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("false ? Public : Private", expected, condition, a, b, 0, 0, 0, 0);
-
-        // false ? Private : Private
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, false);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("false ? Private : Private", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Constant : Constant
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, true);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("true ? Constant : Constant", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Constant : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, true);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Constant : Public", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Public : Constant
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("true ? Public : Constant", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Public : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Public : Public", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Public : Private
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("true ? Public : Private", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Private : Private
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Constant, true);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("true ? Private : Private", expected, condition, a, b, 0, 0, 0, 0);
+                    let name = format!("{} ? {} : {}", mode_condition, mode_a, mode_b);
+                    check_ternary(
+                        &name,
+                        if flag { first } else { second },
+                        condition,
+                        a,
+                        b,
+                        num_constants,
+                        num_public,
+                        num_private,
+                        num_constraints,
+                    );
+                }
+            }
+        }
     }
 
     #[test]
-    fn test_public_condition_and_constant_input() {
-        // false ? Constant : Constant
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Public, false);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("false ? Constant : Constant", expected, condition, a, b, 0, 0, 0, 0);
-
-        // false ? Constant : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Public, false);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Constant : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // false ? Public : Constant
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Public, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("false ? Public : Constant", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Constant : Constant
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Public, true);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("true ? Constant : Constant", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Constant : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Public, true);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Constant : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Public : Constant
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Public, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("true ? Public : Constant", expected, condition, a, b, 0, 0, 1, 1);
+    fn test_if_constant_then_constant_else_constant() {
+        run_test(Mode::Constant, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
     }
 
     #[test]
-    fn test_private_condition_and_constant_input() {
-        // false ? Constant : Constant
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Private, false);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("false ? Constant : Constant", expected, condition, a, b, 0, 0, 0, 0);
-
-        // false ? Constant : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Private, false);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Constant : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // false ? Public : Constant
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Private, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("false ? Public : Constant", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Constant : Constant
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Private, true);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("true ? Constant : Constant", expected, condition, a, b, 0, 0, 0, 0);
-
-        // true ? Constant : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Private, true);
-        let a = Boolean::<Circuit>::new(Mode::Constant, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Constant : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Public : Constant
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Private, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Constant, false);
-        check_ternary("true ? Public : Constant", expected, condition, a, b, 0, 0, 1, 1);
+    fn test_if_constant_then_constant_else_public() {
+        run_test(Mode::Constant, Mode::Constant, Mode::Public, 0, 0, 0, 0);
     }
 
     #[test]
-    fn test_public_condition_and_variable_inputs() {
-        // false ? Public : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Public, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Public : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // false ? Public : Private
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Public, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("false ? Public : Private", expected, condition, a, b, 0, 0, 1, 1);
-
-        // false ? Private : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Public, false);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Private : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // false ? Private : Private
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Public, false);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("false ? Private : Private", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Public : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Public, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Public : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Public : Private
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Public, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("true ? Public : Private", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Private : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Public, true);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Private : Public", expected, condition, a, b, 0, 0, 1, 1);
-
-        // true ? Private : Private
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Public, true);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("true ? Private : Private", expected, condition, a, b, 0, 0, 1, 1);
+    fn test_if_constant_then_constant_else_private() {
+        run_test(Mode::Constant, Mode::Constant, Mode::Private, 0, 0, 0, 0);
     }
 
     #[test]
-    fn test_private_condition_and_variable_inputs() {
-        // false ? Public : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Private, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Public : Public", expected, condition, a, b, 0, 0, 1, 1);
+    fn test_if_constant_then_public_else_constant() {
+        run_test(Mode::Constant, Mode::Public, Mode::Constant, 0, 0, 0, 0);
+    }
 
-        // false ? Public : Private
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Private, false);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("false ? Public : Private", expected, condition, a, b, 0, 0, 1, 1);
+    #[test]
+    fn test_if_constant_then_public_else_public() {
+        run_test(Mode::Constant, Mode::Public, Mode::Public, 0, 0, 0, 0);
+    }
 
-        // false ? Private : Public
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Private, false);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("false ? Private : Public", expected, condition, a, b, 0, 0, 1, 1);
+    #[test]
+    fn test_if_constant_then_public_else_private() {
+        run_test(Mode::Constant, Mode::Public, Mode::Private, 0, 0, 0, 0);
+    }
 
-        // false ? Private : Private
-        let expected = false;
-        let condition = Boolean::<Circuit>::new(Mode::Private, false);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("false ? Private : Private", expected, condition, a, b, 0, 0, 1, 1);
+    #[test]
+    fn test_if_constant_then_private_else_constant() {
+        run_test(Mode::Constant, Mode::Private, Mode::Constant, 0, 0, 0, 0);
+    }
 
-        // true ? Public : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Private, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Public : Public", expected, condition, a, b, 0, 0, 1, 1);
+    #[test]
+    fn test_if_constant_then_private_else_public() {
+        run_test(Mode::Constant, Mode::Private, Mode::Public, 0, 0, 0, 0);
+    }
 
-        // true ? Public : Private
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Private, true);
-        let a = Boolean::<Circuit>::new(Mode::Public, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("true ? Public : Private", expected, condition, a, b, 0, 0, 1, 1);
+    #[test]
+    fn test_if_constant_then_private_else_private() {
+        run_test(Mode::Constant, Mode::Private, Mode::Private, 0, 0, 0, 0);
+    }
 
-        // true ? Private : Public
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Private, true);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Public, false);
-        check_ternary("true ? Private : Public", expected, condition, a, b, 0, 0, 1, 1);
+    #[test]
+    fn test_if_public_then_constant_else_constant() {
+        run_test(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
+    }
 
-        // true ? Private : Private
-        let expected = true;
-        let condition = Boolean::<Circuit>::new(Mode::Private, true);
-        let a = Boolean::<Circuit>::new(Mode::Private, true);
-        let b = Boolean::<Circuit>::new(Mode::Private, false);
-        check_ternary("true ? Private : Private", expected, condition, a, b, 0, 0, 1, 1);
+    #[test]
+    fn test_if_public_then_constant_else_public() {
+        run_test(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_public_then_constant_else_private() {
+        run_test(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_public_then_public_else_constant() {
+        run_test(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_public_then_public_else_public() {
+        run_test(Mode::Public, Mode::Public, Mode::Public, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_public_then_public_else_private() {
+        run_test(Mode::Public, Mode::Public, Mode::Private, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_public_then_private_else_constant() {
+        run_test(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_public_then_private_else_public() {
+        run_test(Mode::Public, Mode::Private, Mode::Public, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_public_then_private_else_private() {
+        run_test(Mode::Public, Mode::Private, Mode::Private, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_constant_else_constant() {
+        run_test(Mode::Private, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn test_if_private_then_constant_else_public() {
+        run_test(Mode::Private, Mode::Constant, Mode::Public, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_constant_else_private() {
+        run_test(Mode::Private, Mode::Constant, Mode::Private, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_public_else_constant() {
+        run_test(Mode::Private, Mode::Public, Mode::Constant, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_public_else_public() {
+        run_test(Mode::Private, Mode::Public, Mode::Public, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_public_else_private() {
+        run_test(Mode::Private, Mode::Public, Mode::Private, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_private_else_constant() {
+        run_test(Mode::Private, Mode::Private, Mode::Constant, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_private_else_public() {
+        run_test(Mode::Private, Mode::Private, Mode::Public, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_if_private_then_private_else_private() {
+        run_test(Mode::Private, Mode::Private, Mode::Private, 0, 0, 1, 1);
     }
 }

--- a/circuits/types/boolean/src/xor.rs
+++ b/circuits/types/boolean/src/xor.rs
@@ -197,6 +197,33 @@ mod tests {
     }
 
     #[test]
+    fn test_constant_xor_private() {
+        // false != false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_xor("false != false", expected, a, b, 0, 0, 0, 0);
+
+        // false != true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, false);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_xor("false != true", expected, a, b, 0, 0, 0, 0);
+
+        // true != false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, false);
+        check_xor("true != false", expected, a, b, 0, 0, 0, 0);
+
+        // true != true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Constant, true);
+        let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_xor("true != true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
     fn test_public_xor_constant() {
         // false != false
         let expected = false;
@@ -274,6 +301,60 @@ mod tests {
         let expected = false;
         let a = Boolean::<Circuit>::new(Mode::Public, true);
         let b = Boolean::<Circuit>::new(Mode::Private, true);
+        check_xor("true != true", expected, a, b, 0, 0, 1, 1);
+    }
+
+    #[test]
+    fn test_private_xor_constant() {
+        // false != false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_xor("false != false", expected, a, b, 0, 0, 0, 0);
+
+        // false != true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_xor("false != true", expected, a, b, 0, 0, 0, 0);
+
+        // true != false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, false);
+        check_xor("true != false", expected, a, b, 0, 0, 0, 0);
+
+        // true != true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Constant, true);
+        check_xor("true != true", expected, a, b, 0, 0, 0, 0);
+    }
+
+    #[test]
+    fn test_private_xor_public() {
+        // false != false
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_xor("false != false", expected, a, b, 0, 0, 1, 1);
+
+        // false != true
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, false);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
+        check_xor("false != true", expected, a, b, 0, 0, 1, 1);
+
+        // true != false
+        let expected = true;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, false);
+        check_xor("true != false", expected, a, b, 0, 0, 1, 1);
+
+        // true != true
+        let expected = false;
+        let a = Boolean::<Circuit>::new(Mode::Private, true);
+        let b = Boolean::<Circuit>::new(Mode::Public, true);
         check_xor("true != true", expected, a, b, 0, 0, 1, 1);
     }
 


### PR DESCRIPTION
This PR:
- Fixes the implementation of Boolean::not.
- Adds test cases for Boolean operations.
