### PR TITLE
Add header authorization checks for REST endpoints.

### DIFF
--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -34,7 +34,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
                     if token == format!("Basic {}", auth_token) || token == format!("Bearer {}", auth_token) {
                         Ok(())
                     } else {
-                        Err(reject::custom(RestError::Request("Unauthorized caller".to_string())))
+                        Err(reject::custom(RestError::Request("Unauthorized caller.".to_string())))
                     }
                 },
             )

--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -43,8 +43,6 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
         // GET /testnet3/latest/height
         let latest_height = warp::get()
             .and(warp::path!("testnet3" / "latest" / "height"))
-            .and(auth(auth_token.clone()))
-            .untuple_one()
             .and(with(self.ledger.clone()))
             .and_then(Self::latest_height);
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a primitive header authorization check for the REST API endpoints related to records.

The authorized token is specified before initializing the `routes` and supports Bearer tokens and Basic base64 encoded `username:password` formats.

