### PR TITLE
Add additional API endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "anyhow",
  "indexmap",
  "parking_lot 0.12.1",
+ "serde",
  "snarkvm-compiler",
  "snarkvm-console",
  "tokio",

--- a/rest/Cargo.toml
+++ b/rest/Cargo.toml
@@ -40,6 +40,11 @@ version = "1.8.2"
 [dependencies.parking_lot]
 version = "0.12"
 
+[dependencies.serde]
+version = "1.0.144"
+default-features = false
+features = [ "derive" ]
+
 [dependencies.tokio]
 version = "1"
 

--- a/rest/src/lib.rs
+++ b/rest/src/lib.rs
@@ -39,6 +39,7 @@ use snarkvm_console::{
 use anyhow::Result;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::{sync::mpsc, task::JoinHandle};
 use warp::{http::StatusCode, reject, reply, Filter, Rejection, Reply};

--- a/rest/src/lib.rs
+++ b/rest/src/lib.rs
@@ -29,7 +29,12 @@ mod start;
 pub use start::*;
 
 use snarkvm_compiler::{BlockStorage, Ledger, ProgramStorage, RecordsFilter, Transaction};
-use snarkvm_console::{account::ViewKey, prelude::Network, types::Field};
+use snarkvm_console::{
+    account::{Address, ViewKey},
+    prelude::Network,
+    program::ProgramID,
+    types::Field,
+};
 
 use anyhow::Result;
 use indexmap::IndexMap;

--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -216,7 +216,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
 
     /// Returns the transactions in the memory pool.
     async fn get_transactions_mempool(ledger: Arc<RwLock<Ledger<N, B, P>>>) -> Result<impl Reply, Rejection> {
-        Ok(reply::json(&ledger.read().memory_pool()))
+        Ok(reply::json(&ledger.read().memory_pool().values().collect::<Vec<_>>()))
     }
 
     /// Returns the program for the given program id.

--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -60,7 +60,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
 
         // GET /testnet3/transactions/mempool
         let get_transactions_mempool = warp::get()
-            .and(warp::path!("testnet3" / "transaction" / "mempool"))
+            .and(warp::path!("testnet3" / "transactions" / "mempool"))
             .and(with(self.ledger.clone()))
             .and_then(Self::get_transactions_mempool);
 

--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -59,6 +59,12 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
             .and(with(self.ledger.clone()))
             .and_then(Self::get_transaction);
 
+        // GET /testnet3/transactions/mempool
+        let get_transactions_mempool = warp::get()
+            .and(warp::path!("testnet3" / "transaction" / "mempool"))
+            .and(with(self.ledger.clone()))
+            .and_then(Self::get_transactions_mempool);
+
         // GET /testnet3/program/{id}
         let get_program = warp::get()
             .and(warp::path!("testnet3" / "program" / ..))
@@ -114,6 +120,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
             .or(get_block)
             .or(get_transactions)
             .or(get_transaction)
+            .or(get_transactions_mempool)
             .or(get_program)
             .or(get_state_path)
             .or(records_all)
@@ -155,6 +162,11 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
         ledger: Arc<RwLock<Ledger<N, B, P>>>,
     ) -> Result<impl Reply, Rejection> {
         Ok(reply::json(&ledger.read().get_transaction(transaction_id).or_reject()?))
+    }
+
+    /// Returns the transactions in the memory pool.
+    async fn get_transactions_mempool(ledger: Arc<RwLock<Ledger<N, B, P>>>) -> Result<impl Reply, Rejection> {
+        Ok(reply::json(&ledger.read().memory_pool()))
     }
 
     /// Returns the program for the given program id.

--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -16,6 +16,7 @@
 
 use super::*;
 
+/// The `get_blocks` query object.
 #[derive(Deserialize, Serialize)]
 struct BlockRange {
     start: u32,
@@ -171,7 +172,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
         Ok(reply::json(&ledger.read().get_block(height).or_reject()?))
     }
 
-    /// Returns the block for the given block height.
+    /// Returns the blocks for the given block range.
     async fn get_blocks(
         block_range: BlockRange,
         ledger: Arc<RwLock<Ledger<N, B, P>>>,
@@ -185,8 +186,8 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
         }
 
         // Ensure the block range is bounded.
-        const BLOCK_RANGE: u32 = 50;
-        if end_height - start_height >= BLOCK_RANGE {
+        const MAX_BLOCK_RANGE: u32 = 50;
+        if end_height - start_height >= MAX_BLOCK_RANGE {
             return Err(reject::custom(RestError::Request(format!(
                 "Too many blocks requested. Max 50, requested {}",
                 end_height - start_height

--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -72,7 +72,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
             .and(with(self.ledger.clone()))
             .and_then(Self::get_program);
 
-        // GET /testnet3/transactions/mempool
+        // GET /testnet3/validators
         let get_validators = warp::get()
             .and(warp::path!("testnet3" / "validators"))
             .and(with(self.ledger.clone()))

--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -219,7 +219,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
         Ok(reply::json(&ledger.read().memory_pool().values().collect::<Vec<_>>()))
     }
 
-    /// Returns the program for the given program id.
+    /// Returns the program for the given program ID.
     async fn get_program(
         program_id: ProgramID<N>,
         ledger: Arc<RwLock<Ledger<N, B, P>>>,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds the following API endpoints:

#### GET /testnet3/program/{id}

Returns the program for the given program ID.

- https://github.com/AleoHQ/snarkOS/issues/1921

#### GET /testnet3/transactions/mempool

Returns a list of transactions currently in the node's mempool.

- https://github.com/AleoHQ/snarkOS/issues/1922

#### GET /testnet3/validators

Returns a list of the current validators.

- https://github.com/AleoHQ/snarkOS/issues/1925

NOTE: The validators endpoint currently only returns a list of validator addresses, this will be updated once staking has been integrated

#### GET /testnet3/blocks?start={start_height}&end={end_height}

Returns a list of blocks between (inclusive) a start and end height.

- https://github.com/AleoHQ/snarkOS/issues/1920


