### PR TITLE
Fixes cast instruction to allow `MAX_DATA_ENTRIES` operands.

### DIFF
--- a/console/network/environment/src/prelude.rs
+++ b/console/network/environment/src/prelude.rs
@@ -76,7 +76,7 @@ pub use nom::{
     branch::alt,
     bytes::{complete::tag, streaming::take},
     character::complete::{alpha1, alphanumeric1, char, one_of},
-    combinator::{complete, map, map_res, opt, recognize},
+    combinator::{complete, fail, map, map_res, opt, recognize},
     multi::{many0, many1, separated_list0, separated_list1},
     sequence::{pair, terminated},
 };

--- a/console/program/src/data_types/record_type/parse.rs
+++ b/console/program/src/data_types/record_type/parse.rs
@@ -112,8 +112,8 @@ impl<N: Network> Parser for RecordType<N> {
                 return Err(error(format!("Duplicate entry type found in record '{}'", name)));
             }
             // Ensure the number of members is within `N::MAX_DATA_ENTRIES`.
-            // Since a record has two reserved entries, the maximum number of additional entries is `N::MAX_DATA_ENTRIES - 2`.
-            if entries.len() > N::MAX_DATA_ENTRIES - 2 {
+            // Since a record has two reserved entries, the maximum number of entries is `N::MAX_DATA_ENTRIES`.
+            if entries.len() > N::MAX_DATA_ENTRIES {
                 return Err(error("Failed to parse record: too many entries"));
             }
             Ok(entries)
@@ -252,7 +252,7 @@ record message:
     #[test]
     fn test_parse_max_members() {
         let mut string = "record message:\n    owner as address.private;\n    gates as u64.public;\n".to_string();
-        for i in 0..(CurrentNetwork::MAX_DATA_ENTRIES - 2) {
+        for i in 0..CurrentNetwork::MAX_DATA_ENTRIES {
             string += &format!("    member_{} as field.private;\n", i);
         }
         let candidate = RecordType::<CurrentNetwork>::parse(&string);
@@ -262,7 +262,7 @@ record message:
     #[test]
     fn test_parse_too_many_members() {
         let mut string = "record message:\n    owner as address.private;\n    gates as u64.public;\n".to_string();
-        for i in 0..(CurrentNetwork::MAX_DATA_ENTRIES - 1) {
+        for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES {
             string += &format!("    member_{} as field.private;\n", i);
         }
         let candidate = RecordType::<CurrentNetwork>::parse(&string);

--- a/console/program/src/data_types/record_type/parse.rs
+++ b/console/program/src/data_types/record_type/parse.rs
@@ -100,7 +100,7 @@ impl<N: Network> Parser for RecordType<N> {
         // Parse the ";" from the string.
         let (string, _) = tag(";")(string)?;
 
-        // Parse the additional entries from the string.
+        // Parse the entries from the string.
         let (string, entries) = map_res(many0(parse_entry), |entries| {
             // Prepare the reserved entry names.
             let reserved = [
@@ -112,7 +112,6 @@ impl<N: Network> Parser for RecordType<N> {
                 return Err(error(format!("Duplicate entry type found in record '{}'", name)));
             }
             // Ensure the number of members is within `N::MAX_DATA_ENTRIES`.
-            // Since a record has two reserved entries, the maximum number of entries is `N::MAX_DATA_ENTRIES`.
             if entries.len() > N::MAX_DATA_ENTRIES {
                 return Err(error("Failed to parse record: too many entries"));
             }

--- a/console/program/src/data_types/struct_/parse.rs
+++ b/console/program/src/data_types/struct_/parse.rs
@@ -194,4 +194,22 @@ struct message:
             Struct::<CurrentNetwork>::parse("struct message:\n    first as field.public;\n    first as field.private;");
         assert!(candidate.is_err());
     }
+
+    #[test]
+    fn test_max_members() {
+        let mut string = "struct message:\n".to_string();
+        for i in 0..CurrentNetwork::MAX_DATA_ENTRIES {
+            string += &format!("    member_{} as field;\n", i);
+        }
+        assert!(Struct::<CurrentNetwork>::parse(&string).is_ok());
+    }
+
+    #[test]
+    fn test_too_many_members() {
+        let mut string = "struct message:\n".to_string();
+        for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES {
+            string += &format!("    member_{} as field;\n", i);
+        }
+        assert!(Struct::<CurrentNetwork>::parse(&string).is_err());
+    }
 }

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -446,14 +446,7 @@ impl<N: Network> Parser for Cast<N> {
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the operands from the string.
-        let (string, operands) = map_res(many1(parse_operand), |operands: Vec<Operand<N>>| {
-            // Ensure the number of operands is within the bounds.
-            // Since a cast operation creates an interface or record, the maximum number of operands is `MAX_DATA_ENTRIES`.
-            match operands.len() <= N::MAX_DATA_ENTRIES {
-                true => Ok(operands),
-                false => Err(error("Failed to parse 'cast' opcode: too many operands")),
-            }
-        })(string)?;
+        let (string, operands) = many1(parse_operand)(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "into" from the string.
@@ -470,8 +463,20 @@ impl<N: Network> Parser for Cast<N> {
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the register type from the string.
         let (string, register_type) = RegisterType::parse(string)?;
-
-        Ok((string, Self { operands, destination, register_type }))
+        // Check that the number of operands does not exceed the maximum number of data entries.
+        let max_operands = match register_type {
+            RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
+        };
+        match operands.len() <= max_operands {
+            true => Ok((string, Self { operands, destination, register_type })),
+            false => {
+                map_res(fail, |_: ParserResult<Self>| Err(error("Failed to parse 'cast' opcode: too many operands")))(
+                    string,
+                )
+            }
+        }
     }
 }
 
@@ -504,8 +509,13 @@ impl<N: Network> Display for Cast<N> {
     /// Prints the operation to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Ensure the number of operands is within the bounds.
-        if self.operands.len().is_zero() || self.operands.len() > N::MAX_OPERANDS {
-            eprintln!("The number of operands must be nonzero and <= {}", N::MAX_OPERANDS);
+        let max_operands = match self.register_type() {
+            RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
+        };
+        if self.operands.len().is_zero() || self.operands.len() > max_operands {
+            eprintln!("The number of operands must be nonzero and <= {}", max_operands);
             return Err(fmt::Error);
         }
         // Print the operation.
@@ -521,9 +531,10 @@ impl<N: Network> FromBytes for Cast<N> {
         // Read the number of operands.
         let num_operands = u8::read_le(&mut reader)? as usize;
 
-        // Ensure the number of operands is within the bounds.
-        if num_operands.is_zero() || num_operands > N::MAX_OPERANDS {
-            return Err(error(format!("The number of operands must be nonzero and <= {}", N::MAX_OPERANDS)));
+        // Ensure that the number of operands does not exceed the upper bound.
+        // Note: although a similar check is performed later, this check is performed to ensure that an exceedingly large number of operands is not allocated.
+        if num_operands.is_zero() || num_operands > N::MAX_DATA_ENTRIES + 2 {
+            return Err(error(format!("The number of operands must be nonzero and <= {}", N::MAX_DATA_ENTRIES + 2)));
         }
 
         // Initialize the vector for the operands.
@@ -539,6 +550,16 @@ impl<N: Network> FromBytes for Cast<N> {
         // Read the casted register type.
         let register_type = RegisterType::read_le(&mut reader)?;
 
+        // Ensure the number of operands is within the bounds for the register type.
+        let max_operands = match register_type {
+            RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
+        };
+        if num_operands.is_zero() || num_operands > max_operands {
+            return Err(error(format!("The number of operands must be nonzero and <= {}", max_operands)));
+        }
+
         // Return the operation.
         Ok(Self { operands, destination, register_type })
     }
@@ -548,8 +569,13 @@ impl<N: Network> ToBytes for Cast<N> {
     /// Writes the operation to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Ensure the number of operands is within the bounds.
-        if self.operands.len().is_zero() || self.operands.len() > N::MAX_OPERANDS {
-            return Err(error(format!("The number of operands must be nonzero and <= {}", N::MAX_OPERANDS)));
+        let max_operands = match self.register_type() {
+            RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
+        };
+        if self.operands.len().is_zero() || self.operands.len() > max_operands {
+            return Err(error(format!("The number of operands must be nonzero and <= {}", max_operands)));
         }
 
         // Write the number of operands.
@@ -600,14 +626,14 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_max_operands() {
+    fn test_parse_cast_into_plaintext_max_operands() {
         let mut string = "cast ".to_string();
         let mut operands = Vec::with_capacity(CurrentNetwork::MAX_DATA_ENTRIES);
         for i in 0..CurrentNetwork::MAX_DATA_ENTRIES {
             string.push_str(&format!("r{} ", i));
             operands.push(Operand::Register(Register::Locator(i as u64)));
         }
-        string.push_str(&format!("into r{} as token.record", CurrentNetwork::MAX_DATA_ENTRIES));
+        string.push_str(&format!("into r{} as foo", CurrentNetwork::MAX_DATA_ENTRIES));
         let (string, cast) = Cast::<CurrentNetwork>::parse(&string).unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(cast.operands.len(), CurrentNetwork::MAX_DATA_ENTRIES, "The number of operands is incorrect");
@@ -619,18 +645,53 @@ mod tests {
         );
         assert_eq!(
             cast.register_type,
+            RegisterType::Plaintext(PlaintextType::Struct(Identifier::from_str("foo").unwrap())),
+            "The value type is incorrect"
+        );
+    }
+
+    #[test]
+    fn test_parse_cast_into_record_max_operands() {
+        let mut string = "cast ".to_string();
+        let mut operands = Vec::with_capacity(CurrentNetwork::MAX_DATA_ENTRIES + 2);
+        for i in 0..CurrentNetwork::MAX_DATA_ENTRIES + 2 {
+            string.push_str(&format!("r{} ", i));
+            operands.push(Operand::Register(Register::Locator(i as u64)));
+        }
+        string.push_str(&format!("into r{} as token.record", CurrentNetwork::MAX_DATA_ENTRIES + 2));
+        let (string, cast) = Cast::<CurrentNetwork>::parse(&string).unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+        assert_eq!(cast.operands.len(), CurrentNetwork::MAX_DATA_ENTRIES + 2, "The number of operands is incorrect");
+        assert_eq!(cast.operands, operands, "The operands are incorrect");
+        assert_eq!(
+            cast.destination,
+            Register::Locator((CurrentNetwork::MAX_DATA_ENTRIES + 2) as u64),
+            "The destination register is incorrect"
+        );
+        assert_eq!(
+            cast.register_type,
             RegisterType::Record(Identifier::from_str("token").unwrap()),
             "The value type is incorrect"
         );
     }
 
     #[test]
-    fn test_parse_too_many_operands() {
+    fn test_parse_cast_into_record_too_many_operands() {
+        let mut string = "cast ".to_string();
+        for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES + 2 {
+            string.push_str(&format!("r{} ", i));
+        }
+        string.push_str(&format!("into r{} as token.record", CurrentNetwork::MAX_DATA_ENTRIES + 3));
+        assert!(Cast::<CurrentNetwork>::parse(&string).is_err(), "Parser did not error");
+    }
+
+    #[test]
+    fn test_parse_cast_into_plaintext_too_many_operands() {
         let mut string = "cast ".to_string();
         for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES {
             string.push_str(&format!("r{} ", i));
         }
-        string.push_str(&format!("into r{} as token.record", CurrentNetwork::MAX_DATA_ENTRIES + 1));
+        string.push_str(&format!("into r{} as foo", CurrentNetwork::MAX_DATA_ENTRIES + 1));
         assert!(Cast::<CurrentNetwork>::parse(&string).is_err(), "Parser did not error");
     }
 }

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -466,7 +466,7 @@ impl<N: Network> Parser for Cast<N> {
         // Check that the number of operands does not exceed the maximum number of data entries.
         let max_operands = match register_type {
             RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
-            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which are not data entries.
             RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
         };
         match operands.len() <= max_operands {
@@ -511,7 +511,7 @@ impl<N: Network> Display for Cast<N> {
         // Ensure the number of operands is within the bounds.
         let max_operands = match self.register_type() {
             RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
-            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which are not data entries.
             RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
         };
         if self.operands.len().is_zero() || self.operands.len() > max_operands {
@@ -553,7 +553,7 @@ impl<N: Network> FromBytes for Cast<N> {
         // Ensure the number of operands is within the bounds for the register type.
         let max_operands = match register_type {
             RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
-            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which are not data entries.
             RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
         };
         if num_operands.is_zero() || num_operands > max_operands {
@@ -571,7 +571,7 @@ impl<N: Network> ToBytes for Cast<N> {
         // Ensure the number of operands is within the bounds.
         let max_operands = match self.register_type() {
             RegisterType::Plaintext(_) => N::MAX_DATA_ENTRIES,
-            // Note that if the register type is a record, then we must account for `owner` and `gates` which do not count as data entries.
+            // Note that if the register type is a record, then we must account for `owner` and `gates` which are not data entries.
             RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
         };
         if self.operands.len().is_zero() || self.operands.len() > max_operands {


### PR DESCRIPTION
This PR,
- Fixes parsing for the cast instruction to allow `MAX_DATA_ENTRIES` operands. Note that the check is conditional on the `RegisterType` of the instruction.
- Adds parser tests for `Record` and `Struct`.
