### PR TITLE
Minor updates to validator selection

### DIFF
--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -594,9 +594,36 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
         Ok(())
     }
 
+    /// Adds a given address to the validator set.
+    pub fn add_validator(&mut self, address: Address<N>) -> Result<()> {
+        if self.validators().contains_key(&address) {
+            bail!("'{address}' is already in the validator set.")
+        }
+
+        // Insert the address into the validator set.
+        self.validators.insert(address, ());
+        Ok(())
+    }
+
+    /// Removes a given address from the validator set.
+    pub fn remove_validator(&mut self, address: Address<N>) -> Result<()> {
+        if !self.validators().contains_key(&address) {
+            bail!("'{address}' is not in the validator set.")
+        }
+
+        // Remove the address from the validator set.
+        self.validators.remove(&address);
+        Ok(())
+    }
+
     /// Returns the block tree.
     pub const fn block_tree(&self) -> &BlockTree<N> {
         &self.block_tree
+    }
+
+    /// Returns the validator set.
+    pub const fn validators(&self) -> &IndexMap<Address<N>, ()> {
+        &self.validators
     }
 
     /// Returns the memory pool.

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -113,10 +113,8 @@ impl<N: Network> Ledger<N, BlockMemory<N>, ProgramMemory<N>> {
     pub fn new() -> Result<Self> {
         // Load the genesis block.
         let genesis = Block::<N>::from_bytes_le(GenesisBytes::load_bytes())?;
-        // Initialize the address.
-        let address = Address::<N>::from_str("aleo1q6qstg8q8shwqf5m6q5fcenuwsdqsvp4hhsgfnx5chzjm3secyzqt9mxm8")?;
         // Initialize the ledger.
-        Self::new_with_genesis(&genesis, address)
+        Self::new_with_genesis(&genesis, genesis.signature().to_address())
     }
 }
 

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -146,12 +146,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
             transitions: blocks.transition_store().clone(),
             blocks,
             // TODO (howardwu): Update this to retrieve from a validators store.
-            validators: [(
-                Address::<N>::from_str("aleo1q6qstg8q8shwqf5m6q5fcenuwsdqsvp4hhsgfnx5chzjm3secyzqt9mxm8")?,
-                (),
-            )]
-            .into_iter()
-            .collect(),
+            validators: [].into_iter().collect(),
             vm,
             memory_pool: Default::default(),
         };
@@ -169,6 +164,10 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
                 genesis.height()
             }
         };
+
+        // Add the initial validator.
+        let genesis_block = ledger.get_block(0)?;
+        ledger.add_validator(genesis_block.signature().to_address())?;
 
         // Fetch the latest block.
         let block = ledger.get_block(latest_height)?;

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -144,7 +144,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
             transitions: blocks.transition_store().clone(),
             blocks,
             // TODO (howardwu): Update this to retrieve from a validators store.
-            validators: [].into_iter().collect(),
+            validators: Default::default(),
             vm,
             memory_pool: Default::default(),
         };
@@ -593,24 +593,20 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
 
     /// Adds a given address to the validator set.
     pub fn add_validator(&mut self, address: Address<N>) -> Result<()> {
-        if self.validators().contains_key(&address) {
+        if self.validators.insert(address, ()).is_some() {
             bail!("'{address}' is already in the validator set.")
+        } else {
+            Ok(())
         }
-
-        // Insert the address into the validator set.
-        self.validators.insert(address, ());
-        Ok(())
     }
 
     /// Removes a given address from the validator set.
     pub fn remove_validator(&mut self, address: Address<N>) -> Result<()> {
-        if !self.validators().contains_key(&address) {
+        if self.validators.remove(&address).is_none() {
             bail!("'{address}' is not in the validator set.")
+        } else {
+            Ok(())
         }
-
-        // Remove the address from the validator set.
-        self.validators.remove(&address);
-        Ok(())
     }
 
     /// Returns the block tree.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds basic functionality for getting, adding, and removing validators. Additionally, initializing a fresh ledger or loading a ledger from storage will now select the address from the genesis block signature as the initial validator, instead of the hard-coded address.


NOTE: The current validator model is just a placeholder and will be updated for Phase 3 of Testnet3.