### PR TITLE
Renamings

### DIFF
--- a/circuit/program/src/data/plaintext/find.rs
+++ b/circuit/program/src/data/plaintext/find.rs
@@ -26,7 +26,7 @@ impl<A: Aleo> Plaintext<A> {
 
         match self {
             // Halts if the value is not an interface.
-            Self::Literal(..) => A::halt("Literal is not an interface"),
+            Self::Literal(..) => A::halt("Literal is not a struct"),
             // Retrieve the value of the member (from the value).
             Self::Interface(members, ..) => {
                 // Initialize the members starting from the top-level.
@@ -41,11 +41,11 @@ impl<A: Aleo> Plaintext<A> {
                     if i != path.len() - 1 {
                         match submembers.get(identifier) {
                             // Halts if the member is not an interface.
-                            Some(Self::Literal(..)) => bail!("'{identifier}' must be an interface"),
+                            Some(Self::Literal(..)) => bail!("'{identifier}' must be a struct"),
                             // Retrieve the member and update `submembers` for the next iteration.
                             Some(Self::Interface(members, ..)) => submembers = members,
                             // Halts if the member does not exist.
-                            None => bail!("Failed to locate member '{identifier}' in interface"),
+                            None => bail!("Failed to locate member '{identifier}' in struct"),
                         }
                     }
                     // Otherwise, return the final member.
@@ -54,7 +54,7 @@ impl<A: Aleo> Plaintext<A> {
                             // Return the plaintext member.
                             Some(plaintext) => output = Some(plaintext.clone()),
                             // Halts if the member does not exist.
-                            None => bail!("Failed to locate member '{identifier}' in interface"),
+                            None => bail!("Failed to locate member '{identifier}' in struct"),
                         }
                     }
                 }
@@ -62,7 +62,7 @@ impl<A: Aleo> Plaintext<A> {
                 // Return the output.
                 match output {
                     Some(output) => Ok(output),
-                    None => A::halt("Failed to locate member in interface from path"),
+                    None => A::halt("Failed to locate member in struct from path"),
                 }
             }
         }

--- a/console/program/src/data/plaintext/bytes.rs
+++ b/console/program/src/data/plaintext/bytes.rs
@@ -63,7 +63,7 @@ impl<N: Network> ToBytes for Plaintext<N> {
 
                 // Write the number of members in the interface.
                 u16::try_from(interface.len())
-                    .or_halt_with::<N>("Plaintext interface length exceeds u16::MAX.")
+                    .or_halt_with::<N>("Plaintext struct length exceeds u16::MAX.")
                     .write_le(&mut writer)?;
 
                 // Write each member.

--- a/console/program/src/data/plaintext/find.rs
+++ b/console/program/src/data/plaintext/find.rs
@@ -24,7 +24,7 @@ impl<N: Network> Plaintext<N> {
 
         match self {
             // Halts if the value is not an interface.
-            Self::Literal(..) => bail!("'{self}' is not an interface"),
+            Self::Literal(..) => bail!("'{self}' is not a struct"),
             // Retrieve the value of the member (from the value).
             Self::Interface(members, ..) => {
                 // Initialize the members starting from the top-level.
@@ -39,7 +39,7 @@ impl<N: Network> Plaintext<N> {
                     if i != path.len() - 1 {
                         match submembers.get(identifier) {
                             // Halts if the member is not an interface.
-                            Some(Self::Literal(..)) => bail!("'{identifier}' must be an interface"),
+                            Some(Self::Literal(..)) => bail!("'{identifier}' must be a struct"),
                             // Retrieve the member and update `submembers` for the next iteration.
                             Some(Self::Interface(members, ..)) => submembers = members,
                             // Halts if the member does not exist.

--- a/console/program/src/data/plaintext/from_bits.rs
+++ b/console/program/src/data/plaintext/from_bits.rs
@@ -62,7 +62,7 @@ impl<N: Network> FromBits for Plaintext<N> {
                 counter += member_size as usize;
 
                 if members.insert(identifier, value).is_some() {
-                    bail!("Duplicate identifier in interface.");
+                    bail!("Duplicate identifier in struct.");
                 }
             }
 
@@ -125,7 +125,7 @@ impl<N: Network> FromBits for Plaintext<N> {
                 counter += member_size as usize;
 
                 if members.insert(identifier, value).is_some() {
-                    bail!("Duplicate identifier in interface.");
+                    bail!("Duplicate identifier in struct.");
                 }
             }
 

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -46,7 +46,7 @@ impl<N: Network> Parser for Plaintext<N> {
             let (string, members) = map_res(separated_list1(tag(","), parse_pair), |members: Vec<_>| {
                 // Ensure the members has no duplicate names.
                 if has_duplicates(members.iter().map(|(name, ..)| name)) {
-                    return Err(error("Duplicate member in interface"));
+                    return Err(error("Duplicate member in struct"));
                 }
                 // Ensure the number of interfaces is within `N::MAX_DATA_ENTRIES`.
                 match members.len() <= N::MAX_DATA_ENTRIES {

--- a/console/program/src/data/plaintext/to_bits.rs
+++ b/console/program/src/data/plaintext/to_bits.rs
@@ -34,7 +34,7 @@ impl<N: Network> ToBits for Plaintext<N> {
                     let mut bits_le = vec![false, true]; // Variant bits.
                     bits_le.extend(
                         u8::try_from(interface.len())
-                            .or_halt_with::<N>("Plaintext interface length exceeds u8::MAX")
+                            .or_halt_with::<N>("Plaintext struct length exceeds u8::MAX")
                             .to_bits_le(),
                     );
                     for (identifier, value) in interface {
@@ -71,7 +71,7 @@ impl<N: Network> ToBits for Plaintext<N> {
                     let mut bits_be = vec![false, true]; // Variant bits.
                     bits_be.extend(
                         u8::try_from(interface.len())
-                            .or_halt_with::<N>("Plaintext interface length exceeds u8::MAX")
+                            .or_halt_with::<N>("Plaintext struct length exceeds u8::MAX")
                             .to_bits_be(),
                     );
                     for (identifier, value) in interface {

--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -73,13 +73,13 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             let (string, (members, mode)) = map_res(separated_list1(tag(","), parse_pair), |members: Vec<_>| {
                 // Ensure the members has no duplicate names.
                 if has_duplicates(members.iter().map(|(name, ..)| name)) {
-                    return Err(error("Duplicate member in interface"));
+                    return Err(error("Duplicate member in struct"));
                 }
                 // Ensure the members all have the same visibility.
                 let mode = members.iter().map(|(_, _, mode)| mode).dedup().collect::<Vec<_>>();
                 let mode = match mode.len() == 1 {
                     true => *mode[0],
-                    false => return Err(error("Members of interface in entry have different visibilities")),
+                    false => return Err(error("Members of struct in entry have different visibilities")),
                 };
                 // Ensure the number of interfaces is within `N::MAX_DATA_ENTRIES`.
                 match members.len() <= N::MAX_DATA_ENTRIES {

--- a/console/program/src/data_types/interface/bytes.rs
+++ b/console/program/src/data_types/interface/bytes.rs
@@ -17,9 +17,9 @@
 use super::*;
 
 impl<N: Network> FromBytes for Interface<N> {
-    /// Reads an interface from a buffer.
+    /// Reads a struct from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        // Read the name of the interface.
+        // Read the name of the struct.
         let name = Identifier::read_le(&mut reader)?;
 
         // Read the number of members.
@@ -40,7 +40,7 @@ impl<N: Network> FromBytes for Interface<N> {
             let plaintext_type = PlaintextType::read_le(&mut reader)?;
             // Insert the member, and ensure the member has no duplicate names.
             if members.insert(identifier, plaintext_type).is_some() {
-                return Err(error(format!("Duplicate identifier in interface '{name}'")));
+                return Err(error(format!("Duplicate identifier in struct '{name}'")));
             };
         }
 
@@ -49,18 +49,18 @@ impl<N: Network> FromBytes for Interface<N> {
 }
 
 impl<N: Network> ToBytes for Interface<N> {
-    /// Writes the interface to a buffer.
+    /// Writes the struct to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Ensure the number of members is within `N::MAX_DATA_ENTRIES`.
         if self.members.len() > N::MAX_DATA_ENTRIES {
-            return Err(error("Failed to serialize interface: too many members"));
+            return Err(error("Failed to serialize struct: too many members"));
         }
 
-        // Write the name of the interface.
+        // Write the name of the struct.
         self.name.write_le(&mut writer)?;
 
         // Write the number of members.
-        u16::try_from(self.members.len()).or_halt_with::<N>("Interface length exceeds u16").write_le(&mut writer)?;
+        u16::try_from(self.members.len()).or_halt_with::<N>("struct length exceeds u16").write_le(&mut writer)?;
         // Write the members as bytes.
         for (identifier, plaintext_type) in &self.members {
             // Write the identifier.
@@ -82,7 +82,7 @@ mod tests {
     #[test]
     fn test_bytes() -> Result<()> {
         let expected =
-            Interface::<CurrentNetwork>::from_str("interface message:\n    first as field;\n    second as field;")?;
+            Interface::<CurrentNetwork>::from_str("struct message:\n    first as field;\n    second as field;")?;
         let candidate = Interface::from_bytes_le(&expected.to_bytes_le().unwrap()).unwrap();
         assert_eq!(expected, candidate);
         Ok(())

--- a/console/program/src/data_types/interface/mod.rs
+++ b/console/program/src/data_types/interface/mod.rs
@@ -25,20 +25,20 @@ use indexmap::IndexMap;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Interface<N: Network> {
-    /// The name of the interface.
+    /// The name of the struct.
     name: Identifier<N>,
-    /// The name and type for the members of the interface.
+    /// The name and type for the members of the struct.
     members: IndexMap<Identifier<N>, PlaintextType<N>>,
 }
 
 impl<N: Network> Interface<N> {
-    /// Returns the name of the interface.
+    /// Returns the name of the struct.
     #[inline]
     pub const fn name(&self) -> &Identifier<N> {
         &self.name
     }
 
-    /// Returns the members of the interface.
+    /// Returns the members of the struct.
     #[inline]
     pub const fn members(&self) -> &IndexMap<Identifier<N>, PlaintextType<N>> {
         &self.members
@@ -48,6 +48,6 @@ impl<N: Network> Interface<N> {
 impl<N: Network> TypeName for Interface<N> {
     /// Returns the type name.
     fn type_name() -> &'static str {
-        "interface"
+        "struct"
     }
 }

--- a/console/program/src/data_types/interface/parse.rs
+++ b/console/program/src/data_types/interface/parse.rs
@@ -187,8 +187,7 @@ struct message:
     #[test]
     fn test_display_fails() {
         // Duplicate identifier.
-        let candidate =
-            Interface::<CurrentNetwork>::parse("struct message:\n    first as field;\n    first as field;");
+        let candidate = Interface::<CurrentNetwork>::parse("struct message:\n    first as field;\n    first as field;");
         assert!(candidate.is_err());
         // Visibility in plaintext type.
         let candidate = Interface::<CurrentNetwork>::parse(

--- a/console/program/src/data_types/interface/serialize.rs
+++ b/console/program/src/data_types/interface/serialize.rs
@@ -17,7 +17,7 @@
 use super::*;
 
 impl<N: Network> Serialize for Interface<N> {
-    /// Serializes the interface into string or bytes.
+    /// Serializes the struct into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => serializer.collect_str(self),
@@ -27,11 +27,11 @@ impl<N: Network> Serialize for Interface<N> {
 }
 
 impl<'de, N: Network> Deserialize<'de> for Interface<N> {
-    /// Deserializes the interface from a string or bytes.
+    /// Deserializes the struct from a string or bytes.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "interface"),
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "struct"),
         }
     }
 }
@@ -44,7 +44,7 @@ mod tests {
     type CurrentNetwork = Testnet3;
 
     /// Add test cases here to be checked for serialization.
-    const TEST_CASES: &[&str] = &["interface message: owner as address; is_new as boolean; total_supply as u64;"];
+    const TEST_CASES: &[&str] = &["struct message: owner as address; is_new as boolean; total_supply as u64;"];
 
     fn check_serde_json<
         T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -31,7 +31,7 @@ impl<N: Network> Request<N> {
         // Ensure the number of inputs matches the number of input types.
         if input_types.len() != inputs.len() {
             bail!(
-                "Function '{}' in the program '{}' expects {} inputs, but {} were provided.",
+                "Transition '{}' in the program '{}' expects {} inputs, but {} were provided.",
                 function_name,
                 program_id,
                 input_types.len(),

--- a/console/program/src/request/verify.rs
+++ b/console/program/src/request/verify.rs
@@ -75,7 +75,7 @@ impl<N: Network> Request<N> {
         ) {
             Ok(function_id) => function_id,
             Err(error) => {
-                eprintln!("Failed to construct the function ID: {error}");
+                eprintln!("Failed to construct the Transition ID: {error}");
                 return false;
             }
         };

--- a/synthesizer/src/block/transaction/merkle.rs
+++ b/synthesizer/src/block/transaction/merkle.rs
@@ -61,7 +61,7 @@ impl<N: Network> Transaction<N> {
                     }
                 }
                 // Error if the function ID was not found.
-                bail!("Function ID not found in deployment transaction");
+                bail!("Transition ID not found in deployment transaction");
             }
             Self::Execute(_, execution, additional_fee) => {
                 // Check if the ID is the transition ID for the additional fee, if it is present.
@@ -213,14 +213,14 @@ impl<N: Network> Transaction<N> {
         // Ensure the number of functions and verifying keys match.
         ensure!(
             functions.len() == verifying_keys.len(),
-            "Number of functions ('{}') and verifying keys ('{}') do not match",
+            "Number of transitions ('{}') and verifying keys ('{}') do not match",
             functions.len(),
             verifying_keys.len()
         );
         // Ensure the number of functions is within the allowed range.
         ensure!(
             functions.len() < Self::MAX_TRANSITIONS, // Note: Observe we hold back 1 for the additional fee.
-            "Deployment must contain less than {} functions, found {}",
+            "Deployment must contain less than {} transitions, found {}",
             Self::MAX_TRANSITIONS,
             functions.len()
         );

--- a/synthesizer/src/process/additional_fee.rs
+++ b/synthesizer/src/process/additional_fee.rs
@@ -123,7 +123,7 @@ impl<N: Network> Process<N> {
         let function = stack.get_function(additional_fee.function_name())?;
         // Ensure the number of function calls in this function is 1.
         if stack.get_number_of_calls(function.name())? != 1 {
-            bail!("The number of function calls in '{}/{}' should be 1", stack.program_id(), function.name())
+            bail!("The number of transition calls in '{}/{}' should be 1", stack.program_id(), function.name())
         }
 
         #[cfg(debug_assertions)]

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -688,7 +688,7 @@ function hello_world:
         let program = Program::<CurrentNetwork>::from_str(
             r"program id.aleo;
 
-  interface data:
+  struct data:
     owner as address;
 
   function initialize:

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -755,7 +755,7 @@ record token:
     token_amount as u64.private;
 
 // (a + (a + b)) + (a + b) == (3a + 2b)
-closure execute:
+function execute:
     input r0 as field;
     input r1 as field;
     add r0 r1 into r2;
@@ -765,7 +765,7 @@ closure execute:
     output r3 as field;
     output r2 as field;
 
-closure check_not_equal:
+function check_not_equal:
     input r0 as field;
     input r1 as field;
     assert.neq r0 r1;

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -261,7 +261,7 @@ pub(crate) mod test_helpers {
                     r"
 program testing.aleo;
 
-function compute:
+transition compute:
     input r0 as u32.private;
     input r1 as u32.public;
     add r0 r1 into r2;
@@ -300,7 +300,7 @@ function compute:
                     r"
 program testing.aleo;
 
-function compute:
+transition compute:
     input r0 as u32.private;
     input r1 as u32.public;
     add r0 r1 into r2;
@@ -457,7 +457,7 @@ mod tests {
     owner as address.private;
     gates as u64.private;
 
-  function genesis:
+  transition genesis:
     input r0 as address.private;
     input r1 as u64.private;
     cast r0 r1 into r2 as token.record;
@@ -489,7 +489,7 @@ mod tests {
         let program = Program::<CurrentNetwork>::from_str(
             r#"program testing.aleo;
 
-function hello_world:
+transition hello_world:
     input r0 as u32.public;
     input r1 as u32.private;
     add r0 r1 into r2;
@@ -521,7 +521,7 @@ function hello_world:
     owner as address.private;
     gates as u64.private;
 
-  function initialize:
+  transition initialize:
     input r0 as record_a.record;
     input r1 as record_b.record;
     cast r0.owner r0.gates into r2 as record_a.record;
@@ -619,7 +619,7 @@ function hello_world:
     owner as address.private;
     gates as u64.private;
 
-  function initialize:
+  transition initialize:
     input r0 as data.record;
     cast self.caller r0.gates into r1 as data.record;
     output r1 as data.record;",
@@ -691,7 +691,7 @@ function hello_world:
   struct data:
     owner as address;
 
-  function initialize:
+  transition initialize:
     cast id.aleo into r0 as data;
     output r0 as data.private;",
         )
@@ -770,7 +770,7 @@ closure check_not_equal:
     input r1 as field;
     assert.neq r0 r1;
 
-function compute:
+transition compute:
     input r0 as field.private;
     input r1 as field.public;
     input r2 as token.record;
@@ -881,23 +881,23 @@ record token:
     gates as u64.private;
     amount as u64.private;
 
-function mint:
+transition mint:
     input r0 as address.private;
     input r1 as u64.private;
     cast r0 0u64 r1 into r2 as token.record;
     output r2 as token.record;
 
-function produce_magic_number:
+transition produce_magic_number:
     add 1234u64 0u64 into r0;
     output r0 as u64.private;
 
-function check_magic_number:
+transition check_magic_number:
     input r0 as u64.private;
     assert.eq r0 1234u64;
 
-function noop:
+transition noop:
 
-function transfer:
+transition transfer:
     input r0 as token.record;
     input r1 as address.private;
     input r2 as u64.private;
@@ -919,7 +919,7 @@ import token.aleo;
 
 program wallet.aleo;
 
-function transfer:
+transition transfer:
     input r0 as token.aleo/token.record;
     input r1 as address.private;
     input r2 as u64.private;
@@ -1038,7 +1038,7 @@ mapping account:
     key owner as address.public;
     value amount as u64.public;
 
-function compute:
+transition compute:
     input r0 as address.public;
     input r1 as u64.public;
     input r2 as u64.public;
@@ -1134,7 +1134,7 @@ mapping account:
     key owner as address.public;
     value amount as u64.public;
 
-function compute:
+transition compute:
     input r0 as address.public;
     input r1 as u64.public;
     input r2 as u64.public;
@@ -1235,9 +1235,9 @@ mapping account:
     // The token amount.
     value amount as u64.public;
 
-// The function `mint_public` issues the specified token amount
+// The transition `mint_public` issues the specified token amount
 // for the token receiver publicly on the network.
-function mint_public:
+transition mint_public:
     // Input the token receiver.
     input r0 as address.public;
     // Input the token amount.
@@ -1350,9 +1350,9 @@ mapping account:
     // The token amount.
     value amount as u64.public;
 
-// The function `mint_public` issues the specified token amount
+// The transition `mint_public` issues the specified token amount
 // for the token receiver publicly on the network.
-function mint_public:
+transition mint_public:
     // Input the token receiver.
     input r0 as address.public;
     // Input the token amount.
@@ -1415,7 +1415,7 @@ import token.aleo;
 
 program public_wallet.aleo;
 
-function mint:
+transition mint:
     input r0 as address.public;
     input r1 as u64.public;
     call token.aleo/mint_public r0 r1;",

--- a/synthesizer/src/process/stack/authorize.rs
+++ b/synthesizer/src/process/stack/authorize.rs
@@ -27,7 +27,7 @@ impl<N: Network> Stack<N> {
         rng: &mut R,
     ) -> Result<Authorization<N>> {
         // Ensure the program contains functions.
-        ensure!(!self.program.functions().is_empty(), "Program '{}' has no functions", self.program.id());
+        ensure!(!self.program.functions().is_empty(), "Program '{}' has no transitions", self.program.id());
 
         // Retrieve the function.
         let function = self.get_function(&function_name)?;
@@ -36,7 +36,7 @@ impl<N: Network> Stack<N> {
         // Ensure the number of inputs matches the number of input types.
         if function.inputs().len() != input_types.len() {
             bail!(
-                "Function '{function_name}' in program '{}' expects {} inputs, but {} types were found.",
+                "Transition '{function_name}' in program '{}' expects {} inputs, but {} types were found.",
                 self.program.id(),
                 function.inputs().len(),
                 input_types.len()

--- a/synthesizer/src/process/stack/deploy.rs
+++ b/synthesizer/src/process/stack/deploy.rs
@@ -21,7 +21,7 @@ impl<N: Network> Stack<N> {
     #[inline]
     pub fn deploy<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(&self, rng: &mut R) -> Result<Deployment<N>> {
         // Ensure the program contains functions.
-        ensure!(!self.program.functions().is_empty(), "Program '{}' has no functions", self.program.id());
+        ensure!(!self.program.functions().is_empty(), "Program '{}' has no transitions", self.program.id());
 
         // Initialize a mapping for the bundle.
         let mut bundle = IndexMap::with_capacity(self.program.functions().len());
@@ -71,7 +71,7 @@ impl<N: Network> Stack<N> {
         // Ensure the program network-level domain (NLD) is correct.
         ensure!(program_id.is_aleo(), "Program '{program_id}' has an incorrect network-level domain (NLD)");
         // Ensure the program contains functions.
-        ensure!(!program.functions().is_empty(), "No functions present in the deployment for program '{program_id}'");
+        ensure!(!program.functions().is_empty(), "No transitions present in the deployment for program '{program_id}'");
         // Ensure the deployment contains verifying keys.
         ensure!(!verifying_keys.is_empty(), "No verifying keys present in the deployment for program '{program_id}'");
 
@@ -79,18 +79,18 @@ impl<N: Network> Stack<N> {
 
         // Ensure the number of verifying keys matches the number of program functions.
         if verifying_keys.len() != program.functions().len() {
-            bail!("The number of verifying keys does not match the number of program functions");
+            bail!("The number of verifying keys does not match the number of program transitions");
         }
 
         // Ensure the program functions are in the same order as the verifying keys.
         for ((function_name, function), candidate_name) in program.functions().iter().zip_eq(verifying_keys.keys()) {
             // Ensure the function name is correct.
             if function_name != function.name() {
-                bail!("The function key is '{function_name}', but the function name is '{}'", function.name())
+                bail!("The transition key is '{function_name}', but the transition name is '{}'", function.name())
             }
             // Ensure the function name with the verifying key is correct.
             if candidate_name != function.name() {
-                bail!("The verifier key is '{candidate_name}', but the function name is '{}'", function.name())
+                bail!("The verifier key is '{candidate_name}', but the transition name is '{}'", function.name())
             }
         }
 
@@ -127,11 +127,11 @@ impl<N: Network> Stack<N> {
             let _response = self.execute_function::<A, R>(call_stack, rng)?;
             // Check the certificate.
             match assignments.read().last() {
-                None => bail!("The assignment for function '{}' is missing in '{program_id}'", function.name()),
+                None => bail!("The assignment for transition '{}' is missing in '{program_id}'", function.name()),
                 Some(assignment) => {
                     // Ensure the certificate is valid.
                     if !certificate.verify(function.name(), assignment, verifying_key) {
-                        bail!("The certificate for function '{}' is invalid in '{program_id}'", function.name())
+                        bail!("The certificate for transition '{}' is invalid in '{program_id}'", function.name())
                     }
                 }
             };

--- a/synthesizer/src/process/stack/deployment/mod.rs
+++ b/synthesizer/src/process/stack/deployment/mod.rs
@@ -87,7 +87,7 @@ pub(crate) mod test_helpers {
                     r"
 program testing.aleo;
 
-function compute:
+transition compute:
     input r0 as u32.private;
     input r1 as u32.public;
     add r0 r1 into r2;

--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -95,7 +95,7 @@ impl<N: Network> Stack<N> {
         // Ensure the number of inputs matches.
         if function.inputs().len() != inputs.len() {
             bail!(
-                "Function '{}' in the program '{}' expects {} inputs, but {} were provided.",
+                "Transition '{}' in the program '{}' expects {} inputs, but {} were provided.",
                 function.name(),
                 self.program.id(),
                 function.inputs().len(),

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -208,12 +208,12 @@ impl<N: Network> Stack<N> {
             .collect::<Result<Vec<_>>>()?;
 
         #[cfg(debug_assertions)]
-        Self::log_circuit::<A, _>(format!("Function '{}()'", function.name()));
+        Self::log_circuit::<A, _>(format!("Transition '{}()'", function.name()));
 
         // If the function does not contain function calls, ensure no new public variables were injected.
         if !contains_function_call {
             // Ensure the number of public variables remains the same.
-            ensure!(A::num_public() == num_public, "Instructions in function injected public variables");
+            ensure!(A::num_public() == num_public, "Instructions in transition injected public variables");
         }
 
         // Construct the response.

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -262,7 +262,7 @@ impl<N: Network> Stack<N> {
                         circuit::Value::Plaintext(circuit::Plaintext::Literal(..)) => (),
                         circuit::Value::Plaintext(circuit::Plaintext::Interface(..)) => {
                             bail!(
-                                "'{}/{}' attempts to pass an 'interface' into 'finalize'",
+                                "'{}/{}' attempts to pass a 'struct' into 'finalize'",
                                 self.program_id(),
                                 function.name()
                             );

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -74,7 +74,7 @@ impl<N: Network> Stack<N> {
         }
 
         // Ensure the number of public variables remains the same.
-        ensure!(A::num_public() == num_public, "Illegal closure operation: instructions injected public variables");
+        ensure!(A::num_public() == num_public, "Illegal function operation: instructions injected public variables");
 
         // Load the outputs.
         let outputs = closure.outputs().iter().map(|output| {

--- a/synthesizer/src/process/stack/finalize_registers/load.rs
+++ b/synthesizer/src/process/stack/finalize_registers/load.rs
@@ -95,7 +95,7 @@ impl<N: Network> FinalizeRegisters<N> {
             // Ensure the stack value matches the register type.
             Ok(register_type) => stack.matches_register_type(&stack_value, &register_type)?,
             // Ensure the register is defined.
-            Err(error) => bail!("Register '{register}' is not a member of the function: {error}"),
+            Err(error) => bail!("Register '{register}' is not a member of the transition: {error}"),
         };
 
         Ok(stack_value)

--- a/synthesizer/src/process/stack/finalize_types/initialize.rs
+++ b/synthesizer/src/process/stack/finalize_types/initialize.rs
@@ -106,7 +106,7 @@ impl<N: Network> FinalizeTypes<N> {
             RegisterType::Plaintext(PlaintextType::Interface(interface_name)) => {
                 // Ensure the interface is defined in the program.
                 if !stack.program().contains_interface(interface_name) {
-                    bail!("Interface '{interface_name}' in '{}' is not defined.", stack.program_id())
+                    bail!("Struct '{interface_name}' in '{}' is not defined.", stack.program_id())
                 }
             }
             RegisterType::Record(identifier) => {
@@ -236,7 +236,7 @@ impl<N: Network> FinalizeTypes<N> {
                 }
             }
             RegisterType::Plaintext(PlaintextType::Interface(..)) => {
-                bail!("Decrement cannot decrement by an 'interface' (found at '{decrement}')")
+                bail!("Decrement cannot decrement by a 'struct' (found at '{decrement}')")
             }
             RegisterType::Record(..) => bail!("Decrement cannot decrement by a 'record' (found at '{decrement}')"),
             RegisterType::ExternalRecord(..) => {
@@ -292,7 +292,7 @@ impl<N: Network> FinalizeTypes<N> {
                 }
             }
             RegisterType::Plaintext(PlaintextType::Interface(..)) => {
-                bail!("Increment cannot increment by an 'interface' (found at '{increment}')")
+                bail!("Increment cannot increment by a 'struct' (found at '{increment}')")
             }
             RegisterType::Record(..) => bail!("Increment cannot increment by a 'record' (found at '{increment}')"),
             RegisterType::ExternalRecord(..) => {
@@ -400,7 +400,7 @@ impl<N: Network> FinalizeTypes<N> {
                     RegisterType::Plaintext(PlaintextType::Interface(interface_name)) => {
                         // Ensure the interface name exists in the program.
                         if !stack.program().contains_interface(interface_name) {
-                            bail!("Interface '{interface_name}' is not defined.")
+                            bail!("Struct '{interface_name}' is not defined.")
                         }
                         // Retrieve the interface.
                         let interface = stack.program().get_interface(interface_name)?;

--- a/synthesizer/src/process/stack/finalize_types/matches.rs
+++ b/synthesizer/src/process/stack/finalize_types/matches.rs
@@ -17,17 +17,17 @@
 use super::*;
 
 impl<N: Network> FinalizeTypes<N> {
-    /// Checks that the given operands matches the layout of the interface. The ordering of the operands matters.
+    /// Checks that the given operands match the layout of the interface. The ordering of the operands matters.
     pub fn matches_interface(&self, stack: &Stack<N>, operands: &[Operand<N>], interface: &Interface<N>) -> Result<()> {
         // Ensure the operands is not empty.
         if operands.is_empty() {
-            bail!("Casting to an interface requires at least one operand")
+            bail!("Casting to a struct requires at least one operand")
         }
 
         // Retrieve the interface name.
         let interface_name = interface.name();
         // Ensure the interface name is valid.
-        ensure!(!Program::is_reserved_keyword(interface_name), "Interface name '{interface_name}' is reserved");
+        ensure!(!Program::is_reserved_keyword(interface_name), "Struct name '{interface_name}' is reserved");
 
         // Ensure the number of interface members does not exceed the maximum.
         let num_members = operands.len();
@@ -46,7 +46,7 @@ impl<N: Network> FinalizeTypes<N> {
                 Operand::Literal(literal) => {
                     ensure!(
                         PlaintextType::Literal(literal.to_type()) == *member_type,
-                        "Interface member '{interface_name}.{member_name}' expects a {member_type}, but found '{operand}' in the operand.",
+                        "Struct member '{interface_name}.{member_name}' expects a {member_type}, but found '{operand}' in the operand.",
                     )
                 }
                 // Ensure the register type matches the member type.
@@ -56,12 +56,12 @@ impl<N: Network> FinalizeTypes<N> {
                     // Ensure the register type is not a record.
                     ensure!(
                         !matches!(register_type, RegisterType::Record(..)),
-                        "Casting a record into an interface is illegal"
+                        "Casting a record into a struct is illegal"
                     );
                     // Ensure the register type matches the member type.
                     ensure!(
                         register_type == RegisterType::Plaintext(*member_type),
-                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{register_type}' in the operand '{operand}'.",
+                        "Struct member '{interface_name}.{member_name}' expects {member_type}, but found '{register_type}' in the operand '{operand}'.",
                     )
                 }
                 // Ensure the program ID type (address) matches the member type.
@@ -71,7 +71,7 @@ impl<N: Network> FinalizeTypes<N> {
                     // Ensure the program ID type matches the member type.
                     ensure!(
                         program_ref_type == RegisterType::Plaintext(*member_type),
-                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{program_ref_type}' in the operand '{operand}'.",
+                        "Struct member '{interface_name}.{member_name}' expects {member_type}, but found '{program_ref_type}' in the operand '{operand}'.",
                     )
                 }
                 // Ensure the caller type (address) matches the member type.
@@ -81,7 +81,7 @@ impl<N: Network> FinalizeTypes<N> {
                     // Ensure the caller type matches the member type.
                     ensure!(
                         caller_type == RegisterType::Plaintext(*member_type),
-                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{caller_type}' in the operand '{operand}'.",
+                        "Struct member '{interface_name}.{member_name}' expects {member_type}, but found '{caller_type}' in the operand '{operand}'.",
                     )
                 }
             }

--- a/synthesizer/src/process/stack/finalize_types/mod.rs
+++ b/synthesizer/src/process/stack/finalize_types/mod.rs
@@ -111,7 +111,7 @@ impl<N: Network> FinalizeTypes<N> {
                     match stack.program().get_interface(interface_name)?.members().get(path_name) {
                         // Update the member type.
                         Some(plaintext_type) => RegisterType::Plaintext(*plaintext_type),
-                        None => bail!("'{path_name}' does not exist in interface '{interface_name}'"),
+                        None => bail!("'{path_name}' does not exist in struct '{interface_name}'"),
                     }
                 }
                 RegisterType::Record(record_name) => {

--- a/synthesizer/src/process/stack/helpers/initialize.rs
+++ b/synthesizer/src/process/stack/helpers/initialize.rs
@@ -81,7 +81,7 @@ impl<N: Network> Stack<N> {
         // Retrieve the closure name.
         let name = closure.name();
         // Ensure the closure name is not already added.
-        ensure!(!self.register_types.contains_key(name), "Closure '{name}' already exists");
+        ensure!(!self.register_types.contains_key(name), "Function '{name}' already exists");
 
         // Compute the register types.
         let register_types = RegisterTypes::from_closure(self, closure)?;

--- a/synthesizer/src/process/stack/helpers/initialize.rs
+++ b/synthesizer/src/process/stack/helpers/initialize.rs
@@ -97,7 +97,7 @@ impl<N: Network> Stack<N> {
         // Retrieve the function name.
         let name = function.name();
         // Ensure the function name is not already added.
-        ensure!(!self.register_types.contains_key(name), "Function '{name}' already exists");
+        ensure!(!self.register_types.contains_key(name), "Transition '{name}' already exists");
 
         // Compute the register types.
         let register_types = RegisterTypes::from_function(self, function)?;

--- a/synthesizer/src/process/stack/helpers/matches.rs
+++ b/synthesizer/src/process/stack/helpers/matches.rs
@@ -210,26 +210,26 @@ impl<N: Network> Stack<N> {
                     }
                 }
                 // If `plaintext` is an interface, this is a mismatch.
-                Plaintext::Interface(..) => bail!("'{plaintext_type}' is invalid: expected literal, found interface"),
+                Plaintext::Interface(..) => bail!("'{plaintext_type}' is invalid: expected literal, found struct"),
             },
             PlaintextType::Interface(interface_name) => {
                 // Ensure the interface name is valid.
-                ensure!(!Program::is_reserved_keyword(interface_name), "Interface '{interface_name}' is reserved");
+                ensure!(!Program::is_reserved_keyword(interface_name), "Struct '{interface_name}' is reserved");
 
                 // Retrieve the interface from the program.
                 let interface = match self.program().get_interface(interface_name) {
                     Ok(interface) => interface,
-                    Err(..) => bail!("Interface '{interface_name}' is not defined in the program"),
+                    Err(..) => bail!("Struct '{interface_name}' is not defined in the program"),
                 };
 
                 // Ensure the interface name matches.
                 if interface.name() != interface_name {
-                    bail!("Expected interface '{interface_name}', found interface '{}'", interface.name())
+                    bail!("Expected struct '{interface_name}', found struct '{}'", interface.name())
                 }
 
                 // Retrieve the interface members.
                 let members = match plaintext {
-                    Plaintext::Literal(..) => bail!("'{interface_name}' is invalid: expected interface, found literal"),
+                    Plaintext::Literal(..) => bail!("'{interface_name}' is invalid: expected struct, found literal"),
                     Plaintext::Interface(members, ..) => members,
                 };
 

--- a/synthesizer/src/process/stack/helpers/synthesize.rs
+++ b/synthesizer/src/process/stack/helpers/synthesize.rs
@@ -62,9 +62,9 @@ impl<N: Network> Stack<N> {
         let _response = self.execute_function::<A, R>(call_stack, rng)?;
 
         // Ensure the proving key exists.
-        ensure!(self.contains_proving_key(function_name), "Function '{function_name}' is missing a proving key.");
+        ensure!(self.contains_proving_key(function_name), "Transition '{function_name}' is missing a proving key.");
         // Ensure the verifying key exists.
-        ensure!(self.contains_verifying_key(function_name), "Function '{function_name}' is missing a verifying key.");
+        ensure!(self.contains_verifying_key(function_name), "Transition '{function_name}' is missing a verifying key.");
         Ok(())
     }
 

--- a/synthesizer/src/process/stack/mod.rs
+++ b/synthesizer/src/process/stack/mod.rs
@@ -197,7 +197,7 @@ impl<N: Network> Stack<N> {
         // Ensure the program network-level domain (NLD) is correct.
         ensure!(program_id.is_aleo(), "Program '{program_id}' has an incorrect network-level domain (NLD)");
         // Ensure the program contains functions.
-        ensure!(!program.functions().is_empty(), "No functions present in the deployment for program '{program_id}'");
+        ensure!(!program.functions().is_empty(), "No transitions present in the deployment for program '{program_id}'");
 
         // Serialize the program into bytes.
         let program_bytes = program.to_bytes_le()?;
@@ -269,7 +269,7 @@ impl<N: Network> Stack<N> {
         // Ensure the function exists.
         match self.program.contains_function(function_name) {
             true => self.program.get_function(function_name),
-            false => bail!("Function '{function_name}' does not exist in program '{}'.", self.program.id()),
+            false => bail!("Transition '{function_name}' does not exist in program '{}'.", self.program.id()),
         }
     }
 
@@ -347,7 +347,7 @@ impl<N: Network> Stack<N> {
         // Ensure the function name exists in the program.
         ensure!(
             self.program.contains_function(function_name),
-            "Function '{function_name}' does not exist in program '{}'.",
+            "Transition '{function_name}' does not exist in program '{}'.",
             self.program.id()
         );
         // Insert the proving key.
@@ -361,7 +361,7 @@ impl<N: Network> Stack<N> {
         // Ensure the function name exists in the program.
         ensure!(
             self.program.contains_function(function_name),
-            "Function '{function_name}' does not exist in program '{}'.",
+            "Transition '{function_name}' does not exist in program '{}'.",
             self.program.id()
         );
         // Insert the verifying key.

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -97,7 +97,7 @@ impl<N: Network> RegisterTypes<N> {
                     RegisterType::Plaintext(PlaintextType::Literal(..)) => (),
                     RegisterType::Plaintext(PlaintextType::Interface(..)) => {
                         bail!(
-                            "'{}/{}' attempts to pass an 'interface' into 'finalize'",
+                            "'{}/{}' attempts to pass a 'struct' into 'finalize'",
                             stack.program_id(),
                             function.name()
                         );
@@ -184,7 +184,7 @@ impl<N: Network> RegisterTypes<N> {
             RegisterType::Plaintext(PlaintextType::Interface(interface_name)) => {
                 // Ensure the interface is defined in the program.
                 if !stack.program().contains_interface(interface_name) {
-                    bail!("Interface '{interface_name}' in '{}' is not defined.", stack.program_id())
+                    bail!("Struct '{interface_name}' in '{}' is not defined.", stack.program_id())
                 }
             }
             RegisterType::Record(identifier) => {
@@ -230,7 +230,7 @@ impl<N: Network> RegisterTypes<N> {
             RegisterType::Plaintext(PlaintextType::Interface(interface_name)) => {
                 // Ensure the interface is defined in the program.
                 if !stack.program().contains_interface(interface_name) {
-                    bail!("Interface '{interface_name}' in '{}' is not defined.", stack.program_id())
+                    bail!("Struct '{interface_name}' in '{}' is not defined.", stack.program_id())
                 }
             }
             RegisterType::Record(identifier) => {
@@ -405,7 +405,7 @@ impl<N: Network> RegisterTypes<N> {
                     RegisterType::Plaintext(PlaintextType::Interface(interface_name)) => {
                         // Ensure the interface name exists in the program.
                         if !stack.program().contains_interface(interface_name) {
-                            bail!("Interface '{interface_name}' is not defined.")
+                            bail!("Struct '{interface_name}' is not defined.")
                         }
                         // Retrieve the interface.
                         let interface = stack.program().get_interface(interface_name)?;

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -33,7 +33,7 @@ impl<N: Network> RegisterTypes<N> {
         // Step 2. Check the instructions are well-formed.
         for instruction in closure.instructions() {
             // Ensure the closure contains no call instructions.
-            ensure!(instruction.opcode() != Opcode::Call, "A 'call' instruction is not allowed in closures");
+            ensure!(instruction.opcode() != Opcode::Call, "A 'call' instruction is not allowed in functions");
             // Check the instruction opcode, operands, and destinations.
             register_types.check_instruction(stack, closure.name(), instruction)?;
         }
@@ -373,7 +373,7 @@ impl<N: Network> RegisterTypes<N> {
                         //  We could invoke the internal function without a state transition, but need to match visibility.
                         if stack.program().contains_function(resource) {
                             bail!(
-                                "Cannot call '{resource}' from '{closure_or_function_name}'. Use a closure ('closure {resource}:') instead."
+                                "Cannot call '{resource}' from '{closure_or_function_name}'. Use a function ('function {resource}:') instead."
                             )
                         }
                         // Ensure the function or closure exists in the program.

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -82,7 +82,7 @@ impl<N: Network> RegisterTypes<N> {
             // Ensure the number of finalize operands is within bounds.
             ensure!(
                 command.operands().len() <= N::MAX_INPUTS,
-                "Function '{}' has too many finalize operands",
+                "Transition '{}' has too many finalize operands",
                 function.name()
             );
 

--- a/synthesizer/src/process/stack/register_types/matches.rs
+++ b/synthesizer/src/process/stack/register_types/matches.rs
@@ -21,13 +21,13 @@ impl<N: Network> RegisterTypes<N> {
     pub fn matches_interface(&self, stack: &Stack<N>, operands: &[Operand<N>], interface: &Interface<N>) -> Result<()> {
         // Ensure the operands is not empty.
         if operands.is_empty() {
-            bail!("Casting to an interface requires at least one operand")
+            bail!("Casting to a struct requires at least one operand")
         }
 
         // Retrieve the interface name.
         let interface_name = interface.name();
         // Ensure the interface name is valid.
-        ensure!(!Program::is_reserved_keyword(interface_name), "Interface name '{interface_name}' is reserved");
+        ensure!(!Program::is_reserved_keyword(interface_name), "Struct name '{interface_name}' is reserved");
 
         // Ensure the number of interface members does not exceed the maximum.
         let num_members = operands.len();
@@ -46,7 +46,7 @@ impl<N: Network> RegisterTypes<N> {
                 Operand::Literal(literal) => {
                     ensure!(
                         PlaintextType::Literal(literal.to_type()) == *member_type,
-                        "Interface member '{interface_name}.{member_name}' expects a {member_type}, but found '{operand}' in the operand.",
+                        "Struct member '{interface_name}.{member_name}' expects a {member_type}, but found '{operand}' in the operand.",
                     )
                 }
                 // Ensure the register type matches the member type.
@@ -56,12 +56,12 @@ impl<N: Network> RegisterTypes<N> {
                     // Ensure the register type is not a record.
                     ensure!(
                         !matches!(register_type, RegisterType::Record(..)),
-                        "Casting a record into an interface is illegal"
+                        "Casting a record into a struct is illegal"
                     );
                     // Ensure the register type matches the member type.
                     ensure!(
                         register_type == RegisterType::Plaintext(*member_type),
-                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{register_type}' in the operand '{operand}'.",
+                        "Struct member '{interface_name}.{member_name}' expects {member_type}, but found '{register_type}' in the operand '{operand}'.",
                     )
                 }
                 // Ensure the program ID type (address) matches the member type.
@@ -71,7 +71,7 @@ impl<N: Network> RegisterTypes<N> {
                     // Ensure the program ID type matches the member type.
                     ensure!(
                         program_ref_type == RegisterType::Plaintext(*member_type),
-                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{program_ref_type}' in the operand '{operand}'.",
+                        "Struct member '{interface_name}.{member_name}' expects {member_type}, but found '{program_ref_type}' in the operand '{operand}'.",
                     )
                 }
                 // Ensure the caller type (address) matches the member type.
@@ -81,7 +81,7 @@ impl<N: Network> RegisterTypes<N> {
                     // Ensure the caller type matches the member type.
                     ensure!(
                         caller_type == RegisterType::Plaintext(*member_type),
-                        "Interface member '{interface_name}.{member_name}' expects {member_type}, but found '{caller_type}' in the operand '{operand}'.",
+                        "Struct member '{interface_name}.{member_name}' expects {member_type}, but found '{caller_type}' in the operand '{operand}'.",
                     )
                 }
             }

--- a/synthesizer/src/process/stack/register_types/mod.rs
+++ b/synthesizer/src/process/stack/register_types/mod.rs
@@ -121,7 +121,7 @@ impl<N: Network> RegisterTypes<N> {
                     match stack.program().get_interface(interface_name)?.members().get(path_name) {
                         // Update the member type.
                         Some(plaintext_type) => RegisterType::Plaintext(*plaintext_type),
-                        None => bail!("'{path_name}' does not exist in interface '{interface_name}'"),
+                        None => bail!("'{path_name}' does not exist in struct '{interface_name}'"),
                     }
                 }
                 RegisterType::Record(record_name) => {

--- a/synthesizer/src/process/stack/registers/load.rs
+++ b/synthesizer/src/process/stack/registers/load.rs
@@ -81,7 +81,7 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
             // Ensure the stack value matches the register type.
             Ok(register_type) => stack.matches_register_type(&stack_value, &register_type)?,
             // Ensure the register is defined.
-            Err(error) => bail!("Register '{register}' is not a member of the function: {error}"),
+            Err(error) => bail!("Register '{register}' is not a member of the transition: {error}"),
         };
 
         Ok(stack_value)
@@ -170,7 +170,7 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
                 stack.matches_register_type(&circuit::Eject::eject_value(&circuit_value), &register_type)?
             }
             // Ensure the register is defined.
-            Err(error) => bail!("Register '{register}' is not a member of the function: {error}"),
+            Err(error) => bail!("Register '{register}' is not a member of the transition: {error}"),
         };
 
         Ok(circuit_value)

--- a/synthesizer/src/program/bytes.rs
+++ b/synthesizer/src/program/bytes.rs
@@ -127,7 +127,7 @@ impl<N: Network> ToBytes for Program<N> {
                         // Write the function.
                         function.write_le(&mut writer)?;
                     }
-                    None => return Err(error(format!("Function '{identifier}' is not defined."))),
+                    None => return Err(error(format!("Transition '{identifier}' is not defined."))),
                 },
             }
         }
@@ -153,7 +153,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;";

--- a/synthesizer/src/program/bytes.rs
+++ b/synthesizer/src/program/bytes.rs
@@ -100,7 +100,7 @@ impl<N: Network> ToBytes for Program<N> {
                         // Write the interface.
                         interface.write_le(&mut writer)?;
                     }
-                    None => return Err(error(format!("Interface '{identifier}' is not defined."))),
+                    None => return Err(error(format!("Struct '{identifier}' is not defined."))),
                 },
                 ProgramDefinition::Record => match self.records.get(identifier) {
                     Some(record) => {

--- a/synthesizer/src/program/bytes.rs
+++ b/synthesizer/src/program/bytes.rs
@@ -118,7 +118,7 @@ impl<N: Network> ToBytes for Program<N> {
                         // Write the closure.
                         closure.write_le(&mut writer)?;
                     }
-                    None => return Err(error(format!("Closure '{identifier}' is not defined."))),
+                    None => return Err(error(format!("Function '{identifier}' is not defined."))),
                 },
                 ProgramDefinition::Function => match self.functions.get(identifier) {
                     Some(function) => {

--- a/synthesizer/src/program/closure/bytes.rs
+++ b/synthesizer/src/program/closure/bytes.rs
@@ -33,7 +33,7 @@ impl<N: Network> FromBytes for Closure<N> {
         // Read the instructions.
         let num_instructions = u32::read_le(&mut reader)?;
         if num_instructions > N::MAX_INSTRUCTIONS as u32 {
-            return Err(error(format!("Failed to deserialize a closure: too many instructions ({num_instructions})")));
+            return Err(error(format!("Failed to deserialize a function: too many instructions ({num_instructions})")));
         }
         let mut instructions = Vec::with_capacity(num_instructions as usize);
         for _ in 0..num_instructions {
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn test_closure_bytes() -> Result<()> {
         let closure_string = r"
-closure main:
+function main:
     input r0 as field;
     input r1 as field;
     add r0 r1 into r2;

--- a/synthesizer/src/program/closure/mod.rs
+++ b/synthesizer/src/program/closure/mod.rs
@@ -143,6 +143,6 @@ impl<N: Network> TypeName for Closure<N> {
     /// Returns the type name as a string.
     #[inline]
     fn type_name() -> &'static str {
-        "closure"
+        "function"
     }
 }

--- a/synthesizer/src/program/closure/parse.rs
+++ b/synthesizer/src/program/closure/parse.rs
@@ -97,7 +97,7 @@ mod tests {
     fn test_closure_parse() {
         let closure = Closure::<CurrentNetwork>::parse(
             r"
-closure foo:
+function foo:
     input r0 as field;
     input r1 as field;
     add r0 r1 into r2;
@@ -115,7 +115,7 @@ closure foo:
     fn test_closure_parse_cast() {
         let closure = Closure::<CurrentNetwork>::parse(
             r"
-closure foo:
+function foo:
     input r0 as token.record;
     cast r0.owner r0.gates r0.token_amount into r1 as token.record;
     output r1 as token.record;",
@@ -130,7 +130,7 @@ closure foo:
 
     #[test]
     fn test_closure_display() {
-        let expected = r"closure foo:
+        let expected = r"function foo:
     input r0 as field;
     input r1 as field;
     add r0 r1 into r2;

--- a/synthesizer/src/program/finalize/command/decrement.rs
+++ b/synthesizer/src/program/finalize/command/decrement.rs
@@ -85,7 +85,7 @@ impl<N: Network> Decrement<N> {
         // Retrieve the starting value from storage as a literal.
         let start = match store.get_value(stack.program_id(), &self.mapping, &key)? {
             Some(Value::Plaintext(Plaintext::Literal(literal, _))) => literal,
-            Some(Value::Plaintext(Plaintext::Interface(..))) => bail!("Cannot 'decrement' by an 'interface'"),
+            Some(Value::Plaintext(Plaintext::Interface(..))) => bail!("Cannot 'decrement' by a 'struct'"),
             Some(Value::Record(..)) => bail!("Cannot 'decrement' by a 'record'"),
             // If the key does not exist, set the starting value to 0.
             // Infer the starting type from the decrement type.

--- a/synthesizer/src/program/finalize/command/increment.rs
+++ b/synthesizer/src/program/finalize/command/increment.rs
@@ -85,7 +85,7 @@ impl<N: Network> Increment<N> {
         // Retrieve the starting value from storage as a literal.
         let start = match store.get_value(stack.program_id(), &self.mapping, &key)? {
             Some(Value::Plaintext(Plaintext::Literal(literal, _))) => literal,
-            Some(Value::Plaintext(Plaintext::Interface(..))) => bail!("Cannot 'increment' by an 'interface'"),
+            Some(Value::Plaintext(Plaintext::Interface(..))) => bail!("Cannot 'increment' by a 'struct'"),
             Some(Value::Record(..)) => bail!("Cannot 'increment' by a 'record'"),
             // If the key does not exist, set the starting value to 0.
             // Infer the starting type from the increment type.

--- a/synthesizer/src/program/function/bytes.rs
+++ b/synthesizer/src/program/function/bytes.rs
@@ -33,7 +33,9 @@ impl<N: Network> FromBytes for Function<N> {
         // Read the instructions.
         let num_instructions = u32::read_le(&mut reader)?;
         if num_instructions > N::MAX_INSTRUCTIONS as u32 {
-            return Err(error(format!("Failed to deserialize a transition: too many instructions ({num_instructions})")));
+            return Err(error(format!(
+                "Failed to deserialize a transition: too many instructions ({num_instructions})"
+            )));
         }
         let mut instructions = Vec::with_capacity(num_instructions as usize);
         for _ in 0..num_instructions {
@@ -52,7 +54,9 @@ impl<N: Network> FromBytes for Function<N> {
         let finalize = match variant {
             0 => None,
             1 => Some((FinalizeCommand::read_le(&mut reader)?, Finalize::read_le(&mut reader)?)),
-            _ => return Err(error(format!("Failed to deserialize a transition: invalid finalize variant ({variant})"))),
+            _ => {
+                return Err(error(format!("Failed to deserialize a transition: invalid finalize variant ({variant})")));
+            }
         };
 
         // Initialize a new function.

--- a/synthesizer/src/program/function/bytes.rs
+++ b/synthesizer/src/program/function/bytes.rs
@@ -33,7 +33,7 @@ impl<N: Network> FromBytes for Function<N> {
         // Read the instructions.
         let num_instructions = u32::read_le(&mut reader)?;
         if num_instructions > N::MAX_INSTRUCTIONS as u32 {
-            return Err(error(format!("Failed to deserialize a function: too many instructions ({num_instructions})")));
+            return Err(error(format!("Failed to deserialize a transition: too many instructions ({num_instructions})")));
         }
         let mut instructions = Vec::with_capacity(num_instructions as usize);
         for _ in 0..num_instructions {
@@ -52,7 +52,7 @@ impl<N: Network> FromBytes for Function<N> {
         let finalize = match variant {
             0 => None,
             1 => Some((FinalizeCommand::read_le(&mut reader)?, Finalize::read_le(&mut reader)?)),
-            _ => return Err(error(format!("Failed to deserialize a function: invalid finalize variant ({variant})"))),
+            _ => return Err(error(format!("Failed to deserialize a transition: invalid finalize variant ({variant})"))),
         };
 
         // Initialize a new function.
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn test_function_bytes() -> Result<()> {
         let function_string = r"
-function main:
+transition main:
     input r0 as field.public;
     input r1 as field.private;
     add r0 r1 into r2;

--- a/synthesizer/src/program/function/mod.rs
+++ b/synthesizer/src/program/function/mod.rs
@@ -192,9 +192,9 @@ impl<N: Network> Function<N> {
     #[inline]
     fn add_finalize(&mut self, command: FinalizeCommand<N>, finalize: Finalize<N>) -> Result<()> {
         // Ensure there is no finalize scope in memory.
-        ensure!(self.finalize.is_none(), "Cannot add multiple finalize scopes to function '{}'", self.name);
+        ensure!(self.finalize.is_none(), "Cannot add multiple finalize scopes to transition '{}'", self.name);
         // Ensure the finalize scope name matches the function name.
-        ensure!(*finalize.name() == self.name, "Finalize scope name must match function name '{}'", self.name);
+        ensure!(*finalize.name() == self.name, "Finalize scope name must match transition name '{}'", self.name);
         // Ensure the number of finalize inputs has not been exceeded.
         ensure!(finalize.inputs().len() <= N::MAX_INPUTS, "Cannot add more than {} inputs to finalize", N::MAX_INPUTS);
         // Ensure the finalize command has the same number of operands as the finalize inputs.
@@ -215,6 +215,6 @@ impl<N: Network> TypeName for Function<N> {
     /// Returns the type name as a string.
     #[inline]
     fn type_name() -> &'static str {
-        "function"
+        "transition"
     }
 }

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -22,7 +22,7 @@ impl<N: Network> Parser for Function<N> {
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
-        // Parse the 'function' keyword from the string.
+        // Parse the 'transition' keyword from the string.
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
@@ -135,7 +135,7 @@ mod tests {
     fn test_function_parse() {
         let function = Function::<CurrentNetwork>::parse(
             r"
-function foo:
+transition foo:
     input r0 as field.public;
     input r1 as field.private;
     add r0 r1 into r2;
@@ -151,7 +151,7 @@ function foo:
         // Function with 0 inputs.
         let function = Function::<CurrentNetwork>::parse(
             r"
-function foo:
+transition foo:
     add 1u32 2u32 into r0;
     output r0 as u32.private;",
         )
@@ -167,7 +167,7 @@ function foo:
     fn test_function_parse_cast() {
         let function = Function::<CurrentNetwork>::parse(
             r"
-function foo:
+transition foo:
     input r0 as token.record;
     cast r0.owner r0.gates r0.token_amount into r1 as token.record;
     output r1 as token.record;",
@@ -184,7 +184,7 @@ function foo:
     fn test_function_parse_no_instruction_or_output() {
         let function = Function::<CurrentNetwork>::parse(
             r"
-function foo:
+transition foo:
     input r0 as token.record;",
         )
         .unwrap()
@@ -199,7 +199,7 @@ function foo:
     fn test_function_parse_finalize() {
         let function = Function::<CurrentNetwork>::parse(
             r"
-function mint_public:
+transition mint_public:
     // Input the token receiver.
     input r0 as address.public;
     // Input the token amount.
@@ -233,7 +233,7 @@ finalize mint_public:
 
         let function = Function::<CurrentNetwork>::parse(
             r"
-function foo:
+transition foo:
     input r0 as token.record;
     cast r0.owner r0.gates r0.token_amount into r1 as token.record;
     finalize r1.token_amount;
@@ -254,7 +254,7 @@ finalize foo:
 
         let function = Function::<CurrentNetwork>::parse(
             r"
-function compute:
+transition compute:
     input r0 as address.public;
     input r1 as u64.public;
     input r2 as u64.public;
@@ -278,7 +278,7 @@ finalize compute:
 
     #[test]
     fn test_function_display() {
-        let expected = r"function foo:
+        let expected = r"transition foo:
     input r0 as field.public;
     input r1 as field.private;
     add r0 r1 into r2;

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -279,7 +279,7 @@ mod tests {
         // Initialize the program.
         let program = Program::from_str(&format!(
             "program testing.aleo;
-            function {function_name}:
+            transition {function_name}:
                 input {r0} as {type_a}.{mode_a};
                 input {r1} as {type_b}.{mode_b};
                 {opcode} {r0} {r1};

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -182,7 +182,7 @@ impl<N: Network> Call<N> {
                 //  But there are legitimate uses for passing a record through to an internal function.
                 //  We could invoke the internal function without a state transition, but need to match visibility.
                 if stack.program().contains_function(resource) {
-                    bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
+                    bail!("Cannot call '{resource}'. Use a function ('function {resource}:') instead.")
                 }
 
                 (stack.clone(), resource)
@@ -251,7 +251,7 @@ impl<N: Network> Call<N> {
                 //  But there are legitimate uses for passing a record through to an internal function.
                 //  We could invoke the internal function without a state transition, but need to match visibility.
                 if stack.program().contains_function(resource) {
-                    bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
+                    bail!("Cannot call '{resource}'. Use a function ('function {resource}:') instead.")
                 }
 
                 (stack.clone(), resource)
@@ -446,7 +446,7 @@ impl<N: Network> Call<N> {
                 //  But there are legitimate uses for passing a record through to an internal function.
                 //  We could invoke the internal function without a state transition, but need to match visibility.
                 if stack.program().contains_function(resource) {
-                    bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
+                    bail!("Cannot call '{resource}'. Use a function ('function {resource}:') instead.")
                 }
 
                 (false, stack.program(), resource)

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -342,7 +342,7 @@ impl<N: Network> Call<N> {
                     }
                     // If the circuit is in evaluate mode, then throw an error.
                     CallStack::Evaluate(..) => {
-                        bail!("Cannot 'execute' a function in 'evaluate' mode.")
+                        bail!("Cannot 'execute' a transition in 'evaluate' mode.")
                     }
                     // If the circuit is in execute mode, then evaluate and execute the instructions.
                     CallStack::Execute(authorization, ..) => {
@@ -362,7 +362,7 @@ impl<N: Network> Call<N> {
                         if console_response.outputs() != response.outputs() {
                             #[cfg(debug_assertions)]
                             eprintln!("\n{:#?} != {:#?}\n", console_response.outputs(), response.outputs());
-                            bail!("Function '{}' outputs do not match in a 'call' instruction.", function.name())
+                            bail!("Transition '{}' outputs do not match in a 'call' instruction.", function.name())
                         }
                         // Return the request and response.
                         (request, response)

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -89,7 +89,7 @@ impl<N: Network> Cast<N> {
             RegisterType::Plaintext(PlaintextType::Literal(..)) => bail!("Casting to literal is currently unsupported"),
             RegisterType::Plaintext(PlaintextType::Interface(interface_name)) => {
                 // Ensure the operands is not empty.
-                ensure!(!inputs.is_empty(), "Casting to an interface requires at least one operand");
+                ensure!(!inputs.is_empty(), "Casting to a struct requires at least one operand");
 
                 // Retrieve the interface and ensure it is defined in the program.
                 let interface = stack.program().get_interface(&interface_name)?;
@@ -108,7 +108,7 @@ impl<N: Network> Cast<N> {
                             plaintext.clone()
                         }
                         // Ensure the interface member is not a record.
-                        Value::Record(..) => bail!("Casting a record into an interface member is illegal"),
+                        Value::Record(..) => bail!("Casting a record into a struct member is illegal"),
                     };
                     // Append the member to the interface members.
                     members.insert(*member_name, plaintext);
@@ -215,7 +215,7 @@ impl<N: Network> Cast<N> {
             RegisterType::Plaintext(PlaintextType::Literal(..)) => bail!("Casting to literal is currently unsupported"),
             RegisterType::Plaintext(PlaintextType::Interface(interface_name)) => {
                 // Ensure the operands is not empty.
-                ensure!(!inputs.is_empty(), "Casting to an interface requires at least one operand");
+                ensure!(!inputs.is_empty(), "Casting to a struct requires at least one operand");
 
                 // Retrieve the interface and ensure it is defined in the program.
                 let interface = stack.program().get_interface(&interface_name)?;
@@ -238,7 +238,7 @@ impl<N: Network> Cast<N> {
                         }
                         // Ensure the interface member is not a record.
                         circuit::Value::Record(..) => {
-                            bail!("Casting a record into an interface member is illegal")
+                            bail!("Casting a record into a struct member is illegal")
                         }
                     };
                     // Append the member to the interface members.
@@ -366,16 +366,16 @@ impl<N: Network> Cast<N> {
                         RegisterType::Plaintext(plaintext_type) => {
                             ensure!(
                                 member_type == plaintext_type,
-                                "Interface '{interface_name}' member type mismatch: expected '{member_type}', found '{plaintext_type}'"
+                                "Struct '{interface_name}' member type mismatch: expected '{member_type}', found '{plaintext_type}'"
                             )
                         }
                         // Ensure the input type cannot be a record (this is unsupported behavior).
                         RegisterType::Record(record_name) => bail!(
-                            "Interface '{interface_name}' member type mismatch: expected '{member_type}', found record '{record_name}'"
+                            "Struct '{interface_name}' member type mismatch: expected '{member_type}', found record '{record_name}'"
                         ),
                         // Ensure the input type cannot be an external record (this is unsupported behavior).
                         RegisterType::ExternalRecord(locator) => bail!(
-                            "Interface '{interface_name}' member type mismatch: expected '{member_type}', found external record '{locator}'"
+                            "Struct '{interface_name}' member type mismatch: expected '{member_type}', found external record '{locator}'"
                         ),
                     }
                 }

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -290,7 +290,7 @@ mod tests {
         // Initialize the program.
         let program = Program::from_str(&format!(
             "program testing.aleo;
-            function {function_name}:
+            transition {function_name}:
                 input {r0} as {type_a}.{mode_a};
                 input {r1} as {type_b}.{mode_b};
                 {opcode} {r0} {r1} into {r2};

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -224,8 +224,7 @@ transition fee:
     /// Returns the interface with the given name.
     pub fn get_interface(&self, name: &Identifier<N>) -> Result<Interface<N>> {
         // Attempt to retrieve the interface.
-        let interface =
-            self.interfaces.get(name).cloned().ok_or_else(|| anyhow!("Struct '{name}' is not defined."))?;
+        let interface = self.interfaces.get(name).cloned().ok_or_else(|| anyhow!("Struct '{name}' is not defined."))?;
         // Ensure the interface name matches.
         ensure!(interface.name() == name, "Expected interface '{name}', but found struct '{}'", interface.name());
         // Ensure the interface contains members.
@@ -265,7 +264,8 @@ transition fee:
     /// Returns the function with the given name.
     pub fn get_function(&self, name: &Identifier<N>) -> Result<Function<N>> {
         // Attempt to retrieve the function.
-        let function = self.functions.get(name).cloned().ok_or_else(|| anyhow!("Transition '{name}' is not defined."))?;
+        let function =
+            self.functions.get(name).cloned().ok_or_else(|| anyhow!("Transition '{name}' is not defined."))?;
         // Ensure the function name matches.
         ensure!(function.name() == name, "Expected transition '{name}', but found transition '{}'", function.name());
         // Ensure the number of inputs is within the allowed range.

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -225,11 +225,11 @@ function fee:
     pub fn get_interface(&self, name: &Identifier<N>) -> Result<Interface<N>> {
         // Attempt to retrieve the interface.
         let interface =
-            self.interfaces.get(name).cloned().ok_or_else(|| anyhow!("Interface '{name}' is not defined."))?;
+            self.interfaces.get(name).cloned().ok_or_else(|| anyhow!("Struct '{name}' is not defined."))?;
         // Ensure the interface name matches.
-        ensure!(interface.name() == name, "Expected interface '{name}', but found interface '{}'", interface.name());
+        ensure!(interface.name() == name, "Expected interface '{name}', but found struct '{}'", interface.name());
         // Ensure the interface contains members.
-        ensure!(!interface.members().is_empty(), "Interface '{name}' is missing members.");
+        ensure!(!interface.members().is_empty(), "Struct '{name}' is missing members.");
         // Return the interface.
         Ok(interface)
     }
@@ -358,7 +358,7 @@ impl<N: Network> Program<N> {
         ensure!(!Self::is_reserved_keyword(&interface_name), "'{interface_name}' is a reserved keyword.");
 
         // Ensure the interface contains members.
-        ensure!(!interface.members().is_empty(), "Interface '{interface_name}' is missing members.");
+        ensure!(!interface.members().is_empty(), "Struct '{interface_name}' is missing members.");
 
         // Ensure all interface members are well-formed.
         // Note: This design ensures cyclic references are not possible.
@@ -371,7 +371,7 @@ impl<N: Network> Program<N> {
                 PlaintextType::Interface(member_identifier) => {
                     // Ensure the member interface name exists in the program.
                     if !self.interfaces.contains_key(member_identifier) {
-                        bail!("'{member_identifier}' in interface '{}' is not defined.", interface_name)
+                        bail!("'{member_identifier}' in struct '{}' is not defined.", interface_name)
                     }
                 }
             }
@@ -424,7 +424,7 @@ impl<N: Network> Program<N> {
                     PlaintextType::Literal(..) => continue,
                     PlaintextType::Interface(identifier) => {
                         if !self.interfaces.contains_key(identifier) {
-                            bail!("Interface '{identifier}' in record '{record_name}' is not defined.")
+                            bail!("Struct '{identifier}' in record '{record_name}' is not defined.")
                         }
                     }
                 },
@@ -569,7 +569,7 @@ impl<N: Network> Program<N> {
         "gates",
         // Program
         "function",
-        "interface",
+        "struct",
         "closure",
         "program",
         "aleo",
@@ -682,7 +682,7 @@ mapping message:
         // Create a new interface.
         let interface = Interface::<CurrentNetwork>::from_str(
             r"
-interface message:
+struct message:
     first as field;
     second as field;",
         )?;
@@ -884,7 +884,7 @@ function swap:
             r"
 program example.aleo;
 
-interface message:
+struct message:
     first as field;
     second as field;
 

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -247,17 +247,17 @@ transition fee:
     /// Returns the closure with the given name.
     pub fn get_closure(&self, name: &Identifier<N>) -> Result<Closure<N>> {
         // Attempt to retrieve the closure.
-        let closure = self.closures.get(name).cloned().ok_or_else(|| anyhow!("Closure '{name}' is not defined."))?;
+        let closure = self.closures.get(name).cloned().ok_or_else(|| anyhow!("Function '{name}' is not defined."))?;
         // Ensure the closure name matches.
-        ensure!(closure.name() == name, "Expected closure '{name}', but found closure '{}'", closure.name());
+        ensure!(closure.name() == name, "Expected function '{name}', but found function '{}'", closure.name());
         // Ensure there are input statements in the closure.
-        ensure!(!closure.inputs().is_empty(), "Cannot evaluate a closure without input statements");
+        ensure!(!closure.inputs().is_empty(), "Cannot evaluate a function without input statements");
         // Ensure the number of inputs is within the allowed range.
-        ensure!(closure.inputs().len() <= N::MAX_INPUTS, "Closure exceeds maximum number of inputs");
+        ensure!(closure.inputs().len() <= N::MAX_INPUTS, "Function exceeds maximum number of inputs");
         // Ensure there are instructions in the closure.
-        ensure!(!closure.instructions().is_empty(), "Cannot evaluate a closure without instructions");
+        ensure!(!closure.instructions().is_empty(), "Cannot evaluate a function without instructions");
         // Ensure the number of outputs is within the allowed range.
-        ensure!(closure.outputs().len() <= N::MAX_OUTPUTS, "Closure exceeds maximum number of outputs");
+        ensure!(closure.outputs().len() <= N::MAX_OUTPUTS, "Function exceeds maximum number of outputs");
         // Return the closure.
         Ok(closure)
     }
@@ -468,13 +468,13 @@ impl<N: Network> Program<N> {
         ensure!(!Self::is_reserved_keyword(&closure_name), "'{closure_name}' is a reserved keyword.");
 
         // Ensure there are input statements in the closure.
-        ensure!(!closure.inputs().is_empty(), "Cannot evaluate a closure without input statements");
+        ensure!(!closure.inputs().is_empty(), "Cannot evaluate a function without input statements");
         // Ensure the number of inputs is within the allowed range.
-        ensure!(closure.inputs().len() <= N::MAX_INPUTS, "Closure exceeds maximum number of inputs");
+        ensure!(closure.inputs().len() <= N::MAX_INPUTS, "Function exceeds maximum number of inputs");
         // Ensure there are instructions in the closure.
-        ensure!(!closure.instructions().is_empty(), "Cannot evaluate a closure without instructions");
+        ensure!(!closure.instructions().is_empty(), "Cannot evaluate a function without instructions");
         // Ensure the number of outputs is within the allowed range.
-        ensure!(closure.outputs().len() <= N::MAX_OUTPUTS, "Closure exceeds maximum number of outputs");
+        ensure!(closure.outputs().len() <= N::MAX_OUTPUTS, "Function exceeds maximum number of outputs");
 
         // Add the function name to the identifiers.
         if self.identifiers.insert(closure_name, ProgramDefinition::Closure).is_some() {
@@ -570,7 +570,7 @@ impl<N: Network> Program<N> {
         // Program
         "transition",
         "struct",
-        "closure",
+        "function",
         "program",
         "aleo",
         "self",
@@ -1014,7 +1014,7 @@ transition compute:
 program example_call.aleo;
 
 // (a + (a + b)) + (a + b) == (3a + 2b)
-closure execute:
+function execute:
     input r0 as field;
     input r1 as field;
     add r0 r1 into r2;

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -108,19 +108,19 @@ record credits:
     owner as address.private;
     gates as u64.private;
 
-function genesis:
+transition genesis:
     input r0 as address.private;
     input r1 as u64.private;
     cast r0 r1 into r2 as credits.record;
     output r2 as credits.record;
 
-function mint:
+transition mint:
     input r0 as address.private;
     input r1 as u64.private;
     cast r0 r1 into r2 as credits.record;
     output r2 as credits.record;
 
-function transfer:
+transition transfer:
     input r0 as credits.record;
     input r1 as address.private;
     input r2 as u64.private;
@@ -130,14 +130,14 @@ function transfer:
     output r4 as credits.record;
     output r5 as credits.record;
 
-function join:
+transition join:
     input r0 as credits.record;
     input r1 as credits.record;
     add r0.gates r1.gates into r2;
     cast r0.owner r2 into r3 as credits.record;
     output r3 as credits.record;
 
-function split:
+transition split:
     input r0 as credits.record;
     input r1 as u64.private;
     sub r0.gates r1 into r2;
@@ -146,7 +146,7 @@ function split:
     output r3 as credits.record;
     output r4 as credits.record;
 
-function fee:
+transition fee:
     input r0 as credits.record;
     input r1 as u64.private;
     sub r0.gates r1 into r2;
@@ -265,15 +265,15 @@ function fee:
     /// Returns the function with the given name.
     pub fn get_function(&self, name: &Identifier<N>) -> Result<Function<N>> {
         // Attempt to retrieve the function.
-        let function = self.functions.get(name).cloned().ok_or_else(|| anyhow!("Function '{name}' is not defined."))?;
+        let function = self.functions.get(name).cloned().ok_or_else(|| anyhow!("Transition '{name}' is not defined."))?;
         // Ensure the function name matches.
-        ensure!(function.name() == name, "Expected function '{name}', but found function '{}'", function.name());
+        ensure!(function.name() == name, "Expected transition '{name}', but found transition '{}'", function.name());
         // Ensure the number of inputs is within the allowed range.
-        ensure!(function.inputs().len() <= N::MAX_INPUTS, "Function exceeds maximum number of inputs");
+        ensure!(function.inputs().len() <= N::MAX_INPUTS, "Transition exceeds maximum number of inputs");
         // Ensure the number of instructions is within the allowed range.
-        ensure!(function.instructions().len() <= N::MAX_INSTRUCTIONS, "Function exceeds maximum instructions");
+        ensure!(function.instructions().len() <= N::MAX_INSTRUCTIONS, "Transition exceeds maximum instructions");
         // Ensure the number of outputs is within the allowed range.
-        ensure!(function.outputs().len() <= N::MAX_OUTPUTS, "Function exceeds maximum number of outputs");
+        ensure!(function.outputs().len() <= N::MAX_OUTPUTS, "Transition exceeds maximum number of outputs");
         // Return the function.
         Ok(function)
     }
@@ -513,11 +513,11 @@ impl<N: Network> Program<N> {
         ensure!(!Self::is_reserved_keyword(&function_name), "'{function_name}' is a reserved keyword.");
 
         // Ensure the number of inputs is within the allowed range.
-        ensure!(function.inputs().len() <= N::MAX_INPUTS, "Function exceeds maximum number of inputs");
+        ensure!(function.inputs().len() <= N::MAX_INPUTS, "Transition exceeds maximum number of inputs");
         // Ensure the number of instructions is within the allowed range.
-        ensure!(function.instructions().len() <= N::MAX_INSTRUCTIONS, "Function exceeds maximum instructions");
+        ensure!(function.instructions().len() <= N::MAX_INSTRUCTIONS, "Transition exceeds maximum instructions");
         // Ensure the number of outputs is within the allowed range.
-        ensure!(function.outputs().len() <= N::MAX_OUTPUTS, "Function exceeds maximum number of outputs");
+        ensure!(function.outputs().len() <= N::MAX_OUTPUTS, "Transition exceeds maximum number of outputs");
 
         // Add the function name to the identifiers.
         if self.identifiers.insert(function_name, ProgramDefinition::Function).is_some() {
@@ -568,7 +568,7 @@ impl<N: Network> Program<N> {
         "record",
         "gates",
         // Program
-        "function",
+        "transition",
         "struct",
         "closure",
         "program",
@@ -730,7 +730,7 @@ record foo:
         // Create a new function.
         let function = Function::<CurrentNetwork>::from_str(
             r"
-function compute:
+transition compute:
     input r0 as field.public;
     input r1 as field.private;
     add r0 r1 into r2;
@@ -762,7 +762,7 @@ program swap.aleo;
 
 // The `swap` function transfers ownership of the record
 // for token A to the record owner of token B, and vice-versa.
-function swap:
+transition swap:
     // Input the record for token A.
     input r0 as eth.aleo/eth.record;
     // Input the record for token B.
@@ -821,7 +821,7 @@ function swap:
             r"
     program example.aleo;
 
-    function foo:
+    transition foo:
         input r0 as field.public;
         input r1 as field.private;
         add r0 r1 into r2;
@@ -888,7 +888,7 @@ struct message:
     first as field;
     second as field;
 
-function compute:
+transition compute:
     input r0 as message.private;
     add r0.first r0.second into r1;
     output r1 as field.private;",
@@ -952,7 +952,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;",
@@ -1024,7 +1024,7 @@ closure execute:
     output r3 as field;
     output r2 as field;
 
-function compute:
+transition compute:
     input r0 as field.private;
     input r1 as field.public;
     call execute r0 r1 into r2 r3 r4;
@@ -1141,7 +1141,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     cast r0.owner r0.gates r0.token_amount into r1 as token.record;
     output r1 as token.record;",

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -226,7 +226,7 @@ transition fee:
         // Attempt to retrieve the interface.
         let interface = self.interfaces.get(name).cloned().ok_or_else(|| anyhow!("Struct '{name}' is not defined."))?;
         // Ensure the interface name matches.
-        ensure!(interface.name() == name, "Expected interface '{name}', but found struct '{}'", interface.name());
+        ensure!(interface.name() == name, "Expected struct '{name}', but found struct '{}'", interface.name());
         // Ensure the interface contains members.
         ensure!(!interface.members().is_empty(), "Struct '{name}' is missing members.");
         // Return the interface.

--- a/synthesizer/src/program/parse.rs
+++ b/synthesizer/src/program/parse.rs
@@ -176,7 +176,7 @@ impl<N: Network> Display for Program<N> {
                 ProgramDefinition::Function => match self.functions.get(identifier) {
                     Some(function) => program.push_str(&format!("{function}\n\n")),
                     None => {
-                        eprintln!("Function '{}' is not defined.", identifier);
+                        eprintln!("Transition '{}' is not defined.", identifier);
                         return Err(fmt::Error);
                     }
                 },
@@ -207,7 +207,7 @@ struct message:
     first as field;
     second as field;
 
-function compute:
+transition compute:
     input r0 as message.private;
     add r0.first r0.second into r1;
     output r1 as field.private;",
@@ -230,7 +230,7 @@ function compute:
             r"
 program to_parse.aleo;
 
-function compute:
+transition compute:
     add 1u32 2u32 into r0;
     output r0 as u32.private;",
         )
@@ -251,7 +251,7 @@ struct message:
     first as field;
     second as field;
 
-function compute:
+transition compute:
     input r0 as message.private;
     add r0.first r0.second into r1;
     output r1 as field.private;

--- a/synthesizer/src/program/parse.rs
+++ b/synthesizer/src/program/parse.rs
@@ -169,7 +169,7 @@ impl<N: Network> Display for Program<N> {
                 ProgramDefinition::Closure => match self.closures.get(identifier) {
                     Some(closure) => program.push_str(&format!("{closure}\n\n")),
                     None => {
-                        eprintln!("Closure '{}' is not defined.", identifier);
+                        eprintln!("Function '{}' is not defined.", identifier);
                         return Err(fmt::Error);
                     }
                 },

--- a/synthesizer/src/program/parse.rs
+++ b/synthesizer/src/program/parse.rs
@@ -155,7 +155,7 @@ impl<N: Network> Display for Program<N> {
                 ProgramDefinition::Interface => match self.interfaces.get(identifier) {
                     Some(interface) => program.push_str(&format!("{interface}\n\n")),
                     None => {
-                        eprintln!("Interface '{}' is not defined.", identifier);
+                        eprintln!("Struct '{}' is not defined.", identifier);
                         return Err(fmt::Error);
                     }
                 },
@@ -203,7 +203,7 @@ mod tests {
             r"
 program to_parse.aleo;
 
-interface message:
+struct message:
     first as field;
     second as field;
 
@@ -247,7 +247,7 @@ function compute:
     fn test_program_display() -> Result<()> {
         let expected = r"program to_parse.aleo;
 
-interface message:
+struct message:
     first as field;
     second as field;
 

--- a/synthesizer/src/program/serialize.rs
+++ b/synthesizer/src/program/serialize.rs
@@ -51,7 +51,7 @@ struct message:
     first as field;
     second as field;
 
-function compute:
+transition compute:
     input r0 as message.private;
     add r0.first r0.second into r1;
     output r1 as field.private;
@@ -79,7 +79,7 @@ struct message:
     first as field;
     second as field;
 
-function compute:
+transition compute:
     input r0 as message.private;
     add r0.first r0.second into r1;
     output r1 as field.private;

--- a/synthesizer/src/program/serialize.rs
+++ b/synthesizer/src/program/serialize.rs
@@ -47,7 +47,7 @@ mod tests {
     fn test_serde_json() -> Result<()> {
         let program_string = r"program to_parse.aleo;
 
-interface message:
+struct message:
     first as field;
     second as field;
 
@@ -75,7 +75,7 @@ function compute:
     fn test_bincode() -> Result<()> {
         let program_string = r"program to_parse.aleo;
 
-interface message:
+struct message:
     first as field;
     second as field;
 

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -157,7 +157,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         // Ensure the deployment contains the correct functions.
         for function_name in program.functions().keys() {
             if !deployment.verifying_keys().keys().contains(function_name) {
-                bail!("Deployment is missing a verifying key for function '{function_name}'.");
+                bail!("Deployment is missing a verifying key for transition '{function_name}'.");
             }
         }
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -195,7 +195,7 @@ record token:
     gates as u64.private;
     amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as message.private;
     input r1 as message.public;
     input r2 as message.private;

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -187,7 +187,7 @@ pub(crate) mod test_helpers {
                     r"
 program testing.aleo;
 
-interface message:
+struct message:
     amount as u128;
 
 record token:

--- a/vm/file/aleo.rs
+++ b/vm/file/aleo.rs
@@ -71,7 +71,7 @@ impl<N: Network> AleoFile<N> {
             r#"// The '{program_id}' program.
 program {program_id};
 
-function hello:
+transition hello:
     input r0 as u32.public;
     input r1 as u32.private;
     add r0 r1 into r2;
@@ -259,7 +259,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;";
@@ -288,7 +288,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;";

--- a/vm/file/avm.rs
+++ b/vm/file/avm.rs
@@ -202,7 +202,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;";

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -41,7 +41,11 @@ impl<N: Network> ProverFile<N> {
         // Ensure the directory path exists.
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
         // Ensure the function name is valid.
-        ensure!(!Program::is_reserved_keyword(function_name), "Transition name is invalid (reserved): {}", function_name);
+        ensure!(
+            !Program::is_reserved_keyword(function_name),
+            "Transition name is invalid (reserved): {}",
+            function_name
+        );
 
         // Create the candidate prover file.
         let prover_file = Self { function_name: *function_name, proving_key };

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -41,7 +41,7 @@ impl<N: Network> ProverFile<N> {
         // Ensure the directory path exists.
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
         // Ensure the function name is valid.
-        ensure!(!Program::is_reserved_keyword(function_name), "Function name is invalid (reserved): {}", function_name);
+        ensure!(!Program::is_reserved_keyword(function_name), "Transition name is invalid (reserved): {}", function_name);
 
         // Create the candidate prover file.
         let prover_file = Self { function_name: *function_name, proving_key };
@@ -75,7 +75,7 @@ impl<N: Network> ProverFile<N> {
         // Ensure the function name matches.
         if prover.function_name() != function_name {
             bail!(
-                "The prover file for '{}' contains an incorrect function name of '{}'",
+                "The prover file for '{}' contains an incorrect transition name of '{}'",
                 function_name,
                 prover.function_name()
             );
@@ -149,7 +149,7 @@ impl<N: Network> ProverFile<N> {
             .ok_or_else(|| anyhow!("File name not found."))?
             .to_string();
         // Ensure the function name matches the file stem.
-        ensure!(prover.function_name.to_string() == file_stem, "Function name does not match file stem.");
+        ensure!(prover.function_name.to_string() == file_stem, "Transition name does not match file stem.");
 
         // Return the prover file.
         Ok(prover)
@@ -168,7 +168,7 @@ impl<N: Network> ProverFile<N> {
             .ok_or_else(|| anyhow!("File name not found."))?
             .to_string();
         // Ensure the function name matches the file stem.
-        ensure!(self.function_name.to_string() == file_stem, "Function name does not match file stem.");
+        ensure!(self.function_name.to_string() == file_stem, "Transition name does not match file stem.");
 
         // Write to the file (overwriting if it already exists).
         Ok(File::create(path)?.write_all(&self.to_bytes_le()?)?)
@@ -220,7 +220,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;";

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -41,7 +41,11 @@ impl<N: Network> VerifierFile<N> {
         // Ensure the directory path exists.
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
         // Ensure the function name is valid.
-        ensure!(!Program::is_reserved_keyword(function_name), "Transition name is invalid (reserved): {}", function_name);
+        ensure!(
+            !Program::is_reserved_keyword(function_name),
+            "Transition name is invalid (reserved): {}",
+            function_name
+        );
 
         // Create the candidate verifier file.
         let verifier_file = Self { function_name: *function_name, verifying_key };

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -41,7 +41,7 @@ impl<N: Network> VerifierFile<N> {
         // Ensure the directory path exists.
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
         // Ensure the function name is valid.
-        ensure!(!Program::is_reserved_keyword(function_name), "Function name is invalid (reserved): {}", function_name);
+        ensure!(!Program::is_reserved_keyword(function_name), "Transition name is invalid (reserved): {}", function_name);
 
         // Create the candidate verifier file.
         let verifier_file = Self { function_name: *function_name, verifying_key };
@@ -75,7 +75,7 @@ impl<N: Network> VerifierFile<N> {
         // Ensure the function name matches.
         if verifier.function_name() != function_name {
             bail!(
-                "The verifier file for '{}' contains an incorrect function name of '{}'",
+                "The verifier file for '{}' contains an incorrect transition name of '{}'",
                 function_name,
                 verifier.function_name()
             );
@@ -149,7 +149,7 @@ impl<N: Network> VerifierFile<N> {
             .ok_or_else(|| anyhow!("File name not found."))?
             .to_string();
         // Ensure the function name matches the file stem.
-        ensure!(verifier.function_name.to_string() == file_stem, "Function name does not match file stem.");
+        ensure!(verifier.function_name.to_string() == file_stem, "Transition name does not match file stem.");
 
         // Return the verifier file.
         Ok(verifier)
@@ -168,7 +168,7 @@ impl<N: Network> VerifierFile<N> {
             .ok_or_else(|| anyhow!("File name not found."))?
             .to_string();
         // Ensure the function name matches the file stem.
-        ensure!(self.function_name.to_string() == file_stem, "Function name does not match file stem.");
+        ensure!(self.function_name.to_string() == file_stem, "Transition name does not match file stem.");
 
         // Write to the file (overwriting if it already exists).
         Ok(File::create(path)?.write_all(&self.to_bytes_le()?)?)
@@ -220,7 +220,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;";

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -200,7 +200,7 @@ impl<N: Network> Package<N> {
                     // Ensure the function name matches.
                     ensure!(
                         response.function_name() == function_name,
-                        "Function name mismatch: {} != {function_name}",
+                        "Transition name mismatch: {} != {function_name}",
                         response.function_name()
                     );
                     // Insert the proving key.

--- a/vm/package/is_build_required.rs
+++ b/vm/package/is_build_required.rs
@@ -113,7 +113,7 @@ record token:
     gates as u64.private;
     token_amount as u64.private;
 
-function compute:
+transition compute:
     input r0 as token.record;
     add.w r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;",

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -207,13 +207,13 @@ record token:
     gates as u64.private;
     amount as u64.private;
 
-function mint:
+transition mint:
     input r0 as address.private;
     input r1 as u64.private;
     cast r0 0u64 r1 into r2 as token.record;
     output r2 as token.record;
 
-function transfer:
+transition transfer:
     input r0 as token.record;
     input r1 as address.private;
     input r2 as u64.private;
@@ -257,13 +257,13 @@ record token:
     gates as u64.private;
     amount as u64.private;
 
-function mint:
+transition mint:
     input r0 as address.private;
     input r1 as u64.private;
     cast r0 0u64 r1 into r2 as token.record;
     output r2 as token.record;
 
-function transfer:
+transition transfer:
     input r0 as token.record;
     input r1 as address.private;
     input r2 as u64.private;
@@ -293,7 +293,7 @@ import token.aleo;
 
 program {main_program_id};
 
-function transfer:
+transition transfer:
     input r0 as token.aleo/token.record;
     input r1 as address.private;
     input r2 as u64.private;

--- a/vm/package/run.rs
+++ b/vm/package/run.rs
@@ -32,7 +32,7 @@ impl<N: Network> Package<N> {
         let program_id = program.id();
         // Ensure that the function exists.
         if !program.contains_function(&function_name) {
-            bail!("Function '{function_name}' does not exist.")
+            bail!("Transition '{function_name}' does not exist.")
         }
 
         // Build the package, if the package requires building.


### PR DESCRIPTION
These commits carry out the following renamings at the user level (i.e. in parser and error messages):
- interfaces to structs
- functions to transitions
- closures to functions

As discussed, type names, variable names, comments, etc. will be renamed separately.
