### PR TITLE
Update GET statePath endpoint

### DIFF
--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -94,9 +94,9 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
 
         // GET /testnet3/statePath/{commitment}
         let get_state_path = warp::get()
-            .and(warp::path!("testnet3" / "statePath"))
-            .and(warp::body::content_length_limit(128))
-            .and(warp::body::json())
+            .and(warp::path!("testnet3" / "statePath" / ..))
+            .and(warp::path::param::<Field<N>>())
+            .and(warp::path::end())
             .and(with(self.ledger.clone()))
             .and_then(Self::get_state_path);
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes the `GET /testnet3/statePath/{commitment}` endpoint parsing of the commitment. This addresses an uncaught case from AleoHQ/snarkOS#2010 