### PR TITLE
Add `timers` for `VM`, `Process`, and `Stack` operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
 name = "snarkvm-synthesizer"
 version = "0.9.7"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "bincode",
  "blake2",

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -34,6 +34,17 @@ path = "benches/coinbase_puzzle.rs"
 harness = false
 required-features = [ "setup" ]
 
+[features]
+default = [ "parallel" ]
+parallel = [
+  "rayon",
+  "snarkvm-fields/parallel",
+  "snarkvm-utilities/parallel"
+]
+aleo-cli = [ ]
+setup = [ ]
+timer = [ "aleo-std/timer" ]
+
 [dependencies.circuit]
 package = "snarkvm-circuit"
 path = "../circuit"
@@ -59,6 +70,10 @@ version = "0.9.7"
 [dependencies.snarkvm-utilities]
 path = "../utilities"
 version = "0.9.7"
+default-features = false
+
+[dependencies.aleo-std]
+version = "0.1.15"
 default-features = false
 
 [dependencies.anyhow]
@@ -114,13 +129,3 @@ version = "1.3"
 
 [dev-dependencies.criterion]
 version = "0.4.0"
-
-[features]
-default = [ "parallel" ]
-parallel = [
-  "rayon",
-  "snarkvm-fields/parallel",
-  "snarkvm-utilities/parallel"
-]
-aleo-cli = [ ]
-setup = [ ]

--- a/synthesizer/src/process/evaluate.rs
+++ b/synthesizer/src/process/evaluate.rs
@@ -20,6 +20,8 @@ impl<N: Network> Process<N> {
     /// Evaluates a program function on the given request.
     #[inline]
     pub fn evaluate<A: circuit::Aleo<Network = N>>(&self, authorization: Authorization<N>) -> Result<Response<N>> {
+        let timer = timer!("Process::evaluate");
+
         // Retrieve the main request (without popping it).
         let request = authorization.peek_next()?;
 
@@ -27,6 +29,12 @@ impl<N: Network> Process<N> {
         println!("{}", format!(" • Evaluating '{}/{}'...", request.program_id(), request.function_name()).dimmed());
 
         // Evaluate the function.
-        self.get_stack(request.program_id())?.evaluate_function::<A>(CallStack::evaluate(authorization)?)
+        let response =
+            self.get_stack(request.program_id())?.evaluate_function::<A>(CallStack::evaluate(authorization)?);
+        lap!(timer, "Evaluate the function");
+
+        finish!(timer);
+
+        response
     }
 }

--- a/synthesizer/src/process/execute.rs
+++ b/synthesizer/src/process/execute.rs
@@ -24,6 +24,8 @@ impl<N: Network> Process<N> {
         authorization: Authorization<N>,
         rng: &mut R,
     ) -> Result<(Response<N>, Execution<N>, Inclusion<N>)> {
+        let timer = timer!("Process::execute");
+
         // Retrieve the main request (without popping it).
         let request = authorization.peek_next()?;
 
@@ -36,8 +38,10 @@ impl<N: Network> Process<N> {
         let inclusion = Arc::new(RwLock::new(Inclusion::new()));
         // Initialize the call stack.
         let call_stack = CallStack::execute(authorization, execution.clone(), inclusion.clone())?;
+        lap!(timer, "Initialize call stack");
         // Execute the circuit.
         let response = self.get_stack(request.program_id())?.execute_function::<A, R>(call_stack, rng)?;
+        lap!(timer, "Execute the function");
         // Extract the execution.
         let execution = Arc::try_unwrap(execution).unwrap().into_inner();
         // Ensure the execution is not empty.
@@ -45,6 +49,7 @@ impl<N: Network> Process<N> {
         // Extract the inclusion.
         let inclusion = Arc::try_unwrap(inclusion).unwrap().into_inner();
 
+        finish!(timer);
         Ok((response, execution, inclusion))
     }
 
@@ -52,6 +57,8 @@ impl<N: Network> Process<N> {
     /// Note: This does *not* check that the global state root exists in the ledger.
     #[inline]
     pub fn verify_execution<const VERIFY_INCLUSION: bool>(&self, execution: &Execution<N>) -> Result<()> {
+        let timer = timer!("Process::verify_execution");
+
         // Ensure the execution contains transitions.
         ensure!(!execution.is_empty(), "There are no transitions in the execution");
 
@@ -69,10 +76,12 @@ impl<N: Network> Process<N> {
                 execution.len()
             );
         }
+        lap!(timer, "Verify the number of transitions");
 
         // Ensure the inclusion proof is valid.
         if VERIFY_INCLUSION {
             Inclusion::verify_execution(execution)?;
+            lap!(timer, "Verify the inclusion proof");
         }
 
         // Replicate the execution stack for verification.
@@ -110,6 +119,8 @@ impl<N: Network> Process<N> {
             {
                 bail!("Failed to verify a transition input")
             }
+            lap!(timer, "Verify the inputs");
+
             // Ensure each output is valid.
             let num_inputs = transition.inputs().len();
             if transition
@@ -120,6 +131,7 @@ impl<N: Network> Process<N> {
             {
                 bail!("Failed to verify a transition output")
             }
+            lap!(timer, "Verify the outputs");
 
             // Ensure the fee is correct.
             match Program::is_coinbase(transition.program_id(), transition.function_name()) {
@@ -195,6 +207,7 @@ impl<N: Network> Process<N> {
 
             // [Inputs] Extend the verifier inputs with the fee.
             inputs.push(*I64::<N>::new(*transition.fee()).to_field()?);
+            lap!(timer, "Construct the verifier inputs");
 
             #[cfg(debug_assertions)]
             println!("Transition public inputs ({} elements): {:#?}", inputs.len(), inputs);
@@ -206,7 +219,11 @@ impl<N: Network> Process<N> {
                 verifying_key.verify(function.name(), &inputs, transition.proof()),
                 "Transition is invalid - failed to verify transition proof"
             );
+
+            lap!(timer, "Verify transition {}", transition.id());
         }
+
+        finish!(timer);
         Ok(())
     }
 
@@ -218,6 +235,8 @@ impl<N: Network> Process<N> {
         store: &ProgramStore<N, P>,
         execution: &Execution<N>,
     ) -> Result<()> {
+        let timer = timer!("Program::finalize_execution");
+
         // Ensure the execution contains transitions.
         ensure!(!execution.is_empty(), "There are no transitions in the execution");
 
@@ -235,6 +254,7 @@ impl<N: Network> Process<N> {
                 execution.len()
             );
         }
+        lap!(timer, "Verify the number of transitions");
 
         // TODO (howardwu): This is a temporary approach. We should create a "CallStack" and recurse through the stack.
         //  Currently this loop assumes a linearly execution stack.
@@ -287,8 +307,11 @@ impl<N: Network> Process<N> {
                         registers.load(stack, &Operand::Register(register.clone()))
                     })
                     .collect::<Result<Vec<_>>>()?;
+
+                lap!(timer, "Finalize transition {}", transition.id());
             }
         }
+        finish!(timer);
 
         Ok(())
     }

--- a/synthesizer/src/process/execute.rs
+++ b/synthesizer/src/process/execute.rs
@@ -220,7 +220,7 @@ impl<N: Network> Process<N> {
                 "Transition is invalid - failed to verify transition proof"
             );
 
-            lap!(timer, "Verify transition {}", transition.id());
+            lap!(timer, "Verify transition proof for {}", function.name());
         }
 
         finish!(timer);
@@ -308,7 +308,7 @@ impl<N: Network> Process<N> {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                lap!(timer, "Finalize transition {}", transition.id());
+                lap!(timer, "Finalize transition for {function_name}");
             }
         }
         finish!(timer);

--- a/synthesizer/src/process/execute_fee.rs
+++ b/synthesizer/src/process/execute_fee.rs
@@ -26,6 +26,8 @@ impl<N: Network> Process<N> {
         fee_in_gates: u64,
         rng: &mut R,
     ) -> Result<(Response<N>, Transition<N>, Inclusion<N>)> {
+        let timer = timer!("Process::execute_fee");
+
         // Ensure the fee has the correct program ID.
         let program_id = ProgramID::from_str("credits.aleo")?;
         // Ensure the fee has the correct function.
@@ -35,14 +37,18 @@ impl<N: Network> Process<N> {
         let input_types = self.get_program(program_id)?.get_function(&function_name)?.input_types();
         // Construct the inputs.
         let inputs = [Value::Record(credits), Value::from_str(&format!("{}", U64::<N>::new(fee_in_gates)))?];
+        lap!(timer, "Construct the inputs");
         // Compute the request.
         let request = Request::sign(private_key, program_id, function_name, inputs.iter(), &input_types, rng)?;
+        lap!(timer, "Compute the request");
         // Initialize the authorization.
         let authorization = Authorization::new(&[request.clone()]);
+        lap!(timer, "Initialize the authorization");
         // Construct the call stack.
         let call_stack = CallStack::Authorize(vec![request], *private_key, authorization.clone());
         // Construct the authorization from the function.
         let _response = self.get_stack(program_id)?.execute_function::<A, R>(call_stack, rng)?;
+        lap!(timer, "Construct the authorization from the function");
 
         // Retrieve the main request (without popping it).
         let request = authorization.peek_next()?;
@@ -60,12 +66,16 @@ impl<N: Network> Process<N> {
         let call_stack = CallStack::execute(authorization, execution.clone(), inclusion.clone())?;
         // Execute the circuit.
         let response = stack.execute_function::<A, R>(call_stack, rng)?;
+        lap!(timer, "Execute the circuit");
+
         // Extract the execution.
         let execution = Arc::try_unwrap(execution).unwrap().into_inner();
         // Ensure the execution contains 1 transition.
         ensure!(execution.len() == 1, "Execution of '{}/{}' does not contain 1 transition", program_id, function_name);
         // Extract the inclusion.
         let inclusion = Arc::try_unwrap(inclusion).unwrap().into_inner();
+
+        finish!(timer);
 
         Ok((response, execution.peek()?.clone(), inclusion))
     }
@@ -74,6 +84,8 @@ impl<N: Network> Process<N> {
     /// Note: This does *not* check that the global state root exists in the ledger.
     #[inline]
     pub fn verify_fee(&self, fee: &Fee<N>) -> Result<()> {
+        let timer = timer!("Process::verify_fee");
+
         #[cfg(debug_assertions)]
         println!("Verifying fee from {}/{}...", fee.program_id(), fee.function_name());
 
@@ -103,6 +115,8 @@ impl<N: Network> Process<N> {
         if fee.inputs().iter().enumerate().any(|(index, input)| !input.verify(function_id, fee.tcm(), index)) {
             bail!("Failed to verify a fee input")
         }
+        lap!(timer, "Verify the inputs");
+
         // Ensure each output is valid.
         let num_inputs = fee.inputs().len();
         if fee
@@ -113,12 +127,14 @@ impl<N: Network> Process<N> {
         {
             bail!("Failed to verify a fee output")
         }
+        lap!(timer, "Verify the outputs");
 
         // Ensure the fee is not negative.
         ensure!(fee.fee() >= &0, "The fee must be zero or positive");
 
         // Ensure the inclusion proof is valid.
         Inclusion::verify_fee(fee)?;
+        lap!(timer, "Verify the inclusion proof");
 
         // Compute the x- and y-coordinate of `tpk`.
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
@@ -131,6 +147,7 @@ impl<N: Network> Process<N> {
         inputs.extend(fee.outputs().iter().flat_map(|output| output.verifier_inputs()));
         // Extend the inputs with the fee.
         inputs.push(*I64::<N>::new(*fee.fee()).to_field()?);
+        lap!(timer, "Construct the verifier inputs");
 
         // Retrieve the stack.
         let stack = self.get_stack(fee.program_id())?;
@@ -157,6 +174,9 @@ impl<N: Network> Process<N> {
             verifying_key.verify(function.name(), &inputs, fee.proof()),
             "Fee is invalid - failed to verify transition proof"
         );
+        lap!(timer, "Verify the transition proof");
+
+        finish!(timer);
 
         Ok(())
     }

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -36,6 +36,7 @@ use console::{
     types::{I64, U16, U64},
 };
 
+use aleo_std::prelude::{finish, lap, timer};
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 #[cfg(test)]

--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -62,15 +62,15 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Evaluate the instructions");
 
         // Load the outputs.
-        let outputs = closure.outputs().iter().map(|output| {
+        let outputs_iter = closure.outputs().iter().map(|output| {
             // Retrieve the stack value from the register.
             registers.load(self, &Operand::Register(output.register().clone()))
         });
+        let outputs = outputs_iter.collect();
         lap!(timer, "Load the outputs");
 
         finish!(timer);
-
-        outputs.collect()
+        outputs
     }
 
     /// Evaluates a program function on the given inputs.

--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -30,6 +30,8 @@ impl<N: Network> Stack<N> {
         caller: Address<N>,
         tvk: Field<N>,
     ) -> Result<Vec<Value<N>>> {
+        let timer = timer!("Stack::evaluate_closure");
+
         // Ensure the number of inputs matches the number of input statements.
         if closure.inputs().len() != inputs.len() {
             bail!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len())
@@ -41,12 +43,14 @@ impl<N: Network> Stack<N> {
         registers.set_caller(caller);
         // Set the transition view key.
         registers.set_tvk(tvk);
+        lap!(timer, "Initialize the registers");
 
         // Store the inputs.
         closure.inputs().iter().map(|i| i.register()).zip_eq(inputs).try_for_each(|(register, input)| {
             // Assign the input value to the register.
             registers.store(self, register, input.clone())
         })?;
+        lap!(timer, "Store the inputs");
 
         // Evaluate the instructions.
         for instruction in closure.instructions() {
@@ -55,12 +59,16 @@ impl<N: Network> Stack<N> {
                 bail!("Failed to evaluate instruction ({instruction}): {error}");
             }
         }
+        lap!(timer, "Evaluate the instructions");
 
         // Load the outputs.
         let outputs = closure.outputs().iter().map(|output| {
             // Retrieve the stack value from the register.
             registers.load(self, &Operand::Register(output.register().clone()))
         });
+        lap!(timer, "Load the outputs");
+
+        finish!(timer);
 
         outputs.collect()
     }
@@ -71,12 +79,15 @@ impl<N: Network> Stack<N> {
     /// This method will halt if the given inputs are not the same length as the input statements.
     #[inline]
     pub fn evaluate_function<A: circuit::Aleo<Network = N>>(&self, call_stack: CallStack<N>) -> Result<Response<N>> {
+        let timer = timer!("Stack::evaluate_function");
+
         // Retrieve the next request, based on the call stack mode.
         let (request, call_stack) = match &call_stack {
             CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
             CallStack::Execute(authorization, ..) => (authorization.peek_next()?, call_stack.replicate()),
             _ => bail!("Illegal operation: call stack must be `Evaluate` or `Execute` in `evaluate_function`."),
         };
+        lap!(timer, "Retrieve the next request");
 
         // Ensure the network ID matches.
         ensure!(
@@ -102,6 +113,7 @@ impl<N: Network> Stack<N> {
                 inputs.len()
             )
         }
+        lap!(timer, "Perform input checks");
 
         // Initialize the registers.
         let mut registers = Registers::<N, A>::new(call_stack, self.get_register_types(function.name())?.clone());
@@ -109,15 +121,18 @@ impl<N: Network> Stack<N> {
         registers.set_caller(caller);
         // Set the transition view key.
         registers.set_tvk(tvk);
+        lap!(timer, "Initialize the registers");
 
         // Ensure the request is well-formed.
         ensure!(request.verify(&function.input_types()), "Request is invalid");
+        lap!(timer, "Verify the request");
 
         // Store the inputs.
         function.inputs().iter().map(|i| i.register()).zip_eq(inputs).try_for_each(|(register, input)| {
             // Assign the input value to the register.
             registers.store(self, register, input.clone())
         })?;
+        lap!(timer, "Store the inputs");
 
         // Evaluate the instructions.
         for instruction in function.instructions() {
@@ -126,9 +141,11 @@ impl<N: Network> Stack<N> {
                 bail!("Failed to evaluate instruction ({instruction}): {error}");
             }
         }
+        lap!(timer, "Evaluate the instructions");
 
         // Retrieve the output registers.
         let output_registers = &function.outputs().iter().map(|output| output.register().clone()).collect::<Vec<_>>();
+        lap!(timer, "Retrieve the output registers");
 
         // Load the outputs.
         let outputs = output_registers
@@ -138,6 +155,9 @@ impl<N: Network> Stack<N> {
                 registers.load(self, &Operand::Register(register.clone()))
             })
             .collect::<Result<Vec<_>>>()?;
+        lap!(timer, "Load the outputs");
+
+        finish!(timer);
 
         // Compute the response.
         Response::new(

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -83,15 +83,15 @@ impl<N: Network> Stack<N> {
         ensure!(A::num_public() == num_public, "Illegal closure operation: instructions injected public variables");
 
         // Load the outputs.
-        let outputs = closure.outputs().iter().map(|output| {
+        let outputs_iter = closure.outputs().iter().map(|output| {
             // Retrieve the circuit output from the register.
             registers.load_circuit(self, &Operand::Register(output.register().clone()))
         });
+        let outputs = outputs_iter.collect();
         lap!(timer, "Load the outputs");
 
         finish!(timer);
-
-        outputs.collect()
+        outputs
     }
 
     /// Executes a program function on the given inputs.

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -30,6 +30,8 @@ impl<N: Network> Stack<N> {
         caller: circuit::Address<A>,
         tvk: circuit::Field<A>,
     ) -> Result<Vec<circuit::Value<A>>> {
+        let timer = timer!("Stack::execute_closure");
+
         // Ensure the call stack is not `Evaluate`.
         ensure!(!matches!(call_stack, CallStack::Evaluate(..)), "Illegal operation: cannot evaluate in execute mode");
 
@@ -37,6 +39,7 @@ impl<N: Network> Stack<N> {
         if closure.inputs().len() != inputs.len() {
             bail!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len())
         }
+        lap!(timer, "Check the number of inputs");
 
         // Retrieve the number of public variables in the circuit.
         let num_public = A::num_public();
@@ -47,6 +50,7 @@ impl<N: Network> Stack<N> {
         registers.set_caller_circuit(caller);
         // Set the transition view key, as a circuit.
         registers.set_tvk_circuit(tvk);
+        lap!(timer, "Initialize the registers");
 
         // Store the inputs.
         closure.inputs().iter().map(|i| i.register()).zip_eq(inputs).try_for_each(|(register, input)| {
@@ -59,6 +63,7 @@ impl<N: Network> Stack<N> {
             // Assign the circuit input to the register.
             registers.store_circuit(self, register, input.clone())
         })?;
+        lap!(timer, "Store the inputs");
 
         // Execute the instructions.
         for instruction in closure.instructions() {
@@ -72,6 +77,7 @@ impl<N: Network> Stack<N> {
             // Execute the instruction.
             instruction.execute(self, &mut registers)?;
         }
+        lap!(timer, "Execute the instructions");
 
         // Ensure the number of public variables remains the same.
         ensure!(A::num_public() == num_public, "Illegal closure operation: instructions injected public variables");
@@ -81,6 +87,9 @@ impl<N: Network> Stack<N> {
             // Retrieve the circuit output from the register.
             registers.load_circuit(self, &Operand::Register(output.register().clone()))
         });
+        lap!(timer, "Load the outputs");
+
+        finish!(timer);
 
         outputs.collect()
     }
@@ -97,6 +106,8 @@ impl<N: Network> Stack<N> {
         mut call_stack: CallStack<N>,
         rng: &mut R,
     ) -> Result<Response<N>> {
+        let timer = timer!("Stack::execute_function");
+
         // Ensure the call stack is not `Evaluate`.
         ensure!(!matches!(call_stack, CallStack::Evaluate(..)), "Illegal operation: cannot evaluate in execute mode");
 
@@ -126,15 +137,18 @@ impl<N: Network> Stack<N> {
         let input_types = function.input_types();
         // Retrieve the output types.
         let output_types = function.output_types();
+        lap!(timer, "Retrieve the input and output types");
 
         // Ensure the inputs match their expected types.
         console_request.inputs().iter().zip_eq(&input_types).try_for_each(|(input, input_type)| {
             // Ensure the input matches the input type in the function.
             self.matches_value_type(input, input_type)
         })?;
+        lap!(timer, "Verify the input types");
 
         // Ensure the request is well-formed.
         ensure!(console_request.verify(&input_types), "Request is invalid");
+        lap!(timer, "Verify the request");
 
         // Initialize the registers.
         let mut registers = Registers::new(call_stack, self.get_register_types(function.name())?.clone());
@@ -158,6 +172,8 @@ impl<N: Network> Stack<N> {
         // Set the transition view key, as a circuit.
         registers.set_tvk_circuit(request.tvk().clone());
 
+        lap!(timer, "Initialize the registers");
+
         #[cfg(debug_assertions)]
         Self::log_circuit::<A, _>("Request");
 
@@ -174,6 +190,7 @@ impl<N: Network> Stack<N> {
             // Assign the circuit input to the register.
             registers.store_circuit(self, register, input.clone())
         })?;
+        lap!(timer, "Store the inputs");
 
         // Initialize a tracker to determine if there are any function calls.
         let mut contains_function_call = false;
@@ -199,6 +216,7 @@ impl<N: Network> Stack<N> {
                 }
             }
         }
+        lap!(timer, "Execute the instructions");
 
         // Load the outputs.
         let output_registers = &function.outputs().iter().map(|output| output.register().clone()).collect::<Vec<_>>();
@@ -206,6 +224,7 @@ impl<N: Network> Stack<N> {
             .iter()
             .map(|register| registers.load_circuit(self, &Operand::Register(register.clone())))
             .collect::<Result<Vec<_>>>()?;
+        lap!(timer, "Load the outputs");
 
         #[cfg(debug_assertions)]
         Self::log_circuit::<A, _>(format!("Function '{}()'", function.name()));
@@ -228,6 +247,7 @@ impl<N: Network> Stack<N> {
             &output_types,
             output_registers,
         );
+        lap!(timer, "Construct the response");
 
         #[cfg(debug_assertions)]
         Self::log_circuit::<A, _>("Response");
@@ -293,6 +313,8 @@ impl<N: Network> Stack<N> {
 
                 #[cfg(debug_assertions)]
                 Self::log_circuit::<A, _>("Finalize");
+
+                lap!(timer, "Construct the finalize inputs");
 
                 // Return the (console) finalize inputs.
                 Some(console_finalize_inputs)
@@ -371,6 +393,8 @@ impl<N: Network> Stack<N> {
         #[cfg(debug_assertions)]
         Self::log_circuit::<A, _>("Complete");
 
+        lap!(timer, "Perform the fee operations");
+
         // Eject the fee.
         let fee = i64_gates.eject_value();
         // Eject the response.
@@ -405,6 +429,7 @@ impl<N: Network> Stack<N> {
             if !self.contains_proving_key(function.name()) {
                 // Add the circuit key to the mapping.
                 self.synthesize_from_assignment(function.name(), &assignment)?;
+                lap!(timer, "Synthesize the {} circuit key", function.name());
             }
         }
 
@@ -412,6 +437,7 @@ impl<N: Network> Stack<N> {
         if let CallStack::CheckDeployment(_, _, ref assignments) = registers.call_stack() {
             // Add the assignment to the assignments.
             assignments.write().push(assignment);
+            lap!(timer, "Save the circuit assignment");
         }
         // If the circuit is in `Execute` mode, then execute the circuit into a transition.
         else if let CallStack::Execute(_, ref execution, ref inclusion) = registers.call_stack() {
@@ -424,6 +450,7 @@ impl<N: Network> Stack<N> {
                 Ok(proof) => proof,
                 Err(error) => bail!("Execution proof failed - {error}"),
             };
+            lap!(timer, "Execute the circuit");
 
             // Construct the transition.
             let transition =
@@ -434,6 +461,8 @@ impl<N: Network> Stack<N> {
             // Add the transition to the execution.
             execution.write().push(transition);
         }
+
+        finish!(timer);
 
         // Return the response.
         Ok(response)

--- a/synthesizer/src/process/stack/mod.rs
+++ b/synthesizer/src/process/stack/mod.rs
@@ -86,6 +86,7 @@ use console::{
     types::{Field, Group, U64},
 };
 
+use aleo_std::prelude::{finish, lap, timer};
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 use std::sync::Arc;

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -20,6 +20,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Deploys a program with the given program ID.
     #[inline]
     pub fn deploy<R: Rng + CryptoRng>(&self, program: &Program<N>, rng: &mut R) -> Result<Deployment<N>> {
+        let timer = timer!("VM::deploy");
+
         // Compute the core logic.
         macro_rules! logic {
             ($process:expr, $network:path, $aleo:path) => {{
@@ -28,9 +30,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
                 // Compute the deployment.
                 let deployment = $process.deploy::<$aleo, _>(program, rng)?;
+                lap!(timer, "Compute the deployment");
 
                 // Prepare the return.
                 let deployment = cast_ref!(deployment as Deployment<N>).clone();
+                lap!(timer, "Prepare the deployment");
+
+                finish!(timer);
                 // Return the deployment.
                 Ok(deployment)
             }};

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -30,13 +30,14 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Finalize the transaction.
                 match transaction {
                     Transaction::Deploy(_, deployment, _) => {
-                        process.finalize_deployment(self.program_store(), deployment)?
+                        process.finalize_deployment(self.program_store(), deployment)?;
+                        lap!(timer, "Finalize deployment");
                     }
                     Transaction::Execute(_, execution, _) => {
-                        process.finalize_execution(self.program_store(), execution)?
+                        process.finalize_execution(self.program_store(), execution)?;
+                        lap!(timer, "Finalize execution");
                     }
                 }
-                lap!(timer, "Finalize transaction");
             }
             Ok(())
         });

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -21,6 +21,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// This method assumes the given transactions **are valid**.
     #[inline]
     pub fn finalize(&self, transactions: &Transactions<N>) -> Result<()> {
+        let timer = timer!("VM::finalize");
         atomic_write_batch!(self, {
             // Acquire the write lock on the process.
             let mut process = self.process.write();
@@ -35,9 +36,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         process.finalize_execution(self.program_store(), execution)?
                     }
                 }
+                lap!(timer, "Finalize transaction");
             }
             Ok(())
         });
+
+        finish!(timer);
+
         Ok(())
     }
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -37,6 +37,7 @@ use console::{
     program::{Identifier, Plaintext, ProgramID, Record, Response, Value},
 };
 
+use aleo_std::prelude::{finish, lap, timer};
 use parking_lot::RwLock;
 use std::sync::Arc;
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds timers for operations in `VM`, `Process`, and `Stack`. For example, `VM::execute`, `VM::verify_deployment`, `Process::execute_fee`, `Stack::deploy`, etc. 
