### PR TITLE
Fix address for deploy request

### DIFF
--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -129,23 +129,24 @@ impl<N: Network> Package<N> {
     ) -> Result<Deployment<N>> {
         // Retrieve the main program.
         let program = self.program();
-
-        let program_owner_address = self.manifest_file().development_address();
-
-        // Retrieve the program ID.
+        // Retrieve the main program ID.
         let program_id = program.id();
+
+        // Retrieve the Aleo address of the deployment caller.
+        let caller = self.manifest_file().development_address();
 
         // Construct the process.
         let process = Process::<N>::load()?;
         let rng = &mut test_crypto_rng();
 
-        // Make the deploy
+        // Compute the deployment.
         let deployment = process.deploy::<A, _>(program, rng).unwrap();
 
         match endpoint {
             Some(ref endpoint) => {
-                // Prepare the request
-                let request = DeployRequest::new(deployment.clone(), *program_owner_address, *program_id);
+                // Construct the deploy request.
+                let request = DeployRequest::new(deployment.clone(), *caller, *program_id);
+                // Send the deploy request.
                 let response = request.send(endpoint)?;
                 // Ensure the program ID matches.
                 ensure!(


### PR DESCRIPTION
## Motivation

The address inside the body of the request sent to the explorer to deploy a program, wasn't the expected one. 
The used address was the one associated with the program and not the one of the developer/owner of it.
Now the deploy command get the address from the manifest file and use that to send it on the request.

