### PR TITLE
Update the record ID and commitment computation

### DIFF
--- a/circuit/program/src/record/decrypt.rs
+++ b/circuit/program/src/record/decrypt.rs
@@ -54,6 +54,6 @@ impl<A: Aleo> Record<A> {
         A::assert_eq(&self.bcm, &candidate_bcm);
 
         // Output the state.
-        State::from((self.program.clone(), owner, balance, self.data.clone(), self.nonce.clone()))
+        State::from((self.program.clone(), self.process.clone(), owner, balance, self.data.clone(), self.nonce.clone()))
     }
 }

--- a/circuit/program/src/record/encrypt.rs
+++ b/circuit/program/src/record/encrypt.rs
@@ -50,6 +50,7 @@ impl<A: Aleo> Record<A> {
 
         Self {
             program: state.program().clone(),
+            process: state.process().clone(),
             owner,
             balance,
             data: state.data().clone(),

--- a/circuit/program/src/record/mod.rs
+++ b/circuit/program/src/record/mod.rs
@@ -33,6 +33,8 @@ use snarkvm_circuit_types::{environment::prelude::*, Address, Boolean, Field, Gr
 pub struct Record<A: Aleo> {
     /// The program this record belongs to.
     program: Field<A>,
+    /// The process this record corresponds to.
+    process: Field<A>,
     /// The **encrypted** address this record belongs to (i.e. `owner + HashMany(G^r^view_key, 2)[0]`).
     owner: Field<A>,
     /// The **encrypted** balance in this record (i.e. `balance.to_field() + HashMany(G^r^view_key, 2)[1]`).

--- a/circuit/program/src/record/to_id.rs
+++ b/circuit/program/src/record/to_id.rs
@@ -19,10 +19,19 @@ use super::*;
 impl<A: Aleo> Record<A> {
     /// Returns the record ID.
     pub fn to_id(&self) -> Field<A> {
-        // TODO (howardwu): Abstraction - add support for a custom BHP hash size.
         // Compute the BHP hash of the program state.
-        let left = A::hash_bhp1024(&[&self.program, &self.owner, &self.balance, &self.data].to_bits_le());
-        let right = A::hash_bhp1024(&[&self.nonce.to_x_coordinate(), &self.mac, &self.bcm].to_bits_le());
-        A::hash_bhp512(&[&left, &right].to_bits_le())
+        A::hash_bhp1024(
+            &[
+                &self.program,
+                &self.process,
+                &self.owner,
+                &self.balance,
+                &self.data,
+                &self.nonce.to_x_coordinate(),
+                &self.mac,
+                &self.bcm,
+            ]
+            .to_bits_le(),
+        )
     }
 }

--- a/circuit/program/src/state/mod.rs
+++ b/circuit/program/src/state/mod.rs
@@ -32,6 +32,8 @@ use snarkvm_circuit_types::{environment::prelude::*, Address, Field, Group, Scal
 pub struct State<A: Aleo> {
     /// The program this state belongs to.
     program: Field<A>,
+    /// The process this state corresponds to.
+    process: Field<A>,
     /// The Aleo address this state belongs to.
     owner: Address<A>,
     /// The account balance in this program state.
@@ -42,10 +44,12 @@ pub struct State<A: Aleo> {
     nonce: Group<A>,
 }
 
-impl<A: Aleo> From<(Field<A>, Address<A>, U64<A>, Field<A>, Group<A>)> for State<A> {
+impl<A: Aleo> From<(Field<A>, Field<A>, Address<A>, U64<A>, Field<A>, Group<A>)> for State<A> {
     /// Initializes a new `State` from the given parameters.
-    fn from((program, owner, balance, data, nonce): (Field<A>, Address<A>, U64<A>, Field<A>, Group<A>)) -> Self {
-        Self { program, owner, balance, data, nonce }
+    fn from(
+        (program, process, owner, balance, data, nonce): (Field<A>, Field<A>, Address<A>, U64<A>, Field<A>, Group<A>),
+    ) -> Self {
+        Self { program, process, owner, balance, data, nonce }
     }
 }
 
@@ -53,6 +57,11 @@ impl<A: Aleo> State<A> {
     /// Returns the program ID.
     pub fn program(&self) -> &Field<A> {
         &self.program
+    }
+
+    /// Returns the process ID.
+    pub fn process(&self) -> &Field<A> {
+        &self.process
     }
 
     /// Returns the account owner.

--- a/circuit/program/src/state/to_commitment.rs
+++ b/circuit/program/src/state/to_commitment.rs
@@ -23,10 +23,9 @@ impl<A: Aleo> State<A> {
         let owner = self.owner.to_field();
         // Convert the balance into a field element.
         let balance = self.balance.to_field();
-        // TODO (howardwu): Abstraction - add support for a custom BHP hash size.
         // Compute the BHP hash of the program state.
-        let left = A::hash_bhp1024(&[&self.program, &owner, &balance, &self.data].to_bits_le());
-        let right = A::hash_bhp1024(&[&self.nonce].to_bits_le());
-        A::hash_bhp512(&[&left, &right].to_bits_le())
+        A::hash_bhp512(
+            &[&self.program, &self.process, &owner, &balance, &self.data, &self.nonce.to_x_coordinate()].to_bits_le(),
+        )
     }
 }

--- a/circuit/program/src/state/to_commitment.rs
+++ b/circuit/program/src/state/to_commitment.rs
@@ -24,7 +24,7 @@ impl<A: Aleo> State<A> {
         // Convert the balance into a field element.
         let balance = self.balance.to_field();
         // Compute the BHP hash of the program state.
-        A::hash_bhp512(
+        A::hash_bhp1024(
             &[&self.program, &self.process, &owner, &balance, &self.data, &self.nonce.to_x_coordinate()].to_bits_le(),
         )
     }

--- a/console/program/src/record/mod.rs
+++ b/console/program/src/record/mod.rs
@@ -60,7 +60,6 @@ impl<N: Network> Record<N> {
     pub fn to_id(&self, program: &N::Field, process: &N::Field) -> Result<N::Field> {
         // Retrieve the x-coordinate of the nonce.
         let nonce = self.nonce.to_x_coordinate();
-        // TODO (howardwu): Abstraction - add support for a custom BHP hash size.
         // Compute the BHP hash of the program state.
         N::hash_bhp1024(
             &[*program, *process, self.owner, self.balance, self.data.to_id()?, nonce, self.mac, self.bcm].to_bits_le(),

--- a/console/program/src/record/mod.rs
+++ b/console/program/src/record/mod.rs
@@ -62,7 +62,7 @@ impl<N: Network> Record<N> {
         let nonce = self.nonce.to_x_coordinate();
         // TODO (howardwu): Abstraction - add support for a custom BHP hash size.
         // Compute the BHP hash of the program state.
-        N::hash_bhp512(
+        N::hash_bhp1024(
             &[*program, *process, self.owner, self.balance, self.data.to_id()?, nonce, self.mac, self.bcm].to_bits_le(),
         )
     }

--- a/console/program/src/record/mod.rs
+++ b/console/program/src/record/mod.rs
@@ -62,9 +62,9 @@ impl<N: Network> Record<N> {
         let nonce = self.nonce.to_x_coordinate();
         // TODO (howardwu): Abstraction - add support for a custom BHP hash size.
         // Compute the BHP hash of the program state.
-        let left = N::hash_bhp1024(&[*program, *process, self.owner, self.balance].to_bits_le())?;
-        let right = N::hash_bhp1024(&[self.data.to_id()?, nonce, self.mac, self.bcm].to_bits_le())?;
-        N::hash_bhp512(&[left, right].to_bits_le())
+        N::hash_bhp512(
+            &[*program, *process, self.owner, self.balance, self.data.to_id()?, nonce, self.mac, self.bcm].to_bits_le(),
+        )
     }
 
     /// Initializes a new record by encrypting the given state with a given randomizer.

--- a/console/program/src/state/mod.rs
+++ b/console/program/src/state/mod.rs
@@ -61,11 +61,8 @@ impl<N: Network> State<N> {
         let balance = N::Field::from(self.balance as u128);
         // Retrieve the x-coordinate of the nonce.
         let nonce = self.nonce.to_x_coordinate();
-        // TODO (howardwu): Abstraction - add support for a custom BHP hash size.
         // Compute the BHP hash of the program state.
-        let left = N::hash_bhp1024(&[program, process, owner, balance].to_bits_le())?;
-        let right = N::hash_bhp1024(&[data, nonce].to_bits_le())?;
-        N::hash_bhp512(&[left, right].to_bits_le())
+        N::hash_bhp1024(&[program, process, owner, balance, data, nonce].to_bits_le())
     }
 
     /// Returns the account owner.


### PR DESCRIPTION
## Motivation

Update the record ID and commitment computation.

With BHP now supporting variable-length inputs, these TODOs have been resolved.