### PR TITLE
Fix instruction opcodes with a dot `.`

### DIFF
--- a/vm/compiler/src/process/add_program.rs
+++ b/vm/compiler/src/process/add_program.rs
@@ -279,7 +279,7 @@ impl<N: Network> Process<N> {
         match instruction.opcode() {
             Opcode::Literal(opcode) => {
                 // Ensure the opcode **is** a reserved opcode.
-                ensure!(Self::is_reserved_opcode(&Identifier::from_str(opcode)?), "'{opcode}' is not an opcode.");
+                ensure!(Self::is_reserved_opcode(opcode), "'{opcode}' is not an opcode.");
                 // Ensure the instruction is not the cast operation.
                 ensure!(!matches!(instruction, Instruction::Cast(..)), "Instruction '{instruction}' is a 'cast'.");
                 // Ensure the instruction has one destination register.
@@ -436,10 +436,8 @@ impl<N: Network> Process<N> {
     }
 
     /// Returns `true` if the given name is a reserved opcode.
-    fn is_reserved_opcode(name: &Identifier<N>) -> bool {
-        // Convert the given name to a string.
-        let name = name.to_string();
-        // Check if the given name matches the root of any opcode (the first part, up to the first '.').
-        Instruction::<N>::OPCODES.iter().any(|opcode| (**opcode).split('.').next() == Some(&name))
+    fn is_reserved_opcode(name: &str) -> bool {
+        // Check if the given name matches any opcode.
+        Instruction::<N>::OPCODES.iter().any(|opcode| opcode.to_string() == *name)
     }
 }


### PR DESCRIPTION
## Overview
Removes a call to `Identifier::from_str` (which requires alphanumeric characters) in `check_instruction_opcode`.


## Previous Error
Previously, any program that contained an instruction with a dot (`is.eq`, `add.w`, etc) would fail to build in the Aleo CLI during a call to `Package::build` which calls `check_instruction_opcode`.
```
⚠️  Identifier 'is.eq' must be alphanumeric and underscores
```
