### PR TITLE
Enforce value exists in transition, adds `Transaction::fee` & `Transaction::find_transition` methods

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -104,6 +104,8 @@ pub trait Network:
     #[allow(clippy::cast_possible_truncation)]
     const MAX_DATA_SIZE_IN_FIELDS: u32 = ((128 * 1024 * 8) / Field::<Self>::SIZE_IN_DATA_BITS) as u32;
 
+    /// The maximum number of functions in a program.
+    const MAX_FUNCTIONS: usize = 15;
     /// The maximum number of operands in an instruction.
     const MAX_OPERANDS: usize = Self::MAX_INPUTS;
     /// The maximum number of instructions in a closure or function.

--- a/console/program/src/state_path/configuration/mod.rs
+++ b/console/program/src/state_path/configuration/mod.rs
@@ -52,3 +52,27 @@ pub type TransactionPath<N> = MerklePath<N, TRANSACTION_DEPTH>;
 pub type TransitionTree<N> = BHPMerkleTree<N, TRANSITION_DEPTH>;
 /// The Merkle path for an input or output ID in the transition.
 pub type TransitionPath<N> = MerklePath<N, TRANSITION_DEPTH>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Network;
+
+    type CurrentNetwork = snarkvm_console_network::Testnet3;
+
+    #[test]
+    fn test_transaction_depth_is_correct() {
+        // We ensure 2^TRANSACTION_DEPTH - 1 == MAX_FUNCTIONS.
+        // The "- 1" is for the fee transition.
+        assert_eq!((2u32.checked_pow(TRANSACTION_DEPTH as u32).unwrap() - 1) as usize, CurrentNetwork::MAX_FUNCTIONS);
+    }
+
+    #[test]
+    fn test_transition_depth_is_correct() {
+        // We ensure 2^TRANSITION_DEPTH == (MAX_INPUTS + MAX_OUTPUTS).
+        assert_eq!(
+            2u32.checked_pow(TRANSITION_DEPTH as u32).unwrap() as usize,
+            CurrentNetwork::MAX_INPUTS + CurrentNetwork::MAX_OUTPUTS
+        );
+    }
+}

--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -176,7 +176,9 @@ impl<N: Network> Transaction<N> {
             cumulative.checked_add(*fee).ok_or_else(|| anyhow!("Transaction fee overflowed"))
         })
     }
+}
 
+impl<N: Network> Transaction<N> {
     /// Returns the transition with the corresponding transition ID.
     pub fn find_transition(&self, id: &N::TransitionID) -> Option<&Transition<N>> {
         match self {

--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -176,9 +176,32 @@ impl<N: Network> Transaction<N> {
             cumulative.checked_add(*fee).ok_or_else(|| anyhow!("Transaction fee overflowed"))
         })
     }
+
+    /// Returns the transition with the corresponding transition ID.
+    pub fn find_transition(&self, id: &N::TransitionID) -> Option<&Transition<N>> {
+        match self {
+            // Check the fee.
+            Self::Deploy(_, _, fee) => match fee.id() == id {
+                true => Some(fee.transition()),
+                false => None,
+            },
+            // Check the execution and fee.
+            Self::Execute(_, execution, fee) => execution.find_transition(id).or_else(|| {
+                fee.as_ref().and_then(|fee| match fee.id() == id {
+                    true => Some(fee.transition()),
+                    false => None,
+                })
+            }),
+        }
+    }
 }
 
 impl<N: Network> Transaction<N> {
+    /// Returns an iterator over the transition IDs, for all transitions.
+    pub fn transition_ids(&self) -> impl '_ + Iterator<Item = &N::TransitionID> {
+        self.transitions().map(Transition::id)
+    }
+
     /// Returns an iterator over all transitions.
     pub fn transitions(&self) -> impl '_ + Iterator<Item = &Transition<N>> {
         match self {
@@ -187,11 +210,6 @@ impl<N: Network> Transaction<N> {
                 IterWrap::Execute(execution.transitions().chain(additional_fee.as_ref().map(|f| f.transition())))
             }
         }
-    }
-
-    /// Returns an iterator over the transition IDs, for all transitions.
-    pub fn transition_ids(&self) -> impl '_ + Iterator<Item = &N::TransitionID> {
-        self.transitions().map(Transition::id)
     }
 
     /* Input */
@@ -240,6 +258,11 @@ impl<N: Network> Transaction<N> {
 }
 
 impl<N: Network> Transaction<N> {
+    /// Returns a consuming iterator over the transition IDs, for all transitions.
+    pub fn into_transition_ids(self) -> impl Iterator<Item = N::TransitionID> {
+        self.into_transitions().map(Transition::into_id)
+    }
+
     /// Returns a consuming iterator over all transitions.
     pub fn into_transitions(self) -> impl Iterator<Item = Transition<N>> {
         match self {
@@ -248,11 +271,6 @@ impl<N: Network> Transaction<N> {
                 IterWrap::Execute(execution.into_transitions().chain(additional_fee.map(|f| f.into_transition())))
             }
         }
-    }
-
-    /// Returns a consuming iterator over the transition IDs, for all transitions.
-    pub fn into_transition_ids(self) -> impl Iterator<Item = N::TransitionID> {
-        self.into_transitions().map(Transition::into_id)
     }
 
     /// Returns a consuming iterator over the transition public keys, for all transitions.

--- a/synthesizer/src/block/transition/input/mod.rs
+++ b/synthesizer/src/block/transition/input/mod.rs
@@ -159,11 +159,12 @@ impl<N: Network> Input<N> {
                     Err(error) => Err(error),
                 }
             }
-            Input::Constant(_, None)
-            | Input::Public(_, None)
-            | Input::Private(_, None)
-            | Input::Record(_, _)
-            | Input::ExternalRecord(_) => Ok(true),
+            Input::Constant(_, None) | Input::Public(_, None) | Input::Private(_, None) => {
+                // This enforces that the transition *must* contain the value for this transition input.
+                // A similar rule is enforced for the transition output.
+                bail!("A transition input value is missing")
+            }
+            Input::Record(_, _) | Input::ExternalRecord(_) => Ok(true),
         };
 
         match result() {

--- a/synthesizer/src/process/stack/execution/mod.rs
+++ b/synthesizer/src/process/stack/execution/mod.rs
@@ -72,7 +72,7 @@ impl<N: Network> Execution<N> {
     }
 
     /// Returns the `Transition` corresponding to the given transition ID.
-    pub fn find(&self, id: &N::TransitionID) -> Option<&Transition<N>> {
+    pub fn find_transition(&self, id: &N::TransitionID) -> Option<&Transition<N>> {
         self.transitions.get(id)
     }
 

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -505,6 +505,9 @@ impl<N: Network> Program<N> {
         // Retrieve the function name.
         let function_name = *function.name();
 
+        // Ensure the program has not exceeded the maximum number of functions.
+        ensure!(self.functions.len() < N::MAX_FUNCTIONS, "Program exceeds the maximum number of functions");
+
         // Ensure the function name is new.
         ensure!(self.is_unique_name(&function_name), "'{function_name}' is already in use.");
         // Ensure the function name is not a reserved opcode.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

- Enforce the input and output value exists in each transition
- Adds a `Transaction::fee` method
- Adds a `Transaction::find_transition` method
- Adds a maximum number of functions rule check
