### PR TITLE
perf: optimize PoseidonSponge::apply_s_box

### DIFF
--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -111,14 +111,15 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
     #[inline]
     fn apply_s_box(&mut self, is_full_round: bool) {
         // Full rounds apply the S Box (x^alpha) to every element of state
+        let alpha = Field::from_u64(self.parameters.alpha);
         if is_full_round {
             for elem in self.state.iter_mut() {
-                *elem = elem.pow(Field::from_u64(self.parameters.alpha));
+                *elem = elem.pow(alpha);
             }
         }
         // Partial rounds apply the S Box (x^alpha) to just the first element of state
         else {
-            self.state[0] = self.state[0].pow(Field::from_u64(self.parameters.alpha));
+            self.state[0] = self.state[0].pow(alpha);
         }
     }
 

--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -22,7 +22,7 @@ use snarkvm_console_types::{prelude::*, Field};
 use snarkvm_fields::PoseidonParameters;
 
 use smallvec::SmallVec;
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 /// A duplex sponge based using the Poseidon permutation.
 ///
@@ -111,15 +111,16 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
     #[inline]
     fn apply_s_box(&mut self, is_full_round: bool) {
         // Full rounds apply the S Box (x^alpha) to every element of state
-        let alpha = Field::from_u64(self.parameters.alpha);
         if is_full_round {
             for elem in self.state.iter_mut() {
-                *elem = elem.pow(alpha);
+                let e = elem.deref_mut();
+                *e = e.pow([self.parameters.alpha]);
             }
         }
         // Partial rounds apply the S Box (x^alpha) to just the first element of state
         else {
-            self.state[0] = self.state[0].pow(alpha);
+            let e = self.state[0].deref_mut();
+            *e = e.pow(&[self.parameters.alpha]);
         }
     }
 

--- a/console/network/environment/src/prelude.rs
+++ b/console/network/environment/src/prelude.rs
@@ -50,6 +50,7 @@ pub use core::{
         BitXor,
         BitXorAssign,
         Deref,
+        DerefMut,
         Div,
         DivAssign,
         Mul,

--- a/console/types/field/src/lib.rs
+++ b/console/types/field/src/lib.rs
@@ -107,3 +107,10 @@ impl<E: Environment> Deref for Field<E> {
         &self.field
     }
 }
+
+impl<E: Environment> DerefMut for Field<E> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.field
+    }
+}


### PR DESCRIPTION
## Motivation

Just a simple change that takes some small computation out of the loop. It has a little impact for the performance of Poseidon hashing.

I've measured performance by running `is_owner` on 4000 records with a set of view keys. The measurements were done having #1220 as `before`.

```
before:
ViewKey 1 is_owner - took 1016ms
ViewKey 2 is_owner - took 983ms
ViewKey 3 is_owner - took 979ms
ViewKey 4 is_owner - took 995ms

after:
ViewKey 1 is_owner - took 981ms
ViewKey 2 is_owner - took 966ms
ViewKey 3 is_owner - took 960ms
ViewKey 4 is_owner - took 974ms

delta: - 2.3%
```

Benchmarks also show some improvement:
```
cargo bench -p snarkvm-console-algorithms
     Running benches/poseidon.rs (target/release/deps/poseidon_sponge-6420e1a66de45bd7)

Initializing 'TestRng' with seed '17000280702372166668'

Poseidon2 Hash 4 -> 1   time:   [60.148 µs 60.183 µs 60.227 µs]
                        change: [-1.4331% -1.0807% -0.7079%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe

Poseidon2 Hash 4 -> 2   time:   [60.025 µs 60.041 µs 60.059 µs]
                        change: [-1.8530% -1.5603% -1.2386%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) high mild
  3 (6.00%) high severe

Poseidon2 Hash 10 -> 1  time:   [119.64 µs 120.03 µs 120.28 µs]
                        change: [-1.9526% -1.5066% -1.0496%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 50 measurements (12.00%)
  4 (8.00%) low severe
  2 (4.00%) high severe

Poseidon2 Hash 10 -> 4  time:   [140.58 µs 140.69 µs 140.78 µs]
                        change: [-1.3156% -0.8590% -0.3932%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 50 measurements (14.00%)
  4 (8.00%) low severe
  1 (2.00%) low mild
  2 (4.00%) high severe

Poseidon2 Hash 10 -> 8  time:   [180.00 µs 180.20 µs 180.34 µs]
                        change: [+0.5574% +1.0724% +1.5183%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 50 measurements (12.00%)
  1 (2.00%) low severe
  1 (2.00%) low mild
  1 (2.00%) high mild
  3 (6.00%) high severe


Initializing 'TestRng' with seed '17457241366828768168'

Poseidon4 Hash 4 -> 1   time:   [61.996 µs 62.044 µs 62.083 µs]
                        change: [-2.2549% -1.9119% -1.5309%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  3 (6.00%) high severe

Poseidon4 Hash 4 -> 2   time:   [62.044 µs 62.084 µs 62.135 µs]
                        change: [-2.3325% -2.0143% -1.6640%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) low severe
  1 (2.00%) low mild
  2 (4.00%) high severe

Poseidon4 Hash 10 -> 1  time:   [123.96 µs 123.99 µs 124.02 µs]
                        change: [-2.3253% -1.9996% -1.6815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 50 measurements (14.00%)
  1 (2.00%) high mild
  6 (12.00%) high severe

Poseidon4 Hash 10 -> 4  time:   [124.24 µs 124.40 µs 124.68 µs]
                        change: [-1.6629% -1.1981% -0.7099%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) high mild
  3 (6.00%) high severe

Poseidon4 Hash 10 -> 8  time:   [155.01 µs 155.03 µs 155.07 µs]
                        change: [-1.7102% -1.2586% -0.7658%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 50 measurements (16.00%)
  1 (2.00%) low severe
  3 (6.00%) high mild
  4 (8.00%) high severe


Initializing 'TestRng' with seed '1836092315237582325'

Poseidon8 Hash 4 -> 1   time:   [121.06 µs 121.13 µs 121.19 µs]
                        change: [-2.1097% -1.8514% -1.5573%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 50 measurements (12.00%)
  2 (4.00%) low severe
  1 (2.00%) low mild
  3 (6.00%) high severe

Poseidon8 Hash 4 -> 2   time:   [121.19 µs 121.23 µs 121.27 µs]
                        change: [-1.9838% -1.6460% -1.3075%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe

Poseidon8 Hash 10 -> 1  time:   [182.59 µs 182.75 µs 182.90 µs]
                        change: [-2.0556% -1.6922% -1.3484%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high severe

Poseidon8 Hash 10 -> 4  time:   [182.12 µs 182.21 µs 182.30 µs]
                        change: [-2.0102% -1.6464% -1.2514%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 50 measurements (10.00%)
  1 (2.00%) high mild
  4 (8.00%) high severe

Poseidon8 Hash 10 -> 8  time:   [182.14 µs 182.21 µs 182.27 µs]
                        change: [-2.2222% -1.9227% -1.6142%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 50 measurements (10.00%)
  1 (2.00%) high mild
  4 (8.00%) high severe
```
