### PR TITLE
Updates record `is_owner` for better performance

### DIFF
--- a/console/program/src/data/record/is_owner.rs
+++ b/console/program/src/data/record/is_owner.rs
@@ -17,11 +17,19 @@
 use super::*;
 
 impl<N: Network> Record<N, Ciphertext<N>> {
-    /// Decrypts `self` into plaintext using the given view key & nonce.
-    pub fn is_owner(&self, address: &Address<N>, view_key: &ViewKey<N>) -> bool {
+    /// Decrypts `self` into plaintext using the given view key.
+    pub fn is_owner(&self, view_key: &ViewKey<N>) -> bool {
+        // Compute the address.
+        let address = view_key.to_address();
+        // Check if the address is the owner.
+        self.is_owner_with_address_x_coordinate(&view_key, &address.to_x_coordinate())
+    }
+
+    /// Decrypts `self` into plaintext using the x-coordinate of the address corresponding to the given view key.
+    pub fn is_owner_with_address_x_coordinate(&self, view_key: &ViewKey<N>, address_x_coordinate: &Field<N>) -> bool {
         match &self.owner {
             // If the owner is public, check if the address is the owner.
-            Owner::Public(owner) => owner == address,
+            Owner::Public(owner) => &owner.to_x_coordinate() == address_x_coordinate,
             // If the owner is private, decrypt the owner to check if it matches the address.
             Owner::Private(ciphertext) => {
                 // Compute the record view key.
@@ -38,7 +46,7 @@ impl<N: Network> Record<N, Ciphertext<N>> {
                 // together are an authenticated encryption scheme, we know that the ciphertext has not been malleated.
                 // Thus overall we know that if the x-coordinate matches that of `address`, then the underlying `address`es must also match.
                 // Therefore we can skip recomputing the address from `owner_x` and instead compare the x-coordinates directly.
-                owner_x == address.to_x_coordinate()
+                &owner_x == address_x_coordinate
             }
         }
     }
@@ -84,7 +92,7 @@ mod tests {
         let address = Address::try_from(&view_key)?;
 
         // Ensure the record belongs to the owner.
-        assert!(ciphertext.is_owner(&address, &view_key));
+        assert!(ciphertext.is_owner(&view_key));
 
         // Sample a random view key and address.
         let private_key = PrivateKey::<N>::new(rng)?;
@@ -92,7 +100,7 @@ mod tests {
         let address = Address::try_from(&private_key)?;
 
         // Ensure the random address is not the owner.
-        assert!(!ciphertext.is_owner(&address, &view_key));
+        assert!(!ciphertext.is_owner(&view_key));
 
         Ok(())
     }

--- a/console/program/src/data/record/is_owner.rs
+++ b/console/program/src/data/record/is_owner.rs
@@ -27,6 +27,13 @@ impl<N: Network> Record<N, Ciphertext<N>> {
 
     /// Decrypts `self` into plaintext using the x-coordinate of the address corresponding to the given view key.
     pub fn is_owner_with_address_x_coordinate(&self, view_key: &ViewKey<N>, address_x_coordinate: &Field<N>) -> bool {
+        // In debug mode, check that the address corresponds to the given view key.
+        debug_assert_eq!(
+            &view_key.to_address().to_x_coordinate(),
+            address_x_coordinate,
+            "Failed to check record - view key and address do not match"
+        );
+
         match &self.owner {
             // If the owner is public, check if the address is the owner.
             Owner::Public(owner) => &owner.to_x_coordinate() == address_x_coordinate,

--- a/console/program/src/data/record/is_owner.rs
+++ b/console/program/src/data/record/is_owner.rs
@@ -22,7 +22,7 @@ impl<N: Network> Record<N, Ciphertext<N>> {
         // Compute the address.
         let address = view_key.to_address();
         // Check if the address is the owner.
-        self.is_owner_with_address_x_coordinate(&view_key, &address.to_x_coordinate())
+        self.is_owner_with_address_x_coordinate(view_key, &address.to_x_coordinate())
     }
 
     /// Decrypts `self` into plaintext using the x-coordinate of the address corresponding to the given view key.
@@ -88,16 +88,12 @@ mod tests {
         // Encrypt the record.
         let ciphertext = record.encrypt(randomizer)?;
 
-        // Compute the address.
-        let address = Address::try_from(&view_key)?;
-
         // Ensure the record belongs to the owner.
         assert!(ciphertext.is_owner(&view_key));
 
         // Sample a random view key and address.
         let private_key = PrivateKey::<N>::new(rng)?;
         let view_key = ViewKey::try_from(&private_key)?;
-        let address = Address::try_from(&private_key)?;
 
         // Ensure the random address is not the owner.
         assert!(!ciphertext.is_owner(&view_key));

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -87,7 +87,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
     pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Program<N>> {
         match self {
             Self::VM(block_store) => {
-                block_store.get_program(program_id)?.ok_or(anyhow!("Program {program_id} not found in storage"))
+                block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
             }
             Self::REST(url) => match N::ID {
                 3 => Ok(Self::get_request(&format!("{url}/testnet3/program/{program_id}"))?.json()?),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes the call to convert the address to affine format in each call to `is_owner` by passing the x-coordinate of the address in directly.

## Performance

I observed a 10% speedup after making this change.