### PR TITLE
Use an IndexMap inside the MemoryMap

### DIFF
--- a/vm/compiler/src/ledger/map/iterators.rs
+++ b/vm/compiler/src/ledger/map/iterators.rs
@@ -14,16 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{borrow::Cow, collections::hash_map};
+use indexmap::map;
+
+use std::borrow::Cow;
 
 /// An iterator over all key-value pairs in a MemoryMap.
 pub struct Iter<'a, K: 'a + Clone, V: 'a + Clone> {
-    pub(crate) inner: hash_map::Iter<'a, K, V>,
+    pub(crate) inner: map::Iter<'a, K, V>,
 }
 
 impl<'a, K: 'a + Clone, V: 'a + Clone> Iter<'a, K, V> {
     #[inline]
-    pub(crate) fn new(inner: hash_map::Iter<'a, K, V>) -> Self {
+    pub(crate) fn new(inner: map::Iter<'a, K, V>) -> Self {
         Self { inner }
     }
 }

--- a/vm/compiler/src/ledger/map/memory_map.rs
+++ b/vm/compiler/src/ledger/map/memory_map.rs
@@ -20,16 +20,17 @@ use crate::ledger::map::{
     MapReader,
 };
 use console::network::prelude::*;
+use indexmap::IndexMap;
 
 use core::{borrow::Borrow, hash::Hash};
-use std::{borrow::Cow, collections::hash_map::HashMap};
+use std::borrow::Cow;
 
 #[derive(Clone)]
 pub struct MemoryMap<
     K: PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de>,
     V: PartialEq + Eq + Serialize + for<'de> Deserialize<'de>,
 > {
-    pub(super) map: HashMap<K, V>,
+    pub(super) map: IndexMap<K, V>,
 }
 
 impl<
@@ -39,7 +40,7 @@ impl<
 {
     /// Initializes a new `MemoryMap` from the given iterator.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        Self { map: HashMap::from_iter(iter) }
+        Self { map: IndexMap::from_iter(iter) }
     }
 }
 
@@ -132,6 +133,6 @@ impl<
 > Default for MemoryMap<K, V>
 {
     fn default() -> Self {
-        Self { map: HashMap::new() }
+        Self { map: Default::default() }
     }
 }


### PR DESCRIPTION
This change has the benefit of allowing to index the `MemoryMap` by keys like the block height, (making lookups faster if we tweak the API), and making the iteration order deterministic.