### PR TITLE
update instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ cargo install --path .
 
 Now to use `snarkvm`, in your terminal, run:
 ```bash
-snarkvm
+vm
 ```
 
 ## 3. Usage Guide


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Snarkvm is installed as an executable with the named `vm`, not `snarkvm`
- replaced `snarkvm` with `vm`.