### PR TITLE
Renames `Storage::new` to `Storage::open`

### DIFF
--- a/vm/compiler/src/ledger/map/mod.rs
+++ b/vm/compiler/src/ledger/map/mod.rs
@@ -26,7 +26,7 @@ pub trait Map<
     'a,
     K: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + Deserialize<'a> + Send + Sync,
     V: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Send + Sync,
->: Clone + MapRead<'a, K, V> + FromIterator<(K, V)> + Sync
+>: Clone + MapRead<'a, K, V> + Sync
 {
     ///
     /// Inserts the given key-value pair into the map.

--- a/vm/compiler/src/ledger/map/mod.rs
+++ b/vm/compiler/src/ledger/map/mod.rs
@@ -26,7 +26,7 @@ pub trait Map<
     'a,
     K: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + Deserialize<'a> + Send + Sync,
     V: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Send + Sync,
->: Clone + Default + MapRead<'a, K, V> + FromIterator<(K, V)> + Sync
+>: Clone + MapRead<'a, K, V> + FromIterator<(K, V)> + Sync
 {
     ///
     /// Inserts the given key-value pair into the map.

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -115,7 +115,7 @@ impl<N: Network> Ledger<N, BlockMemory<N>> {
     /// Initializes a new instance of `Ledger` with the given genesis block.
     pub fn new_with_genesis(genesis: &Block<N>) -> Result<Self> {
         // Initialize the block store.
-        let blocks = BlockStore::<N, BlockMemory<N>>::open();
+        let blocks = BlockStore::<N, BlockMemory<N>>::open()?;
         // Initialize a new VM.
         let vm = VM::<N>::new()?;
 
@@ -756,7 +756,7 @@ mod tests {
         let genesis = Block::<CurrentNetwork>::from_bytes_le(GenesisBytes::load_bytes()).unwrap();
 
         // Initialize a ledger without the genesis block.
-        let ledger = CurrentLedger::from(BlockStore::<CurrentNetwork, BlockMemory<CurrentNetwork>>::open()).unwrap();
+        let ledger = CurrentLedger::from(BlockStore::<_, BlockMemory<_>>::open().unwrap()).unwrap();
         assert_eq!(ledger.latest_hash(), genesis.hash());
         assert_eq!(ledger.latest_height(), genesis.height());
         assert_eq!(ledger.latest_round(), genesis.round());

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -115,7 +115,7 @@ impl<N: Network> Ledger<N, BlockMemory<N>> {
     /// Initializes a new instance of `Ledger` with the given genesis block.
     pub fn new_with_genesis(genesis: &Block<N>) -> Result<Self> {
         // Initialize the block store.
-        let blocks = BlockStore::<N, BlockMemory<N>>::new();
+        let blocks = BlockStore::<N, BlockMemory<N>>::open();
         // Initialize a new VM.
         let vm = VM::<N>::new()?;
 
@@ -756,7 +756,7 @@ mod tests {
         let genesis = Block::<CurrentNetwork>::from_bytes_le(GenesisBytes::load_bytes()).unwrap();
 
         // Initialize a ledger without the genesis block.
-        let ledger = CurrentLedger::from(BlockStore::<CurrentNetwork, BlockMemory<CurrentNetwork>>::new()).unwrap();
+        let ledger = CurrentLedger::from(BlockStore::<CurrentNetwork, BlockMemory<CurrentNetwork>>::open()).unwrap();
         assert_eq!(ledger.latest_hash(), genesis.hash());
         assert_eq!(ledger.latest_height(), genesis.height());
         assert_eq!(ledger.latest_round(), genesis.round());

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -142,6 +142,14 @@ impl<N: Network> Ledger<N, BlockMemory<N>> {
 
 impl<N: Network, B: BlockStorage<N>> Ledger<N, B> {
     /// Initializes the `Ledger` from storage.
+    pub fn open() -> Result<Self> {
+        // Initialize the block store.
+        let blocks = BlockStore::<N, B>::open()?;
+        // Return the ledger.
+        Self::from(blocks)
+    }
+
+    /// Initializes the `Ledger` from storage.
     pub fn from(blocks: BlockStore<N, B>) -> Result<Self> {
         // Initialize a new VM.
         let vm = VM::<N>::from(&blocks)?;

--- a/vm/compiler/src/ledger/store/block/mod.rs
+++ b/vm/compiler/src/ledger/store/block/mod.rs
@@ -65,8 +65,8 @@ pub trait BlockStorage<N: Network>: Clone + Sync {
     /// The mapping of `block hash` to `block signature`.
     type SignatureMap: for<'a> Map<'a, N::BlockHash, Signature<N>>;
 
-    /// Creates a new block storage.
-    fn new() -> Self;
+    /// Initializes the block storage.
+    fn open() -> Self;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -286,12 +286,12 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     type TransitionStorage = TransitionMemory<N>;
     type SignatureMap = MemoryMap<N::BlockHash, Signature<N>>;
 
-    /// Creates a new block storage.
-    fn new() -> Self {
+    /// Initializes the block storage.
+    fn open() -> Self {
         // Initialize the transition store.
-        let transition_store = TransitionStore::<N, TransitionMemory<N>>::new();
+        let transition_store = TransitionStore::<N, TransitionMemory<N>>::open();
         // Initialize the transaction store.
-        let transaction_store = TransactionStore::<N, TransactionMemory<N>>::new(transition_store);
+        let transaction_store = TransactionStore::<N, TransactionMemory<N>>::open(transition_store);
         // Return the block storage.
         Self {
             id_map: MemoryMap::default(),
@@ -341,7 +341,7 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
 }
 
 /// The block store.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct BlockStore<N: Network, B: BlockStorage<N>> {
     /// The block storage.
     storage: B,
@@ -350,10 +350,10 @@ pub struct BlockStore<N: Network, B: BlockStorage<N>> {
 }
 
 impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
-    /// Initializes a new block store.
-    pub fn new() -> Self {
+    /// Initializes the block store.
+    pub fn open() -> Self {
         // Initialize the block storage.
-        let storage = B::new();
+        let storage = B::open();
         // Return the block store.
         Self { storage, _phantom: PhantomData }
     }
@@ -463,7 +463,7 @@ mod tests {
         let block_hash = block.hash();
 
         // Initialize a new block store.
-        let block_store = BlockStore::<_, BlockMemory<_>>::new();
+        let block_store = BlockStore::<_, BlockMemory<_>>::open();
 
         // Ensure the block does not exist.
         let candidate = block_store.get_block(&block_hash).unwrap();
@@ -492,7 +492,7 @@ mod tests {
         assert!(block.transactions().len() > 0, "This test must be run with at least one transaction.");
 
         // Initialize a new block store.
-        let block_store = BlockStore::<_, BlockMemory<_>>::new();
+        let block_store = BlockStore::<_, BlockMemory<_>>::open();
 
         // Ensure the block does not exist.
         let candidate = block_store.get_block(&block_hash).unwrap();

--- a/vm/compiler/src/ledger/store/block/mod.rs
+++ b/vm/compiler/src/ledger/store/block/mod.rs
@@ -66,7 +66,7 @@ pub trait BlockStorage<N: Network>: Clone + Sync {
     type SignatureMap: for<'a> Map<'a, N::BlockHash, Signature<N>>;
 
     /// Initializes the block storage.
-    fn open() -> Self;
+    fn open() -> Result<Self>;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -287,13 +287,13 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     type SignatureMap = MemoryMap<N::BlockHash, Signature<N>>;
 
     /// Initializes the block storage.
-    fn open() -> Self {
+    fn open() -> Result<Self> {
         // Initialize the transition store.
-        let transition_store = TransitionStore::<N, TransitionMemory<N>>::open();
+        let transition_store = TransitionStore::<N, TransitionMemory<N>>::open()?;
         // Initialize the transaction store.
-        let transaction_store = TransactionStore::<N, TransactionMemory<N>>::open(transition_store);
+        let transaction_store = TransactionStore::<N, TransactionMemory<N>>::open(transition_store)?;
         // Return the block storage.
-        Self {
+        Ok(Self {
             id_map: MemoryMap::default(),
             reverse_id_map: MemoryMap::default(),
             header_map: MemoryMap::default(),
@@ -301,7 +301,7 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
             reverse_transactions_map: MemoryMap::default(),
             transaction_store,
             signature_map: MemoryMap::default(),
-        }
+        })
     }
 
     /// Returns the ID map.
@@ -351,11 +351,11 @@ pub struct BlockStore<N: Network, B: BlockStorage<N>> {
 
 impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     /// Initializes the block store.
-    pub fn open() -> Self {
+    pub fn open() -> Result<Self> {
         // Initialize the block storage.
-        let storage = B::open();
+        let storage = B::open()?;
         // Return the block store.
-        Self { storage, _phantom: PhantomData }
+        Ok(Self { storage, _phantom: PhantomData })
     }
 
     /// Initializes a block store from storage.
@@ -463,7 +463,7 @@ mod tests {
         let block_hash = block.hash();
 
         // Initialize a new block store.
-        let block_store = BlockStore::<_, BlockMemory<_>>::open();
+        let block_store = BlockStore::<_, BlockMemory<_>>::open().unwrap();
 
         // Ensure the block does not exist.
         let candidate = block_store.get_block(&block_hash).unwrap();
@@ -492,7 +492,7 @@ mod tests {
         assert!(block.transactions().len() > 0, "This test must be run with at least one transaction.");
 
         // Initialize a new block store.
-        let block_store = BlockStore::<_, BlockMemory<_>>::open();
+        let block_store = BlockStore::<_, BlockMemory<_>>::open().unwrap();
 
         // Ensure the block does not exist.
         let candidate = block_store.get_block(&block_hash).unwrap();

--- a/vm/compiler/src/ledger/store/transaction/deployment.rs
+++ b/vm/compiler/src/ledger/store/transaction/deployment.rs
@@ -55,8 +55,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Sync {
     /// The transition storage.
     type TransitionStorage: TransitionStorage<N>;
 
-    /// Creates a new deployment storage.
-    fn new(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self;
+    /// Initializes the deployment storage.
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -371,8 +371,8 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
     type AdditionalFeeMap = MemoryMap<N::TransactionID, N::TransitionID>;
     type TransitionStorage = TransitionMemory<N>;
 
-    /// Creates a new deployment storage.
-    fn new(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self {
+    /// Initializes the deployment storage.
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self {
         Self {
             id_map: MemoryMap::default(),
             edition_map: MemoryMap::default(),
@@ -436,10 +436,10 @@ pub struct DeploymentStore<N: Network, D: DeploymentStorage<N>> {
 }
 
 impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
-    /// Initializes a new deployment store.
-    pub fn new(transition_store: TransitionStore<N, D::TransitionStorage>) -> Self {
+    /// Initializes the deployment store.
+    pub fn open(transition_store: TransitionStore<N, D::TransitionStorage>) -> Self {
         // Initialize the deployment storage.
-        let storage = D::new(transition_store);
+        let storage = D::open(transition_store);
         // Return the deployment store.
         Self { storage, _phantom: PhantomData }
     }
@@ -567,9 +567,9 @@ mod tests {
         let transaction_id = transaction.id();
 
         // Initialize a new transition store.
-        let transition_store = TransitionStore::new();
+        let transition_store = TransitionStore::open();
         // Initialize a new deployment store.
-        let deployment_store = DeploymentMemory::new(transition_store);
+        let deployment_store = DeploymentMemory::open(transition_store);
 
         // Ensure the deployment transaction does not exist.
         let candidate = deployment_store.get_transaction(&transaction_id).unwrap();
@@ -601,9 +601,9 @@ mod tests {
         };
 
         // Initialize a new transition store.
-        let transition_store = TransitionStore::new();
+        let transition_store = TransitionStore::open();
         // Initialize a new deployment store.
-        let deployment_store = DeploymentMemory::new(transition_store);
+        let deployment_store = DeploymentMemory::open(transition_store);
 
         // Ensure the deployment transaction does not exist.
         let candidate = deployment_store.get_transaction(&transaction_id).unwrap();

--- a/vm/compiler/src/ledger/store/transaction/execution.rs
+++ b/vm/compiler/src/ledger/store/transaction/execution.rs
@@ -43,7 +43,7 @@ pub trait ExecutionStorage<N: Network>: Clone + Sync {
     type TransitionStorage: TransitionStorage<N>;
 
     /// Initializes the execution storage.
-    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self;
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self>;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -240,13 +240,13 @@ impl<N: Network> ExecutionStorage<N> for ExecutionMemory<N> {
     type TransitionStorage = TransitionMemory<N>;
 
     /// Initializes the execution storage.
-    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self {
-        Self {
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
+        Ok(Self {
             id_map: MemoryMap::default(),
             reverse_id_map: MemoryMap::default(),
             edition_map: MemoryMap::default(),
             transition_store,
-        }
+        })
     }
 
     /// Returns the ID map.
@@ -281,11 +281,11 @@ pub struct ExecutionStore<N: Network, E: ExecutionStorage<N>> {
 
 impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
     /// Initializes the execution store.
-    pub fn open(transition_store: TransitionStore<N, E::TransitionStorage>) -> Self {
+    pub fn open(transition_store: TransitionStore<N, E::TransitionStorage>) -> Result<Self> {
         // Initialize the execution storage.
-        let storage = E::open(transition_store);
+        let storage = E::open(transition_store)?;
         // Return the execution store.
-        Self { storage, _phantom: PhantomData }
+        Ok(Self { storage, _phantom: PhantomData })
     }
 
     /// Initializes an execution store from storage.
@@ -368,9 +368,9 @@ mod tests {
         let transaction_id = transaction.id();
 
         // Initialize a new transition store.
-        let transition_store = TransitionStore::open();
+        let transition_store = TransitionStore::open().unwrap();
         // Initialize a new execution store.
-        let execution_store = ExecutionMemory::open(transition_store);
+        let execution_store = ExecutionMemory::open(transition_store).unwrap();
 
         // Ensure the execution transaction does not exist.
         let candidate = execution_store.get_transaction(&transaction_id).unwrap();
@@ -404,9 +404,9 @@ mod tests {
         };
 
         // Initialize a new transition store.
-        let transition_store = TransitionStore::open();
+        let transition_store = TransitionStore::open().unwrap();
         // Initialize a new execution store.
-        let execution_store = ExecutionMemory::open(transition_store);
+        let execution_store = ExecutionMemory::open(transition_store).unwrap();
 
         // Ensure the execution transaction does not exist.
         let candidate = execution_store.get_transaction(&transaction_id).unwrap();

--- a/vm/compiler/src/ledger/store/transaction/execution.rs
+++ b/vm/compiler/src/ledger/store/transaction/execution.rs
@@ -42,8 +42,8 @@ pub trait ExecutionStorage<N: Network>: Clone + Sync {
     /// The transition storage.
     type TransitionStorage: TransitionStorage<N>;
 
-    /// Creates a new execution storage.
-    fn new(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self;
+    /// Initializes the execution storage.
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -239,8 +239,8 @@ impl<N: Network> ExecutionStorage<N> for ExecutionMemory<N> {
     type EditionMap = MemoryMap<N::TransactionID, u16>;
     type TransitionStorage = TransitionMemory<N>;
 
-    /// Creates a new execution storage.
-    fn new(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self {
+    /// Initializes the execution storage.
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self {
         Self {
             id_map: MemoryMap::default(),
             reverse_id_map: MemoryMap::default(),
@@ -280,10 +280,10 @@ pub struct ExecutionStore<N: Network, E: ExecutionStorage<N>> {
 }
 
 impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
-    /// Initializes a new execution store.
-    pub fn new(transition_store: TransitionStore<N, E::TransitionStorage>) -> Self {
+    /// Initializes the execution store.
+    pub fn open(transition_store: TransitionStore<N, E::TransitionStorage>) -> Self {
         // Initialize the execution storage.
-        let storage = E::new(transition_store);
+        let storage = E::open(transition_store);
         // Return the execution store.
         Self { storage, _phantom: PhantomData }
     }
@@ -368,9 +368,9 @@ mod tests {
         let transaction_id = transaction.id();
 
         // Initialize a new transition store.
-        let transition_store = TransitionStore::new();
+        let transition_store = TransitionStore::open();
         // Initialize a new execution store.
-        let execution_store = ExecutionMemory::new(transition_store);
+        let execution_store = ExecutionMemory::open(transition_store);
 
         // Ensure the execution transaction does not exist.
         let candidate = execution_store.get_transaction(&transaction_id).unwrap();
@@ -404,9 +404,9 @@ mod tests {
         };
 
         // Initialize a new transition store.
-        let transition_store = TransitionStore::new();
+        let transition_store = TransitionStore::open();
         // Initialize a new execution store.
-        let execution_store = ExecutionMemory::new(transition_store);
+        let execution_store = ExecutionMemory::open(transition_store);
 
         // Ensure the execution transaction does not exist.
         let candidate = execution_store.get_transaction(&transaction_id).unwrap();

--- a/vm/compiler/src/ledger/store/transaction/mod.rs
+++ b/vm/compiler/src/ledger/store/transaction/mod.rs
@@ -60,8 +60,8 @@ pub trait TransactionStorage<N: Network>: Clone + Sync {
     /// The transition storage.
     type TransitionStorage: TransitionStorage<N>;
 
-    /// Creates a new transaction storage.
-    fn new(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self;
+    /// Initializes the transaction storage.
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -152,12 +152,12 @@ impl<N: Network> TransactionStorage<N> for TransactionMemory<N> {
     type ExecutionStorage = ExecutionMemory<N>;
     type TransitionStorage = TransitionMemory<N>;
 
-    /// Creates a new transaction storage.
-    fn new(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self {
+    /// Initializes the transaction storage.
+    fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Self {
         // Initialize the deployment store.
-        let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::new(transition_store.clone());
+        let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::open(transition_store.clone());
         // Initialize the execution store.
-        let execution_store = ExecutionStore::<N, ExecutionMemory<N>>::new(transition_store);
+        let execution_store = ExecutionStore::<N, ExecutionMemory<N>>::open(transition_store);
         // Return the transaction storage.
         Self { id_map: MemoryMap::default(), deployment_store, execution_store }
     }
@@ -188,10 +188,10 @@ pub struct TransactionStore<N: Network, T: TransactionStorage<N>> {
 }
 
 impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
-    /// Initializes a new transaction store.
-    pub fn new(transition_store: TransitionStore<N, T::TransitionStorage>) -> Self {
+    /// Initializes the transaction store.
+    pub fn open(transition_store: TransitionStore<N, T::TransitionStorage>) -> Self {
         // Initialize the transaction storage.
-        let storage = T::new(transition_store);
+        let storage = T::open(transition_store);
         // Return the transaction store.
         Self { transaction_ids: storage.id_map().clone(), storage }
     }
@@ -392,9 +392,9 @@ mod tests {
             let transaction_id = transaction.id();
 
             // Initialize a new transition store.
-            let transition_store = TransitionStore::<_, TransitionMemory<_>>::new();
+            let transition_store = TransitionStore::<_, TransitionMemory<_>>::open();
             // Initialize a new transaction store.
-            let transaction_store = TransactionStore::<_, TransactionMemory<_>>::new(transition_store);
+            let transaction_store = TransactionStore::<_, TransactionMemory<_>>::open(transition_store);
 
             // Ensure the transaction does not exist.
             let candidate = transaction_store.get_transaction(&transaction_id).unwrap();
@@ -429,9 +429,9 @@ mod tests {
         };
 
         // Initialize a new transition store.
-        let transition_store = TransitionStore::<_, TransitionMemory<_>>::new();
+        let transition_store = TransitionStore::<_, TransitionMemory<_>>::open();
         // Initialize a new transaction store.
-        let transaction_store = TransactionStore::<_, TransactionMemory<_>>::new(transition_store);
+        let transaction_store = TransactionStore::<_, TransactionMemory<_>>::open(transition_store);
 
         // Ensure the execution transaction does not exist.
         let candidate = transaction_store.get_transaction(&transaction_id).unwrap();

--- a/vm/compiler/src/ledger/store/transition/input.rs
+++ b/vm/compiler/src/ledger/store/transition/input.rs
@@ -46,8 +46,8 @@ pub trait InputStorage<N: Network>: Clone + Sync {
     /// The mapping of `external commitment` to `()`. Note: This is **not** the record commitment.
     type ExternalRecordMap: for<'a> Map<'a, Field<N>, ()>;
 
-    /// Creates a new transition input storage.
-    fn new() -> Self;
+    /// Initializes the transition input storage.
+    fn open() -> Self;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -225,8 +225,8 @@ impl<N: Network> InputStorage<N> for InputMemory<N> {
     type RecordTagMap = MemoryMap<Field<N>, Field<N>>;
     type ExternalRecordMap = MemoryMap<Field<N>, ()>;
 
-    /// Creates a new transition input storage.
-    fn new() -> Self {
+    /// Initializes the transition input storage.
+    fn open() -> Self {
         Self {
             id_map: MemoryMap::default(),
             reverse_id_map: MemoryMap::default(),
@@ -281,7 +281,7 @@ impl<N: Network> InputStorage<N> for InputMemory<N> {
 }
 
 /// The transition input store.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct InputStore<N: Network, I: InputStorage<N>> {
     /// The map of constant inputs.
     constant: I::ConstantMap,
@@ -300,10 +300,10 @@ pub struct InputStore<N: Network, I: InputStorage<N>> {
 }
 
 impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
-    /// Initializes a new transition input store.
-    pub fn new() -> Self {
+    /// Initializes the transition input store.
+    pub fn open() -> Self {
         // Initialize a new transition input storage.
-        let storage = I::new();
+        let storage = I::open();
         // Return the transition input store.
         Self {
             constant: storage.constant_map().clone(),
@@ -459,7 +459,7 @@ mod tests {
         // Sample the transition inputs.
         for (transition_id, input) in crate::ledger::transition::input::test_helpers::sample_inputs() {
             // Initialize a new input store.
-            let input_store = InputMemory::new();
+            let input_store = InputMemory::open();
 
             // Ensure the transition input does not exist.
             let candidate = input_store.get(&transition_id).unwrap();
@@ -486,7 +486,7 @@ mod tests {
         // Sample the transition inputs.
         for (transition_id, input) in crate::ledger::transition::input::test_helpers::sample_inputs() {
             // Initialize a new input store.
-            let input_store = InputMemory::new();
+            let input_store = InputMemory::open();
 
             // Ensure the transition input does not exist.
             let candidate = input_store.get(&transition_id).unwrap();

--- a/vm/compiler/src/ledger/store/transition/input.rs
+++ b/vm/compiler/src/ledger/store/transition/input.rs
@@ -47,7 +47,7 @@ pub trait InputStorage<N: Network>: Clone + Sync {
     type ExternalRecordMap: for<'a> Map<'a, Field<N>, ()>;
 
     /// Initializes the transition input storage.
-    fn open() -> Self;
+    fn open() -> Result<Self>;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -226,8 +226,8 @@ impl<N: Network> InputStorage<N> for InputMemory<N> {
     type ExternalRecordMap = MemoryMap<Field<N>, ()>;
 
     /// Initializes the transition input storage.
-    fn open() -> Self {
-        Self {
+    fn open() -> Result<Self> {
+        Ok(Self {
             id_map: MemoryMap::default(),
             reverse_id_map: MemoryMap::default(),
             constant: MemoryMap::default(),
@@ -236,7 +236,7 @@ impl<N: Network> InputStorage<N> for InputMemory<N> {
             record: MemoryMap::default(),
             record_tag: MemoryMap::default(),
             external_record: MemoryMap::default(),
-        }
+        })
     }
 
     /// Returns the ID map.
@@ -301,11 +301,11 @@ pub struct InputStore<N: Network, I: InputStorage<N>> {
 
 impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
     /// Initializes the transition input store.
-    pub fn open() -> Self {
+    pub fn open() -> Result<Self> {
         // Initialize a new transition input storage.
-        let storage = I::open();
+        let storage = I::open()?;
         // Return the transition input store.
-        Self {
+        Ok(Self {
             constant: storage.constant_map().clone(),
             public: storage.public_map().clone(),
             private: storage.private_map().clone(),
@@ -313,7 +313,7 @@ impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
             record_tag: storage.record_tag_map().clone(),
             external_record: storage.external_record_map().clone(),
             storage,
-        }
+        })
     }
 
     /// Initializes a transition input store from storage.
@@ -459,7 +459,7 @@ mod tests {
         // Sample the transition inputs.
         for (transition_id, input) in crate::ledger::transition::input::test_helpers::sample_inputs() {
             // Initialize a new input store.
-            let input_store = InputMemory::open();
+            let input_store = InputMemory::open().unwrap();
 
             // Ensure the transition input does not exist.
             let candidate = input_store.get(&transition_id).unwrap();
@@ -486,7 +486,7 @@ mod tests {
         // Sample the transition inputs.
         for (transition_id, input) in crate::ledger::transition::input::test_helpers::sample_inputs() {
             // Initialize a new input store.
-            let input_store = InputMemory::open();
+            let input_store = InputMemory::open().unwrap();
 
             // Ensure the transition input does not exist.
             let candidate = input_store.get(&transition_id).unwrap();

--- a/vm/compiler/src/ledger/store/transition/mod.rs
+++ b/vm/compiler/src/ledger/store/transition/mod.rs
@@ -62,8 +62,8 @@ pub trait TransitionStorage<N: Network>: Clone + Sync {
     /// The transition fees.
     type FeeMap: for<'a> Map<'a, N::TransitionID, i64>;
 
-    /// Creates a new transition storage.
-    fn new() -> Self;
+    /// Initializes the transition storage.
+    fn open() -> Self;
 
     /// Returns the transition program IDs and function names.
     fn locator_map(&self) -> &Self::LocatorMap;
@@ -224,12 +224,12 @@ impl<N: Network> TransitionStorage<N> for TransitionMemory<N> {
     type ReverseTCMMap = MemoryMap<Field<N>, N::TransitionID>;
     type FeeMap = MemoryMap<N::TransitionID, i64>;
 
-    /// Creates a new transition storage.
-    fn new() -> Self {
+    /// Initializes the transition storage.
+    fn open() -> Self {
         Self {
             locator_map: MemoryMap::default(),
-            input_store: InputStore::new(),
-            output_store: OutputStore::new(),
+            input_store: InputStore::open(),
+            output_store: OutputStore::open(),
             proof_map: MemoryMap::default(),
             tpk_map: MemoryMap::default(),
             reverse_tpk_map: MemoryMap::default(),
@@ -286,7 +286,7 @@ impl<N: Network> TransitionStorage<N> for TransitionMemory<N> {
 }
 
 /// The transition store.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct TransitionStore<N: Network, T: TransitionStorage<N>> {
     /// The map of transition program IDs and function names.
     locator: T::LocatorMap,
@@ -311,10 +311,10 @@ pub struct TransitionStore<N: Network, T: TransitionStorage<N>> {
 }
 
 impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {
-    /// Initializes a new transition store.
-    pub fn new() -> Self {
+    /// Initializes the transition store.
+    pub fn open() -> Self {
         // Initialize the transition storage.
-        let storage = T::new();
+        let storage = T::open();
         // Return the transition store.
         Self {
             locator: storage.locator_map().clone(),
@@ -656,7 +656,7 @@ mod tests {
         assert!(transitions.len() > 1, "\n\nNumber of transitions: {}\n", transitions.len());
 
         // Initialize a new transition store.
-        let transition_store = TransitionMemory::new();
+        let transition_store = TransitionMemory::open();
 
         // Test each transition in isolation.
         for transition in transitions.iter() {

--- a/vm/compiler/src/ledger/store/transition/output.rs
+++ b/vm/compiler/src/ledger/store/transition/output.rs
@@ -47,7 +47,7 @@ pub trait OutputStorage<N: Network>: Clone + Sync {
     type ExternalRecordMap: for<'a> Map<'a, Field<N>, ()>;
 
     /// Initializes the transition output storage.
-    fn open() -> Self;
+    fn open() -> Result<Self>;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -231,8 +231,8 @@ impl<N: Network> OutputStorage<N> for OutputMemory<N> {
     type ExternalRecordMap = MemoryMap<Field<N>, ()>;
 
     /// Initializes the transition output storage.
-    fn open() -> Self {
-        Self {
+    fn open() -> Result<Self> {
+        Ok(Self {
             id_map: Default::default(),
             reverse_id_map: Default::default(),
             constant: Default::default(),
@@ -241,7 +241,7 @@ impl<N: Network> OutputStorage<N> for OutputMemory<N> {
             record: Default::default(),
             record_nonce: Default::default(),
             external_record: Default::default(),
-        }
+        })
     }
 
     /// Returns the ID map.
@@ -306,11 +306,11 @@ pub struct OutputStore<N: Network, O: OutputStorage<N>> {
 
 impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
     /// Initializes the transition output store.
-    pub fn open() -> Self {
+    pub fn open() -> Result<Self> {
         // Initialize a new transition output storage.
-        let storage = O::open();
+        let storage = O::open()?;
         // Return the transition output store.
-        Self {
+        Ok(Self {
             constant: storage.constant_map().clone(),
             public: storage.public_map().clone(),
             private: storage.private_map().clone(),
@@ -318,7 +318,7 @@ impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
             record_nonce: storage.record_nonce_map().clone(),
             external_record: storage.external_record_map().clone(),
             storage,
-        }
+        })
     }
 
     /// Initializes a transition output store from storage.
@@ -494,7 +494,7 @@ mod tests {
         // Sample the transition outputs.
         for (transition_id, output) in crate::ledger::transition::output::test_helpers::sample_outputs() {
             // Initialize a new output store.
-            let output_store = OutputMemory::open();
+            let output_store = OutputMemory::open().unwrap();
 
             // Ensure the transition output does not exist.
             let candidate = output_store.get(&transition_id).unwrap();
@@ -521,7 +521,7 @@ mod tests {
         // Sample the transition outputs.
         for (transition_id, output) in crate::ledger::transition::output::test_helpers::sample_outputs() {
             // Initialize a new output store.
-            let output_store = OutputMemory::open();
+            let output_store = OutputMemory::open().unwrap();
 
             // Ensure the transition output does not exist.
             let candidate = output_store.get(&transition_id).unwrap();

--- a/vm/compiler/src/ledger/store/transition/output.rs
+++ b/vm/compiler/src/ledger/store/transition/output.rs
@@ -46,8 +46,8 @@ pub trait OutputStorage<N: Network>: Clone + Sync {
     /// The mapping of `external commitment` to `()`. Note: This is **not** the record commitment.
     type ExternalRecordMap: for<'a> Map<'a, Field<N>, ()>;
 
-    /// Creates a new transition output storage.
-    fn new() -> Self;
+    /// Initializes the transition output storage.
+    fn open() -> Self;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -230,8 +230,8 @@ impl<N: Network> OutputStorage<N> for OutputMemory<N> {
     type RecordNonceMap = MemoryMap<Group<N>, Field<N>>;
     type ExternalRecordMap = MemoryMap<Field<N>, ()>;
 
-    /// Creates a new transition output storage.
-    fn new() -> Self {
+    /// Initializes the transition output storage.
+    fn open() -> Self {
         Self {
             id_map: Default::default(),
             reverse_id_map: Default::default(),
@@ -286,7 +286,7 @@ impl<N: Network> OutputStorage<N> for OutputMemory<N> {
 }
 
 /// The transition output store.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct OutputStore<N: Network, O: OutputStorage<N>> {
     /// The map of constant outputs.
     constant: O::ConstantMap,
@@ -305,10 +305,10 @@ pub struct OutputStore<N: Network, O: OutputStorage<N>> {
 }
 
 impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
-    /// Initializes a new transition output store.
-    pub fn new() -> Self {
+    /// Initializes the transition output store.
+    pub fn open() -> Self {
         // Initialize a new transition output storage.
-        let storage = O::new();
+        let storage = O::open();
         // Return the transition output store.
         Self {
             constant: storage.constant_map().clone(),
@@ -494,7 +494,7 @@ mod tests {
         // Sample the transition outputs.
         for (transition_id, output) in crate::ledger::transition::output::test_helpers::sample_outputs() {
             // Initialize a new output store.
-            let output_store = OutputMemory::new();
+            let output_store = OutputMemory::open();
 
             // Ensure the transition output does not exist.
             let candidate = output_store.get(&transition_id).unwrap();
@@ -521,7 +521,7 @@ mod tests {
         // Sample the transition outputs.
         for (transition_id, output) in crate::ledger::transition::output::test_helpers::sample_outputs() {
             // Initialize a new output store.
-            let output_store = OutputMemory::new();
+            let output_store = OutputMemory::open();
 
             // Ensure the transition output does not exist.
             let candidate = output_store.get(&transition_id).unwrap();


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

- Removes `Default` from `Map` trait
- Removes `FromIter` from `Map` trait
- Renames `Storage::new` to `Storage::open`
- Adds `Result` to `Storage::open` return type
- Adds `Ledger::open`