### PR TITLE
[CU-383p3pb] Fix build skipping when program code has changed

### DIFF
--- a/vm/package/is_build_required.rs
+++ b/vm/package/is_build_required.rs
@@ -39,34 +39,32 @@ impl<N: Network> Package<N> {
             Err(_) => return true,
         };
 
-        // Initialize a boolean indicator if we need to build the circuit.
-        let mut is_complete = true;
-
         // Check if the program ID in the manifest matches the program ID in the AVM file.
-        if avm_file.program().id() == &self.program_id {
-            // Retrieve the main program.
-            let program = self.program();
+        if avm_file.program().id() != &self.program_id {
+            return true;
+        }
 
-            // Check if the program matches.
-            if avm_file.program() == program {
-                // Next, check if the prover and verifier exist for each function.
-                for function_name in program.functions().keys() {
-                    // Check if the prover file exists.
-                    if !ProverFile::exists_at(&build_directory, function_name) {
-                        // If not, we need to build the circuit.
-                        is_complete = false;
-                        break;
-                    }
-                    // Check if the verifier file exists.
-                    if !VerifierFile::exists_at(&build_directory, function_name) {
-                        // If not, we need to build the circuit.
-                        is_complete = false;
-                        break;
-                    }
-                }
+        // Check if the main program matches.
+        let program = self.program();
+        if avm_file.program() != program {
+            return true;
+        }
+
+        // Next, check if the prover and verifier exist for each function.
+        for function_name in program.functions().keys() {
+            // Check if the prover file exists.
+            if !ProverFile::exists_at(&build_directory, function_name) {
+                // If not, we need to build the circuit.
+                return true;
+            }
+            // Check if the verifier file exists.
+            if !VerifierFile::exists_at(&build_directory, function_name) {
+                // If not, we need to build the circuit.
+                return true;
             }
         }
 
-        !is_complete
+        // Package hasn't changed, no need to build
+        return false;
     }
 }

--- a/vm/package/is_build_required.rs
+++ b/vm/package/is_build_required.rs
@@ -65,6 +65,6 @@ impl<N: Network> Package<N> {
         }
 
         // Package hasn't changed, no need to build
-        return false;
+        false
     }
 }


### PR DESCRIPTION
## Motivation

I noticed when trying the aleo cli that after updating my instructions code, I needed to run `aleo clean` to wipe the build dir for changes to pick up. Otherwise the build would be skipped but I would get an error e.g. when running a new function, because the verifier was missing:


```
facundo@entropy ~/d/e/p/aleo_instructions aleo run hello 1u32

🚀 Executing 'foo.aleo/hello'...

 • Calling 'foo.aleo/hello'...
 • Executed 'hello' (in 4656 ms)

➡️  Output

 • 120u32

✅ Executed 'foo.aleo/hello' (in "/Users/facundo/dev/entropy1729/platform-tools/aleo_instructions")

# (updated my main.aleo with a new function here)

facundo@entropy ~/d/e/p/aleo_instructions $ aleo run another 1u32

🚀 Executing 'foo.aleo/another'...

⚠️  The prover file is missing: '/Users/facundo/dev/entropy1729/platform-tools/aleo_instructions/build/another.prover'

aleo build

✅ Built 'foo.aleo' (in "/Users/facundo/dev/entropy1729/platform-tools/aleo_instructions")

facundo@entropy ~/d/e/p/aleo_instructions $ aleo clean

✅ Cleaned the build directory (in "/Users/facundo/dev/entropy1729/platform-tools/aleo_instructions/build")

facundo@entropy ~/d/e/p/aleo_instructions $ aleo build

⏳ Compiling 'foo.aleo'...

 • Loaded universal setup (in 2611 ms)
 • Built 'hello' (in 15228 ms)
 • Built 'another' (in 15899 ms)
```


## Test Plan

I tested this manually by repeating the steps that were producing the error before, but we need to add unit tests to the is_build_required module before merging this.
