### PR TITLE
chore: cargo clippy

### DIFF
--- a/algorithms/benches/fft/fft.rs
+++ b/algorithms/benches/fft/fft.rs
@@ -102,13 +102,13 @@ fn bench_coset_ifft_in_place<F: PrimeField>(b: &mut Bencher, degree: &usize) {
 }
 
 fn fft_benches<F: PrimeField>(c: &mut Criterion, name: &str) {
-    let description = format!("{:?} - subgroup_fft_in_place", name);
+    let description = format!("{name:?} - subgroup_fft_in_place");
     setup_bench(c, &description, bench_fft_in_place::<F>);
-    let description = format!("{:?} - subgroup_ifft_in_place", name);
+    let description = format!("{name:?} - subgroup_ifft_in_place");
     setup_bench(c, &description, bench_ifft_in_place::<F>);
-    let description = format!("{:?} - coset_fft_in_place", name);
+    let description = format!("{name:?} - coset_fft_in_place");
     setup_bench(c, &description, bench_coset_fft_in_place::<F>);
-    let description = format!("{:?} - coset_ifft_in_place", name);
+    let description = format!("{name:?} - coset_ifft_in_place");
     setup_bench(c, &description, bench_coset_ifft_in_place::<F>);
 }
 

--- a/algorithms/benches/msm/variable_base.rs
+++ b/algorithms/benches/msm/variable_base.rs
@@ -40,7 +40,7 @@ fn variable_base_bls12_377(c: &mut Criterion) {
     let (bases, scalars) = create_scalar_bases::<G1Affine, Fr>(2000000);
 
     for size in [10_000, 100_000, 200_000, 300_000, 400_000, 500_000, 1_000_000, 2_000_000] {
-        c.bench_function(&format!("VariableBase MSM on BLS12-377 ({})", size), |b| {
+        c.bench_function(&format!("VariableBase MSM on BLS12-377 ({size})"), |b| {
             b.iter(|| VariableBase::msm(&bases[..size], &scalars[..size]))
         });
     }
@@ -51,7 +51,7 @@ fn variable_base_edwards_bls12(c: &mut Criterion) {
     let (bases, scalars) = create_scalar_bases::<EdwardsAffine, Fr>(1_000_000);
 
     for size in [10_000, 100_000, 1_000_000] {
-        c.bench_function(&format!("Variable MSM on Edwards-BLS12 ({})", size), |b| {
+        c.bench_function(&format!("Variable MSM on Edwards-BLS12 ({size})"), |b| {
             b.iter(|| VariableBase::msm(&bases[..size], &scalars[..size]))
         });
     }

--- a/algorithms/benches/snark/marlin.rs
+++ b/algorithms/benches/snark/marlin.rs
@@ -57,11 +57,11 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for Benchmark<Constr
         )?;
 
         for i in 0..(self.num_variables - 3) {
-            let _ = cs.alloc(|| format!("var {}", i), || self.a.ok_or(SynthesisError::AssignmentMissing))?;
+            let _ = cs.alloc(|| format!("var {i}"), || self.a.ok_or(SynthesisError::AssignmentMissing))?;
         }
 
         for i in 0..(self.num_constraints - 1) {
-            cs.enforce(|| format!("constraint {}", i), |lc| lc + a, |lc| lc + b, |lc| lc + c);
+            cs.enforce(|| format!("constraint {i}"), |lc| lc + a, |lc| lc + b, |lc| lc + c);
         }
 
         Ok(())

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -302,10 +302,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
                 debug_assert_eq!(
                     chunk.len(),
                     self.state.rate_state[range.clone()].len(),
-                    "failed with squeeze {} at rate {} and rate_start {}",
-                    output_size,
-                    RATE,
-                    rate_start
+                    "failed with squeeze {output_size} at rate {RATE} and rate_start {rate_start}"
                 );
                 chunk.copy_from_slice(&self.state.rate_state[range]);
                 // Are we in the last chunk?

--- a/algorithms/src/crypto_hash/tests.rs
+++ b/algorithms/src/crypto_hash/tests.rs
@@ -38,7 +38,7 @@ fn expect_file_with_name(name: impl ToString, val: impl std::fmt::Debug) {
     if !path.exists() {
         std::fs::File::create(&path).expect("failed to create file");
     }
-    expect_test::expect_file![path].assert_eq(&format!("{:?}", val));
+    expect_test::expect_file![path].assert_eq(&format!("{val:?}"));
 }
 
 #[test]
@@ -55,17 +55,17 @@ fn test_poseidon_sponge_consistency() {
     let sponge_param = Arc::new(Fr::default_poseidon_parameters::<RATE>().unwrap());
     for absorb in 0..10 {
         for squeeze in 0..10 {
-            let iteration_name = format!("Absorb {} and Squeeze {}", absorb, squeeze);
+            let iteration_name = format!("Absorb {absorb} and Squeeze {squeeze}");
             let mut sponge = PoseidonSponge::<Fr, RATE, 1>::new_with_parameters(&sponge_param);
             sponge.absorb_native_field_elements(&vec![Fr::from(1237812u64); absorb]);
             let next_absorb_index = if absorb % RATE != 0 || absorb == 0 { absorb % RATE } else { RATE };
-            assert_eq!(sponge.mode, DuplexSpongeMode::Absorbing { next_absorb_index }, "{}", iteration_name);
+            assert_eq!(sponge.mode, DuplexSpongeMode::Absorbing { next_absorb_index }, "{iteration_name}");
             expect_file_with_name(&iteration_name, sponge.squeeze_native_field_elements(squeeze));
             let next_squeeze_index = if squeeze % RATE != 0 || squeeze == 0 { squeeze % RATE } else { RATE };
             if squeeze == 0 {
-                assert_eq!(sponge.mode, DuplexSpongeMode::Absorbing { next_absorb_index }, "{}", iteration_name);
+                assert_eq!(sponge.mode, DuplexSpongeMode::Absorbing { next_absorb_index }, "{iteration_name}");
             } else {
-                assert_eq!(sponge.mode, DuplexSpongeMode::Squeezing { next_squeeze_index }, "{}", iteration_name);
+                assert_eq!(sponge.mode, DuplexSpongeMode::Squeezing { next_squeeze_index }, "{iteration_name}");
             }
         }
     }
@@ -75,7 +75,7 @@ fn test_poseidon_sponge_consistency() {
 fn bls12_377_fr_poseidon_default_parameters_test() {
     fn single_rate_test<const RATE: usize>() {
         let params = Fr::default_poseidon_parameters::<RATE>().unwrap();
-        let name = format!("rate {} and optimize_for_weights false", RATE);
+        let name = format!("rate {RATE} and optimize_for_weights false");
         expect_file_with_name("Ark for ".to_string() + &name, params.ark);
         expect_file_with_name("MDS for ".to_string() + &name, params.mds);
     }

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -1085,13 +1085,11 @@ mod tests {
 
             assert_eq!(
                 random_polynomial, randon_polynomial_from_subgroup,
-                "degree = {}, domain size = {}",
-                degree, domain_size
+                "degree = {degree}, domain size = {domain_size}"
             );
             assert_eq!(
                 random_polynomial, random_polynomial_from_coset,
-                "degree = {}, domain size = {}",
-                degree, domain_size
+                "degree = {degree}, domain size = {domain_size}"
             );
         }
     }
@@ -1142,7 +1140,7 @@ mod tests {
     fn test_fft_correctness_cuda() {
         let mut rng = TestRng::default();
         for log_domain in 2..20 {
-            println!("Testing domain size {}", log_domain);
+            println!("Testing domain size {log_domain}");
             let domain_size = 1 << log_domain;
             let random_polynomial = DensePolynomial::<Fr>::rand(domain_size - 1, &mut rng);
             let mut polynomial_evaluations = random_polynomial.coeffs.clone();
@@ -1164,7 +1162,7 @@ mod tests {
                 println!("cuda error!");
             }
 
-            assert_eq!(polynomial_evaluations, polynomial_evaluations_cuda, "domain size = {}", domain_size);
+            assert_eq!(polynomial_evaluations, polynomial_evaluations_cuda, "domain size = {domain_size}");
 
             // iNTT
             if snarkvm_algorithms_cuda::NTT::<Fr>(
@@ -1178,7 +1176,7 @@ mod tests {
             {
                 println!("cuda error!");
             }
-            assert_eq!(random_polynomial.coeffs, polynomial_evaluations_cuda, "domain size = {}", domain_size);
+            assert_eq!(random_polynomial.coeffs, polynomial_evaluations_cuda, "domain size = {domain_size}");
 
             // Coset NTT
             polynomial_evaluations = random_polynomial.coeffs.clone();
@@ -1199,7 +1197,7 @@ mod tests {
                 println!("cuda error!");
             }
 
-            assert_eq!(polynomial_evaluations, polynomial_evaluations_cuda, "domain size = {}", domain_size);
+            assert_eq!(polynomial_evaluations, polynomial_evaluations_cuda, "domain size = {domain_size}");
 
             // Coset iNTT
             if snarkvm_algorithms_cuda::NTT::<Fr>(
@@ -1213,7 +1211,7 @@ mod tests {
             {
                 println!("cuda error!");
             }
-            assert_eq!(random_polynomial.coeffs, polynomial_evaluations_cuda, "domain size = {}", domain_size);
+            assert_eq!(random_polynomial.coeffs, polynomial_evaluations_cuda, "domain size = {domain_size}");
         }
     }
 }

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -46,7 +46,7 @@ impl<F: Field> fmt::Debug for DensePolynomial<F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         for (i, coeff) in self.coeffs.iter().enumerate().filter(|(_, c)| !c.is_zero()) {
             if i == 0 {
-                write!(f, "\n{:?}", coeff)?;
+                write!(f, "\n{coeff:?}",)?;
             } else if i == 1 {
                 write!(f, " + \n{:?} * x", coeff)?;
             } else {

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -48,9 +48,9 @@ impl<F: Field> fmt::Debug for DensePolynomial<F> {
             if i == 0 {
                 write!(f, "\n{coeff:?}",)?;
             } else if i == 1 {
-                write!(f, " + \n{:?} * x", coeff)?;
+                write!(f, " + \n{coeff:?} * x")?;
             } else {
-                write!(f, " + \n{:?} * x^{}", coeff, i)?;
+                write!(f, " + \n{coeff:?} * x^{i}")?;
             }
         }
         Ok(())
@@ -613,12 +613,12 @@ mod tests {
             // Include polynomials and evaluations
             let num_polys = (rng.next_u32() as usize) % 8;
             let num_evals = (rng.next_u32() as usize) % 4;
-            println!("\nnum_polys {}, num_evals {}", num_polys, num_evals);
+            println!("\nnum_polys {num_polys}, num_evals {num_evals}");
 
             for _ in 1..num_polys {
                 let degree = (rng.next_u32() as usize) % max_degree;
                 mul_degree += degree + 1;
-                println!("poly degree {}", degree);
+                println!("poly degree {degree}");
                 let a = DensePolynomial::<Fr>::rand(degree, rng);
                 naive = naive.naive_mul(&a);
                 multiplier.add_polynomial(a.clone(), "a");
@@ -632,7 +632,7 @@ mod tests {
                 let a = DensePolynomial::<Fr>::rand(mul_degree / 8, rng);
                 eval_degree += a.len() + 1;
                 if eval_degree < domain.size() {
-                    println!("eval degree {}", eval_degree);
+                    println!("eval degree {eval_degree}");
                     let mut a_evals = a.clone().coeffs;
                     domain.fft_in_place(&mut a_evals);
                     let a_evals = Evaluations::from_vec_and_domain(a_evals, domain);

--- a/algorithms/src/fft/polynomial/sparse.rs
+++ b/algorithms/src/fft/polynomial/sparse.rs
@@ -35,11 +35,11 @@ impl<F: Field> fmt::Debug for SparsePolynomial<F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         for (i, coeff) in self.coeffs.iter().filter(|(_, c)| !c.is_zero()) {
             if *i == 0 {
-                write!(f, "\n{:?}", coeff)?;
+                write!(f, "\n{coeff:?}")?;
             } else if *i == 1 {
-                write!(f, " + \n{:?} * x", coeff)?;
+                write!(f, " + \n{coeff:?} * x")?;
             } else {
-                write!(f, " + \n{:?} * x^{}", coeff, i)?;
+                write!(f, " + \n{coeff:?} * x^{i}")?;
             }
         }
         Ok(())

--- a/algorithms/src/fft/tests.rs
+++ b/algorithms/src/fft/tests.rs
@@ -144,8 +144,8 @@ fn test_fft_correctness() {
         let rand_poly_from_subgroup = DensePolynomial::from_coefficients_vec(domain.ifft(&poly_evals));
         let rand_poly_from_coset = DensePolynomial::from_coefficients_vec(domain.coset_ifft(&poly_coset_evals));
 
-        assert_eq!(rand_poly, rand_poly_from_subgroup, "degree = {}, domain size = {}", degree, domain_size);
-        assert_eq!(rand_poly, rand_poly_from_coset, "degree = {}, domain size = {}", degree, domain_size);
+        assert_eq!(rand_poly, rand_poly_from_subgroup, "degree = {degree}, domain size = {domain_size}");
+        assert_eq!(rand_poly, rand_poly_from_coset, "degree = {degree}, domain size = {domain_size}");
     }
 }
 

--- a/algorithms/src/polycommit/error.rs
+++ b/algorithms/src/polycommit/error.rs
@@ -110,49 +110,45 @@ impl core::fmt::Display for PCError {
         match self {
             Self::AnyhowError(error) => write!(f, "{error}"),
             Self::MissingPolynomial { label } => {
-                write!(f, "`QuerySet` refers to polynomial \"{}\", but it was not provided.", label)
+                write!(f, "`QuerySet` refers to polynomial \"{label}\", but it was not provided.")
             }
             Self::MissingEvaluation { label } => write!(
                 f,
-                "`QuerySet` refers to polynomial \"{}\", but `Evaluations` does not contain an evaluation for it.",
-                label
+                "`QuerySet` refers to polynomial \"{label}\", but `Evaluations` does not contain an evaluation for it."
             ),
             Self::MissingRng => write!(f, "hiding commitments require `Some(rng)`"),
             Self::DegreeIsZero => write!(f, "this scheme does not support committing to degree 0 polynomials"),
             Self::TooManyCoefficients { num_coefficients, num_powers } => write!(
                 f,
-                "the number of coefficients in the polynomial ({:?}) is greater than\
-                 the maximum number of powers in `Powers` ({:?})",
-                num_coefficients, num_powers
+                "the number of coefficients in the polynomial ({num_coefficients:?}) is greater than\
+                 the maximum number of powers in `Powers` ({num_powers:?})"
             ),
             Self::HidingBoundIsZero => write!(f, "this scheme does not support non-`None` hiding bounds that are 0"),
             Self::HidingBoundToolarge { hiding_poly_degree, num_powers } => write!(
                 f,
-                "the degree of the hiding poly ({:?}) is not less than the maximum number of powers in `Powers` ({:?})",
-                hiding_poly_degree, num_powers
+                "the degree of the hiding poly ({hiding_poly_degree:?}) is not less than the maximum number of powers in `Powers` ({num_powers:?})"
             ),
             Self::TrimmingDegreeTooLarge => write!(f, "the degree provided to `trim` was too large"),
             Self::EquationHasDegreeBounds(e) => {
-                write!(f, "the eqaution \"{}\" contained degree-bounded polynomials", e)
+                write!(f, "the eqaution \"{e}\" contained degree-bounded polynomials")
             }
             Self::UnsupportedDegreeBound(bound) => {
-                write!(f, "the degree bound ({:?}) is not supported by the parameters", bound)
+                write!(f, "the degree bound ({bound:?}) is not supported by the parameters")
             }
             Self::LagrangeBasisSizeIsNotPowerOfTwo => {
                 write!(f, "the Lagrange Basis size is not a power of two")
             }
             Self::UnsupportedLagrangeBasisSize(size) => {
-                write!(f, "the Lagrange basis size ({:?}) is not supported by the parameters", size)
+                write!(f, "the Lagrange basis size ({size:?}) is not supported by the parameters")
             }
             Self::LagrangeBasisSizeIsTooLarge => {
                 write!(f, "the Lagrange Basis size larger than max supported degree")
             }
             Self::IncorrectDegreeBound { poly_degree, degree_bound, supported_degree, label } => write!(
                 f,
-                "the degree bound ({:?}) for the polynomial {} \
-                 (having degree {:?}) is greater than the maximum \
-                 supported degree ({:?})",
-                degree_bound, label, poly_degree, supported_degree
+                "the degree bound ({degree_bound:?}) for the polynomial {label} \
+                 (having degree {poly_degree:?}) is greater than the maximum \
+                 supported degree ({supported_degree:?})"
             ),
             Self::Terminated => write!(f, "terminated"),
         }

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -140,7 +140,7 @@ impl<E: PairingEngine> KZG10<E> {
         if let Some(hiding_degree) = hiding_bound {
             let mut rng = rng.ok_or(PCError::MissingRng)?;
             let sample_random_poly_time =
-                start_timer!(|| format!("Sampling a random polynomial of degree {}", hiding_degree));
+                start_timer!(|| format!("Sampling a random polynomial of degree {hiding_degree}"));
 
             randomness = KZGRandomness::rand(hiding_degree, false, &mut rng);
             Self::check_hiding_bound(
@@ -199,7 +199,7 @@ impl<E: PairingEngine> KZG10<E> {
         if let Some(hiding_degree) = hiding_bound {
             let mut rng = rng.ok_or(PCError::MissingRng)?;
             let sample_random_poly_time =
-                start_timer!(|| format!("Sampling a random polynomial of degree {}", hiding_degree));
+                start_timer!(|| format!("Sampling a random polynomial of degree {hiding_degree}"));
 
             randomness = KZGRandomness::rand(hiding_degree, false, &mut rng);
             Self::check_hiding_bound(

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -416,7 +416,7 @@ impl<E: PairingEngine> KZG10<E> {
         )
         .is_one();
         end_timer!(pairing_time);
-        end_timer!(check_time, || format!("Result: {}", result));
+        end_timer!(check_time, || format!("Result: {result}"));
         Ok(result)
     }
 

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -605,7 +605,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                     coeffs_and_comms.push((*coeff, cur_comm.commitment()));
                 }
             }
-            let lc_time = start_timer!(|| format!("Combining {} commitments for {}", num_polys, lc_label));
+            let lc_time = start_timer!(|| format!("Combining {num_polys} commitments for {lc_label}"));
             lc_commitments.push(Self::combine_commitments(coeffs_and_comms));
             end_timer!(lc_time);
             lc_info.push((lc_label, degree_bound));

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -585,7 +585,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
 
             for (coeff, label) in lc.iter() {
                 if label.is_one() {
-                    for (&(ref label, _), ref mut eval) in evaluations.iter_mut() {
+                    for ((label, _), ref mut eval) in evaluations.iter_mut() {
                         if label == &lc_label {
                             **eval -= coeff;
                         }

--- a/algorithms/src/polycommit/test_templates.rs
+++ b/algorithms/src/polycommit/test_templates.rs
@@ -81,7 +81,7 @@ pub fn bad_degree_bound_test<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>() -
         let mut degree_bounds = Vec::new();
 
         for i in 0..10 {
-            let label = format!("Test{}", i);
+            let label = format!("Test{i}");
             labels.push(label.clone());
             let poly = DensePolynomial::rand(supported_degree, rng);
 
@@ -144,7 +144,7 @@ pub fn lagrange_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>()
         // Generate polynomials
         let num_points_in_query_set = distributions::Uniform::from(1..=max_num_queries).sample(rng);
         for i in 0..num_polynomials {
-            let label = format!("Test{}", i);
+            let label = format!("Test{i}");
             labels.push(label.clone());
             let eval_size: usize = distributions::Uniform::from(1..eval_size).sample(rng).next_power_of_two();
             let mut evals = vec![E::Fr::zero(); eval_size];
@@ -257,7 +257,7 @@ where
         // Generate polynomials
         let num_points_in_query_set = distributions::Uniform::from(1..=max_num_queries).sample(rng);
         for i in 0..num_polynomials {
-            let label = format!("Test{}", i);
+            let label = format!("Test{i}");
             labels.push(label.clone());
             let degree = distributions::Uniform::from(1..=supported_degree).sample(rng);
             let poly = DensePolynomial::rand(degree, rng);
@@ -375,7 +375,7 @@ fn equation_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>(
         // Generate polynomials
         let num_points_in_query_set = distributions::Uniform::from(1..=max_num_queries).sample(rng);
         for i in 0..num_polynomials {
-            let label = format!("Test{}", i);
+            let label = format!("Test{i}");
             labels.push(label.clone());
             let degree = distributions::Uniform::from(1..=supported_degree).sample(rng);
             let poly = DensePolynomial::rand(degree, rng);
@@ -453,7 +453,7 @@ fn equation_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>(
                 if !lc.is_empty() {
                     linear_combinations.push(lc);
                     // Insert query
-                    query_set.insert((label.clone(), (format!("rand_{}", i), point)));
+                    query_set.insert((label.clone(), (format!("rand_{i}"), point)));
                 }
             }
         }

--- a/algorithms/src/polycommit/test_templates.rs
+++ b/algorithms/src/polycommit/test_templates.rs
@@ -92,7 +92,7 @@ pub fn bad_degree_bound_test<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>() -
             polynomials.push(LabeledPolynomial::new(label, poly, Some(degree_bound), hiding_bound))
         }
 
-        println!("supported degree: {:?}", supported_degree);
+        println!("supported degree: {supported_degree:?}");
         let (ck, vk) =
             SonicKZG10::<E, S>::trim(&pp, supported_degree, None, supported_degree, Some(degree_bounds.as_slice()))?;
         println!("Trimmed");
@@ -113,7 +113,7 @@ pub fn bad_degree_bound_test<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>() -
         let proof = SonicKZG10::batch_open(&ck, &polynomials, &comms, &query_set, &rands, &mut sponge_for_open)?;
         let mut sponge_for_check = S::new();
         let result = SonicKZG10::batch_check(&vk, &comms, &query_set, &values, &proof, &mut sponge_for_check)?;
-        assert!(result, "proof was incorrect, Query set: {:#?}", query_set);
+        assert!(result, "proof was incorrect, Query set: {query_set:#?}");
     }
     Ok(())
 }
@@ -164,9 +164,9 @@ pub fn lagrange_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>()
             lagrange_polynomials.push(LabeledPolynomialWithBasis::new_lagrange_basis(label, evals, hiding_bound))
         }
         let supported_hiding_bound = polynomials.iter().map(|p| p.hiding_bound().unwrap_or(0)).max().unwrap_or(0);
-        println!("supported degree: {:?}", supported_degree);
-        println!("supported hiding bound: {:?}", supported_hiding_bound);
-        println!("num_points_in_query_set: {:?}", num_points_in_query_set);
+        println!("supported degree: {supported_degree:?}");
+        println!("supported hiding bound: {supported_hiding_bound:?}");
+        println!("num_points_in_query_set: {num_points_in_query_set:?}");
         let (ck, vk) = SonicKZG10::<E, S>::trim(
             &pp,
             supported_degree,
@@ -185,7 +185,7 @@ pub fn lagrange_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>()
         for point_id in 0..num_points_in_query_set {
             let point = E::Fr::rand(rng);
             for (polynomial, label) in polynomials.iter().zip_eq(labels.iter()) {
-                query_set.insert((label.clone(), (format!("rand_{}", point_id), point)));
+                query_set.insert((label.clone(), (format!("rand_{point_id}"), point)));
                 let value = polynomial.evaluate(point);
                 values.insert((label.clone(), point), value);
             }
@@ -197,16 +197,13 @@ pub fn lagrange_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>()
         let mut sponge_for_check = S::new();
         let result = SonicKZG10::batch_check(&vk, &comms, &query_set, &values, &proof, &mut sponge_for_check)?;
         if !result {
-            println!(
-                "Failed with {} polynomials, num_points_in_query_set: {:?}",
-                num_polynomials, num_points_in_query_set
-            );
+            println!("Failed with {num_polynomials} polynomials, num_points_in_query_set: {num_points_in_query_set:?}");
             println!("Degree of polynomials:");
             for poly in polynomials {
                 println!("Degree: {:?}", poly.degree());
             }
         }
-        assert!(result, "proof was incorrect, Query set: {:#?}", query_set);
+        assert!(result, "proof was incorrect, Query set: {query_set:#?}");
 
         test_components.push(TestComponents {
             verification_key: vk,
@@ -284,14 +281,14 @@ where
             };
 
             let hiding_bound = Some(1);
-            println!("Hiding bound: {:?}", hiding_bound);
+            println!("Hiding bound: {hiding_bound:?}");
 
             polynomials.push(LabeledPolynomial::new(label, poly, degree_bound, hiding_bound))
         }
         let supported_hiding_bound = polynomials.iter().map(|p| p.hiding_bound().unwrap_or(0)).max().unwrap_or(0);
-        println!("supported degree: {:?}", supported_degree);
-        println!("supported hiding bound: {:?}", supported_hiding_bound);
-        println!("num_points_in_query_set: {:?}", num_points_in_query_set);
+        println!("supported degree: {supported_degree:?}");
+        println!("supported hiding bound: {supported_hiding_bound:?}");
+        println!("num_points_in_query_set: {num_points_in_query_set:?}");
         let (ck, vk) =
             SonicKZG10::<E, S>::trim(&pp, supported_degree, None, supported_hiding_bound, degree_bounds.as_deref())?;
         println!("Trimmed");
@@ -305,7 +302,7 @@ where
         for point_id in 0..num_points_in_query_set {
             let point = E::Fr::rand(rng);
             for (polynomial, label) in polynomials.iter().zip_eq(labels.iter()) {
-                query_set.insert((label.clone(), (format!("rand_{}", point_id), point)));
+                query_set.insert((label.clone(), (format!("rand_{point_id}"), point)));
                 let value = polynomial.evaluate(point);
                 values.insert((label.clone(), point), value);
             }
@@ -317,16 +314,13 @@ where
         let mut sponge_for_check = S::new();
         let result = SonicKZG10::batch_check(&vk, &comms, &query_set, &values, &proof, &mut sponge_for_check)?;
         if !result {
-            println!(
-                "Failed with {} polynomials, num_points_in_query_set: {:?}",
-                num_polynomials, num_points_in_query_set
-            );
+            println!("Failed with {num_polynomials} polynomials, num_points_in_query_set: {num_points_in_query_set:?}");
             println!("Degree of polynomials:");
             for poly in polynomials {
                 println!("Degree: {:?}", poly.degree());
             }
         }
-        assert!(result, "proof was incorrect, Query set: {:#?}", query_set);
+        assert!(result, "proof was incorrect, Query set: {query_set:#?}");
 
         test_components.push(TestComponents {
             verification_key: vk,
@@ -402,17 +396,17 @@ fn equation_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>(
             };
 
             let hiding_bound = Some(1);
-            println!("Hiding bound: {:?}", hiding_bound);
+            println!("Hiding bound: {hiding_bound:?}");
 
             polynomials.push(LabeledPolynomial::new(label, poly, degree_bound, hiding_bound))
         }
         let supported_hiding_bound = polynomials.iter().map(|p| p.hiding_bound().unwrap_or(0)).max().unwrap_or(0);
-        println!("supported degree: {:?}", supported_degree);
-        println!("supported hiding bound: {:?}", supported_hiding_bound);
-        println!("num_points_in_query_set: {:?}", num_points_in_query_set);
-        println!("{:?}", degree_bounds);
-        println!("{}", num_polynomials);
-        println!("{}", enforce_degree_bounds);
+        println!("supported degree: {supported_degree:?}");
+        println!("supported hiding bound: {supported_hiding_bound:?}");
+        println!("num_points_in_query_set: {num_points_in_query_set:?}");
+        println!("{degree_bounds:?}");
+        println!("{num_polynomials}");
+        println!("{enforce_degree_bounds}");
 
         let (ck, vk) =
             SonicKZG10::<E, S>::trim(&pp, supported_degree, None, supported_hiding_bound, degree_bounds.as_deref())?;
@@ -427,7 +421,7 @@ fn equation_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>(
         for i in 0..num_points_in_query_set {
             let point = E::Fr::rand(rng);
             for j in 0..num_equations.unwrap() {
-                let label = format!("query {} eqn {}", i, j);
+                let label = format!("query {i} eqn {j}");
                 let mut lc = LinearCombination::empty(label.clone());
 
                 let mut value = E::Fr::zero();
@@ -461,7 +455,7 @@ fn equation_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>(
             continue;
         }
         println!("Generated query set");
-        println!("Linear combinations: {:?}", linear_combinations);
+        println!("Linear combinations: {linear_combinations:?}");
 
         let mut sponge_for_open = S::new();
         let proof = SonicKZG10::open_combinations(
@@ -485,16 +479,13 @@ fn equation_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>(
             &mut sponge_for_check,
         )?;
         if !result {
-            println!(
-                "Failed with {} polynomials, num_points_in_query_set: {:?}",
-                num_polynomials, num_points_in_query_set
-            );
+            println!("Failed with {num_polynomials} polynomials, num_points_in_query_set: {num_points_in_query_set:?}");
             println!("Degree of polynomials:");
             for poly in polynomials {
                 println!("Degree: {:?}", poly.degree());
             }
         }
-        assert!(result, "proof was incorrect, equations: {:#?}", linear_combinations);
+        assert!(result, "proof was incorrect, equations: {linear_combinations:#?}");
 
         test_components.push(TestComponents {
             verification_key: vk,

--- a/algorithms/src/snark/marlin/ahp/ahp.rs
+++ b/algorithms/src/snark/marlin/ahp/ahp.rs
@@ -487,7 +487,7 @@ mod tests {
                     other.elements().map(|y| domain.eval_unnormalized_bivariate_lagrange_poly(x, y)).collect();
                 let fast =
                     domain.batch_eval_unnormalized_bivariate_lagrange_poly_with_diff_inputs_over_domain(x, &other);
-                assert_eq!(fast, manual, "failed for self {:?} and other {:?}", domain, other);
+                assert_eq!(fast, manual, "failed for self {domain:?} and other {other:?}");
             }
         }
     }
@@ -506,9 +506,9 @@ mod tests {
         }
         let first = poly.coeffs[0] * size_as_fe;
         let last = *poly.coeffs.last().unwrap() * size_as_fe;
-        println!("sum: {:?}", sum);
-        println!("a_0: {:?}", first);
-        println!("a_n: {:?}", last);
+        println!("sum: {sum:?}");
+        println!("a_0: {first:?}");
+        println!("a_n: {last:?}");
         println!("first + last: {:?}\n", first + last);
         assert_eq!(sum, first + last);
     }
@@ -534,7 +534,7 @@ mod tests {
 
                 for element in domain_i.elements() {
                     if j_elements.contains(&element) {
-                        assert_eq!(slow_selector.evaluate(element), Fr::one(), "failed for {} vs {}", i, j);
+                        assert_eq!(slow_selector.evaluate(element), Fr::one(), "failed for {i} vs {j}");
                     } else {
                         assert_eq!(slow_selector.evaluate(element), Fr::zero());
                     }

--- a/algorithms/src/snark/marlin/ahp/ahp.rs
+++ b/algorithms/src/snark/marlin/ahp/ahp.rs
@@ -41,7 +41,7 @@ pub struct AHPForR1CS<F: Field, MM: MarlinMode> {
 }
 
 pub(crate) fn witness_label(poly: &str, i: usize) -> String {
-    format!("{poly}_{:0>8}", i)
+    format!("{poly}_{i:0>8}")
 }
 
 impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {

--- a/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
@@ -144,21 +144,21 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         let num_variables = num_padded_public_variables + num_private_variables;
 
         if cfg!(debug_assertions) {
-            println!("Number of padded public variables: {}", num_padded_public_variables);
-            println!("Number of private variables: {}", num_private_variables);
-            println!("Number of num_constraints: {}", num_constraints);
-            println!("Number of non-zero entries in A: {}", num_non_zero_a);
-            println!("Number of non-zero entries in B: {}", num_non_zero_b);
-            println!("Number of non-zero entries in C: {}", num_non_zero_c);
+            println!("Number of padded public variables: {num_padded_public_variables}");
+            println!("Number of private variables: {num_private_variables}");
+            println!("Number of num_constraints: {num_constraints}");
+            println!("Number of non-zero entries in A: {num_non_zero_a}");
+            println!("Number of non-zero entries in B: {num_non_zero_b}");
+            println!("Number of non-zero entries in C: {num_non_zero_c}");
         }
 
         if num_constraints != num_variables {
-            eprintln!("Number of padded public variables: {}", num_padded_public_variables);
-            eprintln!("Number of private variables: {}", num_private_variables);
-            eprintln!("Number of num_constraints: {}", num_constraints);
-            eprintln!("Number of non-zero entries in A: {}", num_non_zero_a);
-            eprintln!("Number of non-zero entries in B: {}", num_non_zero_b);
-            eprintln!("Number of non-zero entries in C: {}", num_non_zero_c);
+            eprintln!("Number of padded public variables: {num_padded_public_variables}");
+            eprintln!("Number of private variables: {num_private_variables}");
+            eprintln!("Number of num_constraints: {num_constraints}");
+            eprintln!("Number of non-zero entries in A: {num_non_zero_a}");
+            eprintln!("Number of non-zero entries in B: {num_non_zero_b}");
+            eprintln!("Number of non-zero entries in C: {num_non_zero_c}");
             return Err(AHPError::NonSquareMatrix);
         }
 

--- a/algorithms/src/snark/marlin/ahp/matrices.rs
+++ b/algorithms/src/snark/marlin/ahp/matrices.rs
@@ -67,7 +67,7 @@ pub(crate) fn pad_input_for_indexer_and_prover<F: PrimeField, CS: ConstraintSyst
     let padded_size = power_of_two.unwrap().size();
     if padded_size > num_public_variables {
         for i in 0..(padded_size - num_public_variables) {
-            cs.alloc_input(|| format!("pad_input_{}", i), || Ok(F::zero())).unwrap();
+            cs.alloc_input(|| format!("pad_input_{i}"), || Ok(F::zero())).unwrap();
         }
     }
 }
@@ -80,12 +80,12 @@ pub(crate) fn make_matrices_square<F: Field, CS: ConstraintSystem<F>>(cs: &mut C
         use core::convert::identity as iden;
         // Add dummy constraints of the form 0 * 0 == 0
         for i in 0..matrix_padding {
-            cs.enforce(|| format!("pad_constraint_{}", i), iden, iden, iden);
+            cs.enforce(|| format!("pad_constraint_{i}"), iden, iden, iden);
         }
     } else {
         // Add dummy unconstrained variables
         for i in 0..matrix_padding {
-            let _ = cs.alloc(|| format!("pad_variable_{}", i), || Ok(F::one())).expect("alloc failed");
+            let _ = cs.alloc(|| format!("pad_variable_{i}"), || Ok(F::one())).expect("alloc failed");
         }
     }
 }

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/first.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/first.rs
@@ -150,11 +150,11 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             .map(|mask_poly| LabeledPolynomial::new("mask_poly".to_string(), mask_poly, None, None))
     }
 
-    fn calculate_w<'a>(
+    fn calculate_w(
         label: String,
         private_variables: Vec<F>,
         x_poly: &DensePolynomial<F>,
-        state: &prover::State<'a, F, MM>,
+        state: &prover::State<F, MM>,
     ) -> PoolResult<F> {
         let constraint_domain = state.constraint_domain;
         let input_domain = state.input_domain;

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/fourth.rs
@@ -30,9 +30,9 @@ use snarkvm_fields::PrimeField;
 
 impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     /// Output the fourth round message and the next state.
-    pub fn prover_fourth_round<'a, R: RngCore>(
+    pub fn prover_fourth_round<R: RngCore>(
         verifier_message: &verifier::ThirdMessage<F>,
-        state: prover::State<'a, F, MM>,
+        state: prover::State<F, MM>,
         _r: &mut R,
     ) -> Result<prover::FourthOracles<F>, AHPError> {
         let verifier::ThirdMessage { r_b, r_c, .. } = verifier_message;

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/mod.rs
@@ -75,11 +75,11 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
 
                 if cfg!(debug_assertions) {
                     println!("Number of padded public variables in Prover::Init: {}", num_public_variables);
-                    println!("Number of private variables: {}", num_private_variables);
-                    println!("Number of constraints: {}", num_constraints);
-                    println!("Number of non-zero entries in A: {}", num_non_zero_a);
-                    println!("Number of non-zero entries in B: {}", num_non_zero_b);
-                    println!("Number of non-zero entries in C: {}", num_non_zero_c);
+                    println!("Number of private variables: {num_private_variables}");
+                    println!("Number of constraints: {num_constraints}");
+                    println!("Number of non-zero entries in A: {num_non_zero_a}");
+                    println!("Number of non-zero entries in B: {num_non_zero_b}");
+                    println!("Number of non-zero entries in C: {num_non_zero_c}");
                 }
 
                 if index.index_info.num_constraints != num_constraints

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/mod.rs
@@ -74,7 +74,7 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
                 assert_eq!(private_variables.len(), num_private_variables);
 
                 if cfg!(debug_assertions) {
-                    println!("Number of padded public variables in Prover::Init: {}", num_public_variables);
+                    println!("Number of padded public variables in Prover::Init: {num_public_variables}");
                     println!("Number of private variables: {num_private_variables}");
                     println!("Number of constraints: {num_constraints}");
                     println!("Number of non-zero entries in A: {num_non_zero_a}");

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/second.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/second.rs
@@ -240,8 +240,8 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         (summed_z_m, t)
     }
 
-    fn calculate_t<'a>(
-        matrices: &[&'a Matrix<F>],
+    fn calculate_t(
+        matrices: &[&Matrix<F>],
         matrix_randomizers: [F; 3],
         input_domain: &EvaluationDomain<F>,
         constraint_domain: &EvaluationDomain<F>,

--- a/algorithms/src/snark/marlin/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/marlin/data_structures/circuit_verifying_key.rs
@@ -211,7 +211,7 @@ impl<E: PairingEngine, MM: MarlinMode> fmt::Display for CircuitVerifyingKey<E, M
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let vk_hex = hex::encode(self.to_bytes_le().expect("Failed to convert verifying key to bytes"));
-        write!(f, "{}", vk_hex)
+        write!(f, "{vk_hex}")
     }
 }
 

--- a/algorithms/src/snark/marlin/errors.rs
+++ b/algorithms/src/snark/marlin/errors.rs
@@ -57,7 +57,7 @@ impl From<MarlinError> for SNARKError {
     fn from(error: MarlinError) -> Self {
         match error {
             MarlinError::Terminated => SNARKError::Terminated,
-            err => SNARKError::Crate("marlin", format!("{:?}", err)),
+            err => SNARKError::Crate("marlin", format!("{err:?}")),
         }
     }
 }

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -216,7 +216,7 @@ where
     type VerifyingKey = CircuitVerifyingKey<E, MM>;
 
     fn universal_setup(max_degree: &Self::UniversalSetupConfig) -> Result<Self::UniversalSetupParameters, SNARKError> {
-        let setup_time = start_timer!(|| { format!("Marlin::UniversalSetup with max_degree {}", max_degree,) });
+        let setup_time = start_timer!(|| { format!("Marlin::UniversalSetup with max_degree {max_degree}",) });
 
         let srs = SonicKZG10::<E, FS>::load_srs(*max_degree).map_err(Into::into);
         end_timer!(setup_time);

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -811,11 +811,11 @@ pub mod test {
             )?;
 
             for i in 0..(self.num_variables - 3) {
-                let _ = cs.alloc(|| format!("var {}", i), || self.a.ok_or(SynthesisError::AssignmentMissing))?;
+                let _ = cs.alloc(|| format!("var {i}"), || self.a.ok_or(SynthesisError::AssignmentMissing))?;
             }
 
             for i in 0..(self.num_constraints - 1) {
-                cs.enforce(|| format!("constraint {}", i), |lc| lc + a, |lc| lc + b, |lc| lc + c);
+                cs.enforce(|| format!("constraint {i}"), |lc| lc + a, |lc| lc + b, |lc| lc + c);
             }
 
             Ok(())

--- a/algorithms/src/snark/marlin/tests.rs
+++ b/algorithms/src/snark/marlin/tests.rs
@@ -53,11 +53,11 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for Circuit<Constrai
         )?;
 
         for i in 0..(self.num_variables - 3) {
-            let _ = cs.alloc(|| format!("var {}", i), || self.a.ok_or(SynthesisError::AssignmentMissing))?;
+            let _ = cs.alloc(|| format!("var {i}"), || self.a.ok_or(SynthesisError::AssignmentMissing))?;
         }
 
         for i in 0..(self.num_constraints - 1) {
-            cs.enforce(|| format!("constraint {}", i), |lc| lc + a, |lc| lc + b, |lc| lc + c);
+            cs.enforce(|| format!("constraint {i}"), |lc| lc + a, |lc| lc + b, |lc| lc + c);
         }
         cs.enforce(|| "constraint_final", |lc| lc + c, |lc| lc + b, |lc| lc + d);
 

--- a/circuit/account/src/compute_key/from_private_key.rs
+++ b/circuit/account/src/compute_key/from_private_key.rs
@@ -57,7 +57,7 @@ mod tests {
             // Initialize the private key.
             let private_key = PrivateKey::<Circuit>::new(mode, private_key);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = ComputeKey::from_private_key(&private_key);
                 assert_eq!(compute_key, candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.

--- a/circuit/account/src/compute_key/to_address.rs
+++ b/circuit/account/src/compute_key/to_address.rs
@@ -49,7 +49,7 @@ mod tests {
             // Initialize the compute key.
             let candidate = ComputeKey::<Circuit>::new(mode, compute_key);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_address();
                 assert_eq!(*address, candidate.to_group().eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.

--- a/circuit/account/src/private_key/to_compute_key.rs
+++ b/circuit/account/src/private_key/to_compute_key.rs
@@ -46,7 +46,7 @@ mod tests {
             // Initialize the private key.
             let candidate = PrivateKey::<Circuit>::new(mode, private_key);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_compute_key();
                 assert_eq!(compute_key, candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.

--- a/circuit/account/src/private_key/to_view_key.rs
+++ b/circuit/account/src/private_key/to_view_key.rs
@@ -46,7 +46,7 @@ mod tests {
             // Initialize the private key.
             let candidate = PrivateKey::<Circuit>::new(mode, private_key);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_view_key();
                 assert_eq!(view_key, candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.

--- a/circuit/account/src/signature/verify.rs
+++ b/circuit/account/src/signature/verify.rs
@@ -75,7 +75,7 @@ pub(crate) mod tests {
             let signature = Signature::<Circuit>::new(mode, signature);
             let address = Address::new(mode, address);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = signature.verify(&address, &message);
                 assert!(candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.
@@ -115,7 +115,7 @@ pub(crate) mod tests {
             let signature = Signature::<Circuit>::new(mode, signature);
             let address = Address::new(mode, address);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = signature.verify(&address, &message);
                 assert!(candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.

--- a/circuit/account/src/view_key/from_private_key.rs
+++ b/circuit/account/src/view_key/from_private_key.rs
@@ -49,7 +49,7 @@ mod tests {
             // Initialize the private key.
             let private_key = PrivateKey::<Circuit>::new(mode, private_key);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = ViewKey::from_private_key(&private_key);
                 assert_eq!(view_key, candidate.eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.

--- a/circuit/account/src/view_key/to_address.rs
+++ b/circuit/account/src/view_key/to_address.rs
@@ -46,7 +46,7 @@ mod tests {
             // Initialize the view key.
             let candidate = ViewKey::<Circuit>::new(mode, view_key);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_address();
                 assert_eq!(*address, candidate.to_group().eject_value());
                 // TODO (howardwu): Resolve skipping the cost count checks for the burn-in round.

--- a/circuit/algorithms/src/pedersen/commit.rs
+++ b/circuit/algorithms/src/pedersen/commit.rs
@@ -159,7 +159,7 @@ mod tests {
         second: C,
         rng: &mut TestRng,
     ) {
-        println!("Checking homomorphic addition on {} + {}", first, second);
+        println!("Checking homomorphic addition on {first} + {second}");
 
         // Sample the circuit randomizers.
         let first_randomizer: Scalar<_> = Inject::new(Mode::Private, Uniform::rand(rng));

--- a/circuit/algorithms/src/pedersen/commit_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/commit_uncompressed.rs
@@ -165,7 +165,7 @@ mod tests {
         second: C,
         rng: &mut TestRng,
     ) {
-        println!("Checking homomorphic addition on {} + {}", first, second);
+        println!("Checking homomorphic addition on {first} + {second}");
 
         // Sample the circuit randomizers.
         let first_randomizer: Scalar<_> = Inject::new(Mode::Private, Uniform::rand(rng));

--- a/circuit/algorithms/src/pedersen/hash_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/hash_uncompressed.rs
@@ -155,7 +155,7 @@ mod tests {
         first: C,
         second: C,
     ) {
-        println!("Checking homomorphic addition on {} + {}", first, second);
+        println!("Checking homomorphic addition on {first} + {second}");
 
         // Compute the expected hash, by hashing them individually and summing their results.
         let a = pedersen.hash_uncompressed(&first.to_bits_le());

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -352,7 +352,7 @@ mod tests {
     fn test_print_circuit() {
         let _candidate = create_example_circuit::<Circuit>();
         let output = format!("{}", Circuit);
-        println!("{}", output);
+        println!("{output}");
     }
 
     #[test]

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -156,10 +156,7 @@ impl Environment for Circuit {
                             assert_eq!(
                                 a.value() * b.value(),
                                 c.value(),
-                                "Constant constraint failed: ({} * {}) =?= {}",
-                                a,
-                                b,
-                                c
+                                "Constant constraint failed: ({a} * {b}) =?= {c}"
                             );
 
                             // match self.counter.scope().is_empty() {
@@ -351,7 +348,7 @@ mod tests {
     #[test]
     fn test_print_circuit() {
         let _candidate = create_example_circuit::<Circuit>();
-        let output = format!("{}", Circuit);
+        let output = format!("{Circuit}");
         println!("{output}");
     }
 

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -24,10 +24,10 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     type Network: console::Network<Affine = Self::Affine, Field = Self::BaseField, Scalar = Self::ScalarField>;
 
     type Affine: AffineCurve<
-        BaseField = Self::BaseField,
-        ScalarField = Self::ScalarField,
-        Coordinates = (Self::BaseField, Self::BaseField),
-    >;
+            BaseField = Self::BaseField,
+            ScalarField = Self::ScalarField,
+            Coordinates = (Self::BaseField, Self::BaseField),
+        >;
     type BaseField: PrimeField + SquareRootField + Copy;
     type ScalarField: PrimeField<BigInteger = <Self::BaseField as PrimeField>::BigInteger> + Copy;
 

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -24,10 +24,10 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     type Network: console::Network<Affine = Self::Affine, Field = Self::BaseField, Scalar = Self::ScalarField>;
 
     type Affine: AffineCurve<
-            BaseField = Self::BaseField,
-            ScalarField = Self::ScalarField,
-            Coordinates = (Self::BaseField, Self::BaseField),
-        >;
+        BaseField = Self::BaseField,
+        ScalarField = Self::ScalarField,
+        Coordinates = (Self::BaseField, Self::BaseField),
+    >;
     type BaseField: PrimeField + SquareRootField + Copy;
     type ScalarField: PrimeField<BigInteger = <Self::BaseField as PrimeField>::BigInteger> + Copy;
 

--- a/circuit/environment/src/helpers/count.rs
+++ b/circuit/environment/src/helpers/count.rs
@@ -113,7 +113,7 @@ impl<V: Copy + Debug + Ord + Add<Output = V> + Sub<Output = V> + Mul<Output = V>
         };
 
         if !outcome {
-            eprintln!("Metrics claims the count should be {:?}, found {:?} during synthesis", self, candidate);
+            eprintln!("Metrics claims the count should be {self:?}, found {candidate:?} during synthesis");
         }
 
         outcome

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -448,9 +448,9 @@ impl<F: PrimeField> fmt::Debug for LinearCombination<F> {
 
         for (variable, coefficient) in &terms {
             output += &match (variable.mode(), coefficient.is_one()) {
-                (Mode::Constant, _) => panic!("Malformed linear combination at: ({} * {:?})", coefficient, variable),
-                (_, true) => format!(" + {:?}", variable),
-                _ => format!(" + {} * {:?}", coefficient, variable),
+                (Mode::Constant, _) => panic!("Malformed linear combination at: ({coefficient} * {variable:?})"),
+                (_, true) => format!(" + {variable:?}"),
+                _ => format!(" + {coefficient} * {variable:?}"),
             };
         }
         write!(f, "{output}")
@@ -548,61 +548,61 @@ mod tests {
             let expected = "Constant(1) + Public(1, 1) + Private(0, 1)";
 
             let candidate = LinearCombination::one() + one_public + one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_private + one_public + LinearCombination::one();
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_private + LinearCombination::one() + one_public;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_public + LinearCombination::one() + one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
         }
         {
             let expected = "Constant(1) + 2 * Public(1, 1) + Private(0, 1)";
 
             let candidate = LinearCombination::one() + one_public + one_public + one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_private + one_public + LinearCombination::one() + one_public;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_public + one_private + LinearCombination::one() + one_public;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_public + LinearCombination::one() + one_private + one_public;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
         }
         {
             let expected = "Constant(1) + Public(1, 1) + 2 * Private(0, 1)";
 
             let candidate = LinearCombination::one() + one_public + one_private + one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_private + one_public + LinearCombination::one() + one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_private + one_private + LinearCombination::one() + one_public;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_public + LinearCombination::one() + one_private + one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
         }
         {
             let expected = "Constant(1) + Public(1, 1)";
 
             let candidate = LinearCombination::one() + one_public + one_private - one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_private + one_public + LinearCombination::one() - one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_private - one_private + LinearCombination::one() + one_public;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
 
             let candidate = one_public + LinearCombination::one() + one_private - one_private;
-            assert_eq!(expected, format!("{:?}", candidate));
+            assert_eq!(expected, format!("{candidate:?}"));
         }
     }
 

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -453,7 +453,7 @@ impl<F: PrimeField> fmt::Debug for LinearCombination<F> {
                 _ => format!(" + {} * {:?}", coefficient, variable),
             };
         }
-        write!(f, "{}", output)
+        write!(f, "{output}")
     }
 }
 

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -177,6 +177,6 @@ impl<F: PrimeField> Display for R1CS<F> {
         }
         output += "\n";
 
-        write!(f, "{}", output)
+        write!(f, "{output}")
     }
 }

--- a/circuit/environment/src/helpers/variable.rs
+++ b/circuit/environment/src/helpers/variable.rs
@@ -260,9 +260,9 @@ impl<F: PrimeField> Sub<&LinearCombination<F>> for &Variable<F> {
 impl<F: PrimeField> fmt::Debug for Variable<F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", match self {
-            Self::Constant(value) => format!("Constant({})", value),
-            Self::Public(index, value) => format!("Public({}, {})", index, value),
-            Self::Private(index, value) => format!("Private({}, {})", index, value),
+            Self::Constant(value) => format!("Constant({value})"),
+            Self::Public(index, value) => format!("Public({index}, {value})"),
+            Self::Private(index, value) => format!("Private({index}, {value})"),
         })
     }
 }

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -442,7 +442,7 @@ mod tests {
         let circuit = CurrentAleo {};
         let _candidate = create_example_circuit::<CurrentAleo>();
         let output = format!("{circuit}");
-        println!("{}", output);
+        println!("{output}");
     }
 
     #[test]

--- a/circuit/program/src/data/plaintext/equal.rs
+++ b/circuit/program/src/data/plaintext/equal.rs
@@ -108,13 +108,13 @@ mod tests {
         let plaintext = sample_plaintext(mode);
         let mismatched_plaintext = sample_mismatched_plaintext(mode);
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = plaintext.is_equal(&plaintext);
             assert!(candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
         });
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = plaintext.is_equal(&mismatched_plaintext);
             assert!(!candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
@@ -135,13 +135,13 @@ mod tests {
         let plaintext = sample_plaintext(mode);
         let mismatched_plaintext = sample_mismatched_plaintext(mode);
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = plaintext.is_not_equal(&mismatched_plaintext);
             assert!(candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
         });
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = plaintext.is_not_equal(&plaintext);
             assert!(!candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/program/src/data/record/decrypt.rs
+++ b/circuit/program/src/data/record/decrypt.rs
@@ -78,7 +78,7 @@ impl<A: Aleo> Record<A, Ciphertext<A>> {
             };
             // Insert the decrypted entry.
             if decrypted_data.insert(id.clone(), entry).is_some() {
-                A::halt(format!("Duplicate identifier in record: {}", id))
+                A::halt(format!("Duplicate identifier in record: {id}"))
             }
             // Increment the index.
             index += num_randomizers as usize;

--- a/circuit/program/src/data/record/encrypt.rs
+++ b/circuit/program/src/data/record/encrypt.rs
@@ -80,7 +80,7 @@ impl<A: Aleo> Record<A, Plaintext<A>> {
             };
             // Insert the encrypted entry.
             if encrypted_data.insert(id.clone(), entry).is_some() {
-                A::halt(format!("Duplicate identifier in record: {}", id))
+                A::halt(format!("Duplicate identifier in record: {id}"))
             }
             // Increment the index.
             index += num_randomizers as usize;

--- a/circuit/program/src/data/record/equal.rs
+++ b/circuit/program/src/data/record/equal.rs
@@ -116,13 +116,13 @@ mod tests {
         let record = sample_record(mode);
         let mismatched_record = sample_mismatched_record(mode);
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = record.is_equal(&record);
             assert!(candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
         });
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = record.is_equal(&mismatched_record);
             assert!(!candidate.eject_value());
         });
@@ -142,13 +142,13 @@ mod tests {
         let record = sample_record(mode);
         let mismatched_record = sample_mismatched_record(mode);
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = record.is_not_equal(&mismatched_record);
             assert!(candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
         });
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = record.is_not_equal(&record);
             assert!(!candidate.eject_value());
         });

--- a/circuit/program/src/data/record/mod.rs
+++ b/circuit/program/src/data/record/mod.rs
@@ -197,7 +197,7 @@ impl<A: Aleo> Eject for Record<A, Plaintext<A>> {
             self.nonce.eject_value(),
         ) {
             Ok(record) => record,
-            Err(error) => A::halt(format!("Record::<Plaintext>::eject_value: {}", error)),
+            Err(error) => A::halt(format!("Record::<Plaintext>::eject_value: {error}")),
         }
     }
 }
@@ -255,7 +255,7 @@ impl<A: Aleo> Eject for Record<A, Ciphertext<A>> {
             self.nonce.eject_value(),
         ) {
             Ok(record) => record,
-            Err(error) => A::halt(format!("Record::<Ciphertext>::eject_value: {}", error)),
+            Err(error) => A::halt(format!("Record::<Ciphertext>::eject_value: {error}")),
         }
     }
 }

--- a/circuit/types/address/src/compare.rs
+++ b/circuit/types/address/src/compare.rs
@@ -94,7 +94,7 @@ mod tests {
             let a = Address::<Circuit>::new(mode_a, console::Address::new(first));
             let b = Address::<Circuit>::new(mode_b, console::Address::new(second));
             let expected = first.to_x_coordinate() < second.to_x_coordinate();
-            let name = format!("{} {} {}", mode_a, mode_b, i);
+            let name = format!("{mode_a} {mode_b} {i}");
             check_is_less_than(&name, expected, &a, &b, num_constants, num_public, num_private, num_constraints);
 
             // Check `first` is not less than `first`.

--- a/circuit/types/address/src/helpers/from_bits.rs
+++ b/circuit/types/address/src/helpers/from_bits.rs
@@ -45,7 +45,7 @@ mod tests {
             let expected: console::Group<<Circuit as Environment>::Network> = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected).to_bits_le();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Address::<Circuit>::from_bits_le(&candidate);
                 assert_eq!(expected, *candidate.eject_value());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);
@@ -62,7 +62,7 @@ mod tests {
             let expected: console::Group<<Circuit as Environment>::Network> = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected).to_bits_be();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Address::<Circuit>::from_bits_be(&candidate);
                 assert_eq!(expected, *candidate.eject_value());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/types/address/src/helpers/from_field.rs
+++ b/circuit/types/address/src/helpers/from_field.rs
@@ -54,7 +54,7 @@ mod tests {
             let expected: console::Group<<Circuit as Environment>::Network> = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected).to_x_coordinate();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Address::from_field(candidate);
                 assert_eq!(expected.to_x_coordinate(), candidate.eject_value().to_x_coordinate());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/types/address/src/helpers/to_bits.rs
+++ b/circuit/types/address/src/helpers/to_bits.rs
@@ -61,7 +61,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Address::<Circuit>::from_group(Group::new(mode, expected));
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_le();
                 assert_eq!(expected_number_of_bits, candidate.len());
                 for (expected_bit, candidate_bit) in
@@ -84,7 +84,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Address::<Circuit>::from_group(Group::new(mode, expected));
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_be();
                 assert_eq!(expected_number_of_bits, candidate.len());
                 for (expected_bit, candidate_bit) in

--- a/circuit/types/address/src/helpers/to_field.rs
+++ b/circuit/types/address/src/helpers/to_field.rs
@@ -54,7 +54,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Address::<Circuit>::from_group(Group::new(mode, expected));
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_field();
                 assert_eq!(expected.to_x_coordinate(), candidate.eject_value());
                 assert_scope!(0, 0, 0, 0);

--- a/circuit/types/boolean/src/helpers/adder.rs
+++ b/circuit/types/boolean/src/helpers/adder.rs
@@ -55,8 +55,8 @@ mod tests {
         Circuit::scope(name, || {
             let case = format!("({} ADD {} WITH {})", a.eject_value(), b.eject_value(), c.eject_value());
             let (candidate_sum, candidate_carry) = a.adder(&b, &c);
-            assert_eq!(expected_sum, candidate_sum.eject_value(), "SUM {}", case);
-            assert_eq!(expected_carry, candidate_carry.eject_value(), "CARRY {}", case);
+            assert_eq!(expected_sum, candidate_sum.eject_value(), "SUM {case}");
+            assert_eq!(expected_carry, candidate_carry.eject_value(), "CARRY {case}");
             assert_scope!(case, num_constants, num_public, num_private, num_constraints);
         });
     }

--- a/circuit/types/boolean/src/helpers/subtractor.rs
+++ b/circuit/types/boolean/src/helpers/subtractor.rs
@@ -55,8 +55,8 @@ mod tests {
         Circuit::scope(name, || {
             let case = format!("({} SUB {} WITH {})", a.eject_value(), b.eject_value(), c.eject_value());
             let (candidate_difference, candidate_borrow) = a.subtractor(&b, &c);
-            assert_eq!(expected_difference, candidate_difference.eject_value(), "DIFF {}", case);
-            assert_eq!(expected_borrow, candidate_borrow.eject_value(), "BORROW {}", case);
+            assert_eq!(expected_difference, candidate_difference.eject_value(), "DIFF {case}");
+            assert_eq!(expected_borrow, candidate_borrow.eject_value(), "BORROW {case}");
             assert_scope!(case, num_constants, num_public, num_private, num_constraints);
         });
     }

--- a/circuit/types/boolean/src/lib.rs
+++ b/circuit/types/boolean/src/lib.rs
@@ -303,21 +303,21 @@ mod tests {
     #[test]
     fn test_display() {
         let candidate = Boolean::<Circuit>::new(Mode::Constant, false);
-        assert_eq!("false.constant", format!("{}", candidate));
+        assert_eq!("false.constant", format!("{candidate}"));
 
         let candidate = Boolean::<Circuit>::new(Mode::Constant, true);
-        assert_eq!("true.constant", format!("{}", candidate));
+        assert_eq!("true.constant", format!("{candidate}"));
 
         let candidate = Boolean::<Circuit>::new(Mode::Public, false);
-        assert_eq!("false.public", format!("{}", candidate));
+        assert_eq!("false.public", format!("{candidate}"));
 
         let candidate = Boolean::<Circuit>::new(Mode::Public, true);
-        assert_eq!("true.public", format!("{}", candidate));
+        assert_eq!("true.public", format!("{candidate}"));
 
         let candidate = Boolean::<Circuit>::new(Mode::Private, false);
-        assert_eq!("false.private", format!("{}", candidate));
+        assert_eq!("false.private", format!("{candidate}"));
 
         let candidate = Boolean::<Circuit>::new(Mode::Private, true);
-        assert_eq!("true.private", format!("{}", candidate));
+        assert_eq!("true.private", format!("{candidate}"));
     }
 }

--- a/circuit/types/boolean/src/ternary.rs
+++ b/circuit/types/boolean/src/ternary.rs
@@ -118,7 +118,7 @@ mod tests {
                     let a = Boolean::<Circuit>::new(mode_a, first);
                     let b = Boolean::<Circuit>::new(mode_b, second);
 
-                    let name = format!("{} ? {} : {}", mode_condition, mode_a, mode_b);
+                    let name = format!("{mode_condition} ? {mode_a} : {mode_b}");
                     check_ternary(
                         &name,
                         if flag { first } else { second },

--- a/circuit/types/field/src/add.rs
+++ b/circuit/types/field/src/add.rs
@@ -145,22 +145,22 @@ mod tests {
             let a = Field::<Circuit>::new(mode_a, first);
             let b = Field::<Circuit>::new(mode_b, second);
 
-            let name = format!("Add: a + b {}", i);
+            let name = format!("Add: a + b {i}");
             check_add(&name, &expected, &a, &b);
-            let name = format!("AddAssign: a + b {}", i);
+            let name = format!("AddAssign: a + b {i}");
             check_add_assign(&name, &expected, &a, &b);
 
             // Test identity.
-            let name = format!("Add: a + 0 {}", i);
+            let name = format!("Add: a + 0 {i}");
             let zero = Field::<Circuit>::new(mode_b, console::Field::<<Circuit as Environment>::Network>::zero());
             check_add(&name, &first, &a, &zero);
-            let name = format!("AddAssign: a + 0 {}", i);
+            let name = format!("AddAssign: a + 0 {i}");
             check_add_assign(&name, &first, &a, &zero);
 
-            let name = format!("Add: 0 + b {}", i);
+            let name = format!("Add: 0 + b {i}");
             let zero = Field::<Circuit>::new(mode_a, console::Field::<<Circuit as Environment>::Network>::zero());
             check_add(&name, &second, &zero, &b);
-            let name = format!("AddAssign: 0 + b {}", i);
+            let name = format!("AddAssign: 0 + b {i}");
             check_add_assign(&name, &second, &zero, &b);
         }
     }

--- a/circuit/types/field/src/compare.rs
+++ b/circuit/types/field/src/compare.rs
@@ -145,7 +145,7 @@ mod tests {
             let a = Field::<Circuit>::new(mode_a, first);
             let b = Field::<Circuit>::new(mode_b, second);
             let expected = first < second;
-            let name = format!("{} {} {}", mode_a, mode_b, i);
+            let name = format!("{mode_a} {mode_b} {i}");
             check_is_less_than(&name, expected, &a, &b, num_constants, num_public, num_private, num_constraints);
 
             // Check `first` is not less than `first`.

--- a/circuit/types/field/src/div.rs
+++ b/circuit/types/field/src/div.rs
@@ -186,23 +186,23 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Div: a / b {}", i);
+            let name = format!("Div: a / b {i}");
             check_div(&name, &first, &second, mode_a, mode_b);
-            let name = format!("DivAssign: a / b {}", i);
+            let name = format!("DivAssign: a / b {i}");
             check_div_assign(&name, &first, &second, mode_a, mode_b);
 
             // Check division by one.
             let one = console::Field::<<Circuit as Environment>::Network>::one();
-            let name = format!("Div By One {}", i);
+            let name = format!("Div By One {i}");
             check_div(&name, &first, &one, mode_a, mode_b);
-            let name = format!("DivAssign By One {}", i);
+            let name = format!("DivAssign By One {i}");
             check_div_assign(&name, &first, &one, mode_a, mode_b);
 
             // Check division by zero.
             let zero = console::Field::<<Circuit as Environment>::Network>::zero();
-            let name = format!("Div By Zero {}", i);
+            let name = format!("Div By Zero {i}");
             check_div(&name, &first, &zero, mode_a, mode_b);
-            let name = format!("DivAssign By Zero {}", i);
+            let name = format!("DivAssign By Zero {i}");
             check_div_assign(&name, &first, &zero, mode_a, mode_b);
         }
     }

--- a/circuit/types/field/src/div_unchecked.rs
+++ b/circuit/types/field/src/div_unchecked.rs
@@ -129,17 +129,17 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Div: a / b {}", i);
+            let name = format!("Div: a / b {i}");
             check_div_unchecked(&name, &first, &second, mode_a, mode_b);
 
             // Check division by one.
             let one = console::Field::<<Circuit as Environment>::Network>::one();
-            let name = format!("Div By One {}", i);
+            let name = format!("Div By One {i}");
             check_div_unchecked(&name, &first, &one, mode_a, mode_b);
 
             // Check division by zero.
             let zero = console::Field::<<Circuit as Environment>::Network>::zero();
-            let name = format!("Div By Zero {}", i);
+            let name = format!("Div By Zero {i}");
             check_div_unchecked(&name, &first, &zero, mode_a, mode_b);
         }
     }

--- a/circuit/types/field/src/equal.rs
+++ b/circuit/types/field/src/equal.rs
@@ -199,13 +199,13 @@ mod tests {
             // Check first is equal to first.
             let a = Field::<Circuit>::new(mode_a, first);
             let b = Field::<Circuit>::new(mode_b, first);
-            let name = format!("{} == {}", first, first);
+            let name = format!("{first} == {first}");
             check_is_equal(&name, true, &a, &b);
 
             // Check second is equal to second.
             let a = Field::<Circuit>::new(mode_a, second);
             let b = Field::<Circuit>::new(mode_b, second);
-            let name = format!("{} == {}", second, second);
+            let name = format!("{second} == {second}");
             check_is_equal(&name, true, &a, &b);
         }
     }

--- a/circuit/types/field/src/equal.rs
+++ b/circuit/types/field/src/equal.rs
@@ -190,10 +190,10 @@ mod tests {
             let a = Field::<Circuit>::new(mode_a, first);
             let b = Field::<Circuit>::new(mode_b, second);
 
-            let name = format!("Equal: a == b {}", i);
+            let name = format!("Equal: a == b {i}");
             check_is_equal(&name, first == second, &a, &b);
 
-            let name = format!("Not Equal: a != b {}", i);
+            let name = format!("Not Equal: a != b {i}");
             check_is_not_equal(&name, first != second, &a, &b);
 
             // Check first is equal to first.

--- a/circuit/types/field/src/helpers/from_bits.rs
+++ b/circuit/types/field/src/helpers/from_bits.rs
@@ -140,7 +140,7 @@ mod tests {
             // Add excess zero bits.
             let candidate = vec![given_bits, vec![Boolean::new(mode, false); i as usize]].concat();
 
-            Circuit::scope(&format!("Excess {} {}", mode, i), || {
+            Circuit::scope(&format!("Excess {mode} {i}"), || {
                 let candidate = Field::<Circuit>::from_bits_le(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.get().expect("Caching failed").len());
@@ -180,7 +180,7 @@ mod tests {
             // Add excess zero bits.
             let candidate = vec![vec![Boolean::new(mode, false); i as usize], given_bits].concat();
 
-            Circuit::scope(&format!("Excess {} {}", mode, i), || {
+            Circuit::scope(&format!("Excess {mode} {i}"), || {
                 let candidate = Field::<Circuit>::from_bits_be(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.get().expect("Caching failed").len());

--- a/circuit/types/field/src/helpers/to_bits.rs
+++ b/circuit/types/field/src/helpers/to_bits.rs
@@ -103,7 +103,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Field::<Circuit>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate_bits = candidate.to_bits_le();
                 assert_eq!(expected_number_of_bits, candidate_bits.len());
                 for (expected_bit, candidate_bit) in expected.to_bits_le().iter().zip_eq(&candidate_bits) {
@@ -131,7 +131,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Field::<Circuit>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate_bits = candidate.to_bits_be();
                 assert_eq!(expected_number_of_bits, candidate_bits.len());
                 for (expected_bit, candidate_bit) in expected.to_bits_be().iter().zip_eq(&candidate_bits) {

--- a/circuit/types/field/src/helpers/to_lower_bits.rs
+++ b/circuit/types/field/src/helpers/to_lower_bits.rs
@@ -108,7 +108,7 @@ mod tests {
                 let candidate = candidate.to_lower_bits_le(I::BITS as usize);
                 assert_eq!(I::BITS, candidate.len() as u64);
                 for (i, (expected_bit, candidate_bit)) in expected.iter().zip_eq(candidate.iter()).enumerate() {
-                    assert_eq!(*expected_bit, candidate_bit.eject_value(), "LSB+{}", i);
+                    assert_eq!(*expected_bit, candidate_bit.eject_value(), "LSB+{i}");
                 }
                 assert_count!(ToLowerBits<Boolean>() => Field, &(mode, I::BITS));
                 assert_output_mode!(ToLowerBits<Boolean>() => Field, &mode, candidate);

--- a/circuit/types/field/src/helpers/to_lower_bits.rs
+++ b/circuit/types/field/src/helpers/to_lower_bits.rs
@@ -104,7 +104,7 @@ mod tests {
             // Construct the unsigned integer as a field element.
             let candidate = Field::<Circuit>::new(mode, console::Field::from_bits_le(&expected).unwrap());
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_lower_bits_le(I::BITS as usize);
                 assert_eq!(I::BITS, candidate.len() as u64);
                 for (i, (expected_bit, candidate_bit)) in expected.iter().zip_eq(candidate.iter()).enumerate() {

--- a/circuit/types/field/src/helpers/to_upper_bits.rs
+++ b/circuit/types/field/src/helpers/to_upper_bits.rs
@@ -131,7 +131,7 @@ mod tests {
                 Field::<Circuit>::new(mode, console::Field::from_bits_be(&bits_be).unwrap())
             };
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let num_bits_with_capacity = I::BITS + 1;
                 let candidate = candidate.to_upper_bits_be(num_bits_with_capacity as usize);
                 assert_eq!(num_bits_with_capacity, candidate.len() as u64);

--- a/circuit/types/field/src/helpers/to_upper_bits.rs
+++ b/circuit/types/field/src/helpers/to_upper_bits.rs
@@ -136,7 +136,7 @@ mod tests {
                 let candidate = candidate.to_upper_bits_be(num_bits_with_capacity as usize);
                 assert_eq!(num_bits_with_capacity, candidate.len() as u64);
                 for (i, (expected_bit, candidate_bit)) in expected.iter().zip_eq(candidate.iter().skip(1)).enumerate() {
-                    assert_eq!(*expected_bit, candidate_bit.eject_value(), "MSB-{}", i);
+                    assert_eq!(*expected_bit, candidate_bit.eject_value(), "MSB-{i}");
                 }
                 assert_count!(ToUpperBits<Boolean>() => Field, &(mode, num_bits_with_capacity));
                 assert_output_mode!(ToUpperBits<Boolean>() => Field, &mode, candidate);

--- a/circuit/types/field/src/lib.rs
+++ b/circuit/types/field/src/lib.rs
@@ -203,15 +203,15 @@ mod tests {
 
         // Constant
         let candidate = Field::<Circuit>::new(Mode::Constant, zero);
-        assert_eq!("0field.constant", &format!("{}", candidate));
+        assert_eq!("0field.constant", &format!("{candidate}"));
 
         // Public
         let candidate = Field::<Circuit>::new(Mode::Public, zero);
-        assert_eq!("0field.public", &format!("{}", candidate));
+        assert_eq!("0field.public", &format!("{candidate}"));
 
         // Private
         let candidate = Field::<Circuit>::new(Mode::Private, zero);
-        assert_eq!("0field.private", &format!("{}", candidate));
+        assert_eq!("0field.private", &format!("{candidate}"));
     }
 
     #[test]
@@ -220,15 +220,15 @@ mod tests {
 
         // Constant
         let candidate = Field::<Circuit>::new(Mode::Constant, one);
-        assert_eq!("1field.constant", &format!("{}", candidate));
+        assert_eq!("1field.constant", &format!("{candidate}"));
 
         // Public
         let candidate = Field::<Circuit>::new(Mode::Public, one);
-        assert_eq!("1field.public", &format!("{}", candidate));
+        assert_eq!("1field.public", &format!("{candidate}"));
 
         // Private
         let candidate = Field::<Circuit>::new(Mode::Private, one);
-        assert_eq!("1field.private", &format!("{}", candidate));
+        assert_eq!("1field.private", &format!("{candidate}"));
     }
 
     #[test]
@@ -238,15 +238,15 @@ mod tests {
 
         // Constant
         let candidate = Field::<Circuit>::new(Mode::Constant, two);
-        assert_eq!("2field.constant", &format!("{}", candidate));
+        assert_eq!("2field.constant", &format!("{candidate}"));
 
         // Public
         let candidate = Field::<Circuit>::new(Mode::Public, two);
-        assert_eq!("2field.public", &format!("{}", candidate));
+        assert_eq!("2field.public", &format!("{candidate}"));
 
         // Private
         let candidate = Field::<Circuit>::new(Mode::Private, two);
-        assert_eq!("2field.private", &format!("{}", candidate));
+        assert_eq!("2field.private", &format!("{candidate}"));
     }
 
     #[test]

--- a/circuit/types/field/src/mul.rs
+++ b/circuit/types/field/src/mul.rs
@@ -162,35 +162,35 @@ mod tests {
             let a = Field::<Circuit>::new(mode_a, first);
             let b = Field::<Circuit>::new(mode_b, second);
 
-            let name = format!("Mul: a + b {}", i);
+            let name = format!("Mul: a + b {i}");
             check_mul(&name, &expected, &a, &b);
-            let name = format!("MulAssign: a + b {}", i);
+            let name = format!("MulAssign: a + b {i}");
             check_mul_assign(&name, &expected, &a, &b);
 
             // Test identity.
-            let name = format!("Mul: a * 1 {}", i);
+            let name = format!("Mul: a * 1 {i}");
             let one = Field::<Circuit>::new(mode_b, console::Field::<<Circuit as Environment>::Network>::one());
             check_mul(&name, &first, &a, &one);
-            let name = format!("MulAssign: a * 1 {}", i);
+            let name = format!("MulAssign: a * 1 {i}");
             check_mul_assign(&name, &first, &a, &one);
 
-            let name = format!("Mul: 1 * b {}", i);
+            let name = format!("Mul: 1 * b {i}");
             let one = Field::<Circuit>::new(mode_a, console::Field::<<Circuit as Environment>::Network>::one());
             check_mul(&name, &second, &one, &b);
-            let name = format!("MulAssign: 1 * b {}", i);
+            let name = format!("MulAssign: 1 * b {i}");
             check_mul_assign(&name, &second, &one, &b);
 
             // Test zero.
-            let name = format!("Mul: a * 0 {}", i);
+            let name = format!("Mul: a * 0 {i}");
             let zero = Field::<Circuit>::new(mode_b, console::Field::<<Circuit as Environment>::Network>::zero());
             check_mul(&name, &console::Field::<<Circuit as Environment>::Network>::zero(), &a, &zero);
-            let name = format!("MulAssign: a * 0 {}", i);
+            let name = format!("MulAssign: a * 0 {i}");
             check_mul_assign(&name, &console::Field::<<Circuit as Environment>::Network>::zero(), &a, &zero);
 
-            let name = format!("Mul: 0 * b {}", i);
+            let name = format!("Mul: 0 * b {i}");
             let zero = Field::<Circuit>::new(mode_a, console::Field::<<Circuit as Environment>::Network>::zero());
             check_mul(&name, &console::Field::<<Circuit as Environment>::Network>::zero(), &zero, &b);
-            let name = format!("MulAssign: 0 * b {}", i);
+            let name = format!("MulAssign: 0 * b {i}");
             check_mul_assign(&name, &console::Field::<<Circuit as Environment>::Network>::zero(), &zero, &b);
         }
     }

--- a/circuit/types/field/src/pow.rs
+++ b/circuit/types/field/src/pow.rs
@@ -166,29 +166,29 @@ mod tests {
 
             let expected = first.pow(second);
 
-            let name = format!("Pow: a ^ b {}", i);
+            let name = format!("Pow: a ^ b {i}");
             check_pow(&name, &expected, &a, &b);
 
             // Test one exponent.
-            let name = format!("Pow: a ^ 1 {}", i);
+            let name = format!("Pow: a ^ 1 {i}");
             let a = Field::<Circuit>::new(mode_a, first);
             let one = Field::<Circuit>::new(mode_b, console::Field::<<Circuit as Environment>::Network>::one());
             check_pow(&name, &first, &a, &one);
 
             // Test one base.
-            let name = format!("Pow: 1 ^ b {}", i);
+            let name = format!("Pow: 1 ^ b {i}");
             let one = Field::<Circuit>::new(mode_a, console::Field::<<Circuit as Environment>::Network>::one());
             let b = Field::<Circuit>::new(mode_b, second);
             check_pow(&name, &console::Field::<<Circuit as Environment>::Network>::one(), &one, &b);
 
             // Test zero exponent.
-            let name = format!("Pow: a ^ 0 {}", i);
+            let name = format!("Pow: a ^ 0 {i}");
             let a = Field::<Circuit>::new(mode_a, first);
             let zero = Field::<Circuit>::new(mode_b, console::Field::<<Circuit as Environment>::Network>::zero());
             check_pow(&name, &console::Field::<<Circuit as Environment>::Network>::one(), &a, &zero);
 
             // Test zero base.
-            let name = format!("Mul: 0 ^ b {}", i);
+            let name = format!("Mul: 0 ^ b {i}");
             let zero = Field::<Circuit>::new(mode_a, console::Field::<<Circuit as Environment>::Network>::zero());
             let b = Field::<Circuit>::new(mode_b, second);
             check_pow(&name, &console::Field::<<Circuit as Environment>::Network>::zero(), &zero, &b);

--- a/circuit/types/field/src/square.rs
+++ b/circuit/types/field/src/square.rs
@@ -68,7 +68,7 @@ mod tests {
             let first = Uniform::rand(rng);
             let a = Field::<Circuit>::new(mode, first);
 
-            let name = format!("Square: {}", i);
+            let name = format!("Square: {i}");
             check_square(&name, &first.square(), &a);
         }
 

--- a/circuit/types/field/src/sub.rs
+++ b/circuit/types/field/src/sub.rs
@@ -137,23 +137,23 @@ mod tests {
             let a = Field::<Circuit>::new(mode_a, first);
             let b = Field::<Circuit>::new(mode_b, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
 
             // Test identity.
-            let name = format!("Sub: a - 0 {}", i);
+            let name = format!("Sub: a - 0 {i}");
             let zero = Field::<Circuit>::new(mode_b, console::Field::<<Circuit as Environment>::Network>::zero());
             check_sub(&name, &first, &a, &zero);
-            let name = format!("SubAssign: a - 0 {}", i);
+            let name = format!("SubAssign: a - 0 {i}");
             check_sub_assign(&name, &first, &a, &zero);
 
             // Test negation.
-            let name = format!("Sub: 0 - b {}", i);
+            let name = format!("Sub: 0 - b {i}");
             let zero = Field::<Circuit>::new(mode_a, console::Field::<<Circuit as Environment>::Network>::zero());
             check_sub(&name, &(-second), &zero, &b);
-            let name = format!("SubAssign: 0 - b {}", i);
+            let name = format!("SubAssign: 0 - b {i}");
             check_sub_assign(&name, &(-second), &zero, &b);
         }
     }

--- a/circuit/types/group/src/add.rs
+++ b/circuit/types/group/src/add.rs
@@ -182,9 +182,9 @@ mod tests {
 
             let expected = first + second;
 
-            let name = format!("Add: a + b {}", i);
+            let name = format!("Add: a + b {i}");
             check_add(&name, &expected, &a, &b);
-            let name = format!("AddAssign: a + b {}", i);
+            let name = format!("AddAssign: a + b {i}");
             check_add_assign(&name, &expected, &a, &b);
         }
     }

--- a/circuit/types/group/src/double.rs
+++ b/circuit/types/group/src/double.rs
@@ -81,7 +81,7 @@ mod tests {
             // Constant variable
             let affine = Group::<Circuit>::new(Mode::Constant, point);
 
-            Circuit::scope(&format!("Constant {}", i), || {
+            Circuit::scope(&format!("Constant {i}"), || {
                 let candidate = affine.double();
                 assert_eq!(expected, candidate.eject_value());
                 assert_scope!(3, 0, 0, 0);
@@ -91,7 +91,7 @@ mod tests {
             // Public variable
             let affine = Group::<Circuit>::new(Mode::Public, point);
 
-            Circuit::scope(&format!("Public {}", i), || {
+            Circuit::scope(&format!("Public {i}"), || {
                 let candidate = affine.double();
                 assert_eq!(expected, candidate.eject_value());
                 assert_scope!(1, 0, 5, 5);
@@ -101,7 +101,7 @@ mod tests {
             // Private variable
             let affine = Group::<Circuit>::new(Mode::Private, point);
 
-            Circuit::scope(&format!("Private {}", i), || {
+            Circuit::scope(&format!("Private {i}"), || {
                 let candidate = affine.double();
                 assert_eq!(expected, candidate.eject_value());
                 assert_scope!(1, 0, 5, 5);

--- a/circuit/types/group/src/equal.rs
+++ b/circuit/types/group/src/equal.rs
@@ -63,14 +63,14 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, a);
             let b = Group::<Circuit>::new(Mode::Constant, b);
 
-            Circuit::scope(&format!("Constant Equals {}", i), || {
+            Circuit::scope(&format!("Constant Equals {i}"), || {
                 let equals = a.is_equal(&b);
                 assert!(!equals.eject_value());
                 assert_scope!(2, 0, 0, 0);
             });
             Circuit::reset();
 
-            Circuit::scope(&format!("Constant Not Equals {}", i), || {
+            Circuit::scope(&format!("Constant Not Equals {i}"), || {
                 let equals = a.is_not_equal(&b);
                 assert!(equals.eject_value());
                 assert_scope!(2, 0, 0, 0);
@@ -87,14 +87,14 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, a);
             let b = Group::<Circuit>::new(Mode::Public, b);
 
-            Circuit::scope(&format!("Constant and Public Equals {}", i), || {
+            Circuit::scope(&format!("Constant and Public Equals {i}"), || {
                 let equals = a.is_equal(&b);
                 assert!(!equals.eject_value());
                 assert_scope!(0, 0, 5, 7);
             });
             Circuit::reset();
 
-            Circuit::scope(&format!("Constant and Public Not Equals {}", i), || {
+            Circuit::scope(&format!("Constant and Public Not Equals {i}"), || {
                 let equals = a.is_not_equal(&b);
                 assert!(equals.eject_value());
                 assert_scope!(0, 0, 5, 7);
@@ -111,14 +111,14 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, a);
             let b = Group::<Circuit>::new(Mode::Constant, b);
 
-            Circuit::scope(&format!("Public and Constant Equals {}", i), || {
+            Circuit::scope(&format!("Public and Constant Equals {i}"), || {
                 let equals = a.is_equal(&b);
                 assert!(!equals.eject_value());
                 assert_scope!(0, 0, 5, 7);
             });
             Circuit::reset();
 
-            Circuit::scope(&format!("Public and Constant Not Equals {}", i), || {
+            Circuit::scope(&format!("Public and Constant Not Equals {i}"), || {
                 let equals = a.is_not_equal(&b);
                 assert!(equals.eject_value());
                 assert_scope!(0, 0, 5, 7);
@@ -135,14 +135,14 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, a);
             let b = Group::<Circuit>::new(Mode::Public, b);
 
-            Circuit::scope(&format!("Public Equals {}", i), || {
+            Circuit::scope(&format!("Public Equals {i}"), || {
                 let equals = a.is_equal(&b);
                 assert!(!equals.eject_value());
                 assert_scope!(0, 0, 5, 7);
             });
             Circuit::reset();
 
-            Circuit::scope(&format!("Public Not Equals {}", i), || {
+            Circuit::scope(&format!("Public Not Equals {i}"), || {
                 let equals = a.is_not_equal(&b);
                 assert!(equals.eject_value());
                 assert_scope!(0, 0, 5, 7);
@@ -159,14 +159,14 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Private, a);
             let b = Group::<Circuit>::new(Mode::Private, b);
 
-            Circuit::scope(&format!("Private Equals {}", i), || {
+            Circuit::scope(&format!("Private Equals {i}"), || {
                 let equals = a.is_equal(&b);
                 assert!(!equals.eject_value());
                 assert_scope!(0, 0, 5, 7);
             });
             Circuit::reset();
 
-            Circuit::scope(&format!("Private Not Equals {}", i), || {
+            Circuit::scope(&format!("Private Not Equals {i}"), || {
                 let equals = a.is_not_equal(&b);
                 assert!(equals.eject_value());
                 assert_scope!(0, 0, 5, 7);

--- a/circuit/types/group/src/helpers/from_bits.rs
+++ b/circuit/types/group/src/helpers/from_bits.rs
@@ -51,7 +51,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected).to_bits_le();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Group::<Circuit>::from_bits_le(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);
@@ -68,7 +68,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected).to_bits_be();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Group::<Circuit>::from_bits_be(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/types/group/src/helpers/mul_by_cofactor.rs
+++ b/circuit/types/group/src/helpers/mul_by_cofactor.rs
@@ -48,7 +48,7 @@ mod tests {
             // Initialize the input.
             let affine = Group::<Circuit>::new(mode, input);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = affine.mul_by_cofactor();
                 assert_eq!(expected, candidate.eject_value());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/types/group/src/helpers/mul_by_cofactor.rs
+++ b/circuit/types/group/src/helpers/mul_by_cofactor.rs
@@ -88,7 +88,7 @@ mod tests {
             // Initialize the input.
             let affine = Group::<Circuit>::new(Mode::Private, input);
 
-            Circuit::scope(&format!("Constant {}", i), || {
+            Circuit::scope(&format!("Constant {i}"), || {
                 let candidate =
                     affine * Scalar::constant(console::Scalar::new(<Circuit as Environment>::ScalarField::from(4u128)));
                 assert_eq!(expected, candidate.eject_value());

--- a/circuit/types/group/src/helpers/to_bits.rs
+++ b/circuit/types/group/src/helpers/to_bits.rs
@@ -61,7 +61,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_le();
                 assert_eq!(expected_number_of_bits, candidate.len());
                 for (expected_bit, candidate_bit) in
@@ -84,7 +84,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_be();
                 assert_eq!(expected_number_of_bits, candidate.len());
                 for (expected_bit, candidate_bit) in

--- a/circuit/types/group/src/helpers/to_x_coordinate.rs
+++ b/circuit/types/group/src/helpers/to_x_coordinate.rs
@@ -36,7 +36,7 @@ mod tests {
             let expected = Uniform::rand(&mut TestRng::default());
             let candidate = Group::<Circuit>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_x_coordinate();
                 assert_eq!(expected.to_x_coordinate(), candidate.eject_value());
                 assert_scope!(0, 0, 0, 0);

--- a/circuit/types/group/src/helpers/to_y_coordinate.rs
+++ b/circuit/types/group/src/helpers/to_y_coordinate.rs
@@ -38,7 +38,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Group::<Circuit>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_y_coordinate();
                 assert_eq!(expected.to_y_coordinate(), candidate.eject_value());
                 assert_scope!(0, 0, 0, 0);

--- a/circuit/types/group/src/lib.rs
+++ b/circuit/types/group/src/lib.rs
@@ -225,7 +225,7 @@ mod tests {
             // Sample a random element.
             let point = Uniform::rand(&mut rng);
 
-            Circuit::scope(&format!("Constant {}", i), || {
+            Circuit::scope(&format!("Constant {i}"), || {
                 let affine = Group::<Circuit>::new(Mode::Constant, point);
                 assert_eq!(point, affine.eject_value());
                 assert_scope!(10, 0, 0, 0);
@@ -237,7 +237,7 @@ mod tests {
             // Sample a random element.
             let point = Uniform::rand(&mut rng);
 
-            Circuit::scope(&format!("Public {}", i), || {
+            Circuit::scope(&format!("Public {i}"), || {
                 let affine = Group::<Circuit>::new(Mode::Public, point);
                 assert_eq!(point, affine.eject_value());
                 assert_scope!(4, 2, 14, 14);
@@ -249,7 +249,7 @@ mod tests {
             // Sample a random element.
             let point = Uniform::rand(&mut rng);
 
-            Circuit::scope(&format!("Private {}", i), || {
+            Circuit::scope(&format!("Private {i}"), || {
                 let affine = Group::<Circuit>::new(Mode::Private, point);
                 assert_eq!(point, affine.eject_value());
                 assert_scope!(4, 0, 14, 13);

--- a/circuit/types/group/src/mul.rs
+++ b/circuit/types/group/src/mul.rs
@@ -243,9 +243,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, base);
             let b = Scalar::<Circuit>::new(Mode::Constant, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, num_constant, 0, 0, 0);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, num_constant, 0, 0, 0);
         }
     }
@@ -262,9 +262,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, base);
             let b = Scalar::<Circuit>::new(Mode::Public, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, 750, 0, 2751, 2752);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, 750, 0, 2500, 2500);
         }
     }
@@ -281,9 +281,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, base);
             let b = Scalar::<Circuit>::new(Mode::Private, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, 750, 0, 2751, 2752);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, 750, 0, 2500, 2500);
         }
     }
@@ -311,9 +311,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, base);
             let b = Scalar::<Circuit>::new(Mode::Constant, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, num_constant, 0, num_private, num_constraints);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, num_constant, 0, num_private, num_constraints);
         }
     }
@@ -341,9 +341,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Private, base);
             let b = Scalar::<Circuit>::new(Mode::Constant, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, num_constant, 0, num_private, num_constraints);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, num_constant, 0, num_private, num_constraints);
         }
     }
@@ -360,9 +360,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, base);
             let b = Scalar::<Circuit>::new(Mode::Public, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, 750, 0, 3503, 3504);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, 750, 0, 3252, 3252);
         }
     }
@@ -379,9 +379,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, base);
             let b = Scalar::<Circuit>::new(Mode::Private, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, 750, 0, 3503, 3504);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, 750, 0, 3252, 3252);
         }
     }
@@ -398,9 +398,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Private, base);
             let b = Scalar::<Circuit>::new(Mode::Public, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, 750, 0, 3503, 3504);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, 750, 0, 3252, 3252);
         }
     }
@@ -417,9 +417,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Private, base);
             let b = Scalar::<Circuit>::new(Mode::Private, scalar);
 
-            let name = format!("Mul: a * b {}", i);
+            let name = format!("Mul: a * b {i}");
             check_mul(&name, &expected, &a, &b, 750, 0, 3503, 3504);
-            let name = format!("MulAssign: a * b {}", i);
+            let name = format!("MulAssign: a * b {i}");
             check_mul_assign(&name, &expected, &a, &b, 750, 0, 3252, 3252);
         }
     }

--- a/circuit/types/group/src/neg.rs
+++ b/circuit/types/group/src/neg.rs
@@ -84,7 +84,7 @@ mod tests {
             let expected: console::Group<_> = -point;
 
             let candidate_input = Group::<Circuit>::new(Mode::Constant, point);
-            check_neg(&format!("NEG Constant {}", i), expected, candidate_input);
+            check_neg(&format!("NEG Constant {i}"), expected, candidate_input);
         }
     }
 
@@ -98,7 +98,7 @@ mod tests {
             let expected: console::Group<_> = -point;
 
             let candidate_input = Group::<Circuit>::new(Mode::Public, point);
-            check_neg(&format!("NEG Public {}", i), expected, candidate_input);
+            check_neg(&format!("NEG Public {i}"), expected, candidate_input);
         }
     }
 
@@ -112,7 +112,7 @@ mod tests {
             let expected: console::Group<_> = -point;
 
             let candidate_input = Group::<Circuit>::new(Mode::Private, point);
-            check_neg(&format!("NEG Private {}", i), expected, candidate_input);
+            check_neg(&format!("NEG Private {i}"), expected, candidate_input);
         }
     }
 

--- a/circuit/types/group/src/sub.rs
+++ b/circuit/types/group/src/sub.rs
@@ -123,9 +123,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, first);
             let b = Group::<Circuit>::new(Mode::Constant, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -142,9 +142,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, first);
             let b = Group::<Circuit>::new(Mode::Public, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -161,9 +161,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, first);
             let b = Group::<Circuit>::new(Mode::Constant, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -180,9 +180,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Constant, first);
             let b = Group::<Circuit>::new(Mode::Private, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -199,9 +199,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Private, first);
             let b = Group::<Circuit>::new(Mode::Constant, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -218,9 +218,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, first);
             let b = Group::<Circuit>::new(Mode::Public, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -237,9 +237,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Public, first);
             let b = Group::<Circuit>::new(Mode::Private, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -256,9 +256,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Private, first);
             let b = Group::<Circuit>::new(Mode::Public, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }
@@ -275,9 +275,9 @@ mod tests {
             let a = Group::<Circuit>::new(Mode::Private, first);
             let b = Group::<Circuit>::new(Mode::Private, second);
 
-            let name = format!("Sub: a - b {}", i);
+            let name = format!("Sub: a - b {i}");
             check_sub(&name, &expected, &a, &b);
-            let name = format!("SubAssign: a - b {}", i);
+            let name = format!("SubAssign: a - b {i}");
             check_sub_assign(&name, &expected, &a, &b);
         }
     }

--- a/circuit/types/integers/src/abs_checked.rs
+++ b/circuit/types/integers/src/abs_checked.rs
@@ -103,21 +103,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         for i in 0..ITERATIONS {
-            let name = format!("Abs: {} {}", mode, i);
+            let name = format!("Abs: {mode} {i}");
             let value = Uniform::rand(&mut rng);
             check_abs::<I>(&name, value, mode);
         }
 
         // Check the 0 case.
-        let name = format!("Abs: {} zero", mode);
+        let name = format!("Abs: {mode} zero");
         check_abs::<I>(&name, console::Integer::zero(), mode);
 
         // Check the 1 case.
-        let name = format!("Abs: {} one", mode);
+        let name = format!("Abs: {mode} one");
         check_abs::<I>(&name, console::Integer::one(), mode);
 
         // Check the console::Integer::MIN (checked) case.
-        let name = format!("Abs: {} one", mode);
+        let name = format!("Abs: {mode} one");
         check_abs::<I>(&name, console::Integer::MIN, mode);
     }
 
@@ -128,7 +128,7 @@ mod tests {
         for value in I::MIN..=I::MAX {
             let value = console::Integer::<_, I>::new(value);
 
-            let name = format!("Abs: {}", mode);
+            let name = format!("Abs: {mode}");
             check_abs::<I>(&name, value, mode);
         }
     }

--- a/circuit/types/integers/src/abs_wrapped.rs
+++ b/circuit/types/integers/src/abs_wrapped.rs
@@ -93,21 +93,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         for i in 0..ITERATIONS {
-            let name = format!("Abs: {} {}", mode, i);
+            let name = format!("Abs: {mode} {i}");
             let value = Uniform::rand(&mut rng);
             check_abs::<I>(&name, value, mode);
         }
 
         // Check the 0 case.
-        let name = format!("Abs: {} zero", mode);
+        let name = format!("Abs: {mode} zero");
         check_abs::<I>(&name, console::Integer::zero(), mode);
 
         // Check the 1 case.
-        let name = format!("Abs: {} one", mode);
+        let name = format!("Abs: {mode} one");
         check_abs::<I>(&name, console::Integer::one(), mode);
 
         // Check the console::Integer::MIN (wrapped) case.
-        let name = format!("Abs: {} one", mode);
+        let name = format!("Abs: {mode} one");
         check_abs::<I>(&name, console::Integer::MIN, mode);
     }
 
@@ -118,7 +118,7 @@ mod tests {
         for value in I::MIN..=I::MAX {
             let value = console::Integer::<_, I>::new(value);
 
-            let name = format!("Abs: {}", mode);
+            let name = format!("Abs: {mode}");
             check_abs::<I>(&name, value, mode);
         }
     }

--- a/circuit/types/integers/src/add_checked.rs
+++ b/circuit/types/integers/src/add_checked.rs
@@ -205,7 +205,7 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Add: {} + {} {}", mode_a, mode_b, i);
+            let name = format!("Add: {mode_a} + {mode_b} {i}");
             check_add::<I>(&name, first, second, mode_a, mode_b);
             check_add::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
         }
@@ -230,7 +230,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Add: ({} + {})", first, second);
+                let name = format!("Add: ({first} + {second})");
                 check_add::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/add_wrapped.rs
+++ b/circuit/types/integers/src/add_wrapped.rs
@@ -102,7 +102,7 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Add: {} + {} {}", mode_a, mode_b, i);
+            let name = format!("Add: {mode_a} + {mode_b} {i}");
             check_add::<I>(&name, first, second, mode_a, mode_b);
             check_add::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
         }
@@ -127,7 +127,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Add: ({} + {})", first, second);
+                let name = format!("Add: ({first} + {second})");
                 check_add::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/and.rs
+++ b/circuit/types/integers/src/and.rs
@@ -146,11 +146,11 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("BitAnd: ({} & {}) {}", mode_a, mode_b, i);
+            let name = format!("BitAnd: ({mode_a} & {mode_b}) {i}");
             check_and::<I>(&name, first, second, mode_a, mode_b);
             check_and::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
 
-            let name = format!("BitAnd Identity: ({} & {}) {}", mode_a, mode_b, i);
+            let name = format!("BitAnd Identity: ({mode_a} & {mode_b}) {i}");
             let identity = if I::is_signed() { -console::Integer::one() } else { console::Integer::MAX };
             check_and::<I>(&name, identity, first, mode_a, mode_b);
             check_and::<I>(&name, first, identity, mode_a, mode_b); // Commute the operation.
@@ -172,7 +172,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("BitAnd: ({} & {})", first, second);
+                let name = format!("BitAnd: ({first} & {second})");
                 check_and::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/compare.rs
+++ b/circuit/types/integers/src/compare.rs
@@ -165,7 +165,7 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Compare: ({}, {}) - {}th iteration", mode_a, mode_b, i);
+            let name = format!("Compare: ({mode_a}, {mode_b}) - {i}th iteration");
             check_compare::<I>(&name, first, second, mode_a, mode_b);
         }
     }
@@ -179,7 +179,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Compare: ({}, {})", first, second);
+                let name = format!("Compare: ({first}, {second})");
                 check_compare::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/div_checked.rs
+++ b/circuit/types/integers/src/div_checked.rs
@@ -225,7 +225,7 @@ mod tests {
             let name = format!("Div by One: {first} / 1");
             check_div::<I>(&name, first, console::Integer::one(), mode_a, mode_b);
 
-            let name = format!("Div by Self: {first} / {second}");
+            let name = format!("Div by Self: {first} / {first}");
             check_div::<I>(&name, first, first, mode_a, mode_b);
 
             let name = format!("Div by Zero: {first} / 0");

--- a/circuit/types/integers/src/div_checked.rs
+++ b/circuit/types/integers/src/div_checked.rs
@@ -259,7 +259,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Div: ({} / {})", first, second);
+                let name = format!("Div: ({first} / {second})");
                 check_div::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/div_checked.rs
+++ b/circuit/types/integers/src/div_checked.rs
@@ -219,16 +219,16 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Div: {} / {}", first, second);
+            let name = format!("Div: {first} / {second}");
             check_div::<I>(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Div by One: {} / 1", first);
+            let name = format!("Div by One: {first} / 1");
             check_div::<I>(&name, first, console::Integer::one(), mode_a, mode_b);
 
-            let name = format!("Div by Self: {} / {}", first, first);
+            let name = format!("Div by Self: {first} / {second}");
             check_div::<I>(&name, first, first, mode_a, mode_b);
 
-            let name = format!("Div by Zero: {} / 0", first);
+            let name = format!("Div by Zero: {first} / 0");
             check_div::<I>(&name, first, console::Integer::zero(), mode_a, mode_b);
         }
 

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -209,13 +209,13 @@ mod tests {
             let name = format!("Div: {first} / {second}");
             check_div::<I>(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Div by One: {} / 1", first);
+            let name = format!("Div by One: {first} / 1");
             check_div::<I>(&name, first, console::Integer::one(), mode_a, mode_b);
 
-            let name = format!("Div by Self: {} / {}", first, first);
+            let name = format!("Div by Self: {first} / {first}");
             check_div::<I>(&name, first, first, mode_a, mode_b);
 
-            let name = format!("Div by Zero: {} / 0", first);
+            let name = format!("Div by Zero: {first} / 0");
             check_div::<I>(&name, first, console::Integer::zero(), mode_a, mode_b);
         }
 
@@ -246,7 +246,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Div: ({} / {})", first, second);
+                let name = format!("Div: ({first} / {second})");
                 check_div::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -206,7 +206,7 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Div: {} / {}", first, second);
+            let name = format!("Div: {first} / {second}");
             check_div::<I>(&name, first, second, mode_a, mode_b);
 
             let name = format!("Div by One: {} / 1", first);

--- a/circuit/types/integers/src/equal.rs
+++ b/circuit/types/integers/src/equal.rs
@@ -108,7 +108,7 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Eq: {} == {} {}", mode_a, mode_b, i);
+            let name = format!("Eq: {mode_a} == {mode_b} {i}");
             check_equals::<I>(&name, first, second, mode_a, mode_b);
             check_equals::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
         }
@@ -123,7 +123,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Equals: ({} == {})", first, second);
+                let name = format!("Equals: ({first} == {second})");
                 check_equals::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/helpers/from_bits.rs
+++ b/circuit/types/integers/src/helpers/from_bits.rs
@@ -71,7 +71,7 @@ mod tests {
             let given_bits = Integer::<Circuit, I>::new(mode, expected).to_bits_le();
             let expected_size_in_bits = given_bits.len();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Integer::<Circuit, I>::from_bits_le(&given_bits);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.len());
@@ -81,7 +81,7 @@ mod tests {
             // Add excess zero bits.
             let candidate = vec![given_bits, vec![Boolean::new(mode, false); i as usize]].concat();
 
-            Circuit::scope(&format!("Excess {} {}", mode, i), || {
+            Circuit::scope(&format!("Excess {mode} {i}"), || {
                 let candidate = Integer::<Circuit, I>::from_bits_le(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.len());
@@ -112,7 +112,7 @@ mod tests {
             let given_bits = Integer::<Circuit, I>::new(mode, expected).to_bits_be();
             let expected_size_in_bits = given_bits.len();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Integer::<Circuit, I>::from_bits_be(&given_bits);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.len());
@@ -122,7 +122,7 @@ mod tests {
             // Add excess zero bits.
             let candidate = vec![vec![Boolean::new(mode, false); i as usize], given_bits].concat();
 
-            Circuit::scope(&format!("Excess {} {}", mode, i), || {
+            Circuit::scope(&format!("Excess {mode} {i}"), || {
                 let candidate = Integer::<Circuit, I>::from_bits_be(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.len());

--- a/circuit/types/integers/src/helpers/to_bits.rs
+++ b/circuit/types/integers/src/helpers/to_bits.rs
@@ -67,7 +67,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Integer::<Circuit, I>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_le();
                 assert_eq!(I::BITS, candidate.len() as u64);
 
@@ -96,7 +96,7 @@ mod tests {
             let expected = Uniform::rand(&mut rng);
             let candidate = Integer::<Circuit, I>::new(mode, expected);
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_be();
                 assert_eq!(I::BITS, candidate.len() as u64);
 

--- a/circuit/types/integers/src/lib.rs
+++ b/circuit/types/integers/src/lib.rs
@@ -266,15 +266,15 @@ mod tests {
     fn check_display<I: IntegerType>() {
         // Constant
         let candidate = Integer::<Circuit, I>::new(Mode::Constant, console::Integer::one() + console::Integer::one());
-        assert_eq!(format!("2{}.constant", I::type_name()), format!("{}", candidate));
+        assert_eq!(format!("2{}.constant", I::type_name()), format!("{candidate}"));
 
         // Public
         let candidate = Integer::<Circuit, I>::new(Mode::Public, console::Integer::one() + console::Integer::one());
-        assert_eq!(format!("2{}.public", I::type_name()), format!("{}", candidate));
+        assert_eq!(format!("2{}.public", I::type_name()), format!("{candidate}"));
 
         // Private
         let candidate = Integer::<Circuit, I>::new(Mode::Private, console::Integer::one() + console::Integer::one());
-        assert_eq!(format!("2{}.private", I::type_name()), format!("{}", candidate));
+        assert_eq!(format!("2{}.private", I::type_name()), format!("{candidate}"));
     }
 
     // u8

--- a/circuit/types/integers/src/modulo.rs
+++ b/circuit/types/integers/src/modulo.rs
@@ -82,16 +82,16 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Mod: {} MOD {}", first, second);
+            let name = format!("Mod: {first} MOD {second}");
             check_modulo::<I>(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Mod by One: {} MOD 1", first);
+            let name = format!("Mod by One: {first} MOD 1");
             check_modulo::<I>(&name, first, console::Integer::one(), mode_a, mode_b);
 
-            let name = format!("Mod by Self: {} MOD {}", first, first);
+            let name = format!("Mod by Self: {first} MOD {first}");
             check_modulo::<I>(&name, first, first, mode_a, mode_b);
 
-            let name = format!("Mod by Zero: {} MOD 0", first);
+            let name = format!("Mod by Zero: {first} MOD 0");
             check_modulo::<I>(&name, first, console::Integer::zero(), mode_a, mode_b);
         }
 
@@ -122,7 +122,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Mod: ({} MOD {})", first, second);
+                let name = format!("Mod: ({first} MOD {second})");
                 check_modulo::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/mul_checked.rs
+++ b/circuit/types/integers/src/mul_checked.rs
@@ -292,15 +292,15 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Mul: {} * {} {}", mode_a, mode_b, i);
+            let name = format!("Mul: {mode_a} * {mode_b} {i}");
             check_mul::<I>(&name, first, second, mode_a, mode_b);
             check_mul::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
 
-            let name = format!("Double: {} * {} {}", mode_a, mode_b, i);
+            let name = format!("Double: {mode_a} * {mode_b} {i}");
             check_mul::<I>(&name, first, console::Integer::one() + console::Integer::one(), mode_a, mode_b);
             check_mul::<I>(&name, console::Integer::one() + console::Integer::one(), first, mode_a, mode_b); // Commute the operation.
 
-            let name = format!("Square: {} * {} {}", mode_a, mode_b, i);
+            let name = format!("Square: {mode_a} * {mode_b} {i}");
             check_mul::<I>(&name, first, first, mode_a, mode_b);
         }
 
@@ -363,7 +363,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Mul: ({} * {})", first, second);
+                let name = format!("Mul: ({first} * {second})");
                 check_mul::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/mul_wrapped.rs
+++ b/circuit/types/integers/src/mul_wrapped.rs
@@ -121,15 +121,15 @@ mod tests {
             let first = Uniform::rand(rng);
             let second = Uniform::rand(rng);
 
-            let name = format!("Mul: {} * {} {}", mode_a, mode_b, i);
+            let name = format!("Mul: {mode_a} * {mode_b} {i}");
             check_mul::<I>(&name, first, second, mode_a, mode_b);
             check_mul::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
 
-            let name = format!("Double: {} * {} {}", mode_a, mode_b, i);
+            let name = format!("Double: {mode_a} * {mode_b} {i}");
             check_mul::<I>(&name, first, console::Integer::one() + console::Integer::one(), mode_a, mode_b);
             check_mul::<I>(&name, console::Integer::one() + console::Integer::one(), first, mode_a, mode_b); // Commute the operation.
 
-            let name = format!("Square: {} * {} {}", mode_a, mode_b, i);
+            let name = format!("Square: {mode_a} * {mode_b} {i}");
             check_mul::<I>(&name, first, first, mode_a, mode_b);
         }
 
@@ -192,7 +192,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Mul: ({} * {})", first, second);
+                let name = format!("Mul: ({first} * {second})");
                 check_mul::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/neg.rs
+++ b/circuit/types/integers/src/neg.rs
@@ -102,15 +102,15 @@ mod tests {
 
     fn run_test<I: IntegerType + UnwindSafe + Neg<Output = I>>(mode: Mode) {
         // Check the 0 case.
-        check_neg::<I>(&format!("Neg: {} zero", mode), console::Integer::zero(), mode);
+        check_neg::<I>(&format!("Neg: {mode} zero"), console::Integer::zero(), mode);
         // Check the 1 case.
-        check_neg::<I>(&format!("Neg: {} one", mode), -console::Integer::one(), mode);
+        check_neg::<I>(&format!("Neg: {mode} one"), -console::Integer::one(), mode);
         // Check random values.
         let mut rng = TestRng::default();
 
         for i in 0..ITERATIONS {
             let value = Uniform::rand(&mut rng);
-            check_neg::<I>(&format!("Neg: {} {}", mode, i), value, mode);
+            check_neg::<I>(&format!("Neg: {mode} {i}"), value, mode);
         }
     }
 
@@ -127,7 +127,7 @@ mod tests {
         for value in I::MIN..=I::MAX {
             let value = console::Integer::<_, I>::new(value);
 
-            let name = format!("Neg: {}", mode);
+            let name = format!("Neg: {mode}");
             check_neg::<I>(&name, value, mode);
         }
     }

--- a/circuit/types/integers/src/not.rs
+++ b/circuit/types/integers/src/not.rs
@@ -82,17 +82,17 @@ mod tests {
         let mut rng = TestRng::default();
 
         for i in 0..ITERATIONS {
-            let name = format!("Not: {} {}", mode, i);
+            let name = format!("Not: {mode} {i}");
             let value = Uniform::rand(&mut rng);
             check_not::<I>(&name, value, mode);
         }
 
         // Check the 0 case.
-        let name = format!("Not: {} zero", mode);
+        let name = format!("Not: {mode} zero");
         check_not::<I>(&name, console::Integer::zero(), mode);
 
         // Check the 1 case.
-        let name = format!("Not: {} one", mode);
+        let name = format!("Not: {mode} one");
         check_not::<I>(&name, console::Integer::one(), mode);
     }
 
@@ -103,7 +103,7 @@ mod tests {
         for value in I::MIN..=I::MAX {
             let value = console::Integer::<_, I>::new(value);
 
-            let name = format!("Not: {}", mode);
+            let name = format!("Not: {mode}");
             check_not::<I>(&name, value, mode);
         }
     }

--- a/circuit/types/integers/src/or.rs
+++ b/circuit/types/integers/src/or.rs
@@ -144,15 +144,15 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("BitOr: ({} | {}) {}", mode_a, mode_b, i);
+            let name = format!("BitOr: ({mode_a} | {mode_b}) {i}");
             check_or::<I>(&name, first, second, mode_a, mode_b);
             check_or::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
 
-            let name = format!("BitOr Identity: ({} | {}) {}", mode_a, mode_b, i);
+            let name = format!("BitOr Identity: ({mode_a} | {mode_b}) {i}");
             check_or::<I>(&name, console::Integer::zero(), first, mode_a, mode_b);
             check_or::<I>(&name, first, console::Integer::zero(), mode_a, mode_b); // Commute the operation.
 
-            let name = format!("BitOr Invariant: ({} | {}) {}", mode_a, mode_b, i);
+            let name = format!("BitOr Invariant: ({mode_a} | {mode_b}) {i}");
             let invariant = if I::is_signed() { -console::Integer::one() } else { console::Integer::MAX };
             check_or::<I>(&name, invariant, first, mode_a, mode_b);
             check_or::<I>(&name, first, invariant, mode_a, mode_b); // Commute the operation.
@@ -174,7 +174,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("BitOr: ({} | {})", first, second);
+                let name = format!("BitOr: ({first} | {second})");
                 check_or::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/pow_checked.rs
+++ b/circuit/types/integers/src/pow_checked.rs
@@ -200,21 +200,21 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Pow: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Pow: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Pow Zero: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Pow Zero: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, console::Integer::zero(), mode_a, mode_b);
 
-            let name = format!("Pow One: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Pow One: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, console::Integer::one(), mode_a, mode_b);
 
             // Check that the square is computed correctly.
-            let name = format!("Square: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Square: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, console::Integer::one() + console::Integer::one(), mode_a, mode_b);
 
             // Check that the cube is computed correctly.
-            let name = format!("Cube: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Cube: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(
                 &name,
                 first,
@@ -242,7 +242,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, M>::new(second);
 
-                let name = format!("Pow: ({} ** {})", first, second);
+                let name = format!("Pow: ({first} ** {second})");
                 check_pow::<I, M>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/pow_wrapped.rs
+++ b/circuit/types/integers/src/pow_wrapped.rs
@@ -120,21 +120,21 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Pow: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Pow: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Pow Zero: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Pow Zero: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, console::Integer::zero(), mode_a, mode_b);
 
-            let name = format!("Pow One: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Pow One: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, console::Integer::one(), mode_a, mode_b);
 
             // Check that the square is computed correctly.
-            let name = format!("Square: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Square: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(&name, first, console::Integer::one() + console::Integer::one(), mode_a, mode_b);
 
             // Check that the cube is computed correctly.
-            let name = format!("Cube: {} ** {} {}", mode_a, mode_b, i);
+            let name = format!("Cube: {mode_a} ** {mode_b} {i}");
             check_pow::<I, M>(
                 &name,
                 first,
@@ -162,7 +162,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, M>::new(second);
 
-                let name = format!("Pow: ({} ** {})", first, second);
+                let name = format!("Pow: ({first} ** {second})");
                 check_pow::<I, M>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/rem_checked.rs
+++ b/circuit/types/integers/src/rem_checked.rs
@@ -217,16 +217,16 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Rem: {} % {}", first, second);
+            let name = format!("Rem: {first} % {second}");
             check_rem::<I>(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Rem by One: {} % 1", first);
+            let name = format!("Rem by One: {first} % 1");
             check_rem::<I>(&name, first, console::Integer::one(), mode_a, mode_b);
 
-            let name = format!("Rem by Self: {} % {}", first, first);
+            let name = format!("Rem by Self: {first} % {first}");
             check_rem::<I>(&name, first, first, mode_a, mode_b);
 
-            let name = format!("Rem by Zero: {} % 0", first);
+            let name = format!("Rem by Zero: {first} % 0");
             check_rem::<I>(&name, first, console::Integer::zero(), mode_a, mode_b);
         }
 
@@ -257,7 +257,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Rem: ({} % {})", first, second);
+                let name = format!("Rem: ({first} % {second})");
                 check_rem::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/rem_wrapped.rs
+++ b/circuit/types/integers/src/rem_wrapped.rs
@@ -145,16 +145,16 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Rem: {} % {}", first, second);
+            let name = format!("Rem: {first} % {second}");
             check_rem::<I>(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Rem by One: {} % 1", first);
+            let name = format!("Rem by One: {first} % 1");
             check_rem::<I>(&name, first, console::Integer::one(), mode_a, mode_b);
 
-            let name = format!("Rem by Self: {} % {}", first, first);
+            let name = format!("Rem by Self: {first} % {first}");
             check_rem::<I>(&name, first, first, mode_a, mode_b);
 
-            let name = format!("Rem by Zero: {} % 0", first);
+            let name = format!("Rem by Zero: {first} % 0");
             check_rem::<I>(&name, first, console::Integer::zero(), mode_a, mode_b);
         }
 

--- a/circuit/types/integers/src/rem_wrapped.rs
+++ b/circuit/types/integers/src/rem_wrapped.rs
@@ -185,7 +185,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Rem: ({} % {})", first, second);
+                let name = format!("Rem: ({first} % {second})");
                 check_rem::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/shl_checked.rs
+++ b/circuit/types/integers/src/shl_checked.rs
@@ -217,23 +217,23 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Shl: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Shl: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, first, second, mode_a, mode_b);
 
             // Check that shift left by zero is computed correctly.
-            let name = format!("Identity: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Identity: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, first, console::Integer::zero(), mode_a, mode_b);
 
             // Check that shift left by one is computed correctly.
-            let name = format!("Double: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Double: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, first, console::Integer::one(), mode_a, mode_b);
 
             // Check that shift left by two is computed correctly.
-            let name = format!("Quadruple: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Quadruple: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, first, console::Integer::one() + console::Integer::one(), mode_a, mode_b);
 
             // Check that zero shifted left by `second` is computed correctly.
-            let name = format!("Zero: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Zero: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, console::Integer::zero(), second, mode_a, mode_b);
         }
     }
@@ -250,7 +250,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, M>::new(second);
 
-                let name = format!("Shl: ({} << {})", first, second);
+                let name = format!("Shl: ({first} << {second})");
                 check_shl::<I, M>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/shl_wrapped.rs
+++ b/circuit/types/integers/src/shl_wrapped.rs
@@ -148,15 +148,15 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Shl: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Shl: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, first, second, mode_a, mode_b);
 
             // Check that shift left by one is computed correctly.
-            let name = format!("Double: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Double: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, first, console::Integer::one(), mode_a, mode_b);
 
             // Check that shift left by two is computed correctly.
-            let name = format!("Quadruple: {} << {} {}", mode_a, mode_b, i);
+            let name = format!("Quadruple: {mode_a} << {mode_b} {i}");
             check_shl::<I, M>(&name, first, console::Integer::one() + console::Integer::one(), mode_a, mode_b);
         }
     }
@@ -171,7 +171,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, M>::new(second);
 
-                let name = format!("Shl: ({} << {})", first, second);
+                let name = format!("Shl: ({first} << {second})");
                 check_shl::<I, M>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/shr_checked.rs
+++ b/circuit/types/integers/src/shr_checked.rs
@@ -193,11 +193,11 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Shr: {} >> {} {}", mode_a, mode_b, i);
+            let name = format!("Shr: {mode_a} >> {mode_b} {i}");
             check_shr::<I, M>(&name, first, second, mode_a, mode_b);
 
             // Check that shift right by one is computed correctly.
-            let name = format!("Half: {} >> {} {}", mode_a, mode_b, i);
+            let name = format!("Half: {mode_a} >> {mode_b} {i}");
             check_shr::<I, M>(&name, first, console::Integer::one(), mode_a, mode_b);
         }
     }

--- a/circuit/types/integers/src/shr_checked.rs
+++ b/circuit/types/integers/src/shr_checked.rs
@@ -212,7 +212,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, M>::new(second);
 
-                let name = format!("Shr: ({} >> {})", first, second);
+                let name = format!("Shr: ({first} >> {second})");
                 check_shr::<I, M>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -232,7 +232,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, M>::new(second);
 
-                let name = format!("Shr: ({} >> {})", first, second);
+                let name = format!("Shr: ({first} >> {second})");
                 check_shr::<I, M>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -213,11 +213,11 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Shr: {} >> {} {}", mode_a, mode_b, i);
+            let name = format!("Shr: {mode_a} >> {mode_b} {i}");
             check_shr::<I, M>(&name, first, second, mode_a, mode_b);
 
             // Check that shift right by one is computed correctly.
-            let name = format!("Half: {} >> {} {}", mode_a, mode_b, i);
+            let name = format!("Half: {mode_a} >> {mode_b} {i}");
             check_shr::<I, M>(&name, first, console::Integer::one(), mode_a, mode_b);
         }
     }

--- a/circuit/types/integers/src/sub_checked.rs
+++ b/circuit/types/integers/src/sub_checked.rs
@@ -201,7 +201,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         for i in 0..ITERATIONS {
-            let name = format!("Sub: {} - {} {}", mode_a, mode_b, i);
+            let name = format!("Sub: {mode_a} - {mode_b} {i}");
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
             check_sub::<I>(&name, first, second, mode_a, mode_b);
@@ -224,7 +224,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Sub: ({} - {})", first, second);
+                let name = format!("Sub: ({first} - {second})");
                 check_sub::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/sub_wrapped.rs
+++ b/circuit/types/integers/src/sub_wrapped.rs
@@ -99,7 +99,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         for i in 0..ITERATIONS {
-            let name = format!("Sub: {} - {} {}", mode_a, mode_b, i);
+            let name = format!("Sub: {mode_a} - {mode_b} {i}");
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
             check_sub::<I>(&name, first, second, mode_a, mode_b);
@@ -122,7 +122,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("Sub: ({} - {})", first, second);
+                let name = format!("Sub: ({first} - {second})");
                 check_sub::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/integers/src/ternary.rs
+++ b/circuit/types/integers/src/ternary.rs
@@ -99,7 +99,7 @@ mod tests {
             let a = Integer::<Circuit, I>::new(mode_a, first);
             let b = Integer::new(mode_b, second);
 
-            let name = format!("Ternary({}): if ({}) then ({}) else ({})", flag, mode_condition, mode_a, mode_b);
+            let name = format!("Ternary({flag}): if ({mode_condition}) then ({mode_a}) else ({mode_b})");
             Circuit::scope(name, || {
                 let candidate = Integer::ternary(&condition, &a, &b);
                 assert_eq!(expected, candidate.eject_value());

--- a/circuit/types/integers/src/xor.rs
+++ b/circuit/types/integers/src/xor.rs
@@ -138,15 +138,15 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("BitXor: ({} ^ {}) {}", mode_a, mode_b, i);
+            let name = format!("BitXor: ({mode_a} ^ {mode_b}) {i}");
             check_bitxor::<I>(&name, first, second, mode_a, mode_b);
             check_bitxor::<I>(&name, second, first, mode_a, mode_b); // Commute the operation.
 
-            let name = format!("BitXor Identity: ({} ^ {}) {}", mode_a, mode_b, i);
+            let name = format!("BitXor Identity: ({mode_a} ^ {mode_b}) {i}");
             check_bitxor::<I>(&name, console::Integer::zero(), first, mode_a, mode_b);
             check_bitxor::<I>(&name, first, console::Integer::zero(), mode_a, mode_b); // Commute the operation.
 
-            let name = format!("BitXor Inverse Identity: ({} ^ {}) {}", mode_a, mode_b, i);
+            let name = format!("BitXor Inverse Identity: ({mode_a} ^ {mode_b}) {i}");
             let inverse = if I::is_signed() { -console::Integer::one() } else { console::Integer::MAX };
             check_bitxor::<I>(&name, inverse, first, mode_a, mode_b);
             check_bitxor::<I>(&name, first, inverse, mode_a, mode_b); // Commute the operation.
@@ -168,7 +168,7 @@ mod tests {
                 let first = console::Integer::<_, I>::new(first);
                 let second = console::Integer::<_, I>::new(second);
 
-                let name = format!("BitXor: ({} ^ {})", first, second);
+                let name = format!("BitXor: ({first} ^ {second})");
                 check_bitxor::<I>(&name, first, second, mode_a, mode_b);
             }
         }

--- a/circuit/types/scalar/src/add.rs
+++ b/circuit/types/scalar/src/add.rs
@@ -143,7 +143,7 @@ mod tests {
 
         Circuit::scope(name, || {
             let candidate = a + b;
-            assert_eq!(expected, candidate.eject_value(), "{}", case);
+            assert_eq!(expected, candidate.eject_value(), "{case}");
             assert_count!(Add(Scalar, Scalar) => Scalar, &(mode_a, mode_b));
             assert_output_mode!(Add(Scalar, Scalar) => Scalar, &(mode_a, mode_b), candidate);
         });
@@ -160,10 +160,10 @@ mod tests {
             let first = Uniform::rand(&mut rng);
             let second = Uniform::rand(&mut rng);
 
-            let name = format!("Add: {} + {} {}", mode_a, mode_b, i);
+            let name = format!("Add: {mode_a} + {mode_b} {i}");
             check_add(&name, first, second, mode_a, mode_b);
 
-            let name = format!("Add: {} + {} {} (commutative)", mode_a, mode_b, i);
+            let name = format!("Add: {mode_a} + {mode_b} {i} (commutative)");
             check_add(&name, second, first, mode_a, mode_b);
         }
     }

--- a/circuit/types/scalar/src/compare.rs
+++ b/circuit/types/scalar/src/compare.rs
@@ -85,7 +85,7 @@ mod tests {
             let candidate_b = Scalar::<Circuit>::new(mode_b, expected_b);
 
             // Perform the less than comparison.
-            Circuit::scope(&format!("{} {} {}", mode_a, mode_b, i), || {
+            Circuit::scope(&format!("{mode_a} {mode_b} {i}"), || {
                 let candidate = candidate_a.is_less_than(&candidate_b);
                 assert_eq!(expected_a < expected_b, candidate.eject_value());
                 assert_scope!(<=num_constants, <=num_public, <=num_private, <=num_constraints);

--- a/circuit/types/scalar/src/helpers/from_bits.rs
+++ b/circuit/types/scalar/src/helpers/from_bits.rs
@@ -109,7 +109,7 @@ mod tests {
             let given_bits = Scalar::<Circuit>::new(mode, expected).to_bits_le();
             let expected_size_in_bits = given_bits.len();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Scalar::<Circuit>::from_bits_le(&given_bits);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.get().unwrap().len());
@@ -120,7 +120,7 @@ mod tests {
             // Add excess zero bits.
             let candidate = vec![given_bits, vec![Boolean::new(mode, false); i as usize]].concat();
 
-            Circuit::scope(&format!("Excess {} {}", mode, i), || {
+            Circuit::scope(&format!("Excess {mode} {i}"), || {
                 let candidate = Scalar::<Circuit>::from_bits_le(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.get().unwrap().len());
@@ -145,7 +145,7 @@ mod tests {
             let given_bits = Scalar::<Circuit>::new(mode, expected).to_bits_be();
             let expected_size_in_bits = given_bits.len();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = Scalar::<Circuit>::from_bits_be(&given_bits);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.get().unwrap().len());
@@ -156,7 +156,7 @@ mod tests {
             // Add excess zero bits.
             let candidate = vec![vec![Boolean::new(mode, false); i as usize], given_bits].concat();
 
-            Circuit::scope(&format!("Excess {} {}", mode, i), || {
+            Circuit::scope(&format!("Excess {mode} {i}"), || {
                 let candidate = Scalar::<Circuit>::from_bits_be(&candidate);
                 assert_eq!(expected, candidate.eject_value());
                 assert_eq!(expected_size_in_bits, candidate.bits_le.get().unwrap().len());

--- a/circuit/types/scalar/src/lib.rs
+++ b/circuit/types/scalar/src/lib.rs
@@ -230,15 +230,15 @@ mod tests {
 
         // Constant
         let candidate = Scalar::<Circuit>::new(Mode::Constant, zero);
-        assert_eq!("0scalar.constant", &format!("{}", candidate));
+        assert_eq!("0scalar.constant", &format!("{candidate}"));
 
         // Public
         let candidate = Scalar::<Circuit>::new(Mode::Public, zero);
-        assert_eq!("0scalar.public", &format!("{}", candidate));
+        assert_eq!("0scalar.public", &format!("{candidate}"));
 
         // Private
         let candidate = Scalar::<Circuit>::new(Mode::Private, zero);
-        assert_eq!("0scalar.private", &format!("{}", candidate));
+        assert_eq!("0scalar.private", &format!("{candidate}"));
     }
 
     #[test]
@@ -247,15 +247,15 @@ mod tests {
 
         // Constant
         let candidate = Scalar::<Circuit>::new(Mode::Constant, one);
-        assert_eq!("1scalar.constant", &format!("{}", candidate));
+        assert_eq!("1scalar.constant", &format!("{candidate}"));
 
         // Public
         let candidate = Scalar::<Circuit>::new(Mode::Public, one);
-        assert_eq!("1scalar.public", &format!("{}", candidate));
+        assert_eq!("1scalar.public", &format!("{candidate}"));
 
         // Private
         let candidate = Scalar::<Circuit>::new(Mode::Private, one);
-        assert_eq!("1scalar.private", &format!("{}", candidate));
+        assert_eq!("1scalar.private", &format!("{candidate}"));
     }
 
     #[test]
@@ -265,15 +265,15 @@ mod tests {
 
         // Constant
         let candidate = Scalar::<Circuit>::new(Mode::Constant, two);
-        assert_eq!("2scalar.constant", &format!("{}", candidate));
+        assert_eq!("2scalar.constant", &format!("{candidate}"));
 
         // Public
         let candidate = Scalar::<Circuit>::new(Mode::Public, two);
-        assert_eq!("2scalar.public", &format!("{}", candidate));
+        assert_eq!("2scalar.public", &format!("{candidate}"));
 
         // Private
         let candidate = Scalar::<Circuit>::new(Mode::Private, two);
-        assert_eq!("2scalar.private", &format!("{}", candidate));
+        assert_eq!("2scalar.private", &format!("{candidate}"));
     }
 
     #[test]

--- a/circuit/types/scalar/src/ternary.rs
+++ b/circuit/types/scalar/src/ternary.rs
@@ -94,7 +94,7 @@ mod tests {
 
         for i in 0..ITERATIONS {
             for flag in [true, false] {
-                let name = format!("{} ? {} : {}, {}", flag, mode_a, mode_b, i);
+                let name = format!("{flag} ? {mode_a} : {mode_b}, {i}");
 
                 let first = Uniform::rand(&mut rng);
                 let second = Uniform::rand(&mut rng);

--- a/circuit/types/string/src/equal.rs
+++ b/circuit/types/string/src/equal.rs
@@ -61,13 +61,13 @@ mod tests {
         let string_a = sample_string(mode, &mut rng);
         let string_b = sample_string(mode, &mut rng);
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = string_a.is_equal(&string_a);
             assert!(candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
         });
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = string_a.is_equal(&string_b);
             assert!(!candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
@@ -90,13 +90,13 @@ mod tests {
         let string_a = sample_string(mode, &mut rng);
         let string_b = sample_string(mode, &mut rng);
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = string_a.is_not_equal(&string_b);
             assert!(candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);
         });
 
-        Circuit::scope(&format!("{}", mode), || {
+        Circuit::scope(format!("{mode}"), || {
             let candidate = string_a.is_not_equal(&string_a);
             assert!(!candidate.eject_value());
             assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/types/string/src/helpers/from_bits.rs
+++ b/circuit/types/string/src/helpers/from_bits.rs
@@ -87,7 +87,7 @@ mod tests {
 
             let candidate = StringType::<Circuit>::new(mode, console::StringType::new(&expected)).to_bits_le();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = StringType::<Circuit>::from_bits_le(&candidate);
                 assert_eq!(expected, *candidate.eject_value());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);
@@ -107,7 +107,7 @@ mod tests {
 
             let candidate = StringType::<Circuit>::new(mode, console::StringType::new(&expected)).to_bits_be();
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = StringType::<Circuit>::from_bits_be(&candidate);
                 assert_eq!(expected, *candidate.eject_value());
                 assert_scope!(num_constants, num_public, num_private, num_constraints);

--- a/circuit/types/string/src/helpers/to_bits.rs
+++ b/circuit/types/string/src/helpers/to_bits.rs
@@ -64,7 +64,7 @@ mod tests {
 
             Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_le();
-                assert_eq!({ expected_num_bytes * 8 }, candidate.len());
+                assert_eq!(expected_num_bytes * 8, candidate.len());
 
                 // Ensure every bit matches.
                 for (expected_bit, candidate_bit) in expected.to_bits_le().iter().zip_eq(candidate.iter()) {
@@ -89,7 +89,7 @@ mod tests {
 
             Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_be();
-                assert_eq!({ expected_num_bytes * 8 }, candidate.len());
+                assert_eq!(expected_num_bytes * 8, candidate.len());
 
                 // Ensure every bit matches.
                 for (expected_bit, candidate_bit) in expected.to_bits_be().iter().zip_eq(candidate.iter()) {

--- a/circuit/types/string/src/helpers/to_bits.rs
+++ b/circuit/types/string/src/helpers/to_bits.rs
@@ -62,9 +62,9 @@ mod tests {
 
             let candidate = StringType::<Circuit>::new(mode, console::StringType::new(&expected));
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_le();
-                assert_eq!((expected_num_bytes * 8) as usize, candidate.len());
+                assert_eq!({ expected_num_bytes * 8 }, candidate.len());
 
                 // Ensure every bit matches.
                 for (expected_bit, candidate_bit) in expected.to_bits_le().iter().zip_eq(candidate.iter()) {
@@ -87,9 +87,9 @@ mod tests {
 
             let candidate = StringType::<Circuit>::new(mode, console::StringType::new(&expected));
 
-            Circuit::scope(&format!("{} {}", mode, i), || {
+            Circuit::scope(&format!("{mode} {i}"), || {
                 let candidate = candidate.to_bits_be();
-                assert_eq!((expected_num_bytes * 8) as usize, candidate.len());
+                assert_eq!({ expected_num_bytes * 8 }, candidate.len());
 
                 // Ensure every bit matches.
                 for (expected_bit, candidate_bit) in expected.to_bits_be().iter().zip_eq(candidate.iter()) {

--- a/circuit/types/string/src/lib.rs
+++ b/circuit/types/string/src/lib.rs
@@ -88,7 +88,7 @@ impl<E: Environment> Eject for StringType<E> {
         match num_bytes <= E::MAX_STRING_BYTES as usize {
             true => console::StringType::new(
                 &String::from_utf8(self.bytes.eject_value().into_iter().map(|byte| *byte).collect())
-                    .unwrap_or_else(|error| E::halt(&format!("Failed to eject a string value: {error}"))),
+                    .unwrap_or_else(|error| E::halt(format!("Failed to eject a string value: {error}"))),
             ),
             false => E::halt(format!("Attempted to eject a string of size {num_bytes}")),
         }

--- a/console/algorithms/src/blake2xs/hash_to_curve.rs
+++ b/console/algorithms/src/blake2xs/hash_to_curve.rs
@@ -24,7 +24,7 @@ impl Blake2Xs {
         // Attempt to increment counter `k` at most `8 * G::SERIALIZED_SIZE` times.
         for k in 0..128 {
             // Construct a new message.
-            let message = format!("{} in {}", input, k);
+            let message = format!("{input} in {k}");
 
             // Output the generator if a valid generator was found.
             if let Some(g) = Self::try_hash_to_curve::<G>(&message) {
@@ -33,7 +33,7 @@ impl Blake2Xs {
         }
 
         // Panic with probability 2^-128.
-        panic!("Unable to hash to curve on {}", input)
+        panic!("Unable to hash to curve on {input}")
     }
 
     /// Evaluates **one** round of hash-to-curve and returns a generator on success.

--- a/console/algorithms/src/elligator2/decode.rs
+++ b/console/algorithms/src/elligator2/decode.rs
@@ -131,7 +131,7 @@ mod tests {
             }
         }
 
-        println!("Sign high: {}, sign low: {}", high_ctr, low_ctr);
+        println!("Sign high: {high_ctr}, sign low: {low_ctr}");
         Ok(())
     }
 

--- a/console/algorithms/src/poseidon/mod.rs
+++ b/console/algorithms/src/poseidon/mod.rs
@@ -91,7 +91,7 @@ mod tests {
 
         // Create the `resources` folder, if it does not exist.
         if !path.exists() {
-            std::fs::create_dir_all(&path).unwrap_or_else(|_| panic!("Failed to create resources folder: {:?}", path));
+            std::fs::create_dir_all(&path).unwrap_or_else(|_| panic!("Failed to create resources folder: {path:?}"));
         }
         // Output the path.
         path
@@ -106,7 +106,7 @@ mod tests {
 
         // Create the test folder, if it does not exist.
         if !path.exists() {
-            std::fs::create_dir(&path).unwrap_or_else(|_| panic!("Failed to create test folder: {:?}", path));
+            std::fs::create_dir(&path).unwrap_or_else(|_| panic!("Failed to create test folder: {path:?}"));
         }
 
         // Construct the path for the test file.
@@ -115,11 +115,11 @@ mod tests {
 
         // Create the test file, if it does not exist.
         if !path.exists() {
-            std::fs::File::create(&path).unwrap_or_else(|_| panic!("Failed to create file: {:?}", path));
+            std::fs::File::create(&path).unwrap_or_else(|_| panic!("Failed to create file: {path:?}"));
         }
 
         // Assert the test file is equal to the expected value.
-        expect_test::expect_file![path].assert_eq(&format!("{:?}", candidate));
+        expect_test::expect_file![path].assert_eq(&format!("{candidate:?}"));
     }
 
     #[test]

--- a/console/collections/benches/merkle_tree.rs
+++ b/console/collections/benches/merkle_tree.rs
@@ -43,7 +43,7 @@ fn new(c: &mut Criterion) {
     for num_leaves in NUM_LEAVES {
         let leaves = generate_leaves!(*num_leaves, &mut rng);
 
-        c.bench_function(&format!("MerkleTree::new ({} leaves)", num_leaves), move |b| {
+        c.bench_function(&format!("MerkleTree::new ({num_leaves} leaves)"), move |b| {
             b.iter(|| {
                 let _tree = Testnet3::merkle_tree_bhp::<DEPTH>(&leaves).unwrap();
             })
@@ -61,7 +61,7 @@ fn append(c: &mut Criterion) {
         let new_leaf = generate_leaves!(1, &mut rng);
 
         c.bench_function(
-            &format!("MerkleTree::append (adding single leaf to a tree with {} leaves)", num_leaves),
+            &format!("MerkleTree::append (adding single leaf to a tree with {num_leaves} leaves)"),
             move |b| {
                 b.iter_with_setup(
                     || merkle_tree.clone(),
@@ -77,10 +77,7 @@ fn append(c: &mut Criterion) {
             let new_leaves = generate_leaves!(*num_new_leaves, &mut rng);
 
             c.bench_function(
-                &format!(
-                    "MerkleTree::append (adding {} new leaves to a tree with {} leaves)",
-                    num_new_leaves, num_leaves
-                ),
+                &format!("MerkleTree::append (adding {num_new_leaves} new leaves to a tree with {num_leaves} leaves)"),
                 move |b| {
                     b.iter_with_setup(
                         || merkle_tree.clone(),

--- a/console/collections/src/merkle_tree/tests/append.rs
+++ b/console/collections/src/merkle_tree/tests/append.rs
@@ -604,7 +604,7 @@ fn test_profiler() -> Result<()> {
     let mut rng = TestRng::default();
 
     for num_leaves in NUM_LEAVES {
-        println!("Generating Merkle tree with {} leaves, and appending 1 leaf...", num_leaves);
+        println!("Generating Merkle tree with {num_leaves} leaves, and appending 1 leaf...");
 
         // New
         let leaves = generate_leaves!(*num_leaves, &mut rng);

--- a/console/network/environment/src/environment.rs
+++ b/console/network/environment/src/environment.rs
@@ -33,11 +33,11 @@ pub trait Environment:
     'static + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync
 {
     type Affine: AffineCurve<
-        Projective = Self::Projective,
-        BaseField = Self::Field,
-        ScalarField = Self::Scalar,
-        Coordinates = (Self::Field, Self::Field),
-    >;
+            Projective = Self::Projective,
+            BaseField = Self::Field,
+            ScalarField = Self::Scalar,
+            Coordinates = (Self::Field, Self::Field),
+        >;
     type BigInteger: BigInteger;
     type Field: PrimeField<BigInteger = Self::BigInteger> + SquareRootField + Copy;
     type PairingCurve: PairingEngine<Fr = Self::Field>;

--- a/console/network/environment/src/environment.rs
+++ b/console/network/environment/src/environment.rs
@@ -33,11 +33,11 @@ pub trait Environment:
     'static + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync
 {
     type Affine: AffineCurve<
-            Projective = Self::Projective,
-            BaseField = Self::Field,
-            ScalarField = Self::Scalar,
-            Coordinates = (Self::Field, Self::Field),
-        >;
+        Projective = Self::Projective,
+        BaseField = Self::Field,
+        ScalarField = Self::Scalar,
+        Coordinates = (Self::Field, Self::Field),
+    >;
     type BigInteger: BigInteger;
     type Field: PrimeField<BigInteger = Self::BigInteger> + SquareRootField + Copy;
     type PairingCurve: PairingEngine<Fr = Self::Field>;

--- a/console/network/environment/src/helpers/variable_length.rs
+++ b/console/network/environment/src/helpers/variable_length.rs
@@ -52,7 +52,7 @@ pub fn read_variable_length_integer<R: Read>(mut reader: R) -> IoResult<u64> {
         },
         _ => match u64::read_le(&mut reader)? {
             s if s < 4_294_967_296 => Err(error("Invalid variable size integer")),
-            s => Ok(s as u64),
+            s => Ok(s),
         },
     }
 }

--- a/console/program/src/data/literal/from_bits.rs
+++ b/console/program/src/data/literal/from_bits.rs
@@ -102,7 +102,7 @@ mod tests {
     const ITERATIONS: u32 = 1000;
 
     fn check_serialization(expected: Literal<CurrentNetwork>) -> Result<()> {
-        println!("{}", expected);
+        println!("{expected}");
         assert_eq!(expected, Literal::from_bits_le(expected.variant(), &expected.to_bits_le())?);
         assert_eq!(expected, Literal::from_bits_be(expected.variant(), &expected.to_bits_be())?);
         Ok(())

--- a/console/program/src/data/register/serialize.rs
+++ b/console/program/src/data/register/serialize.rs
@@ -54,7 +54,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/finalize_type/bytes.rs
+++ b/console/program/src/data_types/finalize_type/bytes.rs
@@ -36,7 +36,7 @@ impl<N: Network> FromBytes for FinalizeType<N> {
             0 => Ok(Self::Public(PlaintextType::read_le(&mut reader)?)),
             1 => Ok(Self::Record(Identifier::read_le(&mut reader)?)),
             2 => Ok(Self::ExternalRecord(Locator::read_le(&mut reader)?)),
-            3.. => Err(error(format!("Failed to deserialize finalize type variant {}", variant))),
+            3.. => Err(error(format!("Failed to deserialize finalize type variant {variant}"))),
         }
     }
 }

--- a/console/program/src/data_types/finalize_type/serialize.rs
+++ b/console/program/src/data_types/finalize_type/serialize.rs
@@ -83,7 +83,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/literal_type/serialize.rs
+++ b/console/program/src/data_types/literal_type/serialize.rs
@@ -57,7 +57,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/plaintext_type/serialize.rs
+++ b/console/program/src/data_types/plaintext_type/serialize.rs
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/record_type/bytes.rs
+++ b/console/program/src/data_types/record_type/bytes.rs
@@ -55,7 +55,7 @@ impl<N: Network> FromBytes for RecordType<N> {
         ];
         // Ensure the entries has no duplicate names.
         if has_duplicates(entries.iter().map(|(identifier, _)| identifier).chain(reserved.iter())) {
-            return Err(error(format!("Duplicate entry type found in record '{}'", name)));
+            return Err(error(format!("Duplicate entry type found in record '{name}'")));
         }
         // Ensure the number of members is within `N::MAX_DATA_ENTRIES`.
         if entries.len() > N::MAX_DATA_ENTRIES {

--- a/console/program/src/data_types/record_type/entry_type/bytes.rs
+++ b/console/program/src/data_types/record_type/entry_type/bytes.rs
@@ -36,7 +36,7 @@ impl<N: Network> FromBytes for EntryType<N> {
             0 => Ok(Self::Constant(PlaintextType::read_le(&mut reader)?)),
             1 => Ok(Self::Public(PlaintextType::read_le(&mut reader)?)),
             2 => Ok(Self::Private(PlaintextType::read_le(&mut reader)?)),
-            3.. => Err(error(format!("Failed to deserialize entry type variant {}", variant))),
+            3.. => Err(error(format!("Failed to deserialize entry type variant {variant}"))),
         }
     }
 }

--- a/console/program/src/data_types/record_type/entry_type/serialize.rs
+++ b/console/program/src/data_types/record_type/entry_type/serialize.rs
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/record_type/parse.rs
+++ b/console/program/src/data_types/record_type/parse.rs
@@ -109,7 +109,7 @@ impl<N: Network> Parser for RecordType<N> {
             ];
             // Ensure the entries has no duplicate names.
             if has_duplicates(entries.iter().map(|(identifier, _)| identifier).chain(reserved.iter())) {
-                return Err(error(format!("Duplicate entry type found in record '{}'", name)));
+                return Err(error(format!("Duplicate entry type found in record '{name}'")));
             }
             // Ensure the number of members is within `N::MAX_DATA_ENTRIES`.
             if entries.len() > N::MAX_DATA_ENTRIES {
@@ -224,7 +224,7 @@ record message:
     fn test_display() {
         let expected = "record message:\n    owner as address.private;\n    gates as u64.public;\n    first as field.private;\n    second as field.constant;";
         let message = RecordType::<CurrentNetwork>::parse(expected).unwrap().1;
-        assert_eq!(expected, format!("{}", message));
+        assert_eq!(expected, format!("{message}"));
     }
 
     #[test]
@@ -252,7 +252,7 @@ record message:
     fn test_parse_max_members() {
         let mut string = "record message:\n    owner as address.private;\n    gates as u64.public;\n".to_string();
         for i in 0..CurrentNetwork::MAX_DATA_ENTRIES {
-            string += &format!("    member_{} as field.private;\n", i);
+            string += &format!("    member_{i} as field.private;\n");
         }
         let candidate = RecordType::<CurrentNetwork>::parse(&string);
         assert!(candidate.is_ok());
@@ -262,7 +262,7 @@ record message:
     fn test_parse_too_many_members() {
         let mut string = "record message:\n    owner as address.private;\n    gates as u64.public;\n".to_string();
         for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES {
-            string += &format!("    member_{} as field.private;\n", i);
+            string += &format!("    member_{i} as field.private;\n");
         }
         let candidate = RecordType::<CurrentNetwork>::parse(&string);
         assert!(candidate.is_err());

--- a/console/program/src/data_types/record_type/serialize.rs
+++ b/console/program/src/data_types/record_type/serialize.rs
@@ -59,7 +59,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/register_type/bytes.rs
+++ b/console/program/src/data_types/register_type/bytes.rs
@@ -36,7 +36,7 @@ impl<N: Network> FromBytes for RegisterType<N> {
             0 => Ok(Self::Plaintext(PlaintextType::read_le(&mut reader)?)),
             1 => Ok(Self::Record(Identifier::read_le(&mut reader)?)),
             2 => Ok(Self::ExternalRecord(Locator::read_le(&mut reader)?)),
-            3.. => Err(error(format!("Failed to deserialize register type variant {}", variant))),
+            3.. => Err(error(format!("Failed to deserialize register type variant {variant}"))),
         }
     }
 }

--- a/console/program/src/data_types/register_type/serialize.rs
+++ b/console/program/src/data_types/register_type/serialize.rs
@@ -87,7 +87,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/struct_/parse.rs
+++ b/console/program/src/data_types/struct_/parse.rs
@@ -109,7 +109,7 @@ impl<N: Network> Display for Struct<N> {
             output += &format!("    {identifier} as {plaintext_type};\n");
         }
         output.pop(); // trailing newline
-        write!(f, "{}", output)
+        write!(f, "{output}")
     }
 }
 

--- a/console/program/src/data_types/struct_/parse.rs
+++ b/console/program/src/data_types/struct_/parse.rs
@@ -63,7 +63,7 @@ impl<N: Network> Parser for Struct<N> {
         let (string, members) = map_res(many1(parse_tuple), |members| {
             // Ensure the members has no duplicate names.
             if has_duplicates(members.iter().map(|(identifier, _)| identifier)) {
-                return Err(error(format!("Duplicate identifier found in struct '{}'", name)));
+                return Err(error(format!("Duplicate identifier found in struct '{name}'")));
             }
             // Ensure the number of members is within `N::MAX_DATA_ENTRIES`.
             if members.len() > N::MAX_DATA_ENTRIES {
@@ -181,7 +181,7 @@ struct message:
     fn test_display() {
         let expected = "struct message:\n    first as field;\n    second as field;";
         let message = Struct::<CurrentNetwork>::parse(expected).unwrap().1;
-        assert_eq!(expected, format!("{}", message));
+        assert_eq!(expected, format!("{message}"));
     }
 
     #[test]
@@ -199,7 +199,7 @@ struct message:
     fn test_max_members() {
         let mut string = "struct message:\n".to_string();
         for i in 0..CurrentNetwork::MAX_DATA_ENTRIES {
-            string += &format!("    member_{} as field;\n", i);
+            string += &format!("    member_{i} as field;\n");
         }
         assert!(Struct::<CurrentNetwork>::parse(&string).is_ok());
     }
@@ -208,7 +208,7 @@ struct message:
     fn test_too_many_members() {
         let mut string = "struct message:\n".to_string();
         for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES {
-            string += &format!("    member_{} as field;\n", i);
+            string += &format!("    member_{i} as field;\n");
         }
         assert!(Struct::<CurrentNetwork>::parse(&string).is_err());
     }

--- a/console/program/src/data_types/struct_/serialize.rs
+++ b/console/program/src/data_types/struct_/serialize.rs
@@ -57,7 +57,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/data_types/value_type/bytes.rs
+++ b/console/program/src/data_types/value_type/bytes.rs
@@ -40,7 +40,7 @@ impl<N: Network> FromBytes for ValueType<N> {
             2 => Ok(Self::Private(PlaintextType::read_le(&mut reader)?)),
             3 => Ok(Self::Record(Identifier::read_le(&mut reader)?)),
             4 => Ok(Self::ExternalRecord(Locator::read_le(&mut reader)?)),
-            5.. => Err(error(format!("Failed to deserialize value type variant {}", variant))),
+            5.. => Err(error(format!("Failed to deserialize value type variant {variant}"))),
         }
     }
 }

--- a/console/program/src/data_types/value_type/serialize.rs
+++ b/console/program/src/data_types/value_type/serialize.rs
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/id/serialize.rs
+++ b/console/program/src/id/serialize.rs
@@ -57,7 +57,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/locator/serialize.rs
+++ b/console/program/src/locator/serialize.rs
@@ -57,7 +57,7 @@ mod tests {
         assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/program/src/request/input_id/serialize.rs
+++ b/console/program/src/request/input_id/serialize.rs
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(expected_string, candidate.to_string());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/console/types/boolean/src/parse.rs
+++ b/console/types/boolean/src/parse.rs
@@ -71,7 +71,7 @@ mod tests {
         assert!(Boolean::<CurrentEnvironment>::parse("").is_err());
 
         for boolean in &[true, false] {
-            let expected = format!("{}", boolean);
+            let expected = format!("{boolean}");
             let (remainder, candidate) = Boolean::<CurrentEnvironment>::parse(&expected).unwrap();
             assert_eq!(format!("{expected}"), candidate.to_string());
             assert_eq!("", remainder);
@@ -99,13 +99,13 @@ mod tests {
     fn test_display_false() {
         // Constant
         let candidate = Boolean::<CurrentEnvironment>::new(false);
-        assert_eq!("false", &format!("{}", candidate));
+        assert_eq!("false", &format!("{candidate}"));
     }
 
     #[test]
     fn test_display_true() {
         // Constant
         let candidate = Boolean::<CurrentEnvironment>::new(true);
-        assert_eq!("true", &format!("{}", candidate));
+        assert_eq!("true", &format!("{candidate}"));
     }
 }

--- a/console/types/field/src/parse.rs
+++ b/console/types/field/src/parse.rs
@@ -122,7 +122,7 @@ mod tests {
         let zero = <CurrentEnvironment as Environment>::Field::zero();
 
         let candidate = Field::<CurrentEnvironment>::new(zero);
-        assert_eq!("0field", &format!("{}", candidate));
+        assert_eq!("0field", &format!("{candidate}"));
     }
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
         let one = <CurrentEnvironment as Environment>::Field::one();
 
         let candidate = Field::<CurrentEnvironment>::new(one);
-        assert_eq!("1field", &format!("{}", candidate));
+        assert_eq!("1field", &format!("{candidate}"));
     }
 
     #[test]
@@ -139,6 +139,6 @@ mod tests {
         let two = one + one;
 
         let candidate = Field::<CurrentEnvironment>::new(two);
-        assert_eq!("2field", &format!("{}", candidate));
+        assert_eq!("2field", &format!("{candidate}"));
     }
 }

--- a/console/types/group/src/parse.rs
+++ b/console/types/group/src/parse.rs
@@ -123,6 +123,6 @@ mod tests {
         let zero = <CurrentEnvironment as Environment>::Affine::zero();
 
         let candidate = Group::<CurrentEnvironment>::new(zero);
-        assert_eq!("0group", &format!("{}", candidate));
+        assert_eq!("0group", &format!("{candidate}"));
     }
 }

--- a/console/types/integers/src/parse.rs
+++ b/console/types/integers/src/parse.rs
@@ -128,7 +128,7 @@ mod tests {
         let zero = i8::zero();
 
         let candidate = Integer::<CurrentEnvironment, i8>::new(zero);
-        assert_eq!("0i8", &format!("{}", candidate));
+        assert_eq!("0i8", &format!("{candidate}"));
     }
 
     #[test]
@@ -136,7 +136,7 @@ mod tests {
         let one = i8::one();
 
         let candidate = Integer::<CurrentEnvironment, i8>::new(one);
-        assert_eq!("1i8", &format!("{}", candidate));
+        assert_eq!("1i8", &format!("{candidate}"));
     }
 
     #[test]
@@ -145,6 +145,6 @@ mod tests {
         let two = one + one;
 
         let candidate = Integer::<CurrentEnvironment, i8>::new(two);
-        assert_eq!("2i8", &format!("{}", candidate));
+        assert_eq!("2i8", &format!("{candidate}"));
     }
 }

--- a/console/types/scalar/src/parse.rs
+++ b/console/types/scalar/src/parse.rs
@@ -122,7 +122,7 @@ mod tests {
         let zero = <CurrentEnvironment as Environment>::Scalar::zero();
 
         let candidate = Scalar::<CurrentEnvironment>::new(zero);
-        assert_eq!("0scalar", &format!("{}", candidate));
+        assert_eq!("0scalar", &format!("{candidate}"));
     }
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
         let one = <CurrentEnvironment as Environment>::Scalar::one();
 
         let candidate = Scalar::<CurrentEnvironment>::new(one);
-        assert_eq!("1scalar", &format!("{}", candidate));
+        assert_eq!("1scalar", &format!("{candidate}"));
     }
 
     #[test]
@@ -139,6 +139,6 @@ mod tests {
         let two = one + one;
 
         let candidate = Scalar::<CurrentEnvironment>::new(two);
-        assert_eq!("2scalar", &format!("{}", candidate));
+        assert_eq!("2scalar", &format!("{candidate}"));
     }
 }

--- a/curves/src/edwards_bls12/tests.rs
+++ b/curves/src/edwards_bls12/tests.rs
@@ -312,7 +312,7 @@ fn test_isomorphism() {
 
     let group = EdwardsAffine::new(x, y, x * y);
 
-    println!("{:?}", group);
+    println!("{group:?}");
 
     // Convert the twisted Edwards element (x, y) to the alternate Montgomery element (u, v)
     let (u_reconstructed, v_reconstructed) = {

--- a/curves/src/edwards_bls12/tests.rs
+++ b/curves/src/edwards_bls12/tests.rs
@@ -180,7 +180,7 @@ fn print_montgomery_to_weierstrass_parameters() {
     let denominator = twenty_seven * b3;
     let b = numerator * denominator.inverse().unwrap();
 
-    println!("A - {}\nB - {}", a, b);
+    println!("A - {a}\nB - {b}");
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn test_isomorphism() {
     // Sample a random Fr element.
     let fr_element: Fr = Fr::rand(&mut rng);
 
-    println!("Starting Fr element is - {:?}", fr_element);
+    println!("Starting Fr element is - {fr_element:?}");
 
     // Map it to its corresponding Fq element.
     let fq_element = {
@@ -200,7 +200,7 @@ fn test_isomorphism() {
         output.unwrap()
     };
 
-    println!("Starting Fq element is {:?}", fq_element);
+    println!("Starting Fq element is {fq_element:?}");
 
     // Declare the parameters for the Montgomery equation: B * v^2 == u^3 + A * u^2 + u.
     const A: Fq = <EdwardsParameters as MontgomeryParameters>::MONTGOMERY_A;

--- a/curves/src/errors.rs
+++ b/curves/src/errors.rs
@@ -46,12 +46,12 @@ impl From<snarkvm_fields::FieldError> for GroupError {
 
 impl From<std::io::Error> for GroupError {
     fn from(error: std::io::Error) -> Self {
-        GroupError::Crate("std::io", format!("{:?}", error))
+        GroupError::Crate("std::io", format!("{error:?}"))
     }
 }
 
 impl From<GroupError> for std::io::Error {
     fn from(error: GroupError) -> Self {
-        std::io::Error::new(std::io::ErrorKind::Other, format!("{}", error))
+        std::io::Error::new(std::io::ErrorKind::Other, format!("{error}"))
     }
 }

--- a/curves/src/templates/bls12/bls12.rs
+++ b/curves/src/templates/bls12/bls12.rs
@@ -57,9 +57,9 @@ pub trait Bls12Parameters: 'static + Copy + Clone + Debug + PartialEq + Eq + Has
     type Fp12Params: Fp12Parameters<Fp6Params = Self::Fp6Params>;
     type G1Parameters: ShortWeierstrassParameters<BaseField = Self::Fp>;
     type G2Parameters: ShortWeierstrassParameters<
-        BaseField = Fp2<Self::Fp2Params>,
-        ScalarField = <Self::G1Parameters as ModelParameters>::ScalarField,
-    >;
+            BaseField = Fp2<Self::Fp2Params>,
+            ScalarField = <Self::G1Parameters as ModelParameters>::ScalarField,
+        >;
 
     fn g1_is_in_correct_subgroup(p: &short_weierstrass_jacobian::Affine<Self::G1Parameters>) -> bool {
         p.mul_bits(BitIteratorBE::new(<Self::G1Parameters as ModelParameters>::ScalarField::characteristic())).is_zero()
@@ -108,21 +108,21 @@ impl<P: Bls12Parameters> Bls12<P> {
 impl<P: Bls12Parameters> PairingEngine for Bls12<P>
 where
     G1Affine<P>: PairingCurve<
-        BaseField = <P::G1Parameters as ModelParameters>::BaseField,
-        ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
-        Projective = G1Projective<P>,
-        PairWith = G2Affine<P>,
-        Prepared = G1Prepared<P>,
-        PairingResult = Fp12<P::Fp12Params>,
-    >,
+            BaseField = <P::G1Parameters as ModelParameters>::BaseField,
+            ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
+            Projective = G1Projective<P>,
+            PairWith = G2Affine<P>,
+            Prepared = G1Prepared<P>,
+            PairingResult = Fp12<P::Fp12Params>,
+        >,
     G2Affine<P>: PairingCurve<
-        BaseField = <P::G2Parameters as ModelParameters>::BaseField,
-        ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
-        Projective = G2Projective<P>,
-        PairWith = G1Affine<P>,
-        Prepared = G2Prepared<P>,
-        PairingResult = Fp12<P::Fp12Params>,
-    >,
+            BaseField = <P::G2Parameters as ModelParameters>::BaseField,
+            ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
+            Projective = G2Projective<P>,
+            PairWith = G1Affine<P>,
+            Prepared = G2Prepared<P>,
+            PairingResult = Fp12<P::Fp12Params>,
+        >,
 {
     type Fq = P::Fp;
     type Fqe = Fp2<P::Fp2Params>;

--- a/curves/src/templates/bls12/bls12.rs
+++ b/curves/src/templates/bls12/bls12.rs
@@ -57,9 +57,9 @@ pub trait Bls12Parameters: 'static + Copy + Clone + Debug + PartialEq + Eq + Has
     type Fp12Params: Fp12Parameters<Fp6Params = Self::Fp6Params>;
     type G1Parameters: ShortWeierstrassParameters<BaseField = Self::Fp>;
     type G2Parameters: ShortWeierstrassParameters<
-            BaseField = Fp2<Self::Fp2Params>,
-            ScalarField = <Self::G1Parameters as ModelParameters>::ScalarField,
-        >;
+        BaseField = Fp2<Self::Fp2Params>,
+        ScalarField = <Self::G1Parameters as ModelParameters>::ScalarField,
+    >;
 
     fn g1_is_in_correct_subgroup(p: &short_weierstrass_jacobian::Affine<Self::G1Parameters>) -> bool {
         p.mul_bits(BitIteratorBE::new(<Self::G1Parameters as ModelParameters>::ScalarField::characteristic())).is_zero()
@@ -108,21 +108,21 @@ impl<P: Bls12Parameters> Bls12<P> {
 impl<P: Bls12Parameters> PairingEngine for Bls12<P>
 where
     G1Affine<P>: PairingCurve<
-            BaseField = <P::G1Parameters as ModelParameters>::BaseField,
-            ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
-            Projective = G1Projective<P>,
-            PairWith = G2Affine<P>,
-            Prepared = G1Prepared<P>,
-            PairingResult = Fp12<P::Fp12Params>,
-        >,
+        BaseField = <P::G1Parameters as ModelParameters>::BaseField,
+        ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
+        Projective = G1Projective<P>,
+        PairWith = G2Affine<P>,
+        Prepared = G1Prepared<P>,
+        PairingResult = Fp12<P::Fp12Params>,
+    >,
     G2Affine<P>: PairingCurve<
-            BaseField = <P::G2Parameters as ModelParameters>::BaseField,
-            ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
-            Projective = G2Projective<P>,
-            PairWith = G1Affine<P>,
-            Prepared = G2Prepared<P>,
-            PairingResult = Fp12<P::Fp12Params>,
-        >,
+        BaseField = <P::G2Parameters as ModelParameters>::BaseField,
+        ScalarField = <P::G1Parameters as ModelParameters>::ScalarField,
+        Projective = G2Projective<P>,
+        PairWith = G1Affine<P>,
+        Prepared = G2Prepared<P>,
+        PairingResult = Fp12<P::Fp12Params>,
+    >,
 {
     type Fq = P::Fp;
     type Fqe = Fp2<P::Fp2Params>;

--- a/curves/src/traits/tests_field.rs
+++ b/curves/src/traits/tests_field.rs
@@ -201,7 +201,7 @@ fn random_string_tests<F: PrimeField>(rng: &mut TestRng) {
     for _ in 0..ITERATIONS {
         let n: u64 = rng.gen();
 
-        let a = F::from_str(&format!("{}", n)).map_err(|_| ()).unwrap();
+        let a = F::from_str(&format!("{n}")).map_err(|_| ()).unwrap();
         let b = F::from_bigint(n.into()).unwrap();
 
         assert_eq!(a, b);

--- a/curves/src/traits/tests_projective.rs
+++ b/curves/src/traits/tests_projective.rs
@@ -80,7 +80,7 @@ fn random_addition_test<G: ProjectiveCurve>(rng: &mut TestRng) {
                 if tmp[i] != tmp[j] {
                     println!("{} \n{}", tmp[i], tmp[j]);
                 }
-                assert_eq!(tmp[i], tmp[j], "Associativity failed {} {}", i, j);
+                assert_eq!(tmp[i], tmp[j], "Associativity failed {i} {j}");
                 assert_eq!(tmp[i].to_affine(), tmp[j].to_affine(), "Associativity failed");
             }
 
@@ -166,7 +166,7 @@ fn random_negation_test<G: ProjectiveCurve>(rng: &mut TestRng) {
 
         let mut t3 = t1;
         t3.add_assign(t2);
-        println!("t3 = {}", t3);
+        println!("t3 = {t3}");
         assert!(t3.is_zero());
 
         let mut t4 = t1;

--- a/fields/src/errors/constraint_field.rs
+++ b/fields/src/errors/constraint_field.rs
@@ -28,6 +28,6 @@ pub enum ConstraintFieldError {
 
 impl From<std::io::Error> for ConstraintFieldError {
     fn from(error: std::io::Error) -> Self {
-        ConstraintFieldError::Crate("std::io", format!("{:?}", error))
+        ConstraintFieldError::Crate("std::io", format!("{error:?}"))
     }
 }

--- a/fields/src/errors/field.rs
+++ b/fields/src/errors/field.rs
@@ -37,12 +37,12 @@ pub enum FieldError {
 
 impl From<std::io::Error> for FieldError {
     fn from(error: std::io::Error) -> Self {
-        FieldError::Crate("std::io", format!("{:?}", error))
+        FieldError::Crate("std::io", format!("{error:?}"))
     }
 }
 
 impl From<FieldError> for std::io::Error {
     fn from(error: FieldError) -> Self {
-        std::io::Error::new(std::io::ErrorKind::Other, format!("{}", error))
+        std::io::Error::new(std::io::ErrorKind::Other, format!("{error}"))
     }
 }

--- a/fields/src/to_field_vec.rs
+++ b/fields/src/to_field_vec.rs
@@ -83,7 +83,7 @@ impl<F: PrimeField> ToConstraintField<F> for [u8] {
     #[inline]
     fn to_field_elements(&self) -> Result<Vec<F>, ConstraintFieldError> {
         // Derive the field size in bytes, floored to be conservative.
-        let floored_field_size_in_bytes = (F::size_in_data_bits() / 8) as usize;
+        let floored_field_size_in_bytes = F::size_in_data_bits() / 8;
         let next_power_of_two = floored_field_size_in_bytes
             .checked_next_power_of_two()
             .ok_or(ConstraintFieldError::Message("Field size is too large"))?;

--- a/parameters/examples/inclusion.rs
+++ b/parameters/examples/inclusion.rs
@@ -43,7 +43,7 @@ fn checksum(bytes: &[u8]) -> String {
 
 fn versioned_filename(filename: &str, checksum: &str) -> String {
     match checksum.get(0..7) {
-        Some(sum) => format!("{}.{}", filename, sum),
+        Some(sum) => format!("{filename}.{sum}"),
         _ => filename.to_string(),
     }
 }

--- a/parameters/examples/setup.rs
+++ b/parameters/examples/setup.rs
@@ -35,7 +35,7 @@ fn checksum(bytes: &[u8]) -> String {
 
 fn versioned_filename(filename: &str, checksum: &str) -> String {
     match checksum.get(0..7) {
-        Some(sum) => format!("{}.{}", filename, sum),
+        Some(sum) => format!("{filename}.{sum}"),
         _ => filename.to_string(),
     }
 }

--- a/parameters/src/errors/parameter.rs
+++ b/parameters/src/errors/parameter.rs
@@ -37,31 +37,31 @@ pub enum ParameterError {
 #[cfg(not(feature = "wasm"))]
 impl From<curl::Error> for ParameterError {
     fn from(error: curl::Error) -> Self {
-        ParameterError::Crate("curl::error", format!("{:?}", error))
+        ParameterError::Crate("curl::error", format!("{error:?}"))
     }
 }
 
 #[cfg(feature = "wasm")]
 impl From<reqwest::Error> for ParameterError {
     fn from(error: reqwest::Error) -> Self {
-        ParameterError::Crate("request::error", format!("{:?}", error))
+        ParameterError::Crate("request::error", format!("{error:?}"))
     }
 }
 
 impl From<std::io::Error> for ParameterError {
     fn from(error: std::io::Error) -> Self {
-        ParameterError::Crate("std::io", format!("{:?}", error))
+        ParameterError::Crate("std::io", format!("{error:?}"))
     }
 }
 
 impl From<std::path::StripPrefixError> for ParameterError {
     fn from(error: std::path::StripPrefixError) -> Self {
-        ParameterError::Crate("std::path", format!("{:?}", error))
+        ParameterError::Crate("std::path", format!("{error:?}"))
     }
 }
 
 impl From<ParameterError> for std::io::Error {
     fn from(error: ParameterError) -> Self {
-        std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", error))
+        std::io::Error::new(std::io::ErrorKind::Other, format!("{error:?}"))
     }
 }

--- a/r1cs/src/test_constraint_system.rs
+++ b/r1cs/src/test_constraint_system.rs
@@ -275,7 +275,7 @@ impl<F: Field> TestConstraintSystem<F> {
         let interned_field = self.interned_fields.insert_full(to).0;
 
         match self.named_objects.get(&interned_path) {
-            Some(&NamedObject::Var(ref v)) => match v.get_unchecked() {
+            Some(NamedObject::Var(v)) => match v.get_unchecked() {
                 Index::Public(index) => self.public_variables[index] = interned_field,
                 Index::Private(index) => self.private_variables[index] = interned_field,
             },
@@ -288,11 +288,11 @@ impl<F: Field> TestConstraintSystem<F> {
         let interned_path = self.intern_path(path);
 
         let interned_field = match self.named_objects.get(&interned_path) {
-            Some(&NamedObject::Var(ref v)) => match v.get_unchecked() {
+            Some(NamedObject::Var(v)) => match v.get_unchecked() {
                 Index::Public(index) => self.public_variables[index],
                 Index::Private(index) => self.private_variables[index],
             },
-            Some(e) => panic!("tried to get value of path `{}`, but `{:?}` exists there (not a variable)", path, e),
+            Some(e) => panic!("tried to get value of path `{path}`, but `{e:?}` exists there (not a variable)"),
             _ => panic!("no variable exists at path: {path}"),
         };
 

--- a/r1cs/src/test_constraint_system.rs
+++ b/r1cs/src/test_constraint_system.rs
@@ -153,21 +153,21 @@ impl<F: Field> TestConstraintSystem<F> {
             let self_interned_path = self_c.interned_path;
             let other_interned_path = other_c.interned_path;
             if self_c.a != other_c.a {
-                println!("A row {} is different:", i);
+                println!("A row {i} is different:");
                 println!("self: {}", self.unintern_path(self_interned_path));
                 println!("other: {}", other.unintern_path(other_interned_path));
                 break;
             }
 
             if self_c.b != other_c.b {
-                println!("B row {} is different:", i);
+                println!("B row {i} is different:");
                 println!("self: {}", self.unintern_path(self_interned_path));
                 println!("other: {}", other.unintern_path(other_interned_path));
                 break;
             }
 
             if self_c.c != other_c.c {
-                println!("C row {} is different:", i);
+                println!("C row {i} is different:");
                 println!("self: {}", self.unintern_path(self_interned_path));
                 println!("other: {}", other.unintern_path(other_interned_path));
                 break;
@@ -279,8 +279,8 @@ impl<F: Field> TestConstraintSystem<F> {
                 Index::Public(index) => self.public_variables[index] = interned_field,
                 Index::Private(index) => self.private_variables[index] = interned_field,
             },
-            Some(e) => panic!("tried to set path `{}` to value, but `{:?}` already exists there.", path, e),
-            _ => panic!("no variable exists at path: {}", path),
+            Some(e) => panic!("tried to set path `{path}` to value, but `{e:?}` already exists there."),
+            _ => panic!("no variable exists at path: {path}"),
         }
     }
 
@@ -293,7 +293,7 @@ impl<F: Field> TestConstraintSystem<F> {
                 Index::Private(index) => self.private_variables[index],
             },
             Some(e) => panic!("tried to get value of path `{}`, but `{:?}` exists there (not a variable)", path, e),
-            _ => panic!("no variable exists at path: {}", path),
+            _ => panic!("no variable exists at path: {path}"),
         };
 
         *self.interned_fields.get_index(interned_field).unwrap()

--- a/synthesizer/benches/block.rs
+++ b/synthesizer/benches/block.rs
@@ -43,19 +43,19 @@ fn bench_serialization<T: Serialize + DeserializeOwned + ToBytes + FromBytes + C
     // snarkvm_utilities::ToBytes
     {
         let object = object.clone();
-        c.bench_function(&format!("{}::to_bytes_le", name), move |b| b.iter(|| object.to_bytes_le().unwrap()));
+        c.bench_function(&format!("{name}::to_bytes_le"), move |b| b.iter(|| object.to_bytes_le().unwrap()));
     }
     // bincode::serialize
     {
         let object = object.clone();
-        c.bench_function(&format!("{}::serialize (bincode)", name), move |b| {
+        c.bench_function(&format!("{name}::serialize (bincode)"), move |b| {
             b.iter(|| bincode::serialize(&object).unwrap())
         });
     }
     // serde_json::to_string
     {
         let object = object.clone();
-        c.bench_function(&format!("{}::to_string (serde_json)", name), move |b| {
+        c.bench_function(&format!("{name}::to_string (serde_json)"), move |b| {
             b.iter(|| serde_json::to_string(&object).unwrap())
         });
     }
@@ -67,19 +67,19 @@ fn bench_serialization<T: Serialize + DeserializeOwned + ToBytes + FromBytes + C
     // snarkvm_utilities::FromBytes
     {
         let buffer = object.to_bytes_le().unwrap();
-        c.bench_function(&format!("{}::from_bytes_le", name), move |b| b.iter(|| T::from_bytes_le(&buffer).unwrap()));
+        c.bench_function(&format!("{name}::from_bytes_le"), move |b| b.iter(|| T::from_bytes_le(&buffer).unwrap()));
     }
     // bincode::deserialize
     {
         let buffer = bincode::serialize(&object).unwrap();
-        c.bench_function(&format!("{}::deserialize (bincode)", name), move |b| {
+        c.bench_function(&format!("{name}::deserialize (bincode)"), move |b| {
             b.iter(|| bincode::deserialize::<T>(&buffer).unwrap())
         });
     }
     // serde_json::from_str
     {
         let object = serde_json::to_string(&object).unwrap();
-        c.bench_function(&format!("{}::from_str (serde_json)", name), move |b| {
+        c.bench_function(&format!("{name}::from_str (serde_json)"), move |b| {
             b.iter(|| serde_json::from_str::<T>(&object).unwrap())
         });
     }

--- a/synthesizer/src/block/transition/input/serialize.rs
+++ b/synthesizer/src/block/transition/input/serialize.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(expected_string, candidate.to_string());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/synthesizer/src/block/transition/mod.rs
+++ b/synthesizer/src/block/transition/mod.rs
@@ -244,7 +244,7 @@ impl<N: Network> Transition<N> {
                         // Return the record output.
                         Ok(Output::ExternalRecord(*hash))
                     }
-                    _ => bail!("Malformed response output: {:?}, {output}", output_id),
+                    _ => bail!("Malformed response output: {output_id:?}, {output}"),
                 }
             })
             .collect::<Result<Vec<_>>>()?;

--- a/synthesizer/src/block/transition/output/serialize.rs
+++ b/synthesizer/src/block/transition/output/serialize.rs
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(expected_string, candidate.to_string());
 
         // Deserialize
-        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {}", expected_string)));
+        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
         assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
     }
 

--- a/synthesizer/src/program/closure/input/parse.rs
+++ b/synthesizer/src/program/closure/input/parse.rs
@@ -132,7 +132,7 @@ mod tests {
 
         // Record
         let input = Input::<CurrentNetwork>::parse("input r2 as token.record;").unwrap().1;
-        assert_eq!(format!("{}", input), "input r2 as token.record;");
+        assert_eq!(format!("{input}"), "input r2 as token.record;");
 
         Ok(())
     }

--- a/synthesizer/src/program/closure/output/parse.rs
+++ b/synthesizer/src/program/closure/output/parse.rs
@@ -115,14 +115,14 @@ mod tests {
     fn test_output_display() {
         // Literal
         let output = Output::<CurrentNetwork>::parse("output r0 as field;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r0 as field;");
+        assert_eq!(format!("{output}"), "output r0 as field;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r1 as signature;");
+        assert_eq!(format!("{output}"), "output r1 as signature;");
 
         // Record
         let output = Output::<CurrentNetwork>::parse("output r2 as token.record;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r2 as token.record;");
+        assert_eq!(format!("{output}"), "output r2 as token.record;");
     }
 }

--- a/synthesizer/src/program/closure/parse.rs
+++ b/synthesizer/src/program/closure/parse.rs
@@ -80,9 +80,9 @@ impl<N: Network> Display for Closure<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Write the closure to a string.
         write!(f, "{} {}:", Self::type_name(), self.name)?;
-        self.inputs.iter().try_for_each(|input| write!(f, "\n    {}", input))?;
-        self.instructions.iter().try_for_each(|instruction| write!(f, "\n    {}", instruction))?;
-        self.outputs.iter().try_for_each(|output| write!(f, "\n    {}", output))
+        self.inputs.iter().try_for_each(|input| write!(f, "\n    {input}"))?;
+        self.instructions.iter().try_for_each(|instruction| write!(f, "\n    {instruction}"))?;
+        self.outputs.iter().try_for_each(|output| write!(f, "\n    {output}"))
     }
 }
 

--- a/synthesizer/src/program/finalize/command/finalize.rs
+++ b/synthesizer/src/program/finalize/command/finalize.rs
@@ -146,7 +146,7 @@ impl<N: Network, const VARIANT: u8> Display for FinalizeOperation<N, VARIANT> {
         }
         // Print the operation.
         write!(f, "{}", Self::opcode())?;
-        self.operands.iter().try_for_each(|operand| write!(f, " {}", operand))?;
+        self.operands.iter().try_for_each(|operand| write!(f, " {operand}"))?;
         write!(f, ";")
     }
 }

--- a/synthesizer/src/program/finalize/command/mod.rs
+++ b/synthesizer/src/program/finalize/command/mod.rs
@@ -68,7 +68,7 @@ impl<N: Network> FromBytes for Command<N> {
             // Read the increment.
             2 => Ok(Self::Increment(Increment::read_le(&mut reader)?)),
             // Invalid variant.
-            3.. => Err(error(format!("Invalid command variant: {}", variant))),
+            3.. => Err(error(format!("Invalid command variant: {variant}"))),
         }
     }
 }

--- a/synthesizer/src/program/finalize/input/parse.rs
+++ b/synthesizer/src/program/finalize/input/parse.rs
@@ -132,7 +132,7 @@ mod tests {
 
         // Record
         let input = Input::<CurrentNetwork>::parse("input r2 as token.record;").unwrap().1;
-        assert_eq!(format!("{}", input), "input r2 as token.record;");
+        assert_eq!(format!("{input}"), "input r2 as token.record;");
 
         Ok(())
     }

--- a/synthesizer/src/program/finalize/output/parse.rs
+++ b/synthesizer/src/program/finalize/output/parse.rs
@@ -115,14 +115,14 @@ mod tests {
     fn test_output_display() {
         // Literal
         let output = Output::<CurrentNetwork>::parse("output r0 as field.public;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r0 as field.public;");
+        assert_eq!(format!("{output}"), "output r0 as field.public;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.public;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r1 as signature.public;");
+        assert_eq!(format!("{output}"), "output r1 as signature.public;");
 
         // Record
         let output = Output::<CurrentNetwork>::parse("output r2 as token.record;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r2 as token.record;");
+        assert_eq!(format!("{output}"), "output r2 as token.record;");
     }
 }

--- a/synthesizer/src/program/function/input/parse.rs
+++ b/synthesizer/src/program/function/input/parse.rs
@@ -132,7 +132,7 @@ mod tests {
 
         // Record
         let input = Input::<CurrentNetwork>::parse("input r2 as token.record;").unwrap().1;
-        assert_eq!(format!("{}", input), "input r2 as token.record;");
+        assert_eq!(format!("{input}"), "input r2 as token.record;");
 
         Ok(())
     }

--- a/synthesizer/src/program/function/output/parse.rs
+++ b/synthesizer/src/program/function/output/parse.rs
@@ -115,14 +115,14 @@ mod tests {
     fn test_output_display() {
         // Literal
         let output = Output::<CurrentNetwork>::parse("output r0 as field.private;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r0 as field.private;");
+        assert_eq!(format!("{output}"), "output r0 as field.private;");
 
         // Struct
         let output = Output::<CurrentNetwork>::parse("output r1 as signature.private;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r1 as signature.private;");
+        assert_eq!(format!("{output}"), "output r1 as signature.private;");
 
         // Record
         let output = Output::<CurrentNetwork>::parse("output r2 as token.record;").unwrap().1;
-        assert_eq!(format!("{}", output), "output r2 as token.record;");
+        assert_eq!(format!("{output}"), "output r2 as token.record;");
     }
 }

--- a/synthesizer/src/program/instruction/mod.rs
+++ b/synthesizer/src/program/instruction/mod.rs
@@ -389,7 +389,7 @@ impl<N: Network> Debug for Instruction<N> {
 impl<N: Network> Display for Instruction<N> {
     /// Prints the instruction as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        instruction!(self, |instruction| write!(f, "{};", instruction))
+        instruction!(self, |instruction| write!(f, "{instruction};"))
     }
 }
 

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -205,7 +205,7 @@ impl<N: Network, const VARIANT: u8> Display for AssertInstruction<N, VARIANT> {
         }
         // Print the operation.
         write!(f, "{} ", Self::opcode())?;
-        self.operands.iter().try_for_each(|operand| write!(f, "{} ", operand))
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))
     }
 }
 

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -737,13 +737,13 @@ mod tests {
         // Check that the operands are correct.
         assert_eq!(call.operands.len(), expected_operands.len(), "The number of operands is incorrect");
         for (i, (given, expected)) in call.operands.iter().zip(expected_operands.iter()).enumerate() {
-            assert_eq!(given, expected, "The {}-th operand is incorrect", i);
+            assert_eq!(given, expected, "The {i}-th operand is incorrect");
         }
 
         // Check that the destinations are correct.
         assert_eq!(call.destinations.len(), expected_destinations.len(), "The number of destinations is incorrect");
         for (i, (given, expected)) in call.destinations.iter().zip(expected_destinations.iter()).enumerate() {
-            assert_eq!(given, expected, "The {}-th destination is incorrect", i);
+            assert_eq!(given, expected, "The {i}-th destination is incorrect");
         }
     }
 

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -515,12 +515,12 @@ impl<N: Network> Display for Cast<N> {
             RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
         };
         if self.operands.len().is_zero() || self.operands.len() > max_operands {
-            eprintln!("The number of operands must be nonzero and <= {}", max_operands);
+            eprintln!("The number of operands must be nonzero and <= {max_operands}");
             return Err(fmt::Error);
         }
         // Print the operation.
         write!(f, "{} ", Self::opcode())?;
-        self.operands.iter().try_for_each(|operand| write!(f, "{} ", operand))?;
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))?;
         write!(f, "into {} as {}", self.destination, self.register_type)
     }
 }
@@ -557,7 +557,7 @@ impl<N: Network> FromBytes for Cast<N> {
             RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
         };
         if num_operands.is_zero() || num_operands > max_operands {
-            return Err(error(format!("The number of operands must be nonzero and <= {}", max_operands)));
+            return Err(error(format!("The number of operands must be nonzero and <= {max_operands}")));
         }
 
         // Return the operation.
@@ -575,7 +575,7 @@ impl<N: Network> ToBytes for Cast<N> {
             RegisterType::Record(_) | RegisterType::ExternalRecord(_) => N::MAX_DATA_ENTRIES + 2,
         };
         if self.operands.len().is_zero() || self.operands.len() > max_operands {
-            return Err(error(format!("The number of operands must be nonzero and <= {}", max_operands)));
+            return Err(error(format!("The number of operands must be nonzero and <= {max_operands}")));
         }
 
         // Write the number of operands.
@@ -630,7 +630,7 @@ mod tests {
         let mut string = "cast ".to_string();
         let mut operands = Vec::with_capacity(CurrentNetwork::MAX_DATA_ENTRIES);
         for i in 0..CurrentNetwork::MAX_DATA_ENTRIES {
-            string.push_str(&format!("r{} ", i));
+            string.push_str(&format!("r{i} "));
             operands.push(Operand::Register(Register::Locator(i as u64)));
         }
         string.push_str(&format!("into r{} as foo", CurrentNetwork::MAX_DATA_ENTRIES));
@@ -655,7 +655,7 @@ mod tests {
         let mut string = "cast ".to_string();
         let mut operands = Vec::with_capacity(CurrentNetwork::MAX_DATA_ENTRIES + 2);
         for i in 0..CurrentNetwork::MAX_DATA_ENTRIES + 2 {
-            string.push_str(&format!("r{} ", i));
+            string.push_str(&format!("r{i} "));
             operands.push(Operand::Register(Register::Locator(i as u64)));
         }
         string.push_str(&format!("into r{} as token.record", CurrentNetwork::MAX_DATA_ENTRIES + 2));
@@ -679,7 +679,7 @@ mod tests {
     fn test_parse_cast_into_record_too_many_operands() {
         let mut string = "cast ".to_string();
         for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES + 2 {
-            string.push_str(&format!("r{} ", i));
+            string.push_str(&format!("r{i} "));
         }
         string.push_str(&format!("into r{} as token.record", CurrentNetwork::MAX_DATA_ENTRIES + 3));
         assert!(Cast::<CurrentNetwork>::parse(&string).is_err(), "Parser did not error");
@@ -689,7 +689,7 @@ mod tests {
     fn test_parse_cast_into_plaintext_too_many_operands() {
         let mut string = "cast ".to_string();
         for i in 0..=CurrentNetwork::MAX_DATA_ENTRIES {
-            string.push_str(&format!("r{} ", i));
+            string.push_str(&format!("r{i} "));
         }
         string.push_str(&format!("into r{} as foo", CurrentNetwork::MAX_DATA_ENTRIES + 1));
         assert!(Cast::<CurrentNetwork>::parse(&string).is_err(), "Parser did not error");

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -243,7 +243,7 @@ impl<N: Network, const VARIANT: u8> Display for CommitInstruction<N, VARIANT> {
         }
         // Print the operation.
         write!(f, "{} ", Self::opcode())?;
-        self.operands.iter().try_for_each(|operand| write!(f, "{} ", operand))?;
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))?;
         write!(f, "into {}", self.destination)
     }
 }

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -243,7 +243,7 @@ impl<N: Network, const VARIANT: u8> Display for HashInstruction<N, VARIANT> {
         }
         // Print the operation.
         write!(f, "{} ", Self::opcode())?;
-        self.operands.iter().try_for_each(|operand| write!(f, "{} ", operand))?;
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))?;
         write!(f, "into {}", self.destination)
     }
 }

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -212,7 +212,7 @@ impl<N: Network, const VARIANT: u8> Display for IsInstruction<N, VARIANT> {
         }
         // Print the operation.
         write!(f, "{} ", Self::opcode())?;
-        self.operands.iter().try_for_each(|operand| write!(f, "{} ", operand))?;
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))?;
         write!(f, "into {}", self.destination)
     }
 }

--- a/synthesizer/src/program/instruction/operation/literals.rs
+++ b/synthesizer/src/program/instruction/operation/literals.rs
@@ -259,7 +259,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
         }
         // Print the operation.
         write!(f, "{} ", O::OPCODE)?;
-        self.operands.iter().try_for_each(|operand| write!(f, "{} ", operand))?;
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))?;
         write!(f, "into {}", self.destination)
     }
 }
@@ -299,7 +299,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
         }
         // Ensure the number of operands is correct.
         if self.operands.len() > NUM_OPERANDS {
-            return Err(error(format!("The number of operands must be {}", NUM_OPERANDS)));
+            return Err(error(format!("The number of operands must be {NUM_OPERANDS}")));
         }
         // Write the operands.
         self.operands.iter().try_for_each(|operand| operand.write_le(&mut writer))?;

--- a/synthesizer/src/program/instruction/operation/literals.rs
+++ b/synthesizer/src/program/instruction/operation/literals.rs
@@ -254,7 +254,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
         }
         // Ensure the number of operands is correct.
         if self.operands.len() > NUM_OPERANDS {
-            eprintln!("The number of operands must be {}", NUM_OPERANDS);
+            eprintln!("The number of operands must be {NUM_OPERANDS}");
             return Err(fmt::Error);
         }
         // Print the operation.

--- a/synthesizer/src/program/mapping/value/parse.rs
+++ b/synthesizer/src/program/mapping/value/parse.rs
@@ -104,6 +104,6 @@ mod tests {
     fn test_value_display() {
         // Literal
         let value = MapValue::<CurrentNetwork>::parse("value abc as field.public;").unwrap().1;
-        assert_eq!(format!("{}", value), "value abc as field.public;");
+        assert_eq!(format!("{value}"), "value abc as field.public;");
     }
 }

--- a/synthesizer/src/program/parse.rs
+++ b/synthesizer/src/program/parse.rs
@@ -133,7 +133,7 @@ impl<N: Network> Display for Program<N> {
         if !self.imports.is_empty() {
             // Print the imports.
             for import in self.imports.values() {
-                program.push_str(&format!("{}\n", import));
+                program.push_str(&format!("{import}\n"));
             }
 
             // Print a newline.
@@ -148,35 +148,35 @@ impl<N: Network> Display for Program<N> {
                 ProgramDefinition::Mapping => match self.mappings.get(identifier) {
                     Some(mapping) => program.push_str(&format!("{mapping}\n\n")),
                     None => {
-                        eprintln!("Mapping '{}' is not defined.", identifier);
+                        eprintln!("Mapping '{identifier}' is not defined.");
                         return Err(fmt::Error);
                     }
                 },
                 ProgramDefinition::Struct => match self.structs.get(identifier) {
                     Some(struct_) => program.push_str(&format!("{struct_}\n\n")),
                     None => {
-                        eprintln!("Struct '{}' is not defined.", identifier);
+                        eprintln!("Struct '{identifier}' is not defined.");
                         return Err(fmt::Error);
                     }
                 },
                 ProgramDefinition::Record => match self.records.get(identifier) {
                     Some(record) => program.push_str(&format!("{record}\n\n")),
                     None => {
-                        eprintln!("Record '{}' is not defined.", identifier);
+                        eprintln!("Record '{identifier}' is not defined.");
                         return Err(fmt::Error);
                     }
                 },
                 ProgramDefinition::Closure => match self.closures.get(identifier) {
                     Some(closure) => program.push_str(&format!("{closure}\n\n")),
                     None => {
-                        eprintln!("Closure '{}' is not defined.", identifier);
+                        eprintln!("Closure '{identifier}' is not defined.");
                         return Err(fmt::Error);
                     }
                 },
                 ProgramDefinition::Function => match self.functions.get(identifier) {
                     Some(function) => program.push_str(&format!("{function}\n\n")),
                     None => {
-                        eprintln!("Function '{}' is not defined.", identifier);
+                        eprintln!("Function '{identifier}' is not defined.");
                         return Err(fmt::Error);
                     }
                 },

--- a/synthesizer/src/snark/certificate/mod.rs
+++ b/synthesizer/src/snark/certificate/mod.rs
@@ -66,7 +66,7 @@ impl<N: Network> Certificate<N> {
                 #[cfg(feature = "aleo-cli")]
                 {
                     let elapsed = timer.elapsed().as_millis();
-                    println!("{}", format!(" • Verified certificate for '{function_name}': {} ms", elapsed).dimmed());
+                    println!("{}", format!(" • Verified certificate for '{function_name}': {elapsed} ms").dimmed());
                 }
 
                 is_valid

--- a/synthesizer/src/snark/verifying_key/mod.rs
+++ b/synthesizer/src/snark/verifying_key/mod.rs
@@ -45,7 +45,7 @@ impl<N: Network> VerifyingKey<N> {
                 #[cfg(feature = "aleo-cli")]
                 {
                     let elapsed = timer.elapsed().as_millis();
-                    println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
+                    println!("{}", format!(" • Verified '{function_name}' (in {elapsed} ms)").dimmed());
                 }
 
                 is_valid
@@ -69,7 +69,7 @@ impl<N: Network> VerifyingKey<N> {
                 #[cfg(feature = "aleo-cli")]
                 {
                     let elapsed = timer.elapsed().as_millis();
-                    println!("{}", format!(" • Verified '{function_name}' (in {} ms)", elapsed).dimmed());
+                    println!("{}", format!(" • Verified '{function_name}' (in {elapsed} ms)").dimmed());
                 }
 
                 is_valid

--- a/synthesizer/src/store/consensus/mod.rs
+++ b/synthesizer/src/store/consensus/mod.rs
@@ -38,11 +38,7 @@ pub trait ConsensusStorage<N: Network>: 'static + Clone + Send + Sync {
     /// The program storage.
     type ProgramStorage: ProgramStorage<N>;
     /// The block storage.
-    type BlockStorage: BlockStorage<
-        N,
-        TransactionStorage = Self::TransactionStorage,
-        TransitionStorage = Self::TransitionStorage,
-    >;
+    type BlockStorage: BlockStorage<N, TransactionStorage = Self::TransactionStorage, TransitionStorage = Self::TransitionStorage>;
     /// The transaction storage.
     type TransactionStorage: TransactionStorage<N, TransitionStorage = Self::TransitionStorage>;
     /// The transition storage.

--- a/synthesizer/src/store/consensus/mod.rs
+++ b/synthesizer/src/store/consensus/mod.rs
@@ -38,7 +38,11 @@ pub trait ConsensusStorage<N: Network>: 'static + Clone + Send + Sync {
     /// The program storage.
     type ProgramStorage: ProgramStorage<N>;
     /// The block storage.
-    type BlockStorage: BlockStorage<N, TransactionStorage = Self::TransactionStorage, TransitionStorage = Self::TransitionStorage>;
+    type BlockStorage: BlockStorage<
+        N,
+        TransactionStorage = Self::TransactionStorage,
+        TransitionStorage = Self::TransitionStorage,
+    >;
     /// The transaction storage.
     type TransactionStorage: TransactionStorage<N, TransitionStorage = Self::TransitionStorage>;
     /// The transition storage.

--- a/utilities/derives/src/canonical_deserialize.rs
+++ b/utilities/derives/src/canonical_deserialize.rs
@@ -51,7 +51,7 @@ fn impl_valid(ast: &syn::DeriveInput) -> TokenStream {
     let len = if let Data::Struct(ref data_struct) = ast.data {
         data_struct.fields.len()
     } else {
-        panic!("`Valid` can only be derived for structs, {} is not a struct", name);
+        panic!("`Valid` can only be derived for structs, {name} is not a struct");
     };
 
     let mut check_body = Vec::<TokenStream>::with_capacity(len);
@@ -77,7 +77,7 @@ fn impl_valid(ast: &syn::DeriveInput) -> TokenStream {
                 idents.clear();
             }
         }
-        _ => panic!("`Valid` can only be derived for structs, {} is not a struct", name),
+        _ => panic!("`Valid` can only be derived for structs, {name} is not a struct"),
     };
 
     let gen = quote! {
@@ -156,7 +156,7 @@ pub(super) fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream 
                 })
             };
         }
-        _ => panic!("`CanonicalDeserialize` can only be derived for structs, {} is not a Struct", name),
+        _ => panic!("`CanonicalDeserialize` can only be derived for structs, {name} is not a Struct"),
     };
 
     let mut gen = quote! {

--- a/utilities/derives/src/canonical_serialize.rs
+++ b/utilities/derives/src/canonical_serialize.rs
@@ -65,7 +65,7 @@ pub(super) fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
     let len = if let Data::Struct(ref data_struct) = ast.data {
         data_struct.fields.len()
     } else {
-        panic!("`CanonicalSerialize` can only be derived for structs, {} is not a struct", name);
+        panic!("`CanonicalSerialize` can only be derived for structs, {name} is not a struct");
     };
 
     let mut serialize_body = Vec::<TokenStream>::with_capacity(len);
@@ -91,7 +91,7 @@ pub(super) fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
                 idents.clear();
             }
         }
-        _ => panic!("`CanonicalSerialize` can only be derived for structs, {} is not a struct", name),
+        _ => panic!("`CanonicalSerialize` can only be derived for structs, {name} is not a struct"),
     };
 
     let gen = quote! {

--- a/utilities/src/biginteger/tests.rs
+++ b/utilities/src/biginteger/tests.rs
@@ -90,7 +90,7 @@ fn biginteger_to_string_test<B: BigInteger>(rng: &mut TestRng) {
         let start = u64::MAX as u128;
         for integer in start..(start + ITERATIONS as u128) {
             let mut buffer = vec![0u8; 8 * B::NUM_LIMBS];
-            buffer.iter_mut().zip(&(integer as u128).to_le_bytes()).for_each(|(buf, val)| {
+            buffer.iter_mut().zip(&integer.to_le_bytes()).for_each(|(buf, val)| {
                 *buf = *val;
             });
             assert_eq!(format!("{integer}"), B::read_le(&*buffer).unwrap().to_string());

--- a/utilities/src/biginteger/tests.rs
+++ b/utilities/src/biginteger/tests.rs
@@ -65,7 +65,7 @@ fn biginteger_bits_test<B: BigInteger>() {
     assert!(!thirty_two.get_bit(2));
     assert!(!thirty_two.get_bit(3));
     assert!(!thirty_two.get_bit(4));
-    assert!(thirty_two.get_bit(5), "{:?}", thirty_two);
+    assert!(thirty_two.get_bit(5), "{thirty_two:?}");
 }
 
 fn biginteger_bytes_test<B: BigInteger>(rng: &mut TestRng) {
@@ -81,7 +81,7 @@ fn biginteger_to_string_test<B: BigInteger>(rng: &mut TestRng) {
 
     // Sanity check the integers starting from 0 to ITERATIONS.
     for integer in 0..ITERATIONS {
-        assert_eq!(format!("{}", integer), B::from(integer).to_string());
+        assert_eq!(format!("{integer}"), B::from(integer).to_string());
     }
 
     // If the BigInteger has more than one limb, sanity check
@@ -93,14 +93,14 @@ fn biginteger_to_string_test<B: BigInteger>(rng: &mut TestRng) {
             buffer.iter_mut().zip(&(integer as u128).to_le_bytes()).for_each(|(buf, val)| {
                 *buf = *val;
             });
-            assert_eq!(format!("{}", integer), B::read_le(&*buffer).unwrap().to_string());
+            assert_eq!(format!("{integer}"), B::read_le(&*buffer).unwrap().to_string());
         }
     }
 
     // Sample random integers and check they match against num-bigint.
     for _ in 0..ITERATIONS {
         let candidate: B = Uniform::rand(rng);
-        let candidate_hex = format!("{:?}", candidate);
+        let candidate_hex = format!("{candidate:?}");
         let reference = num_bigint::BigUint::parse_bytes(candidate_hex.as_bytes(), 16).unwrap();
         assert_eq!(reference.to_str_radix(10), candidate.to_string());
     }

--- a/utilities/src/serialize/error.rs
+++ b/utilities/src/serialize/error.rs
@@ -38,6 +38,6 @@ pub enum SerializationError {
 
 impl From<SerializationError> for crate::io::Error {
     fn from(error: SerializationError) -> Self {
-        crate::io::Error::new(crate::io::ErrorKind::Other, format!("{}", error))
+        crate::io::Error::new(crate::io::ErrorKind::Other, format!("{error}"))
     }
 }

--- a/utilities/src/serialize/traits.rs
+++ b/utilities/src/serialize/traits.rs
@@ -206,10 +206,7 @@ where
 {
     fn take_from_value<D: Deserializer<'de>>(value: &mut serde_json::Value, field: &str) -> Result<Self, D::Error> {
         serde_json::from_value(
-            value
-                .get_mut(field)
-                .ok_or_else(|| de::Error::custom(format!("The \"{}\" field is missing", field)))?
-                .take(),
+            value.get_mut(field).ok_or_else(|| de::Error::custom(format!("The \"{field}\" field is missing")))?.take(),
         )
         .map_err(de::Error::custom)
     }

--- a/vm/cli/cli.rs
+++ b/vm/cli/cli.rs
@@ -65,7 +65,7 @@ impl Command {
                                     Ok("".to_string())
                                 }
                             }
-                            Err(e) => Ok(format!("\nFailed to update snarkVM to the latest version\n{}\n", e)),
+                            Err(e) => Ok(format!("\nFailed to update snarkVM to the latest version\n{e}\n")),
                         }
                     } else {
                         Ok("".to_string())

--- a/vm/cli/updater.rs
+++ b/vm/cli/updater.rs
@@ -84,7 +84,7 @@ impl Updater {
         if let Ok(latest_version) = Self::update_available() {
             let mut output = "🟢 A new version is available! Run".bold().green().to_string();
             output += &" `aleo update` ".bold().white();
-            output += &format!("to update to v{}.", latest_version).bold().green();
+            output += &format!("to update to v{latest_version}.").bold().green();
             output
         } else {
             "".to_string()

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -47,7 +47,7 @@ impl<N: Network> ProverFile<N> {
         let prover_file = Self { function_name: *function_name, proving_key };
 
         // Create the file name.
-        let file_name = format!("{}.{PROVER_FILE_EXTENSION}", function_name);
+        let file_name = format!("{function_name}.{PROVER_FILE_EXTENSION}");
         // Construct the file path.
         let path = directory.join(&file_name);
         // Write the file (overwriting if it already exists).
@@ -63,7 +63,7 @@ impl<N: Network> ProverFile<N> {
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
 
         // Create the file name.
-        let file_name = format!("{}.{PROVER_FILE_EXTENSION}", function_name);
+        let file_name = format!("{function_name}.{PROVER_FILE_EXTENSION}");
         // Construct the file path.
         let path = directory.join(file_name);
         // Ensure the file path exists.
@@ -87,7 +87,7 @@ impl<N: Network> ProverFile<N> {
     /// Returns `true` if the prover file for the given function name exists at the given directory.
     pub fn exists_at(directory: &Path, function_name: &Identifier<N>) -> bool {
         // Create the file name.
-        let file_name = format!("{}.{PROVER_FILE_EXTENSION}", function_name);
+        let file_name = format!("{function_name}.{PROVER_FILE_EXTENSION}");
         // Construct the file path.
         let path = directory.join(file_name);
         // Ensure the path is well-formed.

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -49,7 +49,7 @@ impl<N: Network> ProverFile<N> {
         // Create the file name.
         let file_name = format!("{function_name}.{PROVER_FILE_EXTENSION}");
         // Construct the file path.
-        let path = directory.join(&file_name);
+        let path = directory.join(file_name);
         // Write the file (overwriting if it already exists).
         File::create(&path)?.write_all(&prover_file.to_bytes_le()?)?;
 

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -49,7 +49,7 @@ impl<N: Network> VerifierFile<N> {
         // Create the file name.
         let file_name = format!("{function_name}.{VERIFIER_FILE_EXTENSION}");
         // Construct the file path.
-        let path = directory.join(&file_name);
+        let path = directory.join(file_name);
         // Write the file (overwriting if it already exists).
         File::create(&path)?.write_all(&verifier_file.to_bytes_le()?)?;
 

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -47,7 +47,7 @@ impl<N: Network> VerifierFile<N> {
         let verifier_file = Self { function_name: *function_name, verifying_key };
 
         // Create the file name.
-        let file_name = format!("{}.{VERIFIER_FILE_EXTENSION}", function_name);
+        let file_name = format!("{function_name}.{VERIFIER_FILE_EXTENSION}");
         // Construct the file path.
         let path = directory.join(&file_name);
         // Write the file (overwriting if it already exists).
@@ -63,7 +63,7 @@ impl<N: Network> VerifierFile<N> {
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
 
         // Create the file name.
-        let file_name = format!("{}.{VERIFIER_FILE_EXTENSION}", function_name);
+        let file_name = format!("{function_name}.{VERIFIER_FILE_EXTENSION}");
         // Construct the file path.
         let path = directory.join(file_name);
         // Ensure the file path exists.
@@ -87,7 +87,7 @@ impl<N: Network> VerifierFile<N> {
     /// Returns `true` if the verifier file for the given function name exists at the given directory.
     pub fn exists_at(directory: &Path, function_name: &Identifier<N>) -> bool {
         // Create the file name.
-        let file_name = format!("{}.{VERIFIER_FILE_EXTENSION}", function_name);
+        let file_name = format!("{function_name}.{VERIFIER_FILE_EXTENSION}");
         // Construct the file path.
         let path = directory.join(file_name);
         // Ensure the path is well-formed.

--- a/vm/package/is_build_required.rs
+++ b/vm/package/is_build_required.rs
@@ -98,7 +98,7 @@ mod tests {
 
         // Create the build directory.
         let build_directory = directory.join("build");
-        std::fs::create_dir_all(&build_directory).unwrap();
+        std::fs::create_dir_all(build_directory).unwrap();
 
         // Open the package at the temporary directory.
         Package::<Testnet3>::open(&directory)

--- a/vm/package/is_build_required.rs
+++ b/vm/package/is_build_required.rs
@@ -90,7 +90,7 @@ mod tests {
 
         // Write the program string to a file in the temporary directory.
         let path = directory.join("main.aleo");
-        let mut file = File::create(&path).unwrap();
+        let mut file = File::create(path).unwrap();
         file.write_all(program_string.as_bytes()).unwrap();
 
         // Create the manifest file.
@@ -106,7 +106,7 @@ mod tests {
 
     fn program_with_id(id: &str) -> String {
         format!(
-            r"program {};
+            r"program {id};
 
 record token:
     owner as address.private;
@@ -116,8 +116,7 @@ record token:
 function compute:
     input r0 as token.record;
     add.w r0.token_amount r0.token_amount into r1;
-    output r1 as u64.private;",
-            id
+    output r1 as u64.private;"
         )
     }
 

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -225,7 +225,7 @@ function transfer:
 
         // Write the program string to a file in the temporary directory.
         let main_filepath = directory.join("main.aleo");
-        let mut file = File::create(&main_filepath).unwrap();
+        let mut file = File::create(main_filepath).unwrap();
         file.write_all(program_string.as_bytes()).unwrap();
 
         // Create the manifest file.
@@ -280,7 +280,7 @@ function transfer:
 
         // Write the imported program string to an imports file in the temporary directory.
         let import_filepath = imports_directory.join(imported_program_id.to_string());
-        let mut file = File::create(&import_filepath).unwrap();
+        let mut file = File::create(import_filepath).unwrap();
         file.write_all(imported_program.to_string().as_bytes()).unwrap();
 
         // Initialize the main program ID.
@@ -304,7 +304,7 @@ function transfer:
 
         // Write the main program string to a file in the temporary directory.
         let main_filepath = directory.join("main.aleo");
-        let mut file = File::create(&main_filepath).unwrap();
+        let mut file = File::create(main_filepath).unwrap();
         file.write_all(main_program.to_string().as_bytes()).unwrap();
 
         // Create the manifest file.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR applies the new Rust 1.67 clippy lints. The most major change is [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) and is mostly stylistic.

Though it is nice to follow the standard and maintain consistency, an alternative solution is ignore the new "warn-by-default" `uninlined_format_args`settings and keep our old syntax.