### PR TITLE
Remove allocations from the Map iterators

### DIFF
--- a/vm/compiler/src/ledger/block/transactions/mod.rs
+++ b/vm/compiler/src/ledger/block/transactions/mod.rs
@@ -118,7 +118,7 @@ impl<N: Network> Transactions<N> {
 
     /// Returns an iterator over all transitions.
     pub fn transitions(&self) -> impl '_ + Iterator<Item = &Transition<N>> {
-        self.transactions.values().flat_map(Transaction::transitions)
+        self.transactions().flat_map(Transaction::transitions)
     }
 
     /// Returns a consuming iterator over all transitions.
@@ -128,7 +128,7 @@ impl<N: Network> Transactions<N> {
 
     /// Returns an iterator over the transition IDs, for all transitions.
     pub fn transition_ids(&self) -> impl '_ + Iterator<Item = &N::TransitionID> {
-        self.transactions.values().flat_map(Transaction::transition_ids)
+        self.transactions().flat_map(Transaction::transition_ids)
     }
 
     /// Returns a consuming iterator over the transition IDs, for all transitions.
@@ -138,7 +138,7 @@ impl<N: Network> Transactions<N> {
 
     /// Returns an iterator over the transition public keys, for all transactions.
     pub fn transition_public_keys(&self) -> impl '_ + Iterator<Item = &Group<N>> {
-        self.transactions.values().flat_map(Transaction::transition_public_keys)
+        self.transactions().flat_map(Transaction::transition_public_keys)
     }
 
     /// Returns a consuming iterator over the transition public keys, for all transactions.

--- a/vm/compiler/src/ledger/block/transactions/mod.rs
+++ b/vm/compiler/src/ledger/block/transactions/mod.rs
@@ -69,14 +69,32 @@ impl<N: Network> Transactions<N> {
         self.transactions.values()
     }
 
+    /// Returns a consuming iterator over all transactions, for all transactions in `self`.
+    pub fn into_transactions(self) -> impl Iterator<Item = Transaction<N>> {
+        self.transactions.into_values()
+    }
+
     /// Returns an iterator over the transaction IDs, for all transactions in `self`.
     pub fn transaction_ids(&self) -> impl '_ + Iterator<Item = &N::TransactionID> {
         self.transactions.keys()
     }
 
+    /// Returns a consuming iterator over the transaction IDs, for all transactions in `self`.
+    pub fn into_transaction_ids(self) -> impl Iterator<Item = N::TransactionID> {
+        self.transactions.into_keys()
+    }
+
     /// Returns an iterator over all transactions in `self` that are deployments.
     pub fn deployments(&self) -> impl '_ + Iterator<Item = &Deployment<N>> {
         self.transactions().filter_map(|transaction| match transaction {
+            Transaction::Deploy(_, deployment, _) => Some(deployment),
+            _ => None,
+        })
+    }
+
+    /// Returns a consuming iterator over all transactions in `self` that are deployments.
+    pub fn into_deployments(self) -> impl Iterator<Item = Deployment<N>> {
+        self.into_transactions().filter_map(|transaction| match transaction {
             Transaction::Deploy(_, deployment, _) => Some(deployment),
             _ => None,
         })
@@ -90,9 +108,22 @@ impl<N: Network> Transactions<N> {
         })
     }
 
+    /// Returns a consuming iterator over all transactions in `self` that are executions.
+    pub fn into_executions(self) -> impl Iterator<Item = Execution<N>> {
+        self.into_transactions().filter_map(|transaction| match transaction {
+            Transaction::Execute(_, execution, _) => Some(execution),
+            _ => None,
+        })
+    }
+
     /// Returns an iterator over all transitions.
     pub fn transitions(&self) -> impl '_ + Iterator<Item = &Transition<N>> {
         self.transactions.values().flat_map(Transaction::transitions)
+    }
+
+    /// Returns a consuming iterator over all transitions.
+    pub fn into_transitions(self) -> impl Iterator<Item = Transition<N>> {
+        self.into_transactions().flat_map(Transaction::into_transitions)
     }
 
     /// Returns an iterator over the transition IDs, for all transitions.
@@ -100,9 +131,19 @@ impl<N: Network> Transactions<N> {
         self.transactions.values().flat_map(Transaction::transition_ids)
     }
 
+    /// Returns a consuming iterator over the transition IDs, for all transitions.
+    pub fn into_transition_ids(self) -> impl Iterator<Item = N::TransitionID> {
+        self.into_transactions().flat_map(Transaction::into_transition_ids)
+    }
+
     /// Returns an iterator over the transition public keys, for all transactions.
     pub fn transition_public_keys(&self) -> impl '_ + Iterator<Item = &Group<N>> {
         self.transactions.values().flat_map(Transaction::transition_public_keys)
+    }
+
+    /// Returns a consuming iterator over the transition public keys, for all transactions.
+    pub fn into_transition_public_keys(self) -> impl Iterator<Item = Group<N>> {
+        self.into_transactions().flat_map(Transaction::into_transition_public_keys)
     }
 
     /// Returns an iterator over the origins, for all transition inputs that are records.
@@ -115,14 +156,29 @@ impl<N: Network> Transactions<N> {
         self.transitions().flat_map(Transition::serial_numbers)
     }
 
-    /// Returns an iterator over the commitments, for all transition outputs that are records.
+    /// Returns a consuming iterator over the serial numbers, for all transition inputs that are records.
+    pub fn into_serial_numbers(self) -> impl Iterator<Item = Field<N>> {
+        self.into_transitions().flat_map(Transition::into_serial_numbers)
+    }
+
+    /// Returns an iterator over the commitments, for all executed transition outputs that are records.
     pub fn commitments(&self) -> impl '_ + Iterator<Item = &Field<N>> {
         self.transitions().flat_map(Transition::commitments)
     }
 
-    /// Returns an iterator over the nonces, for all transition outputs that are records.
+    /// Returns a consuming iterator over the commitments, for all transition outputs that are records.
+    pub fn into_commitments(self) -> impl Iterator<Item = Field<N>> {
+        self.into_transitions().flat_map(Transition::into_commitments)
+    }
+
+    /// Returns an iterator over the nonces, for all executed transition outputs that are records.
     pub fn nonces(&self) -> impl '_ + Iterator<Item = &Group<N>> {
         self.transitions().flat_map(Transition::nonces)
+    }
+
+    /// Returns a consuming iterator over the nonces, for all transition outputs that are records.
+    pub fn into_nonces(self) -> impl Iterator<Item = Group<N>> {
+        self.into_transitions().flat_map(Transition::into_nonces)
     }
 
     /// Returns an iterator over the fees, for all transitions.

--- a/vm/compiler/src/ledger/transition/input/mod.rs
+++ b/vm/compiler/src/ledger/transition/input/mod.rs
@@ -80,6 +80,14 @@ impl<N: Network> Input<N> {
         }
     }
 
+    /// Consumes `self`, returning the serial number, if the input is a record.
+    pub fn into_serial_number(self) -> Option<Field<N>> {
+        match self {
+            Input::Record(serial_number, ..) => Some(serial_number),
+            _ => None,
+        }
+    }
+
     /// Returns the origin, if the input is a record.
     pub const fn origin(&self) -> Option<&Origin<N>> {
         match self {

--- a/vm/compiler/src/ledger/transition/mod.rs
+++ b/vm/compiler/src/ledger/transition/mod.rs
@@ -248,6 +248,11 @@ impl<N: Network> Transition<N> {
         &self.id
     }
 
+    /// Consumes `self`, returning the transition ID.
+    pub fn into_id(self) -> N::TransitionID {
+        self.id
+    }
+
     /// Returns the program ID.
     pub const fn program_id(&self) -> &ProgramID<N> {
         &self.program_id
@@ -283,6 +288,11 @@ impl<N: Network> Transition<N> {
         self.outputs.iter().flat_map(Output::record)
     }
 
+    /// Consumes `self` and returns the output records as a tuple comprised of `(commitment, record)`.
+    pub fn into_output_records(self) -> impl Iterator<Item = (Field<N>, Record<N, Ciphertext<N>>)> {
+        self.outputs.into_iter().flat_map(Output::into_record)
+    }
+
     /// Returns the proof.
     pub const fn proof(&self) -> &Proof<N> {
         &self.proof
@@ -291,6 +301,11 @@ impl<N: Network> Transition<N> {
     /// Returns the transition public key.
     pub const fn tpk(&self) -> &Group<N> {
         &self.tpk
+    }
+
+    /// Consumes `self`, returning the transition public key.
+    pub fn into_tpk(self) -> Group<N> {
+        self.tpk
     }
 
     /// Returns the transition commitment.
@@ -315,13 +330,28 @@ impl<N: Network> Transition<N> {
         self.inputs.iter().flat_map(Input::serial_number)
     }
 
+    /// Returns a consuming iterator over the serial numbers, for inputs that are records.
+    pub fn into_serial_numbers(self) -> impl Iterator<Item = Field<N>> {
+        self.inputs.into_iter().flat_map(Input::into_serial_number)
+    }
+
     /// Returns an iterator over the commitments, for outputs that are records.
     pub fn commitments(&self) -> impl '_ + Iterator<Item = &Field<N>> {
         self.outputs.iter().flat_map(Output::commitment)
     }
 
+    /// Returns a consuming iterator over the commitments, for outputs that are records.
+    pub fn into_commitments(self) -> impl Iterator<Item = Field<N>> {
+        self.outputs.into_iter().flat_map(Output::into_commitment)
+    }
+
     /// Returns an iterator over the nonces, for outputs that are records.
     pub fn nonces(&self) -> impl '_ + Iterator<Item = &Group<N>> {
         self.outputs.iter().flat_map(Output::nonce)
+    }
+
+    /// Returns a consuming iterator over the nonces, for outputs that are records.
+    pub fn into_nonces(self) -> impl Iterator<Item = Group<N>> {
+        self.outputs.into_iter().flat_map(Output::into_nonce)
     }
 }

--- a/vm/compiler/src/ledger/transition/output/mod.rs
+++ b/vm/compiler/src/ledger/transition/output/mod.rs
@@ -73,8 +73,25 @@ impl<N: Network> Output<N> {
         }
     }
 
+    /// Consumes `self` and returns the commitment and record, if the output is a record.
+    #[allow(clippy::type_complexity)]
+    pub fn into_record(self) -> Option<(Field<N>, Record<N, Ciphertext<N>>)> {
+        match self {
+            Output::Record(commitment, _, Some(record)) => Some((commitment, record)),
+            _ => None,
+        }
+    }
+
     /// Returns the commitment, if the output is a record.
     pub const fn commitment(&self) -> Option<&Field<N>> {
+        match self {
+            Output::Record(commitment, ..) => Some(commitment),
+            _ => None,
+        }
+    }
+
+    /// Consumes `self`, returning the commitment, if the output is a record.
+    pub fn into_commitment(self) -> Option<Field<N>> {
         match self {
             Output::Record(commitment, ..) => Some(commitment),
             _ => None,
@@ -85,6 +102,14 @@ impl<N: Network> Output<N> {
     pub const fn nonce(&self) -> Option<&Group<N>> {
         match self {
             Output::Record(_, _, Some(record)) => Some(record.nonce()),
+            _ => None,
+        }
+    }
+
+    /// Consumes `self`, returning the nonce, if the output is a record.
+    pub fn into_nonce(self) -> Option<Group<N>> {
+        match self {
+            Output::Record(_, _, Some(record)) => Some(*record.nonce()),
             _ => None,
         }
     }

--- a/vm/compiler/src/process/execution/mod.rs
+++ b/vm/compiler/src/process/execution/mod.rs
@@ -72,6 +72,11 @@ impl<N: Network> Execution<N> {
     pub fn pop(&mut self) -> Result<Transition<N>> {
         self.transitions.pop().ok_or_else(|| anyhow!("No more transitions in the execution"))
     }
+
+    /// Returns a consuming iterator over the underlying transitions.
+    pub fn into_transitions(self) -> impl Iterator<Item = Transition<N>> {
+        self.transitions.into_iter()
+    }
 }
 
 impl<N: Network> Deref for Execution<N> {


### PR DESCRIPTION
This PR removes all the allocations related to iteration temporarily introduced alongside `Cow` in the `Map`, using a few wrapper objects and extra helper methods.