### PR TITLE
Support for deploying programs with imports

### DIFF
--- a/vm/compiler/src/process/deploy.rs
+++ b/vm/compiler/src/process/deploy.rs
@@ -30,6 +30,21 @@ impl<N: Network> Process<N> {
         stack.deploy::<A, R>(rng)
     }
 
+    /// Deploys all the programs that are in the process's stacks.
+    #[inline]
+    pub fn deploy_with_imports<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
+        &mut self,
+        rng: &mut R,
+    ) -> Result<Vec<Deployment<N>>> {
+        let mut deployments: Vec<Deployment<N>> = Vec::new();
+        self.stacks.iter().try_for_each(|(_, stack)| {
+            let deployment = stack.deploy::<A, R>(rng)?;
+            deployments.push(deployment);
+            Ok::<_, Error>(())
+        })?;
+        Ok(deployments)
+    }
+
     /// Verifies the given deployment is well-formed.
     #[inline]
     pub fn verify_deployment<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(


### PR DESCRIPTION
## Warning!

This PR doesn't work in its actual state. It prints the following error:

```
ERROR unhandled custom rejection, returning 500 response: Request("channel closed")
Error: Invalid transaction found in the transactions list
```

## Motivation

The imported programs are not being deployed before the main program and that causes an error when deploying. 
The error is the following one:

```
WARN Deployment verification failed: Cannot add program 'foo.aleo' because its import 'bar.aleo' must be added first
Error: Invalid transaction found in the transactions list
```

This PR includes the logic to add all the imported programs to the process and make the deployment of them before the main program.


