### PR TITLE
Remove redundant parser call.

### DIFF
--- a/vm/compiler/src/program/parse.rs
+++ b/vm/compiler/src/program/parse.rs
@@ -44,8 +44,6 @@ impl<N: Network> Parser for Program<N> {
         // Parse the semicolon ';' keyword from the string.
         let (string, _) = tag(";")(string)?;
 
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the interface or function from the string.
         let (string, components) = many1(alt((
             map(Mapping::parse, |mapping| P::<N>::M(mapping)),


### PR DESCRIPTION
Since each of `Mapping::parse`, `Interface::parse`, etc. call `Sanitizer::parse`
as their first action, there is no need to call `Sanitizer::parse` before
calling the `alt` of those parsers.
