### PR TITLE
[Testnet3] Downcast truncation protection

### DIFF
--- a/console/program/src/data/ciphertext/bytes.rs
+++ b/console/program/src/data/ciphertext/bytes.rs
@@ -38,7 +38,7 @@ impl<N: Network> ToBytes for Ciphertext<N> {
     #[inline]
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Ensure the number of field elements does not exceed the maximum allowed size.
-        if self.0.len() as u32 > N::MAX_DATA_SIZE_IN_FIELDS {
+        if self.0.len() as u32 > N::MAX_DATA_SIZE_IN_FIELDS || self.0.len() > u16::MAX as usize {
             return Err(error("Ciphertext is too large to encode in field elements."));
         }
         // Write the number of ciphertext field elements.

--- a/console/program/src/data/ciphertext/size_in_fields.rs
+++ b/console/program/src/data/ciphertext/size_in_fields.rs
@@ -24,7 +24,7 @@ impl<N: Network> Visibility for Ciphertext<N> {
         // Ensure the number of field elements does not exceed the maximum allowed size.
         match num_fields <= N::MAX_DATA_SIZE_IN_FIELDS as usize {
             // Return the number of field elements.
-            true => Ok(num_fields as u16),
+            true => Ok(u16::try_from(num_fields)?),
             false => bail!("Ciphertext is too large to encode in field elements."),
         }
     }

--- a/console/program/src/data/plaintext/size_in_fields.rs
+++ b/console/program/src/data/plaintext/size_in_fields.rs
@@ -26,7 +26,7 @@ impl<N: Network> Visibility for Plaintext<N> {
         // Ensure the number of field elements does not exceed the maximum allowed size.
         match num_fields <= N::MAX_DATA_SIZE_IN_FIELDS as usize {
             // Return the number of field elements.
-            true => Ok(num_fields as u16),
+            true => Ok(u16::try_from(num_fields)?),
             false => bail!("Plaintext is too large to encode in field elements."),
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR prevents 3 cases of possible truncation when downcasting integer types. Two fixes use `try_from` and one uses a manual `if` check. 

There is many more potential downcasting issues in the rest of the repo, and should be addressed with https://github.com/AleoHQ/snarkVM/issues/970.

Tracking PR: https://github.com/AleoHQ/snarkVM/pull/957