### PR TITLE
Bump once_cell to 1.12.0

### DIFF
--- a/console/program/Cargo.toml
+++ b/console/program/Cargo.toml
@@ -45,7 +45,7 @@ version = "0.2"
 version = "0.10.1"
 
 [dependencies.once_cell]
-version = "1.10.0"
+version = "1.12.0"
 
 [dependencies.rayon]
 version = "1"


### PR DESCRIPTION
Appears to be missed by dependabot.

See https://github.com/AleoHQ/snarkVM/pull/820
