### PR TITLE
[Feature] get_record method for the Ledger

### DIFF
--- a/vm/compiler/src/ledger/get.rs
+++ b/vm/compiler/src/ledger/get.rs
@@ -105,6 +105,15 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
             None => bail!("Missing signature for block {height}"),
         }
     }
+
+    /// Returns the record for the given `commitment`.
+    ///
+    /// If the record exists, `Ok(Some(record))` is returned.
+    /// If the record was purged, `Ok(None)` is returned.
+    /// If the record does not exist, `Err(error)` is returned.
+    pub fn get_record(&self, commitment: Field<N>) -> Result<Option<Record<N, Ciphertext<N>>>> {
+        self.transitions.get_record(&commitment)
+    }
 }
 
 #[cfg(test)]

--- a/vm/compiler/src/ledger/get.rs
+++ b/vm/compiler/src/ledger/get.rs
@@ -107,10 +107,6 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
     }
 
     /// Returns the record for the given `commitment`.
-    ///
-    /// If the record exists, `Ok(Some(record))` is returned.
-    /// If the record was purged, `Ok(None)` is returned.
-    /// If the record does not exist, `Err(error)` is returned.
     pub fn get_record(&self, commitment: Field<N>) -> Result<Option<Record<N, Ciphertext<N>>>> {
         self.transitions.get_record(&commitment)
     }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

We need to be able to retrieve a record ciphertext from the ledger for a given commitment.

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

This feature will be used in https://github.com/AleoHQ/snarkOS/pull/1907
