### PR TITLE
Remove allocations in EvaluationDomain::mul_polynomials_in_eval…

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -346,8 +346,8 @@ impl<F: FftField> EvaluationDomain<F> {
     /// evaluations in the domain.
     /// Returns the evaluations of the product over the domain.
     #[must_use]
-    pub fn mul_polynomials_in_evaluation_domain(&self, self_evals: &[F], other_evals: &[F]) -> Vec<F> {
-        let mut result = self_evals.to_vec();
+    pub fn mul_polynomials_in_evaluation_domain(&self, self_evals: Vec<F>, other_evals: &[F]) -> Vec<F> {
+        let mut result = self_evals;
 
         cfg_iter_mut!(result).zip_eq(other_evals).for_each(|(a, b)| *a *= b);
 

--- a/synthesizer/src/coinbase_puzzle/mod.rs
+++ b/synthesizer/src/coinbase_puzzle/mod.rs
@@ -122,7 +122,7 @@ impl<N: Network> CoinbasePuzzle<N> {
         let product_evaluations = {
             let polynomial_evaluations = pk.product_domain.in_order_fft_with_pc(&polynomial, &pk.fft_precomputation);
             let product_evaluations = pk.product_domain.mul_polynomials_in_evaluation_domain(
-                &polynomial_evaluations,
+                polynomial_evaluations,
                 &epoch_challenge.epoch_polynomial_evaluations().evaluations,
             );
             product_evaluations
@@ -225,7 +225,7 @@ impl<N: Network> CoinbasePuzzle<N> {
             let accumulated_polynomial_evaluations =
                 pk.product_domain.in_order_fft_with_pc(&accumulated_prover_polynomial.coeffs, &pk.fft_precomputation);
             pk.product_domain.mul_polynomials_in_evaluation_domain(
-                &accumulated_polynomial_evaluations,
+                accumulated_polynomial_evaluations,
                 &epoch_challenge.epoch_polynomial_evaluations().evaluations,
             )
         };


### PR DESCRIPTION
These allocations amount to ~8% of all snarkOS allocations when running a prover, and they can all be avoided by taking the first param by value instead of by reference.