### PR TITLE
Remove some clones when doing serde deserialization

### DIFF
--- a/console/program/src/request/input_id/serialize.rs
+++ b/console/program/src/request/input_id/serialize.rs
@@ -66,26 +66,26 @@ impl<'de, N: Network> Deserialize<'de> for InputID<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the input ID from a string into a value.
-                let input = serde_json::Value::deserialize(deserializer)?;
+                let mut input = serde_json::Value::deserialize(deserializer)?;
                 // Recover the input.
                 let input_id = match input["type"].as_str() {
                     Some("constant") => {
-                        InputID::Constant(serde_json::from_value(input["id"].clone()).map_err(de::Error::custom)?)
+                        InputID::Constant(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
                     }
                     Some("public") => {
-                        InputID::Public(serde_json::from_value(input["id"].clone()).map_err(de::Error::custom)?)
+                        InputID::Public(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
                     }
                     Some("private") => {
-                        InputID::Private(serde_json::from_value(input["id"].clone()).map_err(de::Error::custom)?)
+                        InputID::Private(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
                     }
                     Some("record") => InputID::Record(
-                        serde_json::from_value(input["commitment"].clone()).map_err(de::Error::custom)?,
-                        serde_json::from_value(input["gamma"].clone()).map_err(de::Error::custom)?,
-                        serde_json::from_value(input["serial_number"].clone()).map_err(de::Error::custom)?,
-                        serde_json::from_value(input["tag"].clone()).map_err(de::Error::custom)?,
+                        serde_json::from_value(input["commitment"].take()).map_err(de::Error::custom)?,
+                        serde_json::from_value(input["gamma"].take()).map_err(de::Error::custom)?,
+                        serde_json::from_value(input["serial_number"].take()).map_err(de::Error::custom)?,
+                        serde_json::from_value(input["tag"].take()).map_err(de::Error::custom)?,
                     ),
                     Some("external_record") => {
-                        InputID::ExternalRecord(serde_json::from_value(input["id"].clone()).map_err(de::Error::custom)?)
+                        InputID::ExternalRecord(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
                     }
                     _ => return Err(de::Error::custom("Invalid input type")),
                 };

--- a/console/program/src/request/serialize.rs
+++ b/console/program/src/request/serialize.rs
@@ -46,31 +46,31 @@ impl<'de, N: Network> Deserialize<'de> for Request<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the request from a string into a value.
-                let request = serde_json::Value::deserialize(deserializer)?;
+                let mut request = serde_json::Value::deserialize(deserializer)?;
                 // Recover the request.
                 Ok(Self::from((
                     // Retrieve the caller.
-                    serde_json::from_value(request["caller"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["caller"].take()).map_err(de::Error::custom)?,
                     // Retrieve the network ID.
-                    serde_json::from_value(request["network"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["network"].take()).map_err(de::Error::custom)?,
                     // Retrieve the program ID.
-                    serde_json::from_value(request["program"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["program"].take()).map_err(de::Error::custom)?,
                     // Retrieve the function name.
-                    serde_json::from_value(request["function"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["function"].take()).map_err(de::Error::custom)?,
                     // Retrieve the input IDs.
-                    serde_json::from_value(request["input_ids"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["input_ids"].take()).map_err(de::Error::custom)?,
                     // Retrieve the inputs.
-                    serde_json::from_value(request["inputs"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["inputs"].take()).map_err(de::Error::custom)?,
                     // Retrieve the signature.
-                    serde_json::from_value(request["signature"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["signature"].take()).map_err(de::Error::custom)?,
                     // Retrieve the `sk_tag`.
-                    serde_json::from_value(request["sk_tag"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["sk_tag"].take()).map_err(de::Error::custom)?,
                     // Retrieve the `tvk`.
-                    serde_json::from_value(request["tvk"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["tvk"].take()).map_err(de::Error::custom)?,
                     // Retrieve the `tsk`.
-                    serde_json::from_value(request["tsk"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["tsk"].take()).map_err(de::Error::custom)?,
                     // Retrieve the `tcm`.
-                    serde_json::from_value(request["tcm"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(request["tcm"].take()).map_err(de::Error::custom)?,
                 )))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "request"),

--- a/vm/compiler/src/ledger/block/header/leaf/serialize.rs
+++ b/vm/compiler/src/ledger/block/header/leaf/serialize.rs
@@ -37,13 +37,13 @@ impl<'de, N: Network> Deserialize<'de> for HeaderLeaf<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the leaf from a string into a value.
-                let leaf = serde_json::Value::deserialize(deserializer)?;
+                let mut leaf = serde_json::Value::deserialize(deserializer)?;
                 // Recover the leaf.
                 Ok(Self::new(
                     // Retrieve the index.
-                    serde_json::from_value(leaf["index"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["index"].take()).map_err(de::Error::custom)?,
                     // Retrieve the id.
-                    serde_json::from_value(leaf["id"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["id"].take()).map_err(de::Error::custom)?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "header leaf"),

--- a/vm/compiler/src/ledger/block/header/metadata/serialize.rs
+++ b/vm/compiler/src/ledger/block/header/metadata/serialize.rs
@@ -40,14 +40,14 @@ impl<'de, N: Network> Deserialize<'de> for Metadata<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => {
-                let metadata = serde_json::Value::deserialize(deserializer)?;
+                let mut metadata = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(metadata["network"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["round"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["height"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["coinbase_target"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["proof_target"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["timestamp"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(metadata["network"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(metadata["round"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(metadata["height"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(metadata["coinbase_target"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(metadata["proof_target"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(metadata["timestamp"].take()).map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?)
             }

--- a/vm/compiler/src/ledger/block/header/serialize.rs
+++ b/vm/compiler/src/ledger/block/header/serialize.rs
@@ -37,11 +37,11 @@ impl<'de, N: Network> Deserialize<'de> for Header<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => {
-                let header = serde_json::Value::deserialize(deserializer)?;
+                let mut header = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::from(
-                    serde_json::from_value(header["previous_state_root"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(header["transactions_root"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(header["metadata"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(header["previous_state_root"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(header["transactions_root"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(header["metadata"].take()).map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?)
             }

--- a/vm/compiler/src/ledger/block/serialize.rs
+++ b/vm/compiler/src/ledger/block/serialize.rs
@@ -39,16 +39,16 @@ impl<'de, N: Network> Deserialize<'de> for Block<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => {
-                let block = serde_json::Value::deserialize(deserializer)?;
+                let mut block = serde_json::Value::deserialize(deserializer)?;
                 let block_hash: N::BlockHash =
-                    serde_json::from_value(block["block_hash"].clone()).map_err(de::Error::custom)?;
+                    serde_json::from_value(block["block_hash"].take()).map_err(de::Error::custom)?;
 
                 // Recover the block.
                 let block = Self::from(
-                    serde_json::from_value(block["previous_hash"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(block["header"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(block["transactions"].clone()).map_err(de::Error::custom)?,
-                    serde_json::from_value(block["signature"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(block["previous_hash"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(block["header"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(block["transactions"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(block["signature"].take()).map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/vm/compiler/src/ledger/transaction/leaf/serialize.rs
+++ b/vm/compiler/src/ledger/transaction/leaf/serialize.rs
@@ -40,19 +40,19 @@ impl<'de, N: Network> Deserialize<'de> for TransactionLeaf<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the leaf from a string into a value.
-                let leaf = serde_json::Value::deserialize(deserializer)?;
+                let mut leaf = serde_json::Value::deserialize(deserializer)?;
                 // Recover the leaf.
                 Ok(Self::new(
                     // Retrieve the variant.
-                    serde_json::from_value(leaf["variant"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["variant"].take()).map_err(de::Error::custom)?,
                     // Retrieve the index.
-                    serde_json::from_value(leaf["index"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["index"].take()).map_err(de::Error::custom)?,
                     // Retrieve the program ID.
-                    serde_json::from_value(leaf["program_id"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["program_id"].take()).map_err(de::Error::custom)?,
                     // Retrieve the function name.
-                    serde_json::from_value(leaf["function_name"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["function_name"].take()).map_err(de::Error::custom)?,
                     // Retrieve the id.
-                    serde_json::from_value(leaf["id"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["id"].take()).map_err(de::Error::custom)?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "transaction leaf"),

--- a/vm/compiler/src/ledger/transaction/serialize.rs
+++ b/vm/compiler/src/ledger/transaction/serialize.rs
@@ -51,27 +51,27 @@ impl<'de, N: Network> Deserialize<'de> for Transaction<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Deserialize the transaction into a JSON value.
-                let transaction = serde_json::Value::deserialize(deserializer)?;
+                let mut transaction = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transaction ID.
                 let id: N::TransactionID =
-                    serde_json::from_value(transaction["id"].clone()).map_err(de::Error::custom)?;
+                    serde_json::from_value(transaction["id"].take()).map_err(de::Error::custom)?;
 
                 // Recover the transaction.
                 let transaction = match transaction["type"].as_str() {
                     Some("deploy") => {
                         // Retrieve the deployment.
                         let deployment =
-                            serde_json::from_value(transaction["deployment"].clone()).map_err(de::Error::custom)?;
+                            serde_json::from_value(transaction["deployment"].take()).map_err(de::Error::custom)?;
                         // Retrieve the additional fee.
                         let additional_fee =
-                            serde_json::from_value(transaction["additional_fee"].clone()).map_err(de::Error::custom)?;
+                            serde_json::from_value(transaction["additional_fee"].take()).map_err(de::Error::custom)?;
                         // Construct the transaction.
                         Transaction::from_deployment(deployment, additional_fee).map_err(de::Error::custom)?
                     }
                     Some("execute") => {
                         // Retrieve the execution.
                         let execution =
-                            serde_json::from_value(transaction["execution"].clone()).map_err(de::Error::custom)?;
+                            serde_json::from_value(transaction["execution"].take()).map_err(de::Error::custom)?;
                         // Retrieve the additional fee, if it exists.
                         let additional_fee = match transaction["additional_fee"].as_str() {
                             Some(additional_fee) => {

--- a/vm/compiler/src/ledger/transition/input/serialize.rs
+++ b/vm/compiler/src/ledger/transition/input/serialize.rs
@@ -74,9 +74,9 @@ impl<'de, N: Network> Deserialize<'de> for Input<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the input from a string into a value.
-                let input = serde_json::Value::deserialize(deserializer)?;
+                let mut input = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the ID.
-                let id: Field<N> = serde_json::from_value(input["id"].clone()).map_err(de::Error::custom)?;
+                let id: Field<N> = serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?;
 
                 // Recover the input.
                 let input = match input["type"].as_str() {
@@ -94,8 +94,8 @@ impl<'de, N: Network> Deserialize<'de> for Input<N> {
                     }),
                     Some("record") => Input::Record(
                         id,
-                        serde_json::from_value(input["tag"].clone()).map_err(de::Error::custom)?,
-                        serde_json::from_value(input["origin"].clone()).map_err(de::Error::custom)?,
+                        serde_json::from_value(input["tag"].take()).map_err(de::Error::custom)?,
+                        serde_json::from_value(input["origin"].take()).map_err(de::Error::custom)?,
                     ),
                     Some("external_record") => Input::ExternalRecord(id),
                     _ => return Err(de::Error::custom("Invalid transition input type")),

--- a/vm/compiler/src/ledger/transition/leaf/serialize.rs
+++ b/vm/compiler/src/ledger/transition/leaf/serialize.rs
@@ -41,21 +41,21 @@ impl<'de, N: Network> Deserialize<'de> for TransitionLeaf<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the leaf from a string into a value.
-                let leaf = serde_json::Value::deserialize(deserializer)?;
+                let mut leaf = serde_json::Value::deserialize(deserializer)?;
                 // Recover the leaf.
                 Ok(Self::new(
                     // Retrieve the version.
-                    serde_json::from_value(leaf["version"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["version"].take()).map_err(de::Error::custom)?,
                     // Retrieve the index.
-                    serde_json::from_value(leaf["index"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["index"].take()).map_err(de::Error::custom)?,
                     // Retrieve the program ID.
-                    serde_json::from_value(leaf["program_id"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["program_id"].take()).map_err(de::Error::custom)?,
                     // Retrieve the function name.
-                    serde_json::from_value(leaf["function_name"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["function_name"].take()).map_err(de::Error::custom)?,
                     // Retrieve the variant.
-                    serde_json::from_value(leaf["variant"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["variant"].take()).map_err(de::Error::custom)?,
                     // Retrieve the id.
-                    serde_json::from_value(leaf["id"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(leaf["id"].take()).map_err(de::Error::custom)?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "transition leaf"),

--- a/vm/compiler/src/ledger/transition/output/serialize.rs
+++ b/vm/compiler/src/ledger/transition/output/serialize.rs
@@ -76,9 +76,9 @@ impl<'de, N: Network> Deserialize<'de> for Output<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the output from a string into a value.
-                let output = serde_json::Value::deserialize(deserializer)?;
+                let mut output = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the ID.
-                let id: Field<N> = serde_json::from_value(output["id"].clone()).map_err(de::Error::custom)?;
+                let id: Field<N> = serde_json::from_value(output["id"].take()).map_err(de::Error::custom)?;
 
                 // Recover the output.
                 let output = match output["type"].as_str() {
@@ -97,7 +97,7 @@ impl<'de, N: Network> Deserialize<'de> for Output<N> {
                     Some("record") => {
                         // Retrieve the checksum.
                         let checksum: Field<N> =
-                            serde_json::from_value(output["checksum"].clone()).map_err(de::Error::custom)?;
+                            serde_json::from_value(output["checksum"].take()).map_err(de::Error::custom)?;
                         // Return the record.
                         Output::Record(id, checksum, match output["value"].as_str() {
                             Some(value) => {

--- a/vm/compiler/src/ledger/transition/serialize.rs
+++ b/vm/compiler/src/ledger/transition/serialize.rs
@@ -47,34 +47,33 @@ impl<'de, N: Network> Deserialize<'de> for Transition<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the transition from a string into a value.
-                let transition = serde_json::Value::deserialize(deserializer)?;
+                let mut transition = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the ID.
-                let id: N::TransitionID =
-                    serde_json::from_value(transition["id"].clone()).map_err(de::Error::custom)?;
+                let id: N::TransitionID = serde_json::from_value(transition["id"].take()).map_err(de::Error::custom)?;
 
                 // Recover the transition.
                 let transition = Self::new(
                     // Retrieve the program ID.
-                    serde_json::from_value(transition["program"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["program"].take()).map_err(de::Error::custom)?,
                     // Retrieve the function name.
-                    serde_json::from_value(transition["function"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["function"].take()).map_err(de::Error::custom)?,
                     // Retrieve the inputs.
-                    serde_json::from_value(transition["inputs"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["inputs"].take()).map_err(de::Error::custom)?,
                     // Retrieve the outputs.
-                    serde_json::from_value(transition["outputs"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["outputs"].take()).map_err(de::Error::custom)?,
                     // Retrieve the finalize inputs.
                     match transition.get("finalize") {
                         Some(finalize) => Some(serde_json::from_value(finalize.clone()).map_err(de::Error::custom)?),
                         None => None,
                     },
                     // Retrieve the proof.
-                    serde_json::from_value(transition["proof"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["proof"].take()).map_err(de::Error::custom)?,
                     // Retrieve the `tpk`.
-                    serde_json::from_value(transition["tpk"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["tpk"].take()).map_err(de::Error::custom)?,
                     // Retrieve the `tcm`.
-                    serde_json::from_value(transition["tcm"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["tcm"].take()).map_err(de::Error::custom)?,
                     // Retrieve the fee.
-                    serde_json::from_value(transition["fee"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(transition["fee"].take()).map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/vm/compiler/src/process/stack/deployment/serialize.rs
+++ b/vm/compiler/src/process/stack/deployment/serialize.rs
@@ -38,16 +38,16 @@ impl<'de, N: Network> Deserialize<'de> for Deployment<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the deployment from a string into a value.
-                let deployment = serde_json::Value::deserialize(deserializer)?;
+                let mut deployment = serde_json::Value::deserialize(deserializer)?;
 
                 // Recover the deployment.
                 let deployment = Self::new(
                     // Retrieve the edition.
-                    serde_json::from_value(deployment["edition"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(deployment["edition"].take()).map_err(de::Error::custom)?,
                     // Retrieve the program.
-                    serde_json::from_value(deployment["program"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(deployment["program"].take()).map_err(de::Error::custom)?,
                     // Retrieve the verifying keys.
-                    serde_json::from_value(deployment["verifying_keys"].clone()).map_err(de::Error::custom)?,
+                    serde_json::from_value(deployment["verifying_keys"].take()).map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/vm/compiler/src/process/stack/execution/serialize.rs
+++ b/vm/compiler/src/process/stack/execution/serialize.rs
@@ -37,12 +37,12 @@ impl<'de, N: Network> Deserialize<'de> for Execution<N> {
         match deserializer.is_human_readable() {
             true => {
                 // Parse the execution from a string into a value.
-                let execution = serde_json::Value::deserialize(deserializer)?;
+                let mut execution = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the edition.
-                let edition = serde_json::from_value(execution["edition"].clone()).map_err(de::Error::custom)?;
+                let edition = serde_json::from_value(execution["edition"].take()).map_err(de::Error::custom)?;
                 // Retrieve the transitions.
                 let transitions: Vec<_> =
-                    serde_json::from_value(execution["transitions"].clone()).map_err(de::Error::custom)?;
+                    serde_json::from_value(execution["transitions"].take()).map_err(de::Error::custom)?;
                 // Recover the execution.
                 Self::from(edition, &transitions).map_err(de::Error::custom)
             }

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -64,15 +64,15 @@ impl<'de, N: Network> Deserialize<'de> for BuildRequest<N> {
     /// Deserializes the build request from a string or bytes.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Parse the request from a string into a value.
-        let request = serde_json::Value::deserialize(deserializer)?;
+        let mut request = serde_json::Value::deserialize(deserializer)?;
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program.
-            serde_json::from_value(request["program"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(request["program"].take()).map_err(de::Error::custom)?,
             // Retrieve the imports.
-            serde_json::from_value(request["imports"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(request["imports"].take()).map_err(de::Error::custom)?,
             // Retrieve the function name.
-            serde_json::from_value(request["function_name"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(request["function_name"].take()).map_err(de::Error::custom)?,
         ))
     }
 }
@@ -132,17 +132,17 @@ impl<'de, N: Network> Deserialize<'de> for BuildResponse<N> {
     /// Deserializes the build response from a string or bytes.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Parse the response from a string into a value.
-        let response = serde_json::Value::deserialize(deserializer)?;
+        let mut response = serde_json::Value::deserialize(deserializer)?;
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program ID.
-            serde_json::from_value(response["program_id"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(response["program_id"].take()).map_err(de::Error::custom)?,
             // Retrieve the function name.
-            serde_json::from_value(response["function_name"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(response["function_name"].take()).map_err(de::Error::custom)?,
             // Retrieve the proving key.
-            serde_json::from_value(response["proving_key"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(response["proving_key"].take()).map_err(de::Error::custom)?,
             // Retrieve the verifying key.
-            serde_json::from_value(response["verifying_key"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(response["verifying_key"].take()).map_err(de::Error::custom)?,
         ))
     }
 }

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -70,15 +70,15 @@ impl<'de, N: Network> Deserialize<'de> for DeployRequest<N> {
     /// Deserializes the deploy request from a string or bytes.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Parse the request from a string into a value.
-        let request = serde_json::Value::deserialize(deserializer)?;
+        let mut request = serde_json::Value::deserialize(deserializer)?;
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program.
-            serde_json::from_value(request["deployment"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(request["deployment"].take()).map_err(de::Error::custom)?,
             // Retrieve the address of the program.
-            serde_json::from_value(request["address"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(request["address"].take()).map_err(de::Error::custom)?,
             // Retrieve the program ID.
-            serde_json::from_value(request["program_id"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(request["program_id"].take()).map_err(de::Error::custom)?,
         ))
     }
 }
@@ -112,11 +112,11 @@ impl<'de, N: Network> Deserialize<'de> for DeployResponse<N> {
     /// Deserializes the deploy response from a string or bytes.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Parse the response from a string into a value.
-        let response = serde_json::Value::deserialize(deserializer)?;
+        let mut response = serde_json::Value::deserialize(deserializer)?;
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program ID.
-            serde_json::from_value(response["deployment"].clone()).map_err(de::Error::custom)?,
+            serde_json::from_value(response["deployment"].take()).map_err(de::Error::custom)?,
         ))
     }
 }


### PR DESCRIPTION
This removes some clones in favor of [`Value::take`](https://docs.rs/serde_json/latest/serde_json/enum.Value.html#method.take). I noticed it while reviewing https://github.com/AleoHQ/snarkVM/pull/1100.