### PR TITLE
Don't persist the test ledger across tests

### DIFF
--- a/vm/compiler/src/ledger/mod.rs
+++ b/vm/compiler/src/ledger/mod.rs
@@ -897,25 +897,20 @@ pub(crate) mod test_helpers {
     }
 
     pub(crate) fn sample_genesis_ledger(rng: &mut TestRng) -> CurrentLedger {
-        static INSTANCE: OnceCell<CurrentLedger> = OnceCell::new();
-        INSTANCE
-            .get_or_init(|| {
-                // Sample the genesis private key.
-                let private_key = sample_genesis_private_key(rng);
-                // Sample the genesis block.
-                let genesis = sample_genesis_block_with_pk(rng, private_key);
+        // Sample the genesis private key.
+        let private_key = sample_genesis_private_key(rng);
+        // Sample the genesis block.
+        let genesis = sample_genesis_block_with_pk(rng, private_key);
 
-                // Initialize the ledger with the genesis block and the associated private key.
-                let address = Address::try_from(&private_key).unwrap();
-                let ledger = CurrentLedger::new_with_genesis(&genesis, address, None).unwrap();
-                assert_eq!(0, ledger.latest_height());
-                assert_eq!(genesis.hash(), ledger.latest_hash());
-                assert_eq!(genesis.round(), ledger.latest_round());
-                assert_eq!(genesis, ledger.get_block(0).unwrap());
+        // Initialize the ledger with the genesis block and the associated private key.
+        let address = Address::try_from(&private_key).unwrap();
+        let ledger = CurrentLedger::new_with_genesis(&genesis, address, None).unwrap();
+        assert_eq!(0, ledger.latest_height());
+        assert_eq!(genesis.hash(), ledger.latest_hash());
+        assert_eq!(genesis.round(), ledger.latest_round());
+        assert_eq!(genesis, ledger.get_block(0).unwrap());
 
-                ledger
-            })
-            .clone()
+        ledger
     }
 }
 


### PR DESCRIPTION
I've noticed that an error can be triggered if all the `compiler` tests are run together, and found the root cause to be the fact that some of the tests reuse a single ledger, leading to duplicate (and thus faulty) entries. The solution is to not reuse the ledger, which makes the tests run a bit longer, but not "cross-contaminate" one another.

In addition, the specific error (a duplicate transaction or its component) was erased by a higher-level error, which was also corrected.