### PR TITLE
Use `sum_of_products` for field and curve arithmetic

### DIFF
--- a/algorithms/benches/msm/variable_base.rs
+++ b/algorithms/benches/msm/variable_base.rs
@@ -26,7 +26,11 @@ use rayon::prelude::*;
 extern crate criterion;
 
 fn create_scalar_bases<G: AffineCurve<ScalarField = F>, F: PrimeField>(size: usize) -> (Vec<G>, Vec<F::BigInteger>) {
-    let bases = (0..size).into_par_iter().map(|_| G::rand(&mut thread_rng())).collect::<Vec<_>>();
+    let bases =
+        std::iter::repeat((0..(size / 1000)).into_par_iter().map(|_| G::rand(&mut thread_rng())).collect::<Vec<_>>())
+            .take(1000)
+            .flatten()
+            .collect::<Vec<_>>();
     let scalars = (0..size).into_par_iter().map(|_| F::rand(&mut thread_rng()).to_repr()).collect::<Vec<_>>();
     (bases, scalars)
 }

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -294,12 +294,7 @@ impl<P: Parameters> ProjectiveCurve for Projective<P> {
             self.x -= &v.double();
 
             // Y3 = r*(V-X3)-2*Y1*J
-            j *= &self.y; // J = 2*Y1*J
-            j.double_in_place();
-            self.y = v;
-            self.y -= self.x;
-            self.y *= &r;
-            self.y -= &j;
+            self.y = P::BaseField::sum_of_products([r, -self.y.double()].iter(), [(v - self.x), j].iter());
 
             // Z3 = (Z1+H)^2-Z1Z1-HH
             self.z += &h;
@@ -349,7 +344,7 @@ impl<P: Parameters> ProjectiveCurve for Projective<P> {
             self.z.double_in_place();
 
             // X3 = F-2*D
-            self.x = f - d - d;
+            self.x = f - d.double();
 
             // Y3 = E*(D-X3)-8*C
             c.double_in_place();
@@ -479,7 +474,7 @@ impl<'a, P: Parameters> AddAssign<&'a Self> for Projective<P> {
             self.x = r.square() - j - (v.double());
 
             // Y3 = r*(V - X3) - 2*S1*J
-            self.y = r * (v - self.x) - (s1 * j).double();
+            self.y = P::BaseField::sum_of_products([r, -s1.double()].iter(), [(v - self.x), j].iter());
 
             // Z3 = ((Z1+Z2)^2 - Z1Z1 - Z2Z2)*H
             self.z = ((self.z + other.z).square() - z1z1 - z2z2) * h;

--- a/curves/src/templates/twisted_edwards_extended/projective.rs
+++ b/curves/src/templates/twisted_edwards_extended/projective.rs
@@ -237,15 +237,42 @@ impl<P: Parameters> ProjectiveCurve for Projective<P> {
     #[inline]
     #[must_use]
     fn double(&self) -> Self {
-        let mut tmp = *self;
-        tmp += self;
-        tmp
+        let mut result = *self;
+        result.double_in_place();
+        result
     }
 
     #[inline]
     fn double_in_place(&mut self) {
-        let tmp = *self;
-        *self = tmp.double();
+        // See "Twisted Edwards Curves Revisited"
+        // Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson
+        // 3.3 Doubling in E^e
+        // Source: https://www.hyperelliptic.org/EFD/g1p/data/twisted/extended/doubling/dbl-2008-hwcd
+
+        // A = X1^2
+        let a = self.x.square();
+        // B = Y1^2
+        let b = self.y.square();
+        // C = 2 * Z1^2
+        let c = self.z.square().double();
+        // D = a * A
+        let d = P::mul_by_a(&a);
+        // E = (X1 + Y1)^2 - A - B
+        let e = (self.x + self.y).square() - a - b;
+        // G = D + B
+        let g = d + b;
+        // F = G - C
+        let f = g - c;
+        // H = D - B
+        let h = d - b;
+        // X3 = E * F
+        self.x = e * f;
+        // Y3 = G * H
+        self.y = g * h;
+        // T3 = E * H
+        self.t = e * h;
+        // Z3 = F * G
+        self.z = f * g;
     }
 
     fn to_affine(&self) -> Affine<P> {

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -409,16 +409,10 @@ impl<'a, P: Fp2Parameters> MulAssign<&'a Self> for Fp2<P> {
     #[inline]
     #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
-        // Karatsuba multiplication;
-        // Guide to Pairing-based cryprography, Algorithm 5.16.
-        let v0 = self.c0 * other.c0;
-        let v1 = self.c1 * other.c1;
-
-        self.c1 += &self.c0;
-        self.c1 *= &(other.c0 + other.c1);
-        self.c1 -= &v0;
-        self.c1 -= &v1;
-        self.c0 = v0 + P::mul_fp_by_nonresidue(&v1);
+        *self = Self::new(
+            P::Fp::sum_of_products([self.c0, P::mul_fp_by_nonresidue(&self.c1)].iter(), [other.c0, other.c1].iter()),
+            P::Fp::sum_of_products([self.c0, self.c1].iter(), [other.c1, other.c0].iter()),
+        )
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Use `sum_of_products` to speed up Short Weierstrass arithmetic and Fp2 arithmetic. Overall this gives 2-5% improvements for MSMs, and 15% improvement for pairings. 

I've also implemented specialized doubling for Edwards curves, which should speed up things like signature verification.

## Test Plan

Existing tests should cover this.
