### PR TITLE
Introduce methods for checking correctness of index

### DIFF
--- a/algorithms/benches/snark/marlin.rs
+++ b/algorithms/benches/snark/marlin.rs
@@ -90,12 +90,9 @@ fn snark_circuit_setup(c: &mut Criterion) {
     let max_degree = AHPForR1CS::<Fr, MarlinHidingMode>::max_degree(100000, 100000, 100000).unwrap();
     let universal_srs = MarlinInst::universal_setup(&max_degree, rng).unwrap();
 
+    let circuit = Benchmark::<Fr> { a: Some(x), b: Some(y), num_constraints, num_variables };
     c.bench_function("snark_circuit_setup", move |b| {
-        b.iter(|| {
-            let circuit = Benchmark::<Fr> { a: Some(x), b: Some(y), num_constraints, num_variables };
-
-            MarlinInst::circuit_setup(&universal_srs, &circuit).unwrap()
-        })
+        b.iter(|| MarlinInst::circuit_setup(&universal_srs, &circuit).unwrap())
     });
 }
 

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -319,7 +319,7 @@ impl<F: FftField> EvaluationDomain<F> {
     /// Given an index which assumes the first elements of this domain are the elements of
     /// another (sub)domain with size size_s,
     /// this returns the actual index into this domain.
-    pub fn reindex_by_subdomain(&self, other: Self, index: usize) -> usize {
+    pub fn reindex_by_subdomain(&self, other: &Self, index: usize) -> usize {
         assert!(self.size() >= other.size());
         // Let this subgroup be G, and the subgroup we're re-indexing by be S.
         // Since its a subgroup, the 0th element of S is at index 0 in G, the first element of S is at

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use rayon::prelude::*;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{cfg_iter_mut, serialize::*};
+use snarkvm_utilities::{cfg_iter, cfg_iter_mut, serialize::*};
 
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
@@ -74,6 +74,15 @@ impl<F: PrimeField> Evaluations<F> {
 
     pub fn domain(&self) -> EvaluationDomain<F> {
         self.domain
+    }
+
+    pub fn evaluate(&self, point: &F) -> F {
+        let coeffs = self.domain.evaluate_all_lagrange_coefficients(*point);
+        self.evaluate_with_coeffs(&coeffs)
+    }
+
+    pub fn evaluate_with_coeffs(&self, lagrange_coefficients_at_point: &[F]) -> F {
+        cfg_iter!(self.evaluations).zip_eq(lagrange_coefficients_at_point).map(|(a, b)| *a * b).sum()
     }
 }
 

--- a/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
@@ -70,19 +70,20 @@ impl<F: PrimeField, MM: MarlinMode> Circuit<F, MM> {
 
     /// Iterate over the indexed polynomials.
     pub fn iter(&self) -> impl Iterator<Item = &LabeledPolynomial<F>> {
+        // Alphabetical order
         [
-            &self.a_arith.row,
             &self.a_arith.col,
-            &self.a_arith.val,
-            &self.a_arith.row_col,
-            &self.b_arith.row,
             &self.b_arith.col,
-            &self.b_arith.val,
-            &self.b_arith.row_col,
-            &self.c_arith.row,
             &self.c_arith.col,
-            &self.c_arith.val,
+            &self.a_arith.row,
+            &self.b_arith.row,
+            &self.c_arith.row,
+            &self.a_arith.row_col,
+            &self.b_arith.row_col,
             &self.c_arith.row_col,
+            &self.a_arith.val,
+            &self.b_arith.val,
+            &self.c_arith.val,
         ]
         .into_iter()
     }

--- a/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
@@ -24,22 +24,93 @@ use crate::{
             AHPError,
             AHPForR1CS,
         },
+        matrices::{matrix_evals, precomputation_for_matrix_evals, MatrixEvals},
         num_non_zero,
         MarlinMode,
     },
 };
 use snarkvm_fields::PrimeField;
 use snarkvm_r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem};
+use snarkvm_utilities::cfg_into_iter;
 
 use core::marker::PhantomData;
 use std::collections::BTreeMap;
 
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 #[cfg(not(feature = "std"))]
 use snarkvm_utilities::println;
+
+use super::Matrix;
 
 impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     /// Generate the index for this constraint system.
     pub fn index<C: ConstraintSynthesizer<F>>(c: &C) -> Result<Circuit<F, MM>, AHPError> {
+        let IndexerState {
+            constraint_domain,
+
+            a,
+            non_zero_a_domain,
+            a_evals,
+
+            b,
+            non_zero_b_domain,
+            b_evals,
+
+            c,
+            non_zero_c_domain,
+            c_evals,
+
+            index_info,
+        } = Self::index_helper(c)?;
+        let joint_arithmetization_time = start_timer!(|| "Arithmetizing A");
+
+        let [a_arith, b_arith, c_arith]: [_; 3] = [("a", a_evals), ("b", b_evals), ("c", c_evals)]
+            .into_iter()
+            .map(|(label, evals)| arithmetize_matrix(label, evals))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        end_timer!(joint_arithmetization_time);
+
+        let fft_precomp_time = start_timer!(|| "Precomputing roots of unity");
+
+        let (fft_precomputation, ifft_precomputation) = Self::fft_precomputation(
+            constraint_domain.size(),
+            non_zero_a_domain.size(),
+            non_zero_b_domain.size(),
+            non_zero_c_domain.size(),
+        )
+        .ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+        end_timer!(fft_precomp_time);
+
+        Ok(Circuit {
+            index_info,
+            a,
+            b,
+            c,
+            a_arith,
+            b_arith,
+            c_arith,
+            fft_precomputation,
+            ifft_precomputation,
+            mode: PhantomData,
+        })
+    }
+
+    pub fn index_polynomial_info() -> BTreeMap<PolynomialLabel, PolynomialInfo> {
+        let mut map = BTreeMap::new();
+        for matrix in ["a", "b", "c"] {
+            map.insert(format!("row_{matrix}"), PolynomialInfo::new(format!("row_{matrix}"), None, None));
+            map.insert(format!("col_{matrix}"), PolynomialInfo::new(format!("col_{matrix}"), None, None));
+            map.insert(format!("val_{matrix}"), PolynomialInfo::new(format!("val_{matrix}"), None, None));
+            map.insert(format!("row_col_{matrix}"), PolynomialInfo::new(format!("row_col_{matrix}"), None, None));
+        }
+        map
+    }
+
+    fn index_helper<C: ConstraintSynthesizer<F>>(c: &C) -> Result<IndexerState<F>, AHPError> {
         let index_time = start_timer!(|| "AHP::Index");
 
         let constraint_time = start_timer!(|| "Generating constraints");
@@ -109,46 +180,78 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         let non_zero_c_domain =
             EvaluationDomain::new(num_non_zero_c).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
 
-        let joint_arithmetization_time = start_timer!(|| "Arithmetizing A");
-        let a_arith = arithmetize_matrix(&a, "a", non_zero_a_domain, constraint_domain, input_domain);
-        let b_arith = arithmetize_matrix(&b, "b", non_zero_b_domain, constraint_domain, input_domain);
-        let c_arith = arithmetize_matrix(&c, "c", non_zero_c_domain, constraint_domain, input_domain);
-        end_timer!(joint_arithmetization_time);
+        let (constraint_domain_elements, constraint_domain_eq_poly_vals) =
+            precomputation_for_matrix_evals(&constraint_domain);
 
-        let fft_precomp_time = start_timer!(|| "Precomputing roots of unity");
+        let [a_evals, b_evals, c_evals]: [_; 3] =
+            cfg_into_iter!([(&a, &non_zero_a_domain), (&b, &non_zero_b_domain), (&c, &non_zero_c_domain),])
+                .map(|(matrix, non_zero_domain)| {
+                    matrix_evals(
+                        matrix,
+                        non_zero_domain,
+                        &constraint_domain,
+                        &input_domain,
+                        &constraint_domain_elements,
+                        &constraint_domain_eq_poly_vals,
+                    )
+                })
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap();
 
-        let (fft_precomputation, ifft_precomputation) = Self::fft_precomputation(
-            constraint_domain.size(),
-            non_zero_a_domain.size(),
-            non_zero_b_domain.size(),
-            non_zero_c_domain.size(),
-        )
-        .ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        end_timer!(fft_precomp_time);
+        let result = Ok(IndexerState {
+            constraint_domain,
 
-        end_timer!(index_time);
-        Ok(Circuit {
-            index_info,
             a,
+            non_zero_a_domain,
+            a_evals,
+
             b,
+            non_zero_b_domain,
+            b_evals,
+
             c,
-            a_arith,
-            b_arith,
-            c_arith,
-            fft_precomputation,
-            ifft_precomputation,
-            mode: PhantomData,
-        })
+            non_zero_c_domain,
+            c_evals,
+
+            index_info,
+        });
+        end_timer!(index_time);
+        result
     }
 
-    pub fn index_polynomial_info() -> BTreeMap<PolynomialLabel, PolynomialInfo> {
-        let mut map = BTreeMap::new();
-        for matrix in ["a", "b", "c"] {
-            map.insert(format!("row_{matrix}"), PolynomialInfo::new(format!("row_{matrix}"), None, None));
-            map.insert(format!("col_{matrix}"), PolynomialInfo::new(format!("col_{matrix}"), None, None));
-            map.insert(format!("val_{matrix}"), PolynomialInfo::new(format!("val_{matrix}"), None, None));
-            map.insert(format!("row_col_{matrix}"), PolynomialInfo::new(format!("row_col_{matrix}"), None, None));
-        }
-        map
+    pub fn evaluate_index_polynomials<C: ConstraintSynthesizer<F>>(
+        c: &C,
+        point: F,
+    ) -> Result<impl Iterator<Item = F>, AHPError> {
+        let state = Self::index_helper(c)?;
+        Ok([
+            (state.a_evals, state.non_zero_a_domain),
+            (state.b_evals, state.non_zero_b_domain),
+            (state.c_evals, state.non_zero_c_domain),
+        ]
+        .into_iter()
+        .flat_map(move |(evals, domain)| {
+            let lagrange_coefficients_at_point = domain.evaluate_all_lagrange_coefficients(point);
+            evals.evaluate(&lagrange_coefficients_at_point)
+        }))
     }
+}
+
+struct IndexerState<F: PrimeField> {
+    constraint_domain: EvaluationDomain<F>,
+
+    a: Matrix<F>,
+    non_zero_a_domain: EvaluationDomain<F>,
+    a_evals: MatrixEvals<F>,
+
+    b: Matrix<F>,
+    non_zero_b_domain: EvaluationDomain<F>,
+    b_evals: MatrixEvals<F>,
+
+    c: Matrix<F>,
+    non_zero_c_domain: EvaluationDomain<F>,
+    c_evals: MatrixEvals<F>,
+
+    index_info: CircuitInfo<F>,
 }

--- a/algorithms/src/snark/marlin/ahp/matrices.rs
+++ b/algorithms/src/snark/marlin/ahp/matrices.rs
@@ -96,10 +96,10 @@ pub struct MatrixEvals<F: PrimeField> {
     pub row: EvaluationsOnDomain<F>,
     /// Evaluations of the `col` polynomial.
     pub col: EvaluationsOnDomain<F>,
-    /// Evaluations of the `row_col` polynomial.
-    pub row_col: EvaluationsOnDomain<F>,
     /// Evaluations of the `val` polynomial.
     pub val: EvaluationsOnDomain<F>,
+    /// Evaluations of the `row_col` polynomial.
+    pub row_col: EvaluationsOnDomain<F>,
 }
 
 impl<F: PrimeField> MatrixEvals<F> {
@@ -107,8 +107,8 @@ impl<F: PrimeField> MatrixEvals<F> {
         [
             self.row.evaluate_with_coeffs(lagrange_coefficients_at_point),
             self.col.evaluate_with_coeffs(lagrange_coefficients_at_point),
-            self.row_col.evaluate_with_coeffs(lagrange_coefficients_at_point),
             self.val.evaluate_with_coeffs(lagrange_coefficients_at_point),
+            self.row_col.evaluate_with_coeffs(lagrange_coefficients_at_point),
         ]
     }
 }

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/second.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/second.rs
@@ -228,8 +228,8 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             let t = Self::calculate_t(
                 &[&state.index.a, &state.index.b, &state.index.c],
                 [F::one(), eta_b, eta_c],
-                state.input_domain,
-                state.constraint_domain,
+                &state.input_domain,
+                &state.constraint_domain,
                 &r_alpha_x_evals,
                 ifft_precomputation,
             );
@@ -243,8 +243,8 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     fn calculate_t<'a>(
         matrices: &[&'a Matrix<F>],
         matrix_randomizers: [F; 3],
-        input_domain: EvaluationDomain<F>,
-        constraint_domain: EvaluationDomain<F>,
+        input_domain: &EvaluationDomain<F>,
+        constraint_domain: &EvaluationDomain<F>,
         r_alpha_x_on_h: &[F],
         ifft_precomputation: &IFFTPrecomputation<F>,
     ) -> DensePolynomial<F> {
@@ -257,6 +257,6 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
                 }
             }
         }
-        fft::Evaluations::from_vec_and_domain(t_evals_on_h, constraint_domain).interpolate_with_pc(ifft_precomputation)
+        fft::Evaluations::from_vec_and_domain(t_evals_on_h, *constraint_domain).interpolate_with_pc(ifft_precomputation)
     }
 }

--- a/algorithms/src/snark/marlin/data_structures/index_proof.rs
+++ b/algorithms/src/snark/marlin/data_structures/index_proof.rs
@@ -1,0 +1,51 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::polycommit::sonic_pc;
+use snarkvm_curves::PairingEngine;
+use snarkvm_utilities::{
+    error,
+    io::{self, Read, Write},
+    serialize::*,
+    FromBytes,
+    ToBytes,
+};
+
+/// A zkSNARK proof.
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct IndexProof<E: PairingEngine> {
+    /// An evaluation proof from the polynomial commitment.
+    pub pc_proof: sonic_pc::BatchLCProof<E>,
+}
+
+impl<E: PairingEngine> IndexProof<E> {
+    /// Construct a new proof.
+    pub fn new(pc_proof: sonic_pc::BatchLCProof<E>) -> Self {
+        Self { pc_proof }
+    }
+}
+
+impl<E: PairingEngine> ToBytes for IndexProof<E> {
+    fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
+        Self::serialize_compressed(self, &mut w).map_err(|_| error("could not serialize Proof"))
+    }
+}
+
+impl<E: PairingEngine> FromBytes for IndexProof<E> {
+    fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
+        Self::deserialize_compressed(&mut r).map_err(|_| error("could not deserialize Proof"))
+    }
+}

--- a/algorithms/src/snark/marlin/data_structures/mod.rs
+++ b/algorithms/src/snark/marlin/data_structures/mod.rs
@@ -22,6 +22,8 @@ pub use circuit_proving_key::*;
 pub(super) mod circuit_verifying_key;
 pub use circuit_verifying_key::*;
 
+pub(super) mod index_proof;
+pub use index_proof::*;
 /// The Marlin prepared circuit verifying key.
 pub(super) mod prepared_circuit_verifying_key;
 pub use prepared_circuit_verifying_key::*;

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     fft::EvaluationDomain,
-    polycommit::sonic_pc::{Commitment, Evaluations, LabeledCommitment, Randomness, SonicKZG10},
+    polycommit::sonic_pc::{Commitment, Evaluations, LabeledCommitment, QuerySet, Randomness, SonicKZG10},
     snark::marlin::{
         ahp::{AHPError, AHPForR1CS, EvaluationsProvider},
         fiat_shamir::traits::FiatShamirRng,
@@ -53,6 +53,8 @@ use core::{
     marker::PhantomData,
     sync::atomic::{AtomicBool, Ordering},
 };
+
+use super::IndexProof;
 
 /// The Marlin proof system.
 #[derive(Clone, Debug)]
@@ -163,6 +165,13 @@ impl<E: PairingEngine, FS: FiatShamirRng<E::Fr, E::Fq>, MM: MarlinMode, Input: T
         sponge
     }
 
+    fn init_sponge_for_index_proof(circuit_commitments: &[crate::polycommit::sonic_pc::Commitment<E>]) -> FS {
+        let mut sponge = FS::new();
+        sponge.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME].unwrap());
+        sponge.absorb_native_field_elements(circuit_commitments);
+        sponge
+    }
+
     fn absorb_labeled_with_msg(
         comms: &[LabeledCommitment<Commitment<E>>],
         message: &prover::ThirdMessage<E::Fr>,
@@ -196,6 +205,7 @@ where
     Input: ToConstraintField<E::Fr> + ?Sized,
 {
     type BaseField = E::Fq;
+    type IndexProof = IndexProof<E>;
     type Proof = Proof<E>;
     type ProvingKey = CircuitProvingKey<E, MM>;
     type ScalarField = E::Fr;
@@ -224,6 +234,104 @@ where
             SRS::Universal(srs) => Self::circuit_setup(srs, circuit),
         }
         .map_err(SNARKError::from)
+    }
+
+    fn prove_index(
+        verifying_key: &Self::VerifyingKey,
+        proving_key: &Self::ProvingKey,
+    ) -> Result<Self::IndexProof, SNARKError> {
+        // Initialize sponge
+        let mut sponge = Self::init_sponge_for_index_proof(&verifying_key.circuit_commitments);
+        // Compute challenges for linear combination, and the point to evaluate
+        // the polynomials at.
+        // The linear combination requires `num_polynomials - 1` coefficients
+        // (since the first coeff is 1), and so we squeeze out `num_polynomials` points.
+        let mut challenges = sponge
+            .squeeze_nonnative_field_elements(verifying_key.circuit_commitments.len(), OptimizationType::Weight)
+            .map_err(AHPError::from)?;
+        let point = challenges.pop().unwrap();
+        let one = E::Fr::one();
+        let linear_combination_challenges = core::iter::once(&one).chain(challenges.iter());
+
+        // We will construct a linear combination and provide a proof of evaluation of the lc
+        // at `point`.
+        let mut lc = crate::polycommit::sonic_pc::LinearCombination::empty("circuit_check");
+        let info = AHPForR1CS::<E::Fr, MM>::index_polynomial_info();
+        let mut query_set = QuerySet::new();
+        for (poly_name, &c) in info.keys().zip(linear_combination_challenges) {
+            lc.add(c, poly_name.clone());
+            query_set.insert((poly_name.clone(), ("challenge".into(), point)));
+        }
+        let commitments = verifying_key
+            .iter()
+            .cloned()
+            .zip_eq(info.values())
+            .map(|(c, info)| LabeledCommitment::new_with_info(info, c))
+            .collect::<Vec<_>>();
+
+        let index_polynomials = proving_key.circuit.iter().map(Into::into).collect::<Vec<_>>();
+        let proof = SonicKZG10::<E, FS>::open_combinations(
+            &proving_key.committer_key,
+            &[lc],
+            index_polynomials,
+            &commitments,
+            &query_set,
+            &proving_key.circuit_commitment_randomness.clone(),
+            &mut sponge,
+        )?;
+
+        Ok(Self::IndexProof::new(proof))
+    }
+
+    fn verify_index<C: ConstraintSynthesizer<Self::ScalarField>>(
+        circuit: &C,
+        verifying_key: &Self::VerifyingKey,
+        proof: &Self::IndexProof,
+    ) -> Result<bool, SNARKError> {
+        let circuit = AHPForR1CS::<E::Fr, MM>::index(circuit)?;
+        // Initialize sponge
+        let mut sponge = Self::init_sponge_for_index_proof(&verifying_key.circuit_commitments);
+        // Compute challenges for linear combination, and the point to evaluate
+        // the polynomials at.
+        // The linear combination requires `num_polynomials - 1` coefficients
+        // (since the first coeff is 1), and so we squeeze out `num_polynomials` points.
+        let mut challenges = sponge
+            .squeeze_nonnative_field_elements(verifying_key.circuit_commitments.len(), OptimizationType::Weight)
+            .map_err(AHPError::from)?;
+        let point = challenges.pop().unwrap();
+        let one = E::Fr::one();
+        let linear_combination_challenges = core::iter::once(&one).chain(challenges.iter());
+
+        // We will construct a linear combination and provide a proof of evaluation of the lc
+        // at `point`.
+        let mut lc = crate::polycommit::sonic_pc::LinearCombination::empty("circuit_check");
+        let info = AHPForR1CS::<E::Fr, MM>::index_polynomial_info();
+        let mut query_set = QuerySet::new();
+        let mut evaluation = E::Fr::zero();
+        for ((poly_name, &c), poly) in info.keys().zip(linear_combination_challenges).zip(circuit.iter()) {
+            lc.add(c, poly_name.clone());
+            query_set.insert((poly_name.clone(), ("challenge".into(), point)));
+            evaluation += c * poly.evaluate(point);
+        }
+        let commitments = verifying_key
+            .iter()
+            .cloned()
+            .zip_eq(info.values())
+            .map(|(c, info)| LabeledCommitment::new_with_info(info, c))
+            .collect::<Vec<_>>();
+        let mut evaluations = Evaluations::new();
+        evaluations.insert(("circuit_check".into(), point), evaluation);
+
+        SonicKZG10::<E, FS>::check_combinations(
+            &verifying_key.verifier_key,
+            &[lc],
+            &commitments,
+            &query_set,
+            &evaluations,
+            &proof.pc_proof,
+            &mut sponge,
+        )
+        .map_err(Into::into)
     }
 
     #[allow(clippy::only_used_in_recursion)]

--- a/algorithms/src/snark/marlin/tests.rs
+++ b/algorithms/src/snark/marlin/tests.rs
@@ -109,6 +109,9 @@ mod marlin {
                         let (index_pk, index_vk) = $marlin_inst::circuit_setup(&universal_srs, &circ).unwrap();
                         println!("Called circuit setup");
 
+                        let index_proof = $marlin_inst::prove_index(&index_vk, &index_pk).unwrap();
+                        assert!($marlin_inst::verify_index(&circ, &index_vk, &index_proof).unwrap());
+
                         let proof = $marlin_inst::prove(&index_pk, &circ, rng).unwrap();
                         println!("Called prover");
 

--- a/algorithms/src/traits/snark.rs
+++ b/algorithms/src/traits/snark.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::errors::SNARKError;
-use snarkvm_utilities::{FromBytes, ToBytes, ToMinimalBits};
+use snarkvm_utilities::{CanonicalDeserialize, CanonicalSerialize, FromBytes, ToBytes, ToMinimalBits};
 
 use rand::{CryptoRng, Rng};
 use snarkvm_fields::{PrimeField, ToConstraintField};
@@ -39,6 +39,17 @@ pub trait SNARK {
     type ScalarField: Clone + PrimeField;
     type BaseField: Clone + PrimeField;
 
+    /// A proof that the indexing was performed correctly.
+    type IndexProof: CanonicalSerialize
+        + CanonicalDeserialize
+        + Clone
+        + Debug
+        + ToBytes
+        + FromBytes
+        + PartialEq
+        + Eq
+        + Send
+        + Sync;
     type Proof: Clone + Debug + ToBytes + FromBytes + PartialEq + Eq + Send + Sync;
     type ProvingKey: Clone + ToBytes + FromBytes + Send + Sync;
 
@@ -67,6 +78,17 @@ pub trait SNARK {
         circuit: &C,
         srs: &mut SRS<R, Self::UniversalSetupParameters>,
     ) -> Result<(Self::ProvingKey, Self::VerifyingKey), SNARKError>;
+
+    fn prove_index(
+        verifying_key: &Self::VerifyingKey,
+        proving_key: &Self::ProvingKey,
+    ) -> Result<Self::IndexProof, SNARKError>;
+
+    fn verify_index<C: ConstraintSynthesizer<Self::ScalarField>>(
+        circuit: &C,
+        verifying_key: &Self::VerifyingKey,
+        proof: &Self::IndexProof,
+    ) -> Result<bool, SNARKError>;
 
     fn prove_batch<C: ConstraintSynthesizer<Self::ScalarField>, R: Rng + CryptoRng>(
         proving_key: &Self::ProvingKey,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This makes checking program registration transactions faster. Below are the benchmarks for varying number of constraints.

<table>
<tr>
	<td> num_constraints
	<td> index
	<td> prove_index
	<td> verify_index
<tr>
	<td> 100
	<td> 166.3
	<td> 12
	<td> 21.4
<tr>
	<td> 1_000
	<td> 465
	<td> 16
	<td> 22.4
<tr>
	<td> 10_000
	<td> 4670
	<td> 51.6
	<td> 32.6
	
<tr>
	<td> 100_000
	<td> ---
	<td> 262.2
	<td> 119
</table>

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

(Link your related PRs here)
