### PR TITLE
Faster char validity checks

### DIFF
--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::ParserResult;
+use crate::{string_parser::is_char_unsupported, ParserResult};
 
 use nom::{
     branch::alt,
@@ -88,14 +88,7 @@ impl Sanitizer {
     /// as opposed to returning `A` and leaving another `A` in the input.
     pub fn parse_safe_char(string: &str) -> ParserResult<char> {
         fn is_safe(ch: &char) -> bool {
-            let code = *ch as u32;
-            code == 9
-                || code == 10
-                || code == 13
-                || (32..=126).contains(&code)
-                || (128..=0x2029).contains(&code)
-                || (0x202f..=0x2065).contains(&code)
-                || (0x206a <= code)
+            !is_char_unsupported(*ch)
         }
         verify(anychar, is_safe)(string)
     }

--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{string_parser::is_char_unsupported, ParserResult};
+use crate::{string_parser::is_char_supported, ParserResult};
 
 use nom::{
     branch::alt,
@@ -52,34 +52,12 @@ impl Sanitizer {
         )(string)
     }
 
-    /// Parse a safe character (in the sense explained below).
+    /// Parse a safe character (in the sense explained in [string_parser::is_char_supported]).
     /// Returns an error if no character is found or a non-safe character is found.
     /// The character is returned, along with the remaining input.
     ///
     /// This is used for otherwise unconstrained characters
     /// in (line and block) comments and in string literals.
-    ///
-    /// We regard the following characters as safe:
-    /// - Horizontal tab (code 9).
-    /// - Line feed (code 10).
-    /// - Carriage return (code 13).
-    /// - Space (code 32).
-    /// - Visible ASCII (codes 33-126).
-    /// - Non-ASCII Unicode scalar values except bidi embeddings, overrides, and isolates.
-    ///
-    /// The Unicode bidi characters are well-known for presenting Trojan Source dangers.
-    /// The ASCII backspace (code 8) can be also used to make text look different from what it is,
-    /// and a similar danger may apply to delete (126).
-    /// Other ASCII control characters
-    /// (except for horizontal tab, space, line feed, and carriage return, which are allowed)
-    /// may or may not present dangers, but we see no good reason for allowing them.
-    /// At some point we may want disallow additional non-ASCII characters,
-    /// if we see no good reason to allow them.
-    ///
-    /// Note that we say 'Unicode scalar values' above,
-    /// because we read UTF-8-decoded characters,
-    /// and thus we will never encounter surrogate code points,
-    /// and we do not need to explicitly exclude them in this function.
     ///
     /// Note also that the `nom` documentation for `anychar` says that
     /// it matches one byte as a character.
@@ -88,7 +66,7 @@ impl Sanitizer {
     /// as opposed to returning `A` and leaving another `A` in the input.
     pub fn parse_safe_char(string: &str) -> ParserResult<char> {
         fn is_safe(ch: &char) -> bool {
-            !is_char_unsupported(*ch)
+            is_char_supported(*ch)
         }
         verify(anychar, is_safe)(string)
     }

--- a/console/network/environment/src/traits/string.rs
+++ b/console/network/environment/src/traits/string.rs
@@ -41,7 +41,7 @@ pub mod string_parser {
 
     /// Checks for unsupported "invisible" code points.
     /// See [Sanitizer::parse_safe_char] for an explanation.
-    fn is_char_unsupported(c: char) -> bool {
+    pub fn is_char_unsupported(c: char) -> bool {
         let code = c as u32;
 
         // A quick early return, as anything above is supported.


### PR DESCRIPTION
This PR speeds up `parse_literal` by over 90%; most of the speedup comes from reversing the order of operations in the loop + changing the checks from `&str`s to `char`s, and there's a little bit of extra boost from optimizing the number of comparison operations:
```
8 chars                 time:   [138.92 ns 138.98 ns 139.05 ns]
                        change: [-90.735% -90.716% -90.702%] (p = 0.00 < 0.05)

16 chars                time:   [216.19 ns 216.82 ns 217.52 ns]
                        change: [-91.568% -91.519% -91.479%] (p = 0.00 < 0.05)

32 chars                time:   [451.54 ns 452.01 ns 452.47 ns]
                        change: [-89.654% -89.579% -89.529%] (p = 0.00 < 0.05)

64 chars                time:   [722.19 ns 722.50 ns 722.83 ns]
                        change: [-90.617% -90.598% -90.579%] (p = 0.00 < 0.05)

128 chars               time:   [1.2490 µs 1.2528 µs 1.2575 µs]
                        change: [-91.389% -91.351% -91.314%] (p = 0.00 < 0.05)

256 chars               time:   [2.4217 µs 2.4246 µs 2.4278 µs]
                        change: [-91.546% -91.522% -91.501%] (p = 0.00 < 0.05)
```
Since `Sanitizer::parse_safe_char` was mentioned in the docs, I also compared this implementation to that one, and since the new one performed favorably:
```
8 chars                 time:   [145.44 ns 146.03 ns 146.69 ns]
                        change: [-2.7090% -2.4227% -2.1538%] (p = 0.00 < 0.05)

16 chars                time:   [215.61 ns 215.93 ns 216.25 ns]
                        change: [-9.8945% -9.4574% -9.0315%] (p = 0.00 < 0.05)

32 chars                time:   [439.28 ns 440.86 ns 443.31 ns]
                        change: [-3.5182% -2.8312% -1.9353%] (p = 0.00 < 0.05)

64 chars                time:   [713.74 ns 713.95 ns 714.18 ns]
                        change: [-6.0072% -5.8569% -5.7299%] (p = 0.00 < 0.05)

128 chars               time:   [1.2782 µs 1.2789 µs 1.2797 µs]
                        change: [-6.2688% -5.8473% -5.5859%] (p = 0.00 < 0.05)

256 chars               time:   [2.4301 µs 2.4314 µs 2.4330 µs]
                        change: [-5.6259% -5.2202% -4.7933%] (p = 0.00 < 0.05)
```
I applied it to `Sanitizer::parse_safe_char` as well.