### PR TITLE
Add optional `minimum_proof_target` to `CoinbasePuzzle::prove`

### DIFF
--- a/synthesizer/benches/coinbase_puzzle.rs
+++ b/synthesizer/benches/coinbase_puzzle.rs
@@ -76,7 +76,7 @@ fn coinbase_puzzle_prove(c: &mut Criterion) {
 
         c.bench_function(&format!("CoinbasePuzzle::Prove 2^{}", ((degree + 1) as f64).log2()), |b| {
             let (epoch_challenge, address, nonce) = sample_inputs(degree, rng);
-            b.iter(|| puzzle.prove(&epoch_challenge, address, nonce).unwrap())
+            b.iter(|| puzzle.prove(&epoch_challenge, address, nonce, None).unwrap())
         });
     }
 }
@@ -98,7 +98,7 @@ fn coinbase_puzzle_accumulate(c: &mut Criterion) {
             let solutions = (0..batch_size)
                 .map(|_| {
                     let (address, nonce) = sample_address_and_nonce(rng);
-                    puzzle.prove(&epoch_challenge, address, nonce).unwrap()
+                    puzzle.prove(&epoch_challenge, address, nonce, None).unwrap()
                 })
                 .collect::<Vec<_>>();
 
@@ -127,7 +127,7 @@ fn coinbase_puzzle_verify(c: &mut Criterion) {
             let solutions = (0..batch_size)
                 .map(|_| {
                     let (address, nonce) = sample_address_and_nonce(rng);
-                    puzzle.prove(&epoch_challenge, address, nonce).unwrap()
+                    puzzle.prove(&epoch_challenge, address, nonce, None).unwrap()
                 })
                 .collect::<Vec<_>>();
             let solution = puzzle.accumulate_unchecked(&epoch_challenge, &solutions).unwrap();

--- a/synthesizer/src/coinbase_puzzle/mod.rs
+++ b/synthesizer/src/coinbase_puzzle/mod.rs
@@ -136,7 +136,7 @@ impl<N: Network> CoinbasePuzzle<N> {
         if let Some(proof_target) = minimum_proof_target {
             let prover_solution_target = partial_solution.to_target()?;
             ensure!(
-                partial_solution.to_target()? >= proof_target,
+                prover_solution_target >= proof_target,
                 "Prover solution was below the necessary proof target ({prover_solution_target} < {proof_target})"
             );
         }

--- a/synthesizer/src/coinbase_puzzle/mod.rs
+++ b/synthesizer/src/coinbase_puzzle/mod.rs
@@ -133,11 +133,11 @@ impl<N: Network> CoinbasePuzzle<N> {
         let partial_solution = PartialSolution::new(address, nonce, commitment);
 
         // Check that the minimum target is met.
-        if let Some(proof_target) = minimum_proof_target {
-            let prover_solution_target = partial_solution.to_target()?;
+        if let Some(minimum_target) = minimum_proof_target {
+            let proof_target = partial_solution.to_target()?;
             ensure!(
-                prover_solution_target >= proof_target,
-                "Prover solution was below the necessary proof target ({prover_solution_target} < {proof_target})"
+                proof_target >= minimum_target,
+                "Prover solution was below the necessary proof target ({proof_target} < {minimum_target})"
             );
         }
 

--- a/synthesizer/src/coinbase_puzzle/tests.rs
+++ b/synthesizer/src/coinbase_puzzle/tests.rs
@@ -20,6 +20,8 @@ use snarkvm_utilities::Uniform;
 
 use rand::RngCore;
 
+const ITERATIONS: u64 = 100;
+
 #[test]
 fn test_coinbase_puzzle() {
     let mut rng = TestRng::default();
@@ -40,7 +42,7 @@ fn test_coinbase_puzzle() {
                     let private_key = PrivateKey::<Testnet3>::new(&mut rng).unwrap();
                     let address = Address::try_from(private_key).unwrap();
                     let nonce = u64::rand(&mut rng);
-                    puzzle.prove(&epoch_challenge, address, nonce).unwrap()
+                    puzzle.prove(&epoch_challenge, address, nonce, None).unwrap()
                 })
                 .collect::<Vec<_>>();
             let full_solution = puzzle.accumulate_unchecked(&epoch_challenge, &solutions).unwrap();
@@ -71,7 +73,7 @@ fn test_edge_case_for_degree() {
     let epoch_challenge = EpochChallenge::new(rng.gen(), Default::default(), degree).unwrap();
 
     // Generate a prover solution.
-    let prover_solution = puzzle.prove(&epoch_challenge, address, rng.gen()).unwrap();
+    let prover_solution = puzzle.prove(&epoch_challenge, address, rng.gen(), None).unwrap();
     let coinbase_solution = puzzle.accumulate_unchecked(&epoch_challenge, &[prover_solution]).unwrap();
     assert!(puzzle.verify(&coinbase_solution, &epoch_challenge, 0u64, 0u64).unwrap());
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds an optional `minimum_proof_target` field to the `CoinbasePuzzle::prove` that will prevent completing the KZG10 proof if the commitment does not meet the specified requirements.

This will greatly increase the number of solutions a prover can produce, by removing unnecessary work. 

A quick bench provides the following results (Ryzen threadripper 3960x 24-core processor × 48 thread):
- Prover solution generated successfully - 40.322269ms 
- Prover solution errors due do insufficient proof target - 19.653976ms