### PR TITLE
Add transaction validation to `transaction_broadcast` and mempool operations

### DIFF
--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -130,6 +130,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
             .and(warp::body::content_length_limit(10 * 1024 * 1024))
             .and(warp::body::json())
             .and(with(self.ledger_sender.clone()))
+            .and(with(self.ledger.clone()))
             .and_then(Self::transaction_broadcast);
 
         // Return the list of routes.
@@ -276,7 +277,11 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
     async fn transaction_broadcast(
         transaction: Transaction<N>,
         ledger_sender: LedgerSender<N>,
+        ledger: Arc<RwLock<Ledger<N, B, P>>>,
     ) -> Result<impl Reply, Rejection> {
+        // Validate the transaction.
+        ledger.read().check_transaction(&transaction).or_reject()?;
+
         // Send the transaction to the ledger.
         match ledger_sender.send(LedgerRequest::TransactionBroadcast(transaction)).await {
             Ok(()) => Ok("OK"),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR addresses https://github.com/AleoHQ/snarkVM/issues/1080 by adding an initial transaction check before sending the transaction to the mempool.

Additional changes:
 - The transactions selected from the mempool will now avoid input collisions. 
 - Clears the mempool of transactions that contain spent records.