### PR TITLE
Remove redundant parser call.

### DIFF
--- a/vm/compiler/src/program/function/parse.rs
+++ b/vm/compiler/src/program/function/parse.rs
@@ -40,8 +40,6 @@ impl<N: Network> Parser for Function<N> {
         // Parse the outputs from the string.
         let (string, outputs) = many0(Output::parse)(string)?;
 
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse an optional finalize command from the string.
         let (string, command) = opt(FinalizeCommand::parse)(string)?;
         // If there is a finalize command, parse the finalize scope.


### PR DESCRIPTION
There is no need to skip over comments and whitespace before parsing an optional finalize command and finalizer, because the parser for the finalize command [already does that](https://github.com/AleoHQ/snarkVM/blob/75b6c18ca0d9d9b9bb92a4785cbcf47e73c5c033/vm/compiler/src/program/finalize/command/finalize.rs#L100). Even if there is no optional finalize command and finalizer, the call is still redundant, because as we finish parsing the function (now transition), the parser for the next top-level construct will initially skip over comments and whitespace. Even if there are no more top-level constructs in the program, the parser for the program [concludes by skipping over any remaining comments and whitespace in the file](https://github.com/AleoHQ/snarkVM/blob/75b6c18ca0d9d9b9bb92a4785cbcf47e73c5c033/vm/compiler/src/program/parse.rs#L56).
