### PR TITLE
Allows call instructions without inputs and/or outputs

### DIFF
--- a/console/network/environment/src/prelude.rs
+++ b/console/network/environment/src/prelude.rs
@@ -75,7 +75,7 @@ pub use nom::{
     branch::alt,
     bytes::{complete::tag, streaming::take},
     character::complete::{alpha1, alphanumeric1, char, one_of},
-    combinator::{map, map_res, opt, recognize},
+    combinator::{complete, map, map_res, opt, recognize},
     multi::{many0, many1, separated_list0, separated_list1},
     sequence::{pair, terminated},
 };

--- a/utilities/src/biginteger/mod.rs
+++ b/utilities/src/biginteger/mod.rs
@@ -111,7 +111,7 @@ pub mod arithmetic {
     #[inline(always)]
     pub fn sbb(a: &mut u64, b: u64, borrow: u64) -> u64 {
         let tmp = (1u128 << 64) + u128::from(*a) - u128::from(b) - u128::from(borrow);
-        let carry = if tmp >> 64 == 0 { 1 } else { 0 };
+        let carry = u64::from(tmp >> 64 == 0);
         *a = tmp as u64;
         carry
     }

--- a/vm/compiler/src/program/instruction/operation/call.rs
+++ b/vm/compiler/src/program/instruction/operation/call.rs
@@ -534,7 +534,7 @@ impl<N: Network> Parser for Call<N> {
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the operands from the string.
-        let (string, operands) = map_res(many1(parse_operand), |operands: Vec<Operand<N>>| {
+        let (string, operands) = map_res(many0(complete(parse_operand)), |operands: Vec<Operand<N>>| {
             // Ensure the number of operands is within the bounds.
             match operands.len() <= N::MAX_OPERANDS {
                 true => Ok(operands),
@@ -543,18 +543,28 @@ impl<N: Network> Parser for Call<N> {
         })(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the "into" from the string.
-        let (string, _) = tag("into")(string)?;
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the destination register from the string.
-        let (string, destinations) = map_res(many1(parse_destination), |destinations: Vec<Register<N>>| {
-            // Ensure the number of destination registers is within the bounds.
-            match destinations.len() <= N::MAX_OPERANDS {
-                true => Ok(destinations),
-                false => Err(error("Failed to parse 'call' opcode: too many destination registers")),
+
+        // Optionally parse the "into" from the string.
+        let (string, destinations) = match opt(tag("into"))(string)? {
+            // If the "into" was not parsed, return the string and an empty vector of destinations.
+            (string, None) => (string, vec![]),
+            // If the "into" was parsed, parse the destinations from the string.
+            (string, Some(_)) => {
+                // Parse the whitespace from the string.
+                let (string, _) = Sanitizer::parse_whitespaces(string)?;
+                // Parse the destinations from the string.
+                let (string, destinations) =
+                    map_res(many0(complete(parse_destination)), |destinations: Vec<Register<N>>| {
+                        // Ensure the number of destinations is within the bounds.
+                        match destinations.len() <= N::MAX_OPERANDS {
+                            true => Ok(destinations),
+                            false => Err(error("Failed to parse 'call' opcode: too many destinations")),
+                        }
+                    })(string)?;
+                // Return the string and the destinations.
+                (string, destinations)
             }
-        })(string)?;
+        };
 
         Ok((string, Self { operator, operands, destinations }))
     }
@@ -589,20 +599,23 @@ impl<N: Network> Display for Call<N> {
     /// Prints the operation to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Ensure the number of operands is within the bounds.
-        if self.operands.len().is_zero() || self.operands.len() > N::MAX_OPERANDS {
-            eprintln!("The number of operands must be nonzero and <= {}", N::MAX_OPERANDS);
+        if self.operands.len() > N::MAX_OPERANDS {
+            eprintln!("The number of operands must be <= {}", N::MAX_OPERANDS);
             return Err(fmt::Error);
         }
         // Ensure the number of destinations is within the bounds.
-        if self.destinations.len().is_zero() || self.destinations.len() > N::MAX_OPERANDS {
-            eprintln!("The number of destinations must be nonzero and <= {}", N::MAX_OPERANDS);
+        if self.destinations.len() > N::MAX_OPERANDS {
+            eprintln!("The number of destinations must be <= {}", N::MAX_OPERANDS);
             return Err(fmt::Error);
         }
         // Print the operation.
         write!(f, "{} {}", Self::opcode(), self.operator)?;
         self.operands.iter().try_for_each(|operand| write!(f, " {operand}"))?;
-        write!(f, " into")?;
-        self.destinations.iter().try_for_each(|destination| write!(f, " {destination}"))
+        if !self.destinations.is_empty() {
+            write!(f, " into")?;
+            self.destinations.iter().try_for_each(|destination| write!(f, " {destination}"))?;
+        }
+        Ok(())
     }
 }
 
@@ -615,8 +628,8 @@ impl<N: Network> FromBytes for Call<N> {
         // Read the number of operands.
         let num_operands = u8::read_le(&mut reader)? as usize;
         // Ensure the number of operands is within the bounds.
-        if num_operands.is_zero() || num_operands > N::MAX_OPERANDS {
-            return Err(error(format!("The number of operands must be nonzero and <= {}", N::MAX_OPERANDS)));
+        if num_operands > N::MAX_OPERANDS {
+            return Err(error(format!("The number of operands must be <= {}", N::MAX_OPERANDS)));
         }
 
         // Initialize the vector for the operands.
@@ -629,8 +642,8 @@ impl<N: Network> FromBytes for Call<N> {
         // Read the number of destination registers.
         let num_destinations = u8::read_le(&mut reader)? as usize;
         // Ensure the number of destinations is within the bounds.
-        if num_destinations.is_zero() || num_destinations > N::MAX_OPERANDS {
-            return Err(error(format!("The number of destinations must be nonzero and <= {}", N::MAX_OPERANDS)));
+        if num_destinations > N::MAX_OPERANDS {
+            return Err(error(format!("The number of destinations must be <= {}", N::MAX_OPERANDS)));
         }
 
         // Initialize the vector for the destinations.
@@ -649,12 +662,12 @@ impl<N: Network> ToBytes for Call<N> {
     /// Writes the operation to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Ensure the number of operands is within the bounds.
-        if self.operands.len().is_zero() || self.operands.len() > N::MAX_OPERANDS {
-            return Err(error(format!("The number of operands must be nonzero and <= {}", N::MAX_OPERANDS)));
+        if self.operands.len() > N::MAX_OPERANDS {
+            return Err(error(format!("The number of operands must be <= {}", N::MAX_OPERANDS)));
         }
         // Ensure the number of destinations is within the bounds.
-        if self.destinations.len().is_zero() || self.destinations.len() > N::MAX_OPERANDS {
-            return Err(error(format!("The number of destinations must be nonzero and <= {}", N::MAX_OPERANDS)));
+        if self.destinations.len() > N::MAX_OPERANDS {
+            return Err(error(format!("The number of destinations must be <= {}", N::MAX_OPERANDS)));
         }
 
         // Write the name of the call.
@@ -673,35 +686,73 @@ impl<N: Network> ToBytes for Call<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::{network::Testnet3, program::Identifier};
+    use console::{
+        network::Testnet3,
+        program::{Address, Identifier, Literal, U64},
+    };
 
     type CurrentNetwork = Testnet3;
 
+    fn check_parser(
+        string: &str,
+        expected_operator: CallOperator<CurrentNetwork>,
+        expected_operands: Vec<Operand<CurrentNetwork>>,
+        expected_destinations: Vec<Register<CurrentNetwork>>,
+    ) {
+        // Check that the parser works.
+        let (string, call) = Call::<CurrentNetwork>::parse(string).unwrap();
+
+        // Check that the entire string was consumed.
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+        // Check that the operator is correct.
+        assert_eq!(call.operator, expected_operator, "The call operator is incorrect");
+
+        // Check that the operands are correct.
+        assert_eq!(call.operands.len(), expected_operands.len(), "The number of operands is incorrect");
+        for (i, (given, expected)) in call.operands.iter().zip(expected_operands.iter()).enumerate() {
+            assert_eq!(given, expected, "The {}-th operand is incorrect", i);
+        }
+
+        // Check that the destinations are correct.
+        assert_eq!(call.destinations.len(), expected_destinations.len(), "The number of destinations is incorrect");
+        for (i, (given, expected)) in call.destinations.iter().zip(expected_destinations.iter()).enumerate() {
+            assert_eq!(given, expected, "The {}-th destination is incorrect", i);
+        }
+    }
+
     #[test]
     fn test_parse() {
-        let (string, call) =
-            Call::<CurrentNetwork>::parse("call transfer r0.owner r0.gates r0.token_amount into r1 r2 r3").unwrap();
-        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(call.operator, CallOperator::from_str("transfer").unwrap(), "The call operator is incorrect");
-        assert_eq!(call.operands.len(), 3, "The number of operands is incorrect");
-        assert_eq!(
-            call.operands[0],
-            Operand::Register(Register::Member(0, vec![Identifier::from_str("owner").unwrap()])),
-            "The first operand is incorrect"
+        check_parser(
+            "call transfer r0.owner r0.gates r0.token_amount into r1 r2 r3",
+            CallOperator::from_str("transfer").unwrap(),
+            vec![
+                Operand::Register(Register::Member(0, vec![Identifier::from_str("owner").unwrap()])),
+                Operand::Register(Register::Member(0, vec![Identifier::from_str("gates").unwrap()])),
+                Operand::Register(Register::Member(0, vec![Identifier::from_str("token_amount").unwrap()])),
+            ],
+            vec![Register::Locator(1), Register::Locator(2), Register::Locator(3)],
         );
-        assert_eq!(
-            call.operands[1],
-            Operand::Register(Register::Member(0, vec![Identifier::from_str("gates").unwrap()])),
-            "The second operand is incorrect"
+
+        check_parser(
+            "call mint_public aleo1wfyyj2uvwuqw0c0dqa5x70wrawnlkkvuepn4y08xyaqfqqwweqys39jayw 100u64",
+            CallOperator::from_str("mint_public").unwrap(),
+            vec![
+                Operand::Literal(Literal::Address(
+                    Address::from_str("aleo1wfyyj2uvwuqw0c0dqa5x70wrawnlkkvuepn4y08xyaqfqqwweqys39jayw").unwrap(),
+                )),
+                Operand::Literal(Literal::U64(U64::from_str("100u64").unwrap())),
+            ],
+            vec![],
         );
-        assert_eq!(
-            call.operands[2],
-            Operand::Register(Register::Member(0, vec![Identifier::from_str("token_amount").unwrap()])),
-            "The third operand is incorrect"
+
+        check_parser(
+            "call get_magic_number into r0",
+            CallOperator::from_str("get_magic_number").unwrap(),
+            vec![],
+            vec![Register::Locator(0)],
         );
-        assert_eq!(call.destinations.len(), 3, "The number of destinations is incorrect");
-        assert_eq!(call.destinations[0], Register::Locator(1), "The first destination register is incorrect");
-        assert_eq!(call.destinations[1], Register::Locator(2), "The second destination register is incorrect");
-        assert_eq!(call.destinations[2], Register::Locator(3), "The third destination register is incorrect");
+
+        check_parser("call noop", CallOperator::from_str("noop").unwrap(), vec![], vec![])
     }
 }

--- a/vm/compiler/src/program/instruction/operation/call.rs
+++ b/vm/compiler/src/program/instruction/operation/call.rs
@@ -693,6 +693,22 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
+    const TEST_CASES: &[&str] = &[
+        "call foo",
+        "call foo r0",
+        "call foo r0.owner",
+        "call foo r0 r1",
+        "call foo r0.owner r0.gates",
+        "call foo into r0",
+        "call foo into r0 r1",
+        "call foo into r0 r1 r2",
+        "call foo r0 into r1",
+        "call foo r0 r1 into r2",
+        "call foo r0 r1 into r2 r3",
+        "call foo r0 r1 r2 into r3 r4",
+        "call foo r0 r1 r2 into r3 r4 r5",
+    ];
+
     fn check_parser(
         string: &str,
         expected_operator: CallOperator<CurrentNetwork>,
@@ -758,22 +774,20 @@ mod tests {
 
     #[test]
     fn test_display() {
-        for expected in [
-            "call foo",
-            "call foo r0",
-            "call foo r0.owner",
-            "call foo r0 r1",
-            "call foo r0.owner r0.gates",
-            "call foo into r0",
-            "call foo into r0 r1",
-            "call foo into r0 r1 r2",
-            "call foo r0 into r1",
-            "call foo r0 r1 into r2",
-            "call foo r0 r1 into r2 r3",
-            "call foo r0 r1 r2 into r3 r4",
-            "call foo r0 r1 r2 into r3 r4 r5",
-        ] {
-            assert_eq!(Call::<CurrentNetwork>::from_str(expected).unwrap().to_string(), expected);
+        for expected in TEST_CASES {
+            assert_eq!(Call::<CurrentNetwork>::from_str(expected).unwrap().to_string(), *expected);
+        }
+    }
+
+    #[test]
+    fn test_bytes() {
+        for case in TEST_CASES {
+            let expected = Call::<CurrentNetwork>::from_str(case).unwrap();
+
+            // Check the byte representation.
+            let expected_bytes = expected.to_bytes_le().unwrap();
+            assert_eq!(expected, Call::read_le(&expected_bytes[..]).unwrap());
+            assert!(Call::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/vm/compiler/src/program/instruction/operation/call.rs
+++ b/vm/compiler/src/program/instruction/operation/call.rs
@@ -755,4 +755,25 @@ mod tests {
 
         check_parser("call noop", CallOperator::from_str("noop").unwrap(), vec![], vec![])
     }
+
+    #[test]
+    fn test_display() {
+        for expected in [
+            "call foo",
+            "call foo r0",
+            "call foo r0.owner",
+            "call foo r0 r1",
+            "call foo r0.owner r0.gates",
+            "call foo into r0",
+            "call foo into r0 r1",
+            "call foo into r0 r1 r2",
+            "call foo r0 into r1",
+            "call foo r0 r1 into r2",
+            "call foo r0 r1 into r2 r3",
+            "call foo r0 r1 r2 into r3 r4",
+            "call foo r0 r1 r2 into r3 r4 r5",
+        ] {
+            assert_eq!(Call::<CurrentNetwork>::from_str(expected).unwrap().to_string(), expected);
+        }
+    }
 }


### PR DESCRIPTION
Closures may not necessarily have outputs.
Functions man not necessarily have inputs or outputs.
This PR enables calling closures and functions without inputs and/or outputs.
For example, this is necessary to make an external call to `mint_public` in the token example.

Note:
- Failing clippy is unrelated to PR.
- Other failing CI is due to parameters issue.
