### PR TITLE
[Testnet3] Remove redundant rerun condition

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -52,9 +52,6 @@ fn check_file_licenses<P: AsRef<Path>>(path: P) {
             );
         }
     }
-
-    // Re-run upon any changes to the workspace.
-    println!("cargo:rerun-if-changed=.");
 }
 
 // The build script; it currently only checks the licenses.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes a rerun condition in `build.rs` which will cause unnecessary recompilations for any change in the `target` directory. The default `Cargo` behavior will already rerun the `build.rs` script if any Rust file in the source tree has been changed. 

This particular condition is more meant for use when there are other language files to track that `Cargo` can not, for example `C++` files used in FFI bindings.

Tracking PR: https://github.com/AleoHQ/snarkVM/pull/957