### PR TITLE
Supports operands in `output` instructions

### DIFF
--- a/circuit/program/src/response/from_outputs.rs
+++ b/circuit/program/src/response/from_outputs.rs
@@ -27,7 +27,7 @@ impl<A: Aleo> Response<A> {
         tcm: &Field<A>,
         outputs: Vec<Value<A>>,
         output_types: &[console::ValueType<A::Network>], // Note: Console type
-        output_registers: &[console::Register<A::Network>], // Note: Console type
+        output_registers: &[Option<console::Register<A::Network>>], // Note: Console type
     ) -> Self {
         // Compute the function ID as `Hash(network_id, program_id, function_name)`.
         let function_id =
@@ -99,6 +99,12 @@ impl<A: Aleo> Response<A> {
                             Value::Record(record) => record,
                             // Ensure the output is a record.
                             Value::Plaintext(..) => A::halt("Expected a record output, found a plaintext output"),
+                        };
+
+                        // Retrieve the output register.
+                        let output_register = match output_register {
+                            Some(output_register) => output_register,
+                            None => A::halt("Expected a register to be paired with a record output"),
                         };
 
                         // Compute the record commitment.
@@ -201,11 +207,11 @@ mod tests {
 
             // Construct the output registers.
             let output_registers = vec![
-                console::Register::Locator(5),
-                console::Register::Locator(6),
-                console::Register::Locator(7),
-                console::Register::Locator(8),
-                console::Register::Locator(9),
+                Some(console::Register::Locator(5)),
+                Some(console::Register::Locator(6)),
+                Some(console::Register::Locator(7)),
+                Some(console::Register::Locator(8)),
+                Some(console::Register::Locator(9)),
             ];
 
             // Construct a network ID.

--- a/circuit/program/src/response/process_outputs_from_callback.rs
+++ b/circuit/program/src/response/process_outputs_from_callback.rs
@@ -216,11 +216,11 @@ mod tests {
 
             // Construct the output registers.
             let output_registers = vec![
-                console::Register::Locator(5),
-                console::Register::Locator(6),
-                console::Register::Locator(7),
-                console::Register::Locator(8),
-                console::Register::Locator(9),
+                Some(console::Register::Locator(5)),
+                Some(console::Register::Locator(6)),
+                Some(console::Register::Locator(7)),
+                Some(console::Register::Locator(8)),
+                Some(console::Register::Locator(9)),
             ];
 
             // Construct a network ID.

--- a/console/program/src/response/mod.rs
+++ b/console/program/src/response/mod.rs
@@ -58,7 +58,7 @@ impl<N: Network> Response<N> {
         tcm: &Field<N>,
         outputs: Vec<Value<N>>,
         output_types: &[ValueType<N>],
-        output_registers: &[Register<N>],
+        output_operands: &[Option<Register<N>>],
     ) -> Result<Self> {
         // Compute the function ID as `Hash(network_id, program_id, function_name)`.
         let function_id =
@@ -68,7 +68,7 @@ impl<N: Network> Response<N> {
         let output_ids = outputs
             .iter()
             .zip_eq(output_types)
-            .zip_eq(output_registers)
+            .zip_eq(output_operands)
             .enumerate()
             .map(|(index, ((output, output_type), output_register))| {
                 match output_type {
@@ -140,6 +140,12 @@ impl<N: Network> Response<N> {
                             Value::Record(record) => record,
                             // Ensure the input is a record.
                             Value::Plaintext(..) => bail!("Expected a record output, found a plaintext output"),
+                        };
+
+                        // Retrieve the output register.
+                        let output_register = match output_register {
+                            Some(output_register) => output_register,
+                            None => bail!("Expected a register to be paired with a record output"),
                         };
 
                         // Compute the record commitment.

--- a/synthesizer/src/block/transition/mod.rs
+++ b/synthesizer/src/block/transition/mod.rs
@@ -98,7 +98,7 @@ impl<N: Network> Transition<N> {
         response: &Response<N>,
         finalize: Option<Vec<Value<N>>>,
         output_types: &[ValueType<N>],
-        output_registers: &[Register<N>],
+        output_registers: &[Option<Register<N>>],
         proof: Proof<N>,
         fee: i64,
     ) -> Result<Self> {
@@ -207,6 +207,12 @@ impl<N: Network> Transition<N> {
                             ValueType::Record(record_name) => record_name,
                             // Ensure the input type is a record.
                             _ => bail!("Expected a record type at output {index}"),
+                        };
+
+                        // Retrieve the output register.
+                        let output_register = match output_register {
+                            Some(output_register) => output_register,
+                            None => bail!("Expected a register to be paired with a record output"),
                         };
 
                         // Compute the record commitment.

--- a/synthesizer/src/process/execute.rs
+++ b/synthesizer/src/process/execute.rs
@@ -15,6 +15,7 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
+use console::program::Literal;
 
 impl<N: Network> Process<N> {
     /// Executes the given authorization.
@@ -298,17 +299,28 @@ impl<N: Network> Process<N> {
                     }
                 }
 
-                // Retrieve the output registers.
-                let output_registers =
-                    &finalize.outputs().iter().map(|output| output.register().clone()).collect::<Vec<_>>();
+                // Retrieve the output operands.
+                let output_operands =
+                    &finalize.outputs().iter().map(|output| output.operand().clone()).collect::<Vec<_>>();
 
                 // TODO (howardwu): Save the outputs in ProgramStore.
                 // Load the outputs.
-                let _outputs = output_registers
+                let _outputs = output_operands
                     .iter()
-                    .map(|register| {
-                        // Retrieve the stack value from the register.
-                        registers.load(stack, &Operand::Register(register.clone()))
+                    .map(|operand| {
+                        // Load the outputs.
+                        match operand.clone() {
+                            // If the operand is a literal, use the literal directly.
+                            Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
+                            // If the operand is a register, retrieve the stack value from the register.
+                            Operand::Register(register) => registers.load(stack, &Operand::Register(register)),
+                            // If the operand is the program ID, convert the program ID into an address.
+                            Operand::ProgramID(program_id) => {
+                                Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))
+                            }
+                            // If the operand is the caller, retrieve the caller from the registers.
+                            Operand::Caller => bail!("Forbidden operation: Cannot use 'self.caller' in 'finalize'"),
+                        }
                     })
                     .collect::<Result<Vec<_>>>()?;
 

--- a/synthesizer/src/process/execute.rs
+++ b/synthesizer/src/process/execute.rs
@@ -300,12 +300,11 @@ impl<N: Network> Process<N> {
                 }
 
                 // Retrieve the output operands.
-                let output_operands = finalize.outputs().iter().map(|output| output.operand()).collect::<Vec<_>>();
+                let output_operands = finalize.outputs().iter().map(|output| output.operand());
 
                 // TODO (howardwu): Save the outputs in ProgramStore.
                 // Load the outputs.
                 let _outputs = output_operands
-                    .iter()
                     .map(|operand| {
                         // Load the outputs.
                         match operand {

--- a/synthesizer/src/process/execute.rs
+++ b/synthesizer/src/process/execute.rs
@@ -300,8 +300,7 @@ impl<N: Network> Process<N> {
                 }
 
                 // Retrieve the output operands.
-                let output_operands =
-                    &finalize.outputs().iter().map(|output| output.operand().clone()).collect::<Vec<_>>();
+                let output_operands = finalize.outputs().iter().map(|output| output.operand()).collect::<Vec<_>>();
 
                 // TODO (howardwu): Save the outputs in ProgramStore.
                 // Load the outputs.
@@ -309,11 +308,11 @@ impl<N: Network> Process<N> {
                     .iter()
                     .map(|operand| {
                         // Load the outputs.
-                        match operand.clone() {
+                        match operand {
                             // If the operand is a literal, use the literal directly.
                             Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
                             // If the operand is a register, retrieve the stack value from the register.
-                            Operand::Register(register) => registers.load(stack, &Operand::Register(register)),
+                            Operand::Register(register) => registers.load(stack, &Operand::Register(register.clone())),
                             // If the operand is the program ID, convert the program ID into an address.
                             Operand::ProgramID(program_id) => {
                                 Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))

--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -62,11 +62,20 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Evaluate the instructions");
 
         // Load the outputs.
-        let outputs_iter = closure.outputs().iter().map(|output| {
-            // Retrieve the stack value from the register.
-            registers.load(self, &Operand::Register(output.register().clone()))
-        });
-        let outputs = outputs_iter.collect();
+        let outputs = closure.outputs().iter().map(|output| {
+            match output.operand().clone() {
+                // If the operand is a literal, use the literal directly.
+                Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
+                // If the operand is a register, retrieve the stack value from the register.
+                Operand::Register(register) => registers.load(self, &Operand::Register(register)),
+                // If the operand is the program ID, convert the program ID into an address.
+                Operand::ProgramID(program_id) => {
+                    Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))
+                }
+                // If the operand is the caller, retrieve the caller from the registers.
+                Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),
+            }
+        }).collect();
         lap!(timer, "Load the outputs");
 
         finish!(timer);
@@ -143,21 +152,40 @@ impl<N: Network> Stack<N> {
         }
         lap!(timer, "Evaluate the instructions");
 
-        // Retrieve the output registers.
-        let output_registers = &function.outputs().iter().map(|output| output.register().clone()).collect::<Vec<_>>();
-        lap!(timer, "Retrieve the output registers");
+        // Retrieve the output operands.
+        let output_operands = &function.outputs().iter().map(|output| output.operand().clone()).collect::<Vec<_>>();
+        lap!(timer, "Retrieve the output operands");
 
         // Load the outputs.
-        let outputs = output_registers
+        let outputs = output_operands
             .iter()
-            .map(|register| {
-                // Retrieve the stack value from the register.
-                registers.load(self, &Operand::Register(register.clone()))
+            .map(|operand| {
+                match operand.clone() {
+                    // If the operand is a literal, use the literal directly.
+                    Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
+                    // If the operand is a register, retrieve the stack value from the register.
+                    Operand::Register(register) => registers.load(self, &Operand::Register(register)),
+                    // If the operand is the program ID, convert the program ID into an address.
+                    Operand::ProgramID(program_id) => {
+                        Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))
+                    }
+                    // If the operand is the caller, retrieve the caller from the registers.
+                    Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),
+                }
             })
             .collect::<Result<Vec<_>>>()?;
         lap!(timer, "Load the outputs");
 
         finish!(timer);
+
+        // Map the output operands to registers.
+        let output_registers = output_operands
+            .iter()
+            .map(|operand| match operand {
+                Operand::Register(register) => Some(register.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
         // Compute the response.
         Response::new(
@@ -169,7 +197,7 @@ impl<N: Network> Stack<N> {
             request.tcm(),
             outputs,
             &function.output_types(),
-            output_registers,
+            &output_registers,
         )
     }
 }

--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -62,20 +62,24 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Evaluate the instructions");
 
         // Load the outputs.
-        let outputs = closure.outputs().iter().map(|output| {
-            match output.operand().clone() {
-                // If the operand is a literal, use the literal directly.
-                Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
-                // If the operand is a register, retrieve the stack value from the register.
-                Operand::Register(register) => registers.load(self, &Operand::Register(register)),
-                // If the operand is the program ID, convert the program ID into an address.
-                Operand::ProgramID(program_id) => {
-                    Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))
+        let outputs = closure
+            .outputs()
+            .iter()
+            .map(|output| {
+                match output.operand() {
+                    // If the operand is a literal, use the literal directly.
+                    Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
+                    // If the operand is a register, retrieve the stack value from the register.
+                    Operand::Register(register) => registers.load(self, &Operand::Register(register.clone())),
+                    // If the operand is the program ID, convert the program ID into an address.
+                    Operand::ProgramID(program_id) => {
+                        Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))
+                    }
+                    // If the operand is the caller, retrieve the caller from the registers.
+                    Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),
                 }
-                // If the operand is the caller, retrieve the caller from the registers.
-                Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),
-            }
-        }).collect();
+            })
+            .collect();
         lap!(timer, "Load the outputs");
 
         finish!(timer);
@@ -153,18 +157,18 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Evaluate the instructions");
 
         // Retrieve the output operands.
-        let output_operands = &function.outputs().iter().map(|output| output.operand().clone()).collect::<Vec<_>>();
+        let output_operands = &function.outputs().iter().map(|output| output.operand()).collect::<Vec<_>>();
         lap!(timer, "Retrieve the output operands");
 
         // Load the outputs.
         let outputs = output_operands
             .iter()
             .map(|operand| {
-                match operand.clone() {
+                match operand {
                     // If the operand is a literal, use the literal directly.
                     Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
                     // If the operand is a register, retrieve the stack value from the register.
-                    Operand::Register(register) => registers.load(self, &Operand::Register(register)),
+                    Operand::Register(register) => registers.load(self, &Operand::Register(register.clone())),
                     // If the operand is the program ID, convert the program ID into an address.
                     Operand::ProgramID(program_id) => {
                         Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -82,12 +82,27 @@ impl<N: Network> Stack<N> {
         // Ensure the number of public variables remains the same.
         ensure!(A::num_public() == num_public, "Illegal closure operation: instructions injected public variables");
 
+        use circuit::Inject;
+
         // Load the outputs.
-        let outputs_iter = closure.outputs().iter().map(|output| {
-            // Retrieve the circuit output from the register.
-            registers.load_circuit(self, &Operand::Register(output.register().clone()))
-        });
-        let outputs = outputs_iter.collect();
+        let outputs = closure.outputs().iter().map(|output| {
+            match output.operand().clone() {
+                // If the operand is a literal, use the literal directly.
+                Operand::Literal(literal) => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
+                    circuit::Literal::new(circuit::Mode::Constant, literal),
+                ))),
+                // If the operand is a register, retrieve the stack value from the register.
+                Operand::Register(register) => registers.load_circuit(self, &Operand::Register(register)),
+                // If the operand is the program ID, convert the program ID into an address.
+                Operand::ProgramID(program_id) => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
+                    circuit::Literal::Address(circuit::Address::new(circuit::Mode::Constant, program_id.to_address()?)),
+                ))),
+                // If the operand is the caller, retrieve the caller from the registers.
+                Operand::Caller => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
+                    registers.caller_circuit()?,
+                )))),
+            }
+        }).collect();
         lap!(timer, "Load the outputs");
 
         finish!(timer);
@@ -222,12 +237,40 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Execute the instructions");
 
         // Load the outputs.
-        let output_registers = &function.outputs().iter().map(|output| output.register().clone()).collect::<Vec<_>>();
-        let outputs = output_registers
+        let output_operands = &function.outputs().iter().map(|output| output.operand().clone()).collect::<Vec<_>>();
+        let outputs = output_operands
             .iter()
-            .map(|register| registers.load_circuit(self, &Operand::Register(register.clone())))
+            .map(|operand| {
+                match operand.clone() {
+                    // If the operand is a literal, use the literal directly.
+                    Operand::Literal(literal) => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
+                        circuit::Literal::new(circuit::Mode::Constant, literal),
+                    ))),
+                    // If the operand is a register, retrieve the stack value from the register.
+                    Operand::Register(register) => registers.load_circuit(self, &Operand::Register(register)),
+                    // If the operand is the program ID, convert the program ID into an address.
+                    Operand::ProgramID(program_id) => {
+                        Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
+                            circuit::Address::new(circuit::Mode::Constant, program_id.to_address()?),
+                        ))))
+                    }
+                    // If the operand is the caller, retrieve the caller from the registers.
+                    Operand::Caller => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
+                        circuit::Literal::Address(registers.caller_circuit()?),
+                    ))),
+                }
+            })
             .collect::<Result<Vec<_>>>()?;
         lap!(timer, "Load the outputs");
+
+        // Map the output operands into registers.
+        let output_registers = output_operands
+            .iter()
+            .map(|operand| match operand {
+                Operand::Register(register) => Some(register.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
         #[cfg(debug_assertions)]
         Self::log_circuit::<A, _>(format!("Function '{}()'", function.name()));
@@ -251,7 +294,7 @@ impl<N: Network> Stack<N> {
             request.tcm(),
             outputs,
             &output_types,
-            output_registers,
+            &output_registers,
         );
         lap!(timer, "Construct the response");
 
@@ -463,8 +506,7 @@ impl<N: Network> Stack<N> {
             lap!(timer, "Execute the circuit");
 
             // Construct the transition.
-            let transition =
-                Transition::from(&console_request, &response, finalize, &output_types, output_registers, proof, *fee)?;
+            let transition = Transition::from(&console_request, &response, finalize, &output_types, &output_registers, proof, *fee)?;
 
             // Add the transition commitments.
             inclusion.write().insert_transition(console_request.input_ids(), &transition)?;

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -46,8 +46,8 @@ impl<N: Network> RegisterTypes<N> {
                 "Closure outputs do not support records"
             );
 
-            // Check the output register type.
-            register_types.check_output(stack, output.register(), output.register_type())?;
+            // Check the output operand type.
+            register_types.check_output(stack, output.operand(), output.register_type())?;
         }
 
         Ok(register_types)
@@ -79,8 +79,8 @@ impl<N: Network> RegisterTypes<N> {
 
         // Step 3. Check the outputs are well-formed.
         for output in function.outputs() {
-            // Retrieve the register type and check the output register type.
-            register_types.check_output(stack, output.register(), &RegisterType::from(*output.value_type()))?;
+            // Check the output operand type.
+            register_types.check_output(stack, output.operand(), &RegisterType::from(*output.value_type()))?;
         }
 
         // Step 4. If the function has a finalize command, check that its operands are all defined.
@@ -219,15 +219,18 @@ impl<N: Network> RegisterTypes<N> {
 
     /// Ensure the given output register is well-formed.
     #[inline]
-    fn check_output(
-        &mut self,
-        stack: &Stack<N>,
-        register: &Register<N>,
-        register_type: &RegisterType<N>,
-    ) -> Result<()> {
-        // Inform the user the output register is an input register, to ensure this is intended behavior.
-        if self.is_input(register) {
-            eprintln!("Output {register} in '{}' is an input register, ensure this is intended", stack.program_id());
+    fn check_output(&mut self, stack: &Stack<N>, operand: &Operand<N>, register_type: &RegisterType<N>) -> Result<()> {
+        match operand {
+            // Inform the user the output operand is an input register, to ensure this is intended behavior.
+            Operand::Register(register) if self.is_input(register) => {
+                eprintln!("Output {operand} in '{}' is an input register, ensure this is intended", stack.program_id())
+            }
+            // Inform the user the output operand is a literal, to ensure this is intended behavior.
+            Operand::Literal(..) => {
+                eprintln!("Output {operand} in '{}' is a literal, ensure this is intended", stack.program_id())
+            }
+            // Otherwise, do nothing.
+            _ => (),
         }
 
         // Ensure the register type is defined in the program.
@@ -253,11 +256,11 @@ impl<N: Network> RegisterTypes<N> {
             }
         };
 
-        // Ensure the register type and the output type match.
-        if *register_type != self.get_type(stack, register)? {
+        // Ensure the operand type and the output type match.
+        if *register_type != self.get_type_from_operand(stack, operand)? {
             bail!(
-                "Output '{register}' does not match the expected output register type: expected '{}', found '{}'",
-                self.get_type(stack, register)?,
+                "Output '{operand}' does not match the expected output operand type: expected '{}', found '{}'",
+                self.get_type_from_operand(stack, operand)?,
                 register_type
             )
         }

--- a/synthesizer/src/program/closure/mod.rs
+++ b/synthesizer/src/program/closure/mod.rs
@@ -100,9 +100,13 @@ impl<N: Network> Closure<N> {
     /// Adds the given instruction to the closure.
     ///
     /// # Errors
+    /// This method will halt if there are output statements already.
     /// This method will halt if the maximum number of instructions has been reached.
     #[inline]
     pub fn add_instruction(&mut self, instruction: Instruction<N>) -> Result<()> {
+        // Ensure that there are no outputs in memory.
+        ensure!(self.outputs.is_empty(), "Cannot add instructions after outputs have been added");
+
         // Ensure the maximum number of instructions has not been exceeded.
         ensure!(
             self.instructions.len() <= N::MAX_INSTRUCTIONS,
@@ -123,13 +127,9 @@ impl<N: Network> Closure<N> {
     /// Adds the output statement to the closure.
     ///
     /// # Errors
-    /// This method will halt if there are no instructions in memory.
     /// This method will halt if the maximum number of outputs has been reached.
     #[inline]
     fn add_output(&mut self, output: Output<N>) -> Result<()> {
-        // Ensure there are instructions in memory.
-        ensure!(!self.instructions.is_empty(), "Cannot add outputs before instructions have been added");
-
         // Ensure the maximum number of outputs has not been exceeded.
         ensure!(self.outputs.len() <= N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
 

--- a/synthesizer/src/program/closure/output/bytes.rs
+++ b/synthesizer/src/program/closure/output/bytes.rs
@@ -19,16 +19,16 @@ use super::*;
 impl<N: Network> FromBytes for Output<N> {
     /// Reads the output from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let register = FromBytes::read_le(&mut reader)?;
+        let operand = FromBytes::read_le(&mut reader)?;
         let register_type = FromBytes::read_le(&mut reader)?;
-        Ok(Self { register, register_type })
+        Ok(Self { operand, register_type })
     }
 }
 
 impl<N: Network> ToBytes for Output<N> {
     /// Writes the output to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.register.write_le(&mut writer)?;
+        self.operand.write_le(&mut writer)?;
         self.register_type.write_le(&mut writer)
     }
 }

--- a/synthesizer/src/program/closure/output/mod.rs
+++ b/synthesizer/src/program/closure/output/mod.rs
@@ -17,18 +17,16 @@
 mod bytes;
 mod parse;
 
-use console::{
-    network::prelude::*,
-    program::{Register, RegisterType},
-};
+use crate::Operand;
 
-/// An output statement defines an output of a function, and may refer to the register
-/// in either a register or a register member. An output statement is of the form
-/// `output {register} as {register_type};`.
+use console::{network::prelude::*, program::RegisterType};
+
+/// An output statement defines an output of a closure.
+/// An output statement is of the form `output {operand} as {register_type};`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Output<N: Network> {
-    /// The output register.
-    register: Register<N>,
+    /// The output operand.
+    operand: Operand<N>,
     /// The output register type.
     register_type: RegisterType<N>,
 }
@@ -36,8 +34,8 @@ pub struct Output<N: Network> {
 impl<N: Network> Output<N> {
     /// Returns the output register.
     #[inline]
-    pub const fn register(&self) -> &Register<N> {
-        &self.register
+    pub const fn operand(&self) -> &Operand<N> {
+        &self.operand
     }
 
     /// Returns the output register type.

--- a/synthesizer/src/program/closure/output/parse.rs
+++ b/synthesizer/src/program/closure/output/parse.rs
@@ -126,7 +126,7 @@ mod tests {
 
         // Literal
         let output = Output::<CurrentNetwork>::parse("output 0u8 as u8;").unwrap().1;
-        assert_eq!(format!("{}", output), "output 0u8 as u8;");
+        assert_eq!(format!("{output}"), "output 0u8 as u8;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature;").unwrap().1;

--- a/synthesizer/src/program/closure/output/parse.rs
+++ b/synthesizer/src/program/closure/output/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 
 impl<N: Network> Parser for Output<N> {
     /// Parses a string into an output statement.
-    /// The output statement is of the form `output {register} as {register_type};`.
+    /// The output statement is of the form `output {operand} as {register_type};`.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the whitespace and comments from the string.
@@ -27,8 +27,8 @@ impl<N: Network> Parser for Output<N> {
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the register from the string.
-        let (string, register) = Register::parse(string)?;
+        // Parse the operand from the string.
+        let (string, operand) = Operand::parse(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "as" from the string.
@@ -42,7 +42,7 @@ impl<N: Network> Parser for Output<N> {
         // Parse the semicolon from the string.
         let (string, _) = tag(";")(string)?;
         // Return the output statement.
-        Ok((string, Self { register, register_type }))
+        Ok((string, Self { operand, register_type }))
     }
 }
 
@@ -76,9 +76,9 @@ impl<N: Network> Display for Output<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "{type_} {register} as {register_type};",
+            "{type_} {operand} as {register_type};",
             type_ = Self::type_name(),
-            register = self.register,
+            operand = self.operand,
             register_type = self.register_type
         )
     }
@@ -87,25 +87,32 @@ impl<N: Network> Display for Output<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
+    use console::{
+        network::Testnet3,
+        program::{Literal, Register, U8},
+    };
 
     type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_output_parse() -> Result<()> {
-        // Literal
+        // Register
         let output = Output::<CurrentNetwork>::parse("output r0 as field;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(0));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(0)));
         assert_eq!(output.register_type(), &RegisterType::<CurrentNetwork>::from_str("field")?);
+
+        let output = Output::<CurrentNetwork>::parse("output 0u8 as u8;").unwrap().1;
+        assert_eq!(output.operand(), &Operand::Literal(Literal::<CurrentNetwork>::U8(U8::new(0))));
+        assert_eq!(output.register_type(), &RegisterType::<CurrentNetwork>::from_str("u8")?);
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(1));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(1)));
         assert_eq!(output.register_type(), &RegisterType::<CurrentNetwork>::from_str("signature")?);
 
         // Record
         let output = Output::<CurrentNetwork>::parse("output r2 as token.record;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(2));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(2)));
         assert_eq!(output.register_type(), &RegisterType::<CurrentNetwork>::from_str("token.record")?);
 
         Ok(())
@@ -113,9 +120,13 @@ mod tests {
 
     #[test]
     fn test_output_display() {
-        // Literal
+        // Register
         let output = Output::<CurrentNetwork>::parse("output r0 as field;").unwrap().1;
         assert_eq!(format!("{output}"), "output r0 as field;");
+
+        // Literal
+        let output = Output::<CurrentNetwork>::parse("output 0u8 as u8;").unwrap().1;
+        assert_eq!(format!("{}", output), "output 0u8 as u8;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature;").unwrap().1;

--- a/synthesizer/src/program/finalize/mod.rs
+++ b/synthesizer/src/program/finalize/mod.rs
@@ -113,9 +113,13 @@ impl<N: Network> Finalize<N> {
     /// Adds the given command to finalize.
     ///
     /// # Errors
+    /// This method will halt if there are output statements already.
     /// This method will halt if the maximum number of commands has been reached.
     #[inline]
     pub fn add_command(&mut self, command: Command<N>) -> Result<()> {
+        // Ensure there are no output statements in memory.
+        ensure!(self.outputs.is_empty(), "Cannot add commands after outputs have been added");
+
         // Ensure the maximum number of commands has not been exceeded.
         ensure!(self.commands.len() <= N::MAX_COMMANDS, "Cannot add more than {} commands", N::MAX_COMMANDS);
 
@@ -141,13 +145,9 @@ impl<N: Network> Finalize<N> {
     /// Adds the output statement to finalize.
     ///
     /// # Errors
-    /// This method will halt if there are no commands in memory.
     /// This method will halt if the maximum number of outputs has been reached.
     #[inline]
     fn add_output(&mut self, output: Output<N>) -> Result<()> {
-        // Ensure there are commands in memory.
-        ensure!(!self.commands.is_empty(), "Cannot add outputs before commands have been added");
-
         // Ensure the maximum number of outputs has not been exceeded.
         ensure!(self.outputs.len() <= N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
         // Ensure the output statement was not previously added.

--- a/synthesizer/src/program/finalize/output/bytes.rs
+++ b/synthesizer/src/program/finalize/output/bytes.rs
@@ -19,16 +19,16 @@ use super::*;
 impl<N: Network> FromBytes for Output<N> {
     /// Reads the output from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let register = FromBytes::read_le(&mut reader)?;
+        let operand = FromBytes::read_le(&mut reader)?;
         let finalize_type = FromBytes::read_le(&mut reader)?;
-        Ok(Self { register, finalize_type })
+        Ok(Self { operand, finalize_type })
     }
 }
 
 impl<N: Network> ToBytes for Output<N> {
     /// Writes the output to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.register.write_le(&mut writer)?;
+        self.operand.write_le(&mut writer)?;
         self.finalize_type.write_le(&mut writer)
     }
 }

--- a/synthesizer/src/program/finalize/output/mod.rs
+++ b/synthesizer/src/program/finalize/output/mod.rs
@@ -17,27 +17,25 @@
 mod bytes;
 mod parse;
 
-use console::{
-    network::prelude::*,
-    program::{FinalizeType, Register},
-};
+use crate::Operand;
 
-/// An output statement defines an output of finalize, and may refer to the value
-/// in either a register or a register member. An output statement is of the form
-/// `output {register} as {finalize_type};`.
+use console::{network::prelude::*, program::FinalizeType};
+
+/// An output statement defines an output of finalize.
+/// An output statement is of the form `output {operand} as {finalize_type};`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Output<N: Network> {
-    /// The output register.
-    register: Register<N>,
+    /// The output operand.
+    operand: Operand<N>,
     /// The output finalize type.
     finalize_type: FinalizeType<N>,
 }
 
 impl<N: Network> Output<N> {
-    /// Returns the output register.
+    /// Returns the output operand.
     #[inline]
-    pub const fn register(&self) -> &Register<N> {
-        &self.register
+    pub const fn operand(&self) -> &Operand<N> {
+        &self.operand
     }
 
     /// Returns the output finalize type.

--- a/synthesizer/src/program/finalize/output/parse.rs
+++ b/synthesizer/src/program/finalize/output/parse.rs
@@ -127,7 +127,7 @@ mod tests {
 
         // Literal
         let output = Output::<CurrentNetwork>::parse("output 0u8 as u8.public;").unwrap().1;
-        assert_eq!(format!("{}", output), "output 0u8 as u8.public;");
+        assert_eq!(format!("{output}"), "output 0u8 as u8.public;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.public;").unwrap().1;

--- a/synthesizer/src/program/finalize/output/parse.rs
+++ b/synthesizer/src/program/finalize/output/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 
 impl<N: Network> Parser for Output<N> {
     /// Parses a string into an output statement.
-    /// The output statement is of the form `output {register} as {finalize_type};`.
+    /// The output statement is of the form `output {operand} as {finalize_type};`.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the whitespace and comments from the string.
@@ -27,8 +27,8 @@ impl<N: Network> Parser for Output<N> {
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the register from the string.
-        let (string, register) = Register::parse(string)?;
+        // Parse the operand from the string.
+        let (string, operand) = Operand::parse(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "as" from the string.
@@ -42,7 +42,7 @@ impl<N: Network> Parser for Output<N> {
         // Parse the semicolon from the string.
         let (string, _) = tag(";")(string)?;
         // Return the output statement.
-        Ok((string, Self { register, finalize_type }))
+        Ok((string, Self { operand, finalize_type }))
     }
 }
 
@@ -76,9 +76,9 @@ impl<N: Network> Display for Output<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "{type_} {register} as {finalize_type};",
+            "{type_} {operand} as {finalize_type};",
             type_ = Self::type_name(),
-            register = self.register,
+            operand = self.operand,
             finalize_type = self.finalize_type
         )
     }
@@ -87,25 +87,33 @@ impl<N: Network> Display for Output<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
+    use console::{
+        network::Testnet3,
+        program::{Literal, Register, U8},
+    };
 
     type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_output_parse() -> Result<()> {
-        // Literal
+        // Register
         let output = Output::<CurrentNetwork>::parse("output r0 as field.public;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(0));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(0)));
         assert_eq!(output.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("field.public")?);
+
+        // Literal
+        let output = Output::<CurrentNetwork>::parse("output 0u8 as u8.public;").unwrap().1;
+        assert_eq!(output.operand(), &Operand::Literal(Literal::<CurrentNetwork>::U8(U8::new(0))));
+        assert_eq!(output.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("u8.public")?);
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.public;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(1));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(1)));
         assert_eq!(output.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("signature.public")?);
 
         // Record
         let output = Output::<CurrentNetwork>::parse("output r2 as token.record;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(2));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(2)));
         assert_eq!(output.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("token.record")?);
 
         Ok(())
@@ -113,9 +121,13 @@ mod tests {
 
     #[test]
     fn test_output_display() {
-        // Literal
+        // Register
         let output = Output::<CurrentNetwork>::parse("output r0 as field.public;").unwrap().1;
         assert_eq!(format!("{output}"), "output r0 as field.public;");
+
+        // Literal
+        let output = Output::<CurrentNetwork>::parse("output 0u8 as u8.public;").unwrap().1;
+        assert_eq!(format!("{}", output), "output 0u8 as u8.public;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.public;").unwrap().1;

--- a/synthesizer/src/program/function/mod.rs
+++ b/synthesizer/src/program/function/mod.rs
@@ -134,10 +134,14 @@ impl<N: Network> Function<N> {
     /// Adds the given instruction to the function.
     ///
     /// # Errors
+    /// This method will halt if there are output statements already.
     /// This method will halt if the maximum number of instructions has been reached.
     /// This method will halt if a finalize command has been added.
     #[inline]
     pub fn add_instruction(&mut self, instruction: Instruction<N>) -> Result<()> {
+        // Ensure that there are no output statements in memory.
+        ensure!(self.outputs.is_empty(), "Cannot add instructions after outputs have been added");
+
         // Ensure the maximum number of instructions has not been exceeded.
         ensure!(
             self.instructions.len() <= N::MAX_INSTRUCTIONS,
@@ -161,14 +165,10 @@ impl<N: Network> Function<N> {
     /// Adds the output statement to the function.
     ///
     /// # Errors
-    /// This method will halt if there are no instructions in memory.
     /// This method will halt if the maximum number of outputs has been reached.
     /// This method will halt if a finalize command has been added.
     #[inline]
     fn add_output(&mut self, output: Output<N>) -> Result<()> {
-        // Ensure there are instructions in memory.
-        ensure!(!self.instructions.is_empty(), "Cannot add outputs before instructions have been added");
-
         // Ensure the maximum number of outputs has not been exceeded.
         ensure!(self.outputs.len() <= N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
         // Ensure the output statement was not previously added.

--- a/synthesizer/src/program/function/output/bytes.rs
+++ b/synthesizer/src/program/function/output/bytes.rs
@@ -19,16 +19,16 @@ use super::*;
 impl<N: Network> FromBytes for Output<N> {
     /// Reads the output from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let register = FromBytes::read_le(&mut reader)?;
+        let operand = FromBytes::read_le(&mut reader)?;
         let value_type = FromBytes::read_le(&mut reader)?;
-        Ok(Self { register, value_type })
+        Ok(Self { operand, value_type })
     }
 }
 
 impl<N: Network> ToBytes for Output<N> {
     /// Writes the output to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.register.write_le(&mut writer)?;
+        self.operand.write_le(&mut writer)?;
         self.value_type.write_le(&mut writer)
     }
 }

--- a/synthesizer/src/program/function/output/mod.rs
+++ b/synthesizer/src/program/function/output/mod.rs
@@ -17,27 +17,25 @@
 mod bytes;
 mod parse;
 
-use console::{
-    network::prelude::*,
-    program::{Register, ValueType},
-};
+use crate::Operand;
 
-/// An output statement defines an output of a function, and may refer to the value
-/// in either a register or a register member. An output statement is of the form
-/// `output {register} as {value_type};`.
+use console::{network::prelude::*, program::ValueType};
+
+/// An output statement defines an output of a function.
+///  An output statement is of the form `output {operand} as {value_type};`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Output<N: Network> {
-    /// The output register.
-    register: Register<N>,
+    /// The output operand.
+    operand: Operand<N>,
     /// The output value type.
     value_type: ValueType<N>,
 }
 
 impl<N: Network> Output<N> {
-    /// Returns the output register.
+    /// Returns the output operand.
     #[inline]
-    pub const fn register(&self) -> &Register<N> {
-        &self.register
+    pub const fn operand(&self) -> &Operand<N> {
+        &self.operand
     }
 
     /// Returns the output value type.

--- a/synthesizer/src/program/function/output/parse.rs
+++ b/synthesizer/src/program/function/output/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 
 impl<N: Network> Parser for Output<N> {
     /// Parses a string into an output statement.
-    /// The output statement is of the form `output {register} as {value_type};`.
+    /// The output statement is of the form `output {operand} as {value_type};`.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the whitespace and comments from the string.
@@ -27,8 +27,8 @@ impl<N: Network> Parser for Output<N> {
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the register from the string.
-        let (string, register) = Register::parse(string)?;
+        // Parse the operand from the string.
+        let (string, operand) = Operand::parse(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "as" from the string.
@@ -42,7 +42,7 @@ impl<N: Network> Parser for Output<N> {
         // Parse the semicolon from the string.
         let (string, _) = tag(";")(string)?;
         // Return the output statement.
-        Ok((string, Self { register, value_type }))
+        Ok((string, Self { operand, value_type }))
     }
 }
 
@@ -76,9 +76,9 @@ impl<N: Network> Display for Output<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "{type_} {register} as {value_type};",
+            "{type_} {operand} as {value_type};",
             type_ = Self::type_name(),
-            register = self.register,
+            operand = self.operand,
             value_type = self.value_type
         )
     }
@@ -87,25 +87,33 @@ impl<N: Network> Display for Output<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
+    use console::{
+        network::Testnet3,
+        program::{Literal, Register, U8},
+    };
 
     type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_output_parse() -> Result<()> {
-        // Literal
+        // Register
         let output = Output::<CurrentNetwork>::parse("output r0 as field.private;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(0));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(0)));
         assert_eq!(output.value_type(), &ValueType::<CurrentNetwork>::from_str("field.private")?);
+
+        // Literal
+        let output = Output::<CurrentNetwork>::parse("output 0u8 as u8.public;").unwrap().1;
+        assert_eq!(output.operand(), &Operand::Literal(Literal::<CurrentNetwork>::U8(U8::new(0))));
+        assert_eq!(output.value_type(), &ValueType::<CurrentNetwork>::from_str("u8.public")?);
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.private;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(1));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(1)));
         assert_eq!(output.value_type(), &ValueType::<CurrentNetwork>::from_str("signature.private")?);
 
         // Record
         let output = Output::<CurrentNetwork>::parse("output r2 as token.record;").unwrap().1;
-        assert_eq!(output.register(), &Register::<CurrentNetwork>::Locator(2));
+        assert_eq!(output.operand(), &Operand::Register(Register::<CurrentNetwork>::Locator(2)));
         assert_eq!(output.value_type(), &ValueType::<CurrentNetwork>::from_str("token.record")?);
 
         Ok(())
@@ -113,9 +121,13 @@ mod tests {
 
     #[test]
     fn test_output_display() {
-        // Literal
+        // Register
         let output = Output::<CurrentNetwork>::parse("output r0 as field.private;").unwrap().1;
         assert_eq!(format!("{output}"), "output r0 as field.private;");
+
+        // Literal
+        let output = Output::<CurrentNetwork>::parse("output 0u8 as u8.public;").unwrap().1;
+        assert_eq!(format!("{}", output), "output 0u8 as u8.public;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.private;").unwrap().1;

--- a/synthesizer/src/program/function/output/parse.rs
+++ b/synthesizer/src/program/function/output/parse.rs
@@ -127,7 +127,7 @@ mod tests {
 
         // Literal
         let output = Output::<CurrentNetwork>::parse("output 0u8 as u8.public;").unwrap().1;
-        assert_eq!(format!("{}", output), "output 0u8 as u8.public;");
+        assert_eq!(format!("{output}"), "output 0u8 as u8.public;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.private;").unwrap().1;


### PR DESCRIPTION
This PR allows users to supply an `Operand` to an `output` instruction.
`Operands` can be literals, registers, `self.caller`, or the `ProgramID` (as an address).

TODOs:
- [x] Test parser
- [x] Test validation
- [x] Test execution