### PR TITLE
Fix possible issue in integer bit serialization.

### DIFF
--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -120,7 +120,7 @@ macro_rules! impl_bits_for_integer {
             #[inline]
             fn to_bits_le(&self) -> Vec<bool> {
                 let mut bits_le = Vec::with_capacity(<$int>::BITS as usize);
-                let mut value = self.to_le();
+                let mut value = *self;
                 for _ in 0..<$int>::BITS {
                     bits_le.push(value & 1 == 1);
                     value = value.wrapping_shr(1u32);


### PR DESCRIPTION
The call of `to_le` is a no-op on little-endian machines (i.e. pretty much all the machines we normally use), but it swaps bytes on big-endian machines. Thus, for instance, `0x01ff` would be swapped to `0xff01` by `to_le` on a big-endian machine, and then deserialized to the bits `1000 0000 1111 1111` by the loop that follows the `to_le` call, which would not be the correct deserialization, which should be `1111 1111 1000 0000`.

Note that the deserialization code does nothing to invert the `to_le`, so on a big-endian machine serializing and then deserializing would not be an identity.
