### PR TITLE
Fix #985

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ commands:
       - setup_environment:
           cache_key: << parameters.cache_key >>
       - run:
-          no_output_timeout: 30m
+          no_output_timeout: 45m
           command: |
             cd << parameters.workspace_member >>
             cargo test -- --list --format terse | sed 's/: test//' > test_names.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
     docker:
       - image: cimg/rust:1.62
     resource_class: 2xlarge
-    parallelism: 50
+    parallelism: 4
     steps:
       - run_parallel:
           workspace_member: vm/compiler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
     docker:
       - image: cimg/rust:1.62
     resource_class: 2xlarge
-    parallelism: 4
+    parallelism: 50
     steps:
       - run_parallel:
           workspace_member: vm/compiler

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serial_test",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",

--- a/vm/compiler/Cargo.toml
+++ b/vm/compiler/Cargo.toml
@@ -93,6 +93,9 @@ version = "1.3"
 [dev-dependencies.regex]
 version = "1.6"
 
+[dev-dependencies.serial_test]
+version = "0.9"
+
 [dev-dependencies.tracing-test]
 version = "0.2"
 

--- a/vm/compiler/src/program/instruction/operation/assert.rs
+++ b/vm/compiler/src/program/instruction/operation/assert.rs
@@ -522,9 +522,9 @@ mod tests {
 
         literals_a.par_iter().for_each(|literal_a| {
             for literal_b in &literals_b {
-                for mode_a in &modes_a {
-                    for mode_b in &modes_b {
-                        if literal_a.to_type() != literal_b.to_type() {
+                if literal_a.to_type() != literal_b.to_type() {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
                             // Check the operation fails.
                             check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b);
                         }
@@ -578,9 +578,9 @@ mod tests {
 
         literals_a.par_iter().for_each(|literal_a| {
             for literal_b in &literals_b {
-                for mode_a in &modes_a {
-                    for mode_b in &modes_b {
-                        if literal_a.to_type() != literal_b.to_type() {
+                if literal_a.to_type() != literal_b.to_type() {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
                             // Check the operation fails.
                             check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b);
                         }

--- a/vm/compiler/src/program/instruction/operation/assert.rs
+++ b/vm/compiler/src/program/instruction/operation/assert.rs
@@ -505,6 +505,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_assert_eq_fails() {
         use rayon::prelude::*;
 
@@ -561,6 +562,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_assert_neq_fails() {
         use rayon::prelude::*;
 

--- a/vm/compiler/src/program/instruction/operation/is.rs
+++ b/vm/compiler/src/program/instruction/operation/is.rs
@@ -624,17 +624,19 @@ mod tests {
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
-        literals_a.par_iter().for_each(|literal_a| {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b);
+        literals_a.par_iter().chunks(8).for_each(|literals_a| {
+            literals_a.iter().for_each(|literal_a| {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b);
+                            }
                         }
                     }
                 }
-            }
+            })
         });
     }
 

--- a/vm/compiler/src/program/instruction/operation/is.rs
+++ b/vm/compiler/src/program/instruction/operation/is.rs
@@ -568,9 +568,9 @@ mod tests {
 
         literals_a.par_iter().for_each(|literal_a| {
             for literal_b in &literals_b {
-                for mode_a in &modes_a {
-                    for mode_b in &modes_b {
-                        if literal_a.to_type() != literal_b.to_type() {
+                if literal_a.to_type() != literal_b.to_type() {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
                             // Check the operation fails.
                             check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b);
                         }
@@ -624,9 +624,9 @@ mod tests {
 
         literals_a.par_iter().for_each(|literal_a| {
             for literal_b in &literals_b {
-                for mode_a in &modes_a {
-                    for mode_b in &modes_b {
-                        if literal_a.to_type() != literal_b.to_type() {
+                if literal_a.to_type() != literal_b.to_type() {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
                             // Check the operation fails.
                             check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b);
                         }

--- a/vm/compiler/src/program/instruction/operation/is.rs
+++ b/vm/compiler/src/program/instruction/operation/is.rs
@@ -566,17 +566,19 @@ mod tests {
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
-        literals_a.par_iter().for_each(|literal_a| {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b);
+        literals_a.par_iter().chunks(8).for_each(|literals_a| {
+            literals_a.iter().for_each(|literal_a| {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b);
+                            }
                         }
                     }
                 }
-            }
+            })
         });
     }
 

--- a/vm/compiler/src/program/instruction/operation/is.rs
+++ b/vm/compiler/src/program/instruction/operation/is.rs
@@ -551,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_is_eq_fails() {
         use rayon::prelude::*;
 
@@ -609,6 +610,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_is_neq_fails() {
         use rayon::prelude::*;
 


### PR DESCRIPTION
This PR consists of 2 changes applicable to some tests:
- the order of operations in some loops was adjusted so that the loops do fewer noops
- `test_is_eq_fails` and `test_is_neq_fails` are now run in a "chunked" fashion so that their runs don't fail to conclude

Fixes #985.