### PR TITLE
Fix the use of test_rng in tests

### DIFF
--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -42,6 +42,16 @@ where
 pub fn test_rng() -> XorShiftRng {
     // Obtain the initial seed using entropy provided by the OS.
     let seed = StdRng::from_entropy().gen();
+
+    // Print the seed, so it's displayed if any of the tests using `test_rng` fails.
+    println!("rng seed: {}", seed);
+
+    // Use the seed to initialize a fast, non-cryptographic Rng.
+    XorShiftRng::seed_from_u64(seed)
+}
+
+/// A function that can be used in order to reproduce any failing test cases that use `test_rng`.
+pub fn test_rng_seeded(seed: u64) -> XorShiftRng {
     // Use the seed to initialize a fast, non-cryptographic Rng.
     XorShiftRng::seed_from_u64(seed)
 }

--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -44,14 +44,14 @@ pub fn test_rng() -> XorShiftRng {
     let seed = StdRng::from_entropy().gen();
 
     // Print the seed, so it's displayed if any of the tests using `test_rng` fails.
-    println!("rng seed: {}", seed);
+    println!("\nInitializing 'test_rng' with seed '{seed}'\n");
 
     // Use the seed to initialize a fast, non-cryptographic Rng.
     XorShiftRng::seed_from_u64(seed)
 }
 
 /// A function that can be used in order to reproduce any failing test cases that use `test_rng`.
-pub fn test_rng_seeded(seed: u64) -> XorShiftRng {
+pub fn test_rng_fixed(seed: u64) -> XorShiftRng {
     // Use the seed to initialize a fast, non-cryptographic Rng.
     XorShiftRng::seed_from_u64(seed)
 }

--- a/vm/compiler/src/program/instruction/operation/assert.rs
+++ b/vm/compiler/src/program/instruction/operation/assert.rs
@@ -485,9 +485,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = AssertEq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -508,9 +511,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = AssertEq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -535,9 +541,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = AssertNeq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -558,9 +567,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = AssertNeq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 

--- a/vm/compiler/src/program/instruction/operation/is.rs
+++ b/vm/compiler/src/program/instruction/operation/is.rs
@@ -531,9 +531,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = IsEq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -554,9 +557,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = IsEq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -581,9 +587,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = IsNeq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -604,9 +613,12 @@ mod tests {
         // Initialize the opcode.
         let opcode = IsNeq::<CurrentNetwork>::opcode();
 
+        // Prepare the rng.
+        let mut rng = test_rng();
+
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut test_rng());
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut test_rng());
+        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 

--- a/vm/compiler/src/program/instruction/operation/macros.rs
+++ b/vm/compiler/src/program/instruction/operation/macros.rs
@@ -401,8 +401,11 @@ mod tests {
             paste::paste! {
                 #[test]
                 fn [<test _ $operate _ fails _ on _ invalid _ operands>]() -> Result<()> {
+                    // Prepare the rng.
+                    let mut rng = test_rng();
+
                     for i in 0..8 {
-                        for literal_a in $crate::sample_literals!(CurrentNetwork, &mut test_rng()).iter() {
+                        for literal_a in $crate::sample_literals!(CurrentNetwork, &mut rng).iter() {
                             for mode_a in &[circuit::Mode::Constant, circuit::Mode::Public, circuit::Mode::Private] {
                                 // Skip this iteration, if this is **not** an invalid operand case.
                                 $(if literal_a.to_type() == console::program::LiteralType::$input {
@@ -438,8 +441,11 @@ mod tests {
             paste::paste! {
                 #[test]
                 fn [<test _ $operate _ fails _ on _ invalid _ operands>]() -> Result<()> {
+                    // Prepare the rng.
+                    let mut rng = test_rng();
+
                     for i in 0..8 {
-                        for literal_a in $crate::sample_literals!(CurrentNetwork, &mut test_rng()).iter() {
+                        for literal_a in $crate::sample_literals!(CurrentNetwork, &mut rng).iter() {
                             for mode_a in &[circuit::Mode::Constant, circuit::Mode::Public, circuit::Mode::Private] {
                                 // Skip this iteration, if this is **not** an invalid operand case.
                                 $(if literal_a.to_type() == console::program::LiteralType::$input {
@@ -476,9 +482,12 @@ mod tests {
             paste::paste! {
                 #[test]
                 fn [<test _ $operate _ fails _ on _ invalid _ operands>]() -> Result<()> {
+                    // Prepare the rng.
+                    let mut rng = test_rng();
+
                     for i in 0..8 {
-                        for literal_a in $crate::sample_literals!(CurrentNetwork, &mut test_rng()).iter() {
-                            for literal_b in $crate::sample_literals!(CurrentNetwork, &mut test_rng()).iter() {
+                        for literal_a in $crate::sample_literals!(CurrentNetwork, &mut rng).iter() {
+                            for literal_b in $crate::sample_literals!(CurrentNetwork, &mut rng).iter() {
                                 for mode_a in &[circuit::Mode::Constant, circuit::Mode::Public, circuit::Mode::Private] {
                                     for mode_b in &[circuit::Mode::Constant, circuit::Mode::Public, circuit::Mode::Private] {
                                         // Skip this iteration, if this is **not** an invalid operand case.
@@ -520,9 +529,12 @@ mod tests {
             paste::paste! {
                 #[test]
                 fn [<test _ $operate _ fails _ on _ invalid _ operands>]() -> Result<()> {
-                    for literal_a in $crate::sample_literals!(CurrentNetwork, &mut test_rng()).iter() {
-                        for literal_b in $crate::sample_literals!(CurrentNetwork, &mut test_rng()).iter() {
-                            for literal_c in $crate::sample_literals!(CurrentNetwork, &mut test_rng()).iter() {
+                    // Prepare the rng.
+                    let mut rng = test_rng();
+
+                    for literal_a in $crate::sample_literals!(CurrentNetwork, &mut rng).iter() {
+                        for literal_b in $crate::sample_literals!(CurrentNetwork, &mut rng).iter() {
+                            for literal_c in $crate::sample_literals!(CurrentNetwork, &mut rng).iter() {
                                 for mode_a in &[circuit::Mode::Constant, circuit::Mode::Public, circuit::Mode::Private] {
                                     for mode_b in &[circuit::Mode::Constant, circuit::Mode::Public, circuit::Mode::Private] {
                                         for mode_c in &[circuit::Mode::Constant, circuit::Mode::Public, circuit::Mode::Private] {
@@ -572,6 +584,9 @@ mod tests {
             paste::paste! {
                 #[test]
                 fn [<test _ $operate _ $input:lower _ into _ $output:lower>]() -> Result<()> {
+                    // Prepare the rng.
+                    let mut rng = test_rng();
+
                     // Ensure the expected output type is correct.
                     assert_eq!(
                         console::program::LiteralType::$output,
@@ -584,7 +599,7 @@ mod tests {
                         #[allow(deprecated)]
                         let a = match i {
                             0 => $input::zero(),
-                            1.. => $input::<CurrentNetwork>::rand(&mut test_rng())
+                            1.. => $input::<CurrentNetwork>::rand(&mut rng)
                         };
 
                         // Initialize an indicator whether the operation should succeed or not.
@@ -678,6 +693,9 @@ mod tests {
             paste::paste! {
                 #[test]
                 fn [<test _ $operate _ $input_a:lower _ $input_b:lower _ into _ $output:lower>]() -> Result<()> {
+                    // Prepare the rng.
+                    let mut rng = test_rng();
+
                     // Ensure the expected output type is correct.
                     assert_eq!(
                         console::program::LiteralType::$output,
@@ -696,9 +714,9 @@ mod tests {
                         #[allow(deprecated)]
                         let (a, b) = match i {
                             0 => ($input_a::zero(), $input_b::zero()),
-                            1 => ($input_a::<CurrentNetwork>::rand(&mut test_rng()), $input_b::zero()),
-                            2 => ($input_a::zero(), $input_b::<CurrentNetwork>::rand(&mut test_rng())),
-                            3.. => ($input_a::<CurrentNetwork>::rand(&mut test_rng()), $input_b::<CurrentNetwork>::rand(&mut test_rng()))
+                            1 => ($input_a::<CurrentNetwork>::rand(&mut rng), $input_b::zero()),
+                            2 => ($input_a::zero(), $input_b::<CurrentNetwork>::rand(&mut rng)),
+                            3.. => ($input_a::<CurrentNetwork>::rand(&mut rng), $input_b::<CurrentNetwork>::rand(&mut rng))
                         };
 
                         // Initialize an indicator whether the operation should succeed or not.
@@ -826,6 +844,9 @@ mod tests {
             paste::paste! {
                 #[test]
                 fn [<test _ $operate _ $input_a:lower _ $input_b:lower _ $input_c:lower _ into _ $output:lower>]() -> Result<()> {
+                    // Prepare the rng.
+                    let mut rng = test_rng();
+
                     // Ensure the expected output type is correct.
                     assert_eq!(
                         console::program::LiteralType::$output,
@@ -843,13 +864,13 @@ mod tests {
                         #[allow(deprecated)]
                         let (a, b, c) = match i {
                             0 => ($input_a::zero(), $input_b::zero(), $input_c::zero()),
-                            1 => ($input_a::<CurrentNetwork>::rand(&mut test_rng()), $input_b::<CurrentNetwork>::rand(&mut test_rng()), $input_c::zero()),
-                            2 => ($input_a::<CurrentNetwork>::rand(&mut test_rng()), $input_b::zero(), $input_c::<CurrentNetwork>::rand(&mut test_rng())),
-                            3 => ($input_a::<CurrentNetwork>::rand(&mut test_rng()), $input_b::zero(), $input_c::zero()),
-                            4 => ($input_a::zero(), $input_b::<CurrentNetwork>::rand(&mut test_rng()), $input_c::<CurrentNetwork>::rand(&mut test_rng())),
-                            5 => ($input_a::zero(), $input_b::<CurrentNetwork>::rand(&mut test_rng()), $input_c::<CurrentNetwork>::zero()),
-                            6 => ($input_a::zero(), $input_b::zero(), $input_c::<CurrentNetwork>::rand(&mut test_rng())),
-                            7.. => ($input_a::<CurrentNetwork>::rand(&mut test_rng()), $input_b::<CurrentNetwork>::rand(&mut test_rng()), $input_c::<CurrentNetwork>::rand(&mut test_rng()))
+                            1 => ($input_a::<CurrentNetwork>::rand(&mut rng), $input_b::<CurrentNetwork>::rand(&mut rng), $input_c::zero()),
+                            2 => ($input_a::<CurrentNetwork>::rand(&mut rng), $input_b::zero(), $input_c::<CurrentNetwork>::rand(&mut rng)),
+                            3 => ($input_a::<CurrentNetwork>::rand(&mut rng), $input_b::zero(), $input_c::zero()),
+                            4 => ($input_a::zero(), $input_b::<CurrentNetwork>::rand(&mut rng), $input_c::<CurrentNetwork>::rand(&mut rng)),
+                            5 => ($input_a::zero(), $input_b::<CurrentNetwork>::rand(&mut rng), $input_c::<CurrentNetwork>::zero()),
+                            6 => ($input_a::zero(), $input_b::zero(), $input_c::<CurrentNetwork>::rand(&mut rng)),
+                            7.. => ($input_a::<CurrentNetwork>::rand(&mut rng), $input_b::<CurrentNetwork>::rand(&mut rng), $input_c::<CurrentNetwork>::rand(&mut rng))
                         };
 
                         // Initialize an indicator whether the operation should succeed or not.


### PR DESCRIPTION
I've noticed this while working on https://github.com/AleoHQ/snarkVM/issues/986; with the way `test_rng` is currently used, we're neither benefiting from its speed nor the determinism it provides in case a test fails.

While I continue to work on the aforementioned issue, this adjustment is useful on its own.