### PR TITLE
[Testnet3] Remove bidirectional code points support from `StringType`s

### DIFF
--- a/console/types/string/src/parse.rs
+++ b/console/types/string/src/parse.rs
@@ -92,4 +92,18 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_parse_unsupported_code_points() -> Result<()> {
+        const UNSUPPORTED_CODE_POINTS: [&str; 9] = [
+            "\u{202a}", "\u{202b}", "\u{202c}", "\u{202d}", "\u{202e}", "\u{2066}", "\u{2067}", "\u{2068}", "\u{2069}",
+        ];
+
+        // Ensure that the invalid code point is not allowed in the string.
+        for unsupported_code_point in UNSUPPORTED_CODE_POINTS {
+            assert!(StringType::<CurrentEnvironment>::parse(unsupported_code_point).is_err());
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes support for "invisible" bidirectional code points in `StringType`s. This is important because these characters will effectively be hidden when displaying Aleo programs on Github (some IDEs will be able to display these characters). 

Currently the invalidates support for the following bidirectional override characters - https://unicode.org/reports/tr9/: 
```
U+202A, U+202B, U+202C, U+202D, U+202E, U+2066,
U+2067, U+2068, U+2069
```

### Example
Here is an example to explain the significance of this issue:
Program displayed on Github: 
```
function compare:
    hash.psd2 "aleo" into r0;
    hash.psd2 "aleo" into r1; // Looks like the same string
    is.eq r0 r1 into r2;
    output r3 as boolean;
```

Same program on an IDE that shows the code points:
```
function compare:
    hash.psd2 "aleo" into r0;
    hash.psd2 "aleo[U+202E]" into r1; // Is definitely NOT the same string
    is.eq r0 r1 into r2;
    output r3 as boolean;
```

Tracking PR: https://github.com/AleoHQ/snarkVM/pull/957
