### PR TITLE
Guard against overflow when using next_power_of_two

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -116,7 +116,7 @@ impl<F: FftField> EvaluationDomain<F> {
     /// having `num_coeffs` coefficients.
     pub fn new(num_coeffs: usize) -> Option<Self> {
         // Compute the size of our evaluation domain
-        let size = num_coeffs.next_power_of_two() as u64;
+        let size = num_coeffs.checked_next_power_of_two()? as u64;
         let log_size_of_group = size.trailing_zeros();
 
         // libfqfft uses > https://github.com/scipr-lab/libfqfft/blob/e0183b2cef7d4c5deb21a6eaf3fe3b586d738fe0/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc#L33

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -107,8 +107,11 @@ impl<E: PairingEngine> KZG10<E> {
         if max_degree < 1 {
             return Err(PCError::DegreeIsZero);
         }
-        let max_lagrange_size =
-            if max_degree.is_power_of_two() { max_degree } else { max_degree.next_power_of_two() >> 1 };
+        let max_lagrange_size = if max_degree.is_power_of_two() {
+            max_degree
+        } else {
+            max_degree.checked_next_power_of_two().ok_or(PCError::LagrangeBasisSizeIsTooLarge)? >> 1
+        };
 
         if !max_lagrange_size.is_power_of_two() {
             return Err(PCError::LagrangeBasisSizeIsNotPowerOfTwo);
@@ -288,7 +291,10 @@ impl<E: PairingEngine> KZG10<E> {
         rng: Option<&mut dyn RngCore>,
     ) -> Result<(Commitment<E>, Randomness<E>), PCError> {
         Self::check_degree_is_too_large(evaluations.len() - 1, lagrange_basis.size())?;
-        assert_eq!(evaluations.len().next_power_of_two(), lagrange_basis.size());
+        assert_eq!(
+            evaluations.len().checked_next_power_of_two().ok_or(PCError::LagrangeBasisSizeIsTooLarge)?,
+            lagrange_basis.size()
+        );
 
         let commit_time = start_timer!(|| format!(
             "Committing to polynomial of degree {} with hiding_bound: {:?}",

--- a/fields/src/traits/fft_field.rs
+++ b/fields/src/traits/fft_field.rs
@@ -69,7 +69,7 @@ pub trait FftField: Field + From<u128> + From<u64> + From<u32> + From<u16> + Fro
             }
         } else {
             // Compute the next power of 2.
-            let size = n.next_power_of_two() as u64;
+            let size = n.checked_next_power_of_two()? as u64;
             let log_size_of_group = size.trailing_zeros();
 
             if n != size as usize || log_size_of_group > Self::FftParameters::TWO_ADICITY {

--- a/parameters/src/testnet3/powers.rs
+++ b/parameters/src/testnet3/powers.rs
@@ -148,7 +148,12 @@ impl<E: PairingEngine> PowersOfG<E> {
     /// and updates `Self` in place with the new powers.
     pub fn download_up_to(&mut self, target_degree: usize) -> Result<()> {
         // Initialize the first degree to download.
-        let mut next_degree = std::cmp::max(self.current_degree.next_power_of_two(), DEGREE_16);
+        let mut next_degree = std::cmp::max(
+            self.current_degree
+                .checked_next_power_of_two()
+                .ok_or_else(|| anyhow!("The current degree is too large"))?,
+            DEGREE_16,
+        );
 
         // Determine the degrees to download.
         let mut download_queue = Vec::new();


### PR DESCRIPTION
This PR changes all uses of `next_power_of_two` to `checked_next_power_of_two` outside of tests and benchmarks. @howardwu it's possible that one or more of these changes is overzealous, and I'm happy to adjust if need be.

Fixes https://github.com/AleoHQ/snarkVM/issues/1103.