### PR TITLE
A few missing TestRng bits

### DIFF
--- a/console/account/src/lib.rs
+++ b/console/account/src/lib.rs
@@ -53,7 +53,7 @@ pub use view_key::*;
 //     use crate::{testnet2::Testnet2, Account, Address, Network, PrivateKey, ViewKey};
 //     use snarkvm_algorithms::prelude::*;
 //
-//     use rand::{thread_rng, Rng, SeedableRng};
+//     use rand::{Rng, SeedableRng};
 //     use rand_chacha::ChaChaRng;
 //     use std::str::FromStr;
 //
@@ -183,7 +183,7 @@ pub use view_key::*;
 //
 //         for i in 0..ITERATIONS {
 //             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut rng)).collect();
-//             let signature = private_key.sign(&message, &mut thread_rng()).unwrap();
+//             let signature = private_key.sign(&message, &mut rng).unwrap();
 //             let verification = address.verify_signature(&message, &signature).unwrap();
 //             assert!(verification);
 //         }
@@ -200,7 +200,7 @@ pub use view_key::*;
 //             let message = "Hi, I'm an Aleo account signature!".as_bytes().to_bits_le();
 //             let incorrect_message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut rng)).collect();
 //
-//             let signature = private_key.sign(&message, &mut thread_rng()).unwrap();
+//             let signature = private_key.sign(&message, &mut rng).unwrap();
 //             let verification = address.verify_signature(&incorrect_message, &signature).unwrap();
 //             assert!(!verification);
 //         }
@@ -212,7 +212,7 @@ pub use view_key::*;
 //
 //         for i in 0..25 {
 //             // Sample an Aleo account.
-//             let private_key = PrivateKey::<Testnet2>::new(&mut thread_rng());
+//             let private_key = PrivateKey::<Testnet2>::new(&mut rng);
 //             let address = Address::<Testnet2>::from_private_key(&private_key);
 //
 //             // Derive the signature public key.
@@ -223,7 +223,6 @@ pub use view_key::*;
 //             assert_eq!(*address.to_bytes_le().unwrap(), signature_public_key.to_x_coordinate().to_bytes_le().unwrap());
 //
 //             // Prepare for signing.
-//             let rng = ChaChaRng::seed_from_u64(thread_rng().gen());
 //             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut rng)).collect();
 //
 //             // Ensure the Aleo signatures match.
@@ -256,11 +255,11 @@ pub use view_key::*;
 //
 //         for i in 0..25 {
 //             // Sample an Aleo account.
-//             let private_key = PrivateKey::<Testnet2>::new(&mut thread_rng());
+//             let private_key = PrivateKey::<Testnet2>::new(&mut rng);
 //
 //             // Craft the Aleo signature.
 //             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut rng)).collect();
-//             let expected_signature = private_key.sign(&message, &mut thread_rng()).unwrap();
+//             let expected_signature = private_key.sign(&message, &mut rng).unwrap();
 //
 //             let candidate_string = &expected_signature.to_string();
 //             assert_eq!(216, candidate_string.len(), "Update me if serialization has changed");
@@ -274,11 +273,11 @@ pub use view_key::*;
 //
 //         for i in 0..25 {
 //             // Sample an Aleo account.
-//             let private_key = PrivateKey::<Testnet2>::new(&mut thread_rng());
+//             let private_key = PrivateKey::<Testnet2>::new(&mut rng);
 //
 //             // Craft the Aleo signature.
 //             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut rng)).collect();
-//             let expected_signature = private_key.sign(&message, &mut thread_rng()).unwrap();
+//             let expected_signature = private_key.sign(&message, &mut rng).unwrap();
 //
 //             // Serialize
 //             let expected_string = &expected_signature.to_string();
@@ -297,11 +296,11 @@ pub use view_key::*;
 //
 //         for i in 0..25 {
 //             // Sample an Aleo account.
-//             let private_key = PrivateKey::<Testnet2>::new(&mut thread_rng());
+//             let private_key = PrivateKey::<Testnet2>::new(&mut rng);
 //
 //             // Craft the Aleo signature.
 //             let message: Vec<bool> = (0..(32 * i)).map(|_| bool::rand(&mut rng)).collect();
-//             let expected_signature = private_key.sign(&message, &mut thread_rng()).unwrap();
+//             let expected_signature = private_key.sign(&message, &mut rng).unwrap();
 //
 //             // Serialize
 //             let expected_bytes = expected_signature.to_bytes_le().unwrap();

--- a/vm/compiler/src/ledger/block/bytes.rs
+++ b/vm/compiler/src/ledger/block/bytes.rs
@@ -69,7 +69,9 @@ mod tests {
 
     #[test]
     fn test_bytes() -> Result<()> {
-        for expected in [crate::ledger::test_helpers::sample_genesis_block()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [crate::ledger::test_helpers::sample_genesis_block(&mut rng)].into_iter() {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Block::read_le(&expected_bytes[..])?);

--- a/vm/compiler/src/ledger/block/genesis.rs
+++ b/vm/compiler/src/ledger/block/genesis.rs
@@ -66,9 +66,13 @@ impl<N: Network> Block<N> {
 
 #[cfg(test)]
 mod tests {
+    use snarkvm_utilities::TestRng;
+
     #[test]
     fn test_genesis() {
-        let block = crate::ledger::test_helpers::sample_genesis_block();
+        let mut rng = TestRng::default();
+
+        let block = crate::ledger::test_helpers::sample_genesis_block(&mut rng);
         // println!("{}", serde_json::to_string_pretty(&block).unwrap());
         assert!(block.is_genesis());
     }

--- a/vm/compiler/src/ledger/block/header/bytes.rs
+++ b/vm/compiler/src/ledger/block/header/bytes.rs
@@ -60,7 +60,9 @@ mod tests {
 
     #[test]
     fn test_bytes() -> Result<()> {
-        for expected in [*crate::ledger::test_helpers::sample_genesis_block().header()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [*crate::ledger::test_helpers::sample_genesis_block(&mut rng).header()].into_iter() {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Header::read_le(&expected_bytes[..])?);

--- a/vm/compiler/src/ledger/block/header/genesis.rs
+++ b/vm/compiler/src/ledger/block/header/genesis.rs
@@ -59,18 +59,22 @@ mod tests {
 
     #[test]
     fn test_genesis_header_size() {
+        let mut rng = TestRng::default();
+
         // Prepare the expected size.
         let expected_size = get_expected_size::<CurrentNetwork>();
         // Prepare the genesis block header.
-        let genesis_header = *crate::ledger::test_helpers::sample_genesis_block().header();
+        let genesis_header = *crate::ledger::test_helpers::sample_genesis_block(&mut rng).header();
         // Ensure the size of the genesis block header is correct.
         assert_eq!(expected_size, genesis_header.to_bytes_le().unwrap().len());
     }
 
     #[test]
     fn test_genesis_header() {
+        let mut rng = TestRng::default();
+
         // Prepare the genesis block header.
-        let header = *crate::ledger::test_helpers::sample_genesis_block().header();
+        let header = *crate::ledger::test_helpers::sample_genesis_block(&mut rng).header();
         // Ensure the block header is a genesis block header.
         assert!(header.is_genesis());
 

--- a/vm/compiler/src/ledger/block/header/metadata/bytes.rs
+++ b/vm/compiler/src/ledger/block/header/metadata/bytes.rs
@@ -66,7 +66,9 @@ mod tests {
 
     #[test]
     fn test_bytes() -> Result<()> {
-        for expected in [*crate::ledger::test_helpers::sample_genesis_block().metadata()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [*crate::ledger::test_helpers::sample_genesis_block(&mut rng).metadata()].into_iter() {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Metadata::read_le(&expected_bytes[..])?);

--- a/vm/compiler/src/ledger/block/header/metadata/genesis.rs
+++ b/vm/compiler/src/ledger/block/header/metadata/genesis.rs
@@ -66,18 +66,22 @@ mod tests {
 
     #[test]
     fn test_genesis_metadata_size() {
+        let mut rng = TestRng::default();
+
         // Prepare the expected size.
         let expected_size = get_expected_size::<CurrentNetwork>();
         // Prepare the genesis metadata.
-        let genesis_metadata = *crate::ledger::test_helpers::sample_genesis_block().metadata();
+        let genesis_metadata = *crate::ledger::test_helpers::sample_genesis_block(&mut rng).metadata();
         // Ensure the size of the genesis metadata is correct.
         assert_eq!(expected_size, genesis_metadata.to_bytes_le().unwrap().len());
     }
 
     #[test]
     fn test_genesis_metadata() {
+        let mut rng = TestRng::default();
+
         // Prepare the genesis metadata.
-        let metadata = *crate::ledger::test_helpers::sample_genesis_block().metadata();
+        let metadata = *crate::ledger::test_helpers::sample_genesis_block(&mut rng).metadata();
         // Ensure the metadata is a genesis metadata.
         assert!(metadata.is_genesis());
 

--- a/vm/compiler/src/ledger/block/header/metadata/serialize.rs
+++ b/vm/compiler/src/ledger/block/header/metadata/serialize.rs
@@ -62,7 +62,9 @@ mod tests {
 
     #[test]
     fn test_serde_json() -> Result<()> {
-        for expected in [*crate::ledger::test_helpers::sample_genesis_block().metadata()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [*crate::ledger::test_helpers::sample_genesis_block(&mut rng).metadata()].into_iter() {
             // Serialize
             let expected_string = &expected.to_string();
             let candidate_string = serde_json::to_string(&expected)?;
@@ -76,7 +78,9 @@ mod tests {
 
     #[test]
     fn test_bincode() -> Result<()> {
-        for expected in [*crate::ledger::test_helpers::sample_genesis_block().metadata()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [*crate::ledger::test_helpers::sample_genesis_block(&mut rng).metadata()].into_iter() {
             // Serialize
             let expected_bytes = expected.to_bytes_le()?;
             let expected_bytes_with_size_encoding = bincode::serialize(&expected)?;

--- a/vm/compiler/src/ledger/block/header/serialize.rs
+++ b/vm/compiler/src/ledger/block/header/serialize.rs
@@ -56,7 +56,9 @@ mod tests {
 
     #[test]
     fn test_serde_json() -> Result<()> {
-        for expected in [*crate::ledger::test_helpers::sample_genesis_block().header()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [*crate::ledger::test_helpers::sample_genesis_block(&mut rng).header()].into_iter() {
             // Serialize
             let expected_string = &expected.to_string();
             let candidate_string = serde_json::to_string(&expected)?;
@@ -70,7 +72,9 @@ mod tests {
 
     #[test]
     fn test_bincode() -> Result<()> {
-        for expected in [*crate::ledger::test_helpers::sample_genesis_block().header()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [*crate::ledger::test_helpers::sample_genesis_block(&mut rng).header()].into_iter() {
             // Serialize
             let expected_bytes = expected.to_bytes_le()?;
             let expected_bytes_with_size_encoding = bincode::serialize(&expected)?;

--- a/vm/compiler/src/ledger/block/serialize.rs
+++ b/vm/compiler/src/ledger/block/serialize.rs
@@ -69,7 +69,9 @@ mod tests {
 
     #[test]
     fn test_serde_json() -> Result<()> {
-        for expected in [crate::ledger::test_helpers::sample_genesis_block()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [crate::ledger::test_helpers::sample_genesis_block(&mut rng)].into_iter() {
             // Serialize
             let expected_string = &expected.to_string();
             let candidate_string = serde_json::to_string(&expected)?;
@@ -83,7 +85,9 @@ mod tests {
 
     #[test]
     fn test_bincode() -> Result<()> {
-        for expected in [crate::ledger::test_helpers::sample_genesis_block()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [crate::ledger::test_helpers::sample_genesis_block(&mut rng)].into_iter() {
             // Serialize
             let expected_bytes = expected.to_bytes_le()?;
             let expected_bytes_with_size_encoding = bincode::serialize(&expected)?;

--- a/vm/compiler/src/ledger/block/transactions/bytes.rs
+++ b/vm/compiler/src/ledger/block/transactions/bytes.rs
@@ -57,7 +57,10 @@ mod tests {
 
     #[test]
     fn test_bytes() -> Result<()> {
-        for expected in [crate::ledger::test_helpers::sample_genesis_block().transactions().clone()].into_iter() {
+        let mut rng = TestRng::default();
+
+        for expected in [crate::ledger::test_helpers::sample_genesis_block(&mut rng).transactions().clone()].into_iter()
+        {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Transactions::read_le(&expected_bytes[..])?);

--- a/vm/compiler/src/ledger/block/transactions/serialize.rs
+++ b/vm/compiler/src/ledger/block/transactions/serialize.rs
@@ -89,7 +89,7 @@ mod tests {
         };
 
         // Check the serialization.
-        check_serde_json(crate::ledger::test_helpers::sample_genesis_block().transactions().clone());
+        check_serde_json(crate::ledger::test_helpers::sample_genesis_block(rng).transactions().clone());
 
         for transaction in [
             crate::ledger::vm::test_helpers::sample_deployment_transaction(rng),
@@ -120,7 +120,7 @@ mod tests {
         };
 
         // Check the serialization.
-        check_bincode(crate::ledger::test_helpers::sample_genesis_block().transactions().clone());
+        check_bincode(crate::ledger::test_helpers::sample_genesis_block(rng).transactions().clone());
 
         for transaction in [
             crate::ledger::vm::test_helpers::sample_deployment_transaction(rng),

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -852,24 +852,20 @@ pub(crate) mod test_helpers {
     type CurrentNetwork = Testnet3;
     pub(crate) type CurrentLedger = Ledger<CurrentNetwork, BlockMemory<CurrentNetwork>, ProgramMemory<CurrentNetwork>>;
 
-    pub(crate) fn sample_genesis_private_key() -> PrivateKey<CurrentNetwork> {
+    pub(crate) fn sample_genesis_private_key(rng: &mut TestRng) -> PrivateKey<CurrentNetwork> {
         static INSTANCE: OnceCell<PrivateKey<CurrentNetwork>> = OnceCell::new();
         *INSTANCE.get_or_init(|| {
-            // Initialize the RNG.
-            let rng = &mut TestRng::fixed(1245897092);
             // Initialize a new caller.
             PrivateKey::<CurrentNetwork>::new(rng).unwrap()
         })
     }
 
-    pub(crate) fn sample_genesis_block() -> Block<CurrentNetwork> {
+    pub(crate) fn sample_genesis_block(rng: &mut TestRng) -> Block<CurrentNetwork> {
         static INSTANCE: OnceCell<Block<CurrentNetwork>> = OnceCell::new();
         INSTANCE
             .get_or_init(|| {
                 // Initialize the VM.
                 let vm = crate::ledger::vm::test_helpers::sample_vm();
-                // Initialize the RNG.
-                let rng = &mut TestRng::fixed(1245897092);
                 // Initialize a new caller.
                 let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
                 // Return the block.
@@ -878,14 +874,14 @@ pub(crate) mod test_helpers {
             .clone()
     }
 
-    pub(crate) fn sample_genesis_ledger() -> CurrentLedger {
+    pub(crate) fn sample_genesis_ledger(rng: &mut TestRng) -> CurrentLedger {
         static INSTANCE: OnceCell<CurrentLedger> = OnceCell::new();
         INSTANCE
             .get_or_init(|| {
                 // Sample the genesis block.
-                let genesis = sample_genesis_block();
+                let genesis = sample_genesis_block(rng);
                 // Sample the genesis address.
-                let private_key = sample_genesis_private_key();
+                let private_key = sample_genesis_private_key(rng);
                 let address = Address::try_from(&private_key).unwrap();
 
                 // Initialize the ledger with the genesis block.
@@ -1007,9 +1003,9 @@ mod tests {
         let rng = &mut TestRng::default();
 
         // Sample the genesis private key.
-        let private_key = test_helpers::sample_genesis_private_key();
+        let private_key = test_helpers::sample_genesis_private_key(rng);
         // Sample the genesis ledger.
-        let mut ledger = test_helpers::sample_genesis_ledger();
+        let mut ledger = test_helpers::sample_genesis_ledger(rng);
 
         // Add a transaction to the memory pool.
         let transaction = crate::ledger::vm::test_helpers::sample_deployment_transaction(rng);
@@ -1038,9 +1034,9 @@ mod tests {
         let rng = &mut TestRng::default();
 
         // Sample the genesis private key.
-        let private_key = test_helpers::sample_genesis_private_key();
+        let private_key = test_helpers::sample_genesis_private_key(rng);
         // Sample the genesis ledger.
-        let mut ledger = test_helpers::sample_genesis_ledger();
+        let mut ledger = test_helpers::sample_genesis_ledger(rng);
 
         // Add a transaction to the memory pool.
         let transaction = crate::ledger::vm::test_helpers::sample_execution_transaction(rng);
@@ -1064,7 +1060,7 @@ mod tests {
         let rng = &mut TestRng::default();
 
         // Sample the genesis private key, view key, and address.
-        let private_key = test_helpers::sample_genesis_private_key();
+        let private_key = test_helpers::sample_genesis_private_key(rng);
         let view_key = ViewKey::try_from(private_key).unwrap();
         let address = Address::try_from(&view_key).unwrap();
 

--- a/vm/compiler/src/ledger/state_path/bytes.rs
+++ b/vm/compiler/src/ledger/state_path/bytes.rs
@@ -93,8 +93,10 @@ mod tests {
 
     #[test]
     fn test_bytes() {
+        let mut rng = TestRng::default();
+
         // Sample a ledger.
-        let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+        let ledger = crate::ledger::test_helpers::sample_genesis_ledger(&mut rng);
 
         // Retrieve the genesis block.
         let genesis = ledger.get_block(0).unwrap();

--- a/vm/compiler/src/ledger/state_path/parse.rs
+++ b/vm/compiler/src/ledger/state_path/parse.rs
@@ -82,12 +82,14 @@ mod tests {
 
     #[test]
     fn test_parse() -> Result<()> {
+        let mut rng = TestRng::default();
+
         // Ensure type and empty value fails.
         assert!(StatePath::<CurrentNetwork>::parse(&format!("{STATE_PATH_PREFIX}1")).is_err());
         assert!(StatePath::<CurrentNetwork>::parse("").is_err());
 
         // Sample a ledger.
-        let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+        let ledger = crate::ledger::test_helpers::sample_genesis_ledger(&mut rng);
 
         // Retrieve the genesis block.
         let genesis = ledger.get_block(0).unwrap();
@@ -110,8 +112,10 @@ mod tests {
 
     #[test]
     fn test_string() -> Result<()> {
+        let mut rng = TestRng::default();
+
         // Sample a ledger.
-        let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+        let ledger = crate::ledger::test_helpers::sample_genesis_ledger(&mut rng);
 
         // Retrieve the genesis block.
         let genesis = ledger.get_block(0).unwrap();
@@ -133,8 +137,10 @@ mod tests {
 
     #[test]
     fn test_display() -> Result<()> {
+        let mut rng = TestRng::default();
+
         // Sample a ledger.
-        let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+        let ledger = crate::ledger::test_helpers::sample_genesis_ledger(&mut rng);
 
         // Retrieve the genesis block.
         let genesis = ledger.get_block(0).unwrap();

--- a/vm/compiler/src/ledger/state_path/serialize.rs
+++ b/vm/compiler/src/ledger/state_path/serialize.rs
@@ -42,8 +42,10 @@ mod tests {
 
     #[test]
     fn test_serde_json() -> Result<()> {
+        let mut rng = TestRng::default();
+
         // Sample a ledger.
-        let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+        let ledger = crate::ledger::test_helpers::sample_genesis_ledger(&mut rng);
 
         // Retrieve the genesis block.
         let genesis = ledger.get_block(0).unwrap();
@@ -69,8 +71,10 @@ mod tests {
 
     #[test]
     fn test_bincode() -> Result<()> {
+        let mut rng = TestRng::default();
+
         // Sample a ledger.
-        let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+        let ledger = crate::ledger::test_helpers::sample_genesis_ledger(&mut rng);
 
         // Retrieve the genesis block.
         let genesis = ledger.get_block(0).unwrap();

--- a/vm/compiler/src/ledger/store/block/mod.rs
+++ b/vm/compiler/src/ledger/store/block/mod.rs
@@ -536,8 +536,10 @@ mod tests {
 
     #[test]
     fn test_insert_get_remove() {
+        let mut rng = TestRng::default();
+
         // Sample the block.
-        let block = crate::ledger::test_helpers::sample_genesis_block();
+        let block = crate::ledger::test_helpers::sample_genesis_block(&mut rng);
         let block_hash = block.hash();
 
         // Initialize a new block store.
@@ -564,8 +566,10 @@ mod tests {
 
     #[test]
     fn test_find_block_hash() {
+        let mut rng = TestRng::default();
+
         // Sample the block.
-        let block = crate::ledger::test_helpers::sample_genesis_block();
+        let block = crate::ledger::test_helpers::sample_genesis_block(&mut rng);
         let block_hash = block.hash();
         assert!(block.transactions().len() > 0, "This test must be run with at least one transaction.");
 

--- a/vm/compiler/src/ledger/vm/mod.rs
+++ b/vm/compiler/src/ledger/vm/mod.rs
@@ -177,11 +177,11 @@ function compute:
                 let program = sample_program();
 
                 // Initialize a new caller.
-                let caller_private_key = crate::ledger::test_helpers::sample_genesis_private_key();
+                let caller_private_key = crate::ledger::test_helpers::sample_genesis_private_key(rng);
                 let caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
 
                 // Initialize the ledger.
-                let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+                let ledger = crate::ledger::test_helpers::sample_genesis_ledger(rng);
 
                 // Fetch the unspent records.
                 let records = ledger
@@ -212,12 +212,12 @@ function compute:
         INSTANCE
             .get_or_init(|| {
                 // Initialize a new caller.
-                let caller_private_key = crate::ledger::test_helpers::sample_genesis_private_key();
+                let caller_private_key = crate::ledger::test_helpers::sample_genesis_private_key(rng);
                 let caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
                 let address = Address::try_from(&caller_private_key).unwrap();
 
                 // Initialize the ledger.
-                let ledger = crate::ledger::test_helpers::sample_genesis_ledger();
+                let ledger = crate::ledger::test_helpers::sample_genesis_ledger(rng);
 
                 // Fetch the unspent records.
                 let records = ledger

--- a/vm/compiler/src/unused/benches/record.rs
+++ b/vm/compiler/src/unused/benches/record.rs
@@ -20,7 +20,7 @@ extern crate criterion;
 use snarkvm_dpc::{prelude::*, testnet2::Testnet2};
 
 use criterion::Criterion;
-use snarkvm_utilities::Uniform;
+use snarkvm_utilities::{test_rng, Uniform};
 
 fn bench_record_decryption(
     c: &mut Criterion,
@@ -58,7 +58,7 @@ fn record_decrypt_with_payload(c: &mut Criterion) {
 }
 
 fn record_decrypt_with_program_id(c: &mut Criterion) {
-    let mut rng = &mut thread_rng();
+    let mut rng = &mut TestRng::default();
     let private_key: PrivateKey<Testnet2> = PrivateKey::new(rng);
     let address = private_key.to_address();
     let decryption_key = DecryptionKey::from(ViewKey::from_private_key(&private_key));
@@ -70,7 +70,7 @@ fn record_decrypt_with_program_id(c: &mut Criterion) {
 }
 
 fn record_decrypt_with_payload_and_program_id(c: &mut Criterion) {
-    let mut rng = &mut thread_rng();
+    let mut rng = &mut TestRng::default();
     let private_key: PrivateKey<Testnet2> = PrivateKey::new(rng);
     let address = private_key.to_address();
     let decryption_key = DecryptionKey::from(ViewKey::from_private_key(&private_key));


### PR DESCRIPTION
There are a few spots in tests/benchmarks where the `TestRng` is not used, can get seeded multiple times, or is fixed; all of these are undesirable.

This is probably the last follow-up to https://github.com/AleoHQ/snarkVM/pull/999.