### PR TITLE
Updates Pedersen and BHP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,6 @@ name = "snarkvm-circuit-algorithms"
 version = "0.7.5"
 dependencies = [
  "anyhow",
- "snarkvm-algorithms",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,6 @@ name = "snarkvm-circuit-algorithms"
 version = "0.7.5"
 dependencies = [
  "anyhow",
- "snarkvm-circuit-environment",
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
  "snarkvm-curves",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,8 +2243,6 @@ dependencies = [
  "base58",
  "bech32",
  "bincode",
- "itertools",
- "once_cell",
  "rand",
  "serde",
  "serde_json",

--- a/algorithms/benches/crh/bhp.rs
+++ b/algorithms/benches/crh/bhp.rs
@@ -19,6 +19,7 @@ extern crate criterion;
 
 use snarkvm_algorithms::{crh::BHPCRH, traits::CRH};
 use snarkvm_curves::edwards_bls12::EdwardsProjective;
+use snarkvm_utilities::{test_rng, UniformRand};
 
 use criterion::Criterion;
 
@@ -43,14 +44,15 @@ fn setup(c: &mut Criterion) {
 fn hash(c: &mut Criterion) {
     c.bench_function("BHP hash", move |b| {
         let crh = <BHPCRH<EdwardsProjective, NUM_WINDOWS, WINDOW_SIZE> as CRH>::setup(SETUP_MESSAGE);
-        let input = (0..(NUM_WINDOWS * WINDOW_SIZE)).map(|_| rand::random::<bool>()).collect::<Vec<bool>>();
+        let input = (0..(NUM_WINDOWS * WINDOW_SIZE)).map(|_| bool::rand(&mut test_rng())).collect::<Vec<bool>>();
 
         b.iter(|| crh.hash(&input).unwrap())
     });
 
     c.bench_function("BHP hash (large)", move |b| {
         let crh = <BHPCRH<EdwardsProjective, BIG_NUM_WINDOWS, BIG_WINDOW_SIZE> as CRH>::setup(SETUP_MESSAGE);
-        let input = (0..(BIG_NUM_WINDOWS * BIG_WINDOW_SIZE)).map(|_| rand::random::<bool>()).collect::<Vec<bool>>();
+        let input =
+            (0..(BIG_NUM_WINDOWS * BIG_WINDOW_SIZE)).map(|_| bool::rand(&mut test_rng())).collect::<Vec<bool>>();
 
         b.iter(|| crh.hash(&input).unwrap())
     });

--- a/algorithms/benches/crh/pedersen.rs
+++ b/algorithms/benches/crh/pedersen.rs
@@ -19,6 +19,7 @@ extern crate criterion;
 
 use snarkvm_algorithms::{crh::PedersenCRH, traits::CRH};
 use snarkvm_curves::edwards_bls12::EdwardsProjective;
+use snarkvm_utilities::{test_rng, UniformRand};
 
 use criterion::Criterion;
 
@@ -43,14 +44,15 @@ fn setup(c: &mut Criterion) {
 fn hash(c: &mut Criterion) {
     c.bench_function("Pedersen hash", move |b| {
         let crh = <PedersenCRH<EdwardsProjective, NUM_WINDOWS, WINDOW_SIZE> as CRH>::setup(SETUP_MESSAGE);
-        let input = (0..(NUM_WINDOWS * WINDOW_SIZE)).map(|_| rand::random::<bool>()).collect::<Vec<bool>>();
+        let input = (0..(NUM_WINDOWS * WINDOW_SIZE)).map(|_| bool::rand(&mut test_rng())).collect::<Vec<bool>>();
 
         b.iter(|| crh.hash(&input).unwrap())
     });
 
     c.bench_function("Pedersen hash (large)", move |b| {
         let crh = <PedersenCRH<EdwardsProjective, BIG_NUM_WINDOWS, BIG_WINDOW_SIZE> as CRH>::setup(SETUP_MESSAGE);
-        let input = (0..(BIG_NUM_WINDOWS * BIG_WINDOW_SIZE)).map(|_| rand::random::<bool>()).collect::<Vec<bool>>();
+        let input =
+            (0..(BIG_NUM_WINDOWS * BIG_WINDOW_SIZE)).map(|_| bool::rand(&mut test_rng())).collect::<Vec<bool>>();
 
         b.iter(|| crh.hash(&input).unwrap())
     });

--- a/algorithms/benches/signature/aleo.rs
+++ b/algorithms/benches/signature/aleo.rs
@@ -19,6 +19,7 @@ extern crate criterion;
 
 use snarkvm_algorithms::{signature::AleoSignatureScheme, SignatureScheme as SS};
 use snarkvm_curves::edwards_bls12::EdwardsParameters;
+use snarkvm_utilities::{test_rng, UniformRand};
 
 use criterion::Criterion;
 use rand::{self, thread_rng};
@@ -52,7 +53,7 @@ fn aleo_signature_sign(c: &mut Criterion) {
     let rng = &mut thread_rng();
     let parameters = SignatureScheme::setup("aleo_signature_sign");
     let private_key = SignatureScheme::generate_private_key(&parameters, rng);
-    let message = (0..128).map(|_| rand::random::<bool>()).collect::<Vec<bool>>();
+    let message = (0..128).map(|_| bool::rand(&mut test_rng())).collect::<Vec<bool>>();
 
     c.bench_function("Aleo Signature Sign", move |b| {
         b.iter(|| SignatureScheme::sign(&parameters, &private_key, &message, rng).unwrap())
@@ -64,7 +65,7 @@ fn aleo_signature_verify(c: &mut Criterion) {
     let parameters = SignatureScheme::setup("aleo_signature_verify");
     let private_key = SignatureScheme::generate_private_key(&parameters, rng);
     let public_key = SignatureScheme::generate_public_key(&parameters, &private_key);
-    let message = (0..128).map(|_| rand::random::<bool>()).collect::<Vec<bool>>();
+    let message = (0..128).map(|_| bool::rand(&mut test_rng())).collect::<Vec<bool>>();
     let signature = SignatureScheme::sign(&parameters, &private_key, &message, rng).unwrap();
 
     c.bench_function("Aleo Signature Verify", move |b| {

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -12,10 +12,6 @@ path = "../../console/algorithms"
 version = "0.7.5"
 optional = true
 
-[dependencies.snarkvm-circuit-environment]
-path = "../environment"
-version = "0.7.5"
-
 [dependencies.snarkvm-circuit-types]
 path = "../types"
 version = "0.7.5"
@@ -28,6 +24,7 @@ default-features = false
 [dependencies.snarkvm-fields]
 path = "../../fields"
 version = "0.7.5"
+default-features = false
 
 [dev-dependencies.snarkvm-utilities]
 path = "../../utilities"

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -6,16 +6,18 @@ description = "Algorithm circuit library for a decentralized virtual machine"
 license = "GPL-3.0"
 edition = "2021"
 
+[dependencies.console]
+package = "snarkvm-console-algorithms"
+path = "../../console/algorithms"
+version = "0.7.5"
+optional = true
+
 [dependencies.snarkvm-circuit-environment]
 path = "../environment"
 version = "0.7.5"
 
 [dependencies.snarkvm-circuit-types]
 path = "../types"
-version = "0.7.5"
-
-[dependencies.snarkvm-console-algorithms]
-path = "../../console/algorithms"
 version = "0.7.5"
 
 [dependencies.snarkvm-curves]
@@ -27,15 +29,14 @@ default-features = false
 path = "../../fields"
 version = "0.7.5"
 
-[dependencies.snarkvm-utilities]
+[dev-dependencies.snarkvm-utilities]
 path = "../../utilities"
 version = "0.7.5"
 
-[dev-dependencies.snarkvm-algorithms]
-path = "../../algorithms"
-version = "0.7.5"
-default-features = false
-features = ["crh", "merkle_tree"]
-
 [dev-dependencies.anyhow]
 version = "1.0.57"
+
+[features]
+default = ["enable_console"]
+# Use #[cfg(console)] instead.
+enable_console = ["console"]

--- a/circuit/algorithms/build.rs
+++ b/circuit/algorithms/build.rs
@@ -1,0 +1,21 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    if cfg!(feature = "enable_console") {
+        println!("cargo:rustc-cfg=console");
+    }
+}

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn test_commit_constant() -> Result<()> {
-        check_commit::<32, 48>(Mode::Constant, 7891, 0, 0, 0)
+        check_commit::<32, 48>(Mode::Constant, 7899, 0, 0, 0)
     }
 
     #[test]

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -30,7 +30,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Commit for BH
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -71,6 +71,7 @@ mod tests {
                 assert_scope!(<=num_constants, num_public, num_private, num_constraints);
                 assert_eq!(expected, candidate.eject_value());
             });
+            Circuit::reset();
         }
         Ok(())
     }

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -27,11 +27,10 @@ impl<E: Environment, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Commit 
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{Commit as C, BHP as NativeBHP};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -44,9 +43,11 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::Commit as C;
+
         // Initialize BHP.
-        let native = NativeBHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
-        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE;
 

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<E: Environment, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Commit for BHP<E, NUM_WINDOWS, WINDOW_SIZE> {
+impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Commit for BHP<E, NUM_WINDOWS, WINDOW_SIZE> {
     type Input = Boolean<E>;
     type Output = Field<E>;
     type Randomizer = Scalar<E>;
@@ -36,7 +36,7 @@ mod tests {
     const ITERATIONS: usize = 10;
     const MESSAGE: &str = "BHPCircuit0";
 
-    fn check_commit<const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>(
+    fn check_commit<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
         mode: Mode,
         num_constants: u64,
         num_public: u64,
@@ -49,7 +49,7 @@ mod tests {
         let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
-        let num_input_bits = NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE;
+        let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
 
         for i in 0..ITERATIONS {
             // Sample a random input.

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -33,7 +33,9 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
-    const ITERATIONS: usize = 10;
+    use anyhow::Result;
+
+    const ITERATIONS: u64 = 10;
     const MESSAGE: &str = "BHPCircuit0";
 
     fn check_commit<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
@@ -42,11 +44,11 @@ mod tests {
         num_public: u64,
         num_private: u64,
         num_constraints: u64,
-    ) {
+    ) -> Result<()> {
         use console::Commit as C;
 
         // Initialize BHP.
-        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
@@ -70,20 +72,21 @@ mod tests {
                 assert_eq!(expected, candidate.eject_value());
             });
         }
+        Ok(())
     }
 
     #[test]
-    fn test_commit_constant() {
-        check_commit::<32, 48>(Mode::Constant, 6887, 0, 0, 0);
+    fn test_commit_constant() -> Result<()> {
+        check_commit::<32, 48>(Mode::Constant, 7891, 0, 0, 0)
     }
 
     #[test]
-    fn test_commit_public() {
-        check_commit::<32, 48>(Mode::Public, 631, 0, 9404, 9404);
+    fn test_commit_public() -> Result<()> {
+        check_commit::<32, 48>(Mode::Public, 1044, 0, 10103, 10104)
     }
 
     #[test]
-    fn test_commit_private() {
-        check_commit::<32, 48>(Mode::Private, 631, 0, 9404, 9404);
+    fn test_commit_private() -> Result<()> {
+        check_commit::<32, 48>(Mode::Private, 1044, 0, 10103, 10104)
     }
 }

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -82,11 +82,11 @@ mod tests {
 
     #[test]
     fn test_commit_public() -> Result<()> {
-        check_commit::<32, 48>(Mode::Public, 1044, 0, 10103, 10104)
+        check_commit::<32, 48>(Mode::Public, 1044, 0, 10098, 10099)
     }
 
     #[test]
     fn test_commit_private() -> Result<()> {
-        check_commit::<32, 48>(Mode::Private, 1044, 0, 10103, 10104)
+        check_commit::<32, 48>(Mode::Private, 1044, 0, 10098, 10099)
     }
 }

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -35,7 +35,7 @@ mod tests {
 
     use anyhow::Result;
 
-    const ITERATIONS: u64 = 10;
+    const ITERATIONS: u64 = 100;
     const MESSAGE: &str = "BHPCircuit0";
 
     fn check_commit<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn test_commit_constant() -> Result<()> {
-        check_commit::<32, 48>(Mode::Constant, 7899, 0, 0, 0)
+        check_commit::<32, 48>(Mode::Constant, 7943, 0, 0, 0)
     }
 
     #[test]

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -92,11 +92,11 @@ mod tests {
 
     #[test]
     fn test_commit_uncompressed_public() -> Result<()> {
-        check_commit_uncompressed::<32, 48>(Mode::Public, 1044, 0, 10103, 10104)
+        check_commit_uncompressed::<32, 48>(Mode::Public, 1044, 0, 10098, 10099)
     }
 
     #[test]
     fn test_commit_uncompressed_private() -> Result<()> {
-        check_commit_uncompressed::<32, 48>(Mode::Private, 1044, 0, 10103, 10104)
+        check_commit_uncompressed::<32, 48>(Mode::Private, 1044, 0, 10098, 10099)
     }
 }

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -37,11 +37,10 @@ impl<E: Environment, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CommitU
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{CommitUncompressed as C, BHP as NativeBHP};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -54,9 +53,11 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::CommitUncompressed as C;
+
         // Initialize BHP.
-        let native = NativeBHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
-        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE;
 

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -45,7 +45,7 @@ mod tests {
 
     use anyhow::Result;
 
-    const ITERATIONS: u64 = 10;
+    const ITERATIONS: u64 = 100;
     const MESSAGE: &str = "BHPCircuit0";
 
     fn check_commit_uncompressed<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn test_commit_uncompressed_constant() -> Result<()> {
-        check_commit_uncompressed::<32, 48>(Mode::Constant, 7899, 0, 0, 0)
+        check_commit_uncompressed::<32, 48>(Mode::Constant, 7943, 0, 0, 0)
     }
 
     #[test]

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -40,7 +40,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> CommitUncompr
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -81,6 +81,7 @@ mod tests {
                 assert_scope!(<=num_constants, num_public, num_private, num_constraints);
                 assert_eq!(expected, candidate.eject_value());
             });
+            Circuit::reset();
         }
         Ok(())
     }

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<E: Environment, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CommitUncompressed
+impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> CommitUncompressed
     for BHP<E, NUM_WINDOWS, WINDOW_SIZE>
 {
     type Input = Boolean<E>;
@@ -46,7 +46,7 @@ mod tests {
     const ITERATIONS: usize = 10;
     const MESSAGE: &str = "BHPCircuit0";
 
-    fn check_commit_uncompressed<const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>(
+    fn check_commit_uncompressed<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
         mode: Mode,
         num_constants: u64,
         num_public: u64,
@@ -59,7 +59,7 @@ mod tests {
         let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
-        let num_input_bits = NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE;
+        let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
 
         for i in 0..ITERATIONS {
             // Sample a random input.

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -31,7 +31,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> CommitUncompr
         randomizer
             .to_bits_le()
             .iter()
-            .zip_eq(&self.random_base)
+            .zip_eq(self.hasher.random_base())
             .map(|(bit, power)| Group::ternary(bit, power, &Group::zero()))
             .fold(hash, |acc, x| acc + x)
     }
@@ -43,7 +43,9 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
-    const ITERATIONS: usize = 10;
+    use anyhow::Result;
+
+    const ITERATIONS: u64 = 10;
     const MESSAGE: &str = "BHPCircuit0";
 
     fn check_commit_uncompressed<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
@@ -52,11 +54,11 @@ mod tests {
         num_public: u64,
         num_private: u64,
         num_constraints: u64,
-    ) {
+    ) -> Result<()> {
         use console::CommitUncompressed as C;
 
         // Initialize BHP.
-        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
@@ -80,20 +82,21 @@ mod tests {
                 assert_eq!(expected, candidate.eject_value());
             });
         }
+        Ok(())
     }
 
     #[test]
-    fn test_commit_uncompressed_constant() {
-        check_commit_uncompressed::<32, 48>(Mode::Constant, 6879, 0, 0, 0);
+    fn test_commit_uncompressed_constant() -> Result<()> {
+        check_commit_uncompressed::<32, 48>(Mode::Constant, 7891, 0, 0, 0)
     }
 
     #[test]
-    fn test_commit_uncompressed_public() {
-        check_commit_uncompressed::<32, 48>(Mode::Public, 631, 0, 9404, 9404);
+    fn test_commit_uncompressed_public() -> Result<()> {
+        check_commit_uncompressed::<32, 48>(Mode::Public, 1044, 0, 10103, 10104)
     }
 
     #[test]
-    fn test_commit_uncompressed_private() {
-        check_commit_uncompressed::<32, 48>(Mode::Private, 631, 0, 9404, 9404);
+    fn test_commit_uncompressed_private() -> Result<()> {
+        check_commit_uncompressed::<32, 48>(Mode::Private, 1044, 0, 10103, 10104)
     }
 }

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn test_commit_uncompressed_constant() -> Result<()> {
-        check_commit_uncompressed::<32, 48>(Mode::Constant, 7891, 0, 0, 0)
+        check_commit_uncompressed::<32, 48>(Mode::Constant, 7899, 0, 0, 0)
     }
 
     #[test]

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -29,7 +29,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Hash for BHP<
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<E: Environment, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Hash for BHP<E, NUM_WINDOWS, WINDOW_SIZE> {
+impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Hash for BHP<E, NUM_WINDOWS, WINDOW_SIZE> {
     type Input = Boolean<E>;
     type Output = Field<E>;
 
@@ -35,7 +35,7 @@ mod tests {
     const ITERATIONS: usize = 10;
     const MESSAGE: &str = "BHPCircuit0";
 
-    fn check_hash<const NUM_WINDOWS: usize, const WINDOW_SIZE: usize>(
+    fn check_hash<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
         mode: Mode,
         num_constants: u64,
         num_public: u64,
@@ -48,7 +48,7 @@ mod tests {
         let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
-        let num_input_bits = NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE;
+        let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
 
         for i in 0..ITERATIONS {
             // Sample a random input.

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -34,7 +34,7 @@ mod tests {
 
     use anyhow::Result;
 
-    const ITERATIONS: u64 = 10;
+    const ITERATIONS: u64 = 100;
     const MESSAGE: &str = "BHPCircuit0";
 
     fn check_hash<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -26,11 +26,10 @@ impl<E: Environment, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Hash fo
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{Hash as H, BHP as NativeBHP};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -43,9 +42,11 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::Hash as H;
+
         // Initialize BHP.
-        let native = NativeBHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
-        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE;
 

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -72,16 +72,16 @@ mod tests {
 
     #[test]
     fn test_hash_constant() -> Result<()> {
-        check_hash::<32, 48>(Mode::Constant, 7315, 0, 0, 0)
+        check_hash::<32, 48>(Mode::Constant, 7311, 0, 0, 0)
     }
 
     #[test]
     fn test_hash_public() -> Result<()> {
-        check_hash::<32, 48>(Mode::Public, 542, 0, 8597, 8598)
+        check_hash::<32, 48>(Mode::Public, 542, 0, 8592, 8593)
     }
 
     #[test]
     fn test_hash_private() -> Result<()> {
-        check_hash::<32, 48>(Mode::Private, 542, 0, 8597, 8598)
+        check_hash::<32, 48>(Mode::Private, 542, 0, 8592, 8593)
     }
 }

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -32,7 +32,9 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
-    const ITERATIONS: usize = 10;
+    use anyhow::Result;
+
+    const ITERATIONS: u64 = 10;
     const MESSAGE: &str = "BHPCircuit0";
 
     fn check_hash<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
@@ -41,11 +43,11 @@ mod tests {
         num_public: u64,
         num_private: u64,
         num_constraints: u64,
-    ) {
+    ) -> Result<()> {
         use console::Hash as H;
 
         // Initialize BHP.
-        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
@@ -65,20 +67,21 @@ mod tests {
                 assert_eq!(expected, candidate.eject_value());
             });
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_constant() {
-        check_hash::<32, 48>(Mode::Constant, 6303, 0, 0, 0);
+    fn test_hash_constant() -> Result<()> {
+        check_hash::<32, 48>(Mode::Constant, 7315, 0, 0, 0)
     }
 
     #[test]
-    fn test_hash_public() {
-        check_hash::<32, 48>(Mode::Public, 129, 0, 7898, 7898);
+    fn test_hash_public() -> Result<()> {
+        check_hash::<32, 48>(Mode::Public, 542, 0, 8597, 8598)
     }
 
     #[test]
-    fn test_hash_private() {
-        check_hash::<32, 48>(Mode::Private, 129, 0, 7898, 7898);
+    fn test_hash_private() -> Result<()> {
+        check_hash::<32, 48>(Mode::Private, 542, 0, 8597, 8598)
     }
 }

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -66,6 +66,7 @@ mod tests {
                 assert_scope!(num_constants, num_public, num_private, num_constraints);
                 assert_eq!(expected, candidate.eject_value());
             });
+            Circuit::reset();
         }
         Ok(())
     }

--- a/circuit/algorithms/src/bhp/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hash_uncompressed.rs
@@ -168,11 +168,10 @@ impl<E: Environment, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> HashUnc
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{HashUncompressed as H, BHP as NativeBHP};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -185,9 +184,11 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::HashUncompressed as H;
+
         // Initialize the BHP hash.
-        let native = NativeBHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
-        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE);
+        let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE;
 

--- a/circuit/algorithms/src/bhp/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hash_uncompressed.rs
@@ -71,7 +71,7 @@ mod tests {
 
     use anyhow::Result;
 
-    const ITERATIONS: u64 = 10;
+    const ITERATIONS: u64 = 100;
     const MESSAGE: &str = "BHPCircuit0";
 
     macro_rules! check_hash_uncompressed {

--- a/circuit/algorithms/src/bhp/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hash_uncompressed.rs
@@ -168,7 +168,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;

--- a/circuit/algorithms/src/bhp/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hash_uncompressed.rs
@@ -95,6 +95,7 @@ mod tests {
                     assert_scope!($num_constants, $num_public, $num_private, $num_constraints);
                     assert_eq!(expected, candidate.eject_value());
                 });
+                Circuit::reset();
             }
             Ok::<_, anyhow::Error>(())
         }};
@@ -129,6 +130,7 @@ mod tests {
                 assert_scope!(num_constants, num_public, num_private, num_constraints);
                 assert_eq!(expected, candidate.eject_value());
             });
+            Circuit::reset();
         }
         Ok(())
     }

--- a/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -189,7 +189,7 @@ mod tests {
         let native =
             console::bhp::hasher::BHPHasher::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(
                 MESSAGE,
-            );
+            )?;
 
         // Initialize the circuit BHP hasher.
         let primitive = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;

--- a/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -193,7 +193,7 @@ mod tests {
 
         // Initialize the circuit BHP hasher.
         let primitive = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
-        let circuit = BHPHasher::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, primitive.clone());
+        let circuit = BHPHasher::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, primitive);
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
 

--- a/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -1,0 +1,232 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompressed
+    for BHPHasher<E, NUM_WINDOWS, WINDOW_SIZE>
+{
+    type Input = Boolean<E>;
+    type Output = Group<E>;
+
+    /// Returns the BHP hash of the given input as an affine group element.
+    ///
+    /// This uncompressed variant of the BHP hash function is provided to support
+    /// the BHP commitment scheme, as it is typically not used by applications.
+    fn hash_uncompressed(&self, input: &[Self::Input]) -> Self::Output {
+        // Ensure the input size is at least the window size.
+        if input.len() <= Self::MIN_BITS {
+            E::halt(format!("Inputs to this BHP must be greater than {} bits", Self::MIN_BITS))
+        }
+
+        // Ensure the input size is within the parameter size.
+        let mut input = input.to_vec();
+        match input.len() <= Self::MAX_BITS {
+            true => {
+                // Pad the input to a multiple of `BHP_CHUNK_SIZE` for hashing.
+                if input.len() % BHP_CHUNK_SIZE != 0 {
+                    let padding = BHP_CHUNK_SIZE - (input.len() % BHP_CHUNK_SIZE);
+                    input.resize(input.len() + padding, Boolean::constant(false));
+                    assert_eq!(input.len() % BHP_CHUNK_SIZE, 0, "Input must be a multiple of {BHP_CHUNK_SIZE}");
+                }
+            }
+            false => E::halt(format!("Inputs to this BHP cannot exceed {} bits", Self::MAX_BITS)),
+        }
+
+        // Declare the 1/2 constant field element.
+        let one_half = Field::constant(E::BaseField::half());
+
+        // Declare the constant coefficients A and B for the Montgomery curve.
+        let coeff_a = Field::constant(<E::AffineParameters as TwistedEdwardsParameters>::MontgomeryParameters::COEFF_A);
+        let coeff_b = Field::constant(<E::AffineParameters as TwistedEdwardsParameters>::MontgomeryParameters::COEFF_B);
+
+        // Implements the incomplete addition formulae of two Montgomery curve points.
+        let montgomery_add = |(this_x, this_y): (&Field<E>, &Field<E>), (that_x, that_y): (&Field<E>, &Field<E>)| {
+            // Construct `lambda` as a witness defined as:
+            // `lambda := (that_y - this_y) / (that_x - this_x)`
+            let lambda: Field<E> = witness!(|this_x, this_y, that_x, that_y| (that_y - this_y) / (that_x - this_x));
+
+            // Ensure `lambda` is correct by enforcing:
+            // `lambda * (that_x - this_x) == (that_y - this_y)`
+            E::enforce(|| (&lambda, that_x - this_x, that_y - this_y));
+
+            // Construct `sum_x` as a witness defined as:
+            // `sum_x := (B * lambda^2) - A - this_x - that_x`
+            let sum_x: Field<E> = witness!(|lambda, that_x, this_x, coeff_a, coeff_b| {
+                coeff_b * lambda.square() - coeff_a - this_x - that_x
+            });
+
+            // Ensure `sum_x` is correct by enforcing:
+            // `(B * lambda) * lambda == (A + this_x + that_x + sum_x)`
+            E::enforce(|| (&coeff_b * &lambda, &lambda, &coeff_a + this_x + that_x + &sum_x));
+
+            // Construct `sum_y` as a witness defined as:
+            // `sum_y := -(this_y + (lambda * (this_x - sum_x)))`
+            let sum_y: Field<E> = witness!(|lambda, sum_x, this_x, this_y| -(this_y + (lambda * (sum_x - this_x))));
+
+            // Ensure `sum_y` is correct by enforcing:
+            // `(lambda * (this_x - sum_x)) == (this_y + sum_y)`
+            E::enforce(|| (&lambda, this_x - &sum_x, this_y + &sum_y));
+
+            (sum_x, sum_y)
+        };
+
+        // Compute sum of h_i^{sum of (1-2*c_{i,j,2})*(1+c_{i,j,0}+2*c_{i,j,1})*2^{4*(j-1)} for all j in segment}
+        // for all i. Described in section 5.4.1.7 in the Zcash protocol specification.
+        //
+        // Note: `.zip()` is used here (as opposed to `.zip_eq()`) as the input can be less than
+        // `NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE` in length, which is the parameter size here.
+        input
+            .chunks(WINDOW_SIZE as usize * BHP_CHUNK_SIZE)
+            .zip(self.bases.iter())
+            .map(|(bits, bases)| {
+                // Initialize accumulating sum variables for the x- and y-coordinates.
+                let mut sum = None;
+
+                // One iteration costs 5 constraints.
+                bits.chunks(BHP_CHUNK_SIZE).zip(bases).for_each(|(chunk_bits, base_lookups)| {
+                    // Unzip the base lookups into `x_bases` and `y_bases`.
+                    let (x_bases, y_bases) = base_lookups;
+
+                    // Cast each input chunk bit as a field element.
+                    let bit_0 = Field::from_boolean(&chunk_bits[0]);
+                    let bit_1 = Field::from_boolean(&chunk_bits[1]);
+                    let bit_2 = Field::from_boolean(&chunk_bits[2]);
+                    let bit_0_and_1 = Field::from_boolean(&(&chunk_bits[0] & &chunk_bits[1])); // 1 constraint
+
+                    // Compute the x-coordinate of the Montgomery curve point.
+                    let montgomery_x: Field<E> = &x_bases[0]
+                        + &bit_0 * (&x_bases[1] - &x_bases[0])
+                        + &bit_1 * (&x_bases[2] - &x_bases[0])
+                        + &bit_0_and_1 * (&x_bases[3] - &x_bases[2] - &x_bases[1] + &x_bases[0]);
+
+                    // Compute the y-coordinate of the Montgomery curve point.
+                    let montgomery_y = {
+                        // Compute the y-coordinate of the Montgomery curve point, without any negation.
+                        let y: Field<E> = &y_bases[0]
+                            + bit_0 * (&y_bases[1] - &y_bases[0])
+                            + bit_1 * (&y_bases[2] - &y_bases[0])
+                            + bit_0_and_1 * (&y_bases[3] - &y_bases[2] - &y_bases[1] + &y_bases[0]);
+
+                        // Determine the correct sign of the y-coordinate, as a witness.
+                        //
+                        // Instead of using `Field::ternary`, we create a witness & custom constraint to reduce
+                        // the number of nonzero entries in the circuit, improving setup & proving time for Marlin.
+                        let montgomery_y: Field<E> = witness!(|chunk_bits, y| if chunk_bits[2] { -y } else { y });
+
+                        // Ensure the conditional negation of `witness_y` is correct as follows (1 constraint):
+                        //     `(bit_2 - 1/2) * (-2 * y) == montgomery_y`
+                        // which is equivalent to:
+                        //     if `bit_2 == 0`, then `montgomery_y = -1/2 * -2 * y = y`
+                        //     if `bit_2 == 1`, then `montgomery_y = 1/2 * -2 * y = -y`
+                        E::enforce(|| (bit_2 - &one_half, -y.double(), &montgomery_y)); // 1 constraint
+
+                        montgomery_y
+                    };
+
+                    // Update the accumulating sum, with a constraint-saving technique as follows:
+                    match &sum {
+                        // If `(sum_x, sum_y)` is `None`, then this is the first iteration,
+                        // and we can save constraints by initializing `(sum_x, sum_y)` as
+                        // `(montgomery_x, montgomery_y)` (instead of calling `montgomery_add`).
+                        None => sum = Some((montgomery_x, montgomery_y)),
+                        // Otherwise, call `montgomery_add` to add  to the accumulating sum.
+                        Some((sum_x, sum_y)) => {
+                            // Sum the new Montgomery point into the accumulating sum.
+                            sum = Some(montgomery_add((sum_x, sum_y), (&montgomery_x, &montgomery_y))); // 3 constraints
+                        }
+                    }
+                });
+
+                // Convert the accumulating sum into the twisted Edwards point.
+                match &sum {
+                    Some((sum_x, sum_y)) => {
+                        // Convert the accumulated sum into a point on the twisted Edwards curve.
+                        let edwards_x = sum_x / sum_y; // 1 constraint
+                        Group::from_x_coordinate(edwards_x) // 3 constraints
+                    }
+                    None => E::halt("Invalid iteration of BHP detected, a window was not evaluated"),
+                }
+            })
+            .fold(Group::zero(), |acc, group| acc + group) // 6 constraints
+    }
+}
+
+#[cfg(all(test, console))]
+mod tests {
+    use super::*;
+    use snarkvm_circuit_types::environment::Circuit;
+    use snarkvm_utilities::{test_rng, UniformRand};
+
+    use anyhow::Result;
+
+    const ITERATIONS: usize = 100;
+    const MESSAGE: &str = "BHPCircuit0";
+
+    fn check_hash_uncompressed<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
+        mode: Mode,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+    ) -> Result<()> {
+        use console::HashUncompressed as H;
+
+        // Initialize the native BHP hasher.
+        let native =
+            console::bhp::hasher::BHPHasher::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(
+                MESSAGE,
+            );
+
+        // Initialize the circuit BHP hasher.
+        let primitive = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
+        let circuit = BHPHasher::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, primitive.clone());
+        // Determine the number of inputs.
+        let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
+
+        for i in 0..ITERATIONS {
+            // Sample a random input.
+            let input = (0..num_input_bits).map(|_| bool::rand(&mut test_rng())).collect::<Vec<bool>>();
+            // Compute the expected hash.
+            let expected = native.hash_uncompressed(&input).expect("Failed to hash native input");
+            // Prepare the circuit input.
+            let circuit_input: Vec<Boolean<_>> = Inject::new(mode, input);
+
+            Circuit::scope(format!("BHP {mode} {i}"), || {
+                // Perform the hash operation.
+                let candidate = circuit.hash_uncompressed(&circuit_input);
+                assert_scope!(num_constants, num_public, num_private, num_constraints);
+                assert_eq!(expected, candidate.eject_value());
+            });
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_hash_uncompressed_constant() -> Result<()> {
+        check_hash_uncompressed::<32, 48>(Mode::Constant, 6303, 0, 0, 0)
+    }
+
+    #[test]
+    fn test_hash_uncompressed_public() -> Result<()> {
+        check_hash_uncompressed::<32, 48>(Mode::Public, 129, 0, 7898, 7898)
+    }
+
+    #[test]
+    fn test_hash_uncompressed_private() -> Result<()> {
+        check_hash_uncompressed::<32, 48>(Mode::Private, 129, 0, 7898, 7898)
+    }
+}

--- a/circuit/algorithms/src/bhp/hasher/mod.rs
+++ b/circuit/algorithms/src/bhp/hasher/mod.rs
@@ -91,7 +91,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Inject for BH
                 powers
             })
             .collect::<Vec<Vec<BaseLookups<E>>>>();
-        assert_eq!(bases.len(), NUM_WINDOWS as usize, "Incorrect number of windows ({}) for BHP", bases.len());
+        assert_eq!(bases.len(), NUM_WINDOWS as usize, "Incorrect number of BHP windows ({})", bases.len());
         bases.iter().for_each(|window| assert_eq!(window.len(), WINDOW_SIZE as usize));
 
         // Initialize the random base.

--- a/circuit/algorithms/src/bhp/hasher/mod.rs
+++ b/circuit/algorithms/src/bhp/hasher/mod.rs
@@ -1,0 +1,138 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+mod hash_uncompressed;
+
+#[cfg(all(test, console))]
+use snarkvm_circuit_types::environment::assert_scope;
+
+use crate::HashUncompressed;
+use snarkvm_circuit_types::prelude::*;
+use snarkvm_curves::{MontgomeryParameters, ProjectiveCurve, TwistedEdwardsParameters};
+
+/// The BHP chunk size (this implementation is for a 3-bit BHP).
+const BHP_CHUNK_SIZE: usize = 3;
+
+/// The x-coordinate and y-coordinate of each base on the Montgomery curve.
+type BaseLookups<E> = (Vec<Field<E>>, Vec<Field<E>>);
+
+/// BHP is a collision-resistant hash function that takes a variable-length input.
+/// The BHP hasher is used to process one internal iteration of the BHP hash function.
+pub struct BHPHasher<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> {
+    /// The bases for the BHP hash.
+    bases: Vec<Vec<BaseLookups<E>>>,
+    /// The random base for the BHP commitment.
+    random_base: Vec<Group<E>>,
+}
+
+impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> BHPHasher<E, NUM_WINDOWS, WINDOW_SIZE> {
+    /// The BHP lookup size per iteration.
+    const BHP_LOOKUP_SIZE: usize = 4;
+    /// The maximum number of input bits.
+    const MAX_BITS: usize = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
+    /// The minimum number of input bits (at least one window).
+    const MIN_BITS: usize = WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
+
+    /// Returns the bases.
+    pub(crate) fn bases(&self) -> &Vec<Vec<BaseLookups<E>>> {
+        &self.bases
+    }
+
+    /// Returns the random base window.
+    pub(crate) fn random_base(&self) -> &Vec<Group<E>> {
+        &self.random_base
+    }
+}
+
+#[cfg(console)]
+impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Inject for BHPHasher<E, NUM_WINDOWS, WINDOW_SIZE> {
+    type Primitive = console::BHP<E::Affine, NUM_WINDOWS, WINDOW_SIZE>;
+
+    /// Initializes a new instance of a BHP circuit with the given BHP variant.
+    fn new(_mode: Mode, bhp: Self::Primitive) -> Self {
+        // Compute the bases.
+        let bases = bhp
+            .bases()
+            .iter()
+            .take(NUM_WINDOWS as usize)
+            .map(|window| {
+                // Construct the window with the base.
+                let mut powers = Vec::with_capacity(WINDOW_SIZE as usize);
+                for base in window.iter().take(WINDOW_SIZE as usize).map(|base| Group::constant(base.to_affine())) {
+                    let mut x_bases = Vec::with_capacity(Self::BHP_LOOKUP_SIZE);
+                    let mut y_bases = Vec::with_capacity(Self::BHP_LOOKUP_SIZE);
+                    let mut accumulator = base.clone();
+                    for _ in 0..Self::BHP_LOOKUP_SIZE {
+                        // Convert each base from twisted Edwards point into a Montgomery point.
+                        let x = (Field::one() + accumulator.to_y_coordinate())
+                            / (Field::one() - accumulator.to_y_coordinate());
+                        let y = &x / accumulator.to_x_coordinate();
+
+                        x_bases.push(x);
+                        y_bases.push(y);
+                        accumulator += &base;
+                    }
+                    powers.push((x_bases, y_bases));
+                }
+                powers
+            })
+            .collect::<Vec<Vec<BaseLookups<E>>>>();
+        assert_eq!(bases.len(), NUM_WINDOWS as usize, "Incorrect number of windows ({}) for BHP", bases.len());
+        bases.iter().for_each(|window| assert_eq!(window.len(), WINDOW_SIZE as usize));
+
+        // Initialize the random base.
+        let random_base = Vec::constant(bhp.random_base().iter().map(|base| base.to_affine()).collect());
+        assert_eq!(random_base.len(), E::ScalarField::size_in_bits());
+
+        Self { bases, random_base }
+    }
+}
+
+#[cfg(all(test, console))]
+mod tests {
+    use super::*;
+    use snarkvm_circuit_types::{environment::Circuit, Eject};
+    use snarkvm_curves::{AffineCurve, ProjectiveCurve};
+
+    use anyhow::Result;
+
+    const ITERATIONS: usize = 10;
+    const MESSAGE: &str = "BHPCircuit0";
+
+    #[test]
+    fn test_setup_constant() -> Result<()> {
+        for _ in 0..ITERATIONS {
+            let native = console::BHP::<<Circuit as Environment>::Affine, 8, 32>::setup(MESSAGE)?;
+            let circuit = BHPHasher::<Circuit, 8, 32>::new(Mode::Constant, native.clone());
+
+            native.bases().iter().zip(circuit.bases.iter()).for_each(|(native_bases, circuit_bases)| {
+                native_bases.iter().zip(circuit_bases).for_each(|(native_base, circuit_base_lookups)| {
+                    // Check the first circuit base (when converted back to twisted Edwards) matches the native one.
+                    let (circuit_x, circuit_y) = {
+                        let (x_bases, y_bases) = circuit_base_lookups;
+                        // Convert the Montgomery point to a twisted Edwards point.
+                        let edwards_x = &x_bases[0] / &y_bases[0]; // 1 constraint
+                        let edwards_y = (&x_bases[0] - Field::one()) / (&x_bases[0] + Field::one());
+                        (edwards_x, edwards_y)
+                    };
+                    assert_eq!(native_base.to_affine().to_x_coordinate(), circuit_x.eject_value());
+                    assert_eq!(native_base.to_affine().to_y_coordinate(), circuit_y.eject_value());
+                })
+            });
+        }
+        Ok(())
+    }
+}

--- a/circuit/algorithms/src/bhp/hasher/mod.rs
+++ b/circuit/algorithms/src/bhp/hasher/mod.rs
@@ -46,6 +46,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> BHPHasher<E, 
     /// The minimum number of input bits (at least one window).
     const MIN_BITS: usize = WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
 
+    #[cfg(test)]
     /// Returns the bases.
     pub(crate) fn bases(&self) -> &Vec<Vec<BaseLookups<E>>> {
         &self.bases

--- a/circuit/algorithms/src/bhp/mod.rs
+++ b/circuit/algorithms/src/bhp/mod.rs
@@ -52,7 +52,7 @@ const BHP_CHUNK_SIZE: usize = 3;
 /// ```
 /// Each subsequent iteration is initialized as follows:
 /// ```text
-/// DIGEST_N+1 = \[ DIGEST_N || INPUT\[BLOCK_SIZE..2\*BLOCK_SIZE\] \]
+/// DIGEST_N+1 = BHP([ DIGEST_N || INPUT[(N+1)*BLOCK_SIZE..(N+2)*BLOCK_SIZE] ]);
 /// ```
 pub struct BHP<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> {
     /// The domain separator for the BHP hash function.

--- a/circuit/algorithms/src/bhp/mod.rs
+++ b/circuit/algorithms/src/bhp/mod.rs
@@ -20,7 +20,7 @@ mod hash;
 mod hash_uncompressed;
 
 #[cfg(all(test, console))]
-use snarkvm_circuit_environment::assert_scope;
+use snarkvm_circuit_types::environment::assert_scope;
 
 use crate::{Commit, CommitUncompressed, Hash, HashUncompressed};
 use snarkvm_circuit_types::prelude::*;
@@ -104,8 +104,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Inject for BH
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
-    use snarkvm_circuit_types::Eject;
+    use snarkvm_circuit_types::{environment::Circuit, Eject};
     use snarkvm_curves::{AffineCurve, ProjectiveCurve};
 
     const ITERATIONS: usize = 10;

--- a/circuit/algorithms/src/bhp/mod.rs
+++ b/circuit/algorithms/src/bhp/mod.rs
@@ -52,7 +52,7 @@ const BHP_CHUNK_SIZE: usize = 3;
 /// ```
 /// Each subsequent iteration is initialized as follows:
 /// ```text
-/// DIGEST_N+1 = BHP([ DIGEST_N || INPUT[(N+1)*BLOCK_SIZE..(N+2)*BLOCK_SIZE] ]);
+/// DIGEST_N+1 = BHP([ DIGEST_N[0..DATA_BITS] || INPUT[(N+1)*BLOCK_SIZE..(N+2)*BLOCK_SIZE] ]);
 /// ```
 pub struct BHP<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> {
     /// The domain separator for the BHP hash function.

--- a/circuit/algorithms/src/bhp/mod.rs
+++ b/circuit/algorithms/src/bhp/mod.rs
@@ -19,7 +19,7 @@ mod commit_uncompressed;
 mod hash;
 mod hash_uncompressed;
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 use snarkvm_circuit_environment::assert_scope;
 
 use crate::{Commit, CommitUncompressed, Hash, HashUncompressed};

--- a/circuit/algorithms/src/bhp/mod.rs
+++ b/circuit/algorithms/src/bhp/mod.rs
@@ -61,7 +61,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> BHP<E, NUM_WI
 impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Inject for BHP<E, NUM_WINDOWS, WINDOW_SIZE> {
     type Primitive = console::BHP<E::Affine, NUM_WINDOWS, WINDOW_SIZE>;
 
-    /// Initializes a new instance of a BHP circuit with the given BHP parameters.
+    /// Initializes a new instance of a BHP circuit with the given BHP variant.
     fn new(_mode: Mode, bhp: Self::Primitive) -> Self {
         // Compute the bases.
         let bases = bhp

--- a/circuit/algorithms/src/elligator2/encode.rs
+++ b/circuit/algorithms/src/elligator2/encode.rs
@@ -104,7 +104,7 @@ impl<E: Environment> Elligator2<E> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
@@ -118,7 +118,7 @@ mod tests {
             let given: <Circuit as Environment>::BaseField = UniformRand::rand(&mut test_rng());
 
             // Compute the expected native result.
-            let (expected, _sign) = snarkvm_console_algorithms::Elligator2::<
+            let (expected, _sign) = console::Elligator2::<
                 <Circuit as Environment>::Affine,
                 <Circuit as Environment>::AffineParameters,
             >::encode(&given)

--- a/circuit/algorithms/src/elligator2/encode.rs
+++ b/circuit/algorithms/src/elligator2/encode.rs
@@ -107,7 +107,7 @@ impl<E: Environment> Elligator2<E> {
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 1_000;

--- a/circuit/algorithms/src/elligator2/mod.rs
+++ b/circuit/algorithms/src/elligator2/mod.rs
@@ -16,7 +16,7 @@
 
 mod encode;
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 use snarkvm_circuit_environment::assert_scope;
 
 use snarkvm_circuit_types::prelude::*;

--- a/circuit/algorithms/src/elligator2/mod.rs
+++ b/circuit/algorithms/src/elligator2/mod.rs
@@ -17,7 +17,7 @@
 mod encode;
 
 #[cfg(all(test, console))]
-use snarkvm_circuit_environment::assert_scope;
+use snarkvm_circuit_types::environment::assert_scope;
 
 use snarkvm_circuit_types::prelude::*;
 use snarkvm_curves::{MontgomeryParameters, TwistedEdwardsParameters};

--- a/circuit/algorithms/src/merkle_path/mod.rs
+++ b/circuit/algorithms/src/merkle_path/mod.rs
@@ -73,7 +73,7 @@ mod tests {
         merkle_tree::{MaskedMerkleTreeParameters, MerkleTree},
         traits::MerkleParameters,
     };
-    use snarkvm_circuit_environment::{assert_scope, Circuit, Mode};
+    use snarkvm_circuit_types::environment::{assert_scope, Circuit, Mode};
     use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective};
     use snarkvm_utilities::{test_rng, UniformRand};
 

--- a/circuit/algorithms/src/merkle_path/to_root.rs
+++ b/circuit/algorithms/src/merkle_path/to_root.rs
@@ -68,7 +68,7 @@ mod tests {
         traits::MerkleParameters,
     };
 
-    use snarkvm_circuit_environment::{assert_scope, Circuit, Mode};
+    use snarkvm_circuit_types::environment::{assert_scope, Circuit, Mode};
     use snarkvm_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective};
     use snarkvm_utilities::{test_rng, ToBits, UniformRand};
 

--- a/circuit/algorithms/src/pedersen/commit.rs
+++ b/circuit/algorithms/src/pedersen/commit.rs
@@ -92,7 +92,7 @@ impl<E: Environment, const NUM_BITS: u8>
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;

--- a/circuit/algorithms/src/pedersen/commit.rs
+++ b/circuit/algorithms/src/pedersen/commit.rs
@@ -104,7 +104,7 @@ mod tests {
 
         // Initialize Pedersen.
         let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
-        let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
+        let circuit = Pedersen::<Circuit, NUM_BITS>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Sample a random input.
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn test_pedersen64_homomorphism_private() {
         // Initialize Pedersen64.
-        let pedersen = Pedersen64::setup("Pedersen64HomomorphismTest");
+        let pedersen = Pedersen64::constant(console::Pedersen64::setup("Pedersen64HomomorphismTest"));
 
         for _ in 0..ITERATIONS {
             // Sample two random unsigned integers, with the MSB set to 0.
@@ -268,7 +268,7 @@ mod tests {
         }
 
         // Check Pedersen128.
-        let pedersen128 = Pedersen128::setup("Pedersen128HomomorphismTest");
+        let pedersen128 = Pedersen128::constant(console::Pedersen128::setup("Pedersen128HomomorphismTest"));
         check_pedersen_homomorphism(&pedersen128);
     }
 }

--- a/circuit/algorithms/src/pedersen/commit.rs
+++ b/circuit/algorithms/src/pedersen/commit.rs
@@ -89,11 +89,10 @@ impl<E: Environment, const NUM_BITS: u8>
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{Commit as C, Pedersen as NativePedersen};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;
@@ -101,8 +100,10 @@ mod tests {
     const NUM_BITS_MULTIPLIER: u8 = 8;
 
     fn check_commit<const NUM_BITS: u8>(mode: Mode) {
+        use console::Commit as C;
+
         // Initialize Pedersen.
-        let native = NativePedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
+        let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
         let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
 
         for i in 0..ITERATIONS {

--- a/circuit/algorithms/src/pedersen/commit_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/commit_uncompressed.rs
@@ -114,7 +114,7 @@ mod tests {
 
         // Initialize Pedersen.
         let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
-        let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
+        let circuit = Pedersen::<Circuit, NUM_BITS>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Sample a random input.
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn test_pedersen64_homomorphism_private() {
         // Initialize Pedersen64.
-        let pedersen = Pedersen64::setup("Pedersen64HomomorphismTest");
+        let pedersen = Pedersen64::constant(console::Pedersen64::setup("Pedersen64HomomorphismTest"));
 
         for _ in 0..ITERATIONS {
             // Sample two random unsigned integers, with the MSB set to 0.
@@ -275,7 +275,7 @@ mod tests {
         }
 
         // Check Pedersen128.
-        let pedersen128 = Pedersen128::setup("Pedersen128HomomorphismTest");
+        let pedersen128 = Pedersen128::constant(console::Pedersen128::setup("Pedersen128HomomorphismTest"));
         check_pedersen_homomorphism(&pedersen128);
     }
 }

--- a/circuit/algorithms/src/pedersen/commit_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/commit_uncompressed.rs
@@ -102,7 +102,7 @@ impl<E: Environment, const NUM_BITS: u8>
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;

--- a/circuit/algorithms/src/pedersen/commit_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/commit_uncompressed.rs
@@ -99,11 +99,10 @@ impl<E: Environment, const NUM_BITS: u8>
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{CommitUncompressed as C, Pedersen as NativePedersen};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;
@@ -111,8 +110,10 @@ mod tests {
     const NUM_BITS_MULTIPLIER: u8 = 8;
 
     fn check_commit_uncompressed<const NUM_BITS: u8>(mode: Mode) {
+        use console::CommitUncompressed as C;
+
         // Initialize Pedersen.
-        let native = NativePedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
+        let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
         let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
 
         for i in 0..ITERATIONS {

--- a/circuit/algorithms/src/pedersen/hash.rs
+++ b/circuit/algorithms/src/pedersen/hash.rs
@@ -52,7 +52,7 @@ impl<E: Environment, const NUM_BITS: u8> OutputMode<dyn Hash<Input = Boolean<E>,
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;

--- a/circuit/algorithms/src/pedersen/hash.rs
+++ b/circuit/algorithms/src/pedersen/hash.rs
@@ -49,11 +49,10 @@ impl<E: Environment, const NUM_BITS: u8> OutputMode<dyn Hash<Input = Boolean<E>,
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{Hash as H, Pedersen as NativePedersen};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;
@@ -61,8 +60,10 @@ mod tests {
     const NUM_BITS_MULTIPLIER: u8 = 8;
 
     fn check_hash<const NUM_BITS: u8>(mode: Mode) {
+        use console::Hash as H;
+
         // Initialize the Pedersen hash.
-        let native = NativePedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
+        let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
         let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
 
         for i in 0..ITERATIONS {

--- a/circuit/algorithms/src/pedersen/hash.rs
+++ b/circuit/algorithms/src/pedersen/hash.rs
@@ -64,7 +64,7 @@ mod tests {
 
         // Initialize the Pedersen hash.
         let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
-        let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
+        let circuit = Pedersen::<Circuit, NUM_BITS>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Sample a random input.

--- a/circuit/algorithms/src/pedersen/hash_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/hash_uncompressed.rs
@@ -107,11 +107,10 @@ impl<E: Environment, const NUM_BITS: u8> OutputMode<dyn HashUncompressed<Input =
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::{HashUncompressed as H, Pedersen as NativePedersen};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;
@@ -119,8 +118,10 @@ mod tests {
     const NUM_BITS_MULTIPLIER: u8 = 8;
 
     fn check_hash_uncompressed<const NUM_BITS: u8>(mode: Mode) {
+        use console::HashUncompressed as H;
+
         // Initialize the Pedersen hash.
-        let native = NativePedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
+        let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
         let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
 
         for i in 0..ITERATIONS {

--- a/circuit/algorithms/src/pedersen/hash_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/hash_uncompressed.rs
@@ -122,7 +122,7 @@ mod tests {
 
         // Initialize the Pedersen hash.
         let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
-        let circuit = Pedersen::<Circuit, NUM_BITS>::setup(MESSAGE);
+        let circuit = Pedersen::<Circuit, NUM_BITS>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Sample a random input.
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn test_pedersen64_homomorphism_private() {
         // Initialize Pedersen64.
-        let pedersen = Pedersen64::setup("Pedersen64HomomorphismTest");
+        let pedersen = Pedersen64::constant(console::Pedersen64::setup("Pedersen64HomomorphismTest"));
 
         for _ in 0..ITERATIONS {
             // Sample two random unsigned integers, with the MSB set to 0.
@@ -264,7 +264,7 @@ mod tests {
         }
 
         // Check Pedersen128.
-        let pedersen128 = Pedersen128::setup("Pedersen128HomomorphismTest");
+        let pedersen128 = Pedersen128::constant(console::Pedersen128::setup("Pedersen128HomomorphismTest"));
         check_pedersen_homomorphism(&pedersen128);
     }
 }

--- a/circuit/algorithms/src/pedersen/hash_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/hash_uncompressed.rs
@@ -110,7 +110,7 @@ impl<E: Environment, const NUM_BITS: u8> OutputMode<dyn HashUncompressed<Input =
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: u64 = 10;

--- a/circuit/algorithms/src/pedersen/mod.rs
+++ b/circuit/algorithms/src/pedersen/mod.rs
@@ -23,8 +23,8 @@ mod hash_uncompressed;
 use snarkvm_circuit_environment::{assert_count, assert_output_mode, assert_scope};
 
 use crate::{Commit, CommitUncompressed, Hash, HashUncompressed};
+use console::Blake2Xs;
 use snarkvm_circuit_types::prelude::*;
-use snarkvm_console_algorithms::Blake2Xs;
 
 /// Pedersen64 is an *additively-homomorphic* collision-resistant hash function that takes a 64-bit input.
 pub type Pedersen64<E> = Pedersen<E, 64>;
@@ -69,11 +69,10 @@ impl<E: Environment, const NUM_BITS: u8> Pedersen<E, NUM_BITS> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_environment::Circuit;
-    use snarkvm_console_algorithms::Pedersen as NativePedersen;
     use snarkvm_curves::ProjectiveCurve;
 
     const ITERATIONS: u64 = 10;
@@ -83,7 +82,7 @@ mod tests {
     fn check_setup<const NUM_BITS: u8>(num_constants: u64, num_public: u64, num_private: u64, num_constraints: u64) {
         for _ in 0..ITERATIONS {
             // Initialize the native Pedersen hash.
-            let native = NativePedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
+            let native = console::Pedersen::<<Circuit as Environment>::Affine, NUM_BITS>::setup(MESSAGE);
 
             Circuit::scope("Pedersen::setup", || {
                 // Perform the setup operation.

--- a/circuit/algorithms/src/pedersen/mod.rs
+++ b/circuit/algorithms/src/pedersen/mod.rs
@@ -19,11 +19,10 @@ mod commit_uncompressed;
 mod hash;
 mod hash_uncompressed;
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 use snarkvm_circuit_environment::{assert_count, assert_output_mode, assert_scope};
 
 use crate::{Commit, CommitUncompressed, Hash, HashUncompressed};
-use console::Blake2Xs;
 use snarkvm_circuit_types::prelude::*;
 
 /// Pedersen64 is an *additively-homomorphic* collision-resistant hash function that takes a 64-bit input.
@@ -40,11 +39,12 @@ pub struct Pedersen<E: Environment, const NUM_BITS: u8> {
     random_base: Vec<Group<E>>,
 }
 
+#[cfg(console)]
 impl<E: Environment, const NUM_BITS: u8> Pedersen<E, NUM_BITS> {
     /// Initializes a new instance of Pedersen with the given setup message.
     pub fn setup(message: &str) -> Self {
         // Construct an indexed message to attempt to sample a base.
-        let (generator, _, _) = Blake2Xs::hash_to_curve(&format!("Aleo.Pedersen.Base.{message}"));
+        let (generator, _, _) = console::Blake2Xs::hash_to_curve(&format!("Aleo.Pedersen.Base.{message}"));
         // Inject the new base.
         let mut base = Group::constant(generator);
         // Construct the window with the base.
@@ -55,7 +55,7 @@ impl<E: Environment, const NUM_BITS: u8> Pedersen<E, NUM_BITS> {
         }
 
         // Compute the random base.
-        let (generator, _, _) = Blake2Xs::hash_to_curve(&format!("Aleo.Pedersen.RandomBase.{message}"));
+        let (generator, _, _) = console::Blake2Xs::hash_to_curve(&format!("Aleo.Pedersen.RandomBase.{message}"));
         let mut base = Group::constant(generator);
 
         let num_scalar_bits = E::ScalarField::size_in_bits();

--- a/circuit/algorithms/src/pedersen/mod.rs
+++ b/circuit/algorithms/src/pedersen/mod.rs
@@ -20,7 +20,7 @@ mod hash;
 mod hash_uncompressed;
 
 #[cfg(all(test, console))]
-use snarkvm_circuit_environment::{assert_count, assert_output_mode, assert_scope};
+use snarkvm_circuit_types::environment::{assert_count, assert_output_mode, assert_scope};
 
 use crate::{Commit, CommitUncompressed, Hash, HashUncompressed};
 use snarkvm_circuit_types::prelude::*;
@@ -61,7 +61,7 @@ impl<E: Environment, const NUM_BITS: u8> Inject for Pedersen<E, NUM_BITS> {
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use snarkvm_circuit_environment::Circuit;
+    use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_curves::ProjectiveCurve;
 
     const ITERATIONS: u64 = 10;

--- a/circuit/algorithms/src/poseidon/hash.rs
+++ b/circuit/algorithms/src/poseidon/hash.rs
@@ -212,11 +212,10 @@ impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_types::environment::Circuit;
-    use snarkvm_console_algorithms::{Hash as H, Poseidon as NativePoseidon};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -230,8 +229,10 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::Hash as H;
+
         let rng = &mut test_rng();
-        let native_poseidon = NativePoseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
         let poseidon = Poseidon::<Circuit, RATE>::new();
 
         for i in 0..ITERATIONS {

--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -52,11 +52,10 @@ impl<E: Environment, const RATE: usize> OutputMode<dyn HashMany<Input = Field<E>
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_types::environment::Circuit;
-    use snarkvm_console_algorithms::{HashMany as H, Poseidon as NativePoseidon};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -71,8 +70,10 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::HashMany as H;
+
         let rng = &mut test_rng();
-        let native_poseidon = NativePoseidon::<<Circuit as Environment>::BaseField, { RATE as usize }>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, { RATE as usize }>::setup();
         let poseidon = Poseidon::<Circuit, { RATE as usize }>::new();
 
         for i in 0..ITERATIONS {

--- a/circuit/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/circuit/algorithms/src/poseidon/hash_to_scalar.rs
@@ -53,11 +53,10 @@ impl<E: Environment, const RATE: usize> OutputMode<dyn HashToScalar<Input = Fiel
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_types::environment::Circuit;
-    use snarkvm_console_algorithms::{HashToScalar as H, Poseidon as NativePoseidon};
     use snarkvm_utilities::{test_rng, FromBits, ToBits, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -71,8 +70,10 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::HashToScalar as H;
+
         let rng = &mut test_rng();
-        let native_poseidon = NativePoseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
         let poseidon = Poseidon::<Circuit, RATE>::new();
 
         for i in 0..ITERATIONS {

--- a/circuit/algorithms/src/poseidon/mod.rs
+++ b/circuit/algorithms/src/poseidon/mod.rs
@@ -19,7 +19,7 @@ mod hash_many;
 mod hash_to_scalar;
 mod prf;
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 use snarkvm_circuit_types::environment::assert_scope;
 
 use crate::{Hash, HashMany, HashToScalar, PRF};

--- a/circuit/algorithms/src/poseidon/prf.rs
+++ b/circuit/algorithms/src/poseidon/prf.rs
@@ -54,11 +54,10 @@ impl<E: Environment, const RATE: usize> OutputMode<dyn PRF<Seed = Field<E>, Inpu
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, console))]
 mod tests {
     use super::*;
     use snarkvm_circuit_types::environment::Circuit;
-    use snarkvm_console_algorithms::{Poseidon as NativePoseidon, PRF as P};
     use snarkvm_utilities::{test_rng, UniformRand};
 
     const ITERATIONS: usize = 10;
@@ -72,8 +71,10 @@ mod tests {
         num_private: u64,
         num_constraints: u64,
     ) {
+        use console::PRF as P;
+
         let rng = &mut test_rng();
-        let native_poseidon = NativePoseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
         let poseidon = Poseidon::<Circuit, RATE>::new();
 
         for i in 0..ITERATIONS {

--- a/circuit/network/src/lib.rs
+++ b/circuit/network/src/lib.rs
@@ -23,7 +23,6 @@ pub use v0::*;
 use snarkvm_circuit_types::{environment::Environment, Boolean, Field, Group, Scalar};
 
 pub trait Aleo: Environment {
-    #[cfg(console)]
     type Network: console::Network<Affine = Self::Affine, Field = Self::BaseField, Scalar = Self::ScalarField>;
 
     /// The maximum number of field elements in data (must not exceed u16::MAX).

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -46,27 +46,23 @@ use core::fmt;
 type E = Circuit;
 
 thread_local! {
-    #[cfg(console)]
     /// The group bases for the Aleo signature and encryption schemes.
     static GENERATOR_G: Vec<Group<AleoV0>> = Vec::constant(<console::Testnet3 as console::Network>::g_powers().iter().map(|g| g.to_affine()).collect());
-    #[cfg(console)]
     /// The encryption domain as a constant field element.
     static ENCRYPTION_DOMAIN: Field<AleoV0> = Field::constant(<console::Testnet3 as console::Network>::encryption_domain());
-    #[cfg(console)]
     /// The MAC domain as a constant field element.
     static MAC_DOMAIN: Field<AleoV0> = Field::constant(<console::Testnet3 as console::Network>::mac_domain());
-    #[cfg(console)]
     /// The randomizer domain as a constant field element.
     static RANDOMIZER_DOMAIN: Field<AleoV0> = Field::constant(<console::Testnet3 as console::Network>::randomizer_domain());
 
     /// The BHP gadget, which can take an input of up to 256 bits.
-    static BHP_256: BHP256<AleoV0> = BHP256::<AleoV0>::setup("AleoBHP256");
+    static BHP_256: BHP256<AleoV0> = BHP256::<AleoV0>::constant(console::BHP_256.with(|bhp| bhp.clone()));
     /// The BHP gadget, which can take an input of up to 512 bits.
-    static BHP_512: BHP512<AleoV0> = BHP512::<AleoV0>::setup("AleoBHP512");
+    static BHP_512: BHP512<AleoV0> = BHP512::<AleoV0>::constant(console::BHP_512.with(|bhp| bhp.clone()));
     /// The BHP gadget, which can take an input of up to 768 bits.
-    static BHP_768: BHP768<AleoV0> = BHP768::<AleoV0>::setup("AleoBHP768");
+    static BHP_768: BHP768<AleoV0> = BHP768::<AleoV0>::constant(console::BHP_768.with(|bhp| bhp.clone()));
     /// The BHP gadget, which can take an input of up to 1024 bits.
-    static BHP_1024: BHP1024<AleoV0> = BHP1024::<AleoV0>::setup("AleoBHP1024");
+    static BHP_1024: BHP1024<AleoV0> = BHP1024::<AleoV0>::constant(console::BHP_1024.with(|bhp| bhp.clone()));
 
     /// The Pedersen gadget, which can take an input of up to 64 bits.
     static PEDERSEN_64: Pedersen64<AleoV0> = Pedersen64::<AleoV0>::setup("AleoPedersen64");
@@ -85,7 +81,6 @@ thread_local! {
 pub struct AleoV0;
 
 impl Aleo for AleoV0 {
-    #[cfg(console)]
     type Network = console::Testnet3;
 
     /// The maximum number of bits in data (must not exceed u16::MAX).

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -65,9 +65,9 @@ thread_local! {
     static BHP_1024: BHP1024<AleoV0> = BHP1024::<AleoV0>::constant(console::BHP_1024.with(|bhp| bhp.clone()));
 
     /// The Pedersen gadget, which can take an input of up to 64 bits.
-    static PEDERSEN_64: Pedersen64<AleoV0> = Pedersen64::<AleoV0>::setup("AleoPedersen64");
+    static PEDERSEN_64: Pedersen64<AleoV0> = Pedersen64::<AleoV0>::constant(console::PEDERSEN_64.with(|pedersen| pedersen.clone()));
     /// The Pedersen gadget, which can take an input of up to 128 bits.
-    static PEDERSEN_128: Pedersen128<AleoV0> = Pedersen128::<AleoV0>::setup("AleoPedersen128");
+    static PEDERSEN_128: Pedersen128<AleoV0> = Pedersen128::<AleoV0>::constant(console::PEDERSEN_128.with(|pedersen| pedersen.clone()));
 
     /// The Poseidon hash function, using a rate of 2.
     static POSEIDON_2: Poseidon2<AleoV0> = Poseidon2::<AleoV0>::new();

--- a/console/account/Cargo.toml
+++ b/console/account/Cargo.toml
@@ -37,21 +37,15 @@ version = "0.2"
 [dependencies.bech32]
 version = "0.9"
 
-[dependencies.itertools]
-version = "0.10.1"
-
-[dependencies.once_cell]
-version = "1.10.0"
-
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
-
-[dependencies.serde_json]
-version = "1.0"
 
 [dev-dependencies.bincode]
 version = "1.3"
 
 [dev-dependencies.rand]
 version = "0.8"
+
+[dev-dependencies.serde_json]
+version = "1.0"

--- a/console/account/src/lib.rs
+++ b/console/account/src/lib.rs
@@ -166,7 +166,7 @@ pub use view_key::*;
 //         let address = Address::<Testnet2>::from_private_key(&private_key);
 //
 //         for i in 0..ITERATIONS {
-//             let message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+//             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
 //             let signature = private_key.sign(&message, &mut thread_rng()).unwrap();
 //             let verification = address.verify_signature(&message, &signature).unwrap();
 //             assert!(verification);
@@ -180,7 +180,7 @@ pub use view_key::*;
 //
 //         for i in 0..ITERATIONS {
 //             let message = "Hi, I'm an Aleo account signature!".as_bytes().to_bits_le();
-//             let incorrect_message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+//             let incorrect_message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
 //
 //             let signature = private_key.sign(&message, &mut thread_rng()).unwrap();
 //             let verification = address.verify_signature(&incorrect_message, &signature).unwrap();
@@ -204,7 +204,7 @@ pub use view_key::*;
 //
 //             // Prepare for signing.
 //             let rng = ChaChaRng::seed_from_u64(thread_rng().gen());
-//             let message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+//             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
 //
 //             // Ensure the Aleo signatures match.
 //             let expected_signature = private_key.sign(&message, &mut rng.clone()).unwrap();
@@ -237,7 +237,7 @@ pub use view_key::*;
 //             let private_key = PrivateKey::<Testnet2>::new(&mut thread_rng());
 //
 //             // Craft the Aleo signature.
-//             let message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+//             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
 //             let expected_signature = private_key.sign(&message, &mut thread_rng()).unwrap();
 //
 //             let candidate_string = &expected_signature.to_string();
@@ -253,7 +253,7 @@ pub use view_key::*;
 //             let private_key = PrivateKey::<Testnet2>::new(&mut thread_rng());
 //
 //             // Craft the Aleo signature.
-//             let message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+//             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
 //             let expected_signature = private_key.sign(&message, &mut thread_rng()).unwrap();
 //
 //             // Serialize
@@ -274,7 +274,7 @@ pub use view_key::*;
 //             let private_key = PrivateKey::<Testnet2>::new(&mut thread_rng());
 //
 //             // Craft the Aleo signature.
-//             let message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+//             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
 //             let expected_signature = private_key.sign(&message, &mut thread_rng()).unwrap();
 //
 //             // Serialize

--- a/console/account/src/signature/bytes.rs
+++ b/console/account/src/signature/bytes.rs
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
     use crate::PrivateKey;
     use snarkvm_console_network::Testnet3;
-    use snarkvm_utilities::{test_crypto_rng, UniformRand};
+    use snarkvm_utilities::{test_crypto_rng, test_rng, UniformRand};
 
     use anyhow::Result;
 
@@ -58,7 +58,7 @@ mod tests {
             let address = Address::try_from(&private_key)?;
 
             // Generate a signature.
-            let message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+            let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
             let randomizer = UniformRand::rand(&mut test_crypto_rng());
             let signature = Signature::sign(&private_key, &message, randomizer)?;
             assert!(signature.verify(&address, &message));

--- a/console/account/src/signature/sign.rs
+++ b/console/account/src/signature/sign.rs
@@ -109,7 +109,7 @@ impl<N: Network> Signature<N> {
 mod tests {
     use super::*;
     use snarkvm_console_network::Testnet3;
-    use snarkvm_utilities::{test_crypto_rng, UniformRand};
+    use snarkvm_utilities::{test_crypto_rng, test_rng, UniformRand};
 
     type CurrentNetwork = Testnet3;
 
@@ -143,11 +143,11 @@ mod tests {
     fn test_sign_and_verify() -> Result<()> {
         for i in 0..ITERATIONS {
             // Check that the signature is valid for the message.
-            let message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+            let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
             check_sign_and_verify(&message)?;
 
             // Check that the signature is invalid for an incorrect message.
-            let failure_message: Vec<bool> = (0..(32 * i)).map(|_| rand::random::<bool>()).collect();
+            let failure_message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect();
             if message != failure_message {
                 check_sign_and_verify_fails(&message, &failure_message)?;
             }

--- a/console/algorithms/src/bhp/commit.rs
+++ b/console/algorithms/src/bhp/commit.rs
@@ -16,7 +16,10 @@
 
 use super::*;
 
-impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Commit for BHP<G, NUM_WINDOWS, WINDOW_SIZE> {
+impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Commit for BHP<G, NUM_WINDOWS, WINDOW_SIZE>
+where
+    <G as AffineCurve>::BaseField: PrimeField,
+{
     type Input = bool;
     type Output = G::BaseField;
     type Randomizer = G::ScalarField;

--- a/console/algorithms/src/bhp/commit.rs
+++ b/console/algorithms/src/bhp/commit.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<G: AffineCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Commit for BHP<G, NUM_WINDOWS, WINDOW_SIZE> {
+impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Commit for BHP<G, NUM_WINDOWS, WINDOW_SIZE> {
     type Input = bool;
     type Output = G::BaseField;
     type Randomizer = G::ScalarField;

--- a/console/algorithms/src/bhp/commit_uncompressed.rs
+++ b/console/algorithms/src/bhp/commit_uncompressed.rs
@@ -18,6 +18,8 @@ use super::*;
 
 impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> CommitUncompressed
     for BHP<G, NUM_WINDOWS, WINDOW_SIZE>
+where
+    <G as AffineCurve>::BaseField: PrimeField,
 {
     type Input = bool;
     type Output = G;
@@ -28,7 +30,7 @@ impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> CommitUncompr
         let mut output = self.hash_uncompressed(input)?.to_projective();
 
         // Compute h^r.
-        randomizer.to_bits_le().iter().zip_eq(&*self.random_base).filter(|(bit, _)| **bit).for_each(|(_, base)| {
+        randomizer.to_bits_le().iter().zip_eq(&**self.random_base()).filter(|(bit, _)| **bit).for_each(|(_, base)| {
             output += base;
         });
 

--- a/console/algorithms/src/bhp/commit_uncompressed.rs
+++ b/console/algorithms/src/bhp/commit_uncompressed.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<G: AffineCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> CommitUncompressed
+impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> CommitUncompressed
     for BHP<G, NUM_WINDOWS, WINDOW_SIZE>
 {
     type Input = bool;

--- a/console/algorithms/src/bhp/hash.rs
+++ b/console/algorithms/src/bhp/hash.rs
@@ -16,7 +16,10 @@
 
 use super::*;
 
-impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Hash for BHP<G, NUM_WINDOWS, WINDOW_SIZE> {
+impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Hash for BHP<G, NUM_WINDOWS, WINDOW_SIZE>
+where
+    <G as AffineCurve>::BaseField: PrimeField,
+{
     type Input = bool;
     type Output = G::BaseField;
 

--- a/console/algorithms/src/bhp/hash.rs
+++ b/console/algorithms/src/bhp/hash.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<G: AffineCurve, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> Hash for BHP<G, NUM_WINDOWS, WINDOW_SIZE> {
+impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> Hash for BHP<G, NUM_WINDOWS, WINDOW_SIZE> {
     type Input = bool;
     type Output = G::BaseField;
 

--- a/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompressed
+    for BHPHasher<G, NUM_WINDOWS, WINDOW_SIZE>
+{
+    type Input = bool;
+    type Output = G;
+
+    /// Returns the BHP hash of the given input as an affine group element.
+    ///
+    /// This uncompressed variant of the BHP hash function is provided to support
+    /// the BHP commitment scheme, as it is typically not used by applications.
+    fn hash_uncompressed(&self, input: &[Self::Input]) -> Result<Self::Output> {
+        // Ensure the input size is at least the window size.
+        ensure!(input.len() > Self::MIN_BITS, "Inputs to this BHP must be greater than {} bits", Self::MIN_BITS);
+        // Ensure the input size is within the parameter size,
+        ensure!(
+            input.len() <= Self::MAX_BITS,
+            "Inputs to this BHP cannot exceed {} bits, found {}",
+            Self::MAX_BITS,
+            input.len()
+        );
+
+        // Pad the input to a multiple of `BHP_CHUNK_SIZE` for hashing.
+        let mut input = input.to_vec();
+        if input.len() % BHP_CHUNK_SIZE != 0 {
+            let padding = BHP_CHUNK_SIZE - (input.len() % BHP_CHUNK_SIZE);
+            input.resize(input.len() + padding, false);
+            ensure!((input.len() % BHP_CHUNK_SIZE) == 0, "Input must be a multiple of {BHP_CHUNK_SIZE}");
+        }
+
+        // Compute sum of h_i^{sum of (1-2*c_{i,j,2})*(1+c_{i,j,0}+2*c_{i,j,1})*2^{4*(j-1)} for all j in segment}
+        // for all i. Described in section 5.4.1.7 in the Zcash protocol specification.
+        //
+        // Note: `.zip()` is used here (as opposed to `.zip_eq()`) as the input can be less than
+        // `NUM_WINDOWS * WINDOW_SIZE * BHP_CHUNK_SIZE` in length, which is the parameter size here.
+        Ok(input
+            .chunks(WINDOW_SIZE as usize * BHP_CHUNK_SIZE)
+            .zip(&*self.bases_lookup)
+            .flat_map(|(bits, bases)| {
+                bits.chunks(BHP_CHUNK_SIZE).zip(bases).map(|(chunk_bits, base)| {
+                    base[(chunk_bits[0] as usize) | (chunk_bits[1] as usize) << 1 | (chunk_bits[2] as usize) << 2]
+                })
+            })
+            .sum::<G::Projective>()
+            .to_affine())
+    }
+}

--- a/console/algorithms/src/bhp/hasher/mod.rs
+++ b/console/algorithms/src/bhp/hasher/mod.rs
@@ -1,0 +1,133 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+mod hash_uncompressed;
+
+use crate::{Blake2Xs, HashUncompressed};
+use snarkvm_curves::{AffineCurve, ProjectiveCurve};
+use snarkvm_fields::{PrimeField, Zero};
+use snarkvm_utilities::{cfg_iter, BigInteger};
+
+use anyhow::{ensure, Result};
+use core::ops::Neg;
+use std::sync::Arc;
+
+/// The BHP chunk size (this implementation is for a 3-bit BHP).
+pub(super) const BHP_CHUNK_SIZE: usize = 3;
+pub(super) const BHP_LOOKUP_SIZE: usize = 2usize.pow(BHP_CHUNK_SIZE as u32);
+
+/// BHP is a collision-resistant hash function that takes a variable-length input.
+/// The BHP hasher is used to process one internal iteration of the BHP hash function.
+#[derive(Clone)]
+pub struct BHPHasher<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> {
+    /// The bases for the BHP hash.
+    bases: Arc<Vec<Vec<G::Projective>>>,
+    /// The bases lookup table for the BHP hash.
+    bases_lookup: Arc<Vec<Vec<[G::Projective; BHP_LOOKUP_SIZE]>>>,
+    /// The random base for the BHP commitment.
+    random_base: Arc<Vec<G::Projective>>,
+}
+
+impl<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> BHPHasher<G, NUM_WINDOWS, WINDOW_SIZE> {
+    /// The maximum number of input bits.
+    const MAX_BITS: usize = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
+    /// The minimum number of input bits (at least one window).
+    const MIN_BITS: usize = WINDOW_SIZE as usize * BHP_CHUNK_SIZE;
+
+    /// Initializes a new instance of BHP with the given domain.
+    pub fn setup(domain: &str) -> Self {
+        // Calculate the maximum window size.
+        let mut maximum_window_size = 0;
+        let mut range = <G::ScalarField as PrimeField>::BigInteger::from(2_u64);
+        while range < G::ScalarField::modulus_minus_one_div_two() {
+            // range < (p-1)/2
+            range.muln(4); // range * 2^4
+            maximum_window_size += 1;
+        }
+        assert!(WINDOW_SIZE <= maximum_window_size, "The maximum BHP window size is {maximum_window_size}");
+
+        // Compute the bases.
+        let bases = (0..NUM_WINDOWS)
+            .map(|index| {
+                // Construct an indexed message to attempt to sample a base.
+                let (generator, _, _) =
+                    Blake2Xs::hash_to_curve::<G>(&format!("Aleo.BHP.{NUM_WINDOWS}.{WINDOW_SIZE}.{domain}.{index}"));
+                let mut base = generator.to_projective();
+                // Compute the generators for the sampled base.
+                let mut powers = Vec::with_capacity(WINDOW_SIZE as usize);
+                for _ in 0..WINDOW_SIZE {
+                    powers.push(base);
+                    for _ in 0..4 {
+                        base.double_in_place();
+                    }
+                }
+                powers
+            })
+            .collect::<Vec<Vec<G::Projective>>>();
+        assert_eq!(bases.len(), NUM_WINDOWS as usize, "Incorrect number of windows ({:?}) for BHP", bases.len());
+        bases.iter().for_each(|window| assert_eq!(window.len(), WINDOW_SIZE as usize));
+
+        // Compute the bases lookup.
+        let bases_lookup = cfg_iter!(bases)
+            .map(|x| {
+                x.iter()
+                    .map(|g| {
+                        let mut lookup = [G::Projective::zero(); BHP_LOOKUP_SIZE];
+                        for (i, element) in lookup.iter_mut().enumerate().take(BHP_LOOKUP_SIZE) {
+                            *element = *g;
+                            if (i & 0x01) != 0 {
+                                *element += g;
+                            }
+                            if (i & 0x02) != 0 {
+                                *element += g.double();
+                            }
+                            if (i & 0x04) != 0 {
+                                *element = element.neg();
+                            }
+                        }
+                        lookup
+                    })
+                    .collect()
+            })
+            .collect::<Vec<Vec<[G::Projective; BHP_LOOKUP_SIZE]>>>();
+        assert_eq!(bases_lookup.len(), NUM_WINDOWS as usize);
+        bases_lookup.iter().for_each(|bases| assert_eq!(bases.len(), WINDOW_SIZE as usize));
+
+        // Next, compute the random base.
+        let (generator, _, _) =
+            Blake2Xs::hash_to_curve::<G>(&format!("Aleo.BHP.{NUM_WINDOWS}.{WINDOW_SIZE}.{domain}.Randomizer"));
+        let mut base_power = generator.to_projective();
+        let num_scalar_bits = G::ScalarField::size_in_bits();
+        let mut random_base = Vec::with_capacity(num_scalar_bits);
+        for _ in 0..num_scalar_bits {
+            random_base.push(base_power);
+            base_power.double_in_place();
+        }
+        assert_eq!(random_base.len(), num_scalar_bits);
+
+        Self { bases: Arc::new(bases), bases_lookup: Arc::new(bases_lookup), random_base: Arc::new(random_base) }
+    }
+
+    /// Returns the bases.
+    pub fn bases(&self) -> &Arc<Vec<Vec<G::Projective>>> {
+        &self.bases
+    }
+
+    /// Returns the random base window.
+    pub fn random_base(&self) -> &Arc<Vec<G::Projective>> {
+        &self.random_base
+    }
+}

--- a/console/algorithms/src/bhp/mod.rs
+++ b/console/algorithms/src/bhp/mod.rs
@@ -76,7 +76,7 @@ where
         ensure!(num_bits <= max_bits, "Domain cannot exceed {max_bits} bits, found {num_bits} bits");
 
         // Initialize the BHP hasher.
-        let hasher = BHPHasher::<G, NUM_WINDOWS, WINDOW_SIZE>::setup(domain);
+        let hasher = BHPHasher::<G, NUM_WINDOWS, WINDOW_SIZE>::setup(domain)?;
 
         // Convert the domain into a boolean vector.
         let mut domain = domain.as_bytes().to_bits_le();

--- a/console/algorithms/src/bhp/mod.rs
+++ b/console/algorithms/src/bhp/mod.rs
@@ -54,7 +54,7 @@ pub type BHP1024<G> = BHP<G, 8, 54>; // Supports inputs up to 1044 bits (4 u8 + 
 /// ```
 /// Each subsequent iteration is initialized as follows:
 /// ```text
-/// DIGEST_N+1 = BHP([ DIGEST_N || INPUT[(N+1)*BLOCK_SIZE..(N+2)*BLOCK_SIZE] ]);
+/// DIGEST_N+1 = BHP([ DIGEST_N[0..DATA_BITS] || INPUT[(N+1)*BLOCK_SIZE..(N+2)*BLOCK_SIZE] ]);
 /// ```
 #[derive(Clone)]
 pub struct BHP<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> {

--- a/console/algorithms/src/bhp/mod.rs
+++ b/console/algorithms/src/bhp/mod.rs
@@ -54,7 +54,7 @@ pub type BHP1024<G> = BHP<G, 8, 54>; // Supports inputs up to 1044 bits (4 u8 + 
 /// ```
 /// Each subsequent iteration is initialized as follows:
 /// ```text
-/// DIGEST_N+1 = \[ DIGEST_N || INPUT\[BLOCK_SIZE..2\*BLOCK_SIZE\] \]
+/// DIGEST_N+1 = BHP([ DIGEST_N || INPUT[(N+1)*BLOCK_SIZE..(N+2)*BLOCK_SIZE] ]);
 /// ```
 #[derive(Clone)]
 pub struct BHP<G: AffineCurve, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> {

--- a/console/algorithms/src/lib.rs
+++ b/console/algorithms/src/lib.rs
@@ -17,7 +17,7 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::too_many_arguments)]
 
-mod bhp;
+pub mod bhp;
 pub use bhp::{BHP, BHP1024, BHP256, BHP512, BHP768};
 
 mod blake2xs;

--- a/console/algorithms/src/pedersen/mod.rs
+++ b/console/algorithms/src/pedersen/mod.rs
@@ -48,24 +48,27 @@ impl<G: AffineCurve, const NUM_BITS: u8> Pedersen<G, NUM_BITS> {
         // Construct an indexed message to attempt to sample a base.
         let (generator, _, _) = Blake2Xs::hash_to_curve::<G>(&format!("Aleo.Pedersen.Base.{message}"));
         let mut base_power = generator.to_projective();
+        // Construct the window with the base.
         let mut base_window = vec![G::Projective::zero(); NUM_BITS as usize];
         for base in base_window.iter_mut().take(NUM_BITS as usize) {
             *base = base_power;
             base_power.double_in_place();
         }
+        assert_eq!(base_window.len(), NUM_BITS as usize);
 
-        // Next, compute the random base.
+        // Compute the random base.
         let (generator, _, _) = Blake2Xs::hash_to_curve::<G>(&format!("Aleo.Pedersen.RandomBase.{message}"));
-        let mut base_power = generator.to_projective();
+        let mut base = generator.to_projective();
+        // Construct the window with the random base.
         let num_scalar_bits = G::ScalarField::size_in_bits();
-        let mut random_base_window = Vec::with_capacity(num_scalar_bits);
+        let mut random_base = Vec::with_capacity(num_scalar_bits);
         for _ in 0..num_scalar_bits {
-            random_base_window.push(base_power);
-            base_power.double_in_place();
+            random_base.push(base);
+            base.double_in_place();
         }
-        assert_eq!(random_base_window.len(), num_scalar_bits);
+        assert_eq!(random_base.len(), num_scalar_bits);
 
-        Self { base_window: Arc::new(base_window.to_vec()), random_base_window: Arc::new(random_base_window) }
+        Self { base_window: Arc::new(base_window.to_vec()), random_base_window: Arc::new(random_base) }
     }
 
     /// Returns the base window.

--- a/console/algorithms/src/pedersen/mod.rs
+++ b/console/algorithms/src/pedersen/mod.rs
@@ -35,6 +35,7 @@ pub type Pedersen128<G> = Pedersen<G, 128>;
 
 /// Pedersen is a collision-resistant hash function that takes a variable-length input.
 /// The Pedersen hash function does *not* behave like a random oracle, see Poseidon for one.
+#[derive(Clone)]
 pub struct Pedersen<G: AffineCurve, const NUM_BITS: u8> {
     /// The base window for the Pedersen hash.
     base_window: Arc<Vec<G::Projective>>,

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -38,34 +38,34 @@ use itertools::Itertools;
 // lazy_static! {
 thread_local! {
     /// The group bases for the Aleo signature and encryption schemes.
-    static GENERATOR_G: Vec<<Testnet3 as Network>::Projective> = Testnet3::new_bases("AleoAccountEncryptionAndSignatureScheme0");
+    pub static GENERATOR_G: Vec<<Testnet3 as Network>::Projective> = Testnet3::new_bases("AleoAccountEncryptionAndSignatureScheme0");
     /// The encryption domain as a constant field element.
-    static ENCRYPTION_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoSymmetricEncryption0");
+    pub static ENCRYPTION_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoSymmetricEncryption0");
     /// The MAC domain as a constant field element.
-    static MAC_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoSymmetricKeyCommitment0");
+    pub static MAC_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoSymmetricKeyCommitment0");
     /// The randomizer domain as a constant field element.
-    static RANDOMIZER_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoRandomizer0");
+    pub static RANDOMIZER_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoRandomizer0");
 
     /// The BHP gadget, which can take an input of up to 256 bits.
-    static BHP_256: BHP256<<Testnet3 as Network>::Affine> = BHP256::<<Testnet3 as Network>::Affine>::setup("AleoBHP256");
+    pub static BHP_256: BHP256<<Testnet3 as Network>::Affine> = BHP256::<<Testnet3 as Network>::Affine>::setup("AleoBHP256");
     /// The BHP gadget, which can take an input of up to 512 bits.
-    static BHP_512: BHP512<<Testnet3 as Network>::Affine> = BHP512::<<Testnet3 as Network>::Affine>::setup("AleoBHP512");
+    pub static BHP_512: BHP512<<Testnet3 as Network>::Affine> = BHP512::<<Testnet3 as Network>::Affine>::setup("AleoBHP512");
     /// The BHP gadget, which can take an input of up to 768 bits.
-    static BHP_768: BHP768<<Testnet3 as Network>::Affine> = BHP768::<<Testnet3 as Network>::Affine>::setup("AleoBHP768");
+    pub static BHP_768: BHP768<<Testnet3 as Network>::Affine> = BHP768::<<Testnet3 as Network>::Affine>::setup("AleoBHP768");
     /// The BHP gadget, which can take an input of up to 1024 bits.
-    static BHP_1024: BHP1024<<Testnet3 as Network>::Affine> = BHP1024::<<Testnet3 as Network>::Affine>::setup("AleoBHP1024");
+    pub static BHP_1024: BHP1024<<Testnet3 as Network>::Affine> = BHP1024::<<Testnet3 as Network>::Affine>::setup("AleoBHP1024");
 
     /// The Pedersen gadget, which can take an input of up to 64 bits.
-    static PEDERSEN_64: Pedersen64<<Testnet3 as Network>::Affine> = Pedersen64::<<Testnet3 as Network>::Affine>::setup("AleoPedersen64");
+    pub static PEDERSEN_64: Pedersen64<<Testnet3 as Network>::Affine> = Pedersen64::<<Testnet3 as Network>::Affine>::setup("AleoPedersen64");
     /// The Pedersen gadget, which can take an input of up to 128 bits.
-    static PEDERSEN_128: Pedersen128<<Testnet3 as Network>::Affine> = Pedersen128::<<Testnet3 as Network>::Affine>::setup("AleoPedersen128");
+    pub static PEDERSEN_128: Pedersen128<<Testnet3 as Network>::Affine> = Pedersen128::<<Testnet3 as Network>::Affine>::setup("AleoPedersen128");
 
     /// The Poseidon hash function, using a rate of 2.
-    static POSEIDON_2: Poseidon2<<Testnet3 as Network>::Field> = Poseidon2::<<Testnet3 as Network>::Field>::setup();
+    pub static POSEIDON_2: Poseidon2<<Testnet3 as Network>::Field> = Poseidon2::<<Testnet3 as Network>::Field>::setup();
     /// The Poseidon hash function, using a rate of 4.
-    static POSEIDON_4: Poseidon4<<Testnet3 as Network>::Field> = Poseidon4::<<Testnet3 as Network>::Field>::setup();
+    pub static POSEIDON_4: Poseidon4<<Testnet3 as Network>::Field> = Poseidon4::<<Testnet3 as Network>::Field>::setup();
     /// The Poseidon hash function, using a rate of 8.
-    static POSEIDON_8: Poseidon8<<Testnet3 as Network>::Field> = Poseidon8::<<Testnet3 as Network>::Field>::setup();
+    pub static POSEIDON_8: Poseidon8<<Testnet3 as Network>::Field> = Poseidon8::<<Testnet3 as Network>::Field>::setup();
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -47,13 +47,13 @@ thread_local! {
     pub static RANDOMIZER_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoRandomizer0");
 
     /// The BHP gadget, which can take an input of up to 256 bits.
-    pub static BHP_256: BHP256<<Testnet3 as Network>::Affine> = BHP256::<<Testnet3 as Network>::Affine>::setup("AleoBHP256");
+    pub static BHP_256: BHP256<<Testnet3 as Network>::Affine> = BHP256::<<Testnet3 as Network>::Affine>::setup("AleoBHP256").expect("Failed to setup BHP256");
     /// The BHP gadget, which can take an input of up to 512 bits.
-    pub static BHP_512: BHP512<<Testnet3 as Network>::Affine> = BHP512::<<Testnet3 as Network>::Affine>::setup("AleoBHP512");
+    pub static BHP_512: BHP512<<Testnet3 as Network>::Affine> = BHP512::<<Testnet3 as Network>::Affine>::setup("AleoBHP512").expect("Failed to setup BHP512");
     /// The BHP gadget, which can take an input of up to 768 bits.
-    pub static BHP_768: BHP768<<Testnet3 as Network>::Affine> = BHP768::<<Testnet3 as Network>::Affine>::setup("AleoBHP768");
+    pub static BHP_768: BHP768<<Testnet3 as Network>::Affine> = BHP768::<<Testnet3 as Network>::Affine>::setup("AleoBHP768").expect("Failed to setup BHP768");
     /// The BHP gadget, which can take an input of up to 1024 bits.
-    pub static BHP_1024: BHP1024<<Testnet3 as Network>::Affine> = BHP1024::<<Testnet3 as Network>::Affine>::setup("AleoBHP1024");
+    pub static BHP_1024: BHP1024<<Testnet3 as Network>::Affine> = BHP1024::<<Testnet3 as Network>::Affine>::setup("AleoBHP1024").expect("Failed to setup BHP1024");
 
     /// The Pedersen gadget, which can take an input of up to 64 bits.
     pub static PEDERSEN_64: Pedersen64<<Testnet3 as Network>::Affine> = Pedersen64::<<Testnet3 as Network>::Affine>::setup("AleoPedersen64");

--- a/console/program/src/merkle_tree/helpers/leaf_hash.rs
+++ b/console/program/src/merkle_tree/helpers/leaf_hash.rs
@@ -24,7 +24,7 @@ pub trait LeafHash<N: Network>: Clone + Send + Sync {
     fn hash(&self, leaf: &Self::Leaf) -> Result<N::Field>;
 }
 
-impl<N: Network, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> LeafHash<N>
+impl<N: Network, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash<N>
     for BHP<N::Affine, NUM_WINDOWS, WINDOW_SIZE>
 {
     type Leaf = Vec<bool>;

--- a/console/program/src/merkle_tree/helpers/path_hash.rs
+++ b/console/program/src/merkle_tree/helpers/path_hash.rs
@@ -27,7 +27,7 @@ pub trait PathHash<N: Network>: Clone + Send + Sync {
     }
 }
 
-impl<N: Network, const NUM_WINDOWS: usize, const WINDOW_SIZE: usize> PathHash<N>
+impl<N: Network, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> PathHash<N>
     for BHP<N::Affine, NUM_WINDOWS, WINDOW_SIZE>
 {
     /// Returns the hash of the given path nodes.

--- a/console/program/src/merkle_tree/tests.rs
+++ b/console/program/src/merkle_tree/tests.rs
@@ -365,11 +365,11 @@ fn test_merkle_tree_bhp() -> Result<()> {
         type LH = BHP1024<<CurrentNetwork as Network>::Affine>;
         type PH = BHP512<<CurrentNetwork as Network>::Affine>;
 
-        let leaf_hasher = LH::setup("AleoMerkleTreeTest0");
-        let path_hasher = PH::setup("AleoMerkleTreeTest1");
+        let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+        let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
 
         // TODO (howardwu): Switch to this when BHP has been extended.
-        // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| rand::random::<bool>()).collect()).collect::<Vec<Vec<bool>>>();
+        // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect()).collect::<Vec<Vec<bool>>>();
         let create_leaves = |num_leaves| {
             (0..num_leaves)
                 .map(|_| <CurrentNetwork as Network>::Field::rand(&mut test_rng()).to_bits_le())
@@ -473,10 +473,10 @@ fn test_merkle_tree_depth_2_bhp() -> Result<()> {
     type LH = BHP1024<<CurrentNetwork as Network>::Affine>;
     type PH = BHP512<<CurrentNetwork as Network>::Affine>;
 
-    let leaf_hasher = LH::setup("AleoMerkleTreeTest0");
-    let path_hasher = PH::setup("AleoMerkleTreeTest1");
+    let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+    let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
     // TODO (howardwu): Switch to this when BHP has been extended.
-    // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| rand::random::<bool>()).collect()).collect::<Vec<Vec<bool>>>();
+    // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect()).collect::<Vec<Vec<bool>>>();
     let create_leaves = |num_leaves| {
         (0..num_leaves)
             .map(|_| <CurrentNetwork as Network>::Field::rand(&mut test_rng()).to_bits_le())
@@ -506,10 +506,10 @@ fn test_merkle_tree_depth_3_bhp() -> Result<()> {
     type LH = BHP1024<<CurrentNetwork as Network>::Affine>;
     type PH = BHP512<<CurrentNetwork as Network>::Affine>;
 
-    let leaf_hasher = LH::setup("AleoMerkleTreeTest0");
-    let path_hasher = PH::setup("AleoMerkleTreeTest1");
+    let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+    let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
     // TODO (howardwu): Switch to this when BHP has been extended.
-    // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| rand::random::<bool>()).collect()).collect::<Vec<Vec<bool>>>();
+    // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect()).collect::<Vec<Vec<bool>>>();
     let create_leaves = |num_leaves| {
         (0..num_leaves)
             .map(|_| <CurrentNetwork as Network>::Field::rand(&mut test_rng()).to_bits_le())
@@ -549,10 +549,10 @@ fn test_merkle_tree_depth_4_bhp() -> Result<()> {
     type LH = BHP1024<<CurrentNetwork as Network>::Affine>;
     type PH = BHP512<<CurrentNetwork as Network>::Affine>;
 
-    let leaf_hasher = LH::setup("AleoMerkleTreeTest0");
-    let path_hasher = PH::setup("AleoMerkleTreeTest1");
+    let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+    let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
     // TODO (howardwu): Switch to this when BHP has been extended.
-    // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| rand::random::<bool>()).collect()).collect::<Vec<Vec<bool>>>();
+    // (0..num_leaves).map(|_| (0..(32 * i)).map(|_| bool::rand(&mut test_rng())).collect()).collect::<Vec<Vec<bool>>>();
     let create_leaves = |num_leaves| {
         (0..num_leaves)
             .map(|_| <CurrentNetwork as Network>::Field::rand(&mut test_rng()).to_bits_le())


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

# Motivation

- Updates BHP to support variable-length inputs (beyond the original total window size)
- Adds `Inject` on `Pedersen`, `BHP`, and `Poseidon`

## BHP

BHP is a collision-resistant hash function that takes a variable-length input.

### Design
The BHP hash function splits the given input into blocks, and processes them iteratively.

The first iteration is initialized as follows:
```text
DIGEST_0 = BHP([ 0...0 || DOMAIN || LENGTH(INPUT) || INPUT[0..BLOCK_SIZE] ]);
```
Each subsequent iteration is initialized as follows:
```text
DIGEST_N+1 = BHP([ DIGEST_N[0..DATA_BITS] || INPUT[(N+1)*BLOCK_SIZE..(N+2)*BLOCK_SIZE] ]);
```
