### PR TITLE
Remove two superfluous calls in `.aleo` parser.

### DIFF
--- a/console/program/src/data_types/record_type/parse.rs
+++ b/console/program/src/data_types/record_type/parse.rs
@@ -70,8 +70,6 @@ impl<N: Network> Parser for RecordType<N> {
         let (string, _) = tag("as")(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the owner visibility from the string.
         let (string, owner) = alt((
             map(tag("address.public"), |_| PublicOrPrivate::Public),
@@ -92,8 +90,6 @@ impl<N: Network> Parser for RecordType<N> {
         let (string, _) = tag("as")(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the gates visibility from the string.
         let (string, gates) = alt((
             map(tag("u64.public"), |_| PublicOrPrivate::Public),


### PR DESCRIPTION
The parsing of the two required entries of record types (owner and gates) was doing a superfluous call to `Sanitize::parse()` (which skips over comments and whitespace) just before parsing the entry type. But this call was already preceded by a call to `Sanitize::parse_whitespace()`, which is the appropriate one in this part of the syntax, consistently with the parsing of other (i.e. non-required) record entries in the `parse_entry` function.
