### PR TITLE
Update temp dir handle on pertinent tests

### DIFF
--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -290,7 +290,7 @@ mod tests {
     #[test]
     fn test_build() {
         // Samples a new package at a temporary directory.
-        let (directory, package) = crate::package::test_helpers::sample_package();
+        let (_, package) = crate::package::test_helpers::sample_package();
 
         // Ensure the build directory does *not* exist.
         assert!(!package.build_directory().exists());
@@ -298,15 +298,12 @@ mod tests {
         package.build::<CurrentAleo>(None).unwrap();
         // Ensure the build directory exists.
         assert!(package.build_directory().exists());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
     fn test_build_with_import() {
         // Samples a new package at a temporary directory.
-        let (directory, package) = crate::package::test_helpers::sample_package_with_import();
+        let (_, package) = crate::package::test_helpers::sample_package_with_import();
 
         // Ensure the build directory does *not* exist.
         assert!(!package.build_directory().exists());
@@ -314,8 +311,5 @@ mod tests {
         package.build::<CurrentAleo>(None).unwrap();
         // Ensure the build directory exists.
         assert!(package.build_directory().exists());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/vm/package/clean.rs
+++ b/vm/package/clean.rs
@@ -75,9 +75,6 @@ mod tests {
         Package::<CurrentNetwork>::clean(&directory).unwrap();
         // Ensure the build directory does *not* exist.
         assert!(!package.build_directory().exists());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
@@ -101,8 +98,5 @@ mod tests {
         Package::<CurrentNetwork>::clean(&directory).unwrap();
         // Ensure the build directory does *not* exist.
         assert!(!package.build_directory().exists());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn test_deploy() {
         // Samples a new package at a temporary directory.
-        let (directory, package) = crate::package::test_helpers::sample_package();
+        let (_, package) = crate::package::test_helpers::sample_package();
 
         // Deploy the package.
         let deployment = package.deploy::<CurrentAleo>(None).unwrap();
@@ -200,15 +200,12 @@ mod tests {
         assert_eq!(package.program().id(), deployment.program_id());
         // Ensure the deployment program matches.
         assert_eq!(package.program(), deployment.program());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
     fn test_deploy_with_import() {
         // Samples a new package at a temporary directory.
-        let (directory, package) = crate::package::test_helpers::sample_package_with_import();
+        let (_, package) = crate::package::test_helpers::sample_package_with_import();
 
         // Deploy the package.
         let deployment = package.deploy::<CurrentAleo>(None).unwrap();
@@ -219,8 +216,5 @@ mod tests {
         assert_eq!(package.program().id(), deployment.program_id());
         // Ensure the deployment program matches.
         assert_eq!(package.program(), deployment.program());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -379,9 +379,6 @@ mod tests {
         assert_eq!(package.imports_directory(), directory.join("imports"));
         // Ensure the imports directory does *not* exist, when the package does not contain imports.
         assert!(!package.imports_directory().exists());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
@@ -393,9 +390,6 @@ mod tests {
         assert_eq!(package.imports_directory(), directory.join("imports"));
         // Ensure the imports directory exists, as the package contains an import.
         assert!(package.imports_directory().exists());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
@@ -407,20 +401,14 @@ mod tests {
         assert_eq!(package.build_directory(), directory.join("build"));
         // Ensure the build directory does *not* exist, when the package has not been built.
         assert!(!package.build_directory().exists());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
     fn test_get_process() {
         // Samples a new package at a temporary directory.
-        let (directory, package) = crate::package::test_helpers::sample_package();
+        let (_, package) = crate::package::test_helpers::sample_package();
 
         // Get the program process and check all instructions.
         assert!(package.get_process().is_ok());
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/vm/package/run.rs
+++ b/vm/package/run.rs
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn test_run() {
         // Samples a new package at a temporary directory.
-        let (directory, package) = crate::package::test_helpers::sample_package();
+        let (_, package) = crate::package::test_helpers::sample_package();
 
         // Ensure the build directory does *not* exist.
         assert!(!package.build_directory().exists());
@@ -127,15 +127,12 @@ mod tests {
         // Run the program function.
         let (_response, _execution) =
             package.run::<CurrentAleo, _>(None, &private_key, function_name, &inputs, rng).unwrap();
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
     fn test_run_with_import() {
         // Samples a new package at a temporary directory.
-        let (directory, package) = crate::package::test_helpers::sample_package_with_import();
+        let (_, package) = crate::package::test_helpers::sample_package_with_import();
 
         // Ensure the build directory does *not* exist.
         assert!(!package.build_directory().exists());
@@ -152,8 +149,5 @@ mod tests {
         // Run the program function.
         let (_response, _execution) =
             package.run::<CurrentAleo, _>(None, &private_key, function_name, &inputs, rng).unwrap();
-
-        // Proactively remove the temporary directory (to conserve space).
-        std::fs::remove_dir_all(directory).unwrap();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

[`tempfile::tempdir`](https://docs.rs/tempfile/3.3.0/tempfile/fn.tempdir.html) (used in `test_helpers::sample_package`) automatically removes the temporary directory on `Drop`.