### PR TITLE
Add helper methods for `snarkvm-parameters` objects in `Network` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,6 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-curves",
  "snarkvm-fields",
- "snarkvm-parameters",
  "snarkvm-utilities",
  "time",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "lazy_static",
+ "once_cell",
  "serde",
  "snarkvm-algorithms",
  "snarkvm-console-algorithms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,6 +2433,7 @@ dependencies = [
  "snarkvm-console-types",
  "snarkvm-curves",
  "snarkvm-fields",
+ "snarkvm-parameters",
  "snarkvm-utilities",
 ]
 

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -47,6 +47,8 @@ default = [
   "types"
 ]
 parallel = [ "snarkvm-console-collections/parallel" ]
+wasm = [ "snarkvm-console-network/wasm" ]
+
 account = [ "network", "snarkvm-console-account" ]
 algorithms = [ "snarkvm-console-algorithms" ]
 collections = [ "algorithms", "snarkvm-console-collections" ]

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -57,5 +57,8 @@ version = "0.10.1"
 [dependencies.lazy_static]
 version = "1.4"
 
+[dependencies.once_cell]
+version = "1.13"
+
 [dependencies.serde]
 version = "1.0"

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -40,6 +40,10 @@ path = "../../fields"
 version = "0.9.0"
 default-features = false
 
+[dependencies.snarkvm-parameters]
+path = "../../parameters"
+version = "0.9.0"
+
 [dependencies.snarkvm-utilities]
 path = "../../utilities"
 version = "0.9.0"

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -43,7 +43,6 @@ default-features = false
 [dependencies.snarkvm-parameters]
 path = "../../parameters"
 version = "0.9.0"
-default-features = false
 
 [dependencies.snarkvm-utilities]
 path = "../../utilities"
@@ -66,4 +65,4 @@ version = "1.0"
 
 [features]
 default = []
-wasm = ["snarkvm-parameters/wasm"]
+wasm = [ "snarkvm-parameters/wasm" ]

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -43,6 +43,7 @@ default-features = false
 [dependencies.snarkvm-parameters]
 path = "../../parameters"
 version = "0.9.0"
+default-features = false
 
 [dependencies.snarkvm-utilities]
 path = "../../utilities"
@@ -62,3 +63,7 @@ version = "1.13"
 
 [dependencies.serde]
 version = "1.0"
+
+[features]
+default = []
+wasm = ["snarkvm-parameters/wasm"]

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -103,15 +103,12 @@ pub trait Network:
     /// The transition ID type.
     type TransitionID: Bech32ID<Field<Self>>;
 
-    /// TODO (howardwu): Refactor into returning the genesis block, after migrating ledger into console & circuit.
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];
 
-    /// TODO (howardwu): Refactor into returning the universal SRS, after migrating snark into console.
     /// Returns the universal SRS bytes.
     fn universal_srs_bytes() -> &'static [u8];
 
-    /// TODO (howardwu): Refactor into returning the proving and verifying key, after migrating snark into console.
     /// Returns the `(proving key, verifying key)` bytes for the given function name in `credits.aleo`.
     fn get_credits_key_bytes(function_name: String) -> Result<&'static (Vec<u8>, Vec<u8>)>;
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -107,6 +107,10 @@ pub trait Network:
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];
 
+    /// TODO (howardwu): Refactor into returning the universal SRS, after migrating snark into console.
+    /// Returns the universal SRS bytes.
+    fn universal_srs_bytes() -> &'static [u8];
+
     /// Returns the powers of `G`.
     fn g_powers() -> &'static Vec<Group<Self>>;
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -111,6 +111,10 @@ pub trait Network:
     /// Returns the universal SRS bytes.
     fn universal_srs_bytes() -> &'static [u8];
 
+    /// TODO (howardwu): Refactor into returning the proving and verifying key, after migrating snark into console.
+    /// Returns the `(proving key, verifying key)` bytes for the given function name in `credits.aleo`.
+    fn get_credits_key_bytes(function_name: String) -> Result<&'static (Vec<u8>, Vec<u8>)>;
+
     /// Returns the powers of `G`.
     fn g_powers() -> &'static Vec<Group<Self>>;
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -103,6 +103,10 @@ pub trait Network:
     /// The transition ID type.
     type TransitionID: Bech32ID<Field<Self>>;
 
+    /// TODO (howardwu): Refactor into returning the genesis block, after migrating ledger into console & circuit.
+    /// Returns the genesis block bytes.
+    fn genesis_bytes() -> &'static [u8];
+
     /// Returns the powers of `G`.
     fn g_powers() -> &'static Vec<Group<Self>>;
 

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -28,6 +28,8 @@ use snarkvm_console_algorithms::{
     BHP768,
 };
 
+use once_cell::sync::OnceCell;
+
 lazy_static! {
     /// The group bases for the Aleo signature and encryption schemes.
     pub static ref GENERATOR_G: Vec<Group<Testnet3>> = Testnet3::new_bases("AleoAccountEncryptionAndSignatureScheme0");
@@ -125,9 +127,19 @@ impl Network for Testnet3 {
     /// The network name.
     const NAME: &'static str = "Aleo Testnet3";
 
+    /// TODO (howardwu): Refactor into returning the genesis block, after migrating ledger into console & circuit.
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {
         snarkvm_parameters::testnet3::GenesisBytes::load_bytes()
+    }
+
+    /// TODO (howardwu): Refactor into returning the universal SRS, after migrating snark into console.
+    /// Returns the universal SRS bytes.
+    fn universal_srs_bytes() -> &'static [u8] {
+        static UNIVERSAL_SRS: OnceCell<Vec<u8>> = OnceCell::new();
+        UNIVERSAL_SRS
+            .get_or_try_init(snarkvm_parameters::testnet3::TrialSRS::load_bytes)
+            .expect("Failed to load the universal SRS bytes")
     }
 
     /// Returns the powers of `G`.

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -127,13 +127,11 @@ impl Network for Testnet3 {
     /// The network name.
     const NAME: &'static str = "Aleo Testnet3";
 
-    /// TODO (howardwu): Refactor into returning the genesis block, after migrating ledger into console & circuit.
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {
         snarkvm_parameters::testnet3::GenesisBytes::load_bytes()
     }
 
-    /// TODO (howardwu): Refactor into returning the universal SRS, after migrating snark into console.
     /// Returns the universal SRS bytes.
     fn universal_srs_bytes() -> &'static [u8] {
         static UNIVERSAL_SRS: OnceCell<Vec<u8>> = OnceCell::new();
@@ -142,7 +140,6 @@ impl Network for Testnet3 {
             .expect("Failed to load the universal SRS bytes")
     }
 
-    /// TODO (howardwu): Refactor into returning the proving and verifying key, after migrating snark into console.
     /// Returns the `(proving key, verifying key)` bytes for the given function name in `credits.aleo`.
     fn get_credits_key_bytes(function_name: String) -> Result<&'static (Vec<u8>, Vec<u8>)> {
         snarkvm_parameters::testnet3::TESTNET3_CREDITS_PROGRAM

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -142,6 +142,14 @@ impl Network for Testnet3 {
             .expect("Failed to load the universal SRS bytes")
     }
 
+    /// TODO (howardwu): Refactor into returning the proving and verifying key, after migrating snark into console.
+    /// Returns the `(proving key, verifying key)` bytes for the given function name in `credits.aleo`.
+    fn get_credits_key_bytes(function_name: String) -> Result<&'static (Vec<u8>, Vec<u8>)> {
+        snarkvm_parameters::testnet3::TESTNET3_CREDITS_PROGRAM
+            .get(&function_name.to_string())
+            .ok_or_else(|| anyhow!("Circuit keys for credits.aleo/{function_name}' not found"))
+    }
+
     /// Returns the powers of `G`.
     fn g_powers() -> &'static Vec<Group<Self>> {
         &GENERATOR_G

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -125,6 +125,11 @@ impl Network for Testnet3 {
     /// The network name.
     const NAME: &'static str = "Aleo Testnet3";
 
+    /// Returns the genesis block bytes.
+    fn genesis_bytes() -> &'static [u8] {
+        snarkvm_parameters::testnet3::GenesisBytes::load_bytes()
+    }
+
     /// Returns the powers of `G`.
     fn g_powers() -> &'static Vec<Group<Self>> {
         &GENERATOR_G

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -146,7 +146,7 @@ impl Network for Testnet3 {
     /// Returns the `(proving key, verifying key)` bytes for the given function name in `credits.aleo`.
     fn get_credits_key_bytes(function_name: String) -> Result<&'static (Vec<u8>, Vec<u8>)> {
         snarkvm_parameters::testnet3::TESTNET3_CREDITS_PROGRAM
-            .get(&function_name.to_string())
+            .get(&function_name)
             .ok_or_else(|| anyhow!("Circuit keys for credits.aleo/{function_name}' not found"))
     }
 

--- a/vm/compiler/Cargo.toml
+++ b/vm/compiler/Cargo.toml
@@ -50,10 +50,6 @@ version = "0.9.0"
 path = "../../fields"
 version = "0.9.0"
 
-[dependencies.snarkvm-parameters]
-path = "../../parameters"
-version = "0.9.0"
-
 [dependencies.snarkvm-utilities]
 path = "../../utilities"
 version = "0.9.0"

--- a/vm/compiler/benches/block.rs
+++ b/vm/compiler/benches/block.rs
@@ -19,7 +19,6 @@ extern crate criterion;
 
 use console::{network::Testnet3, prelude::*};
 use snarkvm_compiler::Block;
-use snarkvm_parameters::testnet3::GenesisBytes;
 
 use criterion::Criterion;
 use serde::{de::DeserializeOwned, Serialize};
@@ -28,7 +27,7 @@ type CurrentNetwork = Testnet3;
 
 /// Loads the genesis block.
 fn load_genesis_block() -> Block<CurrentNetwork> {
-    Block::<CurrentNetwork>::from_bytes_le(GenesisBytes::load_bytes()).unwrap()
+    Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap()
 }
 
 /// Helper method to benchmark serialization.

--- a/vm/compiler/src/ledger/get.rs
+++ b/vm/compiler/src/ledger/get.rs
@@ -111,11 +111,14 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
 mod tests {
     use super::*;
     use crate::ledger::test_helpers::CurrentLedger;
+    use console::network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_get_block() {
         // Load the genesis block.
-        let genesis = Block::from_bytes_le(GenesisBytes::load_bytes()).unwrap();
+        let genesis = Block::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();
 
         // Initialize a new ledger.
         let ledger = CurrentLedger::new(None).unwrap();

--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -49,7 +49,6 @@ use console::{
     program::{Ciphertext, Identifier, Plaintext, ProgramID, Record},
     types::{Field, Group},
 };
-use snarkvm_parameters::testnet3::GenesisBytes;
 
 use anyhow::Result;
 use indexmap::IndexMap;
@@ -112,7 +111,7 @@ impl<N: Network> Ledger<N, BlockMemory<N>, ProgramMemory<N>> {
     /// Initializes a new instance of `Ledger` with the genesis block.
     pub fn new(dev: Option<u16>) -> Result<Self> {
         // Load the genesis block.
-        let genesis = Block::<N>::from_bytes_le(GenesisBytes::load_bytes())?;
+        let genesis = Block::<N>::from_bytes_le(N::genesis_bytes())?;
         // Initialize the ledger.
         Self::new_with_genesis(&genesis, genesis.signature().to_address(), dev)
     }
@@ -191,7 +190,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
             // If there are no previous hashes, add the genesis block.
             None => {
                 // Load the genesis block.
-                let genesis = Block::<N>::from_bytes_le(GenesisBytes::load_bytes())?;
+                let genesis = Block::<N>::from_bytes_le(N::genesis_bytes())?;
                 // Add the genesis block.
                 ledger.blocks.insert(&genesis)?;
                 // Return the genesis height.
@@ -967,7 +966,7 @@ mod tests {
     #[test]
     fn test_new() {
         // Load the genesis block.
-        let genesis = Block::<CurrentNetwork>::from_bytes_le(GenesisBytes::load_bytes()).unwrap();
+        let genesis = Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();
 
         // Initialize a ledger with the genesis block.
         let ledger = CurrentLedger::new(None).unwrap();
@@ -980,7 +979,7 @@ mod tests {
     #[test]
     fn test_from() {
         // Load the genesis block.
-        let genesis = Block::<CurrentNetwork>::from_bytes_le(GenesisBytes::load_bytes()).unwrap();
+        let genesis = Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();
         // Initialize the address.
         let address =
             Address::<CurrentNetwork>::from_str("aleo1q6qstg8q8shwqf5m6q5fcenuwsdqsvp4hhsgfnx5chzjm3secyzqt9mxm8")

--- a/vm/compiler/src/process/mod.rs
+++ b/vm/compiler/src/process/mod.rs
@@ -107,11 +107,8 @@ impl<N: Network> Process<N> {
 
         // Synthesize the 'credits.aleo' circuit keys.
         for function_name in program.functions().keys() {
-            // TODO (howardwu): Abstract this into the `Network` trait.
             // Load the proving and verifying key bytes.
-            let (proving_key, verifying_key) = snarkvm_parameters::testnet3::TESTNET3_CREDITS_PROGRAM
-                .get(&function_name.to_string())
-                .ok_or_else(|| anyhow!("Circuit keys for credits.aleo/{function_name}' not found"))?;
+            let (proving_key, verifying_key) = N::get_credits_key_bytes(function_name.to_string())?;
 
             // Insert the proving and verifying key.
             stack.insert_proving_key(function_name, ProvingKey::from_bytes_le(proving_key)?)?;
@@ -139,11 +136,8 @@ impl<N: Network> Process<N> {
 
         // Synthesize the 'credits.aleo' circuit keys.
         for function_name in program.functions().keys() {
-            // TODO (howardwu): Abstract this into the `Network` trait.
             // Load the proving and verifying key bytes.
-            let (proving_key, verifying_key) = snarkvm_parameters::testnet3::TESTNET3_CREDITS_PROGRAM
-                .get(&function_name.to_string())
-                .ok_or_else(|| anyhow!("Circuit keys for credits.aleo/{function_name}' not found"))?;
+            let (proving_key, verifying_key) = N::get_credits_key_bytes(function_name.to_string())?;
 
             let (proving_key, verifying_key) = cache.entry(function_name.to_string()).or_insert_with(|| {
                 (ProvingKey::from_bytes_le(proving_key).unwrap(), VerifyingKey::from_bytes_le(verifying_key).unwrap())

--- a/vm/compiler/src/snark/universal_srs.rs
+++ b/vm/compiler/src/snark/universal_srs.rs
@@ -71,13 +71,10 @@ impl<N: Network> Deref for UniversalSRS<N> {
             let timer = std::time::Instant::now();
 
             // Load the universal SRS bytes.
-            static UNIVERSAL_SRS: OnceCell<Vec<u8>> = OnceCell::new();
-            let srs = UNIVERSAL_SRS
-                .get_or_try_init(snarkvm_parameters::testnet3::TrialSRS::load_bytes)
-                .expect("Failed to load universal SRS bytes");
+            let srs = N::universal_srs_bytes();
 
             // Recover the universal SRS.
-            let universal_srs = CanonicalDeserialize::deserialize_with_mode(&**srs, Compress::No, Validate::No)
+            let universal_srs = CanonicalDeserialize::deserialize_with_mode(srs, Compress::No, Validate::No)
                 .expect("Failed to initialize universal SRS");
 
             #[cfg(feature = "aleo-cli")]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -29,6 +29,7 @@ crate-type = [ "cdylib", "rlib" ]
 [dependencies.snarkvm-console]
 path = "../console"
 version = "0.9.0"
+features = [ "wasm" ]
 optional = true
 
 [dependencies.snarkvm-curves]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Add helper methods for `snarkvm-parameters` objects in `Network` trait.

This PR is useful for accessing network-specific objects from the `Network` trait itself, instead of hardcoding one-off imports in upstream repos such as `snarkOS`.
