### PR TITLE
Disallow comments in a certain place.

### DIFF
--- a/vm/compiler/src/program/finalize/command/finalize.rs
+++ b/vm/compiler/src/program/finalize/command/finalize.rs
@@ -102,8 +102,8 @@ impl<N: Network, const VARIANT: u8> Parser for FinalizeOperation<N, VARIANT> {
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the operands from the string.
         let (string, operands) = many0(parse_operand)(string)?;
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the ';' from the string.
         let (string, _) = tag(";")(string)?;
 


### PR DESCRIPTION
In the rest of the parser, comments and whitespace are allowed before each construct that it typically written in its own line (e.g. instruction, input, etc.), while whitespace only (not comments) is allowed in the middle of such constructs (i.e. in the middle of the line, e.g. between two operands). There are two exceptions to this pattern: one is removed by https://github.com/AleoHQ/snarkVM/pull/1174; the other is removed by this commit and PR. This one applies to what goes between the last (if any) operand of a `finalize` command and the ending semicolon.
