### PR TITLE
[Testnet3] Add `is_on_curve` check for `from_coordinates` call

### DIFF
--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -103,7 +103,9 @@ impl<P: Parameters> AffineCurve for Affine<P> {
     /// Initializes a new affine group element from the given coordinates.
     fn from_coordinates(coordinates: Self::Coordinates) -> Self {
         let (x, y, infinity) = coordinates;
-        Self { x, y, infinity }
+        let point = Self { x, y, infinity };
+        assert!(point.is_on_curve());
+        point
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR checks that the short Weierstrass Jacobian affine element is on the curve when constructed via `from_coordinates`. This check is already done in the Twisted Edwards variant of `from_coordinates`.

Tracking PR: #957 