### PR TITLE
Feature guard `aleo-cli` logs

### DIFF
--- a/vm/compiler/Cargo.toml
+++ b/vm/compiler/Cargo.toml
@@ -96,3 +96,6 @@ version = "0.2"
 [features]
 default = ["parallel"]
 parallel = ["rayon", "snarkvm-fields/parallel", "snarkvm-utilities/parallel"]
+# Toggles CLI logging.
+aleo-cli = []
+

--- a/vm/compiler/src/process/additional_fee.rs
+++ b/vm/compiler/src/process/additional_fee.rs
@@ -50,6 +50,7 @@ impl<N: Network> Process<N> {
         // Prepare the stack.
         let stack = self.get_stack(request.program_id())?;
 
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Calling '{}/{}'...", request.program_id(), request.function_name()).dimmed());
 
         // Initialize the execution.

--- a/vm/compiler/src/process/evaluate.rs
+++ b/vm/compiler/src/process/evaluate.rs
@@ -37,6 +37,7 @@ impl<N: Network> Process<N> {
             bail!("Function '{}' does not exist.", request.function_name())
         }
 
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Evaluating '{}/{}'...", request.program_id(), request.function_name()).dimmed());
 
         // Evaluate the function.

--- a/vm/compiler/src/process/execute.rs
+++ b/vm/compiler/src/process/execute.rs
@@ -41,6 +41,7 @@ impl<N: Network> Process<N> {
             bail!("Function '{}' does not exist.", request.function_name())
         }
 
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Executing '{}/{}'...", request.program_id(), request.function_name()).dimmed());
 
         // Initialize the execution.

--- a/vm/compiler/src/process/mod.rs
+++ b/vm/compiler/src/process/mod.rs
@@ -46,10 +46,12 @@ use console::{
     types::{I64, U64},
 };
 
-use colored::Colorize;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 use std::sync::Arc;
+
+#[cfg(feature = "aleo-cli")]
+use colored::Colorize;
 
 pub struct Process<N: Network> {
     /// The universal SRS.

--- a/vm/compiler/src/snark/certificate/mod.rs
+++ b/vm/compiler/src/snark/certificate/mod.rs
@@ -39,8 +39,10 @@ impl<N: Network> Certificate<N> {
         verifying_key: &VerifyingKey<N>,
     ) -> Result<Certificate<N>> {
         // Compute the certificate.
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         let certificate = Marlin::<N>::prove_vk(verifying_key, proving_key)?;
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Certified '{function_name}': {} ms", timer.elapsed().as_millis()).dimmed());
         Ok(Self::new(certificate))
     }
@@ -53,14 +55,18 @@ impl<N: Network> Certificate<N> {
         verifying_key: &VerifyingKey<N>,
     ) -> bool {
         // Verify the certificate.
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         match Marlin::<N>::verify_vk(assignment, verifying_key, self) {
             Ok(is_valid) => {
+                #[cfg(feature = "aleo-cli")]
                 let elapsed = timer.elapsed().as_millis();
+                #[cfg(feature = "aleo-cli")]
                 println!("{}", format!(" • Verified certificate for '{function_name}': {} ms", elapsed).dimmed());
                 is_valid
             }
             Err(error) => {
+                #[cfg(feature = "aleo-cli")]
                 println!("{}", format!(" • Certificate verification failed: {error}").dimmed());
                 false
             }

--- a/vm/compiler/src/snark/certificate/mod.rs
+++ b/vm/compiler/src/snark/certificate/mod.rs
@@ -41,9 +41,12 @@ impl<N: Network> Certificate<N> {
         // Compute the certificate.
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         let certificate = Marlin::<N>::prove_vk(verifying_key, proving_key)?;
+
         #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Certified '{function_name}': {} ms", timer.elapsed().as_millis()).dimmed());
+
         Ok(Self::new(certificate))
     }
 
@@ -57,12 +60,15 @@ impl<N: Network> Certificate<N> {
         // Verify the certificate.
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         match Marlin::<N>::verify_vk(assignment, verifying_key, self) {
             Ok(is_valid) => {
                 #[cfg(feature = "aleo-cli")]
-                let elapsed = timer.elapsed().as_millis();
-                #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Verified certificate for '{function_name}': {} ms", elapsed).dimmed());
+                {
+                    let elapsed = timer.elapsed().as_millis();
+                    println!("{}", format!(" • Verified certificate for '{function_name}': {} ms", elapsed).dimmed());
+                }
+
                 is_valid
             }
             Err(error) => {

--- a/vm/compiler/src/snark/mod.rs
+++ b/vm/compiler/src/snark/mod.rs
@@ -14,13 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(unused_variables)]
+
 use console::{network::prelude::*, program::Identifier};
 use snarkvm_algorithms::{crypto_hash::PoseidonSponge, snark::marlin, SNARK};
 use snarkvm_curves::PairingEngine;
 use snarkvm_utilities::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 
-use colored::Colorize;
 use std::sync::Arc;
+
+#[cfg(feature = "aleo-cli")]
+use colored::Colorize;
 
 type Fq<N> = <<N as Environment>::PairingCurve as PairingEngine>::Fq;
 type Fr<N> = <N as Environment>::Field;

--- a/vm/compiler/src/snark/proving_key/mod.rs
+++ b/vm/compiler/src/snark/proving_key/mod.rs
@@ -41,7 +41,9 @@ impl<N: Network> ProvingKey<N> {
     ) -> Result<Proof<N>> {
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         let proof = Proof::new(Marlin::<N>::prove_batch(self, std::slice::from_ref(assignment), rng)?);
+
         #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Executed '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
         Ok(proof)
@@ -56,7 +58,9 @@ impl<N: Network> ProvingKey<N> {
     ) -> Result<Proof<N>> {
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         let batch_proof = Proof::new(Marlin::<N>::prove_batch(self, assignments, rng)?);
+
         #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Executed '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
         Ok(batch_proof)

--- a/vm/compiler/src/snark/proving_key/mod.rs
+++ b/vm/compiler/src/snark/proving_key/mod.rs
@@ -39,8 +39,10 @@ impl<N: Network> ProvingKey<N> {
         assignment: &circuit::Assignment<N::Field>,
         rng: &mut R,
     ) -> Result<Proof<N>> {
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         let proof = Proof::new(Marlin::<N>::prove_batch(self, std::slice::from_ref(assignment), rng)?);
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Executed '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
         Ok(proof)
     }
@@ -52,8 +54,10 @@ impl<N: Network> ProvingKey<N> {
         assignments: &[circuit::Assignment<N::Field>],
         rng: &mut R,
     ) -> Result<Proof<N>> {
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         let batch_proof = Proof::new(Marlin::<N>::prove_batch(self, assignments, rng)?);
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Executed '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
         Ok(batch_proof)
     }

--- a/vm/compiler/src/snark/universal_srs.rs
+++ b/vm/compiler/src/snark/universal_srs.rs
@@ -25,8 +25,10 @@ pub struct UniversalSRS<N: Network> {
 impl<N: Network> UniversalSRS<N> {
     /// Initializes the universal SRS.
     pub fn load() -> Result<Self> {
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         let universal_srs = Self::read_le(&*snarkvm_parameters::testnet3::TrialSRS::load_bytes()?)?;
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Loaded universal setup (in {} ms)", timer.elapsed().as_millis()).dimmed());
         Ok(universal_srs)
     }
@@ -37,8 +39,10 @@ impl<N: Network> UniversalSRS<N> {
         function_name: &Identifier<N>,
         assignment: &circuit::Assignment<N::Field>,
     ) -> Result<(ProvingKey<N>, VerifyingKey<N>)> {
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         let (proving_key, verifying_key) = Marlin::<N>::circuit_setup(self, assignment)?;
+        #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Built '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
 
         Ok((ProvingKey::new(proving_key), VerifyingKey::new(verifying_key)))

--- a/vm/compiler/src/snark/universal_srs.rs
+++ b/vm/compiler/src/snark/universal_srs.rs
@@ -27,9 +27,12 @@ impl<N: Network> UniversalSRS<N> {
     pub fn load() -> Result<Self> {
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         let universal_srs = Self::read_le(&*snarkvm_parameters::testnet3::TrialSRS::load_bytes()?)?;
+
         #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Loaded universal setup (in {} ms)", timer.elapsed().as_millis()).dimmed());
+
         Ok(universal_srs)
     }
 
@@ -41,7 +44,9 @@ impl<N: Network> UniversalSRS<N> {
     ) -> Result<(ProvingKey<N>, VerifyingKey<N>)> {
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         let (proving_key, verifying_key) = Marlin::<N>::circuit_setup(self, assignment)?;
+
         #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Built '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
 

--- a/vm/compiler/src/snark/verifying_key/mod.rs
+++ b/vm/compiler/src/snark/verifying_key/mod.rs
@@ -38,12 +38,15 @@ impl<N: Network> VerifyingKey<N> {
     pub fn verify(&self, function_name: &Identifier<N>, inputs: &[N::Field], proof: &Proof<N>) -> bool {
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         match Marlin::<N>::verify_batch(self, std::slice::from_ref(&inputs), proof) {
             Ok(is_valid) => {
                 #[cfg(feature = "aleo-cli")]
-                let elapsed = timer.elapsed().as_millis();
-                #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
+                {
+                    let elapsed = timer.elapsed().as_millis();
+                    println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
+                }
+
                 is_valid
             }
             Err(error) => {
@@ -58,12 +61,15 @@ impl<N: Network> VerifyingKey<N> {
     pub fn verify_batch(&self, function_name: &Identifier<N>, inputs: &[&[N::Field]], proof: &Proof<N>) -> bool {
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
+
         match Marlin::<N>::verify_batch(self, inputs, proof) {
             Ok(is_valid) => {
                 #[cfg(feature = "aleo-cli")]
-                let elapsed = timer.elapsed().as_millis();
-                #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
+                {
+                    let elapsed = timer.elapsed().as_millis();
+                    println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
+                }
+
                 is_valid
             }
             Err(error) => {

--- a/vm/compiler/src/snark/verifying_key/mod.rs
+++ b/vm/compiler/src/snark/verifying_key/mod.rs
@@ -36,14 +36,18 @@ impl<N: Network> VerifyingKey<N> {
 
     /// Returns `true` if the proof is valid for the given public inputs.
     pub fn verify(&self, function_name: &Identifier<N>, inputs: &[N::Field], proof: &Proof<N>) -> bool {
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         match Marlin::<N>::verify_batch(self, std::slice::from_ref(&inputs), proof) {
             Ok(is_valid) => {
+                #[cfg(feature = "aleo-cli")]
                 let elapsed = timer.elapsed().as_millis();
+                #[cfg(feature = "aleo-cli")]
                 println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
                 is_valid
             }
             Err(error) => {
+                #[cfg(feature = "aleo-cli")]
                 println!("{}", format!(" • Verifier failed: {error}").dimmed());
                 false
             }
@@ -52,14 +56,18 @@ impl<N: Network> VerifyingKey<N> {
 
     /// Returns `true` if the batch proof is valid for the given public inputs.
     pub fn verify_batch(&self, function_name: &Identifier<N>, inputs: &[&[N::Field]], proof: &Proof<N>) -> bool {
+        #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
         match Marlin::<N>::verify_batch(self, inputs, proof) {
             Ok(is_valid) => {
+                #[cfg(feature = "aleo-cli")]
                 let elapsed = timer.elapsed().as_millis();
+                #[cfg(feature = "aleo-cli")]
                 println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
                 is_valid
             }
             Err(error) => {
+                #[cfg(feature = "aleo-cli")]
                 println!("{}", format!(" • Verifier failed: {error}").dimmed());
                 false
             }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Adds an `aleo-cli` feature guard that can be toggled on to render CLI logging.
