### PR TITLE
Add a simple license checker

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -10,7 +10,6 @@ use_try_shorthand = true
 
 # Nightly configurations
 imports_layout = "HorizontalVertical"
-license_template_path = ".license_header"
 imports_granularity = "Crate"
 overflow_delimited_expr = true
 reorder_impl_items = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,7 @@ dependencies = [
  "snarkvm-r1cs",
  "snarkvm-utilities",
  "thiserror",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,9 @@ optional = true
 [dev-dependencies.rusty-hook]
 version = "0.11.2"
 
+[build-dependencies.walkdir]
+version = "2"
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{fs::File, io::Read, path::Path};
+
+use walkdir::WalkDir;
+
+// The following license text that should be present at the beginning of every source file.
+const EXPECTED_LICENSE_TEXT: &[u8] = include_bytes!(".license_header");
+
+// The following directories will be excluded from the license scan.
+const DIRS_TO_SKIP: [&str; 5] = [".cargo", ".circleci", ".git", ".github", "target"];
+
+fn check_file_licenses<P: AsRef<Path>>(path: P) {
+    let path = path.as_ref();
+
+    let mut iter = WalkDir::new(path).into_iter();
+    while let Some(entry) = iter.next() {
+        let entry = entry.unwrap();
+        let entry_type = entry.file_type();
+
+        // Skip the specified directories.
+        if entry_type.is_dir() && DIRS_TO_SKIP.contains(&entry.file_name().to_str().unwrap_or("")) {
+            iter.skip_current_dir();
+
+            continue;
+        }
+
+        // Check all files with the ".rs" extension.
+        if entry_type.is_file() && entry.file_name().to_str().unwrap_or("").ends_with(".rs") {
+            let file = File::open(entry.path()).unwrap();
+            let mut contents = Vec::with_capacity(EXPECTED_LICENSE_TEXT.len());
+            file.take(EXPECTED_LICENSE_TEXT.len() as u64).read_to_end(&mut contents).unwrap();
+
+            assert!(
+                contents == EXPECTED_LICENSE_TEXT,
+                "The license in \"{}\" is either missing or it doesn't match the expected string!",
+                entry.path().display()
+            );
+        }
+    }
+
+    // Re-run upon any changes to the workspace.
+    println!("cargo:rerun-if-changed=.");
+}
+
+// The build script; it currently only checks the licenses.
+fn main() {
+    // Check licenses in the current folder.
+    check_file_licenses(".");
+}


### PR DESCRIPTION
Due to https://github.com/rust-lang/rustfmt/issues/5103, rustfmt no longer supports this functionality, but it's simple enough to implement manually within a build script.