### PR TITLE
Update `Map` and `MapReader` to utilize `Cow`s

### DIFF
--- a/vm/compiler/src/ledger/block/transactions/mod.rs
+++ b/vm/compiler/src/ledger/block/transactions/mod.rs
@@ -212,6 +212,11 @@ impl<N: Network> Transactions<N> {
     // ) -> impl Iterator<Item = Record<N>> + 'a {
     //     self.transactions.iter().flat_map(move |transaction| transaction.to_decrypted_records(decryption_key))
     // }
+
+    /// Consumes `Transactions` to return the underlying collection.
+    pub fn into_inner(self) -> IndexMap<N::TransactionID, Transaction<N>> {
+        self.transactions
+    }
 }
 
 impl<N: Network> Deref for Transactions<N> {

--- a/vm/compiler/src/ledger/contains.rs
+++ b/vm/compiler/src/ledger/contains.rs
@@ -28,7 +28,7 @@ impl<
     /// Returns `true` if the given state root exists.
     pub fn contains_state_root(&self, state_root: &Field<N>) -> bool {
         state_root == self.latest_state_root()
-            || self.headers.values().map(Header::previous_state_root).any(|root| root == state_root)
+            || self.headers.values().any(|h| Header::previous_state_root(&h) == state_root)
     }
 
     /// Returns `true` if the given block hash exists.

--- a/vm/compiler/src/ledger/get.rs
+++ b/vm/compiler/src/ledger/get.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 impl<
     N: Network,
     PreviousHashesMap: for<'a> Map<'a, u32, N::BlockHash>,
@@ -30,7 +32,7 @@ impl<
         Block::from(
             self.get_previous_hash(height)?,
             *self.get_header(height)?,
-            self.get_transactions(height)?.clone(),
+            self.get_transactions(height)?.into_owned(),
             *self.get_signature(height)?,
         )
     }
@@ -56,7 +58,7 @@ impl<
     }
 
     /// Returns the block header for the given block height.
-    pub fn get_header(&self, height: u32) -> Result<&Header<N>> {
+    pub fn get_header(&self, height: u32) -> Result<Cow<'_, Header<N>>> {
         match self.headers.get(&height)? {
             Some(header) => Ok(header),
             None => bail!("Missing block header for block {height}"),
@@ -64,7 +66,7 @@ impl<
     }
 
     /// Returns the block transactions for the given block height.
-    pub fn get_transactions(&self, height: u32) -> Result<&Transactions<N>> {
+    pub fn get_transactions(&self, height: u32) -> Result<Cow<'_, Transactions<N>>> {
         match self.transactions.get(&height)? {
             Some(transactions) => Ok(transactions),
             None => bail!("Missing block transactions for block {height}"),
@@ -72,7 +74,7 @@ impl<
     }
 
     /// Returns the block signature for the given block height.
-    pub fn get_signature(&self, height: u32) -> Result<&Signature<N>> {
+    pub fn get_signature(&self, height: u32) -> Result<Cow<'_, Signature<N>>> {
         match self.signatures.get(&height)? {
             Some(signature) => Ok(signature),
             None => bail!("Missing signature for block {height}"),
@@ -88,65 +90,76 @@ impl<
         // Derive the address from the view key.
         let address = view_key.to_address();
 
-        self.transitions().flat_map(Transition::output_records).flat_map(move |(commitment, record)| {
-            // A helper method to derive the serial number from the private key and commitment.
-            let serial_number = |private_key: PrivateKey<N>, commitment: Field<N>| -> Result<Field<N>> {
-                // Compute the generator `H` as `HashToGroup(commitment)`.
-                let h = N::hash_to_group_psd2(&[N::serial_number_domain(), commitment])?;
-                // Compute `gamma` as `sk_sig * H`.
-                let gamma = h * private_key.sk_sig();
-                // Compute `sn_nonce` as `Hash(COFACTOR * gamma)`.
-                let sn_nonce =
-                    N::hash_to_scalar_psd2(&[N::serial_number_domain(), gamma.mul_by_cofactor().to_x_coordinate()])?;
-                // Compute `serial_number` as `Commit(commitment, sn_nonce)`.
-                N::commit_bhp512(&(N::serial_number_domain(), commitment).to_bits_le(), &sn_nonce)
-            };
+        self.transitions()
+            .flat_map(|ts| match ts {
+                Cow::Borrowed(tn) => Transition::output_records(tn)
+                    .map(|(f, r)| (Cow::Borrowed(f), Cow::Borrowed(r)))
+                    .collect::<Vec<_>>(),
+                Cow::Owned(tn) => Transition::output_records(&tn)
+                    .map(|(f, r)| (Cow::Owned(f.to_owned()), Cow::Owned(r.to_owned())))
+                    .collect::<Vec<_>>(),
+            })
+            .flat_map(move |(commitment, record)| {
+                // A helper method to derive the serial number from the private key and commitment.
+                let serial_number = |private_key: PrivateKey<N>, commitment: Field<N>| -> Result<Field<N>> {
+                    // Compute the generator `H` as `HashToGroup(commitment)`.
+                    let h = N::hash_to_group_psd2(&[N::serial_number_domain(), commitment])?;
+                    // Compute `gamma` as `sk_sig * H`.
+                    let gamma = h * private_key.sk_sig();
+                    // Compute `sn_nonce` as `Hash(COFACTOR * gamma)`.
+                    let sn_nonce = N::hash_to_scalar_psd2(&[
+                        N::serial_number_domain(),
+                        gamma.mul_by_cofactor().to_x_coordinate(),
+                    ])?;
+                    // Compute `serial_number` as `Commit(commitment, sn_nonce)`.
+                    N::commit_bhp512(&(N::serial_number_domain(), commitment).to_bits_le(), &sn_nonce)
+                };
 
-            // Determine whether to decrypt this output record (or not), based on the filter.
-            let commitment = match filter {
-                OutputRecordsFilter::All => *commitment,
-                OutputRecordsFilter::Spent(private_key) => {
-                    // Derive the serial number.
-                    match serial_number(private_key, *commitment) {
-                        // Determine if the output record is spent.
-                        Ok(serial_number) => match self.contains_serial_number(&serial_number) {
-                            true => *commitment,
-                            false => return None,
-                        },
-                        Err(e) => {
-                            warn!("Failed to derive serial number for output record: {e}");
-                            return None;
+                // Determine whether to decrypt this output record (or not), based on the filter.
+                let commitment = match filter {
+                    OutputRecordsFilter::All => *commitment,
+                    OutputRecordsFilter::Spent(private_key) => {
+                        // Derive the serial number.
+                        match serial_number(private_key, *commitment) {
+                            // Determine if the output record is spent.
+                            Ok(serial_number) => match self.contains_serial_number(&serial_number) {
+                                true => *commitment,
+                                false => return None,
+                            },
+                            Err(e) => {
+                                warn!("Failed to derive serial number for output record: {e}");
+                                return None;
+                            }
                         }
                     }
-                }
-                OutputRecordsFilter::Unspent(private_key) => {
-                    // Derive the serial number.
-                    match serial_number(private_key, *commitment) {
-                        // Determine if the output record is spent.
-                        Ok(serial_number) => match self.contains_serial_number(&serial_number) {
-                            true => return None,
-                            false => *commitment,
-                        },
-                        Err(e) => {
-                            warn!("Failed to derive serial number for output record: {e}");
-                            return None;
+                    OutputRecordsFilter::Unspent(private_key) => {
+                        // Derive the serial number.
+                        match serial_number(private_key, *commitment) {
+                            // Determine if the output record is spent.
+                            Ok(serial_number) => match self.contains_serial_number(&serial_number) {
+                                true => return None,
+                                false => *commitment,
+                            },
+                            Err(e) => {
+                                warn!("Failed to derive serial number for output record: {e}");
+                                return None;
+                            }
                         }
                     }
-                }
-            };
+                };
 
-            // Decrypt the record.
-            match record.is_owner(&address, view_key) {
-                true => match record.decrypt(view_key) {
-                    Ok(record) => Some((commitment, record)),
-                    Err(e) => {
-                        warn!("Failed to decrypt output record: {e}");
-                        None
-                    }
-                },
-                false => None,
-            }
-        })
+                // Decrypt the record.
+                match record.is_owner(&address, view_key) {
+                    true => match record.decrypt(view_key) {
+                        Ok(record) => Some((commitment, record)),
+                        Err(e) => {
+                            warn!("Failed to decrypt output record: {e}");
+                            None
+                        }
+                    },
+                    false => None,
+                }
+            })
     }
 }
 

--- a/vm/compiler/src/ledger/iterators.rs
+++ b/vm/compiler/src/ledger/iterators.rs
@@ -15,6 +15,16 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
+use std::borrow::Cow;
+
+macro_rules! tx_components {
+    ($self:expr, $component:ident) => {
+        $self.transactions.values().flat_map(|ts| match ts {
+            Cow::Borrowed(ts) => Transactions::$component(ts).map(Cow::Borrowed).collect::<Vec<_>>(),
+            Cow::Owned(ts) => Transactions::$component(&ts).map(|t| Cow::Owned(t.to_owned())).collect::<Vec<_>>(),
+        })
+    };
+}
 
 impl<
     N: Network,
@@ -26,52 +36,52 @@ impl<
 > Ledger<N, PreviousHashesMap, HeadersMap, TransactionsMap, SignatureMap, ProgramsMap>
 {
     /// Returns an iterator over all transactions.
-    pub fn transactions(&self) -> impl '_ + Iterator<Item = &Transaction<N>> {
-        self.transactions.values().flat_map(Transactions::transactions)
+    pub fn transactions(&self) -> impl '_ + Iterator<Item = Cow<'_, Transaction<N>>> {
+        tx_components!(self, transactions)
     }
 
     /// Returns an iterator over the transaction IDs, for all transactions in `self`.
-    pub fn transaction_ids(&self) -> impl '_ + Iterator<Item = &N::TransactionID> {
-        self.transactions.values().flat_map(Transactions::transaction_ids)
+    pub fn transaction_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
+        tx_components!(self, transaction_ids)
     }
 
     /// Returns an iterator over all transactions in `self` that are deployments.
-    pub fn deployments(&self) -> impl '_ + Iterator<Item = &Deployment<N>> {
-        self.transactions.values().flat_map(Transactions::deployments)
+    pub fn deployments(&self) -> impl '_ + Iterator<Item = Cow<'_, Deployment<N>>> {
+        tx_components!(self, deployments)
     }
 
     /// Returns an iterator over all transactions in `self` that are executions.
-    pub fn executions(&self) -> impl '_ + Iterator<Item = &Execution<N>> {
-        self.transactions.values().flat_map(Transactions::executions)
+    pub fn executions(&self) -> impl '_ + Iterator<Item = Cow<'_, Execution<N>>> {
+        tx_components!(self, executions)
     }
 
     /// Returns an iterator over all executed transitions.
-    pub fn transitions(&self) -> impl '_ + Iterator<Item = &Transition<N>> {
-        self.transactions.values().flat_map(Transactions::transitions)
+    pub fn transitions(&self) -> impl '_ + Iterator<Item = Cow<'_, Transition<N>>> {
+        tx_components!(self, transitions)
     }
 
     /// Returns an iterator over the transition IDs, for all executed transitions.
-    pub fn transition_ids(&self) -> impl '_ + Iterator<Item = &N::TransitionID> {
-        self.transactions.values().flat_map(Transactions::transition_ids)
+    pub fn transition_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransitionID>> {
+        tx_components!(self, transition_ids)
     }
 
     /// Returns an iterator over the transition public keys, for all executed transactions.
-    pub fn transition_public_keys(&self) -> impl '_ + Iterator<Item = &Group<N>> {
-        self.transactions.values().flat_map(Transactions::transition_public_keys)
+    pub fn transition_public_keys(&self) -> impl '_ + Iterator<Item = Cow<'_, Group<N>>> {
+        tx_components!(self, transition_public_keys)
     }
 
     /// Returns an iterator over the serial numbers, for all executed transition inputs that are records.
-    pub fn serial_numbers(&self) -> impl '_ + Iterator<Item = &Field<N>> {
-        self.transactions.values().flat_map(Transactions::serial_numbers)
+    pub fn serial_numbers(&self) -> impl '_ + Iterator<Item = Cow<'_, Field<N>>> {
+        tx_components!(self, serial_numbers)
     }
 
     /// Returns an iterator over the commitments, for all executed transition outputs that are records.
-    pub fn commitments(&self) -> impl '_ + Iterator<Item = &Field<N>> {
-        self.transactions.values().flat_map(Transactions::commitments)
+    pub fn commitments(&self) -> impl '_ + Iterator<Item = Cow<'_, Field<N>>> {
+        tx_components!(self, commitments)
     }
 
     /// Returns an iterator over the nonces, for all executed transition outputs that are records.
-    pub fn nonces(&self) -> impl '_ + Iterator<Item = &Group<N>> {
-        self.transactions.values().flat_map(Transactions::nonces)
+    pub fn nonces(&self) -> impl '_ + Iterator<Item = Cow<'_, Group<N>>> {
+        tx_components!(self, nonces)
     }
 }

--- a/vm/compiler/src/ledger/latest.rs
+++ b/vm/compiler/src/ledger/latest.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 impl<
     N: Network,
     PreviousHashesMap: for<'a> Map<'a, u32, N::BlockHash>,
@@ -66,7 +68,7 @@ impl<
     }
 
     /// Returns the latest block transactions.
-    pub fn latest_transactions(&self) -> Result<&Transactions<N>> {
+    pub fn latest_transactions(&self) -> Result<Cow<'_, Transactions<N>>> {
         self.get_transactions(self.current_height)
     }
 }

--- a/vm/compiler/src/ledger/map/iterators.rs
+++ b/vm/compiler/src/ledger/map/iterators.rs
@@ -1,0 +1,95 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{borrow::Cow, collections::hash_map};
+
+/// An iterator over all key-value pairs in a MemoryMap.
+pub struct Iter<'a, K: 'a + Clone, V: 'a + Clone> {
+    pub(crate) inner: hash_map::Iter<'a, K, V>,
+}
+
+impl<'a, K: 'a + Clone, V: 'a + Clone> Iter<'a, K, V> {
+    #[inline]
+    pub(crate) fn new(inner: hash_map::Iter<'a, K, V>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a, K: 'a + Clone, V: 'a + Clone> Iterator for Iter<'a, K, V> {
+    type Item = (Cow<'a, K>, Cow<'a, V>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v)))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+/// An iterator over the keys in a MemoryMap.
+pub struct Keys<'a, K: 'a + Clone, V: 'a + Clone> {
+    inner: Iter<'a, K, V>,
+}
+
+impl<'a, K: 'a + Clone, V: 'a + Clone> Keys<'a, K, V> {
+    #[inline]
+    pub(crate) fn new(inner: Iter<'a, K, V>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a, K: 'a + Clone, V: 'a + Clone> Iterator for Keys<'a, K, V> {
+    type Item = Cow<'a, K>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(k, _)| k)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+/// An iterator over the value in a MemoryMap.
+pub struct Values<'a, K: 'a + Clone, V: 'a + Clone> {
+    inner: Iter<'a, K, V>,
+}
+
+impl<'a, K: 'a + Clone, V: 'a + Clone> Values<'a, K, V> {
+    #[inline]
+    pub(crate) fn new(inner: Iter<'a, K, V>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a, K: 'a + Clone, V: 'a + Clone> Iterator for Values<'a, K, V> {
+    type Item = Cow<'a, V>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(_, v)| v)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}

--- a/vm/compiler/src/ledger/map/memory_map.rs
+++ b/vm/compiler/src/ledger/map/memory_map.rs
@@ -14,11 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::ledger::map::{Map, MapReader};
+use crate::ledger::map::{
+    iterators::{Iter, Keys, Values},
+    Map,
+    MapReader,
+};
 use console::network::prelude::*;
 
 use core::{borrow::Borrow, hash::Hash};
-use std::collections::hash_map::{HashMap, Iter, Keys, Values};
+use std::{borrow::Cow, collections::hash_map::HashMap};
 
 #[derive(Clone)]
 pub struct MemoryMap<
@@ -48,10 +52,7 @@ impl<
     ///
     /// Inserts the given key-value pair into the map.
     ///
-    fn insert<Q>(&mut self, key: K, value: V) -> Result<()>
-    where
-        Q: PartialEq + Eq + Hash + Serialize,
-    {
+    fn insert(&mut self, key: K, value: V) -> Result<()> {
         self.map.insert(key, value);
 
         Ok(())
@@ -95,33 +96,33 @@ impl<
     ///
     /// Returns the value for the given key from the map, if it exists.
     ///
-    fn get<Q>(&'a self, key: &Q) -> Result<Option<&V>>
+    fn get<Q>(&'a self, key: &Q) -> Result<Option<Cow<'a, V>>>
     where
         K: Borrow<Q>,
         Q: PartialEq + Eq + Hash + Serialize + ?Sized,
     {
-        Ok(self.map.get(key))
+        Ok(self.map.get(key).map(Cow::Borrowed))
     }
 
     ///
     /// Returns an iterator visiting each key-value pair in the map.
     ///
     fn iter(&'a self) -> Self::Iterator {
-        self.map.iter()
+        Iter::new(self.map.iter())
     }
 
     ///
     /// Returns an iterator over each key in the map.
     ///
     fn keys(&'a self) -> Self::Keys {
-        self.map.keys()
+        Keys::new(self.iter())
     }
 
     ///
     /// Returns an iterator over each value in the map.
     ///
     fn values(&'a self) -> Self::Values {
-        self.map.values()
+        Values::new(self.iter())
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the use of lifetime objects in the `Map` and `MapReader` traits to `Cow`s. 

This will allow us to use a DataMap with an underlying database, as opposed to just an in-memory map.