### PR TITLE
[Testnet3] Guard blake digest length with `saturating_add`

### DIFF
--- a/console/algorithms/src/blake2xs/mod.rs
+++ b/console/algorithms/src/blake2xs/mod.rs
@@ -43,7 +43,7 @@ impl Blake2Xs {
 
         let mut output = vec![];
 
-        let num_rounds = (xof_digest_length + 31) / 32;
+        let num_rounds = xof_digest_length.saturating_add(31) / 32;
         for node_offset in 0..num_rounds {
             // Calculate the digest length for this round.
             let is_final_round = node_offset == num_rounds - 1;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR guards the number of rounds in `Blake2Xs::evaluate` with `saturating_add` to prevent overflows. This is a minor fix because having to hash an input of size `u16::MAX` is very unlikely.

Tracking PR: #957 