### PR TITLE
Aleo deploy command

### DIFF
--- a/vm/compiler/src/process/deploy.rs
+++ b/vm/compiler/src/process/deploy.rs
@@ -41,7 +41,6 @@ impl<N: Network> Process<N> {
         let program_id = deployment.program().id();
         // Ensure the program does not already exist in the process.
         ensure!(!self.contains_program(program_id), "Program '{program_id}' already exists");
-
         // Ensure the program is well-formed, by computing the stack.
         let stack = Stack::new(self, deployment.program())?;
         // Ensure the verifying keys are well-formed and the certificates are valid.

--- a/vm/lib.rs
+++ b/vm/lib.rs
@@ -82,3 +82,5 @@ pub mod prelude {
     #[cfg(feature = "utilities")]
     pub use crate::utilities::*;
 }
+
+pub(crate) type Aleo = circuit::AleoV0;

--- a/vm/lib.rs
+++ b/vm/lib.rs
@@ -82,5 +82,3 @@ pub mod prelude {
     #[cfg(feature = "utilities")]
     pub use crate::utilities::*;
 }
-
-pub(crate) type Aleo = circuit::AleoV0;

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -105,7 +105,6 @@ impl<N: Network> Package<N> {
         &self,
         endpoint: Option<String>,
     ) -> Result<()> {
-        println!("⏳ Deploying '{}'...\n", self.program_id().to_string().bold());
         // Retrieve the main program.
         let program = self.program();
 

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -131,7 +131,7 @@ impl<N: Network> Package<N> {
     pub fn deploy<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(
         &self,
         endpoint: Option<String>,
-    ) -> Result<()> {
+    ) -> Result<Deployment<N>> {
         // Retrieve the main program.
         let program = self.program();
 
@@ -148,7 +148,7 @@ impl<N: Network> Package<N> {
         match endpoint {
             Some(ref endpoint) => {
                 // Prepare the request
-                let request = DeployRequest::try_from(deployment)?;
+                let request = DeployRequest::try_from(deployment.clone())?;
                 // Load the proving and verifying keys.
                 let response = request.send(endpoint)?;
                 // Ensure the program ID matches.
@@ -157,12 +157,9 @@ impl<N: Network> Package<N> {
                     "Program ID mismatch: {} != {program_id}",
                     response.deployment.program_id()
                 );
+                Ok(deployment)
             }
-            //FIXME correctly manage this case
-            None => {
-                todo!()
-            }
+            None => Ok(deployment),
         }
-        Ok(())
     }
 }

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -1,0 +1,143 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkvm_compiler::Deployment;
+use snarkvm_utilities::test_crypto_rng;
+
+use super::*;
+
+pub struct DeployRequest<N: Network> {
+    deployment: Deployment<N>,
+}
+
+impl<N: Network> DeployRequest<N> {
+    /// Initializes a new deploy request.
+    pub const fn new(deployment: Deployment<N>) -> Self {
+        Self { deployment }
+    }
+
+    /// Sends the request to the given endpoint.
+    pub fn send(&self, endpoint: &str) -> Result<DeployResponse<N>> {
+        Ok(ureq::post(endpoint).send_json(self)?.into_json()?)
+    }
+
+    /// Returns the program.
+    pub const fn deployment(&self) -> &Deployment<N> {
+        &self.deployment
+    }
+}
+
+impl<N: Network> Serialize for DeployRequest<N> {
+    /// Serializes the deploy request into string or bytes.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut request = serializer.serialize_struct("DeployRequest", 1)?;
+        request.serialize_field("deployment", &self.deployment)?;
+        request.end()
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for DeployRequest<N> {
+    /// Deserializes the deploy request from a string or bytes.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Parse the request from a string into a value.
+        let request = serde_json::Value::deserialize(deserializer)?;
+        // Recover the leaf.
+        Ok(Self::new(
+            // Retrieve the program.
+            serde_json::from_value(request["deployment"].clone()).map_err(de::Error::custom)?,
+        ))
+    }
+}
+
+pub struct DeployResponse<N: Network> {
+    deployment: Deployment<N>,
+}
+
+impl<N: Network> DeployResponse<N> {
+    /// Initializes a new deploy response.
+    pub const fn new(deployment: Deployment<N>) -> Self {
+        Self { deployment }
+    }
+
+    /// Returns the program ID.
+    pub const fn deployment(&self) -> &Deployment<N> {
+        &self.deployment
+    }
+}
+
+impl<N: Network> Serialize for DeployResponse<N> {
+    /// Serializes the deploy response into string or bytes.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut response = serializer.serialize_struct("DeployResponse", 1)?;
+        response.serialize_field("deployment", &self.deployment)?;
+        response.end()
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for DeployResponse<N> {
+    /// Deserializes the deploy response from a string or bytes.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Parse the response from a string into a value.
+        let response = serde_json::Value::deserialize(deserializer)?;
+        // Recover the leaf.
+        Ok(Self::new(
+            // Retrieve the program ID.
+            serde_json::from_value(response["program_id"].clone()).map_err(de::Error::custom)?,
+        ))
+    }
+}
+
+impl<N: Network> Package<N> {
+    pub fn deploy<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(
+        package: &Package<N>,
+        endpoint: Option<String>,
+        _offline: bool,
+    ) -> Result<()> {
+        println!("⏳ Deploying '{}'...\n", package.program_id().to_string().bold());
+        // Retrieve the main program.
+        let program = package.program();
+
+        // Retrieve the program ID.
+        let program_id = program.id();
+
+        // Construct the process.
+        let process = Process::<N>::load()?;
+        let rng = &mut test_crypto_rng();
+
+        // Make the deploy
+        let deployment = process.deploy::<A, _>(program, rng).unwrap();
+
+        match endpoint {
+            Some(ref endpoint) => {
+                // Prepare the request
+                let request = DeployRequest::new(deployment);
+                // Load the proving and verifying keys.
+                let response = request.send(endpoint)?;
+                // Ensure the program ID matches.
+                ensure!(
+                    response.deployment.program_id() == program_id,
+                    "Program ID mismatch: {} != {program_id}",
+                    response.deployment.program_id()
+                );
+            }
+            //FIXME correctly manage this case
+            None => {
+                todo!()
+            }
+        }
+        Ok(())
+    }
+}

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -102,6 +102,7 @@ impl<'de, N: Network> Deserialize<'de> for DeployResponse<N> {
 
 impl<N: Network> Package<N> {
     pub fn deploy<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(
+        &self,
         package: &Package<N>,
         endpoint: Option<String>,
         _offline: bool,

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -31,7 +31,7 @@ impl<N: Network> DeployRequest<N> {
 
     /// Sends the request to the given endpoint.
     pub fn send(&self, endpoint: &str) -> Result<DeployResponse<N>> {
-        Ok(ureq::post(endpoint).send_json(self)?.into_json()?)
+        Ok(ureq::post(endpoint).send_json(self.deployment())?.into_json()?)
     }
 
     /// Returns the program.

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -103,13 +103,11 @@ impl<'de, N: Network> Deserialize<'de> for DeployResponse<N> {
 impl<N: Network> Package<N> {
     pub fn deploy<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(
         &self,
-        package: &Package<N>,
         endpoint: Option<String>,
-        _offline: bool,
     ) -> Result<()> {
-        println!("⏳ Deploying '{}'...\n", package.program_id().to_string().bold());
+        println!("⏳ Deploying '{}'...\n", self.program_id().to_string().bold());
         // Retrieve the main program.
-        let program = package.program();
+        let program = self.program();
 
         // Retrieve the program ID.
         let program_id = program.id();

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -16,6 +16,7 @@
 
 mod build;
 mod clean;
+mod deploy;
 mod is_build_required;
 mod run;
 

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -21,6 +21,7 @@ mod is_build_required;
 mod run;
 
 pub use build::{BuildRequest, BuildResponse};
+pub use deploy::{DeployRequest, DeployResponse};
 
 use crate::{
     file::{AVMFile, AleoFile, Manifest, ProverFile, VerifierFile, README},


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

We need to have a CLI command to deploy Aleo projects. During Testnet3's life cycle all program deployments will be sent to the blockchain by Aleo Explorer (https://aleo.network.com/testnet3/deploy) on behalf of the user 🚀

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

This feature will be used by https://github.com/AleoHQ/snarkOS-beacon/pull/13 