### PR TITLE
Don't verify transactions twice

### DIFF
--- a/vm/compiler/src/ledger/vm/finalize.rs
+++ b/vm/compiler/src/ledger/vm/finalize.rs
@@ -21,8 +21,6 @@ impl<N: Network, P: ProgramStorage<N>> VM<N, P> {
     /// This method assumes the given transaction **is valid**.
     #[inline]
     pub fn finalize(&mut self, transaction: &Transaction<N>) -> Result<()> {
-        // Ensure the transaction is valid.
-        ensure!(self.verify(transaction), "Invalid transaction: failed to verify");
         // Finalize the transaction.
         match transaction {
             Transaction::Deploy(_, deployment, _) => self.finalize_deployment(deployment),


### PR DESCRIPTION
When running `Ledger::add_next_block`, the transactions are currently verified twice:
- in `Ledger::check_next_block` (called at `vm/compiler/src/ledger/mod.rs:508`)
- in `VM::finalize` (called at `vm/compiler/src/ledger/mod.rs:556`)

Since this isn't a fast operation, we should only be doing it once, likely just in `Ledger::check_next_block`.