### PR TITLE
Adds `Inject` and `Eject` to account circuits, adds additional account derivation

### DIFF
--- a/circuit/account/src/compute_key/from_private_key.rs
+++ b/circuit/account/src/compute_key/from_private_key.rs
@@ -57,21 +57,12 @@ mod tests {
             // Generate a private key, compute key, view key, and address.
             let (private_key, compute_key, _view_key, _address) = generate_account()?;
 
-            // Retrieve the native compute key components.
-            let pk_sig = compute_key.pk_sig();
-            let pr_sig = compute_key.pr_sig();
-            let pk_vrf = compute_key.pk_vrf();
-            let sk_prf = compute_key.sk_prf();
-
             // Initialize the private key.
             let private_key = PrivateKey::<Circuit>::new(mode, private_key);
 
             Circuit::scope(&format!("{} {}", mode, i), || {
                 let candidate = ComputeKey::from_private_key(&private_key);
-                assert_eq!(pk_sig, candidate.pk_sig().eject_value());
-                assert_eq!(pr_sig, candidate.pr_sig().eject_value());
-                assert_eq!(pk_vrf, candidate.pk_vrf().eject_value());
-                assert_eq!(sk_prf, candidate.sk_prf().eject_value());
+                assert_eq!(compute_key, candidate.eject_value());
 
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
                 if i > 0 {

--- a/circuit/account/src/compute_key/from_private_key.rs
+++ b/circuit/account/src/compute_key/from_private_key.rs
@@ -63,7 +63,6 @@ mod tests {
             Circuit::scope(&format!("{} {}", mode, i), || {
                 let candidate = ComputeKey::from_private_key(&private_key);
                 assert_eq!(compute_key, candidate.eject_value());
-
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
                 if i > 0 {
                     assert_scope!(<=num_constants, num_public, num_private, num_constraints);

--- a/circuit/account/src/compute_key/from_private_key.rs
+++ b/circuit/account/src/compute_key/from_private_key.rs
@@ -57,11 +57,6 @@ mod tests {
             // Generate a private key, compute key, view key, and address.
             let (private_key, compute_key, _view_key, _address) = generate_account()?;
 
-            // Retrieve the native private key components.
-            let sk_sig = private_key.sk_sig();
-            let r_sig = private_key.r_sig();
-            let sk_vrf = private_key.sk_vrf();
-
             // Retrieve the native compute key components.
             let pk_sig = compute_key.pk_sig();
             let pr_sig = compute_key.pr_sig();
@@ -69,7 +64,7 @@ mod tests {
             let sk_prf = compute_key.sk_prf();
 
             // Initialize the private key.
-            let private_key = PrivateKey::<Circuit>::new(mode, (sk_sig, r_sig, sk_vrf));
+            let private_key = PrivateKey::<Circuit>::new(mode, private_key);
 
             Circuit::scope(&format!("{} {}", mode, i), || {
                 let candidate = ComputeKey::from_private_key(&private_key);

--- a/circuit/account/src/compute_key/mod.rs
+++ b/circuit/account/src/compute_key/mod.rs
@@ -14,14 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod from_private_key;
+mod from_private_key;
+mod to_address;
 
 #[cfg(test)]
 use snarkvm_circuit_types::environment::assert_scope;
 
 use crate::PrivateKey;
 use snarkvm_circuit_network::Aleo;
-use snarkvm_circuit_types::{environment::prelude::*, Group, Scalar};
+use snarkvm_circuit_types::{environment::prelude::*, Address, Group, Scalar};
 
 pub struct ComputeKey<A: Aleo> {
     /// The signature public key `pk_sig` := G^sk_sig.

--- a/circuit/account/src/compute_key/to_address.rs
+++ b/circuit/account/src/compute_key/to_address.rs
@@ -1,0 +1,79 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+impl<A: Aleo> ComputeKey<A> {
+    /// Returns the account address for this account compute key.
+    pub fn to_address(&self) -> Address<A> {
+        // Compute pk_prf := G^sk_prf.
+        let pk_prf = A::g_scalar_multiply(&self.sk_prf);
+        // Compute the address := pk_sig + pr_sig + pk_prf.
+        Address::from_group(&self.pk_sig + &self.pr_sig + pk_prf)
+    }
+}
+
+#[cfg(all(test, console))]
+mod tests {
+    use super::*;
+    use crate::{helpers::generate_account, Circuit};
+
+    use anyhow::Result;
+
+    const ITERATIONS: u64 = 100;
+
+    fn check_to_address(
+        mode: Mode,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+    ) -> Result<()> {
+        for i in 0..ITERATIONS {
+            // Generate a private key, compute key, view key, and address.
+            let (_private_key, compute_key, _view_key, address) = generate_account()?;
+
+            // Initialize the compute key.
+            let candidate = ComputeKey::<Circuit>::new(mode, compute_key);
+
+            Circuit::scope(&format!("{} {}", mode, i), || {
+                let candidate = candidate.to_address();
+                assert_eq!(*address, candidate.to_group().eject_value());
+                // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
+                if i > 0 {
+                    assert_scope!(<=num_constants, num_public, num_private, num_constraints);
+                }
+            });
+            Circuit::reset();
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_address_constant() -> Result<()> {
+        check_to_address(Mode::Constant, 1004, 0, 0, 0)
+    }
+
+    #[test]
+    fn test_to_address_public() -> Result<()> {
+        check_to_address(Mode::Public, 504, 0, 1260, 1260)
+    }
+
+    #[test]
+    fn test_to_address_private() -> Result<()> {
+        check_to_address(Mode::Private, 504, 0, 1260, 1260)
+    }
+}

--- a/circuit/account/src/private_key/mod.rs
+++ b/circuit/account/src/private_key/mod.rs
@@ -34,27 +34,31 @@ pub struct PrivateKey<A: Aleo> {
 
 #[cfg(console)]
 impl<A: Aleo> Inject for PrivateKey<A> {
-    type Primitive = (A::ScalarField, A::ScalarField, A::ScalarField);
+    type Primitive = console::PrivateKey<A::Network>;
 
-    /// Initializes an account private key from the given mode and `(sk_sig, r_sig, sk_vrf)`.
-    fn new(mode: Mode, (sk_sig, r_sig, sk_vrf): Self::Primitive) -> Self {
-        Self { sk_sig: Scalar::new(mode, sk_sig), r_sig: Scalar::new(mode, r_sig), sk_vrf: Scalar::new(mode, sk_vrf) }
+    /// Initializes an account private key from the given mode and native private key.
+    fn new(mode: Mode, private_key: Self::Primitive) -> Self {
+        Self {
+            sk_sig: Scalar::new(mode, private_key.sk_sig()),
+            r_sig: Scalar::new(mode, private_key.r_sig()),
+            sk_vrf: Scalar::new(mode, private_key.sk_vrf()),
+        }
     }
 }
 
 impl<A: Aleo> PrivateKey<A> {
     /// Returns the signature secret key.
-    pub fn sk_sig(&self) -> &Scalar<A> {
+    pub const fn sk_sig(&self) -> &Scalar<A> {
         &self.sk_sig
     }
 
     /// Returns the signature randomizer.
-    pub fn r_sig(&self) -> &Scalar<A> {
+    pub const fn r_sig(&self) -> &Scalar<A> {
         &self.r_sig
     }
 
     /// Returns the VRF secret key.
-    pub fn sk_vrf(&self) -> &Scalar<A> {
+    pub const fn sk_vrf(&self) -> &Scalar<A> {
         &self.sk_vrf
     }
 }
@@ -63,17 +67,65 @@ impl<A: Aleo> PrivateKey<A> {
 impl<A: Aleo> Eject for PrivateKey<A> {
     type Primitive = (A::ScalarField, A::ScalarField, A::ScalarField);
 
-    ///
     /// Ejects the mode of the account private key.
-    ///
     fn eject_mode(&self) -> Mode {
         (&self.sk_sig, &self.r_sig, &self.sk_vrf).eject_mode()
     }
 
-    ///
     /// Ejects the account private key as `(sk_sig, r_sig, sk_vrf)`.
-    ///
     fn eject_value(&self) -> Self::Primitive {
         (&self.sk_sig, &self.r_sig, &self.sk_vrf).eject_value()
+    }
+}
+
+#[cfg(all(test, console))]
+mod tests {
+    use super::*;
+    use crate::{helpers::generate_account, Circuit};
+
+    use anyhow::Result;
+
+    const ITERATIONS: u64 = 1000;
+
+    fn check_new(
+        mode: Mode,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+    ) -> Result<()> {
+        for _ in 0..ITERATIONS {
+            // Generate a private key, compute key, view key, and address.
+            let (private_key, _compute_key, _view_key, _address) = generate_account()?;
+
+            // Retrieve the native private key components.
+            let sk_sig = private_key.sk_sig();
+            let r_sig = private_key.r_sig();
+            let sk_vrf = private_key.sk_vrf();
+
+            Circuit::scope(format!("New {mode}"), || {
+                let candidate = PrivateKey::<Circuit>::new(mode, private_key);
+                assert_eq!(mode, candidate.eject_mode());
+                assert_eq!((sk_sig, r_sig, sk_vrf), candidate.eject_value());
+                assert_scope!(num_constants, num_public, num_private, num_constraints);
+            });
+            Circuit::reset();
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_view_key_new_constant() -> Result<()> {
+        check_new(Mode::Constant, 753, 0, 0, 0)
+    }
+
+    #[test]
+    fn test_view_key_new_public() -> Result<()> {
+        check_new(Mode::Public, 0, 753, 0, 753)
+    }
+
+    #[test]
+    fn test_view_key_new_private() -> Result<()> {
+        check_new(Mode::Private, 0, 0, 753, 753)
     }
 }

--- a/circuit/account/src/private_key/mod.rs
+++ b/circuit/account/src/private_key/mod.rs
@@ -15,11 +15,12 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 mod to_compute_key;
+mod to_view_key;
 
 #[cfg(test)]
 use snarkvm_circuit_types::environment::assert_scope;
 
-use crate::ComputeKey;
+use crate::{ComputeKey, ViewKey};
 use snarkvm_circuit_network::Aleo;
 use snarkvm_circuit_types::{environment::prelude::*, Scalar};
 

--- a/circuit/account/src/private_key/mod.rs
+++ b/circuit/account/src/private_key/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod to_compute_key;
+mod to_compute_key;
 
 #[cfg(test)]
 use snarkvm_circuit_types::environment::assert_scope;

--- a/circuit/account/src/private_key/to_compute_key.rs
+++ b/circuit/account/src/private_key/to_compute_key.rs
@@ -43,22 +43,12 @@ mod tests {
             // Generate a private key, compute key, view key, and address.
             let (private_key, compute_key, _view_key, _address) = generate_account()?;
 
-            // Retrieve the native compute key components.
-            let pk_sig = compute_key.pk_sig();
-            let pr_sig = compute_key.pr_sig();
-            let pk_vrf = compute_key.pk_vrf();
-            let sk_prf = compute_key.sk_prf();
-
             // Initialize the private key.
             let candidate = PrivateKey::<Circuit>::new(mode, private_key);
 
             Circuit::scope(&format!("{} {}", mode, i), || {
                 let candidate = candidate.to_compute_key();
-                assert_eq!(pk_sig, candidate.pk_sig().eject_value());
-                assert_eq!(pr_sig, candidate.pr_sig().eject_value());
-                assert_eq!(pk_vrf, candidate.pk_vrf().eject_value());
-                assert_eq!(sk_prf, candidate.sk_prf().eject_value());
-
+                assert_eq!(compute_key, candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
                 if i > 0 {
                     assert_scope!(<=num_constants, num_public, num_private, num_constraints);

--- a/circuit/account/src/private_key/to_compute_key.rs
+++ b/circuit/account/src/private_key/to_compute_key.rs
@@ -43,11 +43,6 @@ mod tests {
             // Generate a private key, compute key, view key, and address.
             let (private_key, compute_key, _view_key, _address) = generate_account()?;
 
-            // Retrieve the native private key components.
-            let sk_sig = private_key.sk_sig();
-            let r_sig = private_key.r_sig();
-            let sk_vrf = private_key.sk_vrf();
-
             // Retrieve the native compute key components.
             let pk_sig = compute_key.pk_sig();
             let pr_sig = compute_key.pr_sig();
@@ -55,7 +50,7 @@ mod tests {
             let sk_prf = compute_key.sk_prf();
 
             // Initialize the private key.
-            let candidate = PrivateKey::<Circuit>::new(mode, (sk_sig, r_sig, sk_vrf));
+            let candidate = PrivateKey::<Circuit>::new(mode, private_key);
 
             Circuit::scope(&format!("{} {}", mode, i), || {
                 let candidate = candidate.to_compute_key();

--- a/circuit/account/src/signature/mod.rs
+++ b/circuit/account/src/signature/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod verify;
+mod verify;
 
 #[cfg(test)]
 use snarkvm_circuit_types::environment::assert_scope;

--- a/circuit/account/src/signature/mod.rs
+++ b/circuit/account/src/signature/mod.rs
@@ -34,30 +34,30 @@ pub struct Signature<A: Aleo> {
 
 #[cfg(console)]
 impl<A: Aleo> Inject for Signature<A> {
-    type Primitive = (A::ScalarField, A::ScalarField, (A::Affine, A::Affine, A::Affine));
+    type Primitive = console::Signature<A::Network>;
 
-    /// Initializes a signature from the given mode and `(challenge, response, (pk_sig, pr_sig, pk_vrf))`.
-    fn new(mode: Mode, (challenge, response, (pk_sig, pr_sig, pk_vrf)): Self::Primitive) -> Signature<A> {
+    /// Initializes a signature from the given mode and native signature.
+    fn new(mode: Mode, signature: Self::Primitive) -> Signature<A> {
         Self {
-            challenge: Scalar::new(mode, challenge),
-            response: Scalar::new(mode, response),
-            compute_key: ComputeKey::new(mode, (pk_sig, pr_sig, pk_vrf)),
+            challenge: Scalar::new(mode, signature.challenge()),
+            response: Scalar::new(mode, signature.response()),
+            compute_key: ComputeKey::new(mode, signature.compute_key()),
         }
     }
 }
 
 #[cfg(console)]
 impl<A: Aleo> Eject for Signature<A> {
-    type Primitive = (A::ScalarField, A::ScalarField, (A::Affine, A::Affine, A::Affine, A::ScalarField));
+    type Primitive = console::Signature<A::Network>;
 
     /// Ejects the mode of the signature.
     fn eject_mode(&self) -> Mode {
         (&self.challenge, &self.response, &self.compute_key).eject_mode()
     }
 
-    /// Ejects the signature as `(challenge, response, (pk_sig, pr_sig, pk_vrf, sk_prf))`.
+    /// Ejects the signature.
     fn eject_value(&self) -> Self::Primitive {
-        (&self.challenge, &self.response, &self.compute_key).eject_value()
+        Self::Primitive::from((&self.challenge, &self.response, &self.compute_key).eject_value())
     }
 }
 
@@ -79,13 +79,7 @@ mod tests {
         num_constraints: u64,
     ) -> Result<()> {
         // Generate a private key, compute key, view key, and address.
-        let (private_key, compute_key, _view_key, _address) = generate_account()?;
-
-        // Retrieve the native compute key components.
-        let pk_sig = compute_key.pk_sig();
-        let pr_sig = compute_key.pr_sig();
-        let pk_vrf = compute_key.pk_vrf();
-        let sk_prf = compute_key.sk_prf();
+        let (private_key, _compute_key, _view_key, _address) = generate_account()?;
 
         for i in 0..ITERATIONS {
             // Generate a signature.
@@ -93,13 +87,9 @@ mod tests {
             let randomizer = UniformRand::rand(&mut test_crypto_rng());
             let signature = console::Signature::sign(&private_key, &message.as_bytes().to_bits_le(), randomizer)?;
 
-            // Retrieve the challenge and response.
-            let challenge = signature.challenge();
-            let response = signature.response();
-
             Circuit::scope(format!("New {mode}"), || {
-                let candidate = Signature::<Circuit>::new(mode, (challenge, response, (pk_sig, pr_sig, pk_vrf)));
-                assert_eq!((challenge, response, (pk_sig, pr_sig, pk_vrf, sk_prf)), candidate.eject_value());
+                let candidate = Signature::<Circuit>::new(mode, signature);
+                assert_eq!(signature, candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
                 if i > 0 {
                     assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/account/src/signature/verify.rs
+++ b/circuit/account/src/signature/verify.rs
@@ -77,12 +77,7 @@ pub(crate) mod tests {
     ) -> Result<()> {
         for i in 0..ITERATIONS {
             // Generate a private key, compute key, view key, and address.
-            let (private_key, compute_key, _view_key, address) = generate_account()?;
-
-            // Retrieve the native compute key components.
-            let pk_sig = compute_key.pk_sig();
-            let pr_sig = compute_key.pr_sig();
-            let pk_vrf = compute_key.pk_vrf();
+            let (private_key, _compute_key, _view_key, address) = generate_account()?;
 
             // Sample a random message.
             let rng = &mut test_rng();
@@ -101,12 +96,8 @@ pub(crate) mod tests {
             let randomizer = UniformRand::rand(&mut test_crypto_rng());
             let signature = console::Signature::sign(&private_key, &message.eject_value(), randomizer)?;
 
-            // Retrieve the challenge and response.
-            let challenge = signature.challenge();
-            let response = signature.response();
-
             // Initialize the signature and address.
-            let signature = Signature::<Circuit>::new(mode, (challenge, response, (pk_sig, pr_sig, pk_vrf)));
+            let signature = Signature::<Circuit>::new(mode, signature);
             let address = Address::new(mode, *address);
 
             Circuit::scope(&format!("{} {}", mode, i), || {

--- a/circuit/account/src/view_key/from_private_key.rs
+++ b/circuit/account/src/view_key/from_private_key.rs
@@ -16,13 +16,13 @@
 
 use super::*;
 
-impl<A: Aleo> ComputeKey<A> {
-    /// Returns the account address for this account compute key.
-    pub fn to_address(&self) -> Address<A> {
-        // Compute pk_prf := G^sk_prf.
-        let pk_prf = A::g_scalar_multiply(&self.sk_prf);
-        // Compute the address := pk_sig + pr_sig + pk_prf.
-        Address::from_group(&self.pk_sig + &self.pr_sig + pk_prf)
+impl<A: Aleo> ViewKey<A> {
+    /// Returns the account view key for this account private key.
+    pub fn from_private_key(private_key: &PrivateKey<A>) -> Self {
+        // Derive the compute key.
+        let compute_key = private_key.to_compute_key();
+        // Compute view_key := sk_sig + r_sig + sk_prf.
+        Self(private_key.sk_sig() + private_key.r_sig() + compute_key.sk_prf())
     }
 }
 
@@ -35,7 +35,7 @@ mod tests {
 
     const ITERATIONS: u64 = 100;
 
-    fn check_to_address(
+    fn check_from_private_key(
         mode: Mode,
         num_constants: u64,
         num_public: u64,
@@ -44,14 +44,14 @@ mod tests {
     ) -> Result<()> {
         for i in 0..ITERATIONS {
             // Generate a private key, compute key, view key, and address.
-            let (_private_key, compute_key, _view_key, address) = generate_account()?;
+            let (private_key, _compute_key, view_key, _address) = generate_account()?;
 
-            // Initialize the compute key.
-            let candidate = ComputeKey::<Circuit>::new(mode, compute_key);
+            // Initialize the private key.
+            let private_key = PrivateKey::<Circuit>::new(mode, private_key);
 
             Circuit::scope(&format!("{} {}", mode, i), || {
-                let candidate = candidate.to_address();
-                assert_eq!(*address, candidate.to_group().eject_value());
+                let candidate = ViewKey::from_private_key(&private_key);
+                assert_eq!(view_key, candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
                 if i > 0 {
                     assert_scope!(<=num_constants, num_public, num_private, num_constraints);
@@ -63,17 +63,17 @@ mod tests {
     }
 
     #[test]
-    fn test_to_address_constant() -> Result<()> {
-        check_to_address(Mode::Constant, 1008, 0, 0, 0)
+    fn test_from_private_key_constant() -> Result<()> {
+        check_from_private_key(Mode::Constant, 3756, 0, 0, 0)
     }
 
     #[test]
-    fn test_to_address_public() -> Result<()> {
-        check_to_address(Mode::Public, 504, 0, 1260, 1260)
+    fn test_from_private_key_public() -> Result<()> {
+        check_from_private_key(Mode::Public, 2009, 0, 5862, 5867)
     }
 
     #[test]
-    fn test_to_address_private() -> Result<()> {
-        check_to_address(Mode::Private, 504, 0, 1260, 1260)
+    fn test_from_private_key_private() -> Result<()> {
+        check_from_private_key(Mode::Private, 2009, 0, 5862, 5867)
     }
 }

--- a/circuit/account/src/view_key/mod.rs
+++ b/circuit/account/src/view_key/mod.rs
@@ -14,11 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+mod from_private_key;
 mod to_address;
 
 #[cfg(test)]
 use snarkvm_circuit_types::environment::assert_scope;
 
+use crate::PrivateKey;
 use snarkvm_circuit_network::Aleo;
 use snarkvm_circuit_types::{environment::prelude::*, Address, Scalar};
 

--- a/circuit/account/src/view_key/to_address.rs
+++ b/circuit/account/src/view_key/to_address.rs
@@ -49,7 +49,6 @@ mod tests {
             Circuit::scope(&format!("{} {}", mode, i), || {
                 let candidate = candidate.to_address();
                 assert_eq!(*address, candidate.to_group().eject_value());
-
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
                 if i > 0 {
                     assert_scope!(<=num_constants, num_public, num_private, num_constraints);

--- a/circuit/account/src/view_key/to_address.rs
+++ b/circuit/account/src/view_key/to_address.rs
@@ -44,7 +44,7 @@ mod tests {
             let (_private_key, _compute_key, view_key, address) = generate_account()?;
 
             // Initialize the view key.
-            let candidate = ViewKey::<Circuit>::new(mode, *view_key);
+            let candidate = ViewKey::<Circuit>::new(mode, view_key);
 
             Circuit::scope(&format!("{} {}", mode, i), || {
                 let candidate = candidate.to_address();

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -55,18 +55,18 @@ thread_local! {
     /// The randomizer domain as a constant field element.
     static RANDOMIZER_DOMAIN: Field<AleoV0> = Field::constant(<console::Testnet3 as console::Network>::randomizer_domain());
 
-    /// The BHP gadget, which can take an input of up to 256 bits.
+    /// The BHP hash function, which can take an input of up to 256 bits.
     static BHP_256: BHP256<AleoV0> = BHP256::<AleoV0>::constant(console::BHP_256.with(|bhp| bhp.clone()));
-    /// The BHP gadget, which can take an input of up to 512 bits.
+    /// The BHP hash function, which can take an input of up to 512 bits.
     static BHP_512: BHP512<AleoV0> = BHP512::<AleoV0>::constant(console::BHP_512.with(|bhp| bhp.clone()));
-    /// The BHP gadget, which can take an input of up to 768 bits.
+    /// The BHP hash function, which can take an input of up to 768 bits.
     static BHP_768: BHP768<AleoV0> = BHP768::<AleoV0>::constant(console::BHP_768.with(|bhp| bhp.clone()));
-    /// The BHP gadget, which can take an input of up to 1024 bits.
+    /// The BHP hash function, which can take an input of up to 1024 bits.
     static BHP_1024: BHP1024<AleoV0> = BHP1024::<AleoV0>::constant(console::BHP_1024.with(|bhp| bhp.clone()));
 
-    /// The Pedersen gadget, which can take an input of up to 64 bits.
+    /// The Pedersen hash function, which can take an input of up to 64 bits.
     static PEDERSEN_64: Pedersen64<AleoV0> = Pedersen64::<AleoV0>::constant(console::PEDERSEN_64.with(|pedersen| pedersen.clone()));
-    /// The Pedersen gadget, which can take an input of up to 128 bits.
+    /// The Pedersen hash function, which can take an input of up to 128 bits.
     static PEDERSEN_128: Pedersen128<AleoV0> = Pedersen128::<AleoV0>::constant(console::PEDERSEN_128.with(|pedersen| pedersen.clone()));
 
     /// The Poseidon hash function, using a rate of 2.

--- a/circuit/program/src/data/encrypt.rs
+++ b/circuit/program/src/data/encrypt.rs
@@ -62,7 +62,7 @@ mod tests {
             let address = snarkvm_console_account::Address::try_from(private_key)?;
 
             // Initialize a view key and address.
-            let view_key = ViewKey::<Circuit>::new(Mode::Private, *view_key);
+            let view_key = ViewKey::<Circuit>::new(Mode::Private, view_key);
             let address = Address::<Circuit>::new(Mode::Private, *address);
 
             let data = Data(vec![(

--- a/console/account/src/private_key/mod.rs
+++ b/console/account/src/private_key/mod.rs
@@ -19,7 +19,6 @@ mod serialize;
 mod string;
 mod try_from;
 
-use snarkvm_console_algorithms::{Poseidon2, PRF};
 use snarkvm_console_network::Network;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{
@@ -41,7 +40,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PrivateKey<N: Network> {
-    /// The starting private key.
+    /// The account seed that derives the full private key.
     seed: N::Scalar,
     /// The derived signature secret key.
     sk_sig: N::Scalar,
@@ -57,6 +56,11 @@ impl<N: Network> PrivateKey<N> {
     pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> Result<Self> {
         // Sample a random account seed.
         Self::try_from(UniformRand::rand(rng))
+    }
+
+    /// Returns the account seed.
+    pub const fn seed(&self) -> N::Scalar {
+        self.seed
     }
 
     /// Returns the signature secret key.

--- a/console/account/src/signature/bytes.rs
+++ b/console/account/src/signature/bytes.rs
@@ -48,7 +48,7 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
-    const ITERATIONS: u64 = 1000;
+    const ITERATIONS: u64 = 100;
 
     #[test]
     fn test_bytes() -> Result<()> {

--- a/console/account/src/signature/sign.rs
+++ b/console/account/src/signature/sign.rs
@@ -113,7 +113,7 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
-    const ITERATIONS: u64 = 1000;
+    const ITERATIONS: u64 = 100;
 
     fn check_sign_and_verify(message: &[bool]) -> Result<()> {
         // Sample an address and a private key.

--- a/console/account/src/view_key/mod.rs
+++ b/console/account/src/view_key/mod.rs
@@ -39,6 +39,13 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ViewKey<N: Network>(N::Scalar);
 
+impl<N: Network> ViewKey<N> {
+    /// Initializes the account view key from a scalar.
+    pub fn from_scalar(view_key: N::Scalar) -> Self {
+        Self(view_key)
+    }
+}
+
 impl<N: Network> Deref for ViewKey<N> {
     type Target = N::Scalar;
 
@@ -61,7 +68,7 @@ mod tests {
     const ITERATIONS: u64 = 1000;
 
     #[test]
-    fn test_deref() -> Result<()> {
+    fn test_from_scalar() -> Result<()> {
         for _ in 0..ITERATIONS {
             // Sample a new address.
             let private_key = PrivateKey::<CurrentNetwork>::new(&mut test_crypto_rng())?;
@@ -69,7 +76,7 @@ mod tests {
 
             // Check the scalar representation.
             let candidate = *expected;
-            assert_eq!(expected, ViewKey(candidate));
+            assert_eq!(expected, ViewKey::from_scalar(candidate));
         }
         Ok(())
     }

--- a/console/algorithms/src/poseidon/mod.rs
+++ b/console/algorithms/src/poseidon/mod.rs
@@ -53,7 +53,7 @@ impl<F: PrimeField, const RATE: usize> Poseidon<F, RATE> {
         ensure!(num_bits <= max_bits, "Domain cannot exceed {max_bits} bits, found {num_bits} bits");
 
         Ok(Self {
-            domain: F::from_bytes_be_mod_order(domain.as_bytes()),
+            domain: F::from_bytes_le_mod_order(domain.as_bytes()),
             parameters: Arc::new(F::default_poseidon_parameters::<RATE>()?),
         })
     }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -156,4 +156,7 @@ pub trait Network: Copy + Clone + fmt::Debug + Eq + PartialEq + hash::Hash {
 
     /// Returns the Poseidon PRF with an input rate of 8.
     fn prf_psd8(seed: &Self::Field, input: &[Self::Field]) -> Result<Self::Field>;
+
+    /// Returns the Poseidon PRF on the **scalar** field with an input rate of 2.
+    fn prf_psd2s(seed: &Self::Scalar, input: &[Self::Scalar]) -> Result<Self::Scalar>;
 }

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -46,18 +46,18 @@ thread_local! {
     /// The randomizer domain as a constant field element.
     pub static RANDOMIZER_DOMAIN: <Testnet3 as Network>::Field = PrimeField::from_bytes_le_mod_order(b"AleoRandomizer0");
 
-    /// The BHP gadget, which can take an input of up to 256 bits.
+    /// The BHP hash function, which can take an input of up to 256 bits.
     pub static BHP_256: BHP256<<Testnet3 as Network>::Affine> = BHP256::<<Testnet3 as Network>::Affine>::setup("AleoBHP256").expect("Failed to setup BHP256");
-    /// The BHP gadget, which can take an input of up to 512 bits.
+    /// The BHP hash function, which can take an input of up to 512 bits.
     pub static BHP_512: BHP512<<Testnet3 as Network>::Affine> = BHP512::<<Testnet3 as Network>::Affine>::setup("AleoBHP512").expect("Failed to setup BHP512");
-    /// The BHP gadget, which can take an input of up to 768 bits.
+    /// The BHP hash function, which can take an input of up to 768 bits.
     pub static BHP_768: BHP768<<Testnet3 as Network>::Affine> = BHP768::<<Testnet3 as Network>::Affine>::setup("AleoBHP768").expect("Failed to setup BHP768");
-    /// The BHP gadget, which can take an input of up to 1024 bits.
+    /// The BHP hash function, which can take an input of up to 1024 bits.
     pub static BHP_1024: BHP1024<<Testnet3 as Network>::Affine> = BHP1024::<<Testnet3 as Network>::Affine>::setup("AleoBHP1024").expect("Failed to setup BHP1024");
 
-    /// The Pedersen gadget, which can take an input of up to 64 bits.
+    /// The Pedersen hash function, which can take an input of up to 64 bits.
     pub static PEDERSEN_64: Pedersen64<<Testnet3 as Network>::Affine> = Pedersen64::<<Testnet3 as Network>::Affine>::setup("AleoPedersen64");
-    /// The Pedersen gadget, which can take an input of up to 128 bits.
+    /// The Pedersen hash function, which can take an input of up to 128 bits.
     pub static PEDERSEN_128: Pedersen128<<Testnet3 as Network>::Affine> = Pedersen128::<<Testnet3 as Network>::Affine>::setup("AleoPedersen128");
 
     /// The Poseidon hash function, using a rate of 2.
@@ -66,6 +66,9 @@ thread_local! {
     pub static POSEIDON_4: Poseidon4<<Testnet3 as Network>::Field> = Poseidon4::<<Testnet3 as Network>::Field>::setup("AleoPoseidon4").expect("Failed to setup Poseidon4");
     /// The Poseidon hash function, using a rate of 8.
     pub static POSEIDON_8: Poseidon8<<Testnet3 as Network>::Field> = Poseidon8::<<Testnet3 as Network>::Field>::setup("AleoPoseidon8").expect("Failed to setup Poseidon8");
+
+    /// The Poseidon hash function on the **scalar** field, using a rate of 2.
+    pub static POSEIDON_2S: Poseidon2<<Testnet3 as Network>::Scalar> = Poseidon2::<<Testnet3 as Network>::Scalar>::setup("AleoPoseidon2S").expect("Failed to setup Poseidon2S");
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -300,5 +303,10 @@ impl Network for Testnet3 {
     /// Returns the Poseidon PRF with an input rate of 8.
     fn prf_psd8(seed: &Self::Field, input: &[Self::Field]) -> Result<Self::Field> {
         POSEIDON_8.with(|poseidon| poseidon.prf(seed, input))
+    }
+
+    /// Returns the Poseidon PRF on the **scalar** field with an input rate of 2.
+    fn prf_psd2s(seed: &Self::Scalar, input: &[Self::Scalar]) -> Result<Self::Scalar> {
+        POSEIDON_2S.with(|poseidon| poseidon.prf(seed, input))
     }
 }


### PR DESCRIPTION
## Motivation

- Adds `Inject` and `Eject` to account circuits, with unit tests
- Adds `ComputeKey::to_address()`, with unit tests
- Adds `ViewKey::from_private_key()`, with unit tests
- Adds `PrivateKey::to_view_key()`, with unit tests