### PR TITLE
Fix imposibility to deploy Aleo programs that have imports

### DIFF
--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -160,7 +160,11 @@ impl<N: Network> Package<N> {
         Ok(())
     }
 
-    fn deploy_program<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(process: &Process<N>, program: &Program<N>, endpoint: &str) -> Result<()> {
+    fn deploy_program<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(
+        process: &Process<N>,
+        program: &Program<N>,
+        endpoint: &str,
+    ) -> Result<()> {
         let rng = &mut test_crypto_rng();
         let program_id = program.id();
         let import_deployment = process.deploy::<A, _>(program, rng).unwrap();
@@ -175,8 +179,12 @@ impl<N: Network> Package<N> {
         );
         Ok(())
     }
-    
-    fn deploy_imported_programs<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(process: &Process<N>, imported_programs: Vec<Program<N>>, endpoint: &str) -> Result<()> {
+
+    fn deploy_imported_programs<A: crate::circuit::Aleo<Network = N, BaseField = N::Field>>(
+        process: &Process<N>,
+        imported_programs: Vec<Program<N>>,
+        endpoint: &str,
+    ) -> Result<()> {
         for imported_program in imported_programs {
             Self::deploy_program::<A>(process, &imported_program, endpoint)?;
         }

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use indexmap::map::Keys;
-use snarkvm_compiler::{Deployment, Import};
+use snarkvm_compiler::Deployment;
 use snarkvm_console::types::Address;
 use snarkvm_utilities::test_crypto_rng;
 
@@ -159,7 +158,7 @@ impl<N: Network> Package<N> {
             let rng = &mut test_crypto_rng();
             // Retrieve the program ID.
             let program_id = program.id();
-            // Deploy program.
+            // Deploy the program.
             let import_deployment = process.deploy::<A, _>(program, rng).unwrap();
             // Prepare the deployment request
             let request = DeployRequest::try_from(import_deployment)?;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

There was not possible to deploy Aleo programs with imports from the Aleo CLI.

## The problem

Only the main program was in the process when deploying.

## Solution

Added all the main program imports to the process before deploying.

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

This issue was mentioned in [this comment](https://github.com/AleoHQ/aleo/pull/326#issuecomment-1227898092) in the Aleo repo.
