### PR TITLE
Adds support for `self.caller` and `{program_id}`

### DIFF
--- a/circuit/program/src/id/mod.rs
+++ b/circuit/program/src/id/mod.rs
@@ -14,12 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(test)]
+use snarkvm_circuit_types::environment::assert_scope;
+
+mod to_address;
 mod to_bits;
 mod to_fields;
 
 use crate::Identifier;
 use snarkvm_circuit_network::Aleo;
-use snarkvm_circuit_types::{environment::prelude::*, Boolean, Field};
+use snarkvm_circuit_types::{environment::prelude::*, Address, Boolean, Field};
 
 /// A program ID is of the form `{name}.{network}`.
 /// If no `network`-level domain is specified, the default network is used.

--- a/circuit/program/src/id/to_address.rs
+++ b/circuit/program/src/id/to_address.rs
@@ -1,0 +1,81 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+impl<A: Aleo> ProgramID<A> {
+    /// Returns the program address for this program ID.
+    pub fn to_address(&self) -> Address<A> {
+        // Compute the program address as `HashToGroup(program_id)`.
+        let group = A::hash_to_group_psd4(&[self.name().to_field(), self.network().to_field()]);
+        // Return the program address.
+        Address::from_group(group)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{data::identifier::tests::sample_console_identifier_as_string, Circuit};
+
+    use anyhow::Result;
+
+    const ITERATIONS: usize = 100;
+
+    fn check_to_address(
+        mode: Mode,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+    ) -> Result<()> {
+        for i in 0..ITERATIONS {
+            // Sample a random fixed-length alphanumeric string, that always starts with an alphabetic character.
+            let expected_name_string = sample_console_identifier_as_string::<Circuit>()?;
+            let expected_program_id = console::ProgramID::<<Circuit as Environment>::Network>::from_str(&format!(
+                "{expected_name_string}.aleo"
+            ))?;
+            let expected = expected_program_id.to_address()?;
+
+            let program_id = ProgramID::<Circuit>::new(mode, expected_program_id);
+
+            Circuit::scope(format!("{mode}"), || {
+                let candidate = program_id.to_address();
+                assert_eq!(expected, candidate.eject_value());
+                if i > 0 {
+                    assert_scope!(num_constants, num_public, num_private, num_constraints);
+                }
+            });
+            Circuit::reset();
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_address_constant() -> Result<()> {
+        check_to_address(Mode::Constant, 553, 0, 0, 0)
+    }
+
+    #[test]
+    fn test_to_address_public() -> Result<()> {
+        check_to_address(Mode::Public, 553, 0, 0, 0)
+    }
+
+    #[test]
+    fn test_to_address_private() -> Result<()> {
+        check_to_address(Mode::Private, 553, 0, 0, 0)
+    }
+}

--- a/console/program/src/id/mod.rs
+++ b/console/program/src/id/mod.rs
@@ -17,15 +17,15 @@
 mod bytes;
 mod parse;
 mod serialize;
+mod to_address;
 mod to_bits;
 mod to_fields;
 
 use crate::Identifier;
 use snarkvm_console_network::prelude::*;
-use snarkvm_console_types::Field;
+use snarkvm_console_types::{Address, Field};
 
 /// A program ID is of the form `{name}.{network}`.
-/// If no `network`-level domain is specified, the default network is used.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ProgramID<N: Network> {
     /// The program name.

--- a/console/program/src/id/parse.rs
+++ b/console/program/src/id/parse.rs
@@ -18,7 +18,6 @@ use super::*;
 
 impl<N: Network> Parser for ProgramID<N> {
     /// Parses a string into a program ID of the form `{name}.{network}`.
-    /// If no `network`-level domain is specified, the default network is used.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the name from the string.

--- a/console/program/src/id/to_address.rs
+++ b/console/program/src/id/to_address.rs
@@ -1,0 +1,27 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+impl<N: Network> ProgramID<N> {
+    /// Returns the program address for this program ID.
+    pub fn to_address(&self) -> Result<Address<N>> {
+        // Compute the program address as `HashToGroup(program_id)`.
+        let group = N::hash_to_group_psd4(&[self.name().to_field()?, self.network().to_field()?])?;
+        // Return the program address.
+        Ok(Address::new(group))
+    }
+}

--- a/vm/compiler/src/process/stack/evaluate.rs
+++ b/vm/compiler/src/process/stack/evaluate.rs
@@ -27,6 +27,7 @@ impl<N: Network> Stack<N> {
         closure: &Closure<N>,
         inputs: &[Value<N>],
         call_stack: CallStack<N>,
+        caller: Address<N>,
         tvk: Field<N>,
     ) -> Result<Vec<Value<N>>> {
         // Ensure the number of inputs matches the number of input statements.
@@ -36,6 +37,8 @@ impl<N: Network> Stack<N> {
 
         // Initialize the registers.
         let mut registers = Registers::<N, A>::new(call_stack, self.get_register_types(closure.name())?.clone());
+        // Set the transition caller.
+        registers.set_caller(caller);
         // Set the transition view key.
         registers.set_tvk(tvk);
 
@@ -86,6 +89,7 @@ impl<N: Network> Stack<N> {
         // Retrieve the function, inputs, and transition view key.
         let function = self.get_function(request.function_name())?;
         let inputs = request.inputs();
+        let caller = *request.caller();
         let tvk = *request.tvk();
 
         // Ensure the number of inputs matches.
@@ -101,6 +105,8 @@ impl<N: Network> Stack<N> {
 
         // Initialize the registers.
         let mut registers = Registers::<N, A>::new(call_stack, self.get_register_types(function.name())?.clone());
+        // Set the transition caller.
+        registers.set_caller(caller);
         // Set the transition view key.
         registers.set_tvk(tvk);
 

--- a/vm/compiler/src/process/stack/execute.rs
+++ b/vm/compiler/src/process/stack/execute.rs
@@ -27,6 +27,7 @@ impl<N: Network> Stack<N> {
         closure: &Closure<N>,
         inputs: &[circuit::Value<A>],
         call_stack: CallStack<N>,
+        caller: circuit::Address<A>,
         tvk: circuit::Field<A>,
     ) -> Result<Vec<circuit::Value<A>>> {
         // Ensure the call stack is not `Evaluate`.
@@ -42,6 +43,8 @@ impl<N: Network> Stack<N> {
 
         // Initialize the registers.
         let mut registers = Registers::new(call_stack, self.get_register_types(closure.name())?.clone());
+        // Set the transition caller, as a circuit.
+        registers.set_caller_circuit(caller);
         // Set the transition view key, as a circuit.
         registers.set_tvk_circuit(tvk);
 
@@ -144,6 +147,11 @@ impl<N: Network> Stack<N> {
         let request = circuit::Request::new(circuit::Mode::Private, console_request.clone());
         // Ensure the request has a valid signature, inputs, and transition view key.
         A::assert(request.verify(&input_types, &tpk));
+
+        // Set the transition caller.
+        registers.set_caller(*console_request.caller());
+        // Set the transition caller, as a circuit.
+        registers.set_caller_circuit(request.caller().clone());
 
         // Set the transition view key.
         registers.set_tvk(*console_request.tvk());

--- a/vm/compiler/src/process/stack/helpers/initialize.rs
+++ b/vm/compiler/src/process/stack/helpers/initialize.rs
@@ -278,6 +278,8 @@ impl<N: Network> Stack<N> {
             operand_types.push(match operand {
                 Operand::Literal(literal) => RegisterType::Plaintext(PlaintextType::from(literal.to_type())),
                 Operand::Register(register) => register_types.get_type(self, register)?,
+                Operand::ProgramID(_) => RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address)),
+                Operand::Caller => RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address)),
             });
         }
 

--- a/vm/compiler/src/process/stack/mod.rs
+++ b/vm/compiler/src/process/stack/mod.rs
@@ -59,6 +59,7 @@ use console::{
         EntryType,
         Identifier,
         Literal,
+        LiteralType,
         Locator,
         Owner,
         Plaintext,

--- a/vm/compiler/src/process/stack/register_types/matches.rs
+++ b/vm/compiler/src/process/stack/register_types/matches.rs
@@ -46,7 +46,7 @@ impl<N: Network> RegisterTypes<N> {
                 Operand::Literal(literal) => {
                     ensure!(
                         PlaintextType::Literal(literal.to_type()) == *member_type,
-                        "Interface member '{interface_name}.{member_name}' expects a {member_type}, but found '{literal}' in the operand.",
+                        "Interface member '{interface_name}.{member_name}' expects a {member_type}, but found '{operand}' in the operand.",
                     )
                 }
                 // Ensure the register type matches the member type.
@@ -61,7 +61,27 @@ impl<N: Network> RegisterTypes<N> {
                     // Ensure the register type matches the member type.
                     ensure!(
                         register_type == RegisterType::Plaintext(*member_type),
-                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{register_type}' in the operand '{register}'.",
+                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{register_type}' in the operand '{operand}'.",
+                    )
+                }
+                // Ensure the program ID type (address) matches the member type.
+                Operand::ProgramID(..) => {
+                    // Retrieve the program ID type.
+                    let program_ref_type = RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address));
+                    // Ensure the program ID type matches the member type.
+                    ensure!(
+                        program_ref_type == RegisterType::Plaintext(*member_type),
+                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{program_ref_type}' in the operand '{operand}'.",
+                    )
+                }
+                // Ensure the caller type (address) matches the member type.
+                Operand::Caller => {
+                    // Retrieve the caller type.
+                    let caller_type = RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address));
+                    // Ensure the caller type matches the member type.
+                    ensure!(
+                        caller_type == RegisterType::Plaintext(*member_type),
+                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{caller_type}' in the operand '{operand}'.",
                     )
                 }
             }
@@ -100,6 +120,8 @@ impl<N: Network> RegisterTypes<N> {
                     "Casting to a record requires the first operand to be an address"
                 );
             }
+            // These operand types are always addresses.
+            Operand::ProgramID(..) | Operand::Caller => {} // Note: The ProgramID is rendered as an address.
         }
 
         // Ensure the second input type is a u64.
@@ -119,6 +141,10 @@ impl<N: Network> RegisterTypes<N> {
                     "Casting to a record requires the second operand to be a u64"
                 )
             }
+            // These operand types are never a `u64` type.
+            Operand::ProgramID(..) | Operand::Caller => {
+                bail!("Casting to a record requires the second operand to be a u64")
+            }
         }
 
         // Ensure the number of record entries does not exceed the maximum.
@@ -132,7 +158,7 @@ impl<N: Network> RegisterTypes<N> {
         }
 
         // Ensure the operand types match the record entry types.
-        for (operand, (_, entry_type)) in operands.iter().skip(2).zip_eq(record_type.entries()) {
+        for (operand, (entry_name, entry_type)) in operands.iter().skip(2).zip_eq(record_type.entries()) {
             match entry_type {
                 EntryType::Constant(plaintext_type)
                 | EntryType::Public(plaintext_type)
@@ -142,8 +168,7 @@ impl<N: Network> RegisterTypes<N> {
                         Operand::Literal(literal) => {
                             ensure!(
                                 PlaintextType::Literal(literal.to_type()) == *plaintext_type,
-                                "Record '{}' expects {plaintext_type}, operand is '{literal}'.",
-                                record_type.name()
+                                "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found '{literal}' in the operand.",
                             )
                         }
                         // Ensure the register type matches the entry type.
@@ -158,8 +183,28 @@ impl<N: Network> RegisterTypes<N> {
                             // Ensure the register type matches the entry type.
                             ensure!(
                                 register_type == RegisterType::Plaintext(*plaintext_type),
-                                "Record '{}' expects {plaintext_type}, operand is '{register_type}'.",
-                                record_type.name()
+                                "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found '{register_type}' in the operand '{operand}'.",
+                            )
+                        }
+                        // Ensure the program ID type (address) matches the member type.
+                        Operand::ProgramID(..) => {
+                            // Retrieve the program ID type.
+                            let program_ref_type =
+                                RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address));
+                            // Ensure the program ID type matches the member type.
+                            ensure!(
+                                program_ref_type == RegisterType::Plaintext(*plaintext_type),
+                                "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found '{program_ref_type}' in the operand '{operand}'.",
+                            )
+                        }
+                        // Ensure the caller type (address) matches the member type.
+                        Operand::Caller => {
+                            // Retrieve the caller type.
+                            let caller_type = RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address));
+                            // Ensure the caller type matches the member type.
+                            ensure!(
+                                caller_type == RegisterType::Plaintext(*plaintext_type),
+                                "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found '{caller_type}' in the operand '{operand}'.",
                             )
                         }
                     }

--- a/vm/compiler/src/process/stack/register_types/matches.rs
+++ b/vm/compiler/src/process/stack/register_types/matches.rs
@@ -120,8 +120,13 @@ impl<N: Network> RegisterTypes<N> {
                     "Casting to a record requires the first operand to be an address"
                 );
             }
-            // These operand types are always addresses.
-            Operand::ProgramID(..) | Operand::Caller => {} // Note: The ProgramID is rendered as an address.
+            Operand::ProgramID(program_id) => {
+                // Note: While the ProgramID is rendered as an address, this address is not recoverable
+                // from a private key. Furthermore, programs are not allowed to own any records.
+                // They must hold all necessary state in storage instead.
+                bail!("Forbidden operation: Cannot cast a program ID ('{program_id}') as a record owner")
+            }
+            Operand::Caller => {}
         }
 
         // Ensure the second input type is a u64.

--- a/vm/compiler/src/process/stack/registers/load.rs
+++ b/vm/compiler/src/process/stack/registers/load.rs
@@ -45,6 +45,12 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
             Operand::Literal(literal) => return Ok(Value::Plaintext(Plaintext::from(literal))),
             // If the operand is a register, load the value from the register.
             Operand::Register(register) => register,
+            // If the operand is the program ID, load the program address.
+            Operand::ProgramID(program_id) => {
+                return Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))));
+            }
+            // If the operand is the caller, load the value of the caller.
+            Operand::Caller => return Ok(Value::Plaintext(Plaintext::from(Literal::Address(self.caller()?)))),
         };
 
         // Retrieve the stack value.
@@ -117,6 +123,18 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
             }
             // If the operand is a register, load the value from the register.
             Operand::Register(register) => register,
+            // If the operand is the program ID, load the program address.
+            Operand::ProgramID(program_id) => {
+                return Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::constant(
+                    Literal::Address(program_id.to_address()?),
+                ))));
+            }
+            // If the operand is the caller, load the value of the caller.
+            Operand::Caller => {
+                return Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
+                    self.caller_circuit()?,
+                ))));
+            }
         };
 
         // Retrieve the circuit value.

--- a/vm/compiler/src/process/stack/registers/mod.rs
+++ b/vm/compiler/src/process/stack/registers/mod.rs
@@ -21,7 +21,7 @@ use crate::{CallStack, Operand, RegisterTypes, Stack};
 use console::{
     network::prelude::*,
     program::{Entry, Literal, Plaintext, Register, Value},
-    types::Field,
+    types::{Address, Field},
 };
 
 use indexmap::IndexMap;
@@ -36,6 +36,10 @@ pub struct Registers<N: Network, A: circuit::Aleo<Network = N>> {
     console_registers: IndexMap<u64, Value<N>>,
     /// The mapping of assigned circuit registers to their values.
     circuit_registers: IndexMap<u64, circuit::Value<A>>,
+    /// The transition caller.
+    caller: Option<Address<N>>,
+    /// The transition caller, as a circuit.
+    caller_circuit: Option<circuit::Address<A>>,
     /// The transition view key.
     tvk: Option<Field<N>>,
     /// The transition view key, as a circuit.
@@ -51,6 +55,8 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
             register_types,
             console_registers: IndexMap::new(),
             circuit_registers: IndexMap::new(),
+            caller: None,
+            caller_circuit: None,
             tvk: None,
             tvk_circuit: None,
         }
@@ -62,10 +68,34 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
         self.call_stack.clone()
     }
 
+    /// Returns the transition caller.
+    #[inline]
+    pub fn caller(&self) -> Result<Address<N>> {
+        self.caller.ok_or_else(|| anyhow!("Caller address (console) is not set in the registers."))
+    }
+
+    /// Returns the transition caller, as a circuit.
+    #[inline]
+    pub fn caller_circuit(&self) -> Result<circuit::Address<A>> {
+        self.caller_circuit.clone().ok_or_else(|| anyhow!("Caller address (circuit) is not set in the registers."))
+    }
+
+    /// Sets the transition caller.
+    #[inline]
+    pub fn set_caller(&mut self, caller: Address<N>) {
+        self.caller = Some(caller);
+    }
+
+    /// Sets the transition caller, as a circuit.
+    #[inline]
+    pub fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>) {
+        self.caller_circuit = Some(caller_circuit);
+    }
+
     /// Returns the transition view key.
     #[inline]
     pub fn tvk(&self) -> Result<Field<N>> {
-        self.tvk.ok_or_else(|| anyhow!("Transition view key is not set in the registers."))
+        self.tvk.ok_or_else(|| anyhow!("Transition view key (console) is not set in the registers."))
     }
 
     /// Returns the transition view key, as a circuit.

--- a/vm/compiler/src/program/closure/mod.rs
+++ b/vm/compiler/src/program/closure/mod.rs
@@ -100,13 +100,9 @@ impl<N: Network> Closure<N> {
     /// Adds the given instruction to the closure.
     ///
     /// # Errors
-    /// This method will halt if there are no input statements in memory.
     /// This method will halt if the maximum number of instructions has been reached.
     #[inline]
     pub fn add_instruction(&mut self, instruction: Instruction<N>) -> Result<()> {
-        // Ensure there are input statements in memory.
-        ensure!(!self.inputs.is_empty(), "Cannot add instructions before inputs have been added");
-
         // Ensure the maximum number of instructions has not been exceeded.
         ensure!(
             self.instructions.len() <= N::MAX_FUNCTION_INSTRUCTIONS,
@@ -127,12 +123,11 @@ impl<N: Network> Closure<N> {
     /// Adds the output statement to the closure.
     ///
     /// # Errors
-    /// This method will halt if there are no input statements or instructions in memory.
+    /// This method will halt if there are no instructions in memory.
     /// This method will halt if the maximum number of outputs has been reached.
     #[inline]
     fn add_output(&mut self, output: Output<N>) -> Result<()> {
-        // Ensure there are input statements and instructions in memory.
-        ensure!(!self.inputs.is_empty(), "Cannot add outputs before inputs have been added");
+        // Ensure there are instructions in memory.
         ensure!(!self.instructions.is_empty(), "Cannot add outputs before instructions have been added");
 
         // Ensure the maximum number of outputs has not been exceeded.

--- a/vm/compiler/src/program/closure/parse.rs
+++ b/vm/compiler/src/program/closure/parse.rs
@@ -34,7 +34,7 @@ impl<N: Network> Parser for Closure<N> {
         let (string, _) = tag(":")(string)?;
 
         // Parse the inputs from the string.
-        let (string, inputs) = many1(Input::parse)(string)?;
+        let (string, inputs) = many0(Input::parse)(string)?;
         // Parse the instructions from the string.
         let (string, instructions) = many1(Instruction::parse)(string)?;
         // Parse the outputs from the string.

--- a/vm/compiler/src/program/function/mod.rs
+++ b/vm/compiler/src/program/function/mod.rs
@@ -110,13 +110,9 @@ impl<N: Network> Function<N> {
     /// Adds the given instruction to the function.
     ///
     /// # Errors
-    /// This method will halt if there are no input statements in memory.
     /// This method will halt if the maximum number of instructions has been reached.
     #[inline]
     pub fn add_instruction(&mut self, instruction: Instruction<N>) -> Result<()> {
-        // Ensure there are input statements in memory.
-        ensure!(!self.inputs.is_empty(), "Cannot add instructions before inputs have been added");
-
         // Ensure the maximum number of instructions has not been exceeded.
         ensure!(
             self.instructions.len() <= N::MAX_FUNCTION_INSTRUCTIONS,
@@ -137,12 +133,11 @@ impl<N: Network> Function<N> {
     /// Adds the output statement to the function.
     ///
     /// # Errors
-    /// This method will halt if there are no input statements or instructions in memory.
+    /// This method will halt if there are no instructions in memory.
     /// This method will halt if the maximum number of outputs has been reached.
     #[inline]
     fn add_output(&mut self, output: Output<N>) -> Result<()> {
-        // Ensure there are input statements and instructions in memory.
-        ensure!(!self.inputs.is_empty(), "Cannot add outputs before inputs have been added");
+        // Ensure there are instructions in memory.
         ensure!(!self.instructions.is_empty(), "Cannot add outputs before instructions have been added");
 
         // Ensure the maximum number of outputs has not been exceeded.

--- a/vm/compiler/src/program/function/parse.rs
+++ b/vm/compiler/src/program/function/parse.rs
@@ -34,7 +34,7 @@ impl<N: Network> Parser for Function<N> {
         let (string, _) = tag(":")(string)?;
 
         // Parse the inputs from the string.
-        let (string, inputs) = many1(Input::parse)(string)?;
+        let (string, inputs) = many0(Input::parse)(string)?;
         // Parse the instructions from the string.
         let (string, instructions) = many1(Instruction::parse)(string)?;
         // Parse the outputs from the string.
@@ -118,6 +118,20 @@ function foo:
         .1;
         assert_eq!("foo", function.name().to_string());
         assert_eq!(2, function.inputs.len());
+        assert_eq!(1, function.instructions.len());
+        assert_eq!(1, function.outputs.len());
+
+        // Function with 0 inputs.
+        let function = Function::<CurrentNetwork>::parse(
+            r"
+function foo:
+    add 1u32 2u32 into r0;
+    output r0 as u32.private;",
+        )
+        .unwrap()
+        .1;
+        assert_eq!("foo", function.name().to_string());
+        assert_eq!(0, function.inputs.len());
         assert_eq!(1, function.instructions.len());
         assert_eq!(1, function.outputs.len());
     }

--- a/vm/compiler/src/program/instruction/operand/bytes.rs
+++ b/vm/compiler/src/program/instruction/operand/bytes.rs
@@ -21,6 +21,8 @@ impl<N: Network> FromBytes for Operand<N> {
         match u8::read_le(&mut reader) {
             Ok(0) => Ok(Self::Literal(Literal::read_le(&mut reader)?)),
             Ok(1) => Ok(Self::Register(Register::read_le(&mut reader)?)),
+            Ok(2) => Ok(Self::ProgramID(ProgramID::read_le(&mut reader)?)),
+            Ok(3) => Ok(Self::Caller),
             Ok(variant) => Err(error(format!("Failed to deserialize operand variant {variant}"))),
             Err(err) => Err(err),
         }
@@ -31,13 +33,18 @@ impl<N: Network> ToBytes for Operand<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         match self {
             Self::Literal(literal) => {
-                u8::write_le(&0u8, &mut writer)?;
+                0u8.write_le(&mut writer)?;
                 literal.write_le(&mut writer)
             }
             Self::Register(register) => {
-                u8::write_le(&1u8, &mut writer)?;
+                1u8.write_le(&mut writer)?;
                 register.write_le(&mut writer)
             }
+            Self::ProgramID(program_id) => {
+                2u8.write_le(&mut writer)?;
+                program_id.write_le(&mut writer)
+            }
+            Self::Caller => 3u8.write_le(&mut writer),
         }
     }
 }

--- a/vm/compiler/src/program/instruction/operand/mod.rs
+++ b/vm/compiler/src/program/instruction/operand/mod.rs
@@ -19,7 +19,7 @@ mod parse;
 
 use console::{
     network::prelude::*,
-    program::{Literal, Register},
+    program::{Literal, ProgramID, Register},
 };
 
 /// The `Operand` enum represents the options for an operand in an instruction.
@@ -30,6 +30,10 @@ pub enum Operand<N: Network> {
     Literal(Literal<N>),
     /// The operand is a register.
     Register(Register<N>),
+    /// The operand is the program ID.
+    ProgramID(ProgramID<N>),
+    /// The operand is the caller address.
+    Caller,
 }
 
 impl<N: Network> From<Literal<N>> for Operand<N> {

--- a/vm/compiler/src/program/instruction/operand/parse.rs
+++ b/vm/compiler/src/program/instruction/operand/parse.rs
@@ -24,6 +24,8 @@ impl<N: Network> Parser for Operand<N> {
         alt((
             map(Literal::parse, |literal| Self::Literal(literal)),
             map(Register::parse, |register| Self::Register(register)),
+            map(tag("self.caller"), |_| Self::Caller),
+            map(ProgramID::parse, |program_id| Self::ProgramID(program_id)),
         ))(string)
     }
 }
@@ -61,6 +63,10 @@ impl<N: Network> Display for Operand<N> {
             Self::Literal(literal) => Display::fmt(literal, f),
             // Prints the register, i.e. r0 or r0.owner
             Self::Register(register) => Display::fmt(register, f),
+            // Prints the program ID, i.e. howard.aleo
+            Self::ProgramID(program_id) => Display::fmt(program_id, f),
+            // Prints the caller, i.e. self.caller
+            Self::Caller => write!(f, "self.caller"),
         }
     }
 }
@@ -83,6 +89,12 @@ mod tests {
         let operand = Operand::<CurrentNetwork>::parse("r0.owner").unwrap().1;
         assert_eq!(Operand::Register(Register::from_str("r0.owner")?), operand);
 
+        let operand = Operand::<CurrentNetwork>::parse("howard.aleo").unwrap().1;
+        assert_eq!(Operand::ProgramID(ProgramID::from_str("howard.aleo")?), operand);
+
+        let operand = Operand::<CurrentNetwork>::parse("self.caller").unwrap().1;
+        assert_eq!(Operand::Caller, operand);
+
         // Sanity check a failure case.
         let (remainder, operand) = Operand::<CurrentNetwork>::parse("1field.private").unwrap();
         assert_eq!(Operand::Literal(Literal::from_str("1field")?), operand);
@@ -101,6 +113,12 @@ mod tests {
 
         let operand = Operand::<CurrentNetwork>::parse("r0.owner").unwrap().1;
         assert_eq!(format!("{operand}"), "r0.owner");
+
+        let operand = Operand::<CurrentNetwork>::parse("howard.aleo").unwrap().1;
+        assert_eq!(format!("{operand}"), "howard.aleo");
+
+        let operand = Operand::<CurrentNetwork>::parse("self.caller").unwrap().1;
+        assert_eq!(format!("{operand}"), "self.caller");
     }
 
     #[test]

--- a/vm/compiler/src/program/instruction/operation/call.rs
+++ b/vm/compiler/src/program/instruction/operation/call.rs
@@ -196,7 +196,13 @@ impl<N: Network> Call<N> {
                 bail!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len())
             }
             // Evaluate the closure, and load the outputs.
-            substack.evaluate_closure::<A>(&closure, &inputs, registers.call_stack(), registers.tvk()?)?
+            substack.evaluate_closure::<A>(
+                &closure,
+                &inputs,
+                registers.call_stack(),
+                registers.caller()?,
+                registers.tvk()?,
+            )?
         }
         // If the operator is a function, retrieve the function and compute the output.
         else if let Ok(function) = substack.program().get_function(resource) {
@@ -255,7 +261,13 @@ impl<N: Network> Call<N> {
         // If the operator is a closure, retrieve the closure and compute the output.
         let outputs = if let Ok(closure) = substack.program().get_closure(resource) {
             // Execute the closure, and load the outputs.
-            substack.execute_closure(&closure, &inputs, registers.call_stack(), registers.tvk_circuit()?)?
+            substack.execute_closure(
+                &closure,
+                &inputs,
+                registers.call_stack(),
+                registers.caller_circuit()?,
+                registers.tvk_circuit()?,
+            )?
         }
         // If the operator is a function, retrieve the function and compute the output.
         else if let Ok(function) = substack.program().get_function(resource) {

--- a/vm/compiler/src/program/instruction/operation/is.rs
+++ b/vm/compiler/src/program/instruction/operation/is.rs
@@ -626,16 +626,18 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, is) = IsEq::<CurrentNetwork>::parse("is.eq r0 r1").unwrap();
+        let (string, is) = IsEq::<CurrentNetwork>::parse("is.eq r0 r1 into r2").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(is.operands.len(), 2, "The number of operands is incorrect");
         assert_eq!(is.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");
         assert_eq!(is.operands[1], Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(is.destination, Register::Locator(2), "The destination register is incorrect");
 
-        let (string, is) = IsNeq::<CurrentNetwork>::parse("is.neq r0 r1").unwrap();
+        let (string, is) = IsNeq::<CurrentNetwork>::parse("is.neq r0 r1 into r2").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(is.operands.len(), 2, "The number of operands is incorrect");
         assert_eq!(is.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");
         assert_eq!(is.operands[1], Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(is.destination, Register::Locator(2), "The destination register is incorrect");
     }
 }

--- a/vm/compiler/src/program/mod.rs
+++ b/vm/compiler/src/program/mod.rs
@@ -238,8 +238,6 @@ function fee:
         let function = self.functions.get(name).cloned().ok_or_else(|| anyhow!("Function '{name}' is not defined."))?;
         // Ensure the function name matches.
         ensure!(function.name() == name, "Expected function '{name}', but found function '{}'", function.name());
-        // Ensure there are input statements in the function.
-        ensure!(!function.inputs().is_empty(), "Cannot evaluate a function without input statements");
         // Ensure the number of inputs is within the allowed range.
         ensure!(function.inputs().len() <= N::MAX_INPUTS, "Function exceeds maximum number of inputs");
         // Ensure there are instructions in the function.
@@ -456,8 +454,6 @@ impl<N: Network> Program<N> {
         // Ensure the function name is not a reserved keyword.
         ensure!(!Self::is_reserved_keyword(&function_name), "'{function_name}' is a reserved keyword.");
 
-        // Ensure there are input statements in the function.
-        ensure!(!function.inputs().is_empty(), "Cannot evaluate a function without input statements");
         // Ensure the number of inputs is within the allowed range.
         ensure!(function.inputs().len() <= N::MAX_INPUTS, "Function exceeds maximum number of inputs");
         // Ensure there are instructions in the function.

--- a/vm/compiler/src/program/mod.rs
+++ b/vm/compiler/src/program/mod.rs
@@ -518,9 +518,11 @@ impl<N: Network> Program<N> {
         "interface",
         "closure",
         "program",
-        "global",
-        // Reserved (catch all)
         "aleo",
+        "self",
+        "storage",
+        // Reserved (catch all)
+        "global",
         "return",
         "break",
         "assert",

--- a/vm/compiler/src/program/parse.rs
+++ b/vm/compiler/src/program/parse.rs
@@ -216,6 +216,26 @@ function compute:
     }
 
     #[test]
+    fn test_program_parse_function_zero_inputs() -> Result<()> {
+        // Initialize a new program.
+        let (string, program) = Program::<CurrentNetwork>::parse(
+            r"
+program to_parse.aleo;
+
+function compute:
+    add 1u32 2u32 into r0;
+    output r0 as u32.private;",
+        )
+        .unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+        // Ensure the program contains the function.
+        assert!(program.contains_function(&Identifier::from_str("compute")?));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_program_display() -> Result<()> {
         let expected = r"program to_parse.aleo;
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

- Adds support for `self.caller` and `{program_id}`
- This PR also relaxes the requirement for function inputs (to 0 required)
