### PR TITLE
Guard against OOM in the CanonicalDeserialize impl for String

### DIFF
--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -22,6 +22,8 @@ pub use crate::{
 };
 use crate::{serialize::traits::*, SerializationError};
 
+use bincode::Options;
+
 use std::{borrow::Cow, collections::BTreeMap, marker::PhantomData, rc::Rc, sync::Arc};
 
 impl Valid for bool {
@@ -87,7 +89,11 @@ impl CanonicalDeserialize for String {
         _compress: Compress,
         _validate: Validate,
     ) -> Result<Self, SerializationError> {
-        Ok(bincode::deserialize_from(reader)?)
+        Ok(bincode::DefaultOptions::new()
+            .with_fixint_encoding() // this option is for compatibility with the defaults
+            .allow_trailing_bytes() // so is this
+            .with_limit(10 * 1024)  // a limit to guard against OOMs
+            .deserialize_from(reader)?)
     }
 }
 


### PR DESCRIPTION
The root cause of the OOM discovered in https://github.com/AleoHQ/snarkVM/issues/1090 is the `CanonicalDeserialize` impl for `String`; the solution is to use custom options in order to limit the maximum number of bytes `bincode` can attempt to deserialize.

The limit was picked arbitrarily and can be set to any other reasonable value.

Fixes https://github.com/AleoHQ/snarkVM/issues/1090.