### PR TITLE
perf: optimize MemoryMap::get_batched

### DIFF
--- a/synthesizer/src/store/helpers/mod.rs
+++ b/synthesizer/src/store/helpers/mod.rs
@@ -21,13 +21,6 @@ use console::network::prelude::*;
 use core::{borrow::Borrow, hash::Hash};
 use std::borrow::Cow;
 
-#[derive(Clone)]
-pub enum BatchOperation<K: Copy + Clone + PartialEq + Eq + Hash + Send + Sync, V: Clone + PartialEq + Eq + Send + Sync>
-{
-    Insert(K, V),
-    Remove(K),
-}
-
 /// A trait representing map-like storage operations with read-write capabilities.
 pub trait Map<
     'a,


### PR DESCRIPTION
This reduces the cost of MemoryMap::get_batched from O(n) to O(1).

The cost of whole `start_atomic` + insertions + removals + `finish_atomic` combined should stay similar to the one before the change