### PR TITLE
profiling in snarkVM fields with an optional feature

### DIFF
--- a/fields/Cargo.toml
+++ b/fields/Cargo.toml
@@ -31,6 +31,7 @@ default-features = false
 [dependencies.aleo-std]
 version = "0.1.14"
 default-features = false
+optional = true
 
 [dependencies.anyhow]
 version = "1.0"


### PR DESCRIPTION
## Motivation

SnarkVM fields has some calls to profiling functions that are being compiled even in release mode.
This PR proposes the use of the feature `profiler` to enable conditional compilation for these calls of profiling macros.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

(Link your related PRs here)
