### PR TITLE
Add `global_state_root` for transitions with no `InclusionProof`

### DIFF
--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -300,6 +300,11 @@ impl<N: Network> Inclusion<N> {
     ) -> Result<Execution<N>> {
         match assignments.is_empty() {
             true => {
+                // Ensure the global state root is zero.
+                if *global_state_root != Field::zero() {
+                    bail!("Inclusion expected the global state root in the execution to match")
+                }
+
                 // Ensure the inclusion proof in the execution is 'None'.
                 if execution.inclusion_proof().is_some() {
                     bail!("Inclusion expected the inclusion proof in the execution to be 'None'")

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -427,6 +427,12 @@ impl<N: Network> Inclusion<N> {
     pub fn verify_execution(execution: &Execution<N>) -> Result<()> {
         // Retrieve the global state root.
         let global_state_root = execution.global_state_root();
+
+        // Ensure the global state root is not zero.
+        if *global_state_root == Field::zero() {
+            bail!("Inclusion expected the global state root in the execution to *not* be zero")
+        }
+
         // Retrieve the inclusion proof.
         let inclusion_proof = execution.inclusion_proof();
 
@@ -471,11 +477,6 @@ impl<N: Network> Inclusion<N> {
 
         // Verify the inclusion proof.
         if let Some(inclusion_proof) = inclusion_proof {
-            // Ensure the global state root is not zero.
-            if *global_state_root == Field::zero() {
-                bail!("Inclusion expected the global state root in the execution to *not* be zero")
-            }
-
             // Fetch the inclusion verifying key.
             let verifying_key = VerifyingKey::<N>::new(N::inclusion_verifying_key().clone());
             // Verify the inclusion proof.

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -426,11 +426,6 @@ impl<N: Network> Inclusion<N> {
         // Retrieve the global state root.
         let global_state_root = execution.global_state_root();
 
-        // Ensure the global state root is not zero.
-        if *global_state_root == Field::zero() {
-            bail!("Inclusion expected the global state root in the execution to *not* be zero")
-        }
-
         // Retrieve the inclusion proof.
         let inclusion_proof = execution.inclusion_proof();
 
@@ -475,6 +470,11 @@ impl<N: Network> Inclusion<N> {
 
         // Verify the inclusion proof.
         if let Some(inclusion_proof) = inclusion_proof {
+            // Ensure the global state root is not zero.
+            if *global_state_root == Field::zero() {
+                bail!("Inclusion expected the global state root in the execution to *not* be zero")
+            }
+
             // Fetch the inclusion verifying key.
             let verifying_key = VerifyingKey::<N>::new(N::inclusion_verifying_key().clone());
             // Verify the inclusion proof.

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -215,6 +215,11 @@ impl<N: Network> Inclusion<N> {
         // Retrieve the global state root.
         let global_state_root = query.current_state_root()?;
 
+        // Ensure the global state root is not zero.
+        if *global_state_root == Field::zero() {
+            bail!("Inclusion expected the global state root in the execution to *not* be zero")
+        }
+
         for (transition_index, transition) in execution.transitions().enumerate() {
             // Construct the transaction leaf.
             let transaction_leaf = TransactionLeaf::new_execution(transition_index as u16, **transition.id());
@@ -250,7 +255,7 @@ impl<N: Network> Inclusion<N> {
                         };
 
                         // Ensure the global state root is the same across iterations.
-                        if *global_state_root != Field::zero() && global_state_root != state_path.global_state_root() {
+                        if global_state_root != state_path.global_state_root() {
                             bail!("Inclusion expected the global state root to be the same across iterations")
                         }
 
@@ -273,11 +278,6 @@ impl<N: Network> Inclusion<N> {
 
             // Insert the leaf into the transaction tree.
             transaction_tree.append(&[transaction_leaf.to_bits_le()])?;
-        }
-
-        // Ensure the global state root is not zero.
-        if *global_state_root == Field::zero() {
-            bail!("Inclusion expected the global state root in the execution to *not* be zero")
         }
 
         if assignments.is_empty() {

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -207,6 +207,11 @@ impl<N: Network> Inclusion<N> {
         // Ensure the number of leaves is within the Merkle tree size.
         Transaction::check_execution_size(execution)?;
 
+        // Ensure the inclusion proof in the execution is 'None'.
+        if execution.inclusion_proof().is_some() {
+            bail!("Inclusion proof in the execution should not be set in 'Inclusion::prepare_execution'")
+        }
+
         // Initialize an empty transaction tree.
         let mut transaction_tree = N::merkle_tree_bhp::<TRANSACTION_DEPTH>(&[])?;
         // Initialize a vector for the assignments.
@@ -278,11 +283,6 @@ impl<N: Network> Inclusion<N> {
 
             // Insert the leaf into the transaction tree.
             transaction_tree.append(&[transaction_leaf.to_bits_le()])?;
-        }
-
-        // Ensure the inclusion proof in the execution is 'None'.
-        if execution.inclusion_proof().is_some() {
-            bail!("Inclusion proof in the execution should not be set in 'Inclusion::prepare_execution'")
         }
 
         Ok((assignments, global_state_root))

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -470,6 +470,11 @@ impl<N: Network> Inclusion<N> {
 
         // Verify the inclusion proof.
         if let Some(inclusion_proof) = inclusion_proof {
+            // Ensure the global state root is not zero.
+            if *global_state_root == Field::zero() {
+                bail!("Inclusion expected the global state root in the execution to *not* be zero")
+            }
+
             // Fetch the inclusion verifying key.
             let verifying_key = VerifyingKey::<N>::new(N::inclusion_verifying_key().clone());
             // Verify the inclusion proof.
@@ -477,11 +482,6 @@ impl<N: Network> Inclusion<N> {
                 verifying_key.verify_batch(N::INCLUSION_FUNCTION_NAME, &batch_verifier_inputs, inclusion_proof),
                 "Inclusion proof is invalid"
             );
-        }
-
-        // Ensure the global state root is not zero.
-        if *global_state_root == Field::zero() {
-            bail!("Inclusion expected the global state root in the execution to *not* be zero")
         }
 
         Ok(())

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -280,11 +280,9 @@ impl<N: Network> Inclusion<N> {
             transaction_tree.append(&[transaction_leaf.to_bits_le()])?;
         }
 
-        if assignments.is_empty() {
-            // Ensure the inclusion proof in the execution is 'None'.
-            if execution.inclusion_proof().is_some() {
-                bail!("Inclusion expected the inclusion proof in the execution to be 'None'")
-            }
+        // Ensure the inclusion proof in the execution is 'None'.
+        if execution.inclusion_proof().is_some() {
+            bail!("Inclusion proof in the execution should not be set in 'Inclusion::prepare_execution'")
         }
 
         Ok((assignments, global_state_root))

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -300,9 +300,9 @@ impl<N: Network> Inclusion<N> {
     ) -> Result<Execution<N>> {
         match assignments.is_empty() {
             true => {
-                // Ensure the global state root is zero.
-                if *global_state_root != Field::zero() {
-                    bail!("Inclusion expected the global state root in the execution to match")
+                // Ensure the global state root is not zero.
+                if *global_state_root == Field::zero() {
+                    bail!("Inclusion expected the global state root in the execution to *not* be zero")
                 }
 
                 // Ensure the inclusion proof in the execution is 'None'.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -52,12 +52,15 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     inclusion.prepare_execution(execution, query)?
                 };
                 let assignments = cast_ref!(assignments as Vec<InclusionAssignment<$network>>);
-                let global_state_root = cast_ref!(global_state_root as Field<$network>);
+                let global_state_root = {
+                    let field = *global_state_root;
+                    cast_ref!(field as Field<$network>).clone()
+                };
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the inclusion proof and update the execution.
                 let execution =
-                    inclusion.prove_execution::<$aleo, _>(execution, assignments, (*global_state_root).into(), rng)?;
+                    inclusion.prove_execution::<$aleo, _>(execution, assignments, global_state_root.into(), rng)?;
                 lap!(timer, "Compute the inclusion proof");
 
                 // Prepare the return.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -52,10 +52,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     inclusion.prepare_execution(execution, query)?
                 };
                 let assignments = cast_ref!(assignments as Vec<InclusionAssignment<$network>>);
-                let global_state_root = {
-                    let field = *global_state_root;
-                    cast_ref!(field as Field<$network>).clone()
-                };
+                let global_state_root = *cast_ref!((*global_state_root) as Field<$network>);
+
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the inclusion proof and update the execution.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -46,12 +46,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Execute the call");
 
                 // Prepare the assignments.
-                let assignments = {
-                    let execution = cast_ref!(execution as Execution<N>);
+                let (assignments, execution) = {
+                    let execution = cast_ref!(execution as Execution<N>).clone();
                     let inclusion = cast_ref!(inclusion as Inclusion<N>);
                     inclusion.prepare_execution(execution, query)?
                 };
                 let assignments = cast_ref!(assignments as Vec<InclusionAssignment<$network>>);
+                let execution = cast_ref!(execution as Execution<$network>).clone();
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the inclusion proof and update the execution.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -16,10 +16,6 @@
 
 use super::*;
 
-// TODO (raychu86): Figure out how to `cast_ref!` the state root object directly.
-#[derive(Clone, Copy)]
-struct WrappedStateRoot<N: Network>(N::StateRoot);
-
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Executes a call to the program function for the given inputs.
     #[inline]
@@ -56,15 +52,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     inclusion.prepare_execution(execution, query)?
                 };
                 let assignments = cast_ref!(assignments as Vec<InclusionAssignment<$network>>);
-                let global_state_root = {
-                    let wrapped_state_root = WrappedStateRoot::<N>(global_state_root);
-                    cast_ref!(wrapped_state_root as WrappedStateRoot<$network>).0
-                };
+                let global_state_root = cast_ref!(global_state_root as Field<$network>);
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the inclusion proof and update the execution.
                 let execution =
-                    inclusion.prove_execution::<$aleo, _>(execution, assignments, global_state_root, rng)?;
+                    inclusion.prove_execution::<$aleo, _>(execution, assignments, (*global_state_root).into(), rng)?;
                 lap!(timer, "Compute the inclusion proof");
 
                 // Prepare the return.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -359,4 +359,112 @@ function compute:
             })
             .clone()
     }
+
+    #[test]
+    fn test_auction_deploy_and_execute() {
+        use crate::{Header, Metadata};
+        use console::types::Field;
+
+        // Initialize the auction program.
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program auction.aleo;
+
+record Bid:
+    owner as address.private;
+    gates as u64.private;
+    bidder as address.private;
+    amount as u64.private;
+    is_winner as boolean.private;
+
+function place_bid:
+    input r0 as address.private;
+    input r1 as u64.private;
+//    assert.eq self.caller r0;
+    cast aleo1sf82t8nwamevgcwj3vd9crer2su8zrgu6dp4cvrl6fv4htpd4sgq3tltj4 0u64 r0 r1 false into r2 as Bid.record;
+    output r2 as Bid.record;",
+        )
+        .unwrap();
+
+        // Initialize the RNG.
+        let rng = &mut TestRng::default();
+
+        // Initialize a new caller.
+        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+        let caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
+        let address = Address::try_from(&caller_private_key).unwrap();
+
+        // Initialize the genesis block.
+        let genesis = crate::vm::test_helpers::sample_genesis_block(rng);
+
+        // Fetch the unspent records.
+        let records = genesis.transitions().cloned().flat_map(Transition::into_records).collect::<IndexMap<_, _>>();
+        trace!("Unspent Records:\n{:#?}", records);
+
+        // Prepare the additional fee.
+        let credits = records.values().next().unwrap().decrypt(&caller_view_key).unwrap();
+        let additional_fee = (credits, 10);
+
+        // Initialize the VM.
+        let vm = sample_vm();
+        // Update the VM.
+        vm.add_next_block(&genesis).unwrap();
+
+        // Deploy.
+        let transaction = Transaction::deploy(&vm, &caller_private_key, &program, additional_fee, None, rng).unwrap();
+        // Verify.
+        assert!(vm.verify(&transaction));
+
+        // Construct the metadata associated with the block.
+        let deployment_metadata = Metadata::new(
+            CurrentNetwork::ID,
+            1,
+            1,
+            CurrentNetwork::GENESIS_COINBASE_TARGET,
+            CurrentNetwork::GENESIS_PROOF_TARGET,
+            genesis.last_coinbase_target(),
+            genesis.last_coinbase_timestamp(),
+            CurrentNetwork::GENESIS_TIMESTAMP + 1,
+        )
+        .unwrap();
+
+        // Construct the new block header.
+        let transactions = Transactions::from(&[transaction]);
+        let deployment_header = Header::from(
+            *vm.block_store().current_state_root(),
+            transactions.to_root().unwrap(),
+            Field::zero(),
+            deployment_metadata,
+        )
+        .unwrap();
+
+        // Construct a new block for the deploy transaction.
+        let deployment_block =
+            Block::new(&caller_private_key, genesis.hash(), deployment_header, transactions, None, rng).unwrap();
+
+        // Update the VM.
+        vm.add_next_block(&deployment_block).unwrap();
+
+        // Authorize.
+        let authorization = vm
+            .authorize(
+                &caller_private_key,
+                "auction.aleo",
+                "place_bid",
+                [
+                    Value::<CurrentNetwork>::from_str(&address.to_string()).unwrap(),
+                    Value::<CurrentNetwork>::from_str("10u64").unwrap(),
+                ]
+                .into_iter(),
+                rng,
+            )
+            .unwrap();
+        assert_eq!(authorization.len(), 1);
+
+        // Execute.
+        let transaction = Transaction::execute_authorization(&vm, authorization, None, rng).unwrap();
+
+        // Verify.
+        assert!(vm.verify(&transaction));
+    }
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -35,6 +35,7 @@ use console::{
     account::PrivateKey,
     network::prelude::*,
     program::{Identifier, Plaintext, ProgramID, Record, Response, Value},
+    types::Field,
 };
 
 use aleo_std::prelude::{finish, lap, timer};


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds the `global_state_root` to executions even if they do not have an `InclusionProof` (input record). This is done by updating the `global_state_root` with in `Inclusion::prepare_execution` using the `Query`. 

## Test Plan

A test (`test_verify_deploy_and_execute`) has been added to enforce that the execution of a test program function with no input record will still have a unique state root.