### PR TITLE
Remove old parameter-related plumbing

### DIFF
--- a/curves/src/templates/macros.rs
+++ b/curves/src/templates/macros.rs
@@ -137,13 +137,8 @@ macro_rules! impl_sw_curve_serializer {
                     let (y, flags) = P::BaseField::deserialize_with_flags::<_, SWFlags>(&mut reader)?;
                     Affine::<P>::new(x, y, flags.is_infinity())
                 };
-                if !snarkvm_utilities::PROCESSING_SNARK_PARAMS.with(|p| p.load(std::sync::atomic::Ordering::Relaxed))
-                    && validate == Validate::Yes
-                {
+                if validate == Validate::Yes {
                     point.check()?;
-                } else {
-                    snarkvm_utilities::SNARK_PARAMS_AFFINE_COUNT
-                        .with(|p| p.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
                 }
                 Ok(point)
             }

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -85,17 +85,3 @@ pub fn error(_msg: &'static str) -> io::Error {
 pub fn error<S: Into<String>>(msg: S) -> io::Error {
     io::Error::new(io::ErrorKind::Other, msg.into())
 }
-
-use std::sync::atomic::{AtomicBool, AtomicU64};
-// A flag used for performance purposes in the process of loading SNARK parameters; it allows the
-// PairingEngine::GXAffine values contained in them to be verified using the computationally-heavy
-// AffineCurve::is_in_correct_subgroup_assuming_on_curve method in parallel after the deserialization
-// is complete; the other instances of PairingEngine::GXAffine are verified during deserialization.
-thread_local!(pub static PROCESSING_SNARK_PARAMS: AtomicBool = AtomicBool::new(false));
-
-// A value used in tandem with the optimization strategy enabled by PROCESSING_SNARK_PARAMS; its
-// purpose is to verify that all the PairingEngine::GXAffine values that had not been validated
-// using the AffineCurve::is_in_correct_subgroup_assuming_on_curve method during deserialization
-// were indeed accounted for afterwards; this also future-proofs the codebase against possible
-// changes to the affected objects, i.e. marlin::snark::Parameters and all of its members.
-thread_local!(pub static SNARK_PARAMS_AFFINE_COUNT: AtomicU64 = AtomicU64::new(0));


### PR DESCRIPTION
This used to be part of [an optimization](https://github.com/AleoHQ/snarkOS/pull/510) which is no longer in use, so it can be removed now.