### PR TITLE
Revert "Bump anyhow from 1.0.58 to 1.0.60"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "arrayref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ path = "./vm/compiler"
 version = "0.7.5"
 
 [dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 optional = true
 
 [dependencies.clap]

--- a/circuit/account/Cargo.toml
+++ b/circuit/account/Cargo.toml
@@ -29,7 +29,7 @@ path = "../../utilities"
 version = "0.7.5"
 
 [dev-dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [features]
 default = ["enable_console"]

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -31,7 +31,7 @@ path = "../../utilities"
 version = "0.7.5"
 
 [dev-dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [features]
 default = ["enable_console"]

--- a/circuit/collections/Cargo.toml
+++ b/circuit/collections/Cargo.toml
@@ -37,7 +37,7 @@ path = "../../utilities"
 version = "0.7.5"
 
 [dev-dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [features]
 default = ["enable_console"]

--- a/circuit/program/Cargo.toml
+++ b/circuit/program/Cargo.toml
@@ -33,7 +33,7 @@ path = "../../console/account"
 version = "0.7.5"
 
 [dev-dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [dev-dependencies.rand]
 version = "0.8"

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -39,7 +39,7 @@ path = "../../utilities"
 version = "0.7.5"
 
 [dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [dependencies.itertools]
 version = "0.10.1"

--- a/console/network/environment/Cargo.toml
+++ b/console/network/environment/Cargo.toml
@@ -21,7 +21,7 @@ path = "../../../utilities"
 version = "0.7.5"
 
 [dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [dependencies.bech32]
 version = "0.9"

--- a/r1cs/Cargo.toml
+++ b/r1cs/Cargo.toml
@@ -32,7 +32,7 @@ path = "../utilities"
 version = "0.7.5"
 
 [dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [dependencies.cfg-if]
 version = "1.0.0"

--- a/vm/compiler/Cargo.toml
+++ b/vm/compiler/Cargo.toml
@@ -49,7 +49,7 @@ version = "0.7.5"
 default-features = false
 
 [dependencies.anyhow]
-version = "1.0.60"
+version = "1.0.57"
 
 [dependencies.colored]
 version = "2"


### PR DESCRIPTION
Reverts AleoHQ/snarkVM#928

Rolling back while tracking this issue: https://github.com/dtolnay/anyhow/issues/250