### PR TITLE
Faster `console::algorithms::Poseidon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ name = "snarkvm-console-algorithms"
 version = "0.7.5"
 dependencies = [
  "blake2s_simd",
+ "criterion",
  "expect-test",
  "hex",
  "serde",

--- a/console/algorithms/Cargo.toml
+++ b/console/algorithms/Cargo.toml
@@ -6,6 +6,11 @@ description = "Console algorithms for a decentralized virtual machine"
 license = "GPL-3.0"
 edition = "2021"
 
+[[bench]]
+name = "poseidon_sponge"
+path = "benches/poseidon.rs"
+harness = false
+
 [dependencies.snarkvm-console-types]
 path = "../types"
 version = "0.7.5"
@@ -33,6 +38,10 @@ features = [ "const_generics", "const_new" ]
 path = "../../curves"
 version = "0.7.5"
 default-features = false
+
+
+[dev-dependencies.criterion]
+version = "0.3.6"
 
 [dev-dependencies.expect-test]
 version = "1.2"

--- a/console/algorithms/benches/poseidon.rs
+++ b/console/algorithms/benches/poseidon.rs
@@ -29,10 +29,13 @@ fn poseidon2(c: &mut Criterion) {
     let hash = Poseidon2::<Console>::setup("Poseidon2").unwrap();
 
     let input = [F::rand(rng), F::rand(rng), F::rand(rng), F::rand(rng)];
-    c.bench_function("Poseidon2 Hash 4", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon2 Hash 4 -> 1", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon2 Hash 4 -> 2", |b| b.iter(|| hash.hash_many(&input, 2)));
 
     let input = [F::rand(rng); 10];
-    c.bench_function("Poseidon2 Hash 10 ", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon2 Hash 10 -> 1", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon2 Hash 10 -> 4", |b| b.iter(|| hash.hash_many(&input, 4)));
+    c.bench_function("Poseidon2 Hash 10 -> 8", |b| b.iter(|| hash.hash_many(&input, 8)));
 }
 
 fn poseidon4(c: &mut Criterion) {
@@ -40,10 +43,13 @@ fn poseidon4(c: &mut Criterion) {
     let hash = Poseidon4::<Console>::setup("Poseidon4").unwrap();
 
     let input = [F::rand(rng), F::rand(rng), F::rand(rng), F::rand(rng)];
-    c.bench_function("Poseidon4 Hash 4", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon4 Hash 4 -> 1", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon4 Hash 4 -> 2", |b| b.iter(|| hash.hash_many(&input, 2)));
 
     let input = [F::rand(rng); 10];
-    c.bench_function("Poseidon4 Hash 10 ", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon4 Hash 10 -> 1", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon4 Hash 10 -> 4", |b| b.iter(|| hash.hash_many(&input, 4)));
+    c.bench_function("Poseidon4 Hash 10 -> 8", |b| b.iter(|| hash.hash_many(&input, 8)));
 }
 
 fn poseidon8(c: &mut Criterion) {
@@ -51,10 +57,13 @@ fn poseidon8(c: &mut Criterion) {
     let hash = Poseidon8::<Console>::setup("Poseidon8").unwrap();
 
     let input = [F::rand(rng), F::rand(rng), F::rand(rng), F::rand(rng)];
-    c.bench_function("Poseidon8 Hash 4", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon8 Hash 4 -> 1", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon8 Hash 4 -> 2", |b| b.iter(|| hash.hash_many(&input, 2)));
 
     let input = [F::rand(rng); 10];
-    c.bench_function("Poseidon8 Hash 10 ", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon8 Hash 10 -> 1", |b| b.iter(|| hash.hash(&input)));
+    c.bench_function("Poseidon8 Hash 10 -> 4", |b| b.iter(|| hash.hash_many(&input, 4)));
+    c.bench_function("Poseidon8 Hash 10 -> 8", |b| b.iter(|| hash.hash_many(&input, 8)));
 }
 
 criterion_group! {

--- a/console/algorithms/benches/poseidon.rs
+++ b/console/algorithms/benches/poseidon.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate criterion;
+
+use snarkvm_console_algorithms::{Poseidon2, Poseidon4, Poseidon8};
+use snarkvm_console_types::prelude::*;
+use snarkvm_utilities::{test_crypto_rng, Uniform};
+
+use criterion::Criterion;
+type F = Field<Console>;
+
+fn poseidon2(c: &mut Criterion) {
+    let rng = &mut test_crypto_rng();
+    let hash = Poseidon2::<Console>::setup("Poseidon2").unwrap();
+
+    let input = [F::rand(rng), F::rand(rng), F::rand(rng), F::rand(rng)];
+    c.bench_function("Poseidon2 Hash 4", |b| b.iter(|| hash.hash(&input)));
+
+    let input = [F::rand(rng); 10];
+    c.bench_function("Poseidon2 Hash 10 ", |b| b.iter(|| hash.hash(&input)));
+}
+
+fn poseidon4(c: &mut Criterion) {
+    let rng = &mut test_crypto_rng();
+    let hash = Poseidon4::<Console>::setup("Poseidon4").unwrap();
+
+    let input = [F::rand(rng), F::rand(rng), F::rand(rng), F::rand(rng)];
+    c.bench_function("Poseidon4 Hash 4", |b| b.iter(|| hash.hash(&input)));
+
+    let input = [F::rand(rng); 10];
+    c.bench_function("Poseidon4 Hash 10 ", |b| b.iter(|| hash.hash(&input)));
+}
+
+fn poseidon8(c: &mut Criterion) {
+    let rng = &mut test_crypto_rng();
+    let hash = Poseidon8::<Console>::setup("Poseidon8").unwrap();
+
+    let input = [F::rand(rng), F::rand(rng), F::rand(rng), F::rand(rng)];
+    c.bench_function("Poseidon8 Hash 4", |b| b.iter(|| hash.hash(&input)));
+
+    let input = [F::rand(rng); 10];
+    c.bench_function("Poseidon8 Hash 10 ", |b| b.iter(|| hash.hash(&input)));
+}
+
+criterion_group! {
+    name = sponge;
+    config = Criterion::default().sample_size(50);
+    targets = poseidon2, poseidon4, poseidon8,
+}
+
+criterion_main!(sponge);

--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -126,8 +126,7 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
     fn apply_mds(&mut self) {
         let mut new_state = State::default();
         new_state.iter_mut().zip(&self.parameters.mds).for_each(|(new_elem, mds_row)| {
-            *new_elem =
-                self.state.iter().zip(mds_row).map(|(state_elem, &mds_elem)| Field::new(mds_elem) * state_elem).sum();
+            *new_elem = Field::new(E::Field::sum_of_products(self.state.iter().map(|e| e.deref()), mds_row.iter()));
         });
         self.state = new_state;
     }

--- a/console/algorithms/src/poseidon/helpers/state.rs
+++ b/console/algorithms/src/poseidon/helpers/state.rs
@@ -44,7 +44,7 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> State<E, RATE, CA
 
 impl<E: Environment, const RATE: usize, const CAPACITY: usize> State<E, RATE, CAPACITY> {
     /// Returns an immutable iterator over the state.
-    pub fn iter(&self) -> impl Iterator<Item = &Field<E>> {
+    pub fn iter(&self) -> impl Iterator<Item = &Field<E>> + Clone {
         self.capacity_state.iter().chain(self.rate_state.iter())
     }
 

--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -159,6 +159,26 @@ fn test_fq_is_half() {
 }
 
 #[test]
+fn test_fr_sum_of_products() {
+    let mut rng = test_rng();
+    for i in [2, 4, 8, 16, 32] {
+        let a = (0..i).map(|_| rng.gen()).collect::<Vec<_>>();
+        let b = (0..i).map(|_| rng.gen()).collect::<Vec<_>>();
+        assert_eq!(Fr::sum_of_products(a.iter(), b.iter()), a.into_iter().zip(b).map(|(a, b)| a * b).sum());
+    }
+}
+
+#[test]
+fn test_fq_sum_of_products() {
+    let mut rng = test_rng();
+    for i in [2, 4, 8, 16, 32] {
+        let a = (0..i).map(|_| rng.gen()).collect::<Vec<_>>();
+        let b = (0..i).map(|_| rng.gen()).collect::<Vec<_>>();
+        assert_eq!(Fq::sum_of_products(a.iter(), b.iter()), a.into_iter().zip(b).map(|(a, b)| a * b).sum());
+    }
+}
+
+#[test]
 fn test_fq_repr_num_bits() {
     let mut a = BigInteger384::from(0);
     assert_eq!(0, a.num_bits());

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -182,6 +182,63 @@ impl<P: Fp256Parameters> Field for Fp256<P> {
         Self::from_repr(two_inv).unwrap() // Guaranteed to be valid.
     }
 
+    fn sum_of_products<'a>(
+        a: impl Iterator<Item = &'a Self> + Clone,
+        b: impl Iterator<Item = &'a Self> + Clone,
+    ) -> Self {
+        // For a single `a x b` multiplication, operand scanning (schoolbook) takes each
+        // limb of `a` in turn, and multiplies it by all of the limbs of `b` to compute
+        // the result as a double-width intermediate representation, which is then fully
+        // reduced at the end. Here however we have pairs of multiplications (a_i, b_i),
+        // the results of which are summed.
+        //
+        // The intuition for this algorithm is two-fold:
+        // - We can interleave the operand scanning for each pair, by processing the jth
+        //   limb of each `a_i` together. As these have the same offset within the overall
+        //   operand scanning flow, their results can be summed directly.
+        // - We can interleave the multiplication and reduction steps, resulting in a
+        //   single bitshift by the limb size after each iteration. This means we only
+        //   need to store a single extra limb overall, instead of keeping around all the
+        //   intermediate results and eventually having twice as many limbs.
+
+        // Algorithm 2, line 2
+        let (u0, u1, u2, u3) = (0..4).fold((0, 0, 0, 0), |(u0, u1, u2, u3), j| {
+            // Algorithm 2, line 3
+            // For each pair in the overall sum of products:
+            let (t0, t1, t2, t3, mut t4) =
+                a.clone().zip(b.clone()).fold((u0, u1, u2, u3, 0), |(t0, t1, t2, t3, mut t4), (a, b)| {
+                    // Compute digit_j x row and accumulate into `u`.
+                    let mut carry = 0;
+                    let t0 = fa::mac_with_carry(t0, a.0.0[j], b.0.0[0], &mut carry);
+                    let t1 = fa::mac_with_carry(t1, a.0.0[j], b.0.0[1], &mut carry);
+                    let t2 = fa::mac_with_carry(t2, a.0.0[j], b.0.0[2], &mut carry);
+                    let t3 = fa::mac_with_carry(t3, a.0.0[j], b.0.0[3], &mut carry);
+                    let _ = fa::adc(&mut t4, 0, carry);
+
+                    (t0, t1, t2, t3, t4)
+                });
+
+            // Algorithm 2, lines 4-5
+            // This is a single step of the usual Montgomery reduction process.
+            let k = t0.wrapping_mul(P::INV);
+            let mut carry = 0;
+            let _ = fa::mac_with_carry(t0, k, P::MODULUS.0[0], &mut carry);
+            let r1 = fa::mac_with_carry(t1, k, P::MODULUS.0[1], &mut carry);
+            let r2 = fa::mac_with_carry(t2, k, P::MODULUS.0[2], &mut carry);
+            let r3 = fa::mac_with_carry(t3, k, P::MODULUS.0[3], &mut carry);
+            let _ = fa::adc(&mut t4, 0, carry);
+            let r4 = t4;
+
+            (r1, r2, r3, r4)
+        });
+
+        // Because we represent F_p elements in non-redundant form, we need a final
+        // conditional subtraction to ensure the output is in range.
+        let mut result = Self::new(BigInteger([u0, u1, u2, u3]));
+        result.reduce();
+        result
+    }
+
     #[inline]
     fn double(&self) -> Self {
         let mut temp = *self;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Improves the speed of `snarkvm_console_algorithms::Poseidon` by anywhere between 10-25% by using `F::sum_of_products`.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->


Added tests for `{Fp256, Fp384}::sum_of_products`

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

