### PR TITLE
Tweak the atomic write batch setup

### DIFF
--- a/vm/compiler/src/ledger/map/memory_map.rs
+++ b/vm/compiler/src/ledger/map/memory_map.rs
@@ -118,6 +118,15 @@ impl<
     }
 
     ///
+    /// Checks whether an atomic operation is currently in progress. This can be done to ensure
+    /// that lower-level operations don't start and finish their individual atomic write batch
+    /// if they are already part of a larger one.
+    ///
+    fn is_atomic_in_progress(&self) -> bool {
+        self.batch_in_progress.load(Ordering::SeqCst)
+    }
+
+    ///
     /// Aborts the current atomic operation.
     ///
     fn abort_atomic(&self) {

--- a/vm/compiler/src/ledger/map/memory_map.rs
+++ b/vm/compiler/src/ledger/map/memory_map.rs
@@ -130,7 +130,7 @@ impl<
     ///
     /// Finishes an atomic operation, performing all the queued writes.
     ///
-    fn finish_atomic(&self) {
+    fn finish_atomic(&self) -> Result<()> {
         // Retrieve the atomic batch.
         let operations = core::mem::take(&mut *self.atomic_batch.lock());
 
@@ -145,8 +145,11 @@ impl<
                 };
             }
         }
+
         // Set the atomic batch flag to `false`.
         self.batch_in_progress.store(false, Ordering::SeqCst);
+
+        Ok(())
     }
 }
 
@@ -264,7 +267,7 @@ mod tests {
         assert!(map.iter().next().is_none());
 
         // Finish the current atomic write batch.
-        map.finish_atomic();
+        map.finish_atomic().unwrap();
 
         // Check that the items are present in the map now.
         for i in 0..NUM_ITEMS {
@@ -285,7 +288,7 @@ mod tests {
         assert_eq!(map.iter().count(), NUM_ITEMS);
 
         // Finish the current atomic write batch.
-        map.finish_atomic();
+        map.finish_atomic().unwrap();
 
         // Check that the map is empty now.
         assert!(map.iter().next().is_none());
@@ -328,7 +331,7 @@ mod tests {
         }
 
         // Finish the current atomic write batch.
-        map.finish_atomic();
+        map.finish_atomic().unwrap();
 
         // The map should contain NUM_ITEMS items now.
         assert_eq!(map.iter().count(), NUM_ITEMS);

--- a/vm/compiler/src/ledger/map/mod.rs
+++ b/vm/compiler/src/ledger/map/mod.rs
@@ -27,22 +27,6 @@ pub enum BatchOperation<K: Copy + Clone + PartialEq + Eq + Hash + Send + Sync, V
     Remove(K),
 }
 
-/// A trait to unwrap a `Result` or `Reject`.
-pub trait OrAbort<T> {
-    /// Returns the result if it is successful, otherwise aborts the operation and returns the error.
-    fn or_abort(self, abort: impl FnOnce()) -> Result<T>;
-}
-
-impl<T> OrAbort<T> for Result<T> {
-    /// Returns the result if it is successful, otherwise aborts the operation and returns the error.
-    fn or_abort(self, abort: impl FnOnce()) -> Result<T> {
-        self.map_err(|e| {
-            abort();
-            e
-        })
-    }
-}
-
 /// A trait representing map-like storage operations with read-write capabilities.
 pub trait Map<
     'a,

--- a/vm/compiler/src/ledger/map/mod.rs
+++ b/vm/compiler/src/ledger/map/mod.rs
@@ -74,7 +74,7 @@ pub trait Map<
     ///
     /// Finishes an atomic operation, performing all the queued writes.
     ///
-    fn finish_atomic(&self);
+    fn finish_atomic(&self) -> Result<()>;
 }
 
 /// A trait representing map-like storage operations with read-only capabilities.

--- a/vm/compiler/src/ledger/store/block/mod.rs
+++ b/vm/compiler/src/ledger/store/block/mod.rs
@@ -106,14 +106,14 @@ pub trait BlockStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.id_map().finish_atomic();
-        self.reverse_id_map().finish_atomic();
-        self.header_map().finish_atomic();
-        self.transactions_map().finish_atomic();
-        self.reverse_transactions_map().finish_atomic();
-        self.transaction_store().finish_atomic();
-        self.signature_map().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.id_map().finish_atomic()?;
+        self.reverse_id_map().finish_atomic()?;
+        self.header_map().finish_atomic()?;
+        self.transactions_map().finish_atomic()?;
+        self.reverse_transactions_map().finish_atomic()?;
+        self.transaction_store().finish_atomic()?;
+        self.signature_map().finish_atomic()
     }
 
     /// Stores the given `block` into storage.
@@ -145,9 +145,7 @@ pub trait BlockStorage<N: Network>: Clone + Sync {
         self.signature_map().insert(block.hash(), *block.signature()).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the block for the given `block hash`.
@@ -188,9 +186,7 @@ pub trait BlockStorage<N: Network>: Clone + Sync {
         self.signature_map().remove(block_hash).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns the block hash that contains the given `transaction ID`.
@@ -441,8 +437,8 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 

--- a/vm/compiler/src/ledger/store/program/mod.rs
+++ b/vm/compiler/src/ledger/store/program/mod.rs
@@ -17,7 +17,7 @@
 use crate::{
     cow_to_cloned,
     cow_to_copied,
-    ledger::map::{memory_map::MemoryMap, Map, MapRead, OrAbort},
+    ledger::map::{memory_map::MemoryMap, Map, MapRead},
 };
 use console::{
     network::prelude::*,
@@ -118,18 +118,14 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         // Insert the new mapping name.
         mapping_names.insert(*mapping_name);
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Update the program ID map with the new mapping name.
-        self.program_id_map().insert(*program_id, mapping_names).or_abort(|| self.abort_atomic())?;
+        self.program_id_map().insert(*program_id, mapping_names)?;
         // Initialize the mapping ID map.
-        self.mapping_id_map().insert((*program_id, *mapping_name), mapping_id).or_abort(|| self.abort_atomic())?;
+        self.mapping_id_map().insert((*program_id, *mapping_name), mapping_id)?;
         // Initialize the key-value ID map.
-        self.key_value_id_map().insert(mapping_id, IndexMap::new()).or_abort(|| self.abort_atomic())?;
+        self.key_value_id_map().insert(mapping_id, IndexMap::new())?;
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Stores the given `(key, value)` pair at the given `program ID` and `mapping name` in storage.
@@ -167,18 +163,14 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         // Insert the new key-value ID.
         key_value_ids.insert(key_id, value_id);
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Update the key-value ID map with the new key-value ID.
-        self.key_value_id_map().insert(mapping_id, key_value_ids).or_abort(|| self.abort_atomic())?;
+        self.key_value_id_map().insert(mapping_id, key_value_ids)?;
         // Insert the key.
-        self.key_map().insert(key_id, key).or_abort(|| self.abort_atomic())?;
+        self.key_map().insert(key_id, key)?;
         // Insert the value.
-        self.value_map().insert(key_id, value).or_abort(|| self.abort_atomic())?;
+        self.value_map().insert(key_id, value)?;
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Stores the given `(key, value)` pair at the given `program ID` and `mapping name` in storage.
@@ -219,18 +211,14 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         // Insert the new key-value ID.
         key_value_ids.insert(key_id, value_id);
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Update the key-value ID map with the new key-value ID.
-        self.key_value_id_map().insert(mapping_id, key_value_ids).or_abort(|| self.abort_atomic())?;
+        self.key_value_id_map().insert(mapping_id, key_value_ids)?;
         // Insert the key.
-        self.key_map().insert(key_id, key).or_abort(|| self.abort_atomic())?;
+        self.key_map().insert(key_id, key)?;
         // Insert the value.
-        self.value_map().insert(key_id, value).or_abort(|| self.abort_atomic())?;
+        self.value_map().insert(key_id, value)?;
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Removes the key-value pair for the given `program ID`, `mapping name`, and `key` from storage.
@@ -259,18 +247,14 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         // Remove the key ID.
         key_value_ids.remove(&key_id);
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Update the key-value ID map with the new key ID.
-        self.key_value_id_map().insert(mapping_id, key_value_ids).or_abort(|| self.abort_atomic())?;
+        self.key_value_id_map().insert(mapping_id, key_value_ids)?;
         // Remove the key.
-        self.key_map().remove(&key_id).or_abort(|| self.abort_atomic())?;
+        self.key_map().remove(&key_id)?;
         // Remove the value.
-        self.value_map().remove(&key_id).or_abort(|| self.abort_atomic())?;
+        self.value_map().remove(&key_id)?;
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Removes the mapping for the given `program ID` and `mapping name` from storage,
@@ -299,23 +283,19 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         // Remove the mapping name.
         mapping_names.remove(mapping_name);
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Update the mapping names.
-        self.program_id_map().insert(*program_id, mapping_names).or_abort(|| self.abort_atomic())?;
+        self.program_id_map().insert(*program_id, mapping_names)?;
         // Remove the mapping ID.
-        self.mapping_id_map().remove(&(*program_id, *mapping_name)).or_abort(|| self.abort_atomic())?;
+        self.mapping_id_map().remove(&(*program_id, *mapping_name))?;
         // Remove the key IDs.
-        self.key_value_id_map().remove(&mapping_id).or_abort(|| self.abort_atomic())?;
+        self.key_value_id_map().remove(&mapping_id)?;
         // Remove the keys.
         for key_id in key_value_ids.keys() {
-            self.key_map().remove(key_id).or_abort(|| self.abort_atomic())?;
-            self.value_map().remove(key_id).or_abort(|| self.abort_atomic())?;
+            self.key_map().remove(key_id)?;
+            self.value_map().remove(key_id)?;
         }
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Removes the program for the given `program ID` from storage,
@@ -327,23 +307,20 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
             None => bail!("Illegal operation: program ID '{program_id}' is not initialized - cannot remove mapping."),
         };
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Update the mapping names.
-        self.program_id_map().remove(program_id).or_abort(|| self.abort_atomic())?;
+        self.program_id_map().remove(program_id)?;
 
         // Remove each mapping.
         for mapping_name in mapping_names.iter() {
             // Retrieve the mapping ID.
-            let mapping_id = match self.get_mapping_id(program_id, mapping_name).or_abort(|| self.abort_atomic())? {
+            let mapping_id = match self.get_mapping_id(program_id, mapping_name)? {
                 Some(mapping_id) => mapping_id,
                 None => {
                     bail!("Illegal operation: mapping '{mapping_name}' is not initialized - cannot remove mapping.")
                 }
             };
             // Retrieve the key-value IDs for the mapping ID.
-            let key_value_ids = match self.key_value_id_map().get(&mapping_id).or_abort(|| self.abort_atomic())? {
+            let key_value_ids = match self.key_value_id_map().get(&mapping_id)? {
                 Some(key_value_ids) => key_value_ids,
                 None => {
                     bail!("Illegal operation: mapping ID '{mapping_id}' is not initialized - cannot remove mapping.")
@@ -351,18 +328,17 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
             };
 
             // Remove the mapping ID.
-            self.mapping_id_map().remove(&(*program_id, *mapping_name)).or_abort(|| self.abort_atomic())?;
+            self.mapping_id_map().remove(&(*program_id, *mapping_name))?;
             // Remove the key IDs.
-            self.key_value_id_map().remove(&mapping_id).or_abort(|| self.abort_atomic())?;
+            self.key_value_id_map().remove(&mapping_id)?;
             // Remove the keys.
             for key_id in key_value_ids.keys() {
-                self.key_map().remove(key_id).or_abort(|| self.abort_atomic())?;
-                self.value_map().remove(key_id).or_abort(|| self.abort_atomic())?;
+                self.key_map().remove(key_id)?;
+                self.value_map().remove(key_id)?;
             }
         }
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Returns `true` if the given `program ID` exist.

--- a/vm/compiler/src/ledger/store/program/mod.rs
+++ b/vm/compiler/src/ledger/store/program/mod.rs
@@ -86,12 +86,12 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.program_id_map().finish_atomic();
-        self.mapping_id_map().finish_atomic();
-        self.key_value_id_map().finish_atomic();
-        self.key_map().finish_atomic();
-        self.value_map().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.program_id_map().finish_atomic()?;
+        self.mapping_id_map().finish_atomic()?;
+        self.key_value_id_map().finish_atomic()?;
+        self.key_map().finish_atomic()?;
+        self.value_map().finish_atomic()
     }
 
     /// Initializes the given `program ID` and `mapping name` in storage.
@@ -129,9 +129,7 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         self.key_value_id_map().insert(mapping_id, IndexMap::new()).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Stores the given `(key, value)` pair at the given `program ID` and `mapping name` in storage.
@@ -180,9 +178,7 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         self.value_map().insert(key_id, value).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Stores the given `(key, value)` pair at the given `program ID` and `mapping name` in storage.
@@ -234,9 +230,7 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         self.value_map().insert(key_id, value).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the key-value pair for the given `program ID`, `mapping name`, and `key` from storage.
@@ -276,9 +270,7 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         self.value_map().remove(&key_id).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the mapping for the given `program ID` and `mapping name` from storage,
@@ -323,9 +315,7 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         }
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the program for the given `program ID` from storage,
@@ -372,9 +362,7 @@ pub trait ProgramStorage<N: Network>: Clone + Sync {
         }
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns `true` if the given `program ID` exist.
@@ -640,8 +628,8 @@ impl<N: Network, P: ProgramStorage<N>> ProgramStore<N, P> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 

--- a/vm/compiler/src/ledger/store/transaction/deployment.rs
+++ b/vm/compiler/src/ledger/store/transaction/deployment.rs
@@ -100,15 +100,15 @@ pub trait DeploymentStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.id_map().finish_atomic();
-        self.edition_map().finish_atomic();
-        self.reverse_id_map().finish_atomic();
-        self.program_map().finish_atomic();
-        self.verifying_key_map().finish_atomic();
-        self.certificate_map().finish_atomic();
-        self.additional_fee_map().finish_atomic();
-        self.transition_store().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.id_map().finish_atomic()?;
+        self.edition_map().finish_atomic()?;
+        self.reverse_id_map().finish_atomic()?;
+        self.program_map().finish_atomic()?;
+        self.verifying_key_map().finish_atomic()?;
+        self.certificate_map().finish_atomic()?;
+        self.additional_fee_map().finish_atomic()?;
+        self.transition_store().finish_atomic()
     }
 
     /// Stores the given `deployment transaction` pair into storage.
@@ -172,9 +172,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Sync {
         self.transition_store().insert(additional_fee.clone()).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the deployment transaction for the given `transaction ID`.
@@ -227,9 +225,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Sync {
         self.transition_store().remove(&additional_fee_id).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns the transaction ID that contains the given `program ID`.
@@ -522,8 +518,8 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 

--- a/vm/compiler/src/ledger/store/transaction/deployment.rs
+++ b/vm/compiler/src/ledger/store/transaction/deployment.rs
@@ -15,6 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    atomic_write_batch,
     cow_to_cloned,
     cow_to_copied,
     ledger::{
@@ -87,6 +88,18 @@ pub trait DeploymentStorage<N: Network>: Clone + Sync {
         self.transition_store().start_atomic();
     }
 
+    /// Checks if an atomic batch is in progress.
+    fn is_atomic_in_progress(&self) -> bool {
+        self.id_map().is_atomic_in_progress()
+            || self.edition_map().is_atomic_in_progress()
+            || self.reverse_id_map().is_atomic_in_progress()
+            || self.program_map().is_atomic_in_progress()
+            || self.verifying_key_map().is_atomic_in_progress()
+            || self.certificate_map().is_atomic_in_progress()
+            || self.additional_fee_map().is_atomic_in_progress()
+            || self.transition_store().is_atomic_in_progress()
+    }
+
     /// Aborts an atomic batch write operation.
     fn abort_atomic(&self) {
         self.id_map().abort_atomic();
@@ -141,28 +154,32 @@ pub trait DeploymentStorage<N: Network>: Clone + Sync {
             }
         }
 
-        // Store the program ID.
-        self.id_map().insert(*transaction_id, program_id)?;
-        // Store the edition.
-        self.edition_map().insert(program_id, edition)?;
+        atomic_write_batch!(self, {
+            // Store the program ID.
+            self.id_map().insert(*transaction_id, program_id)?;
+            // Store the edition.
+            self.edition_map().insert(program_id, edition)?;
 
-        // Store the reverse program ID.
-        self.reverse_id_map().insert((program_id, edition), *transaction_id)?;
-        // Store the program.
-        self.program_map().insert((program_id, edition), program.clone())?;
+            // Store the reverse program ID.
+            self.reverse_id_map().insert((program_id, edition), *transaction_id)?;
+            // Store the program.
+            self.program_map().insert((program_id, edition), program.clone())?;
 
-        // Store the verifying keys and certificates.
-        for (function_name, (verifying_key, certificate)) in deployment.verifying_keys() {
-            // Store the verifying key.
-            self.verifying_key_map().insert((program_id, *function_name, edition), verifying_key.clone())?;
-            // Store the certificate.
-            self.certificate_map().insert((program_id, *function_name, edition), certificate.clone())?;
-        }
+            // Store the verifying keys and certificates.
+            for (function_name, (verifying_key, certificate)) in deployment.verifying_keys() {
+                // Store the verifying key.
+                self.verifying_key_map().insert((program_id, *function_name, edition), verifying_key.clone())?;
+                // Store the certificate.
+                self.certificate_map().insert((program_id, *function_name, edition), certificate.clone())?;
+            }
 
-        // Store the additional fee ID.
-        self.additional_fee_map().insert(*transaction_id, *additional_fee.id())?;
-        // Store the additional fee transition.
-        self.transition_store().insert(additional_fee.clone())?;
+            // Store the additional fee ID.
+            self.additional_fee_map().insert(*transaction_id, *additional_fee.id())?;
+            // Store the additional fee transition.
+            self.transition_store().insert(additional_fee.clone())?;
+
+            Ok(())
+        });
 
         Ok(())
     }
@@ -190,28 +207,32 @@ pub trait DeploymentStorage<N: Network>: Clone + Sync {
             None => bail!("Failed to locate the additional fee ID for transaction '{transaction_id}'"),
         };
 
-        // Remove the program ID.
-        self.id_map().remove(transaction_id)?;
-        // Remove the edition.
-        self.edition_map().remove(&program_id)?;
+        atomic_write_batch!(self, {
+            // Remove the program ID.
+            self.id_map().remove(transaction_id)?;
+            // Remove the edition.
+            self.edition_map().remove(&program_id)?;
 
-        // Remove the reverse program ID.
-        self.reverse_id_map().remove(&(program_id, edition))?;
-        // Remove the program.
-        self.program_map().remove(&(program_id, edition))?;
+            // Remove the reverse program ID.
+            self.reverse_id_map().remove(&(program_id, edition))?;
+            // Remove the program.
+            self.program_map().remove(&(program_id, edition))?;
 
-        // Remove the verifying keys and certificates.
-        for function_name in program.functions().keys() {
-            // Remove the verifying key.
-            self.verifying_key_map().remove(&(program_id, *function_name, edition))?;
-            // Remove the certificate.
-            self.certificate_map().remove(&(program_id, *function_name, edition))?;
-        }
+            // Remove the verifying keys and certificates.
+            for function_name in program.functions().keys() {
+                // Remove the verifying key.
+                self.verifying_key_map().remove(&(program_id, *function_name, edition))?;
+                // Remove the certificate.
+                self.certificate_map().remove(&(program_id, *function_name, edition))?;
+            }
 
-        // Remove the additional fee ID.
-        self.additional_fee_map().remove(transaction_id)?;
-        // Remove the additional fee transition.
-        self.transition_store().remove(&additional_fee_id)?;
+            // Remove the additional fee ID.
+            self.additional_fee_map().remove(transaction_id)?;
+            // Remove the additional fee transition.
+            self.transition_store().remove(&additional_fee_id)?;
+
+            Ok(())
+        });
 
         Ok(())
     }
@@ -498,6 +519,11 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     /// Starts an atomic batch write operation.
     pub fn start_atomic(&self) {
         self.storage.start_atomic();
+    }
+
+    /// Checks if an atomic batch is in progress.
+    pub fn is_atomic_in_progress(&self) -> bool {
+        self.storage.is_atomic_in_progress()
     }
 
     /// Aborts an atomic batch write operation.

--- a/vm/compiler/src/ledger/store/transaction/execution.rs
+++ b/vm/compiler/src/ledger/store/transaction/execution.rs
@@ -72,11 +72,11 @@ pub trait ExecutionStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.id_map().finish_atomic();
-        self.reverse_id_map().finish_atomic();
-        self.edition_map().finish_atomic();
-        self.transition_store().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.id_map().finish_atomic()?;
+        self.reverse_id_map().finish_atomic()?;
+        self.edition_map().finish_atomic()?;
+        self.transition_store().finish_atomic()
     }
 
     /// Stores the given `execution transaction` pair into storage.
@@ -127,9 +127,7 @@ pub trait ExecutionStorage<N: Network>: Clone + Sync {
         }
 
         // Finish an atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the execution transaction for the given `transaction ID`.
@@ -165,9 +163,7 @@ pub trait ExecutionStorage<N: Network>: Clone + Sync {
         }
 
         // Finish an atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.
@@ -358,8 +354,8 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 

--- a/vm/compiler/src/ledger/store/transaction/mod.rs
+++ b/vm/compiler/src/ledger/store/transaction/mod.rs
@@ -85,10 +85,10 @@ pub trait TransactionStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.id_map().finish_atomic();
-        self.deployment_store().finish_atomic();
-        self.execution_store().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.id_map().finish_atomic()?;
+        self.deployment_store().finish_atomic()?;
+        self.execution_store().finish_atomic()
     }
 
     /// Stores the given `transaction` into storage.
@@ -112,9 +112,7 @@ pub trait TransactionStorage<N: Network>: Clone + Sync {
         }
 
         // Finish an atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the transaction for the given `transaction ID`.
@@ -143,9 +141,7 @@ pub trait TransactionStorage<N: Network>: Clone + Sync {
         };
 
         // Finish an atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.
@@ -268,8 +264,8 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 

--- a/vm/compiler/src/ledger/store/transition/input.rs
+++ b/vm/compiler/src/ledger/store/transition/input.rs
@@ -91,15 +91,15 @@ pub trait InputStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.id_map().finish_atomic();
-        self.reverse_id_map().finish_atomic();
-        self.constant_map().finish_atomic();
-        self.public_map().finish_atomic();
-        self.private_map().finish_atomic();
-        self.record_map().finish_atomic();
-        self.record_tag_map().finish_atomic();
-        self.external_record_map().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.id_map().finish_atomic()?;
+        self.reverse_id_map().finish_atomic()?;
+        self.constant_map().finish_atomic()?;
+        self.public_map().finish_atomic()?;
+        self.private_map().finish_atomic()?;
+        self.record_map().finish_atomic()?;
+        self.record_tag_map().finish_atomic()?;
+        self.external_record_map().finish_atomic()
     }
 
     /// Stores the given `(transition ID, input)` pair into storage.
@@ -140,9 +140,7 @@ pub trait InputStorage<N: Network>: Clone + Sync {
         }
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the input for the given `transition ID`.
@@ -179,9 +177,7 @@ pub trait InputStorage<N: Network>: Clone + Sync {
         }
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns the transition ID that contains the given `input ID`.
@@ -409,8 +405,8 @@ impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 

--- a/vm/compiler/src/ledger/store/transition/input.rs
+++ b/vm/compiler/src/ledger/store/transition/input.rs
@@ -15,7 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::ledger::{
-    map::{memory_map::MemoryMap, Map, MapRead, OrAbort},
+    map::{memory_map::MemoryMap, Map, MapRead},
     transition::{Input, Origin},
 };
 use console::{
@@ -104,43 +104,29 @@ pub trait InputStorage<N: Network>: Clone + Sync {
 
     /// Stores the given `(transition ID, input)` pair into storage.
     fn insert(&self, transition_id: N::TransitionID, inputs: &[Input<N>]) -> Result<()> {
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Store the input IDs.
-        self.id_map()
-            .insert(transition_id, inputs.iter().map(Input::id).copied().collect())
-            .or_abort(|| self.abort_atomic())?;
+        self.id_map().insert(transition_id, inputs.iter().map(Input::id).copied().collect())?;
 
         // Store the inputs.
         for input in inputs {
             // Store the reverse input ID.
-            self.reverse_id_map().insert(*input.id(), transition_id).or_abort(|| self.abort_atomic())?;
+            self.reverse_id_map().insert(*input.id(), transition_id)?;
             // Store the input.
             match input.clone() {
-                Input::Constant(input_id, constant) => {
-                    self.constant_map().insert(input_id, constant).or_abort(|| self.abort_atomic())?
-                }
-                Input::Public(input_id, public) => {
-                    self.public_map().insert(input_id, public).or_abort(|| self.abort_atomic())?
-                }
-                Input::Private(input_id, private) => {
-                    self.private_map().insert(input_id, private).or_abort(|| self.abort_atomic())?
-                }
+                Input::Constant(input_id, constant) => self.constant_map().insert(input_id, constant)?,
+                Input::Public(input_id, public) => self.public_map().insert(input_id, public)?,
+                Input::Private(input_id, private) => self.private_map().insert(input_id, private)?,
                 Input::Record(serial_number, tag, origin) => {
                     // Store the record tag.
-                    self.record_tag_map().insert(tag, serial_number).or_abort(|| self.abort_atomic())?;
+                    self.record_tag_map().insert(tag, serial_number)?;
                     // Store the record.
-                    self.record_map().insert(serial_number, (tag, origin)).or_abort(|| self.abort_atomic())?
+                    self.record_map().insert(serial_number, (tag, origin))?
                 }
-                Input::ExternalRecord(input_id) => {
-                    self.external_record_map().insert(input_id, ()).or_abort(|| self.abort_atomic())?
-                }
+                Input::ExternalRecord(input_id) => self.external_record_map().insert(input_id, ())?,
             }
         }
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Removes the input for the given `transition ID`.
@@ -152,32 +138,28 @@ pub trait InputStorage<N: Network>: Clone + Sync {
             None => return Ok(()),
         };
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Remove the input IDs.
-        self.id_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.id_map().remove(transition_id)?;
 
         // Remove the inputs.
         for input_id in input_ids {
             // Remove the reverse input ID.
-            self.reverse_id_map().remove(&input_id).or_abort(|| self.abort_atomic())?;
+            self.reverse_id_map().remove(&input_id)?;
 
             // If the input is a record, remove the record tag.
-            if let Some(record) = self.record_map().get(&input_id).or_abort(|| self.abort_atomic())? {
-                self.record_tag_map().remove(&record.0).or_abort(|| self.abort_atomic())?;
+            if let Some(record) = self.record_map().get(&input_id)? {
+                self.record_tag_map().remove(&record.0)?;
             }
 
             // Remove the input.
-            self.constant_map().remove(&input_id).or_abort(|| self.abort_atomic())?;
-            self.public_map().remove(&input_id).or_abort(|| self.abort_atomic())?;
-            self.private_map().remove(&input_id).or_abort(|| self.abort_atomic())?;
-            self.record_map().remove(&input_id).or_abort(|| self.abort_atomic())?;
-            self.external_record_map().remove(&input_id).or_abort(|| self.abort_atomic())?;
+            self.constant_map().remove(&input_id)?;
+            self.public_map().remove(&input_id)?;
+            self.private_map().remove(&input_id)?;
+            self.record_map().remove(&input_id)?;
+            self.external_record_map().remove(&input_id)?;
         }
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Returns the transition ID that contains the given `input ID`.

--- a/vm/compiler/src/ledger/store/transition/mod.rs
+++ b/vm/compiler/src/ledger/store/transition/mod.rs
@@ -117,17 +117,17 @@ pub trait TransitionStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.locator_map().finish_atomic();
-        self.input_store().finish_atomic();
-        self.output_store().finish_atomic();
-        self.finalize_map().finish_atomic();
-        self.proof_map().finish_atomic();
-        self.tpk_map().finish_atomic();
-        self.reverse_tpk_map().finish_atomic();
-        self.tcm_map().finish_atomic();
-        self.reverse_tcm_map().finish_atomic();
-        self.fee_map().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.locator_map().finish_atomic()?;
+        self.input_store().finish_atomic()?;
+        self.output_store().finish_atomic()?;
+        self.finalize_map().finish_atomic()?;
+        self.proof_map().finish_atomic()?;
+        self.tpk_map().finish_atomic()?;
+        self.reverse_tpk_map().finish_atomic()?;
+        self.tcm_map().finish_atomic()?;
+        self.reverse_tcm_map().finish_atomic()?;
+        self.fee_map().finish_atomic()
     }
 
     /// Stores the given `transition` into storage.
@@ -161,9 +161,7 @@ pub trait TransitionStorage<N: Network>: Clone + Sync {
         self.fee_map().insert(transition_id, *transition.fee()).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the input for the given `transition ID`.
@@ -204,9 +202,7 @@ pub trait TransitionStorage<N: Network>: Clone + Sync {
         self.fee_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns the transition for the given `transition ID`.
@@ -447,8 +443,8 @@ impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 

--- a/vm/compiler/src/ledger/store/transition/mod.rs
+++ b/vm/compiler/src/ledger/store/transition/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     cow_to_cloned,
     cow_to_copied,
     ledger::{
-        map::{memory_map::MemoryMap, Map, MapRead, OrAbort},
+        map::{memory_map::MemoryMap, Map, MapRead},
         Input,
         Origin,
         Output,
@@ -132,36 +132,30 @@ pub trait TransitionStorage<N: Network>: Clone + Sync {
 
     /// Stores the given `transition` into storage.
     fn insert(&self, transition: Transition<N>) -> Result<()> {
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Retrieve the transition ID.
         let transition_id = *transition.id();
         // Store the program ID and function name.
-        self.locator_map()
-            .insert(transition_id, (*transition.program_id(), *transition.function_name()))
-            .or_abort(|| self.abort_atomic())?;
+        self.locator_map().insert(transition_id, (*transition.program_id(), *transition.function_name()))?;
         // Store the inputs.
-        self.input_store().insert(transition_id, transition.inputs()).or_abort(|| self.abort_atomic())?;
+        self.input_store().insert(transition_id, transition.inputs())?;
         // Store the outputs.
-        self.output_store().insert(transition_id, transition.outputs()).or_abort(|| self.abort_atomic())?;
+        self.output_store().insert(transition_id, transition.outputs())?;
         // Store the finalize inputs.
-        self.finalize_map().insert(transition_id, transition.finalize().clone()).or_abort(|| self.abort_atomic())?;
+        self.finalize_map().insert(transition_id, transition.finalize().clone())?;
         // Store the proof.
-        self.proof_map().insert(transition_id, transition.proof().clone()).or_abort(|| self.abort_atomic())?;
+        self.proof_map().insert(transition_id, transition.proof().clone())?;
         // Store `tpk`.
-        self.tpk_map().insert(transition_id, *transition.tpk()).or_abort(|| self.abort_atomic())?;
+        self.tpk_map().insert(transition_id, *transition.tpk())?;
         // Store the reverse `tpk` entry.
-        self.reverse_tpk_map().insert(*transition.tpk(), transition_id).or_abort(|| self.abort_atomic())?;
+        self.reverse_tpk_map().insert(*transition.tpk(), transition_id)?;
         // Store `tcm`.
-        self.tcm_map().insert(transition_id, *transition.tcm()).or_abort(|| self.abort_atomic())?;
+        self.tcm_map().insert(transition_id, *transition.tcm())?;
         // Store the reverse `tcm` entry.
-        self.reverse_tcm_map().insert(*transition.tcm(), transition_id).or_abort(|| self.abort_atomic())?;
+        self.reverse_tcm_map().insert(*transition.tcm(), transition_id)?;
         // Store the fee.
-        self.fee_map().insert(transition_id, *transition.fee()).or_abort(|| self.abort_atomic())?;
+        self.fee_map().insert(transition_id, *transition.fee())?;
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Removes the input for the given `transition ID`.
@@ -177,32 +171,28 @@ pub trait TransitionStorage<N: Network>: Clone + Sync {
             None => return Ok(()),
         };
 
-        // Start an atomic batch write operation.
-        self.start_atomic();
-
         // Remove the program ID and function name.
-        self.locator_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.locator_map().remove(transition_id)?;
         // Remove the inputs.
-        self.input_store().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.input_store().remove(transition_id)?;
         // Remove the outputs.
-        self.output_store().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.output_store().remove(transition_id)?;
         // Remove the finalize inputs.
-        self.finalize_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.finalize_map().remove(transition_id)?;
         // Remove the proof.
-        self.proof_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.proof_map().remove(transition_id)?;
         // Remove `tpk`.
-        self.tpk_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.tpk_map().remove(transition_id)?;
         // Remove the reverse `tpk` entry.
-        self.reverse_tpk_map().remove(&tpk).or_abort(|| self.abort_atomic())?;
+        self.reverse_tpk_map().remove(&tpk)?;
         // Remove `tcm`.
-        self.tcm_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.tcm_map().remove(transition_id)?;
         // Remove the reverse `tcm` entry.
-        self.reverse_tcm_map().remove(&tcm).or_abort(|| self.abort_atomic())?;
+        self.reverse_tcm_map().remove(&tcm)?;
         // Remove the fee.
-        self.fee_map().remove(transition_id).or_abort(|| self.abort_atomic())?;
+        self.fee_map().remove(transition_id)?;
 
-        // Finish the atomic batch write operation.
-        self.finish_atomic()
+        Ok(())
     }
 
     /// Returns the transition for the given `transition ID`.

--- a/vm/compiler/src/ledger/store/transition/output.rs
+++ b/vm/compiler/src/ledger/store/transition/output.rs
@@ -91,15 +91,15 @@ pub trait OutputStorage<N: Network>: Clone + Sync {
     }
 
     /// Finishes an atomic batch write operation.
-    fn finish_atomic(&self) {
-        self.id_map().finish_atomic();
-        self.reverse_id_map().finish_atomic();
-        self.constant_map().finish_atomic();
-        self.public_map().finish_atomic();
-        self.private_map().finish_atomic();
-        self.record_map().finish_atomic();
-        self.record_nonce_map().finish_atomic();
-        self.external_record_map().finish_atomic();
+    fn finish_atomic(&self) -> Result<()> {
+        self.id_map().finish_atomic()?;
+        self.reverse_id_map().finish_atomic()?;
+        self.constant_map().finish_atomic()?;
+        self.public_map().finish_atomic()?;
+        self.private_map().finish_atomic()?;
+        self.record_map().finish_atomic()?;
+        self.record_nonce_map().finish_atomic()?;
+        self.external_record_map().finish_atomic()
     }
 
     /// Stores the given `(transition ID, output)` pair into storage.
@@ -144,9 +144,7 @@ pub trait OutputStorage<N: Network>: Clone + Sync {
         }
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Removes the output for the given `transition ID`.
@@ -185,9 +183,7 @@ pub trait OutputStorage<N: Network>: Clone + Sync {
         }
 
         // Finish the atomic batch write operation.
-        self.finish_atomic();
-
-        Ok(())
+        self.finish_atomic()
     }
 
     /// Returns the transition ID that contains the given `output ID`.
@@ -416,8 +412,8 @@ impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
     }
 
     /// Finishes an atomic batch write operation.
-    pub fn finish_atomic(&self) {
-        self.storage.finish_atomic();
+    pub fn finish_atomic(&self) -> Result<()> {
+        self.storage.finish_atomic()
     }
 }
 


### PR DESCRIPTION
A follow-up to https://github.com/AleoHQ/snarkVM/pull/973.

In the previous atomic write batch PR, I considered the utility of being able to run lower-level operations individually; however, this requires a bit of extra logic in order for the "smaller" atomic operations to not cause the ones that run them underneath to perform (partial) writes prematurely. That's why I added `Map::is_atomic_in_progress` that can allow us to determine if there is already a batch write in progress, which is then used in a new `atomic_write_batch` macro that's used in all the atomic operations.

This means that any atomic batch write operation that executes several other ones underneath starts a large common batch that is "reused" by all the operations involved, so e.g. when `BlockStorage::insert` is called (via `Ledger::add_next_block`), it starts a write batch that's later used by the `IDMap`, `TransactionsMap`, `TransactionStore` etc., but if any of those were to have `insert` called on them in isolation (i.e. not as part of `BlockStorage::insert`), those operations would be atomic as well, creating their own batch in the process (with the previous rule applying to any possible `Map` operations underneath).

In addition, `Map::finish_atomic` now returns a `Result<()>`, in order to accommodate potential related persistent storage errors.

Closes https://github.com/AleoHQ/snarkVM/issues/979.

