### PR TITLE
Remove some `Sanitizer::parse` calls.

### DIFF
--- a/console/program/src/data_types/finalize_type/parse.rs
+++ b/console/program/src/data_types/finalize_type/parse.rs
@@ -20,8 +20,6 @@ impl<N: Network> Parser for FinalizeType<N> {
     /// Parses the string into a finalize type.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the mode from the string.
         alt((
             map(pair(PlaintextType::parse, tag(".public")), |(plaintext_type, _)| Self::Public(plaintext_type)),

--- a/console/program/src/data_types/record_type/entry_type/parse.rs
+++ b/console/program/src/data_types/record_type/entry_type/parse.rs
@@ -20,8 +20,6 @@ impl<N: Network> Parser for EntryType<N> {
     /// Parses a string into the entry type.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the mode from the string.
         alt((
             map(pair(PlaintextType::parse, tag(".constant")), |(plaintext_type, _)| Self::Constant(plaintext_type)),

--- a/console/program/src/data_types/register_type/parse.rs
+++ b/console/program/src/data_types/register_type/parse.rs
@@ -20,8 +20,6 @@ impl<N: Network> Parser for RegisterType<N> {
     /// Parses a string into a register type.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the mode from the string (ordering matters).
         alt((
             map(pair(Locator::parse, tag(".record")), |(locator, _)| Self::ExternalRecord(locator)),

--- a/console/program/src/data_types/value_type/parse.rs
+++ b/console/program/src/data_types/value_type/parse.rs
@@ -20,8 +20,6 @@ impl<N: Network> Parser for ValueType<N> {
     /// Parses the string into a value type.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the mode from the string.
         alt((
             map(pair(PlaintextType::parse, tag(".constant")), |(plaintext_type, _)| Self::Constant(plaintext_type)),


### PR DESCRIPTION
A `Sanitizer::parse` call skips over comments and whitespace.

The calls removed by this commit immediately preceded the parsing of value,
finalize, entry, and register types. However, it looks like these calls may be
unintentional (which motivates this commit), for the following reasons:

- Other kinds of types (namely literal and plaintext types) are not preceded
  by calls to `Sanitizer::parse`.

- The callers of the parsers of value, finalize, entry, and register types
  already skip over whitespace just before parsing these types.

- In the rest of the parser, generally comments (and whitespace) are only
  allowed around, but not inside, instructions and other constructs that are
  normally written in one line; only whitespace (no comments) are allowed inside
  these constructs.

So this commit makes things more uniform across all types.

If allowing comments just before value, finalize, entry, and register types is
intentional, then we should probably look into a more clear and uniform approach
to where comments and whitespace are allowed in the code, as opposed to just
whitespce.
