### PR TITLE
Fix compilation without 'parallel' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ cuda = [ "snarkvm-algorithms/cuda" ]
 parameters_no_std_out = [ "snarkvm-parameters/no_std_out" ]
 parallel = [
   "rayon",
+  "snarkvm-algorithms/parallel",
   "snarkvm-compiler/parallel",
   "snarkvm-fields/parallel",
   "snarkvm-utilities/parallel"
@@ -124,6 +125,7 @@ noconfig = [ ]
 path = "./algorithms"
 version = "0.9.0"
 optional = true
+default-features = false
 
 [dependencies.snarkvm-circuit]
 path = "./circuit"
@@ -168,6 +170,7 @@ optional = true
 [dependencies.snarkvm-compiler]
 path = "./vm/compiler"
 version = "0.9.0"
+default-features = false
 
 [dependencies.anyhow]
 version = "1.0.64"

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -218,7 +218,11 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
         ledger.block_tree.append(&hashes)?;
 
         // Safety check the existence of every block.
-        (0..=latest_height).into_par_iter().try_for_each(|height| {
+        #[cfg(feature = "parallel")]
+        let heights_iter = (0..=latest_height).into_par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let mut heights_iter = (0..=latest_height).into_iter();
+        heights_iter.try_for_each(|height| {
             ledger.get_block(height)?;
             Ok::<_, Error>(())
         })?;
@@ -467,7 +471,11 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
         }
 
         // Ensure each transaction is well-formed and unique.
-        if !block.transactions().par_iter().all(|(_, transaction)| self.check_transaction(transaction).is_ok()) {
+        #[cfg(feature = "parallel")]
+        let transactions_iter = block.transactions().par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let mut transactions_iter = block.transactions().iter();
+        if !transactions_iter.all(|(_, transaction)| self.check_transaction(transaction).is_ok()) {
             bail!("Invalid transaction found in the transactions list");
         }
 


### PR DESCRIPTION
## Motivation

Hi! was playing with some part of snarkVM's compiler a bit and due to the environment I'm running it on I wanted to make sure it compiles with the least possible amount of dependencies and that it runs single-threaded. I've discovered that even if you turn feature `parallel` off, it still gets included with default features of `snarkvm-compiler` and after turning this off, the code stops compiling because `snarkvm-compiler` uses rayon in some places unconditionally.

This PR includes fixes to the both of those.

```bash
cargo tree --no-default-features --features cli
...
├── snarkvm-compiler v0.9.0
│   ├── rayon v1.5.3 (*)
```

### TLDR

The goal is to make `cargo build --lib --no-default-features --features cli` passing without it using rayon. Currently it builds on master but still includes rayon through `snarkvm-compiler`


