### PR TITLE
Guard against overflow in EvaluationDomain::compute_size_of_domain

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -148,7 +148,7 @@ impl<F: FftField> EvaluationDomain<F> {
     /// Return the size of a domain that is large enough for evaluations of a polynomial
     /// having `num_coeffs` coefficients.
     pub fn compute_size_of_domain(num_coeffs: usize) -> Option<usize> {
-        let size = num_coeffs.next_power_of_two();
+        let size = num_coeffs.checked_next_power_of_two()?;
         if size.trailing_zeros() <= F::FftParameters::TWO_ADICITY { Some(size) } else { None }
     }
 


### PR DESCRIPTION
This PR tackles the offending operation causing the panic. I'm not sure if an early return with `None` is the right choice here (perhaps returning a `Result<Option<usize>>` is more desirable), but this is the place where a patch is needed.

Fixes https://github.com/AleoHQ/snarkVM/issues/1087.