### PR TITLE
Improve the range of serialization tests for Transactions

### DIFF
--- a/synthesizer/src/block/transactions/serialize.rs
+++ b/synthesizer/src/block/transactions/serialize.rs
@@ -72,35 +72,36 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
-    const ITERATIONS: usize = 100;
+    const ITERATIONS: usize = 10;
 
     #[test]
     fn test_serde_json() {
         let rng = &mut TestRng::default();
 
-        let check_serde_json = |expected: Transactions<CurrentNetwork>| {
+        let check_serde_json = |expected: &Transactions<CurrentNetwork>| {
             // Serialize
             let expected_string = &expected.to_string();
             let candidate_string = serde_json::to_string(&expected).unwrap();
 
             // Deserialize
-            assert_eq!(expected, Transactions::from_str(expected_string).unwrap());
-            assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+            assert_eq!(*expected, Transactions::from_str(expected_string).unwrap());
+            assert_eq!(*expected, serde_json::from_str(&candidate_string).unwrap());
         };
 
         // Check the serialization.
-        check_serde_json(crate::vm::test_helpers::sample_genesis_block(rng).transactions().clone());
+        check_serde_json(crate::vm::test_helpers::sample_genesis_block(rng).transactions());
 
-        for transaction in [
-            crate::vm::test_helpers::sample_deployment_transaction(rng),
-            crate::vm::test_helpers::sample_execution_transaction(rng),
-        ] {
-            for i in 0..ITERATIONS {
-                // Construct the transactions.
-                let expected: Transactions<CurrentNetwork> = vec![transaction.clone(); i].into_iter().collect();
-                // Check the serialization.
-                check_serde_json(expected);
-            }
+        for i in 0..ITERATIONS {
+            let transaction = if i % 2 == 0 {
+                crate::vm::test_helpers::sample_deployment_transaction(rng)
+            } else {
+                crate::vm::test_helpers::sample_execution_transaction(rng)
+            };
+
+            // Construct the transactions.
+            let expected: Transactions<CurrentNetwork> = [transaction.clone(), transaction].into_iter().collect();
+            // Check the serialization.
+            check_serde_json(&expected);
         }
     }
 
@@ -108,15 +109,15 @@ mod tests {
     fn test_bincode() {
         let rng = &mut TestRng::default();
 
-        let check_bincode = |expected: Transactions<CurrentNetwork>| {
+        let check_bincode = |expected: &Transactions<CurrentNetwork>| {
             // Serialize
             let expected_bytes = expected.to_bytes_le().unwrap();
             let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
             assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
 
             // Deserialize
-            assert_eq!(expected, Transactions::read_le(&expected_bytes[..]).unwrap());
-            assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+            assert_eq!(*expected, Transactions::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(*expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
         };
 
         // Check the serialization.


### PR DESCRIPTION
This is a new instance of https://github.com/AleoHQ/snarkVM/pull/1211.

This PR includes the following adjustment:
- the number of iterations in serialization tests for `Transactions` is reduced, but at the same time the range of tested values is increased; there is little benefit from deserializing the same values in larger collections, as 2 of them (or even just one) deserialized within the context of a collection are deserialized in the same fashion as 100