### PR TITLE
Fix the ordering of object serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,7 @@ optional = true
 [dependencies.serde_json]
 version = "1.0"
 optional = true
+features = [ "preserve_order" ]
 
 [dependencies.thiserror]
 version = "1.0"

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -154,6 +154,7 @@ version = "0.4.0"
 
 [dev-dependencies.serde_json]
 version = "1"
+features = [ "preserve_order" ]
 
 [dev-dependencies.serial_test]
 version = "0.9"

--- a/console/account/Cargo.toml
+++ b/console/account/Cargo.toml
@@ -32,6 +32,7 @@ version = "0.4.0"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]
 
 [features]
 default = [

--- a/console/algorithms/Cargo.toml
+++ b/console/algorithms/Cargo.toml
@@ -52,3 +52,4 @@ version = "1.0"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/console/program/Cargo.toml
+++ b/console/program/Cargo.toml
@@ -46,6 +46,7 @@ version = "1.13.1"
 
 [dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]
 
 [dev-dependencies.bincode]
 version = "1.3"

--- a/console/types/address/Cargo.toml
+++ b/console/types/address/Cargo.toml
@@ -27,3 +27,4 @@ version = "1.3"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/console/types/boolean/Cargo.toml
+++ b/console/types/boolean/Cargo.toml
@@ -15,3 +15,4 @@ version = "1.3"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/console/types/field/Cargo.toml
+++ b/console/types/field/Cargo.toml
@@ -19,3 +19,4 @@ version = "1.3"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/console/types/group/Cargo.toml
+++ b/console/types/group/Cargo.toml
@@ -27,3 +27,4 @@ version = "1.3"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/console/types/integers/Cargo.toml
+++ b/console/types/integers/Cargo.toml
@@ -23,3 +23,4 @@ version = "1.3"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/console/types/scalar/Cargo.toml
+++ b/console/types/scalar/Cargo.toml
@@ -23,3 +23,4 @@ version = "1.3"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/console/types/string/Cargo.toml
+++ b/console/types/string/Cargo.toml
@@ -27,3 +27,4 @@ version = "1.3"
 
 [dev-dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -77,6 +77,7 @@ optional = true
 
 [dependencies.serde_json]
 version = "1"
+features = [ "preserve_order" ]
 
 [dependencies.sha2]
 version = "0.10"

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -116,6 +116,7 @@ version = "1.0"
 
 [dependencies.serde_json]
 version = "1.0"
+features = [ "preserve_order" ]
 
 [dependencies.tracing]
 version = "0.1"

--- a/synthesizer/src/process/deploy.rs
+++ b/synthesizer/src/process/deploy.rs
@@ -39,7 +39,7 @@ impl<N: Network> Process<N> {
         deployment
     }
 
-    /// Verifies the given deployment is well-formed.
+    /// Verifies the given deployment is ordered.
     #[inline]
     pub fn verify_deployment<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
         &self,

--- a/synthesizer/src/process/stack/deploy.rs
+++ b/synthesizer/src/process/stack/deploy.rs
@@ -64,8 +64,8 @@ impl<N: Network> Stack<N> {
 
         // Sanity Checks //
 
-        // Ensure the deployment is well-formed.
-        deployment.check_is_valid()?;
+        // Ensure the deployment is ordered.
+        deployment.check_is_ordered()?;
         // Ensure the program in the stack and deployment matches.
         ensure!(&self.program == deployment.program(), "The stack program does not match the deployment program");
 

--- a/synthesizer/src/process/stack/deploy.rs
+++ b/synthesizer/src/process/stack/deploy.rs
@@ -25,8 +25,8 @@ impl<N: Network> Stack<N> {
         // Ensure the program contains functions.
         ensure!(!self.program.functions().is_empty(), "Program '{}' has no functions", self.program.id());
 
-        // Initialize a mapping for the bundle.
-        let mut bundle = IndexMap::with_capacity(self.program.functions().len());
+        // Initialize a vector for the verifying keys and certificates.
+        let mut verifying_keys = Vec::with_capacity(self.program.functions().len());
 
         for function_name in self.program.functions().keys() {
             // Synthesize the proving and verifying key.
@@ -44,13 +44,13 @@ impl<N: Network> Stack<N> {
             lap!(timer, "Certify the circuit");
 
             // Add the verifying key and certificate to the bundle.
-            bundle.insert(*function_name, (verifying_key, certificate));
+            verifying_keys.push((*function_name, (verifying_key, certificate)));
         }
 
         finish!(timer);
 
         // Return the deployment.
-        Deployment::new(N::EDITION, self.program.clone(), bundle)
+        Deployment::new(N::EDITION, self.program.clone(), verifying_keys)
     }
 
     /// Checks each function in the program on the given verifying key and certificate.
@@ -62,51 +62,21 @@ impl<N: Network> Stack<N> {
     ) -> Result<()> {
         let timer = timer!("Stack::verify_deployment");
 
-        // Retrieve the edition.
-        let edition = deployment.edition();
-        // Retrieve the program.
-        let program = &self.program;
-        // Retrieve the program ID.
-        let program_id = program.id();
-        // Retrieve the verifying keys.
-        let verifying_keys = deployment.verifying_keys();
-
         // Sanity Checks //
 
-        // Ensure the edition matches.
-        ensure!(edition == N::EDITION, "Deployed the wrong edition (expected '{}', found '{edition}').", N::EDITION);
-        // Ensure the program matches.
-        ensure!(program == deployment.program(), "The stack program does not match the deployment program");
-        // Ensure the program network-level domain (NLD) is correct.
-        ensure!(program_id.is_aleo(), "Program '{program_id}' has an incorrect network-level domain (NLD)");
-        // Ensure the program contains functions.
-        ensure!(!program.functions().is_empty(), "No functions present in the deployment for program '{program_id}'");
-        // Ensure the deployment contains verifying keys.
-        ensure!(!verifying_keys.is_empty(), "No verifying keys present in the deployment for program '{program_id}'");
+        // Ensure the deployment is well-formed.
+        deployment.check_is_valid()?;
+        // Ensure the program in the stack and deployment matches.
+        ensure!(&self.program == deployment.program(), "The stack program does not match the deployment program");
 
         // Check Verifying Keys //
 
-        // Ensure the number of verifying keys matches the number of program functions.
-        if verifying_keys.len() != program.functions().len() {
-            bail!("The number of verifying keys does not match the number of program functions");
-        }
-        lap!(timer, "Perform sanity checks");
-
-        // Ensure the program functions are in the same order as the verifying keys.
-        for ((function_name, function), candidate_name) in program.functions().iter().zip_eq(verifying_keys.keys()) {
-            // Ensure the function name is correct.
-            if function_name != function.name() {
-                bail!("The function key is '{function_name}', but the function name is '{}'", function.name())
-            }
-            // Ensure the function name with the verifying key is correct.
-            if candidate_name != function.name() {
-                bail!("The verifier key is '{candidate_name}', but the function name is '{}'", function.name())
-            }
-        }
-        lap!(timer, "Verify the function and verifying key ordering");
+        let program_id = self.program.id();
 
         // Iterate through the program functions.
-        for (function, (verifying_key, certificate)) in program.functions().values().zip_eq(verifying_keys.values()) {
+        for (function, (_, (verifying_key, certificate))) in
+            deployment.program().functions().values().zip_eq(deployment.verifying_keys())
+        {
             // Initialize a burner private key.
             let burner_private_key = PrivateKey::new(rng)?;
             // Compute the burner address.
@@ -147,7 +117,9 @@ impl<N: Network> Stack<N> {
             lap!(timer, "Synthesize the circuit");
             // Check the certificate.
             match assignments.read().last() {
-                None => bail!("The assignment for function '{}' is missing in '{program_id}'", function.name()),
+                None => {
+                    bail!("The assignment for function '{}' is missing in '{program_id}'", function.name())
+                }
                 Some(assignment) => {
                     // Ensure the certificate is valid.
                     if !certificate.verify(function.name(), assignment, verifying_key) {

--- a/synthesizer/src/process/stack/deployment/bytes.rs
+++ b/synthesizer/src/process/stack/deployment/bytes.rs
@@ -33,8 +33,8 @@ impl<N: Network> FromBytes for Deployment<N> {
 
         // Read the number of entries in the bundle.
         let num_entries = u16::read_le(&mut reader)?;
-        // Read the bundle.
-        let mut bundle = IndexMap::with_capacity(num_entries as usize);
+        // Read the verifying keys.
+        let mut verifying_keys = Vec::with_capacity(num_entries as usize);
         for _ in 0..num_entries {
             // Read the identifier.
             let identifier = Identifier::<N>::read_le(&mut reader)?;
@@ -43,10 +43,11 @@ impl<N: Network> FromBytes for Deployment<N> {
             // Read the certificate.
             let certificate = Certificate::<N>::read_le(&mut reader)?;
             // Add the entry.
-            bundle.insert(identifier, (verifying_key, certificate));
+            verifying_keys.push((identifier, (verifying_key, certificate)));
         }
 
-        Ok(Self { edition, program, verifying_keys: bundle })
+        // Return the deployment.
+        Self::new(edition, program, verifying_keys).map_err(|err| error(format!("{err}")))
     }
 }
 

--- a/synthesizer/src/process/stack/deployment/mod.rs
+++ b/synthesizer/src/process/stack/deployment/mod.rs
@@ -43,14 +43,14 @@ impl<N: Network> Deployment<N> {
     ) -> Result<Self> {
         // Construct the deployment.
         let deployment = Self { edition, program, verifying_keys };
-        // Ensure the deployment is well-formed.
-        deployment.check_is_valid()?;
+        // Ensure the deployment is ordered.
+        deployment.check_is_ordered()?;
         // Return the deployment.
         Ok(deployment)
     }
 
-    /// Checks that the deployment is well-formed.
-    pub fn check_is_valid(&self) -> Result<()> {
+    /// Checks that the deployment is ordered.
+    pub fn check_is_ordered(&self) -> Result<()> {
         let program_id = self.program.id();
 
         // Ensure the edition matches.

--- a/synthesizer/src/process/stack/deployment/mod.rs
+++ b/synthesizer/src/process/stack/deployment/mod.rs
@@ -24,8 +24,6 @@ use console::{
     program::{Identifier, ProgramID},
 };
 
-use indexmap::IndexMap;
-
 #[derive(Clone, PartialEq, Eq)]
 pub struct Deployment<N: Network> {
     /// The edition.
@@ -33,7 +31,7 @@ pub struct Deployment<N: Network> {
     /// The program.
     program: Program<N>,
     /// The mapping of function names to their verifying key and certificate.
-    verifying_keys: IndexMap<Identifier<N>, (VerifyingKey<N>, Certificate<N>)>,
+    verifying_keys: Vec<(Identifier<N>, (VerifyingKey<N>, Certificate<N>))>,
 }
 
 impl<N: Network> Deployment<N> {
@@ -41,9 +39,63 @@ impl<N: Network> Deployment<N> {
     pub fn new(
         edition: u16,
         program: Program<N>,
-        verifying_keys: IndexMap<Identifier<N>, (VerifyingKey<N>, Certificate<N>)>,
+        verifying_keys: Vec<(Identifier<N>, (VerifyingKey<N>, Certificate<N>))>,
     ) -> Result<Self> {
-        Ok(Self { edition, program, verifying_keys })
+        // Construct the deployment.
+        let deployment = Self { edition, program, verifying_keys };
+        // Ensure the deployment is well-formed.
+        deployment.check_is_valid()?;
+        // Return the deployment.
+        Ok(deployment)
+    }
+
+    /// Checks that the deployment is well-formed.
+    pub fn check_is_valid(&self) -> Result<()> {
+        let program_id = self.program.id();
+
+        // Ensure the edition matches.
+        ensure!(
+            self.edition == N::EDITION,
+            "Deployed the wrong edition (expected '{}', found '{}').",
+            N::EDITION,
+            self.edition
+        );
+        // Ensure the program network-level domain (NLD) is correct.
+        ensure!(program_id.is_aleo(), "Program '{program_id}' has an incorrect network-level domain (NLD)");
+        // Ensure the program contains functions.
+        ensure!(
+            !self.program.functions().is_empty(),
+            "No functions present in the deployment for program '{program_id}'"
+        );
+        // Ensure the deployment contains verifying keys.
+        ensure!(
+            !self.verifying_keys.is_empty(),
+            "No verifying keys present in the deployment for program '{program_id}'"
+        );
+
+        // Ensure the number of functions matches the number of verifying keys.
+        if self.program.functions().len() != self.verifying_keys.len() {
+            bail!("Deployment has an incorrect number of verifying keys, according to the program.");
+        }
+
+        // Ensure the function and verifying keys correspond.
+        for ((function_name, function), (name, _)) in self.program.functions().iter().zip_eq(&self.verifying_keys) {
+            // Ensure the function name is correct.
+            if function_name != function.name() {
+                bail!("The function key is '{function_name}', but the function name is '{}'", function.name())
+            }
+            // Ensure the function name with the verifying key is correct.
+            if name != function.name() {
+                bail!("The verifier key is '{name}', but the function name is '{}'", function.name())
+            }
+        }
+
+        ensure!(
+            !has_duplicates(self.verifying_keys.iter().map(|(name, ..)| name)),
+            "A duplicate function name was found"
+        );
+
+        Ok(())
     }
 
     /// Returns the edition.
@@ -62,7 +114,7 @@ impl<N: Network> Deployment<N> {
     }
 
     /// Returns the verifying keys.
-    pub const fn verifying_keys(&self) -> &IndexMap<Identifier<N>, (VerifyingKey<N>, Certificate<N>)> {
+    pub const fn verifying_keys(&self) -> &Vec<(Identifier<N>, (VerifyingKey<N>, Certificate<N>))> {
         &self.verifying_keys
     }
 }

--- a/synthesizer/src/process/stack/mod.rs
+++ b/synthesizer/src/process/stack/mod.rs
@@ -412,6 +412,7 @@ impl<N: Network> PartialEq for Stack<N> {
         self.program == other.program
             && self.external_stacks == other.external_stacks
             && self.register_types == other.register_types
+            && self.finalize_types == other.finalize_types
     }
 }
 

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -140,8 +140,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
             }
         };
 
-        // Ensure the deployment is well-formed.
-        if let Err(error) = deployment.check_is_valid() {
+        // Ensure the deployment is ordered.
+        if let Err(error) = deployment.check_is_ordered() {
             bail!("Failed to insert malformed deployment transaction: {error}")
         }
 

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -242,6 +242,11 @@ mod tests {
 
         // Ensure the deployment is valid.
         assert!(vm.verify_deployment(&deployment));
+
+        // Ensure that deserialization doesn't break the transaction verification.
+        let serialized_deployment = deployment.to_string();
+        let deployment_transaction: Deployment<CurrentNetwork> = serde_json::from_str(&serialized_deployment).unwrap();
+        assert!(vm.verify_deployment(&deployment_transaction));
     }
 
     #[test]
@@ -260,6 +265,12 @@ mod tests {
                 assert!(Inclusion::verify_execution(&execution).is_ok());
                 // Verify the execution.
                 assert!(vm.verify_execution(&execution));
+
+                // Ensure that deserialization doesn't break the transaction verification.
+                let serialized_execution = execution.to_string();
+                let execution_transaction: Execution<CurrentNetwork> =
+                    serde_json::from_str(&serialized_execution).unwrap();
+                assert!(vm.verify_execution(&execution_transaction));
             }
             _ => panic!("Expected an execution transaction"),
         }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR addresses #1334, by enforcing that all objects maintain the same ordering after serialization and deserialization. This was necessary due to the requirements of Deployment transaction verification.

The fix was to add the `preserve_order` feature for `serde_json` dependencies.

## Test Plan

Added test to check that serialization/deserialization of deployments and executions don't break the transaction verification.
