### PR TITLE
Cache Inclusion proving and verifying keys

### DIFF
--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -7,14 +7,14 @@ license = "GPL-3.0"
 edition = "2021"
 
 [features]
-default = [ ]
-wasm = [ "snarkvm-parameters/wasm" ]
+default = [ "snarkvm-algorithms/polycommit_full" ]
+wasm = [ "snarkvm-algorithms/polycommit_wasm", "snarkvm-parameters/wasm" ]
 
 [dependencies.snarkvm-algorithms]
 path = "../../algorithms"
 version = "0.9.4"
 default-features = false
-features = [ "crypto_hash" ]
+features = [ "snark" ]
 
 [dependencies.snarkvm-console-algorithms]
 path = "../algorithms"

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -35,11 +35,18 @@ pub mod prelude {
 }
 
 use crate::environment::prelude::*;
-use snarkvm_algorithms::{crypto_hash::PoseidonSponge, AlgebraicSponge};
+use snarkvm_algorithms::{
+    crypto_hash::PoseidonSponge,
+    snark::marlin::{CircuitProvingKey, CircuitVerifyingKey, MarlinHidingMode},
+    AlgebraicSponge,
+};
 use snarkvm_console_algorithms::{Poseidon2, Poseidon4, BHP1024, BHP512};
 use snarkvm_console_collections::merkle_tree::{MerklePath, MerkleTree};
 use snarkvm_console_types::{Field, Group, Scalar};
 use snarkvm_curves::PairingEngine;
+
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
 
 /// A helper type for the BHP Merkle tree.
 pub type BHPMerkleTree<N, const DEPTH: u8> = MerkleTree<N, BHP1024<N>, BHP512<N>, DEPTH>;
@@ -138,6 +145,12 @@ pub trait Network:
 
     /// Returns the `verifying key` bytes for the inclusion circuit.
     fn inclusion_verifying_key_bytes() -> &'static Vec<u8>;
+
+    /// Returns the `proving key` for the inclusion circuit.
+    fn inclusion_proving_key() -> &'static Arc<CircuitProvingKey<Self::PairingCurve, MarlinHidingMode>>;
+
+    /// Returns the `verifying key` for the inclusion circuit.
+    fn inclusion_verifying_key() -> &'static Arc<CircuitVerifyingKey<Self::PairingCurve, MarlinHidingMode>>;
 
     /// Returns the powers of `G`.
     fn g_powers() -> &'static Vec<Group<Self>>;

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -149,6 +149,32 @@ impl Network for Testnet3 {
         &snarkvm_parameters::testnet3::TESTNET3_INCLUSION_VERIFYING_KEY
     }
 
+    /// Returns the `proving key` for the inclusion circuit.
+    fn inclusion_proving_key() -> &'static Arc<CircuitProvingKey<Self::PairingCurve, MarlinHidingMode>> {
+        static INSTANCE: OnceCell<Arc<CircuitProvingKey<<Console as Environment>::PairingCurve, MarlinHidingMode>>> =
+            OnceCell::new();
+        INSTANCE.get_or_init(|| {
+            // Skipping the first 2 bytes, which is the encoded version.
+            Arc::new(
+                CircuitProvingKey::from_bytes_le(&Self::inclusion_proving_key_bytes()[2..])
+                    .expect("Failed to load inclusion proving key."),
+            )
+        })
+    }
+
+    /// Returns the `verifying key` for the inclusion circuit.
+    fn inclusion_verifying_key() -> &'static Arc<CircuitVerifyingKey<Self::PairingCurve, MarlinHidingMode>> {
+        static INSTANCE: OnceCell<Arc<CircuitVerifyingKey<<Console as Environment>::PairingCurve, MarlinHidingMode>>> =
+            OnceCell::new();
+        INSTANCE.get_or_init(|| {
+            // Skipping the first 2 bytes, which is the encoded version.
+            Arc::new(
+                CircuitVerifyingKey::from_bytes_le(&Self::inclusion_verifying_key_bytes()[2..])
+                    .expect("Failed to load inclusion verifying key."),
+            )
+        })
+    }
+
     /// Returns the powers of `G`.
     fn g_powers() -> &'static Vec<Group<Self>> {
         &GENERATOR_G

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -111,6 +111,11 @@ impl<N: Network> Process<N> {
             stack.insert_verifying_key(function_name, VerifyingKey::from_bytes_le(verifying_key)?)?;
         }
 
+        // Initialize the inclusion proving key.
+        let _ = N::inclusion_proving_key();
+        // Initialize the inclusion verifying key.
+        let _ = N::inclusion_verifying_key();
+
         // Add the stack to the process.
         process.stacks.insert(*program.id(), stack);
         // Return the process.

--- a/synthesizer/src/snark/proving_key/bytes.rs
+++ b/synthesizer/src/snark/proving_key/bytes.rs
@@ -26,7 +26,7 @@ impl<N: Network> FromBytes for ProvingKey<N> {
             return Err(error("Invalid verifying key version"));
         }
         // Read the proving key.
-        let proving_key = FromBytes::read_le(&mut reader)?;
+        let proving_key = Arc::new(FromBytes::read_le(&mut reader)?);
         // Return the proving key.
         Ok(Self { proving_key })
     }

--- a/synthesizer/src/snark/proving_key/mod.rs
+++ b/synthesizer/src/snark/proving_key/mod.rs
@@ -23,12 +23,14 @@ mod serialize;
 #[derive(Clone)]
 pub struct ProvingKey<N: Network> {
     /// The proving key for the function.
-    proving_key: marlin::CircuitProvingKey<N::PairingCurve, marlin::MarlinHidingMode>,
+    proving_key: Arc<marlin::CircuitProvingKey<N::PairingCurve, marlin::MarlinHidingMode>>,
 }
 
 impl<N: Network> ProvingKey<N> {
     /// Initializes a new proving key.
-    pub(super) const fn new(proving_key: marlin::CircuitProvingKey<N::PairingCurve, marlin::MarlinHidingMode>) -> Self {
+    pub(crate) const fn new(
+        proving_key: Arc<marlin::CircuitProvingKey<N::PairingCurve, marlin::MarlinHidingMode>>,
+    ) -> Self {
         Self { proving_key }
     }
 

--- a/synthesizer/src/snark/universal_srs.rs
+++ b/synthesizer/src/snark/universal_srs.rs
@@ -42,7 +42,7 @@ impl<N: Network> UniversalSRS<N> {
         #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Built '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
 
-        Ok((ProvingKey::new(proving_key), VerifyingKey::new(verifying_key)))
+        Ok((ProvingKey::new(Arc::new(proving_key)), VerifyingKey::new(Arc::new(verifying_key))))
     }
 }
 

--- a/synthesizer/src/snark/verifying_key/bytes.rs
+++ b/synthesizer/src/snark/verifying_key/bytes.rs
@@ -26,7 +26,7 @@ impl<N: Network> FromBytes for VerifyingKey<N> {
             return Err(error("Invalid verifying key version"));
         }
         // Read the verifying key.
-        let verifying_key = FromBytes::read_le(&mut reader)?;
+        let verifying_key = Arc::new(FromBytes::read_le(&mut reader)?);
         // Return the verifying key.
         Ok(Self { verifying_key })
     }

--- a/synthesizer/src/snark/verifying_key/mod.rs
+++ b/synthesizer/src/snark/verifying_key/mod.rs
@@ -23,13 +23,13 @@ mod serialize;
 #[derive(Clone, PartialEq, Eq)]
 pub struct VerifyingKey<N: Network> {
     /// The verifying key for the function.
-    verifying_key: marlin::CircuitVerifyingKey<N::PairingCurve, marlin::MarlinHidingMode>,
+    verifying_key: Arc<marlin::CircuitVerifyingKey<N::PairingCurve, marlin::MarlinHidingMode>>,
 }
 
 impl<N: Network> VerifyingKey<N> {
     /// Initializes a new verifying key.
-    pub(super) const fn new(
-        verifying_key: marlin::CircuitVerifyingKey<N::PairingCurve, marlin::MarlinHidingMode>,
+    pub(crate) const fn new(
+        verifying_key: Arc<marlin::CircuitVerifyingKey<N::PairingCurve, marlin::MarlinHidingMode>>,
     ) -> Self {
         Self { verifying_key }
     }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR caches the `Inclusion` Proving key and Verifying key in the `Network` trait. This will reduce execution time significantly, because it won't have to deserialize the entire proving key for every Inclusion proof.

For reference, on a Threadripper 3960x, this change reduces execution time from ~6.3 seconds to ~5.1 seconds.
