### PR TITLE
Add support for spending deployment fees

### DIFF
--- a/console/program/src/state_path/transaction_leaf/mod.rs
+++ b/console/program/src/state_path/transaction_leaf/mod.rs
@@ -34,10 +34,13 @@ pub struct TransactionLeaf<N: Network> {
 }
 
 impl<N: Network> TransactionLeaf<N> {
-    // TODO (raychu86): This variant is set to 1 to allow deployments to fulfill the inclusion circuit.
-    //  This should be updated to 0 once the inclusion circuit is updated.
     /// Initializes a new instance of `TransactionLeaf`.
     pub const fn new_deployment(index: u16, id: Field<N>) -> Self {
+        Self { variant: 0, index, id }
+    }
+
+    /// Initializes a new instance of `TransactionLeaf`.
+    pub const fn new_deployment_fee(index: u16, id: Field<N>) -> Self {
         Self { variant: 1, index, id }
     }
 

--- a/console/program/src/state_path/transaction_leaf/mod.rs
+++ b/console/program/src/state_path/transaction_leaf/mod.rs
@@ -34,9 +34,11 @@ pub struct TransactionLeaf<N: Network> {
 }
 
 impl<N: Network> TransactionLeaf<N> {
+    // TODO (raychu86): This variant is set to 1 to allow deployments to fulfill the inclusion circuit.
+    //  This should be updated to 0 once the inclusion circuit is updated.
     /// Initializes a new instance of `TransactionLeaf`.
     pub const fn new_deployment(index: u16, id: Field<N>) -> Self {
-        Self { variant: 0, index, id }
+        Self { variant: 1, index, id }
     }
 
     /// Initializes a new instance of `TransactionLeaf`.

--- a/synthesizer/src/block/transaction/merkle.rs
+++ b/synthesizer/src/block/transaction/merkle.rs
@@ -29,7 +29,7 @@ impl<N: Network> Transaction<N> {
                 // Check if the ID is the transition ID for the fee.
                 if *id == **fee.id() {
                     // Return the transaction leaf.
-                    return Ok(TransactionLeaf::new_deployment(
+                    return Ok(TransactionLeaf::new_deployment_fee(
                         deployment.program().functions().len() as u16, // The last index.
                         *id,
                     ));
@@ -110,7 +110,7 @@ impl<N: Network> Transaction<N> {
                 .to_bits_le())
             })
             .chain(
-                [Ok(TransactionLeaf::new_deployment(
+                [Ok(TransactionLeaf::new_deployment_fee(
                     program.functions().len() as u16, // The last index.
                     **fee.transition_id(),
                 )

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -333,7 +333,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         // Find the transition that contains the commitment.
         let transition_id = self.transition_store().find_transition_id(commitment)?;
         // Find the transaction that contains the transition.
-        let transaction_id = match self.transaction_store().find_transaction_id(&transition_id)? {
+        let transaction_id = match self.transaction_store().find_transaction_id_from_transition_id(&transition_id)? {
             Some(transaction_id) => transaction_id,
             None => bail!("The transaction ID for commitment '{commitment}' is missing in storage"),
         };

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -246,7 +246,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
     }
 
     /// Returns the transaction ID that contains the given `program ID`.
-    fn find_transaction_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
+    fn find_transaction_id_from_program_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
         // Retrieve the edition.
         let edition = match self.get_edition(program_id)? {
             Some(edition) => edition,
@@ -603,8 +603,8 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
 
 impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     /// Returns the transaction ID that deployed the given `program ID`.
-    pub fn find_transaction_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
-        self.storage.find_transaction_id(program_id)
+    pub fn find_transaction_id_from_program_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
+        self.storage.find_transaction_id_from_program_id(program_id)
     }
 
     // TODO (raychu86): Remove this inefficient implementation in favor of a new dedicated map.
@@ -717,21 +717,21 @@ mod tests {
         assert_eq!(None, candidate);
 
         // Ensure the transaction ID is not found.
-        let candidate = deployment_store.find_transaction_id(&program_id).unwrap();
+        let candidate = deployment_store.find_transaction_id_from_program_id(&program_id).unwrap();
         assert_eq!(None, candidate);
 
         // Insert the deployment.
         deployment_store.insert(&transaction).unwrap();
 
         // Find the transaction ID.
-        let candidate = deployment_store.find_transaction_id(&program_id).unwrap();
+        let candidate = deployment_store.find_transaction_id_from_program_id(&program_id).unwrap();
         assert_eq!(Some(transaction_id), candidate);
 
         // Remove the deployment.
         deployment_store.remove(&transaction_id).unwrap();
 
         // Ensure the transaction ID is not found.
-        let candidate = deployment_store.find_transaction_id(&program_id).unwrap();
+        let candidate = deployment_store.find_transaction_id_from_program_id(&program_id).unwrap();
         assert_eq!(None, candidate);
     }
 }

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -606,6 +606,13 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     pub fn find_transaction_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
         self.storage.find_transaction_id(program_id)
     }
+
+    // TODO (raychu86): Remove this inefficient implementation in favor of a new dedicated map.
+    //  i.e. ReverseFeeMap: Map<N::TransitionID, (N::TransactionID, ProgramID<N>)>;
+    /// Returns the transaction ID that deployed the given `transition ID`.
+    pub fn find_transaction_id_from_transition_id(&self, transition_id: &N::TransitionID) -> Option<N::TransactionID> {
+        self.storage.fee_map().iter().find(|(_, fee)| fee.0 == *transition_id).map(|(a, _)| a.into_owned())
+    }
 }
 
 impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -624,7 +624,7 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
 
 impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     /// Returns an iterator over the deployment transaction IDs, for all deployments.
-    pub fn deployment_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
+    pub fn deployment_transaction_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
         self.storage.id_map().keys()
     }
 

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -192,6 +192,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
                 (*fee.transition_id(), fee.global_state_root(), fee.inclusion_proof().cloned()),
             )?;
             self.reverse_fee_map().insert(*fee.transition_id(), *transaction_id)?;
+
             // Store the fee transition.
             self.transition_store().insert(fee)?;
 
@@ -246,6 +247,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
             // Remove the fee.
             self.fee_map().remove(transaction_id)?;
             self.reverse_fee_map().remove(&transition_id)?;
+
             // Remove the fee transition.
             self.transition_store().remove(&transition_id)?;
 

--- a/synthesizer/src/store/transaction/execution.rs
+++ b/synthesizer/src/store/transaction/execution.rs
@@ -200,7 +200,10 @@ pub trait ExecutionStorage<N: Network>: Clone + Send + Sync {
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.
-    fn find_transaction_id(&self, transition_id: &N::TransitionID) -> Result<Option<N::TransactionID>> {
+    fn find_transaction_id_from_transition_id(
+        &self,
+        transition_id: &N::TransitionID,
+    ) -> Result<Option<N::TransactionID>> {
         match self.reverse_id_map().get(transition_id)? {
             Some(transaction_id) => Ok(Some(cow_to_copied!(transaction_id))),
             None => Ok(None),
@@ -433,8 +436,11 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
 
 impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
     /// Returns the transaction ID that executed the given `transition ID`.
-    pub fn find_transaction_id(&self, transition_id: &N::TransitionID) -> Result<Option<N::TransactionID>> {
-        self.storage.find_transaction_id(transition_id)
+    pub fn find_transaction_id_from_transition_id(
+        &self,
+        transition_id: &N::TransitionID,
+    ) -> Result<Option<N::TransactionID>> {
+        self.storage.find_transaction_id_from_transition_id(transition_id)
     }
 }
 
@@ -506,21 +512,21 @@ mod tests {
 
         for transition_id in transition_ids {
             // Ensure the transaction ID is not found.
-            let candidate = execution_store.find_transaction_id(&transition_id).unwrap();
+            let candidate = execution_store.find_transaction_id_from_transition_id(&transition_id).unwrap();
             assert_eq!(None, candidate);
 
             // Insert the execution.
             execution_store.insert(&transaction).unwrap();
 
             // Find the transaction ID.
-            let candidate = execution_store.find_transaction_id(&transition_id).unwrap();
+            let candidate = execution_store.find_transaction_id_from_transition_id(&transition_id).unwrap();
             assert_eq!(Some(transaction_id), candidate);
 
             // Remove the execution.
             execution_store.remove(&transaction_id).unwrap();
 
             // Ensure the transaction ID is not found.
-            let candidate = execution_store.find_transaction_id(&transition_id).unwrap();
+            let candidate = execution_store.find_transaction_id_from_transition_id(&transition_id).unwrap();
             assert_eq!(None, candidate);
         }
     }

--- a/synthesizer/src/store/transaction/execution.rs
+++ b/synthesizer/src/store/transaction/execution.rs
@@ -440,7 +440,7 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
 
 impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
     /// Returns an iterator over the execution transaction IDs, for all executions.
-    pub fn execution_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
+    pub fn execution_transaction_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
         self.storage.id_map().keys()
     }
 }

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -160,8 +160,11 @@ pub trait TransactionStorage<N: Network>: Clone + Send + Sync {
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.
-    fn find_transaction_id(&self, transition_id: &N::TransitionID) -> Result<Option<N::TransactionID>> {
-        self.execution_store().find_transaction_id(transition_id)
+    fn find_transaction_id_from_transition_id(
+        &self,
+        transition_id: &N::TransitionID,
+    ) -> Result<Option<N::TransactionID>> {
+        self.execution_store().find_transaction_id_from_transition_id(transition_id)
     }
 
     /// Returns the transaction ID that contains the given `program ID`.
@@ -391,9 +394,13 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.
-    pub fn find_transaction_id(&self, transition_id: &N::TransitionID) -> Result<Option<N::TransactionID>> {
+    pub fn find_transaction_id_from_transition_id(
+        &self,
+        transition_id: &N::TransitionID,
+    ) -> Result<Option<N::TransactionID>> {
         // Check if the transaction id exists in the execution store.
-        let execution_transaction = self.storage.execution_store().find_transaction_id(transition_id);
+        let execution_transaction =
+            self.storage.execution_store().find_transaction_id_from_transition_id(transition_id);
 
         // Check if the transaction id exists in the transition store.
         match execution_transaction {
@@ -521,21 +528,21 @@ mod tests {
 
         for transition_id in transition_ids {
             // Ensure the transaction ID is not found.
-            let candidate = transaction_store.find_transaction_id(&transition_id).unwrap();
+            let candidate = transaction_store.find_transaction_id_from_transition_id(&transition_id).unwrap();
             assert_eq!(None, candidate);
 
             // Insert the transaction.
             transaction_store.insert(&transaction).unwrap();
 
             // Find the transaction ID.
-            let candidate = transaction_store.find_transaction_id(&transition_id).unwrap();
+            let candidate = transaction_store.find_transaction_id_from_transition_id(&transition_id).unwrap();
             assert_eq!(Some(transaction_id), candidate);
 
             // Remove the transaction.
             transaction_store.remove(&transaction_id).unwrap();
 
             // Ensure the transaction ID is not found.
-            let candidate = transaction_store.find_transaction_id(&transition_id).unwrap();
+            let candidate = transaction_store.find_transaction_id_from_transition_id(&transition_id).unwrap();
             assert_eq!(None, candidate);
         }
     }

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -422,13 +422,13 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     }
 
     /// Returns an iterator over the deployment transaction IDs, for all deployments.
-    pub fn deployment_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
-        self.storage.deployment_store().deployment_ids()
+    pub fn deployment_transaction_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
+        self.storage.deployment_store().deployment_transaction_ids()
     }
 
     /// Returns an iterator over the execution transaction IDs, for all executions.
-    pub fn execution_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
-        self.storage.execution_store().execution_ids()
+    pub fn execution_transaction_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
+        self.storage.execution_store().execution_transaction_ids()
     }
 
     /// Returns an iterator over the program IDs, for all deployments.

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -165,7 +165,7 @@ pub trait TransactionStorage<N: Network>: Clone + Send + Sync {
     }
 
     /// Returns the transaction ID that contains the given `program ID`.
-    fn find_deployment_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
+    fn find_transaction_id_from_program_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
         self.deployment_store().find_transaction_id_from_program_id(program_id)
     }
 
@@ -386,7 +386,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
 
 impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     /// Returns the transaction ID that contains the given `program ID`.
-    pub fn find_deployment_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
+    pub fn find_transaction_id_from_program_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
         self.storage.deployment_store().find_transaction_id_from_program_id(program_id)
     }
 

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -392,7 +392,14 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
 
     /// Returns the transaction ID that contains the given `transition ID`.
     pub fn find_transaction_id(&self, transition_id: &N::TransitionID) -> Result<Option<N::TransactionID>> {
-        self.storage.execution_store().find_transaction_id(transition_id)
+        // Check if the transaction id exists in the execution store.
+        let execution_transaction = self.storage.execution_store().find_transaction_id(transition_id);
+
+        // Check if the transaction id exists in the transition store.
+        match execution_transaction {
+            Ok(None) => Ok(self.storage.deployment_store().find_transaction_id_from_transition_id(transition_id)),
+            _ => execution_transaction,
+        }
     }
 }
 

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -166,7 +166,7 @@ pub trait TransactionStorage<N: Network>: Clone + Send + Sync {
 
     /// Returns the transaction ID that contains the given `program ID`.
     fn find_deployment_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
-        self.deployment_store().find_transaction_id(program_id)
+        self.deployment_store().find_transaction_id_from_program_id(program_id)
     }
 
     /// Returns the transaction for the given `transaction ID`.
@@ -387,7 +387,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
 impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     /// Returns the transaction ID that contains the given `program ID`.
     pub fn find_deployment_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
-        self.storage.deployment_store().find_transaction_id(program_id)
+        self.storage.deployment_store().find_transaction_id_from_program_id(program_id)
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -404,7 +404,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
 
         // Check if the transaction id exists in the transition store.
         match execution_transaction {
-            Ok(None) => Ok(self.storage.deployment_store().find_transaction_id_from_transition_id(transition_id)),
+            Ok(None) => self.storage.deployment_store().find_transaction_id_from_transition_id(transition_id),
             _ => execution_transaction,
         }
     }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -61,7 +61,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Retrieve the transaction store.
         let transaction_store = store.transaction_store();
         // Load the deployments from the store.
-        for transaction_id in transaction_store.deployment_ids() {
+        for transaction_id in transaction_store.deployment_transaction_ids() {
             // Retrieve the deployment.
             match transaction_store.get_deployment(&transaction_id)? {
                 // Load the deployment.

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -325,6 +325,13 @@ mod tests {
         // Add the deployment block.
         vm.add_next_block(&deployment_block).unwrap();
 
+        // Fetch the unspent records.
+        let records = deployment_block.records().collect::<indexmap::IndexMap<_, _>>();
+
+        // Prepare the additional fee.
+        let credits = records.values().next().unwrap().decrypt(&caller_view_key).unwrap();
+        let additional_fee = (credits, 10);
+
         // Authorize.
         let authorization = vm
             .authorize(
@@ -342,7 +349,15 @@ mod tests {
         assert_eq!(authorization.len(), 1);
 
         // Execute.
-        let transaction = Transaction::execute_authorization(&vm, authorization, None, rng).unwrap();
+        let transaction = Transaction::execute_authorization_with_additional_fee(
+            &vm,
+            &caller_private_key,
+            authorization,
+            Some(additional_fee),
+            None,
+            rng,
+        )
+        .unwrap();
 
         // Verify.
         assert!(vm.verify(&transaction));


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR makes 2 primary changes to allow for records created by deployment fees to be spent. 

_Both of these solutions are temporary and will be addressed formally before Phase 3 is launched. (The formal solution will require resetting the network)_

1. Add iterator to fetch the transaction id from a transition id in the deployment store.
    - This is inefficient, as it requires iterating through all program deployments.
    - Formal solution: Add an additional map to the DeploymentStore
2. Update  `TransactionLeaf` for deployment transactions to be compatible with the `Inclusion` circuit.
    - The inclusion circuit will need to be updated to support both execution and deployment.
    - Formal solution: Update the inclusion circuit to support either variant of transactions.
    
## Test Plan

A test has been updated to test spending with a fee record included in a program deployment.

