### PR TITLE
Replace the base58 dep with bs58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,12 +142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base58"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +187,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
@@ -2410,8 +2410,8 @@ dependencies = [
 name = "snarkvm-console-account"
 version = "0.9.0"
 dependencies = [
- "base58",
  "bincode",
+ "bs58",
  "serde_json",
  "snarkvm-console-network",
  "snarkvm-console-types",

--- a/console/account/Cargo.toml
+++ b/console/account/Cargo.toml
@@ -16,8 +16,8 @@ version = "0.9.0"
 default-features = false
 features = [ "address", "field", "group", "scalar" ]
 
-[dependencies.base58]
-version = "0.2"
+[dependencies.bs58]
+version = "0.4"
 
 [dev-dependencies.bincode]
 version = "1.3"

--- a/console/account/src/graph_key/mod.rs
+++ b/console/account/src/graph_key/mod.rs
@@ -25,8 +25,6 @@ use crate::ViewKey;
 use snarkvm_console_network::prelude::*;
 use snarkvm_console_types::Field;
 
-use base58::{FromBase58, ToBase58};
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct GraphKey<N: Network> {
     /// The graph key `sk_tag` := Hash(view_key || ctr).

--- a/console/account/src/graph_key/string.rs
+++ b/console/account/src/graph_key/string.rs
@@ -24,7 +24,7 @@ impl<N: Network> FromStr for GraphKey<N> {
     /// Reads in an account graph key from a base58 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Encode the string into base58.
-        let data = s.from_base58().map_err(|err| anyhow!("{:?}", err))?;
+        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{:?}", err))?;
         if data.len() != 41 {
             bail!("Invalid account graph key length: found {}, expected 41", data.len())
         } else if data[0..9] != GRAPH_KEY_PREFIX {
@@ -43,7 +43,7 @@ impl<N: Network> fmt::Display for GraphKey<N> {
         graph_key[0..9].copy_from_slice(&GRAPH_KEY_PREFIX);
         self.sk_tag.write_le(&mut graph_key[9..41]).map_err(|_| fmt::Error)?;
         // Encode the graph key into base58.
-        write!(f, "{}", graph_key.to_base58())
+        write!(f, "{}", bs58::encode(graph_key).into_string())
     }
 }
 

--- a/console/account/src/private_key/mod.rs
+++ b/console/account/src/private_key/mod.rs
@@ -25,8 +25,6 @@ mod sign;
 use snarkvm_console_network::prelude::*;
 use snarkvm_console_types::{Field, Scalar};
 
-use base58::{FromBase58, ToBase58};
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PrivateKey<N: Network> {
     /// The account seed that derives the full private key.

--- a/console/account/src/private_key/string.rs
+++ b/console/account/src/private_key/string.rs
@@ -24,7 +24,7 @@ impl<N: Network> FromStr for PrivateKey<N> {
     /// Reads in an account private key from a base58 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Encode the string into base58.
-        let data = s.from_base58().map_err(|err| anyhow!("{:?}", err))?;
+        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{:?}", err))?;
         if data.len() != 43 {
             bail!("Invalid account private key length: found {}, expected 43", data.len())
         } else if data[0..11] != PRIVATE_KEY_PREFIX {
@@ -43,7 +43,7 @@ impl<N: Network> fmt::Display for PrivateKey<N> {
         private_key[0..11].copy_from_slice(&PRIVATE_KEY_PREFIX);
         self.seed.write_le(&mut private_key[11..43]).map_err(|_| fmt::Error)?;
         // Encode the private key into base58.
-        write!(f, "{}", private_key.to_base58())
+        write!(f, "{}", bs58::encode(private_key).into_string())
     }
 }
 

--- a/console/account/src/view_key/mod.rs
+++ b/console/account/src/view_key/mod.rs
@@ -28,8 +28,6 @@ use crate::PrivateKey;
 use snarkvm_console_network::prelude::*;
 use snarkvm_console_types::{Address, Scalar};
 
-use base58::{FromBase58, ToBase58};
-
 /// The account view key used to decrypt records and ciphertext.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ViewKey<N: Network>(Scalar<N>);

--- a/console/account/src/view_key/string.rs
+++ b/console/account/src/view_key/string.rs
@@ -24,7 +24,7 @@ impl<N: Network> FromStr for ViewKey<N> {
     /// Reads in an account view key from a base58 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Encode the string into base58.
-        let data = s.from_base58().map_err(|err| anyhow!("{:?}", err))?;
+        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{:?}", err))?;
         if data.len() != 39 {
             bail!("Invalid account view key length: found {}, expected 39", data.len())
         } else if data[0..7] != VIEW_KEY_PREFIX {
@@ -43,7 +43,7 @@ impl<N: Network> fmt::Display for ViewKey<N> {
         view_key[0..7].copy_from_slice(&VIEW_KEY_PREFIX);
         self.0.write_le(&mut view_key[7..39]).map_err(|_| fmt::Error)?;
         // Encode the view key into base58.
-        write!(f, "{}", view_key.to_base58())
+        write!(f, "{}", bs58::encode(view_key).into_string())
     }
 }
 


### PR DESCRIPTION
This PR replaces the `base58` dependency - which appears to be unmaintained - with the `bs58` one, which looks more polished, is just as widely used, and appears to have both more functionalities and greater performance.

Fixes #1121.