### PR TITLE
Remove indexing from serde deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,6 +2285,7 @@ dependencies = [
  "snarkvm-console-collections",
  "snarkvm-console-network",
  "snarkvm-console-types",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2494,6 +2495,7 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "serde",
+ "serde_json",
  "snarkvm-utilities-derives",
  "thiserror",
 ]

--- a/console/program/Cargo.toml
+++ b/console/program/Cargo.toml
@@ -26,6 +26,10 @@ version = "0.9.11"
 path = "../types"
 version = "0.9.11"
 
+[dependencies.snarkvm-utilities]
+path = "../../utilities"
+version = "0.9.11"
+
 [dependencies.enum_index]
 version = "0.2"
 

--- a/console/program/src/request/input_id/serialize.rs
+++ b/console/program/src/request/input_id/serialize.rs
@@ -68,25 +68,61 @@ impl<'de, N: Network> Deserialize<'de> for InputID<N> {
                 // Parse the input ID from a string into a value.
                 let mut input = serde_json::Value::deserialize(deserializer)?;
                 // Recover the input.
-                let input_id = match input["type"].as_str() {
-                    Some("constant") => {
-                        InputID::Constant(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
-                    }
-                    Some("public") => {
-                        InputID::Public(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
-                    }
-                    Some("private") => {
-                        InputID::Private(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
-                    }
-                    Some("record") => InputID::Record(
-                        serde_json::from_value(input["commitment"].take()).map_err(de::Error::custom)?,
-                        serde_json::from_value(input["gamma"].take()).map_err(de::Error::custom)?,
-                        serde_json::from_value(input["serial_number"].take()).map_err(de::Error::custom)?,
-                        serde_json::from_value(input["tag"].take()).map_err(de::Error::custom)?,
+                let input_id = match input.get("type").and_then(|t| t.as_str()) {
+                    Some("constant") => InputID::Constant(
+                        serde_json::from_value(
+                            input.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                        )
+                        .map_err(de::Error::custom)?,
                     ),
-                    Some("external_record") => {
-                        InputID::ExternalRecord(serde_json::from_value(input["id"].take()).map_err(de::Error::custom)?)
-                    }
+                    Some("public") => InputID::Public(
+                        serde_json::from_value(
+                            input.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                    ),
+                    Some("private") => InputID::Private(
+                        serde_json::from_value(
+                            input.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                    ),
+                    Some("record") => InputID::Record(
+                        serde_json::from_value(
+                            input
+                                .get_mut("commitment")
+                                .ok_or_else(|| de::Error::custom("The \"commitment\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                        serde_json::from_value(
+                            input
+                                .get_mut("gamma")
+                                .ok_or_else(|| de::Error::custom("The \"gamma\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                        serde_json::from_value(
+                            input
+                                .get_mut("serial_number")
+                                .ok_or_else(|| de::Error::custom("The \"serial_number\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                        serde_json::from_value(
+                            input
+                                .get_mut("tag")
+                                .ok_or_else(|| de::Error::custom("The \"tag\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                    ),
+                    Some("external_record") => InputID::ExternalRecord(
+                        serde_json::from_value(
+                            input.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                    ),
                     _ => return Err(de::Error::custom("Invalid input type")),
                 };
                 Ok(input_id)

--- a/console/program/src/request/serialize.rs
+++ b/console/program/src/request/serialize.rs
@@ -50,27 +50,84 @@ impl<'de, N: Network> Deserialize<'de> for Request<N> {
                 // Recover the request.
                 Ok(Self::from((
                     // Retrieve the caller.
-                    serde_json::from_value(request["caller"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("caller")
+                            .ok_or_else(|| de::Error::custom("The \"caller\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the network ID.
-                    serde_json::from_value(request["network"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("network")
+                            .ok_or_else(|| de::Error::custom("The \"network\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the program ID.
-                    serde_json::from_value(request["program"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("program")
+                            .ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the function name.
-                    serde_json::from_value(request["function"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("function")
+                            .ok_or_else(|| de::Error::custom("The \"function\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the input IDs.
-                    serde_json::from_value(request["input_ids"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("input_ids")
+                            .ok_or_else(|| de::Error::custom("The \"input_ids\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the inputs.
-                    serde_json::from_value(request["inputs"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("inputs")
+                            .ok_or_else(|| de::Error::custom("The \"inputs\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the signature.
-                    serde_json::from_value(request["signature"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("signature")
+                            .ok_or_else(|| de::Error::custom("The \"signature\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the `sk_tag`.
-                    serde_json::from_value(request["sk_tag"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request
+                            .get_mut("sk_tag")
+                            .ok_or_else(|| de::Error::custom("The \"sk_tag\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the `tvk`.
-                    serde_json::from_value(request["tvk"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request.get_mut("tvk").ok_or_else(|| de::Error::custom("The \"tvk\" field is missing"))?.take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the `tsk`.
-                    serde_json::from_value(request["tsk"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request.get_mut("tsk").ok_or_else(|| de::Error::custom("The \"tsk\" field is missing"))?.take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the `tcm`.
-                    serde_json::from_value(request["tcm"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        request.get_mut("tcm").ok_or_else(|| de::Error::custom("The \"tcm\" field is missing"))?.take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 )))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "request"),

--- a/console/program/src/request/serialize.rs
+++ b/console/program/src/request/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Request<N> {
     /// Serializes the request into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -50,84 +52,27 @@ impl<'de, N: Network> Deserialize<'de> for Request<N> {
                 // Recover the request.
                 Ok(Self::from((
                     // Retrieve the caller.
-                    serde_json::from_value(
-                        request
-                            .get_mut("caller")
-                            .ok_or_else(|| de::Error::custom("The \"caller\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "caller")?,
                     // Retrieve the network ID.
-                    serde_json::from_value(
-                        request
-                            .get_mut("network")
-                            .ok_or_else(|| de::Error::custom("The \"network\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "network")?,
                     // Retrieve the program ID.
-                    serde_json::from_value(
-                        request
-                            .get_mut("program")
-                            .ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "program")?,
                     // Retrieve the function name.
-                    serde_json::from_value(
-                        request
-                            .get_mut("function")
-                            .ok_or_else(|| de::Error::custom("The \"function\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "function")?,
                     // Retrieve the input IDs.
-                    serde_json::from_value(
-                        request
-                            .get_mut("input_ids")
-                            .ok_or_else(|| de::Error::custom("The \"input_ids\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "input_ids")?,
                     // Retrieve the inputs.
-                    serde_json::from_value(
-                        request
-                            .get_mut("inputs")
-                            .ok_or_else(|| de::Error::custom("The \"inputs\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "inputs")?,
                     // Retrieve the signature.
-                    serde_json::from_value(
-                        request
-                            .get_mut("signature")
-                            .ok_or_else(|| de::Error::custom("The \"signature\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "signature")?,
                     // Retrieve the `sk_tag`.
-                    serde_json::from_value(
-                        request
-                            .get_mut("sk_tag")
-                            .ok_or_else(|| de::Error::custom("The \"sk_tag\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "sk_tag")?,
                     // Retrieve the `tvk`.
-                    serde_json::from_value(
-                        request.get_mut("tvk").ok_or_else(|| de::Error::custom("The \"tvk\" field is missing"))?.take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "tvk")?,
                     // Retrieve the `tsk`.
-                    serde_json::from_value(
-                        request.get_mut("tsk").ok_or_else(|| de::Error::custom("The \"tsk\" field is missing"))?.take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "tsk")?,
                     // Retrieve the `tcm`.
-                    serde_json::from_value(
-                        request.get_mut("tcm").ok_or_else(|| de::Error::custom("The \"tcm\" field is missing"))?.take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut request, "tcm")?,
                 )))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "request"),

--- a/console/program/src/state_path/header_leaf/serialize.rs
+++ b/console/program/src/state_path/header_leaf/serialize.rs
@@ -41,9 +41,17 @@ impl<'de, N: Network> Deserialize<'de> for HeaderLeaf<N> {
                 // Recover the leaf.
                 Ok(Self::new(
                     // Retrieve the index.
-                    serde_json::from_value(leaf["index"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("index")
+                            .ok_or_else(|| de::Error::custom("The \"index\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the id.
-                    serde_json::from_value(leaf["id"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "header leaf"),

--- a/console/program/src/state_path/header_leaf/serialize.rs
+++ b/console/program/src/state_path/header_leaf/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for HeaderLeaf<N> {
     /// Serializes the leaf into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -41,17 +43,9 @@ impl<'de, N: Network> Deserialize<'de> for HeaderLeaf<N> {
                 // Recover the leaf.
                 Ok(Self::new(
                     // Retrieve the index.
-                    serde_json::from_value(
-                        leaf.get_mut("index")
-                            .ok_or_else(|| de::Error::custom("The \"index\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "index")?,
                     // Retrieve the id.
-                    serde_json::from_value(
-                        leaf.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "id")?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "header leaf"),

--- a/console/program/src/state_path/transaction_leaf/serialize.rs
+++ b/console/program/src/state_path/transaction_leaf/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for TransactionLeaf<N> {
     /// Serializes the leaf into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -42,24 +44,11 @@ impl<'de, N: Network> Deserialize<'de> for TransactionLeaf<N> {
                 // Recover the leaf.
                 Ok(Self::from(
                     // Retrieve the variant.
-                    serde_json::from_value(
-                        leaf.get_mut("variant")
-                            .ok_or_else(|| de::Error::custom("The \"variant\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "variant")?,
                     // Retrieve the index.
-                    serde_json::from_value(
-                        leaf.get_mut("index")
-                            .ok_or_else(|| de::Error::custom("The \"index\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "index")?,
                     // Retrieve the id.
-                    serde_json::from_value(
-                        leaf.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "id")?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "transaction leaf"),

--- a/console/program/src/state_path/transaction_leaf/serialize.rs
+++ b/console/program/src/state_path/transaction_leaf/serialize.rs
@@ -42,11 +42,24 @@ impl<'de, N: Network> Deserialize<'de> for TransactionLeaf<N> {
                 // Recover the leaf.
                 Ok(Self::from(
                     // Retrieve the variant.
-                    serde_json::from_value(leaf["variant"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("variant")
+                            .ok_or_else(|| de::Error::custom("The \"variant\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the index.
-                    serde_json::from_value(leaf["index"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("index")
+                            .ok_or_else(|| de::Error::custom("The \"index\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the id.
-                    serde_json::from_value(leaf["id"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "transaction leaf"),

--- a/console/program/src/state_path/transition_leaf/serialize.rs
+++ b/console/program/src/state_path/transition_leaf/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for TransitionLeaf<N> {
     /// Serializes the leaf into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -43,31 +45,13 @@ impl<'de, N: Network> Deserialize<'de> for TransitionLeaf<N> {
                 // Recover the leaf.
                 Ok(Self::from(
                     // Retrieve the version.
-                    serde_json::from_value(
-                        leaf.get_mut("version")
-                            .ok_or_else(|| de::Error::custom("The \"version\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "version")?,
                     // Retrieve the index.
-                    serde_json::from_value(
-                        leaf.get_mut("index")
-                            .ok_or_else(|| de::Error::custom("The \"index\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "index")?,
                     // Retrieve the variant.
-                    serde_json::from_value(
-                        leaf.get_mut("variant")
-                            .ok_or_else(|| de::Error::custom("The \"variant\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "variant")?,
                     // Retrieve the id.
-                    serde_json::from_value(
-                        leaf.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut leaf, "id")?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "transition leaf"),

--- a/console/program/src/state_path/transition_leaf/serialize.rs
+++ b/console/program/src/state_path/transition_leaf/serialize.rs
@@ -43,13 +43,31 @@ impl<'de, N: Network> Deserialize<'de> for TransitionLeaf<N> {
                 // Recover the leaf.
                 Ok(Self::from(
                     // Retrieve the version.
-                    serde_json::from_value(leaf["version"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("version")
+                            .ok_or_else(|| de::Error::custom("The \"version\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the index.
-                    serde_json::from_value(leaf["index"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("index")
+                            .ok_or_else(|| de::Error::custom("The \"index\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the variant.
-                    serde_json::from_value(leaf["variant"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("variant")
+                            .ok_or_else(|| de::Error::custom("The \"variant\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the id.
-                    serde_json::from_value(leaf["id"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        leaf.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "transition leaf"),

--- a/synthesizer/src/block/header/metadata/serialize.rs
+++ b/synthesizer/src/block/header/metadata/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Metadata<N> {
     /// Serializes the metadata to a JSON-string or buffer.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -44,62 +46,14 @@ impl<'de, N: Network> Deserialize<'de> for Metadata<N> {
             true => {
                 let mut metadata = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("network")
-                            .ok_or_else(|| de::Error::custom("The \"network\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("round")
-                            .ok_or_else(|| de::Error::custom("The \"round\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("height")
-                            .ok_or_else(|| de::Error::custom("The \"height\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("coinbase_target")
-                            .ok_or_else(|| de::Error::custom("The \"coinbase_target\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("proof_target")
-                            .ok_or_else(|| de::Error::custom("The \"proof_target\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("last_coinbase_target")
-                            .ok_or_else(|| de::Error::custom("The \"last_coinbase_target\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("last_coinbase_timestamp")
-                            .ok_or_else(|| de::Error::custom("The \"last_coinbase_timestamp\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        metadata
-                            .get_mut("timestamp")
-                            .ok_or_else(|| de::Error::custom("The \"timestamp\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "network")?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "round")?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "height")?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "coinbase_target")?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "proof_target")?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "last_coinbase_target")?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "last_coinbase_timestamp")?,
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "timestamp")?,
                 )
                 .map_err(de::Error::custom)?)
             }

--- a/synthesizer/src/block/header/metadata/serialize.rs
+++ b/synthesizer/src/block/header/metadata/serialize.rs
@@ -44,14 +44,62 @@ impl<'de, N: Network> Deserialize<'de> for Metadata<N> {
             true => {
                 let mut metadata = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(metadata["network"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["round"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["height"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["coinbase_target"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["proof_target"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["last_coinbase_target"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["last_coinbase_timestamp"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(metadata["timestamp"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("network")
+                            .ok_or_else(|| de::Error::custom("The \"network\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("round")
+                            .ok_or_else(|| de::Error::custom("The \"round\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("height")
+                            .ok_or_else(|| de::Error::custom("The \"height\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("coinbase_target")
+                            .ok_or_else(|| de::Error::custom("The \"coinbase_target\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("proof_target")
+                            .ok_or_else(|| de::Error::custom("The \"proof_target\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("last_coinbase_target")
+                            .ok_or_else(|| de::Error::custom("The \"last_coinbase_target\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("last_coinbase_timestamp")
+                            .ok_or_else(|| de::Error::custom("The \"last_coinbase_timestamp\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        metadata
+                            .get_mut("timestamp")
+                            .ok_or_else(|| de::Error::custom("The \"timestamp\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?)
             }

--- a/synthesizer/src/block/header/serialize.rs
+++ b/synthesizer/src/block/header/serialize.rs
@@ -40,10 +40,34 @@ impl<'de, N: Network> Deserialize<'de> for Header<N> {
             true => {
                 let mut header = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::from(
-                    serde_json::from_value(header["previous_state_root"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(header["transactions_root"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(header["coinbase_accumulator_point"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(header["metadata"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        header
+                            .get_mut("previous_state_root")
+                            .ok_or_else(|| de::Error::custom("The \"previous_state_root\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        header
+                            .get_mut("transactions_root")
+                            .ok_or_else(|| de::Error::custom("The \"transactions_root\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        header
+                            .get_mut("coinbase_accumulator_point")
+                            .ok_or_else(|| de::Error::custom("The \"coinbase_accumulator_point\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        header
+                            .get_mut("metadata")
+                            .ok_or_else(|| de::Error::custom("The \"metadata\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?)
             }

--- a/synthesizer/src/block/header/serialize.rs
+++ b/synthesizer/src/block/header/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Header<N> {
     /// Serializes the header to a JSON-string or buffer.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -40,34 +42,10 @@ impl<'de, N: Network> Deserialize<'de> for Header<N> {
             true => {
                 let mut header = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::from(
-                    serde_json::from_value(
-                        header
-                            .get_mut("previous_state_root")
-                            .ok_or_else(|| de::Error::custom("The \"previous_state_root\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        header
-                            .get_mut("transactions_root")
-                            .ok_or_else(|| de::Error::custom("The \"transactions_root\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        header
-                            .get_mut("coinbase_accumulator_point")
-                            .ok_or_else(|| de::Error::custom("The \"coinbase_accumulator_point\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
-                    serde_json::from_value(
-                        header
-                            .get_mut("metadata")
-                            .ok_or_else(|| de::Error::custom("The \"metadata\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "previous_state_root")?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "transactions_root")?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "coinbase_accumulator_point")?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "metadata")?,
                 )
                 .map_err(de::Error::custom)?)
             }

--- a/synthesizer/src/block/serialize.rs
+++ b/synthesizer/src/block/serialize.rs
@@ -45,16 +45,46 @@ impl<'de, N: Network> Deserialize<'de> for Block<N> {
         match deserializer.is_human_readable() {
             true => {
                 let mut block = serde_json::Value::deserialize(deserializer)?;
-                let block_hash: N::BlockHash =
-                    serde_json::from_value(block["block_hash"].take()).map_err(de::Error::custom)?;
+                let block_hash: N::BlockHash = serde_json::from_value(
+                    block
+                        .get_mut("block_hash")
+                        .ok_or_else(|| de::Error::custom("The \"block_hash\" field is missing"))?
+                        .take(),
+                )
+                .map_err(de::Error::custom)?;
 
                 // Recover the block.
                 let block = Self::from(
-                    serde_json::from_value(block["previous_hash"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(block["header"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(block["transactions"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(block["coinbase"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(block["signature"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        block
+                            .get_mut("previous_hash")
+                            .ok_or_else(|| de::Error::custom("The \"previous_hash\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        block
+                            .get_mut("header")
+                            .ok_or_else(|| de::Error::custom("The \"header\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        block
+                            .get_mut("transactions")
+                            .ok_or_else(|| de::Error::custom("The \"transactions\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(block.get_mut("coinbase").unwrap_or(&mut serde_json::Value::Null).take())
+                        .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        block
+                            .get_mut("signature")
+                            .ok_or_else(|| de::Error::custom("The \"signature\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/synthesizer/src/block/transaction/serialize.rs
+++ b/synthesizer/src/block/transaction/serialize.rs
@@ -53,28 +53,51 @@ impl<'de, N: Network> Deserialize<'de> for Transaction<N> {
                 // Deserialize the transaction into a JSON value.
                 let mut transaction = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transaction ID.
-                let id: N::TransactionID =
-                    serde_json::from_value(transaction["id"].take()).map_err(de::Error::custom)?;
+                let id: N::TransactionID = serde_json::from_value(
+                    transaction.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                )
+                .map_err(de::Error::custom)?;
 
                 // Recover the transaction.
-                let transaction = match transaction["type"].as_str() {
+                let transaction = match transaction
+                    .get("type")
+                    .ok_or_else(|| de::Error::custom("The \"type\" field is missing"))?
+                    .as_str()
+                {
                     Some("deploy") => {
                         // Retrieve the deployment.
-                        let deployment =
-                            serde_json::from_value(transaction["deployment"].take()).map_err(de::Error::custom)?;
+                        let deployment = serde_json::from_value(
+                            transaction
+                                .get_mut("deployment")
+                                .ok_or_else(|| de::Error::custom("The \"deployment\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?;
                         // Retrieve the additional fee.
-                        let additional_fee =
-                            serde_json::from_value(transaction["additional_fee"].take()).map_err(de::Error::custom)?;
+                        let additional_fee = serde_json::from_value(
+                            transaction
+                                .get_mut("additional_fee")
+                                .ok_or_else(|| de::Error::custom("The \"additional_fee\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?;
                         // Construct the transaction.
                         Transaction::from_deployment(deployment, additional_fee).map_err(de::Error::custom)?
                     }
                     Some("execute") => {
                         // Retrieve the execution.
-                        let execution =
-                            serde_json::from_value(transaction["execution"].take()).map_err(de::Error::custom)?;
+                        let execution = serde_json::from_value(
+                            transaction
+                                .get_mut("execution")
+                                .ok_or_else(|| de::Error::custom("The \"execution\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?;
                         // Retrieve the additional fee, if it exists.
-                        let additional_fee =
-                            serde_json::from_value(transaction["additional_fee"].take()).map_err(de::Error::custom)?;
+                        let additional_fee = serde_json::from_value(
+                            transaction.get_mut("additional_fee").unwrap_or(&mut serde_json::Value::Null).take(),
+                        )
+                        .map_err(de::Error::custom)?;
                         // Construct the transaction.
                         Transaction::from_execution(execution, additional_fee).map_err(de::Error::custom)?
                     }

--- a/synthesizer/src/block/transaction/serialize.rs
+++ b/synthesizer/src/block/transaction/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Transaction<N> {
     /// Serializes the transaction to a JSON-string or buffer.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -53,10 +55,7 @@ impl<'de, N: Network> Deserialize<'de> for Transaction<N> {
                 // Deserialize the transaction into a JSON value.
                 let mut transaction = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transaction ID.
-                let id: N::TransactionID = serde_json::from_value(
-                    transaction.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
-                )
-                .map_err(de::Error::custom)?;
+                let id: N::TransactionID = DeserializeExt::take_from_value::<D>(&mut transaction, "id")?;
 
                 // Recover the transaction.
                 let transaction = match transaction
@@ -66,33 +65,15 @@ impl<'de, N: Network> Deserialize<'de> for Transaction<N> {
                 {
                     Some("deploy") => {
                         // Retrieve the deployment.
-                        let deployment = serde_json::from_value(
-                            transaction
-                                .get_mut("deployment")
-                                .ok_or_else(|| de::Error::custom("The \"deployment\" field is missing"))?
-                                .take(),
-                        )
-                        .map_err(de::Error::custom)?;
+                        let deployment = DeserializeExt::take_from_value::<D>(&mut transaction, "deployment")?;
                         // Retrieve the additional fee.
-                        let additional_fee = serde_json::from_value(
-                            transaction
-                                .get_mut("additional_fee")
-                                .ok_or_else(|| de::Error::custom("The \"additional_fee\" field is missing"))?
-                                .take(),
-                        )
-                        .map_err(de::Error::custom)?;
+                        let additional_fee = DeserializeExt::take_from_value::<D>(&mut transaction, "additional_fee")?;
                         // Construct the transaction.
                         Transaction::from_deployment(deployment, additional_fee).map_err(de::Error::custom)?
                     }
                     Some("execute") => {
                         // Retrieve the execution.
-                        let execution = serde_json::from_value(
-                            transaction
-                                .get_mut("execution")
-                                .ok_or_else(|| de::Error::custom("The \"execution\" field is missing"))?
-                                .take(),
-                        )
-                        .map_err(de::Error::custom)?;
+                        let execution = DeserializeExt::take_from_value::<D>(&mut transaction, "execution")?;
                         // Retrieve the additional fee, if it exists.
                         let additional_fee = serde_json::from_value(
                             transaction.get_mut("additional_fee").unwrap_or(&mut serde_json::Value::Null).take(),

--- a/synthesizer/src/block/transition/serialize.rs
+++ b/synthesizer/src/block/transition/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Transition<N> {
     /// Serializes the transition into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -49,82 +51,31 @@ impl<'de, N: Network> Deserialize<'de> for Transition<N> {
                 // Parse the transition from a string into a value.
                 let mut transition = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the ID.
-                let id: N::TransitionID = serde_json::from_value(
-                    transition.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
-                )
-                .map_err(de::Error::custom)?;
+                let id: N::TransitionID = DeserializeExt::take_from_value::<D>(&mut transition, "id")?;
 
                 // Recover the transition.
                 let transition = Self::new(
                     // Retrieve the program ID.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("program")
-                            .ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "program")?,
                     // Retrieve the function name.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("function")
-                            .ok_or_else(|| de::Error::custom("The \"function\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "function")?,
                     // Retrieve the inputs.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("inputs")
-                            .ok_or_else(|| de::Error::custom("The \"inputs\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "inputs")?,
                     // Retrieve the outputs.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("outputs")
-                            .ok_or_else(|| de::Error::custom("The \"outputs\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "outputs")?,
                     // Retrieve the finalize inputs.
                     match transition.get("finalize") {
                         Some(finalize) => Some(serde_json::from_value(finalize.clone()).map_err(de::Error::custom)?),
                         None => None,
                     },
                     // Retrieve the proof.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("proof")
-                            .ok_or_else(|| de::Error::custom("The \"proof\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "proof")?,
                     // Retrieve the `tpk`.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("tpk")
-                            .ok_or_else(|| de::Error::custom("The \"tpk\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "tpk")?,
                     // Retrieve the `tcm`.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("tcm")
-                            .ok_or_else(|| de::Error::custom("The \"tcm\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "tcm")?,
                     // Retrieve the fee.
-                    serde_json::from_value(
-                        transition
-                            .get_mut("fee")
-                            .ok_or_else(|| de::Error::custom("The \"fee\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut transition, "fee")?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/synthesizer/src/block/transition/serialize.rs
+++ b/synthesizer/src/block/transition/serialize.rs
@@ -49,31 +49,82 @@ impl<'de, N: Network> Deserialize<'de> for Transition<N> {
                 // Parse the transition from a string into a value.
                 let mut transition = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the ID.
-                let id: N::TransitionID = serde_json::from_value(transition["id"].take()).map_err(de::Error::custom)?;
+                let id: N::TransitionID = serde_json::from_value(
+                    transition.get_mut("id").ok_or_else(|| de::Error::custom("The \"id\" field is missing"))?.take(),
+                )
+                .map_err(de::Error::custom)?;
 
                 // Recover the transition.
                 let transition = Self::new(
                     // Retrieve the program ID.
-                    serde_json::from_value(transition["program"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("program")
+                            .ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the function name.
-                    serde_json::from_value(transition["function"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("function")
+                            .ok_or_else(|| de::Error::custom("The \"function\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the inputs.
-                    serde_json::from_value(transition["inputs"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("inputs")
+                            .ok_or_else(|| de::Error::custom("The \"inputs\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the outputs.
-                    serde_json::from_value(transition["outputs"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("outputs")
+                            .ok_or_else(|| de::Error::custom("The \"outputs\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the finalize inputs.
                     match transition.get("finalize") {
                         Some(finalize) => Some(serde_json::from_value(finalize.clone()).map_err(de::Error::custom)?),
                         None => None,
                     },
                     // Retrieve the proof.
-                    serde_json::from_value(transition["proof"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("proof")
+                            .ok_or_else(|| de::Error::custom("The \"proof\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the `tpk`.
-                    serde_json::from_value(transition["tpk"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("tpk")
+                            .ok_or_else(|| de::Error::custom("The \"tpk\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the `tcm`.
-                    serde_json::from_value(transition["tcm"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("tcm")
+                            .ok_or_else(|| de::Error::custom("The \"tcm\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the fee.
-                    serde_json::from_value(transition["fee"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        transition
+                            .get_mut("fee")
+                            .ok_or_else(|| de::Error::custom("The \"fee\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/synthesizer/src/coinbase_puzzle/helpers/coinbase_solution/serialize.rs
+++ b/synthesizer/src/coinbase_puzzle/helpers/coinbase_solution/serialize.rs
@@ -41,11 +41,21 @@ impl<'de, N: Network> Deserialize<'de> for CoinbaseSolution<N> {
             true => {
                 let mut combined_puzzle_solution = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(combined_puzzle_solution["partial_solutions"].take())
-                        .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        combined_puzzle_solution
+                            .get_mut("partial_solutions")
+                            .ok_or_else(|| de::Error::custom("The \"partial_solutions\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     KZGProof {
-                        w: serde_json::from_value(combined_puzzle_solution["proof.w"].take())
-                            .map_err(de::Error::custom)?,
+                        w: serde_json::from_value(
+                            combined_puzzle_solution
+                                .get_mut("proof.w")
+                                .ok_or_else(|| de::Error::custom("The \"proof.w\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?,
                         random_v: match combined_puzzle_solution.get("proof.random_v") {
                             Some(random_v) => {
                                 Some(serde_json::from_value(random_v.clone()).map_err(de::Error::custom)?)

--- a/synthesizer/src/coinbase_puzzle/helpers/coinbase_solution/serialize.rs
+++ b/synthesizer/src/coinbase_puzzle/helpers/coinbase_solution/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for CoinbaseSolution<N> {
     /// Serializes the coinbase solution to a JSON-string or buffer.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -41,21 +43,9 @@ impl<'de, N: Network> Deserialize<'de> for CoinbaseSolution<N> {
             true => {
                 let mut combined_puzzle_solution = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(
-                        combined_puzzle_solution
-                            .get_mut("partial_solutions")
-                            .ok_or_else(|| de::Error::custom("The \"partial_solutions\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut combined_puzzle_solution, "partial_solutions")?,
                     KZGProof {
-                        w: serde_json::from_value(
-                            combined_puzzle_solution
-                                .get_mut("proof.w")
-                                .ok_or_else(|| de::Error::custom("The \"proof.w\" field is missing"))?
-                                .take(),
-                        )
-                        .map_err(de::Error::custom)?,
+                        w: DeserializeExt::take_from_value::<D>(&mut combined_puzzle_solution, "proof.w")?,
                         random_v: match combined_puzzle_solution.get("proof.random_v") {
                             Some(random_v) => {
                                 Some(serde_json::from_value(random_v.clone()).map_err(de::Error::custom)?)

--- a/synthesizer/src/coinbase_puzzle/helpers/partial_solution/serialize.rs
+++ b/synthesizer/src/coinbase_puzzle/helpers/partial_solution/serialize.rs
@@ -39,10 +39,27 @@ impl<'de, N: Network> Deserialize<'de> for PartialSolution<N> {
             true => {
                 let mut partial_prover_solution = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(partial_prover_solution["address"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value(partial_prover_solution["nonce"].take()).map_err(de::Error::custom)?,
-                    serde_json::from_value::<PuzzleCommitment<N>>(partial_prover_solution["commitment"].take())
-                        .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        partial_prover_solution
+                            .get_mut("address")
+                            .ok_or_else(|| de::Error::custom("The \"address\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        partial_prover_solution
+                            .get_mut("nonce")
+                            .ok_or_else(|| de::Error::custom("The \"nonce\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
+                    serde_json::from_value::<PuzzleCommitment<N>>(
+                        partial_prover_solution
+                            .get_mut("commitment")
+                            .ok_or_else(|| de::Error::custom("The \"commitment\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 ))
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "partial solution"),

--- a/synthesizer/src/coinbase_puzzle/helpers/prover_solution/serialize.rs
+++ b/synthesizer/src/coinbase_puzzle/helpers/prover_solution/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for ProverSolution<N> {
     /// Serializes the prover solution to a JSON-string or buffer.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -41,21 +43,9 @@ impl<'de, N: Network> Deserialize<'de> for ProverSolution<N> {
             true => {
                 let mut prover_solution = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(
-                        prover_solution
-                            .get_mut("partial_solution")
-                            .ok_or_else(|| de::Error::custom("The \"partial_solution\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut prover_solution, "partial_solution")?,
                     KZGProof {
-                        w: serde_json::from_value(
-                            prover_solution
-                                .get_mut("proof.w")
-                                .ok_or_else(|| de::Error::custom("The \"proof.w\" field is missing"))?
-                                .take(),
-                        )
-                        .map_err(de::Error::custom)?,
+                        w: DeserializeExt::take_from_value::<D>(&mut prover_solution, "proof.w")?,
                         random_v: serde_json::from_value(
                             prover_solution.get_mut("proof.random_v").unwrap_or(&mut serde_json::Value::Null).take(),
                         )

--- a/synthesizer/src/coinbase_puzzle/helpers/prover_solution/serialize.rs
+++ b/synthesizer/src/coinbase_puzzle/helpers/prover_solution/serialize.rs
@@ -41,11 +41,25 @@ impl<'de, N: Network> Deserialize<'de> for ProverSolution<N> {
             true => {
                 let mut prover_solution = serde_json::Value::deserialize(deserializer)?;
                 Ok(Self::new(
-                    serde_json::from_value(prover_solution["partial_solution"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        prover_solution
+                            .get_mut("partial_solution")
+                            .ok_or_else(|| de::Error::custom("The \"partial_solution\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     KZGProof {
-                        w: serde_json::from_value(prover_solution["proof.w"].take()).map_err(de::Error::custom)?,
-                        random_v: serde_json::from_value(prover_solution["proof.random_v"].take())
-                            .map_err(de::Error::custom)?,
+                        w: serde_json::from_value(
+                            prover_solution
+                                .get_mut("proof.w")
+                                .ok_or_else(|| de::Error::custom("The \"proof.w\" field is missing"))?
+                                .take(),
+                        )
+                        .map_err(de::Error::custom)?,
+                        random_v: serde_json::from_value(
+                            prover_solution.get_mut("proof.random_v").unwrap_or(&mut serde_json::Value::Null).take(),
+                        )
+                        .map_err(de::Error::custom)?,
                     },
                 ))
             }

--- a/synthesizer/src/process/stack/deployment/serialize.rs
+++ b/synthesizer/src/process/stack/deployment/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Deployment<N> {
     /// Serializes the deployment into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -43,29 +45,11 @@ impl<'de, N: Network> Deserialize<'de> for Deployment<N> {
                 // Recover the deployment.
                 let deployment = Self::new(
                     // Retrieve the edition.
-                    serde_json::from_value(
-                        deployment
-                            .get_mut("edition")
-                            .ok_or_else(|| de::Error::custom("The \"edition\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut deployment, "edition")?,
                     // Retrieve the program.
-                    serde_json::from_value(
-                        deployment
-                            .get_mut("program")
-                            .ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut deployment, "program")?,
                     // Retrieve the verifying keys.
-                    serde_json::from_value(
-                        deployment
-                            .get_mut("verifying_keys")
-                            .ok_or_else(|| de::Error::custom("The \"verifying_keys\" field is missing"))?
-                            .take(),
-                    )
-                    .map_err(de::Error::custom)?,
+                    DeserializeExt::take_from_value::<D>(&mut deployment, "verifying_keys")?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/synthesizer/src/process/stack/deployment/serialize.rs
+++ b/synthesizer/src/process/stack/deployment/serialize.rs
@@ -43,11 +43,29 @@ impl<'de, N: Network> Deserialize<'de> for Deployment<N> {
                 // Recover the deployment.
                 let deployment = Self::new(
                     // Retrieve the edition.
-                    serde_json::from_value(deployment["edition"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        deployment
+                            .get_mut("edition")
+                            .ok_or_else(|| de::Error::custom("The \"edition\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the program.
-                    serde_json::from_value(deployment["program"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        deployment
+                            .get_mut("program")
+                            .ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                     // Retrieve the verifying keys.
-                    serde_json::from_value(deployment["verifying_keys"].take()).map_err(de::Error::custom)?,
+                    serde_json::from_value(
+                        deployment
+                            .get_mut("verifying_keys")
+                            .ok_or_else(|| de::Error::custom("The \"verifying_keys\" field is missing"))?
+                            .take(),
+                    )
+                    .map_err(de::Error::custom)?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/synthesizer/src/process/stack/execution/serialize.rs
+++ b/synthesizer/src/process/stack/execution/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Execution<N> {
     /// Serializes the execution into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -43,21 +45,9 @@ impl<'de, N: Network> Deserialize<'de> for Execution<N> {
                 // Parse the execution from a string into a value.
                 let mut execution = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transitions.
-                let transitions: Vec<_> = serde_json::from_value(
-                    execution
-                        .get_mut("transitions")
-                        .ok_or_else(|| de::Error::custom("The \"transitions\" field is missing"))?
-                        .take(),
-                )
-                .map_err(de::Error::custom)?;
+                let transitions: Vec<_> = DeserializeExt::take_from_value::<D>(&mut execution, "transitions")?;
                 // Retrieve the global state root.
-                let global_state_root = serde_json::from_value(
-                    execution
-                        .get_mut("global_state_root")
-                        .ok_or_else(|| de::Error::custom("The \"global_state_root\" field is missing"))?
-                        .take(),
-                )
-                .map_err(de::Error::custom)?;
+                let global_state_root = DeserializeExt::take_from_value::<D>(&mut execution, "global_state_root")?;
                 // Retrieve the inclusion proof.
                 let inclusion_proof = serde_json::from_value(
                     execution.get_mut("inclusion").unwrap_or(&mut serde_json::Value::Null).take(),

--- a/synthesizer/src/process/stack/execution/serialize.rs
+++ b/synthesizer/src/process/stack/execution/serialize.rs
@@ -43,14 +43,26 @@ impl<'de, N: Network> Deserialize<'de> for Execution<N> {
                 // Parse the execution from a string into a value.
                 let mut execution = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transitions.
-                let transitions: Vec<_> =
-                    serde_json::from_value(execution["transitions"].take()).map_err(de::Error::custom)?;
+                let transitions: Vec<_> = serde_json::from_value(
+                    execution
+                        .get_mut("transitions")
+                        .ok_or_else(|| de::Error::custom("The \"transitions\" field is missing"))?
+                        .take(),
+                )
+                .map_err(de::Error::custom)?;
                 // Retrieve the global state root.
-                let global_state_root =
-                    serde_json::from_value(execution["global_state_root"].take()).map_err(de::Error::custom)?;
+                let global_state_root = serde_json::from_value(
+                    execution
+                        .get_mut("global_state_root")
+                        .ok_or_else(|| de::Error::custom("The \"global_state_root\" field is missing"))?
+                        .take(),
+                )
+                .map_err(de::Error::custom)?;
                 // Retrieve the inclusion proof.
-                let inclusion_proof =
-                    serde_json::from_value(execution["inclusion"].take()).map_err(de::Error::custom)?;
+                let inclusion_proof = serde_json::from_value(
+                    execution.get_mut("inclusion").unwrap_or(&mut serde_json::Value::Null).take(),
+                )
+                .map_err(de::Error::custom)?;
                 // Recover the execution.
                 Self::from(transitions.into_iter(), global_state_root, inclusion_proof).map_err(de::Error::custom)
             }

--- a/synthesizer/src/process/stack/fee/serialize.rs
+++ b/synthesizer/src/process/stack/fee/serialize.rs
@@ -42,12 +42,26 @@ impl<'de, N: Network> Deserialize<'de> for Fee<N> {
                 // Parse the fee from a string into a value.
                 let mut fee = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transitions.
-                let transition = serde_json::from_value(fee["transition"].take()).map_err(de::Error::custom)?;
+                let transition = serde_json::from_value(
+                    fee.get_mut("transition")
+                        .ok_or_else(|| de::Error::custom("The \"transition\" field is missing"))?
+                        .take(),
+                )
+                .map_err(de::Error::custom)?;
                 // Retrieve the global state root.
-                let global_state_root =
-                    serde_json::from_value(fee["global_state_root"].take()).map_err(de::Error::custom)?;
+                let global_state_root = serde_json::from_value(
+                    fee.get_mut("global_state_root")
+                        .ok_or_else(|| de::Error::custom("The \"global_state_root\" field is missing"))?
+                        .take(),
+                )
+                .map_err(de::Error::custom)?;
                 // Retrieve the inclusion proof.
-                let inclusion_proof = serde_json::from_value(fee["inclusion"].take()).map_err(de::Error::custom)?;
+                let inclusion_proof = serde_json::from_value(
+                    fee.get_mut("inclusion")
+                        .ok_or_else(|| de::Error::custom("The \"inclusion\" field is missing"))?
+                        .take(),
+                )
+                .map_err(de::Error::custom)?;
                 // Recover the fee.
                 Ok(Self::from(transition, global_state_root, inclusion_proof))
             }

--- a/synthesizer/src/process/stack/fee/serialize.rs
+++ b/synthesizer/src/process/stack/fee/serialize.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 impl<N: Network> Serialize for Fee<N> {
     /// Serializes the fee into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -42,26 +44,11 @@ impl<'de, N: Network> Deserialize<'de> for Fee<N> {
                 // Parse the fee from a string into a value.
                 let mut fee = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transitions.
-                let transition = serde_json::from_value(
-                    fee.get_mut("transition")
-                        .ok_or_else(|| de::Error::custom("The \"transition\" field is missing"))?
-                        .take(),
-                )
-                .map_err(de::Error::custom)?;
+                let transition = DeserializeExt::take_from_value::<D>(&mut fee, "transition")?;
                 // Retrieve the global state root.
-                let global_state_root = serde_json::from_value(
-                    fee.get_mut("global_state_root")
-                        .ok_or_else(|| de::Error::custom("The \"global_state_root\" field is missing"))?
-                        .take(),
-                )
-                .map_err(de::Error::custom)?;
+                let global_state_root = DeserializeExt::take_from_value::<D>(&mut fee, "global_state_root")?;
                 // Retrieve the inclusion proof.
-                let inclusion_proof = serde_json::from_value(
-                    fee.get_mut("inclusion")
-                        .ok_or_else(|| de::Error::custom("The \"inclusion\" field is missing"))?
-                        .take(),
-                )
-                .map_err(de::Error::custom)?;
+                let inclusion_proof = DeserializeExt::take_from_value::<D>(&mut fee, "inclusion")?;
                 // Recover the fee.
                 Ok(Self::from(transition, global_state_root, inclusion_proof))
             }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -59,6 +59,9 @@ optional = true
 version = "1.0"
 default-features = false
 
+[dependencies.serde_json]
+version = "1.0"
+
 [dependencies.thiserror]
 version = "1.0"
 

--- a/utilities/src/serialize/traits.rs
+++ b/utilities/src/serialize/traits.rs
@@ -22,6 +22,8 @@ pub use crate::{
     Vec,
 };
 
+use serde::de::{self, DeserializeOwned, Deserializer};
+
 /// Represents metadata to be appended to an object's serialization. For
 /// example, when serializing elliptic curve points, one can
 /// use a `Flag` to represent whether the serialization is the point
@@ -188,4 +190,27 @@ pub trait CanonicalDeserializeWithFlags: Sized {
     /// Reads `Self` and `Flags` from `reader`.
     /// Returns empty flags by default.
     fn deserialize_with_flags<R: Read, F: Flags>(reader: R) -> Result<(Self, F), SerializationError>;
+}
+
+/// A helper trait used to simplify value extraction.
+pub trait DeserializeExt<'de>
+where
+    Self: DeserializeOwned,
+{
+    fn take_from_value<D: Deserializer<'de>>(value: &mut serde_json::Value, field: &str) -> Result<Self, D::Error>;
+}
+
+impl<'de, T> DeserializeExt<'de> for T
+where
+    T: DeserializeOwned,
+{
+    fn take_from_value<D: Deserializer<'de>>(value: &mut serde_json::Value, field: &str) -> Result<Self, D::Error> {
+        serde_json::from_value(
+            value
+                .get_mut(field)
+                .ok_or_else(|| de::Error::custom(format!("The \"{}\" field is missing", field)))?
+                .take(),
+        )
+        .map_err(de::Error::custom)
+    }
 }

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -68,11 +68,23 @@ impl<'de, N: Network> Deserialize<'de> for BuildRequest<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program.
-            serde_json::from_value(request["program"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                request.get_mut("program").ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?.take(),
+            )
+            .map_err(de::Error::custom)?,
             // Retrieve the imports.
-            serde_json::from_value(request["imports"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                request.get_mut("imports").ok_or_else(|| de::Error::custom("The \"imports\" field is missing"))?.take(),
+            )
+            .map_err(de::Error::custom)?,
             // Retrieve the function name.
-            serde_json::from_value(request["function_name"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                request
+                    .get_mut("function_name")
+                    .ok_or_else(|| de::Error::custom("The \"function_name\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
         ))
     }
 }
@@ -136,13 +148,37 @@ impl<'de, N: Network> Deserialize<'de> for BuildResponse<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program ID.
-            serde_json::from_value(response["program_id"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                response
+                    .get_mut("program_id")
+                    .ok_or_else(|| de::Error::custom("The \"program_id\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
             // Retrieve the function name.
-            serde_json::from_value(response["function_name"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                response
+                    .get_mut("function_name")
+                    .ok_or_else(|| de::Error::custom("The \"function_name\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
             // Retrieve the proving key.
-            serde_json::from_value(response["proving_key"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                response
+                    .get_mut("proving_key")
+                    .ok_or_else(|| de::Error::custom("The \"proving_key\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
             // Retrieve the verifying key.
-            serde_json::from_value(response["verifying_key"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                response
+                    .get_mut("verifying_key")
+                    .ok_or_else(|| de::Error::custom("The \"verifying_key\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
         ))
     }
 }

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+use snarkvm_utilities::DeserializeExt;
+
 pub struct BuildRequest<N: Network> {
     program: Program<N>,
     imports: Vec<Program<N>>,
@@ -68,23 +70,11 @@ impl<'de, N: Network> Deserialize<'de> for BuildRequest<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program.
-            serde_json::from_value(
-                request.get_mut("program").ok_or_else(|| de::Error::custom("The \"program\" field is missing"))?.take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut request, "program")?,
             // Retrieve the imports.
-            serde_json::from_value(
-                request.get_mut("imports").ok_or_else(|| de::Error::custom("The \"imports\" field is missing"))?.take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut request, "imports")?,
             // Retrieve the function name.
-            serde_json::from_value(
-                request
-                    .get_mut("function_name")
-                    .ok_or_else(|| de::Error::custom("The \"function_name\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut request, "function_name")?,
         ))
     }
 }
@@ -148,37 +138,13 @@ impl<'de, N: Network> Deserialize<'de> for BuildResponse<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program ID.
-            serde_json::from_value(
-                response
-                    .get_mut("program_id")
-                    .ok_or_else(|| de::Error::custom("The \"program_id\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut response, "program_id")?,
             // Retrieve the function name.
-            serde_json::from_value(
-                response
-                    .get_mut("function_name")
-                    .ok_or_else(|| de::Error::custom("The \"function_name\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut response, "function_name")?,
             // Retrieve the proving key.
-            serde_json::from_value(
-                response
-                    .get_mut("proving_key")
-                    .ok_or_else(|| de::Error::custom("The \"proving_key\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut response, "proving_key")?,
             // Retrieve the verifying key.
-            serde_json::from_value(
-                response
-                    .get_mut("verifying_key")
-                    .ok_or_else(|| de::Error::custom("The \"verifying_key\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut response, "verifying_key")?,
         ))
     }
 }

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -74,11 +74,26 @@ impl<'de, N: Network> Deserialize<'de> for DeployRequest<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program.
-            serde_json::from_value(request["deployment"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                request
+                    .get_mut("deployment")
+                    .ok_or_else(|| de::Error::custom("The \"deployment\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
             // Retrieve the address of the program.
-            serde_json::from_value(request["address"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                request.get_mut("address").ok_or_else(|| de::Error::custom("The \"address\" field is missing"))?.take(),
+            )
+            .map_err(de::Error::custom)?,
             // Retrieve the program ID.
-            serde_json::from_value(request["program_id"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                request
+                    .get_mut("program_id")
+                    .ok_or_else(|| de::Error::custom("The \"program_id\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
         ))
     }
 }
@@ -116,7 +131,13 @@ impl<'de, N: Network> Deserialize<'de> for DeployResponse<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program ID.
-            serde_json::from_value(response["deployment"].take()).map_err(de::Error::custom)?,
+            serde_json::from_value(
+                response
+                    .get_mut("deployment")
+                    .ok_or_else(|| de::Error::custom("The \"deployment\" field is missing"))?
+                    .take(),
+            )
+            .map_err(de::Error::custom)?,
         ))
     }
 }

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -16,6 +16,7 @@
 
 use crate::synthesizer::Deployment;
 use snarkvm_console::types::Address;
+use snarkvm_utilities::DeserializeExt;
 
 use super::*;
 
@@ -74,26 +75,11 @@ impl<'de, N: Network> Deserialize<'de> for DeployRequest<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program.
-            serde_json::from_value(
-                request
-                    .get_mut("deployment")
-                    .ok_or_else(|| de::Error::custom("The \"deployment\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut request, "deployment")?,
             // Retrieve the address of the program.
-            serde_json::from_value(
-                request.get_mut("address").ok_or_else(|| de::Error::custom("The \"address\" field is missing"))?.take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut request, "address")?,
             // Retrieve the program ID.
-            serde_json::from_value(
-                request
-                    .get_mut("program_id")
-                    .ok_or_else(|| de::Error::custom("The \"program_id\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut request, "program_id")?,
         ))
     }
 }
@@ -131,13 +117,7 @@ impl<'de, N: Network> Deserialize<'de> for DeployResponse<N> {
         // Recover the leaf.
         Ok(Self::new(
             // Retrieve the program ID.
-            serde_json::from_value(
-                response
-                    .get_mut("deployment")
-                    .ok_or_else(|| de::Error::custom("The \"deployment\" field is missing"))?
-                    .take(),
-            )
-            .map_err(de::Error::custom)?,
+            DeserializeExt::take_from_value::<D>(&mut response, "deployment")?,
         ))
     }
 }

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -26,7 +26,6 @@ pub use deploy::{DeployRequest, DeployResponse};
 use crate::{
     file::{AVMFile, AleoFile, Manifest, ProverFile, VerifierFile, README},
     prelude::{
-        de,
         Deserialize,
         Deserializer,
         Identifier,


### PR DESCRIPTION
This PR removes indexing from `serde_json` deserialization impls.

Fixes #1241. 
Fixes #1242.
Fixes #1243.

...and a few other undiscovered issues of the same kind.