### PR TITLE
Update Poseidon

### DIFF
--- a/circuit/account/src/compute_key/from_private_key.rs
+++ b/circuit/account/src/compute_key/from_private_key.rs
@@ -90,16 +90,16 @@ mod tests {
 
     #[test]
     fn test_from_private_key_constant() -> Result<()> {
-        check_from_private_key(Mode::Constant, 3253, 0, 0, 0)
+        check_from_private_key(Mode::Constant, 3254, 0, 0, 0)
     }
 
     #[test]
     fn test_from_private_key_public() -> Result<()> {
-        check_from_private_key(Mode::Public, 1500, 0, 4348, 4349)
+        check_from_private_key(Mode::Public, 1501, 0, 4348, 4349)
     }
 
     #[test]
     fn test_from_private_key_private() -> Result<()> {
-        check_from_private_key(Mode::Private, 1500, 0, 4348, 4349)
+        check_from_private_key(Mode::Private, 1501, 0, 4348, 4349)
     }
 }

--- a/circuit/account/src/compute_key/mod.rs
+++ b/circuit/account/src/compute_key/mod.rs
@@ -136,16 +136,16 @@ pub(crate) mod tests {
 
     #[test]
     fn test_compute_key_new_constant() -> Result<()> {
-        check_new(Mode::Constant, 265, 0, 0, 0)
+        check_new(Mode::Constant, 266, 0, 0, 0)
     }
 
     #[test]
     fn test_compute_key_new_public() -> Result<()> {
-        check_new(Mode::Public, 6, 6, 604, 608)
+        check_new(Mode::Public, 7, 6, 604, 608)
     }
 
     #[test]
     fn test_compute_key_new_private() -> Result<()> {
-        check_new(Mode::Private, 6, 0, 610, 608)
+        check_new(Mode::Private, 7, 0, 610, 608)
     }
 }

--- a/circuit/account/src/private_key/to_compute_key.rs
+++ b/circuit/account/src/private_key/to_compute_key.rs
@@ -76,16 +76,16 @@ mod tests {
 
     #[test]
     fn test_to_compute_key_constant() -> Result<()> {
-        check_to_compute_key(Mode::Constant, 3253, 0, 0, 0)
+        check_to_compute_key(Mode::Constant, 3254, 0, 0, 0)
     }
 
     #[test]
     fn test_to_compute_key_public() -> Result<()> {
-        check_to_compute_key(Mode::Public, 1500, 0, 4348, 4349)
+        check_to_compute_key(Mode::Public, 1501, 0, 4348, 4349)
     }
 
     #[test]
     fn test_to_compute_key_private() -> Result<()> {
-        check_to_compute_key(Mode::Private, 1500, 0, 4348, 4349)
+        check_to_compute_key(Mode::Private, 1501, 0, 4348, 4349)
     }
 }

--- a/circuit/account/src/signature/mod.rs
+++ b/circuit/account/src/signature/mod.rs
@@ -112,16 +112,16 @@ mod tests {
 
     #[test]
     fn test_signature_new_constant() -> Result<()> {
-        check_new(Mode::Constant, 767, 0, 0, 0)
+        check_new(Mode::Constant, 768, 0, 0, 0)
     }
 
     #[test]
     fn test_signature_new_public() -> Result<()> {
-        check_new(Mode::Public, 6, 508, 604, 1110)
+        check_new(Mode::Public, 7, 508, 604, 1110)
     }
 
     #[test]
     fn test_signature_new_private() -> Result<()> {
-        check_new(Mode::Private, 6, 0, 1112, 1110)
+        check_new(Mode::Private, 7, 0, 1112, 1110)
     }
 }

--- a/circuit/account/src/signature/verify.rs
+++ b/circuit/account/src/signature/verify.rs
@@ -124,16 +124,16 @@ pub(crate) mod tests {
 
     #[test]
     fn test_verify_constant() -> Result<()> {
-        check_verify(Mode::Constant, 4325, 0, 0, 0)
+        check_verify(Mode::Constant, 4326, 0, 0, 0)
     }
 
     #[test]
     fn test_verify_public() -> Result<()> {
-        check_verify(Mode::Public, 1757, 0, 6534, 6538)
+        check_verify(Mode::Public, 1758, 0, 6534, 6538)
     }
 
     #[test]
     fn test_verify_private() -> Result<()> {
-        check_verify(Mode::Private, 1757, 0, 6534, 6538)
+        check_verify(Mode::Private, 1758, 0, 6534, 6538)
     }
 }

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -36,7 +36,7 @@ mod tests {
     use anyhow::Result;
 
     const ITERATIONS: u64 = 100;
-    const MESSAGE: &str = "BHPCircuit0";
+    const DOMAIN: &str = "BHPCircuit0";
 
     fn check_commit<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
         mode: Mode,
@@ -48,7 +48,7 @@ mod tests {
         use console::Commit as C;
 
         // Initialize BHP.
-        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(DOMAIN)?;
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -46,7 +46,7 @@ mod tests {
     use anyhow::Result;
 
     const ITERATIONS: u64 = 100;
-    const MESSAGE: &str = "BHPCircuit0";
+    const DOMAIN: &str = "BHPCircuit0";
 
     fn check_commit_uncompressed<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
         mode: Mode,
@@ -58,7 +58,7 @@ mod tests {
         use console::CommitUncompressed as C;
 
         // Initialize BHP.
-        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(DOMAIN)?;
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -35,7 +35,7 @@ mod tests {
     use anyhow::Result;
 
     const ITERATIONS: u64 = 100;
-    const MESSAGE: &str = "BHPCircuit0";
+    const DOMAIN: &str = "BHPCircuit0";
 
     fn check_hash<const NUM_WINDOWS: u8, const WINDOW_SIZE: u8>(
         mode: Mode,
@@ -47,7 +47,7 @@ mod tests {
         use console::Hash as H;
 
         // Initialize BHP.
-        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(DOMAIN)?;
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;

--- a/circuit/algorithms/src/bhp/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hash_uncompressed.rs
@@ -72,12 +72,12 @@ mod tests {
     use anyhow::Result;
 
     const ITERATIONS: u64 = 100;
-    const MESSAGE: &str = "BHPCircuit0";
+    const DOMAIN: &str = "BHPCircuit0";
 
     macro_rules! check_hash_uncompressed {
         ($bhp:ident, $mode:ident, $num_bits:expr, ($num_constants:expr, $num_public:expr, $num_private:expr, $num_constraints:expr)) => {{
             // Initialize BHP.
-            let native = console::$bhp::<<Circuit as Environment>::Affine>::setup(MESSAGE)?;
+            let native = console::$bhp::<<Circuit as Environment>::Affine>::setup(DOMAIN)?;
             let circuit = $bhp::<Circuit>::constant(native.clone());
 
             for i in 0..ITERATIONS {
@@ -111,7 +111,7 @@ mod tests {
         use console::HashUncompressed as H;
 
         // Initialize BHP.
-        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(MESSAGE)?;
+        let native = console::BHP::<<Circuit as Environment>::Affine, NUM_WINDOWS, WINDOW_SIZE>::setup(DOMAIN)?;
         let circuit = BHP::<Circuit, NUM_WINDOWS, WINDOW_SIZE>::new(Mode::Constant, native.clone());
         // Determine the number of inputs.
         let num_input_bits = NUM_WINDOWS as usize * WINDOW_SIZE as usize * BHP_CHUNK_SIZE;

--- a/circuit/algorithms/src/poseidon/hash.rs
+++ b/circuit/algorithms/src/poseidon/hash.rs
@@ -200,6 +200,8 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
+    use anyhow::Result;
+
     const ITERATIONS: usize = 10;
     const RATE: usize = 4;
 
@@ -210,11 +212,11 @@ mod tests {
         num_public: u64,
         num_private: u64,
         num_constraints: u64,
-    ) {
+    ) -> Result<()> {
         use console::Hash as H;
 
         let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup()?;
         let poseidon = Poseidon::<Circuit, RATE>::new();
 
         for i in 0..ITERATIONS {
@@ -232,43 +234,46 @@ mod tests {
                 let case = format!("(mode = {mode}, num_inputs = {num_inputs})");
                 assert_scope!(case, num_constants, num_public, num_private, num_constraints);
             });
+            Circuit::reset();
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_constant() {
+    fn test_hash_constant() -> Result<()> {
         for num_inputs in 0..=RATE {
-            check_hash(Mode::Constant, num_inputs, 0, 0, 0, 0);
+            check_hash(Mode::Constant, num_inputs, 0, 0, 0, 0)?;
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_public() {
-        check_hash(Mode::Public, 0, 0, 0, 0, 0);
-        check_hash(Mode::Public, 1, 0, 0, 335, 335);
-        check_hash(Mode::Public, 2, 0, 0, 340, 340);
-        check_hash(Mode::Public, 3, 0, 0, 345, 345);
-        check_hash(Mode::Public, 4, 0, 0, 350, 350);
-        check_hash(Mode::Public, 5, 0, 0, 705, 705);
-        check_hash(Mode::Public, 6, 0, 0, 705, 705);
-        check_hash(Mode::Public, 7, 0, 0, 705, 705);
-        check_hash(Mode::Public, 8, 0, 0, 705, 705);
-        check_hash(Mode::Public, 9, 0, 0, 1060, 1060);
-        check_hash(Mode::Public, 10, 0, 0, 1060, 1060);
+    fn test_hash_public() -> Result<()> {
+        check_hash(Mode::Public, 0, 0, 0, 0, 0)?;
+        check_hash(Mode::Public, 1, 0, 0, 335, 335)?;
+        check_hash(Mode::Public, 2, 0, 0, 340, 340)?;
+        check_hash(Mode::Public, 3, 0, 0, 345, 345)?;
+        check_hash(Mode::Public, 4, 0, 0, 350, 350)?;
+        check_hash(Mode::Public, 5, 0, 0, 705, 705)?;
+        check_hash(Mode::Public, 6, 0, 0, 705, 705)?;
+        check_hash(Mode::Public, 7, 0, 0, 705, 705)?;
+        check_hash(Mode::Public, 8, 0, 0, 705, 705)?;
+        check_hash(Mode::Public, 9, 0, 0, 1060, 1060)?;
+        check_hash(Mode::Public, 10, 0, 0, 1060, 1060)
     }
 
     #[test]
-    fn test_hash_private() {
-        check_hash(Mode::Private, 0, 0, 0, 0, 0);
-        check_hash(Mode::Private, 1, 0, 0, 335, 335);
-        check_hash(Mode::Private, 2, 0, 0, 340, 340);
-        check_hash(Mode::Private, 3, 0, 0, 345, 345);
-        check_hash(Mode::Private, 4, 0, 0, 350, 350);
-        check_hash(Mode::Private, 5, 0, 0, 705, 705);
-        check_hash(Mode::Private, 6, 0, 0, 705, 705);
-        check_hash(Mode::Private, 7, 0, 0, 705, 705);
-        check_hash(Mode::Private, 8, 0, 0, 705, 705);
-        check_hash(Mode::Private, 9, 0, 0, 1060, 1060);
-        check_hash(Mode::Private, 10, 0, 0, 1060, 1060);
+    fn test_hash_private() -> Result<()> {
+        check_hash(Mode::Private, 0, 0, 0, 0, 0)?;
+        check_hash(Mode::Private, 1, 0, 0, 335, 335)?;
+        check_hash(Mode::Private, 2, 0, 0, 340, 340)?;
+        check_hash(Mode::Private, 3, 0, 0, 345, 345)?;
+        check_hash(Mode::Private, 4, 0, 0, 350, 350)?;
+        check_hash(Mode::Private, 5, 0, 0, 705, 705)?;
+        check_hash(Mode::Private, 6, 0, 0, 705, 705)?;
+        check_hash(Mode::Private, 7, 0, 0, 705, 705)?;
+        check_hash(Mode::Private, 8, 0, 0, 705, 705)?;
+        check_hash(Mode::Private, 9, 0, 0, 1060, 1060)?;
+        check_hash(Mode::Private, 10, 0, 0, 1060, 1060)
     }
 }

--- a/circuit/algorithms/src/poseidon/hash.rs
+++ b/circuit/algorithms/src/poseidon/hash.rs
@@ -32,24 +32,6 @@ impl<E: Environment, const RATE: usize> Hash for Poseidon<E, RATE> {
     }
 }
 
-impl<E: Environment, const RATE: usize> Metrics<dyn Hash<Input = Field<E>, Output = Field<E>>> for Poseidon<E, RATE> {
-    type Case = ();
-
-    fn count(_parameter: &Self::Case) -> Count {
-        todo!()
-    }
-}
-
-impl<E: Environment, const RATE: usize> OutputMode<dyn Hash<Input = Field<E>, Output = Field<E>>>
-    for Poseidon<E, RATE>
-{
-    type Case = ();
-
-    fn output_mode(_parameter: &Self::Case) -> Mode {
-        todo!()
-    }
-}
-
 impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
     /// Absorbs the input elements into state.
     #[inline]

--- a/circuit/algorithms/src/poseidon/hash.rs
+++ b/circuit/algorithms/src/poseidon/hash.rs
@@ -22,175 +22,7 @@ impl<E: Environment, const RATE: usize> Hash for Poseidon<E, RATE> {
 
     #[inline]
     fn hash(&self, input: &[Self::Input]) -> Self::Output {
-        // Initialize a new sponge.
-        let mut state = vec![Field::zero(); RATE + CAPACITY];
-        let mut mode = DuplexSpongeMode::Absorbing { next_absorb_index: 0 };
-
-        // Absorb the input and squeeze the output.
-        self.absorb(&mut state, &mut mode, input);
-        self.squeeze(&mut state, &mut mode, 1)[0].clone()
-    }
-}
-
-impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
-    /// Absorbs the input elements into state.
-    #[inline]
-    pub(super) fn absorb(&self, state: &mut [Field<E>], mode: &mut DuplexSpongeMode, input: &[Field<E>]) {
-        if !input.is_empty() {
-            // Determine the absorb index.
-            let (mut absorb_index, should_permute) = match *mode {
-                DuplexSpongeMode::Absorbing { next_absorb_index } => match next_absorb_index == RATE {
-                    true => (0, true),
-                    false => (next_absorb_index, false),
-                },
-                DuplexSpongeMode::Squeezing { .. } => (0, true),
-            };
-
-            // Proceed to permute the state, if necessary.
-            if should_permute {
-                self.permute(state);
-            }
-
-            let mut remaining = input;
-            loop {
-                // Compute the starting index.
-                let start = CAPACITY + absorb_index;
-
-                // Check if we can exit the loop.
-                if absorb_index + remaining.len() <= RATE {
-                    // Absorb the state elements into the input.
-                    remaining.iter().enumerate().for_each(|(i, element)| state[start + i] += element);
-                    // Update the sponge mode.
-                    *mode = DuplexSpongeMode::Absorbing { next_absorb_index: absorb_index + remaining.len() };
-                    return;
-                }
-
-                // Otherwise, proceed to absorb `(rate - absorb_index)` elements.
-                let num_absorbed = RATE - absorb_index;
-                remaining.iter().enumerate().take(num_absorbed).for_each(|(i, element)| state[start + i] += element);
-
-                // Permute the state.
-                self.permute(state);
-
-                // Repeat with the updated input slice and absorb index.
-                remaining = &remaining[num_absorbed..];
-                absorb_index = 0;
-            }
-        }
-    }
-
-    /// Squeeze the specified number of state elements into the output.
-    #[inline]
-    pub(super) fn squeeze(
-        &self,
-        state: &mut [Field<E>],
-        mode: &mut DuplexSpongeMode,
-        num_outputs: u16,
-    ) -> Vec<Field<E>> {
-        let mut output = vec![Field::zero(); num_outputs as usize];
-        if num_outputs != 0 {
-            self.squeeze_internal(state, mode, &mut output);
-        }
-        output
-    }
-
-    /// Squeeze the state elements into the output.
-    #[inline]
-    fn squeeze_internal(&self, state: &mut [Field<E>], mode: &mut DuplexSpongeMode, output: &mut [Field<E>]) {
-        // Determine the squeeze index.
-        let (mut squeeze_index, should_permute) = match *mode {
-            DuplexSpongeMode::Absorbing { .. } => (0, true),
-            DuplexSpongeMode::Squeezing { next_squeeze_index } => match next_squeeze_index == RATE {
-                true => (0, true),
-                false => (next_squeeze_index, false),
-            },
-        };
-
-        // Proceed to permute the state, if necessary.
-        if should_permute {
-            self.permute(state);
-        }
-
-        let mut remaining = output;
-        loop {
-            // Compute the starting index.
-            let start = CAPACITY + squeeze_index;
-
-            // Check if we can exit the loop.
-            if squeeze_index + remaining.len() <= RATE {
-                // Store the state elements into the output.
-                remaining.clone_from_slice(&state[start..(start + remaining.len())]);
-                // Update the sponge mode.
-                *mode = DuplexSpongeMode::Squeezing { next_squeeze_index: squeeze_index + remaining.len() };
-                return;
-            }
-
-            // Otherwise, proceed to squeeze `(rate - squeeze_index)` elements.
-            let num_squeezed = RATE - squeeze_index;
-            remaining[..num_squeezed].clone_from_slice(&state[start..(start + num_squeezed)]);
-
-            // Unless we are done with squeezing in this call, permute.
-            if remaining.len() != RATE {
-                self.permute(state);
-            }
-            // Repeat with the updated output slice and squeeze index.
-            remaining = &mut remaining[num_squeezed..];
-            squeeze_index = 0;
-        }
-    }
-
-    /// Apply the additive round keys in-place.
-    #[inline]
-    fn apply_ark(&self, state: &mut [Field<E>], round: usize) {
-        for (i, element) in state.iter_mut().enumerate() {
-            *element += &self.ark[round][i];
-        }
-    }
-
-    /// Apply the S-Box based on whether it is a full round or partial round.
-    #[inline]
-    fn apply_s_box(&self, state: &mut [Field<E>], is_full_round: bool) {
-        if is_full_round {
-            // Full rounds apply the S Box (x^alpha) to every element of state
-            for element in state.iter_mut() {
-                *element = (&*element).pow(&self.alpha);
-            }
-        } else {
-            // Partial rounds apply the S Box (x^alpha) to just the first element of state
-            state[0] = (&state[0]).pow(&self.alpha);
-        }
-    }
-
-    /// Apply the Maximally Distance Separating (MDS) matrix in-place.
-    #[inline]
-    fn apply_mds(&self, state: &mut [Field<E>]) {
-        let mut new_state = Vec::with_capacity(state.len());
-        for i in 0..state.len() {
-            let mut accumulator = Field::zero();
-            for (j, element) in state.iter().enumerate() {
-                accumulator += element * &self.mds[i][j];
-            }
-            new_state.push(accumulator);
-        }
-        state.clone_from_slice(&new_state[..state.len()]);
-    }
-
-    /// Apply the permutation for all rounds in-place.
-    #[inline]
-    fn permute(&self, state: &mut [Field<E>]) {
-        // Determine the partial rounds range bound.
-        let partial_rounds = self.partial_rounds;
-        let full_rounds = self.full_rounds;
-        let full_rounds_over_2 = full_rounds / 2;
-        let partial_round_range = full_rounds_over_2..(full_rounds_over_2 + partial_rounds);
-
-        // Iterate through all rounds to permute.
-        for i in 0..(partial_rounds + full_rounds) {
-            let is_full_round = !partial_round_range.contains(&i);
-            self.apply_ark(state, i);
-            self.apply_s_box(state, is_full_round);
-            self.apply_mds(state);
-        }
+        self.hash_many(input, 1)[0].clone()
     }
 }
 
@@ -202,6 +34,7 @@ mod tests {
 
     use anyhow::Result;
 
+    const DOMAIN: &str = "PoseidonCircuit0";
     const ITERATIONS: usize = 10;
     const RATE: usize = 4;
 
@@ -215,18 +48,18 @@ mod tests {
     ) -> Result<()> {
         use console::Hash as H;
 
-        let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup()?;
-        let poseidon = Poseidon::<Circuit, RATE>::new();
+        let native = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup(DOMAIN)?;
+        let poseidon = Poseidon::<Circuit, RATE>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Prepare the preimage.
             let native_input =
-                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(rng)).collect::<Vec<_>>();
+                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(&mut test_rng())).collect::<Vec<_>>();
             let input = native_input.iter().map(|v| Field::<Circuit>::new(mode, *v)).collect::<Vec<_>>();
 
             // Compute the native hash.
-            let expected = native_poseidon.hash(&native_input).expect("Failed to hash native input");
+            let expected = native.hash(&native_input).expect("Failed to hash native input");
+
             // Compute the circuit hash.
             Circuit::scope(format!("Poseidon {mode} {i}"), || {
                 let candidate = poseidon.hash(&input);
@@ -242,38 +75,38 @@ mod tests {
     #[test]
     fn test_hash_constant() -> Result<()> {
         for num_inputs in 0..=RATE {
-            check_hash(Mode::Constant, num_inputs, 0, 0, 0, 0)?;
+            check_hash(Mode::Constant, num_inputs, 1, 0, 0, 0)?;
         }
         Ok(())
     }
 
     #[test]
     fn test_hash_public() -> Result<()> {
-        check_hash(Mode::Public, 0, 0, 0, 0, 0)?;
-        check_hash(Mode::Public, 1, 0, 0, 335, 335)?;
-        check_hash(Mode::Public, 2, 0, 0, 340, 340)?;
-        check_hash(Mode::Public, 3, 0, 0, 345, 345)?;
-        check_hash(Mode::Public, 4, 0, 0, 350, 350)?;
-        check_hash(Mode::Public, 5, 0, 0, 705, 705)?;
-        check_hash(Mode::Public, 6, 0, 0, 705, 705)?;
-        check_hash(Mode::Public, 7, 0, 0, 705, 705)?;
-        check_hash(Mode::Public, 8, 0, 0, 705, 705)?;
-        check_hash(Mode::Public, 9, 0, 0, 1060, 1060)?;
-        check_hash(Mode::Public, 10, 0, 0, 1060, 1060)
+        check_hash(Mode::Public, 0, 1, 0, 0, 0)?;
+        check_hash(Mode::Public, 1, 1, 0, 335, 335)?;
+        check_hash(Mode::Public, 2, 1, 0, 340, 340)?;
+        check_hash(Mode::Public, 3, 1, 0, 345, 345)?;
+        check_hash(Mode::Public, 4, 1, 0, 350, 350)?;
+        check_hash(Mode::Public, 5, 1, 0, 705, 705)?;
+        check_hash(Mode::Public, 6, 1, 0, 705, 705)?;
+        check_hash(Mode::Public, 7, 1, 0, 705, 705)?;
+        check_hash(Mode::Public, 8, 1, 0, 705, 705)?;
+        check_hash(Mode::Public, 9, 1, 0, 1060, 1060)?;
+        check_hash(Mode::Public, 10, 1, 0, 1060, 1060)
     }
 
     #[test]
     fn test_hash_private() -> Result<()> {
-        check_hash(Mode::Private, 0, 0, 0, 0, 0)?;
-        check_hash(Mode::Private, 1, 0, 0, 335, 335)?;
-        check_hash(Mode::Private, 2, 0, 0, 340, 340)?;
-        check_hash(Mode::Private, 3, 0, 0, 345, 345)?;
-        check_hash(Mode::Private, 4, 0, 0, 350, 350)?;
-        check_hash(Mode::Private, 5, 0, 0, 705, 705)?;
-        check_hash(Mode::Private, 6, 0, 0, 705, 705)?;
-        check_hash(Mode::Private, 7, 0, 0, 705, 705)?;
-        check_hash(Mode::Private, 8, 0, 0, 705, 705)?;
-        check_hash(Mode::Private, 9, 0, 0, 1060, 1060)?;
-        check_hash(Mode::Private, 10, 0, 0, 1060, 1060)
+        check_hash(Mode::Private, 0, 1, 0, 0, 0)?;
+        check_hash(Mode::Private, 1, 1, 0, 335, 335)?;
+        check_hash(Mode::Private, 2, 1, 0, 340, 340)?;
+        check_hash(Mode::Private, 3, 1, 0, 345, 345)?;
+        check_hash(Mode::Private, 4, 1, 0, 350, 350)?;
+        check_hash(Mode::Private, 5, 1, 0, 705, 705)?;
+        check_hash(Mode::Private, 6, 1, 0, 705, 705)?;
+        check_hash(Mode::Private, 7, 1, 0, 705, 705)?;
+        check_hash(Mode::Private, 8, 1, 0, 705, 705)?;
+        check_hash(Mode::Private, 9, 1, 0, 1060, 1060)?;
+        check_hash(Mode::Private, 10, 1, 0, 1060, 1060)
     }
 }

--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -22,13 +22,175 @@ impl<E: Environment, const RATE: usize> HashMany for Poseidon<E, RATE> {
 
     #[inline]
     fn hash_many(&self, input: &[Self::Input], num_outputs: u16) -> Vec<Self::Output> {
+        // Construct the preimage: [ DOMAIN || LENGTH(INPUT) || [0; RATE-2] || INPUT ].
+        let mut preimage = Vec::with_capacity(RATE + input.len());
+        preimage.push(self.domain.clone());
+        preimage.push(Field::constant((input.len() as u128).into()));
+        preimage.extend(vec![Field::zero(); RATE - 2]); // Pad up to RATE.
+        preimage.extend_from_slice(input);
+
         // Initialize a new sponge.
         let mut state = vec![Field::zero(); RATE + CAPACITY];
         let mut mode = DuplexSpongeMode::Absorbing { next_absorb_index: 0 };
 
         // Absorb the input and squeeze the output.
-        self.absorb(&mut state, &mut mode, input);
+        self.absorb(&mut state, &mut mode, &preimage);
         self.squeeze(&mut state, &mut mode, num_outputs)
+    }
+}
+
+impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
+    /// Absorbs the input elements into state.
+    #[inline]
+    fn absorb(&self, state: &mut [Field<E>], mode: &mut DuplexSpongeMode, input: &[Field<E>]) {
+        if !input.is_empty() {
+            // Determine the absorb index.
+            let (mut absorb_index, should_permute) = match *mode {
+                DuplexSpongeMode::Absorbing { next_absorb_index } => match next_absorb_index == RATE {
+                    true => (0, true),
+                    false => (next_absorb_index, false),
+                },
+                DuplexSpongeMode::Squeezing { .. } => (0, true),
+            };
+
+            // Proceed to permute the state, if necessary.
+            if should_permute {
+                self.permute(state);
+            }
+
+            let mut remaining = input;
+            loop {
+                // Compute the starting index.
+                let start = CAPACITY + absorb_index;
+
+                // Check if we can exit the loop.
+                if absorb_index + remaining.len() <= RATE {
+                    // Absorb the state elements into the input.
+                    remaining.iter().enumerate().for_each(|(i, element)| state[start + i] += element);
+                    // Update the sponge mode.
+                    *mode = DuplexSpongeMode::Absorbing { next_absorb_index: absorb_index + remaining.len() };
+                    return;
+                }
+
+                // Otherwise, proceed to absorb `(rate - absorb_index)` elements.
+                let num_absorbed = RATE - absorb_index;
+                remaining.iter().enumerate().take(num_absorbed).for_each(|(i, element)| state[start + i] += element);
+
+                // Permute the state.
+                self.permute(state);
+
+                // Repeat with the updated input slice and absorb index.
+                remaining = &remaining[num_absorbed..];
+                absorb_index = 0;
+            }
+        }
+    }
+
+    /// Squeeze the specified number of state elements into the output.
+    #[inline]
+    fn squeeze(&self, state: &mut [Field<E>], mode: &mut DuplexSpongeMode, num_outputs: u16) -> Vec<Field<E>> {
+        let mut output = vec![Field::zero(); num_outputs as usize];
+        if num_outputs != 0 {
+            self.squeeze_internal(state, mode, &mut output);
+        }
+        output
+    }
+
+    /// Squeeze the state elements into the output.
+    #[inline]
+    fn squeeze_internal(&self, state: &mut [Field<E>], mode: &mut DuplexSpongeMode, output: &mut [Field<E>]) {
+        // Determine the squeeze index.
+        let (mut squeeze_index, should_permute) = match *mode {
+            DuplexSpongeMode::Absorbing { .. } => (0, true),
+            DuplexSpongeMode::Squeezing { next_squeeze_index } => match next_squeeze_index == RATE {
+                true => (0, true),
+                false => (next_squeeze_index, false),
+            },
+        };
+
+        // Proceed to permute the state, if necessary.
+        if should_permute {
+            self.permute(state);
+        }
+
+        let mut remaining = output;
+        loop {
+            // Compute the starting index.
+            let start = CAPACITY + squeeze_index;
+
+            // Check if we can exit the loop.
+            if squeeze_index + remaining.len() <= RATE {
+                // Store the state elements into the output.
+                remaining.clone_from_slice(&state[start..(start + remaining.len())]);
+                // Update the sponge mode.
+                *mode = DuplexSpongeMode::Squeezing { next_squeeze_index: squeeze_index + remaining.len() };
+                return;
+            }
+
+            // Otherwise, proceed to squeeze `(rate - squeeze_index)` elements.
+            let num_squeezed = RATE - squeeze_index;
+            remaining[..num_squeezed].clone_from_slice(&state[start..(start + num_squeezed)]);
+
+            // Unless we are done with squeezing in this call, permute.
+            if remaining.len() != RATE {
+                self.permute(state);
+            }
+            // Repeat with the updated output slice and squeeze index.
+            remaining = &mut remaining[num_squeezed..];
+            squeeze_index = 0;
+        }
+    }
+
+    /// Apply the additive round keys in-place.
+    #[inline]
+    fn apply_ark(&self, state: &mut [Field<E>], round: usize) {
+        for (i, element) in state.iter_mut().enumerate() {
+            *element += &self.ark[round][i];
+        }
+    }
+
+    /// Apply the S-Box based on whether it is a full round or partial round.
+    #[inline]
+    fn apply_s_box(&self, state: &mut [Field<E>], is_full_round: bool) {
+        if is_full_round {
+            // Full rounds apply the S Box (x^alpha) to every element of state
+            for element in state.iter_mut() {
+                *element = (&*element).pow(&self.alpha);
+            }
+        } else {
+            // Partial rounds apply the S Box (x^alpha) to just the first element of state
+            state[0] = (&state[0]).pow(&self.alpha);
+        }
+    }
+
+    /// Apply the Maximally Distance Separating (MDS) matrix in-place.
+    #[inline]
+    fn apply_mds(&self, state: &mut [Field<E>]) {
+        let mut new_state = Vec::with_capacity(state.len());
+        for i in 0..state.len() {
+            let mut accumulator = Field::zero();
+            for (j, element) in state.iter().enumerate() {
+                accumulator += element * &self.mds[i][j];
+            }
+            new_state.push(accumulator);
+        }
+        state.clone_from_slice(&new_state[..state.len()]);
+    }
+
+    /// Apply the permutation for all rounds in-place.
+    #[inline]
+    fn permute(&self, state: &mut [Field<E>]) {
+        // Determine the partial rounds range bound.
+        let full_rounds_over_2 = self.full_rounds / 2;
+        let partial_round_range = full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds);
+
+        // Iterate through all rounds to permute.
+        for i in 0..(self.partial_rounds + self.full_rounds) {
+            let is_full_round = !partial_round_range.contains(&i);
+            self.apply_ark(state, i);
+            self.apply_s_box(state, is_full_round);
+            self.apply_mds(state);
+        }
     }
 }
 
@@ -40,6 +202,7 @@ mod tests {
 
     use anyhow::Result;
 
+    const DOMAIN: &str = "PoseidonCircuit0";
     const ITERATIONS: usize = 10;
     const RATE: u16 = 4;
 
@@ -54,18 +217,18 @@ mod tests {
     ) -> Result<()> {
         use console::HashMany as H;
 
-        let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, { RATE as usize }>::setup()?;
-        let poseidon = Poseidon::<Circuit, { RATE as usize }>::new();
+        let native = console::Poseidon::<<Circuit as Environment>::BaseField, { RATE as usize }>::setup(DOMAIN)?;
+        let poseidon = Poseidon::<Circuit, { RATE as usize }>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Prepare the preimage.
             let native_input =
-                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(rng)).collect::<Vec<_>>();
+                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(&mut test_rng())).collect::<Vec<_>>();
             let input = native_input.iter().map(|v| Field::<Circuit>::new(mode, *v)).collect::<Vec<_>>();
 
             // Compute the native hash.
-            let expected = native_poseidon.hash_many(&native_input, num_outputs);
+            let expected = native.hash_many(&native_input, num_outputs);
+
             // Compute the circuit hash.
             Circuit::scope(format!("Poseidon {mode} {i} {num_outputs}"), || {
                 let candidate = poseidon.hash_many(&input, num_outputs);
@@ -84,7 +247,7 @@ mod tests {
     fn test_hash_many_constant() -> Result<()> {
         for num_inputs in 0..=RATE {
             for num_outputs in 0..=RATE {
-                check_hash_many(Mode::Constant, num_inputs as usize, num_outputs, 0, 0, 0, 0)?;
+                check_hash_many(Mode::Constant, num_inputs as usize, num_outputs, 1, 0, 0, 0)?;
             }
         }
         Ok(())
@@ -93,23 +256,23 @@ mod tests {
     #[test]
     fn test_hash_many_public() -> Result<()> {
         for num_outputs in 0..=RATE {
-            check_hash_many(Mode::Public, 0, num_outputs, 0, 0, 0, 0)?;
+            check_hash_many(Mode::Public, 0, num_outputs, 1, 0, 0, 0)?;
         }
         for num_outputs in 1..=RATE {
-            check_hash_many(Mode::Public, 1, num_outputs, 0, 0, 335, 335)?;
-            check_hash_many(Mode::Public, 2, num_outputs, 0, 0, 340, 340)?;
-            check_hash_many(Mode::Public, 3, num_outputs, 0, 0, 345, 345)?;
-            check_hash_many(Mode::Public, 4, num_outputs, 0, 0, 350, 350)?;
-            check_hash_many(Mode::Public, 5, num_outputs, 0, 0, 705, 705)?;
-            check_hash_many(Mode::Public, 6, num_outputs, 0, 0, 705, 705)?;
+            check_hash_many(Mode::Public, 1, num_outputs, 1, 0, 335, 335)?;
+            check_hash_many(Mode::Public, 2, num_outputs, 1, 0, 340, 340)?;
+            check_hash_many(Mode::Public, 3, num_outputs, 1, 0, 345, 345)?;
+            check_hash_many(Mode::Public, 4, num_outputs, 1, 0, 350, 350)?;
+            check_hash_many(Mode::Public, 5, num_outputs, 1, 0, 705, 705)?;
+            check_hash_many(Mode::Public, 6, num_outputs, 1, 0, 705, 705)?;
         }
         for num_outputs in (RATE + 1)..=(RATE * 2) {
-            check_hash_many(Mode::Public, 1, num_outputs, 0, 0, 690, 690)?;
-            check_hash_many(Mode::Public, 2, num_outputs, 0, 0, 695, 695)?;
-            check_hash_many(Mode::Public, 3, num_outputs, 0, 0, 700, 700)?;
-            check_hash_many(Mode::Public, 4, num_outputs, 0, 0, 705, 705)?;
-            check_hash_many(Mode::Public, 5, num_outputs, 0, 0, 1060, 1060)?;
-            check_hash_many(Mode::Public, 6, num_outputs, 0, 0, 1060, 1060)?;
+            check_hash_many(Mode::Public, 1, num_outputs, 1, 0, 690, 690)?;
+            check_hash_many(Mode::Public, 2, num_outputs, 1, 0, 695, 695)?;
+            check_hash_many(Mode::Public, 3, num_outputs, 1, 0, 700, 700)?;
+            check_hash_many(Mode::Public, 4, num_outputs, 1, 0, 705, 705)?;
+            check_hash_many(Mode::Public, 5, num_outputs, 1, 0, 1060, 1060)?;
+            check_hash_many(Mode::Public, 6, num_outputs, 1, 0, 1060, 1060)?;
         }
         Ok(())
     }
@@ -117,23 +280,23 @@ mod tests {
     #[test]
     fn test_hash_many_private() -> Result<()> {
         for num_outputs in 0..=RATE {
-            check_hash_many(Mode::Private, 0, num_outputs, 0, 0, 0, 0)?;
+            check_hash_many(Mode::Private, 0, num_outputs, 1, 0, 0, 0)?;
         }
         for num_outputs in 1..=RATE {
-            check_hash_many(Mode::Private, 1, num_outputs, 0, 0, 335, 335)?;
-            check_hash_many(Mode::Private, 2, num_outputs, 0, 0, 340, 340)?;
-            check_hash_many(Mode::Private, 3, num_outputs, 0, 0, 345, 345)?;
-            check_hash_many(Mode::Private, 4, num_outputs, 0, 0, 350, 350)?;
-            check_hash_many(Mode::Private, 5, num_outputs, 0, 0, 705, 705)?;
-            check_hash_many(Mode::Private, 6, num_outputs, 0, 0, 705, 705)?;
+            check_hash_many(Mode::Private, 1, num_outputs, 1, 0, 335, 335)?;
+            check_hash_many(Mode::Private, 2, num_outputs, 1, 0, 340, 340)?;
+            check_hash_many(Mode::Private, 3, num_outputs, 1, 0, 345, 345)?;
+            check_hash_many(Mode::Private, 4, num_outputs, 1, 0, 350, 350)?;
+            check_hash_many(Mode::Private, 5, num_outputs, 1, 0, 705, 705)?;
+            check_hash_many(Mode::Private, 6, num_outputs, 1, 0, 705, 705)?;
         }
         for num_outputs in (RATE + 1)..=(RATE * 2) {
-            check_hash_many(Mode::Private, 1, num_outputs, 0, 0, 690, 690)?;
-            check_hash_many(Mode::Private, 2, num_outputs, 0, 0, 695, 695)?;
-            check_hash_many(Mode::Private, 3, num_outputs, 0, 0, 700, 700)?;
-            check_hash_many(Mode::Private, 4, num_outputs, 0, 0, 705, 705)?;
-            check_hash_many(Mode::Private, 5, num_outputs, 0, 0, 1060, 1060)?;
-            check_hash_many(Mode::Private, 6, num_outputs, 0, 0, 1060, 1060)?;
+            check_hash_many(Mode::Private, 1, num_outputs, 1, 0, 690, 690)?;
+            check_hash_many(Mode::Private, 2, num_outputs, 1, 0, 695, 695)?;
+            check_hash_many(Mode::Private, 3, num_outputs, 1, 0, 700, 700)?;
+            check_hash_many(Mode::Private, 4, num_outputs, 1, 0, 705, 705)?;
+            check_hash_many(Mode::Private, 5, num_outputs, 1, 0, 1060, 1060)?;
+            check_hash_many(Mode::Private, 6, num_outputs, 1, 0, 1060, 1060)?;
         }
         Ok(())
     }

--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -32,26 +32,6 @@ impl<E: Environment, const RATE: usize> HashMany for Poseidon<E, RATE> {
     }
 }
 
-impl<E: Environment, const RATE: usize> Metrics<dyn HashMany<Input = Field<E>, Output = Field<E>>>
-    for Poseidon<E, RATE>
-{
-    type Case = ();
-
-    fn count(_parameter: &Self::Case) -> Count {
-        todo!()
-    }
-}
-
-impl<E: Environment, const RATE: usize> OutputMode<dyn HashMany<Input = Field<E>, Output = Field<E>>>
-    for Poseidon<E, RATE>
-{
-    type Case = ();
-
-    fn output_mode(_parameter: &Self::Case) -> Mode {
-        todo!()
-    }
-}
-
 #[cfg(all(test, console))]
 mod tests {
     use super::*;

--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -38,6 +38,8 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
+    use anyhow::Result;
+
     const ITERATIONS: usize = 10;
     const RATE: u16 = 4;
 
@@ -49,11 +51,11 @@ mod tests {
         num_public: u64,
         num_private: u64,
         num_constraints: u64,
-    ) {
+    ) -> Result<()> {
         use console::HashMany as H;
 
         let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, { RATE as usize }>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, { RATE as usize }>::setup()?;
         let poseidon = Poseidon::<Circuit, { RATE as usize }>::new();
 
         for i in 0..ITERATIONS {
@@ -73,61 +75,66 @@ mod tests {
                 let case = format!("(mode = {mode}, num_inputs = {num_inputs}, num_outputs = {num_outputs})");
                 assert_scope!(case, num_constants, num_public, num_private, num_constraints);
             });
+            Circuit::reset();
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_many_constant() {
+    fn test_hash_many_constant() -> Result<()> {
         for num_inputs in 0..=RATE {
             for num_outputs in 0..=RATE {
-                check_hash_many(Mode::Constant, num_inputs as usize, num_outputs, 0, 0, 0, 0);
+                check_hash_many(Mode::Constant, num_inputs as usize, num_outputs, 0, 0, 0, 0)?;
             }
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_many_public() {
+    fn test_hash_many_public() -> Result<()> {
         for num_outputs in 0..=RATE {
-            check_hash_many(Mode::Public, 0, num_outputs, 0, 0, 0, 0);
+            check_hash_many(Mode::Public, 0, num_outputs, 0, 0, 0, 0)?;
         }
         for num_outputs in 1..=RATE {
-            check_hash_many(Mode::Public, 1, num_outputs, 0, 0, 335, 335);
-            check_hash_many(Mode::Public, 2, num_outputs, 0, 0, 340, 340);
-            check_hash_many(Mode::Public, 3, num_outputs, 0, 0, 345, 345);
-            check_hash_many(Mode::Public, 4, num_outputs, 0, 0, 350, 350);
-            check_hash_many(Mode::Public, 5, num_outputs, 0, 0, 705, 705);
-            check_hash_many(Mode::Public, 6, num_outputs, 0, 0, 705, 705);
+            check_hash_many(Mode::Public, 1, num_outputs, 0, 0, 335, 335)?;
+            check_hash_many(Mode::Public, 2, num_outputs, 0, 0, 340, 340)?;
+            check_hash_many(Mode::Public, 3, num_outputs, 0, 0, 345, 345)?;
+            check_hash_many(Mode::Public, 4, num_outputs, 0, 0, 350, 350)?;
+            check_hash_many(Mode::Public, 5, num_outputs, 0, 0, 705, 705)?;
+            check_hash_many(Mode::Public, 6, num_outputs, 0, 0, 705, 705)?;
         }
         for num_outputs in (RATE + 1)..=(RATE * 2) {
-            check_hash_many(Mode::Public, 1, num_outputs, 0, 0, 690, 690);
-            check_hash_many(Mode::Public, 2, num_outputs, 0, 0, 695, 695);
-            check_hash_many(Mode::Public, 3, num_outputs, 0, 0, 700, 700);
-            check_hash_many(Mode::Public, 4, num_outputs, 0, 0, 705, 705);
-            check_hash_many(Mode::Public, 5, num_outputs, 0, 0, 1060, 1060);
-            check_hash_many(Mode::Public, 6, num_outputs, 0, 0, 1060, 1060);
+            check_hash_many(Mode::Public, 1, num_outputs, 0, 0, 690, 690)?;
+            check_hash_many(Mode::Public, 2, num_outputs, 0, 0, 695, 695)?;
+            check_hash_many(Mode::Public, 3, num_outputs, 0, 0, 700, 700)?;
+            check_hash_many(Mode::Public, 4, num_outputs, 0, 0, 705, 705)?;
+            check_hash_many(Mode::Public, 5, num_outputs, 0, 0, 1060, 1060)?;
+            check_hash_many(Mode::Public, 6, num_outputs, 0, 0, 1060, 1060)?;
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_many_private() {
+    fn test_hash_many_private() -> Result<()> {
         for num_outputs in 0..=RATE {
-            check_hash_many(Mode::Private, 0, num_outputs, 0, 0, 0, 0);
+            check_hash_many(Mode::Private, 0, num_outputs, 0, 0, 0, 0)?;
         }
         for num_outputs in 1..=RATE {
-            check_hash_many(Mode::Private, 1, num_outputs, 0, 0, 335, 335);
-            check_hash_many(Mode::Private, 2, num_outputs, 0, 0, 340, 340);
-            check_hash_many(Mode::Private, 3, num_outputs, 0, 0, 345, 345);
-            check_hash_many(Mode::Private, 4, num_outputs, 0, 0, 350, 350);
-            check_hash_many(Mode::Private, 5, num_outputs, 0, 0, 705, 705);
-            check_hash_many(Mode::Private, 6, num_outputs, 0, 0, 705, 705);
+            check_hash_many(Mode::Private, 1, num_outputs, 0, 0, 335, 335)?;
+            check_hash_many(Mode::Private, 2, num_outputs, 0, 0, 340, 340)?;
+            check_hash_many(Mode::Private, 3, num_outputs, 0, 0, 345, 345)?;
+            check_hash_many(Mode::Private, 4, num_outputs, 0, 0, 350, 350)?;
+            check_hash_many(Mode::Private, 5, num_outputs, 0, 0, 705, 705)?;
+            check_hash_many(Mode::Private, 6, num_outputs, 0, 0, 705, 705)?;
         }
         for num_outputs in (RATE + 1)..=(RATE * 2) {
-            check_hash_many(Mode::Private, 1, num_outputs, 0, 0, 690, 690);
-            check_hash_many(Mode::Private, 2, num_outputs, 0, 0, 695, 695);
-            check_hash_many(Mode::Private, 3, num_outputs, 0, 0, 700, 700);
-            check_hash_many(Mode::Private, 4, num_outputs, 0, 0, 705, 705);
-            check_hash_many(Mode::Private, 5, num_outputs, 0, 0, 1060, 1060);
-            check_hash_many(Mode::Private, 6, num_outputs, 0, 0, 1060, 1060);
+            check_hash_many(Mode::Private, 1, num_outputs, 0, 0, 690, 690)?;
+            check_hash_many(Mode::Private, 2, num_outputs, 0, 0, 695, 695)?;
+            check_hash_many(Mode::Private, 3, num_outputs, 0, 0, 700, 700)?;
+            check_hash_many(Mode::Private, 4, num_outputs, 0, 0, 705, 705)?;
+            check_hash_many(Mode::Private, 5, num_outputs, 0, 0, 1060, 1060)?;
+            check_hash_many(Mode::Private, 6, num_outputs, 0, 0, 1060, 1060)?;
         }
+        Ok(())
     }
 }

--- a/circuit/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/circuit/algorithms/src/poseidon/hash_to_scalar.rs
@@ -41,6 +41,7 @@ mod tests {
 
     use anyhow::Result;
 
+    const DOMAIN: &str = "PoseidonCircuit0";
     const ITERATIONS: usize = 10;
     const RATE: usize = 4;
 
@@ -54,20 +55,19 @@ mod tests {
     ) -> Result<()> {
         use console::HashToScalar as H;
 
-        let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup()?;
-        let poseidon = Poseidon::<Circuit, RATE>::new();
+        let native = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup(DOMAIN)?;
+        let poseidon = Poseidon::<Circuit, RATE>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Prepare the preimage.
             let native_input =
-                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(rng)).collect::<Vec<_>>();
+                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(&mut test_rng())).collect::<Vec<_>>();
             let input = native_input.iter().map(|v| Field::<Circuit>::new(mode, *v)).collect::<Vec<_>>();
 
             // Compute the native hash to scalar.
             let expected = {
                 // Use Poseidon as a random oracle.
-                let output = native_poseidon
+                let output = native
                     .hash_to_scalar::<<Circuit as Environment>::ScalarField>(&native_input)
                     .expect("Failed to hash native input");
 
@@ -100,38 +100,38 @@ mod tests {
     #[test]
     fn test_hash_to_scalar_constant() -> Result<()> {
         for num_inputs in 0..=RATE {
-            check_hash_to_scalar(Mode::Constant, num_inputs, 253, 0, 0, 0)?;
+            check_hash_to_scalar(Mode::Constant, num_inputs, 254, 0, 0, 0)?;
         }
         Ok(())
     }
 
     #[test]
     fn test_hash_to_scalar_public() -> Result<()> {
-        check_hash_to_scalar(Mode::Public, 0, 253, 0, 0, 0)?;
-        check_hash_to_scalar(Mode::Public, 1, 0, 0, 588, 589)?;
-        check_hash_to_scalar(Mode::Public, 2, 0, 0, 593, 594)?;
-        check_hash_to_scalar(Mode::Public, 3, 0, 0, 598, 599)?;
-        check_hash_to_scalar(Mode::Public, 4, 0, 0, 603, 604)?;
-        check_hash_to_scalar(Mode::Public, 5, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Public, 6, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Public, 7, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Public, 8, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Public, 9, 0, 0, 1313, 1314)?;
-        check_hash_to_scalar(Mode::Public, 10, 0, 0, 1313, 1314)
+        check_hash_to_scalar(Mode::Public, 0, 254, 0, 0, 0)?;
+        check_hash_to_scalar(Mode::Public, 1, 1, 0, 588, 589)?;
+        check_hash_to_scalar(Mode::Public, 2, 1, 0, 593, 594)?;
+        check_hash_to_scalar(Mode::Public, 3, 1, 0, 598, 599)?;
+        check_hash_to_scalar(Mode::Public, 4, 1, 0, 603, 604)?;
+        check_hash_to_scalar(Mode::Public, 5, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 6, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 7, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 8, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 9, 1, 0, 1313, 1314)?;
+        check_hash_to_scalar(Mode::Public, 10, 1, 0, 1313, 1314)
     }
 
     #[test]
     fn test_hash_to_scalar_private() -> Result<()> {
-        check_hash_to_scalar(Mode::Private, 0, 253, 0, 0, 0)?;
-        check_hash_to_scalar(Mode::Private, 1, 0, 0, 588, 589)?;
-        check_hash_to_scalar(Mode::Private, 2, 0, 0, 593, 594)?;
-        check_hash_to_scalar(Mode::Private, 3, 0, 0, 598, 599)?;
-        check_hash_to_scalar(Mode::Private, 4, 0, 0, 603, 604)?;
-        check_hash_to_scalar(Mode::Private, 5, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Private, 6, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Private, 7, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Private, 8, 0, 0, 958, 959)?;
-        check_hash_to_scalar(Mode::Private, 9, 0, 0, 1313, 1314)?;
-        check_hash_to_scalar(Mode::Private, 10, 0, 0, 1313, 1314)
+        check_hash_to_scalar(Mode::Private, 0, 254, 0, 0, 0)?;
+        check_hash_to_scalar(Mode::Private, 1, 1, 0, 588, 589)?;
+        check_hash_to_scalar(Mode::Private, 2, 1, 0, 593, 594)?;
+        check_hash_to_scalar(Mode::Private, 3, 1, 0, 598, 599)?;
+        check_hash_to_scalar(Mode::Private, 4, 1, 0, 603, 604)?;
+        check_hash_to_scalar(Mode::Private, 5, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 6, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 7, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 8, 1, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 9, 1, 0, 1313, 1314)?;
+        check_hash_to_scalar(Mode::Private, 10, 1, 0, 1313, 1314)
     }
 }

--- a/circuit/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/circuit/algorithms/src/poseidon/hash_to_scalar.rs
@@ -39,6 +39,8 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, FromBits, ToBits, UniformRand};
 
+    use anyhow::Result;
+
     const ITERATIONS: usize = 10;
     const RATE: usize = 4;
 
@@ -49,11 +51,11 @@ mod tests {
         num_public: u64,
         num_private: u64,
         num_constraints: u64,
-    ) {
+    ) -> Result<()> {
         use console::HashToScalar as H;
 
         let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup()?;
         let poseidon = Poseidon::<Circuit, RATE>::new();
 
         for i in 0..ITERATIONS {
@@ -90,43 +92,46 @@ mod tests {
                 let case = format!("(mode = {mode}, num_inputs = {num_inputs})");
                 assert_scope!(case, num_constants, num_public, num_private, num_constraints);
             });
+            Circuit::reset();
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_to_scalar_constant() {
+    fn test_hash_to_scalar_constant() -> Result<()> {
         for num_inputs in 0..=RATE {
-            check_hash_to_scalar(Mode::Constant, num_inputs, 253, 0, 0, 0);
+            check_hash_to_scalar(Mode::Constant, num_inputs, 253, 0, 0, 0)?;
         }
+        Ok(())
     }
 
     #[test]
-    fn test_hash_to_scalar_public() {
-        check_hash_to_scalar(Mode::Public, 0, 253, 0, 0, 0);
-        check_hash_to_scalar(Mode::Public, 1, 0, 0, 588, 589);
-        check_hash_to_scalar(Mode::Public, 2, 0, 0, 593, 594);
-        check_hash_to_scalar(Mode::Public, 3, 0, 0, 598, 599);
-        check_hash_to_scalar(Mode::Public, 4, 0, 0, 603, 604);
-        check_hash_to_scalar(Mode::Public, 5, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Public, 6, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Public, 7, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Public, 8, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Public, 9, 0, 0, 1313, 1314);
-        check_hash_to_scalar(Mode::Public, 10, 0, 0, 1313, 1314);
+    fn test_hash_to_scalar_public() -> Result<()> {
+        check_hash_to_scalar(Mode::Public, 0, 253, 0, 0, 0)?;
+        check_hash_to_scalar(Mode::Public, 1, 0, 0, 588, 589)?;
+        check_hash_to_scalar(Mode::Public, 2, 0, 0, 593, 594)?;
+        check_hash_to_scalar(Mode::Public, 3, 0, 0, 598, 599)?;
+        check_hash_to_scalar(Mode::Public, 4, 0, 0, 603, 604)?;
+        check_hash_to_scalar(Mode::Public, 5, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 6, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 7, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 8, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Public, 9, 0, 0, 1313, 1314)?;
+        check_hash_to_scalar(Mode::Public, 10, 0, 0, 1313, 1314)
     }
 
     #[test]
-    fn test_hash_to_scalar_private() {
-        check_hash_to_scalar(Mode::Private, 0, 253, 0, 0, 0);
-        check_hash_to_scalar(Mode::Private, 1, 0, 0, 588, 589);
-        check_hash_to_scalar(Mode::Private, 2, 0, 0, 593, 594);
-        check_hash_to_scalar(Mode::Private, 3, 0, 0, 598, 599);
-        check_hash_to_scalar(Mode::Private, 4, 0, 0, 603, 604);
-        check_hash_to_scalar(Mode::Private, 5, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Private, 6, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Private, 7, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Private, 8, 0, 0, 958, 959);
-        check_hash_to_scalar(Mode::Private, 9, 0, 0, 1313, 1314);
-        check_hash_to_scalar(Mode::Private, 10, 0, 0, 1313, 1314);
+    fn test_hash_to_scalar_private() -> Result<()> {
+        check_hash_to_scalar(Mode::Private, 0, 253, 0, 0, 0)?;
+        check_hash_to_scalar(Mode::Private, 1, 0, 0, 588, 589)?;
+        check_hash_to_scalar(Mode::Private, 2, 0, 0, 593, 594)?;
+        check_hash_to_scalar(Mode::Private, 3, 0, 0, 598, 599)?;
+        check_hash_to_scalar(Mode::Private, 4, 0, 0, 603, 604)?;
+        check_hash_to_scalar(Mode::Private, 5, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 6, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 7, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 8, 0, 0, 958, 959)?;
+        check_hash_to_scalar(Mode::Private, 9, 0, 0, 1313, 1314)?;
+        check_hash_to_scalar(Mode::Private, 10, 0, 0, 1313, 1314)
     }
 }

--- a/circuit/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/circuit/algorithms/src/poseidon/hash_to_scalar.rs
@@ -33,26 +33,6 @@ impl<E: Environment, const RATE: usize> HashToScalar for Poseidon<E, RATE> {
     }
 }
 
-impl<E: Environment, const RATE: usize> Metrics<dyn HashToScalar<Input = Field<E>, Scalar = Field<E>>>
-    for Poseidon<E, RATE>
-{
-    type Case = ();
-
-    fn count(_parameter: &Self::Case) -> Count {
-        todo!()
-    }
-}
-
-impl<E: Environment, const RATE: usize> OutputMode<dyn HashToScalar<Input = Field<E>, Scalar = Field<E>>>
-    for Poseidon<E, RATE>
-{
-    type Case = ();
-
-    fn output_mode(_case: &Self::Case) -> Mode {
-        todo!()
-    }
-}
-
 #[cfg(all(test, console))]
 mod tests {
     use super::*;

--- a/circuit/algorithms/src/poseidon/prf.rs
+++ b/circuit/algorithms/src/poseidon/prf.rs
@@ -34,26 +34,6 @@ impl<E: Environment, const RATE: usize> PRF for Poseidon<E, RATE> {
     }
 }
 
-impl<E: Environment, const RATE: usize> Metrics<dyn PRF<Seed = Field<E>, Input = Field<E>, Output = Field<E>>>
-    for Poseidon<E, RATE>
-{
-    type Case = ();
-
-    fn count(_parameter: &Self::Case) -> Count {
-        todo!()
-    }
-}
-
-impl<E: Environment, const RATE: usize> OutputMode<dyn PRF<Seed = Field<E>, Input = Field<E>, Output = Field<E>>>
-    for Poseidon<E, RATE>
-{
-    type Case = ();
-
-    fn output_mode(_case: &Self::Case) -> Mode {
-        todo!()
-    }
-}
-
 #[cfg(all(test, console))]
 mod tests {
     use super::*;

--- a/circuit/algorithms/src/poseidon/prf.rs
+++ b/circuit/algorithms/src/poseidon/prf.rs
@@ -23,10 +23,9 @@ impl<E: Environment, const RATE: usize> PRF for Poseidon<E, RATE> {
 
     #[inline]
     fn prf(&self, seed: &Self::Seed, input: &[Self::Input]) -> Self::Output {
-        // Construct the preimage: seed || length(input) || input.
-        let mut preimage = Vec::with_capacity(2 + input.len());
+        // Construct the preimage: seed || input.
+        let mut preimage = Vec::with_capacity(1 + input.len());
         preimage.push(seed.clone());
-        preimage.push(Field::constant((input.len() as u128).into())); // <- Input length *must* be constant.
         preimage.extend_from_slice(input);
 
         // Hash the preimage to derive the PRF output.
@@ -42,6 +41,7 @@ mod tests {
 
     use anyhow::Result;
 
+    const DOMAIN: &str = "PoseidonCircuit0";
     const ITERATIONS: usize = 10;
     const RATE: usize = 4;
 
@@ -55,22 +55,21 @@ mod tests {
     ) -> Result<()> {
         use console::PRF as P;
 
-        let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup()?;
-        let poseidon = Poseidon::<Circuit, RATE>::new();
+        let native = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup(DOMAIN)?;
+        let poseidon = Poseidon::<Circuit, RATE>::constant(native.clone());
 
         for i in 0..ITERATIONS {
             // Prepare the seed.
-            let native_seed = <Circuit as Environment>::BaseField::rand(rng);
+            let native_seed = <Circuit as Environment>::BaseField::rand(&mut test_rng());
             let seed = Field::new(mode, native_seed);
 
             // Prepare the preimage.
             let native_input =
-                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(rng)).collect::<Vec<_>>();
+                (0..num_inputs).map(|_| <Circuit as Environment>::BaseField::rand(&mut test_rng())).collect::<Vec<_>>();
             let input = native_input.iter().map(|v| Field::<Circuit>::new(mode, *v)).collect::<Vec<_>>();
 
             // Compute the native hash.
-            let expected = native_poseidon.prf(&native_seed, &native_input).expect("Failed to PRF native input");
+            let expected = native.prf(&native_seed, &native_input).expect("Failed to PRF native input");
 
             // Compute the circuit hash.
             Circuit::scope(format!("Poseidon PRF {mode} {i}"), || {
@@ -97,14 +96,14 @@ mod tests {
         check_prf(Mode::Public, 0, 1, 0, 335, 335)?;
         check_prf(Mode::Public, 1, 1, 0, 340, 340)?;
         check_prf(Mode::Public, 2, 1, 0, 345, 345)?;
-        check_prf(Mode::Public, 3, 1, 0, 700, 700)?;
-        check_prf(Mode::Public, 4, 1, 0, 700, 700)?;
-        check_prf(Mode::Public, 5, 1, 0, 700, 700)?;
-        check_prf(Mode::Public, 6, 1, 0, 700, 700)?;
-        check_prf(Mode::Public, 7, 1, 0, 1055, 1055)?;
-        check_prf(Mode::Public, 8, 1, 0, 1055, 1055)?;
-        check_prf(Mode::Public, 9, 1, 0, 1055, 1055)?;
-        check_prf(Mode::Public, 10, 1, 0, 1055, 1055)
+        check_prf(Mode::Public, 3, 1, 0, 350, 350)?;
+        check_prf(Mode::Public, 4, 1, 0, 705, 705)?;
+        check_prf(Mode::Public, 5, 1, 0, 705, 705)?;
+        check_prf(Mode::Public, 6, 1, 0, 705, 705)?;
+        check_prf(Mode::Public, 7, 1, 0, 705, 705)?;
+        check_prf(Mode::Public, 8, 1, 0, 1060, 1060)?;
+        check_prf(Mode::Public, 9, 1, 0, 1060, 1060)?;
+        check_prf(Mode::Public, 10, 1, 0, 1060, 1060)
     }
 
     #[test]
@@ -112,13 +111,13 @@ mod tests {
         check_prf(Mode::Private, 0, 1, 0, 335, 335)?;
         check_prf(Mode::Private, 1, 1, 0, 340, 340)?;
         check_prf(Mode::Private, 2, 1, 0, 345, 345)?;
-        check_prf(Mode::Private, 3, 1, 0, 700, 700)?;
-        check_prf(Mode::Private, 4, 1, 0, 700, 700)?;
-        check_prf(Mode::Private, 5, 1, 0, 700, 700)?;
-        check_prf(Mode::Private, 6, 1, 0, 700, 700)?;
-        check_prf(Mode::Private, 7, 1, 0, 1055, 1055)?;
-        check_prf(Mode::Private, 8, 1, 0, 1055, 1055)?;
-        check_prf(Mode::Private, 9, 1, 0, 1055, 1055)?;
-        check_prf(Mode::Private, 10, 1, 0, 1055, 1055)
+        check_prf(Mode::Private, 3, 1, 0, 350, 350)?;
+        check_prf(Mode::Private, 4, 1, 0, 705, 705)?;
+        check_prf(Mode::Private, 5, 1, 0, 705, 705)?;
+        check_prf(Mode::Private, 6, 1, 0, 705, 705)?;
+        check_prf(Mode::Private, 7, 1, 0, 705, 705)?;
+        check_prf(Mode::Private, 8, 1, 0, 1060, 1060)?;
+        check_prf(Mode::Private, 9, 1, 0, 1060, 1060)?;
+        check_prf(Mode::Private, 10, 1, 0, 1060, 1060)
     }
 }

--- a/circuit/algorithms/src/poseidon/prf.rs
+++ b/circuit/algorithms/src/poseidon/prf.rs
@@ -40,6 +40,8 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{test_rng, UniformRand};
 
+    use anyhow::Result;
+
     const ITERATIONS: usize = 10;
     const RATE: usize = 4;
 
@@ -50,11 +52,11 @@ mod tests {
         num_public: u64,
         num_private: u64,
         num_constraints: u64,
-    ) {
+    ) -> Result<()> {
         use console::PRF as P;
 
         let rng = &mut test_rng();
-        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup();
+        let native_poseidon = console::Poseidon::<<Circuit as Environment>::BaseField, RATE>::setup()?;
         let poseidon = Poseidon::<Circuit, RATE>::new();
 
         for i in 0..ITERATIONS {
@@ -77,43 +79,46 @@ mod tests {
                 let case = format!("(mode = {mode}, num_inputs = {num_inputs})");
                 assert_scope!(case, num_constants, num_public, num_private, num_constraints);
             });
+            Circuit::reset();
         }
+        Ok(())
     }
 
     #[test]
-    fn test_prf_constant() {
+    fn test_prf_constant() -> Result<()> {
         for num_inputs in 0..=RATE {
-            check_prf(Mode::Constant, num_inputs, 1, 0, 0, 0);
+            check_prf(Mode::Constant, num_inputs, 1, 0, 0, 0)?;
         }
+        Ok(())
     }
 
     #[test]
-    fn test_prf_public() {
-        check_prf(Mode::Public, 0, 1, 0, 335, 335);
-        check_prf(Mode::Public, 1, 1, 0, 340, 340);
-        check_prf(Mode::Public, 2, 1, 0, 345, 345);
-        check_prf(Mode::Public, 3, 1, 0, 700, 700);
-        check_prf(Mode::Public, 4, 1, 0, 700, 700);
-        check_prf(Mode::Public, 5, 1, 0, 700, 700);
-        check_prf(Mode::Public, 6, 1, 0, 700, 700);
-        check_prf(Mode::Public, 7, 1, 0, 1055, 1055);
-        check_prf(Mode::Public, 8, 1, 0, 1055, 1055);
-        check_prf(Mode::Public, 9, 1, 0, 1055, 1055);
-        check_prf(Mode::Public, 10, 1, 0, 1055, 1055);
+    fn test_prf_public() -> Result<()> {
+        check_prf(Mode::Public, 0, 1, 0, 335, 335)?;
+        check_prf(Mode::Public, 1, 1, 0, 340, 340)?;
+        check_prf(Mode::Public, 2, 1, 0, 345, 345)?;
+        check_prf(Mode::Public, 3, 1, 0, 700, 700)?;
+        check_prf(Mode::Public, 4, 1, 0, 700, 700)?;
+        check_prf(Mode::Public, 5, 1, 0, 700, 700)?;
+        check_prf(Mode::Public, 6, 1, 0, 700, 700)?;
+        check_prf(Mode::Public, 7, 1, 0, 1055, 1055)?;
+        check_prf(Mode::Public, 8, 1, 0, 1055, 1055)?;
+        check_prf(Mode::Public, 9, 1, 0, 1055, 1055)?;
+        check_prf(Mode::Public, 10, 1, 0, 1055, 1055)
     }
 
     #[test]
-    fn test_prf_private() {
-        check_prf(Mode::Private, 0, 1, 0, 335, 335);
-        check_prf(Mode::Private, 1, 1, 0, 340, 340);
-        check_prf(Mode::Private, 2, 1, 0, 345, 345);
-        check_prf(Mode::Private, 3, 1, 0, 700, 700);
-        check_prf(Mode::Private, 4, 1, 0, 700, 700);
-        check_prf(Mode::Private, 5, 1, 0, 700, 700);
-        check_prf(Mode::Private, 6, 1, 0, 700, 700);
-        check_prf(Mode::Private, 7, 1, 0, 1055, 1055);
-        check_prf(Mode::Private, 8, 1, 0, 1055, 1055);
-        check_prf(Mode::Private, 9, 1, 0, 1055, 1055);
-        check_prf(Mode::Private, 10, 1, 0, 1055, 1055);
+    fn test_prf_private() -> Result<()> {
+        check_prf(Mode::Private, 0, 1, 0, 335, 335)?;
+        check_prf(Mode::Private, 1, 1, 0, 340, 340)?;
+        check_prf(Mode::Private, 2, 1, 0, 345, 345)?;
+        check_prf(Mode::Private, 3, 1, 0, 700, 700)?;
+        check_prf(Mode::Private, 4, 1, 0, 700, 700)?;
+        check_prf(Mode::Private, 5, 1, 0, 700, 700)?;
+        check_prf(Mode::Private, 6, 1, 0, 700, 700)?;
+        check_prf(Mode::Private, 7, 1, 0, 1055, 1055)?;
+        check_prf(Mode::Private, 8, 1, 0, 1055, 1055)?;
+        check_prf(Mode::Private, 9, 1, 0, 1055, 1055)?;
+        check_prf(Mode::Private, 10, 1, 0, 1055, 1055)
     }
 }

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -70,11 +70,11 @@ thread_local! {
     static PEDERSEN_128: Pedersen128<AleoV0> = Pedersen128::<AleoV0>::constant(console::PEDERSEN_128.with(|pedersen| pedersen.clone()));
 
     /// The Poseidon hash function, using a rate of 2.
-    static POSEIDON_2: Poseidon2<AleoV0> = Poseidon2::<AleoV0>::new();
+    static POSEIDON_2: Poseidon2<AleoV0> = Poseidon2::<AleoV0>::constant(console::POSEIDON_2.with(|poseidon| poseidon.clone()));
     /// The Poseidon hash function, using a rate of 4.
-    static POSEIDON_4: Poseidon4<AleoV0> = Poseidon4::<AleoV0>::new();
+    static POSEIDON_4: Poseidon4<AleoV0> = Poseidon4::<AleoV0>::constant(console::POSEIDON_4.with(|poseidon| poseidon.clone()));
     /// The Poseidon hash function, using a rate of 8.
-    static POSEIDON_8: Poseidon8<AleoV0> = Poseidon8::<AleoV0>::new();
+    static POSEIDON_8: Poseidon8<AleoV0> = Poseidon8::<AleoV0>::constant(console::POSEIDON_8.with(|poseidon| poseidon.clone()));
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/console/account/src/private_key/try_from.rs
+++ b/console/account/src/private_key/try_from.rs
@@ -37,7 +37,7 @@ impl<N: Network> PrivateKey<N> {
         let sk_vrf_domain = N::Scalar::from_bytes_le_mod_order(sk_vrf_input.as_bytes());
 
         // Initialize Poseidon2 on the **scalar** field.
-        let poseidon2 = Poseidon2::<N::Scalar>::setup();
+        let poseidon2 = Poseidon2::<N::Scalar>::setup()?;
 
         Ok(Self {
             seed,

--- a/console/account/src/private_key/try_from.rs
+++ b/console/account/src/private_key/try_from.rs
@@ -19,6 +19,7 @@ use super::*;
 static ACCOUNT_SK_SIG_DOMAIN: &str = "AleoAccountSignatureSecretKey0";
 static ACCOUNT_R_SIG_DOMAIN: &str = "AleoAccountSignatureRandomizer0";
 static ACCOUNT_SK_VRF_DOMAIN: &str = "AleoAccountVRFSecretKey0";
+static ACCOUNT_PRF_DOMAIN: &str = "AleoAccountPRF0";
 
 impl<N: Network> PrivateKey<N> {
     /// Returns the account private key from an account seed.
@@ -37,7 +38,7 @@ impl<N: Network> PrivateKey<N> {
         let sk_vrf_domain = N::Scalar::from_bytes_le_mod_order(sk_vrf_input.as_bytes());
 
         // Initialize Poseidon2 on the **scalar** field.
-        let poseidon2 = Poseidon2::<N::Scalar>::setup()?;
+        let poseidon2 = Poseidon2::<N::Scalar>::setup(ACCOUNT_PRF_DOMAIN)?;
 
         Ok(Self {
             seed,

--- a/console/algorithms/src/nsec5/verify.rs
+++ b/console/algorithms/src/nsec5/verify.rs
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn test_prove_and_verify() -> Result<()> {
         let rng = &mut test_rng();
-        let poseidon4 = Poseidon4::<Fq>::setup();
+        let poseidon4 = Poseidon4::<Fq>::setup()?;
 
         for _ in 0..ITERATIONS {
             let generator_g: EdwardsAffine = UniformRand::rand(rng);

--- a/console/algorithms/src/nsec5/verify.rs
+++ b/console/algorithms/src/nsec5/verify.rs
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn test_prove_and_verify() -> Result<()> {
         let rng = &mut test_rng();
-        let poseidon4 = Poseidon4::<Fq>::setup()?;
+        let poseidon4 = Poseidon4::<Fq>::setup("NSEC5")?;
 
         for _ in 0..ITERATIONS {
             let generator_g: EdwardsAffine = UniformRand::rand(rng);

--- a/console/algorithms/src/poseidon/helpers/mod.rs
+++ b/console/algorithms/src/poseidon/helpers/mod.rs
@@ -22,7 +22,6 @@ pub(super) use state::*;
 
 use snarkvm_fields::PrimeField;
 
-use anyhow::Result;
 use core::fmt::Debug;
 use smallvec::SmallVec;
 
@@ -41,10 +40,6 @@ pub trait AlgebraicSponge<F: PrimeField, const RATE: usize, const CAPACITY: usiz
 
     /// Squeeze `num_elements` field elements from the sponge.
     fn squeeze(&mut self, num_elements: u16) -> SmallVec<[F; 10]>;
-}
-
-pub trait DefaultCapacityAlgebraicSponge<F: PrimeField, const RATE: usize>: AlgebraicSponge<F, RATE, 1> {
-    fn sample_parameters() -> Result<Self::Parameters>;
 }
 
 /// The mode structure for duplex sponges.

--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -15,12 +15,11 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::poseidon::{
-    helpers::{AlgebraicSponge, DefaultCapacityAlgebraicSponge, DuplexSpongeMode},
+    helpers::{AlgebraicSponge, DuplexSpongeMode},
     State,
 };
 use snarkvm_fields::{PoseidonParameters, PrimeField};
 
-use anyhow::Result;
 use smallvec::SmallVec;
 use std::sync::Arc;
 
@@ -38,12 +37,6 @@ pub struct PoseidonSponge<F: PrimeField, const RATE: usize, const CAPACITY: usiz
     state: State<F, RATE, CAPACITY>,
     /// Current mode (whether its absorbing or squeezing)
     pub(in crate::poseidon) mode: DuplexSpongeMode,
-}
-
-impl<F: PrimeField, const RATE: usize> DefaultCapacityAlgebraicSponge<F, RATE> for PoseidonSponge<F, RATE, 1> {
-    fn sample_parameters() -> Result<Arc<PoseidonParameters<F, RATE, 1>>> {
-        Ok(Arc::new(F::default_poseidon_parameters::<RATE>()?))
-    }
 }
 
 impl<F: PrimeField, const RATE: usize, const CAPACITY: usize> AlgebraicSponge<F, RATE, CAPACITY>
@@ -216,10 +209,7 @@ impl<F: PrimeField, const RATE: usize, const CAPACITY: usize> PoseidonSponge<F, 
                 debug_assert_eq!(
                     chunk.len(),
                     self.state.rate_state(range.clone()).len(),
-                    "failed with squeeze {} at rate {} and rate_start {}",
-                    output_size,
-                    RATE,
-                    rate_start
+                    "Failed to squeeze {output_size} at rate {RATE} & rate_start {rate_start}"
                 );
                 chunk.copy_from_slice(self.state.rate_state(range));
                 // Are we in the last chunk?

--- a/console/algorithms/src/poseidon/mod.rs
+++ b/console/algorithms/src/poseidon/mod.rs
@@ -44,8 +44,8 @@ pub struct Poseidon<F: PrimeField, const RATE: usize> {
 
 impl<F: PrimeField, const RATE: usize> Poseidon<F, RATE> {
     /// Initializes a new instance of Poseidon.
-    pub fn setup() -> Self {
-        Self { parameters: Arc::new(F::default_poseidon_parameters::<RATE>().unwrap()) }
+    pub fn setup() -> Result<Self> {
+        Ok(Self { parameters: Arc::new(F::default_poseidon_parameters::<RATE>()?) })
     }
 }
 

--- a/console/algorithms/src/poseidon/mod.rs
+++ b/console/algorithms/src/poseidon/mod.rs
@@ -24,7 +24,7 @@ mod prf;
 use crate::{poseidon::helpers::*, Hash, HashMany, HashToScalar, PRF};
 use snarkvm_fields::{PoseidonParameters, PrimeField};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, ensure, Result};
 use std::sync::Arc;
 
 const CAPACITY: usize = 1;
@@ -38,14 +38,34 @@ pub type Poseidon8<F> = Poseidon<F, 8>;
 
 #[derive(Clone)]
 pub struct Poseidon<F: PrimeField, const RATE: usize> {
+    /// The domain separator for the Poseidon hash function.
+    domain: F,
     /// The Poseidon parameters for hashing.
     parameters: Arc<PoseidonParameters<F, RATE, CAPACITY>>,
 }
 
 impl<F: PrimeField, const RATE: usize> Poseidon<F, RATE> {
     /// Initializes a new instance of Poseidon.
-    pub fn setup() -> Result<Self> {
-        Ok(Self { parameters: Arc::new(F::default_poseidon_parameters::<RATE>()?) })
+    pub fn setup(domain: &str) -> Result<Self> {
+        // Ensure the given domain is within the allowed size in bits.
+        let num_bits = domain.len().saturating_mul(8);
+        let max_bits = F::size_in_data_bits();
+        ensure!(num_bits <= max_bits, "Domain cannot exceed {max_bits} bits, found {num_bits} bits");
+
+        Ok(Self {
+            domain: F::from_bytes_be_mod_order(domain.as_bytes()),
+            parameters: Arc::new(F::default_poseidon_parameters::<RATE>()?),
+        })
+    }
+
+    /// Returns the domain separator for the hash function.
+    pub fn domain(&self) -> F {
+        self.domain
+    }
+
+    /// Returns the Poseidon parameters for hashing.
+    pub fn parameters(&self) -> &Arc<PoseidonParameters<F, RATE, CAPACITY>> {
+        &self.parameters
     }
 }
 

--- a/console/algorithms/src/poseidon/prf.rs
+++ b/console/algorithms/src/poseidon/prf.rs
@@ -23,10 +23,9 @@ impl<F: PrimeField, const RATE: usize> PRF for Poseidon<F, RATE> {
 
     #[inline]
     fn prf(&self, seed: &Self::Seed, input: &[Self::Input]) -> Result<Self::Output> {
-        // Construct the preimage: seed || length(input) || input.
-        let mut preimage = Vec::with_capacity(2 + input.len());
+        // Construct the preimage: seed || input.
+        let mut preimage = Vec::with_capacity(1 + input.len());
         preimage.push(*seed);
-        preimage.push(F::from(input.len() as u128)); // Input length.
         preimage.extend_from_slice(input);
 
         // Hash the preimage to derive the PRF output.

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -61,11 +61,11 @@ thread_local! {
     pub static PEDERSEN_128: Pedersen128<<Testnet3 as Network>::Affine> = Pedersen128::<<Testnet3 as Network>::Affine>::setup("AleoPedersen128");
 
     /// The Poseidon hash function, using a rate of 2.
-    pub static POSEIDON_2: Poseidon2<<Testnet3 as Network>::Field> = Poseidon2::<<Testnet3 as Network>::Field>::setup().expect("Failed to setup Poseidon2");
+    pub static POSEIDON_2: Poseidon2<<Testnet3 as Network>::Field> = Poseidon2::<<Testnet3 as Network>::Field>::setup("AleoPoseidon2").expect("Failed to setup Poseidon2");
     /// The Poseidon hash function, using a rate of 4.
-    pub static POSEIDON_4: Poseidon4<<Testnet3 as Network>::Field> = Poseidon4::<<Testnet3 as Network>::Field>::setup().expect("Failed to setup Poseidon4");
+    pub static POSEIDON_4: Poseidon4<<Testnet3 as Network>::Field> = Poseidon4::<<Testnet3 as Network>::Field>::setup("AleoPoseidon4").expect("Failed to setup Poseidon4");
     /// The Poseidon hash function, using a rate of 8.
-    pub static POSEIDON_8: Poseidon8<<Testnet3 as Network>::Field> = Poseidon8::<<Testnet3 as Network>::Field>::setup().expect("Failed to setup Poseidon8");
+    pub static POSEIDON_8: Poseidon8<<Testnet3 as Network>::Field> = Poseidon8::<<Testnet3 as Network>::Field>::setup("AleoPoseidon8").expect("Failed to setup Poseidon8");
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -61,11 +61,11 @@ thread_local! {
     pub static PEDERSEN_128: Pedersen128<<Testnet3 as Network>::Affine> = Pedersen128::<<Testnet3 as Network>::Affine>::setup("AleoPedersen128");
 
     /// The Poseidon hash function, using a rate of 2.
-    pub static POSEIDON_2: Poseidon2<<Testnet3 as Network>::Field> = Poseidon2::<<Testnet3 as Network>::Field>::setup();
+    pub static POSEIDON_2: Poseidon2<<Testnet3 as Network>::Field> = Poseidon2::<<Testnet3 as Network>::Field>::setup().expect("Failed to setup Poseidon2");
     /// The Poseidon hash function, using a rate of 4.
-    pub static POSEIDON_4: Poseidon4<<Testnet3 as Network>::Field> = Poseidon4::<<Testnet3 as Network>::Field>::setup();
+    pub static POSEIDON_4: Poseidon4<<Testnet3 as Network>::Field> = Poseidon4::<<Testnet3 as Network>::Field>::setup().expect("Failed to setup Poseidon4");
     /// The Poseidon hash function, using a rate of 8.
-    pub static POSEIDON_8: Poseidon8<<Testnet3 as Network>::Field> = Poseidon8::<<Testnet3 as Network>::Field>::setup();
+    pub static POSEIDON_8: Poseidon8<<Testnet3 as Network>::Field> = Poseidon8::<<Testnet3 as Network>::Field>::setup().expect("Failed to setup Poseidon8");
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/console/program/src/merkle_tree/tests.rs
+++ b/console/program/src/merkle_tree/tests.rs
@@ -422,8 +422,8 @@ fn test_merkle_tree_poseidon() -> Result<()> {
         type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
         type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-        let leaf_hasher = LH::setup();
-        let path_hasher = PH::setup();
+        let leaf_hasher = LH::setup()?;
+        let path_hasher = PH::setup()?;
 
         let create_leaves =
             |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
@@ -492,8 +492,8 @@ fn test_merkle_tree_depth_2_poseidon() -> Result<()> {
     type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
     type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-    let leaf_hasher = LH::setup();
-    let path_hasher = PH::setup();
+    let leaf_hasher = LH::setup()?;
+    let path_hasher = PH::setup()?;
     let create_leaves =
         |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
 
@@ -530,8 +530,8 @@ fn test_merkle_tree_depth_3_poseidon() -> Result<()> {
     type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
     type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-    let leaf_hasher = LH::setup();
-    let path_hasher = PH::setup();
+    let leaf_hasher = LH::setup()?;
+    let path_hasher = PH::setup()?;
     let create_leaves =
         |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
 
@@ -573,8 +573,8 @@ fn test_merkle_tree_depth_4_poseidon() -> Result<()> {
     type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
     type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-    let leaf_hasher = LH::setup();
-    let path_hasher = PH::setup();
+    let leaf_hasher = LH::setup()?;
+    let path_hasher = PH::setup()?;
     let create_leaves =
         |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
 

--- a/console/program/src/merkle_tree/tests.rs
+++ b/console/program/src/merkle_tree/tests.rs
@@ -422,8 +422,8 @@ fn test_merkle_tree_poseidon() -> Result<()> {
         type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
         type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-        let leaf_hasher = LH::setup()?;
-        let path_hasher = PH::setup()?;
+        let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+        let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
 
         let create_leaves =
             |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
@@ -492,8 +492,8 @@ fn test_merkle_tree_depth_2_poseidon() -> Result<()> {
     type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
     type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-    let leaf_hasher = LH::setup()?;
-    let path_hasher = PH::setup()?;
+    let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+    let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
     let create_leaves =
         |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
 
@@ -530,8 +530,8 @@ fn test_merkle_tree_depth_3_poseidon() -> Result<()> {
     type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
     type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-    let leaf_hasher = LH::setup()?;
-    let path_hasher = PH::setup()?;
+    let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+    let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
     let create_leaves =
         |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
 
@@ -573,8 +573,8 @@ fn test_merkle_tree_depth_4_poseidon() -> Result<()> {
     type LH = Poseidon<<CurrentNetwork as Network>::Field, 4>;
     type PH = Poseidon<<CurrentNetwork as Network>::Field, 2>;
 
-    let leaf_hasher = LH::setup()?;
-    let path_hasher = PH::setup()?;
+    let leaf_hasher = LH::setup("AleoMerkleTreeTest0")?;
+    let path_hasher = PH::setup("AleoMerkleTreeTest1")?;
     let create_leaves =
         |num_leaves| (0..num_leaves).map(|_| vec![UniformRand::rand(&mut test_rng())]).collect::<Vec<_>>();
 


### PR DESCRIPTION
## Motivation

Updates Poseidon to include a domain separate and input length on all methods: `hash`, `hash_many`, `hash_to_scalar`, `prf`.

### Design

The format for hashes is:
```
POSEIDON.HASH( [ DOMAIN || LENGTH(INPUT) || [0; RATE-2] || INPUT ] )
```

The format for PRFs is:
```
POSEIDON.PRF( [ DOMAIN || LENGTH(INPUT) || [0; RATE-2] || SEED || INPUT ] )
```

### Example

```rs
fn hash_many(&self, input: &[Self::Input], num_outputs: u16) -> Vec<Self::Output> {
    // Construct the preimage: [ DOMAIN || LENGTH(INPUT) || [0; RATE-2] || INPUT ].
    let mut preimage = Vec::with_capacity(RATE + input.len());
    preimage.push(self.domain);
    preimage.push(F::from(input.len() as u128));
    preimage.extend(&vec![F::zero(); RATE - 2]); // Pad up to RATE.
    preimage.extend_from_slice(input);

    let mut sponge = PoseidonSponge::<F, RATE, CAPACITY>::new(&self.parameters);
    sponge.absorb(&preimage);
    sponge.squeeze(num_outputs).to_vec()
}
```