### PR TITLE
A few performance tweaks for the slower tests

### DIFF
--- a/synthesizer/src/ledger/block/transactions/serialize.rs
+++ b/synthesizer/src/ledger/block/transactions/serialize.rs
@@ -72,35 +72,36 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
-    const ITERATIONS: usize = 100;
+    const ITERATIONS: usize = 10;
 
     #[test]
     fn test_serde_json() {
         let rng = &mut TestRng::default();
 
-        let check_serde_json = |expected: Transactions<CurrentNetwork>| {
+        let check_serde_json = |expected: &Transactions<CurrentNetwork>| {
             // Serialize
             let expected_string = &expected.to_string();
             let candidate_string = serde_json::to_string(&expected).unwrap();
 
             // Deserialize
-            assert_eq!(expected, Transactions::from_str(expected_string).unwrap());
-            assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+            assert_eq!(*expected, Transactions::from_str(expected_string).unwrap());
+            assert_eq!(*expected, serde_json::from_str(&candidate_string).unwrap());
         };
 
         // Check the serialization.
-        check_serde_json(crate::ledger::test_helpers::sample_genesis_block(rng).transactions().clone());
+        check_serde_json(crate::ledger::test_helpers::sample_genesis_block(rng).transactions());
 
-        for transaction in [
-            crate::ledger::vm::test_helpers::sample_deployment_transaction(rng),
-            crate::ledger::vm::test_helpers::sample_execution_transaction(rng),
-        ] {
-            for i in 0..ITERATIONS {
-                // Construct the transactions.
-                let expected: Transactions<CurrentNetwork> = vec![transaction.clone(); i].into_iter().collect();
-                // Check the serialization.
-                check_serde_json(expected);
-            }
+        for i in 0..ITERATIONS {
+            let transaction = if i % 2 == 0 {
+                crate::ledger::vm::test_helpers::sample_deployment_transaction(rng)
+            } else {
+                crate::ledger::vm::test_helpers::sample_execution_transaction(rng)
+            };
+
+            // Construct the transactions.
+            let expected: Transactions<CurrentNetwork> = [transaction.clone(), transaction].into_iter().collect();
+            // Check the serialization.
+            check_serde_json(&expected);
         }
     }
 
@@ -108,30 +109,31 @@ mod tests {
     fn test_bincode() {
         let rng = &mut TestRng::default();
 
-        let check_bincode = |expected: Transactions<CurrentNetwork>| {
+        let check_bincode = |expected: &Transactions<CurrentNetwork>| {
             // Serialize
             let expected_bytes = expected.to_bytes_le().unwrap();
             let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
             assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
 
             // Deserialize
-            assert_eq!(expected, Transactions::read_le(&expected_bytes[..]).unwrap());
-            assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+            assert_eq!(*expected, Transactions::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(*expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
         };
 
         // Check the serialization.
-        check_bincode(crate::ledger::test_helpers::sample_genesis_block(rng).transactions().clone());
+        check_bincode(crate::ledger::test_helpers::sample_genesis_block(rng).transactions());
 
-        for transaction in [
-            crate::ledger::vm::test_helpers::sample_deployment_transaction(rng),
-            crate::ledger::vm::test_helpers::sample_execution_transaction(rng),
-        ] {
-            for i in 0..ITERATIONS {
-                // Construct the transactions.
-                let expected: Transactions<CurrentNetwork> = vec![transaction.clone(); i].into_iter().collect();
-                // Check the serialization.
-                check_bincode(expected);
-            }
+        for i in 0..ITERATIONS {
+            let transaction = if i % 2 == 0 {
+                crate::ledger::vm::test_helpers::sample_deployment_transaction(rng)
+            } else {
+                crate::ledger::vm::test_helpers::sample_execution_transaction(rng)
+            };
+
+            // Construct the transactions.
+            let expected: Transactions<CurrentNetwork> = [transaction.clone(), transaction].into_iter().collect();
+            // Check the serialization.
+            check_bincode(&expected);
         }
     }
 }

--- a/synthesizer/src/ledger/mod.rs
+++ b/synthesizer/src/ledger/mod.rs
@@ -1194,21 +1194,20 @@ mod tests {
             let records: Vec<_> = ledger
                 .find_records(&view_key, RecordsFilter::Unspent)
                 .unwrap()
-                .filter(|(_, record)| !record.gates().is_zero())
+                .map(|(_, record)| record)
+                .filter(|record| !record.gates().is_zero())
                 .collect();
             assert_eq!(records.len(), 1 << (height - 1));
 
-            for (_, record) in records {
+            for record in records {
+                let num_gates = ***record.gates() / 2;
                 // Create a new transaction.
                 let transaction = Transaction::execute(
                     ledger.vm(),
                     &private_key,
                     &ProgramID::from_str("credits.aleo").unwrap(),
                     Identifier::from_str("split").unwrap(),
-                    &[
-                        Value::Record(record.clone()),
-                        Value::from_str(&format!("{}u64", ***record.gates() / 2)).unwrap(),
-                    ],
+                    &[Value::Record(record), Value::from_str(&format!("{num_gates}u64")).unwrap()],
                     None,
                     rng,
                 )


### PR DESCRIPTION
This is a new instance of https://github.com/AleoHQ/snarkVM/pull/1199 rebased on top of `testnet3.2`.

This PR includes the following adjustments:
- a few allocations are avoided or reduced in size
- the number of iterations in serialization tests for `Transactions` is reduced, but at the same time the range of tested values is increased; there is little benefit from deserializing the same values in larger collections, as 2 of them (or even just one) deserialized within the context of a collection are deserialized in the same fashion as 100