### PR TITLE
Fix `eject_mode` for Scalar

### DIFF
--- a/circuits/environment/src/traits/eject.rs
+++ b/circuits/environment/src/traits/eject.rs
@@ -70,9 +70,10 @@ fn eject_mode(start_mode: Mode, modes: &[Mode]) -> Mode {
     for next_mode in modes {
         // Check if the current mode matches the next mode.
         if !current_mode.is_private() && current_mode != *next_mode {
-            // - If `current_mode` is Mode::Constant and `next_mode` is not Mode::Constant, then `current_mode = next_mode`.
-            // - If `current_mode` is Mode::Public and `next_mode` is Mode::Private, then `current_mode = next_mode`.
-            // - Otherwise, do nothing.
+            // Intuition: Start from `Mode::Constant`, and see if one needs to lift to `Mode::Public` or `Mode::Private`.
+            //   - If `current_mode == Mode::Constant`, then `current_mode = next_mode`.
+            //   - If `current_mode == Mode::Public` && `next_mode == Mode::Private`, then `current_mode = next_mode`.
+            //   - Otherwise, do nothing.
             match (current_mode, next_mode) {
                 (Mode::Constant, Mode::Public) | (Mode::Constant, Mode::Private) | (Mode::Public, Mode::Private) => {
                     current_mode = *next_mode

--- a/circuits/environment/src/traits/eject.rs
+++ b/circuits/environment/src/traits/eject.rs
@@ -70,9 +70,9 @@ fn eject_mode(start_mode: Mode, modes: &[Mode]) -> Mode {
     for next_mode in modes {
         // Check if the current mode matches the next mode.
         if !current_mode.is_private() && current_mode != *next_mode {
-            // If the current mode is not Mode::Private, and they do not match:
-            //  - If the next mode is Mode::Private, then set the current mode to Mode::Private.
-            //  - If the next mode is Mode::Public, then set the current mode to Mode::Private.
+            // - If `current_mode` is Mode::Constant and `next_mode` is not Mode::Constant, then `current_mode = next_mode`.
+            // - If `current_mode` is Mode::Public and `next_mode` is Mode::Private, then `current_mode = next_mode`.
+            // - Otherwise, do nothing.
             match (current_mode, next_mode) {
                 (Mode::Constant, Mode::Public) | (Mode::Constant, Mode::Private) | (Mode::Public, Mode::Private) => {
                     current_mode = *next_mode

--- a/circuits/types/scalar/src/lib.rs
+++ b/circuits/types/scalar/src/lib.rs
@@ -56,19 +56,7 @@ impl<E: Environment> Eject for Scalar<E> {
     /// Ejects the mode of the scalar field.
     ///
     fn eject_mode(&self) -> Mode {
-        let mut scalar_mode = Mode::Constant;
-        for bit_mode in self.bits_le.iter().map(Eject::eject_mode) {
-            // Check if the mode in the current iteration matches the scalar mode.
-            if scalar_mode != bit_mode {
-                // If they do not match, the scalar mode must be a constant.
-                // Otherwise, this is a malformed scalar, and the program should halt.
-                match scalar_mode == Mode::Constant {
-                    true => scalar_mode = bit_mode,
-                    false => E::halt("Detected an scalar field with a malformed mode"),
-                }
-            }
-        }
-        scalar_mode
+        self.bits_le.eject_mode()
     }
 
     ///

--- a/circuits/types/scalar/src/ternary.rs
+++ b/circuits/types/scalar/src/ternary.rs
@@ -63,6 +63,9 @@ mod tests {
             let candidate = Scalar::ternary(&condition, &a, &b);
             assert_eq!(expected, candidate.eject_value(), "{case}");
             assert_scope!(num_constants, num_public, num_private, num_constraints);
+
+            // Check that `candidate` has a valid mode.
+            candidate.eject_mode()
         });
     }
 

--- a/circuits/types/scalar/src/ternary.rs
+++ b/circuits/types/scalar/src/ternary.rs
@@ -38,174 +38,216 @@ mod tests {
     use snarkvm_circuits_environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
+    const ITERATIONS: u64 = 32;
+
+    fn check_ternary(
+        name: &str,
+        flag: bool,
+        first: <Circuit as Environment>::ScalarField,
+        second: <Circuit as Environment>::ScalarField,
+        mode_condition: Mode,
+        mode_a: Mode,
+        mode_b: Mode,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+    ) {
+        let expected = if flag { first } else { second };
+        let condition = Boolean::<Circuit>::new(mode_condition, flag);
+        let a = Scalar::<Circuit>::new(mode_a, first);
+        let b = Scalar::<Circuit>::new(mode_b, second);
+
+        Circuit::scope(name, || {
+            let case = format!("({} ? {} : {})", condition.eject_value(), a.eject_value(), b.eject_value());
+            let candidate = Scalar::ternary(&condition, &a, &b);
+            assert_eq!(expected, candidate.eject_value(), "{case}");
+            assert_scope!(num_constants, num_public, num_private, num_constraints);
+        });
+    }
+
+    fn run_test(
+        mode_condition: Mode,
+        mode_a: Mode,
+        mode_b: Mode,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+    ) {
+        let check_ternary = |name: &str, flag, first, second| {
+            check_ternary(
+                name,
+                flag,
+                first,
+                second,
+                mode_condition,
+                mode_a,
+                mode_b,
+                num_constants,
+                num_public,
+                num_private,
+                num_constraints,
+            )
+        };
+
+        for i in 0..ITERATIONS {
+            for flag in [true, false] {
+                let name = format!("{} ? {} : {}, {}", flag, mode_a, mode_b, i);
+
+                let first: <Circuit as Environment>::ScalarField = UniformRand::rand(&mut test_rng());
+                let second: <Circuit as Environment>::ScalarField = UniformRand::rand(&mut test_rng());
+
+                check_ternary(&name, flag, first, second);
+            }
+        }
+
+        let zero = <Circuit as Environment>::ScalarField::zero();
+        let one = <Circuit as Environment>::ScalarField::one();
+
+        check_ternary("true ? zero : zero", true, zero, zero);
+        check_ternary("true ? zero : one", true, zero, one);
+        check_ternary("true ? one : zero", true, one, zero);
+        check_ternary("true ? one : one", true, one, one);
+
+        check_ternary("false ? zero : zero", false, zero, zero);
+        check_ternary("false ? zero : one", false, zero, one);
+        check_ternary("false ? one : zero", false, one, zero);
+        check_ternary("false ? one : one", false, one, one);
+    }
+
     #[test]
-    fn test_ternary() {
-        // Constant ? Constant : Constant
-        {
-            let a = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
-            let b = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
+    fn test_if_constant_then_constant_else_constant() {
+        run_test(Mode::Constant, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
+    }
 
-            let condition = Boolean::constant(true);
-            Circuit::scope("Constant(true) ? Constant : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_constant_then_constant_else_public() {
+        run_test(Mode::Constant, Mode::Public, Mode::Constant, 0, 0, 0, 0);
+    }
 
-                assert!(output.is_equal(&a).eject_value());
-                assert!(!output.is_equal(&b).eject_value());
-            });
+    #[test]
+    fn test_if_constant_then_constant_else_private() {
+        run_test(Mode::Constant, Mode::Private, Mode::Constant, 0, 0, 0, 0);
+    }
 
-            let condition = Boolean::constant(false);
-            Circuit::scope("Constant(false) ? Constant : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_constant_then_public_else_constant() {
+        run_test(Mode::Constant, Mode::Constant, Mode::Public, 0, 0, 0, 0);
+    }
 
-                assert!(!output.is_equal(&a).eject_value());
-                assert!(output.is_equal(&b).eject_value());
-            });
-        }
+    #[test]
+    fn test_if_constant_then_public_else_public() {
+        run_test(Mode::Constant, Mode::Public, Mode::Public, 0, 0, 0, 0);
+    }
 
-        // Constant ? Public : Private
-        {
-            let a = Scalar::<Circuit>::new(Mode::Public, UniformRand::rand(&mut test_rng()));
-            let b = Scalar::<Circuit>::new(Mode::Private, UniformRand::rand(&mut test_rng()));
+    #[test]
+    fn test_if_constant_then_public_else_private() {
+        run_test(Mode::Constant, Mode::Private, Mode::Public, 0, 0, 0, 0);
+    }
 
-            let condition = Boolean::constant(true);
-            Circuit::scope("Constant(true) ? Public : Private", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_constant_then_private_else_constant() {
+        run_test(Mode::Constant, Mode::Constant, Mode::Private, 0, 0, 0, 0);
+    }
 
-                assert!(output.is_equal(&a).eject_value());
-                assert!(!output.is_equal(&b).eject_value());
-            });
+    #[test]
+    fn test_if_constant_then_private_else_public() {
+        run_test(Mode::Constant, Mode::Public, Mode::Private, 0, 0, 0, 0);
+    }
 
-            let condition = Boolean::constant(false);
-            Circuit::scope("Constant(false) ? Public : Private", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_constant_then_private_else_private() {
+        run_test(Mode::Constant, Mode::Private, Mode::Private, 0, 0, 0, 0);
+    }
 
-                assert!(!output.is_equal(&a).eject_value());
-                assert!(output.is_equal(&b).eject_value());
-            });
-        }
+    #[test]
+    fn test_if_public_then_constant_else_constant() {
+        run_test(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
+    }
 
-        // Public ? Constant : Constant
-        {
-            let a = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
-            let b = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
+    #[test]
+    fn test_if_public_then_constant_else_public() {
+        run_test(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 251, 251);
+    }
 
-            let condition = Boolean::new(Mode::Public, true);
-            Circuit::scope("Public(true) ? Constant : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_public_then_constant_else_private() {
+        run_test(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 251, 251);
+    }
 
-                assert!(output.is_equal(&a).eject_value());
-                assert!(!output.is_equal(&b).eject_value());
-            });
+    #[test]
+    fn test_if_public_then_public_else_constant() {
+        run_test(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 251, 251);
+    }
 
-            let condition = Boolean::new(Mode::Public, false);
-            Circuit::scope("Public(false) ? Constant : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_public_then_public_else_public() {
+        run_test(Mode::Public, Mode::Public, Mode::Public, 0, 0, 251, 251);
+    }
 
-                assert!(!output.is_equal(&a).eject_value());
-                assert!(output.is_equal(&b).eject_value());
-            });
-        }
+    #[test]
+    fn test_if_public_then_public_else_private() {
+        run_test(Mode::Public, Mode::Public, Mode::Private, 0, 0, 251, 251);
+    }
 
-        // Private ? Constant : Constant
-        {
-            let a = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
-            let b = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
+    #[test]
+    fn test_if_public_then_private_else_constant() {
+        run_test(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 251, 251);
+    }
 
-            let condition = Boolean::new(Mode::Private, true);
-            Circuit::scope("Private(true) ? Constant : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_public_then_private_else_public() {
+        run_test(Mode::Public, Mode::Private, Mode::Public, 0, 0, 251, 251);
+    }
 
-                assert!(output.is_equal(&a).eject_value());
-                assert!(!output.is_equal(&b).eject_value());
-            });
+    #[test]
+    fn test_if_public_then_private_else_private() {
+        run_test(Mode::Public, Mode::Private, Mode::Private, 0, 0, 251, 251);
+    }
 
-            let condition = Boolean::new(Mode::Private, false);
-            Circuit::scope("Private(false) ? Constant : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 0, 0);
+    #[test]
+    fn test_if_private_then_constant_else_constant() {
+        run_test(Mode::Private, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
+    }
 
-                assert!(!output.is_equal(&a).eject_value());
-                assert!(output.is_equal(&b).eject_value());
-            });
-        }
+    #[test]
+    fn test_if_private_then_constant_else_public() {
+        run_test(Mode::Private, Mode::Constant, Mode::Public, 0, 0, 251, 251);
+    }
 
-        // Private ? Public : Constant
-        {
-            let a = Scalar::<Circuit>::new(Mode::Public, UniformRand::rand(&mut test_rng()));
-            let b = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
+    #[test]
+    fn test_if_private_then_constant_else_private() {
+        run_test(Mode::Private, Mode::Constant, Mode::Private, 0, 0, 251, 251);
+    }
 
-            let condition = Boolean::new(Mode::Private, true);
-            Circuit::scope("Private(true) ? Public : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 251, 251);
+    #[test]
+    fn test_if_private_then_public_else_constant() {
+        run_test(Mode::Private, Mode::Public, Mode::Constant, 0, 0, 251, 251);
+    }
 
-                assert!(output.is_equal(&a).eject_value());
-                assert!(!output.is_equal(&b).eject_value());
-            });
+    #[test]
+    fn test_if_private_then_public_else_public() {
+        run_test(Mode::Private, Mode::Public, Mode::Public, 0, 0, 251, 251);
+    }
 
-            let condition = Boolean::new(Mode::Private, false);
-            Circuit::scope("Private(false) ? Public : Constant", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 251, 251);
+    #[test]
+    fn test_if_private_then_public_else_private() {
+        run_test(Mode::Private, Mode::Public, Mode::Private, 0, 0, 251, 251);
+    }
 
-                assert!(!output.is_equal(&a).eject_value());
-                assert!(output.is_equal(&b).eject_value());
-            });
-        }
+    #[test]
+    fn test_if_private_then_private_else_constant() {
+        run_test(Mode::Private, Mode::Private, Mode::Constant, 0, 0, 251, 251);
+    }
 
-        // Private ? Constant : Public
-        {
-            let a = Scalar::<Circuit>::new(Mode::Constant, UniformRand::rand(&mut test_rng()));
-            let b = Scalar::<Circuit>::new(Mode::Public, UniformRand::rand(&mut test_rng()));
+    #[test]
+    fn test_if_private_then_private_else_public() {
+        run_test(Mode::Private, Mode::Private, Mode::Public, 0, 0, 251, 251);
+    }
 
-            let condition = Boolean::new(Mode::Private, true);
-            Circuit::scope("Private(true) ? Constant : Public", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 251, 251);
-
-                assert!(output.is_equal(&a).eject_value());
-                assert!(!output.is_equal(&b).eject_value());
-            });
-
-            let condition = Boolean::new(Mode::Private, false);
-            Circuit::scope("Private(false) ? Constant : Public", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 251, 251);
-
-                assert!(!output.is_equal(&a).eject_value());
-                assert!(output.is_equal(&b).eject_value());
-            });
-        }
-
-        // Private ? Private : Public
-        {
-            let a = Scalar::<Circuit>::new(Mode::Private, UniformRand::rand(&mut test_rng()));
-            let b = Scalar::<Circuit>::new(Mode::Public, UniformRand::rand(&mut test_rng()));
-
-            let condition = Boolean::new(Mode::Private, true);
-            Circuit::scope("Private(true) ? Private : Public", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 251, 251);
-
-                assert!(output.is_equal(&a).eject_value());
-                assert!(!output.is_equal(&b).eject_value());
-            });
-
-            let condition = Boolean::new(Mode::Private, false);
-            Circuit::scope("Private(false) ? Private : Public", || {
-                let output = Scalar::ternary(&condition, &a, &b);
-                assert_scope!(0, 0, 251, 251);
-
-                assert!(!output.is_equal(&a).eject_value());
-                assert!(output.is_equal(&b).eject_value());
-            });
-        }
+    #[test]
+    fn test_if_private_then_private_else_private() {
+        run_test(Mode::Private, Mode::Private, Mode::Private, 0, 0, 251, 251);
     }
 }


### PR DESCRIPTION
This PR:
- Refactors  tests for `Scalar::ternary`, which shows a bug in `Scalar::eject_mode`.
- Fix for `Scalar::eject_mode`.
