### PR TITLE
Fixes `Integer::shr_wrapped`

### DIFF
--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -127,18 +127,21 @@ impl<E: Environment, I: IntegerType> Metrics<dyn DivWrapped<Integer<E, I>, Outpu
     type Case = (Mode, Mode);
 
     fn count(case: &Self::Case) -> Count {
-        match I::is_signed() {
-            true => match (case.0, case.1) {
-                (Mode::Constant, Mode::Constant) => Count::is(2 * I::BITS, 0, 0, 0),
-                (Mode::Constant, _) | (_, Mode::Constant) => {
-                    Count::less_than(9 * I::BITS, 0, (8 * I::BITS) + 2, (8 * I::BITS) + 12)
+        match (case.0, case.1) {
+            (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
+            (Mode::Constant, _) | (_, Mode::Constant) => {
+                match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
+                    (true, true) => Count::less_than(6 * I::BITS + 1, 0, (9 * I::BITS) + 7, (9 * I::BITS) + 13),
+                    (true, false) => Count::less_than(6 * I::BITS + 1, 0, 136 * I::BITS + 5, 137 * I::BITS + 8),
+                    (false, true) => Count::less_than(2 * I::BITS + 1, 0, (3 * I::BITS) + 3, (3 * I::BITS) + 6),
+                    (false, false) => Count::less_than(2 * I::BITS + 1, 0, 130 * I::BITS + 1, 131 * I::BITS + 1),
                 }
-                (_, _) => Count::is(8 * I::BITS, 0, (10 * I::BITS) + 15, (10 * I::BITS) + 27),
-            },
-            false => match (case.0, case.1) {
-                (Mode::Constant, Mode::Constant) => Count::is(2 * I::BITS, 0, 0, 0),
-                (_, Mode::Constant) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 1, (3 * I::BITS) + 4),
-                (Mode::Constant, _) | (_, _) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 4, (3 * I::BITS) + 9),
+            }
+            (_, _) => match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
+                (true, true) => Count::is(5 * I::BITS, 0, (9 * I::BITS) + 7, (9 * I::BITS) + 13),
+                (true, false) => Count::less_than(5 * I::BITS, 0, 136 * I::BITS + 5, 137 * I::BITS + 8),
+                (false, true) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 3, (3 * I::BITS) + 6),
+                (false, false) => Count::less_than(2 * I::BITS, 0, 130 * I::BITS + 1, 131 * I::BITS + 1),
             },
         }
     }
@@ -192,9 +195,8 @@ mod tests {
                 let candidate = a.div_wrapped(&b);
                 assert_eq!(expected, *candidate.eject_value());
                 assert_eq!(console::Integer::new(expected), candidate.eject_value());
-                // assert_count!(DivWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
-                // assert_output_mode!(DivWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b), candidate);
-                assert!(Circuit::is_satisfied_in_scope(), "(is_satisfied_in_scope)");
+                assert_count!(DivWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
+                assert_output_mode!(DivWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b), candidate);
             })
         }
         Circuit::reset();

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -63,6 +63,7 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
     /// Divides `self` by `other`, via witnesses, returning the quotient and remainder.
     /// This method does not check that `other` is non-zero.
     /// This method should only be used when 2 * I::BITS < E::BaseField::size_in_data_bits().
+    /// This method assumes the `self` and `other` are unsigned integers.
     pub(super) fn unsigned_division_via_witness(&self, other: &Self) -> (Self, Self) {
         // Eject the dividend and divisor, to compute the quotient as a witness.
         let dividend_value = self.eject_value();

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -62,6 +62,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
                 // Calculate the value of the shift directly in the field.
                 // Since 2^{rhs} < Integer::MAX, we know that the operation will not overflow Integer::MAX or the field modulus.
                 let two = Field::one() + Field::one();
+                // Note that `shift_in_field` is always greater than zero and does not wrap around the field modulus.
                 let mut shift_in_field = Field::one();
                 for bit in rhs.bits_le[..first_upper_bit_index].iter().rev() {
                     shift_in_field = shift_in_field.square();
@@ -75,9 +76,11 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
                 if I::is_signed() {
                     // Divide the absolute value of `self` and `shift` (as a divisor) in the base field.
                     let dividend_unsigned = self.abs_wrapped().cast_as_dual();
+                    // Note that `divisor_unsigned` is greater than zero since `shift_in_field` is greater than zero.
                     let divisor_unsigned = shift_as_divisor.cast_as_dual();
 
                     // Compute the quotient and remainder using wrapped, unsigned division.
+                    // Note that do not invoke `div_wrapped` since we need the quotient AND the remainder.
                     // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
                     let (quotient_unsigned, remainder_field) = if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64
                     {

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -77,28 +77,16 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
                     let dividend_unsigned = self.abs_wrapped().cast_as_dual();
                     let divisor_unsigned = shift_as_divisor.cast_as_dual();
 
-                    let dividend = dividend_unsigned.eject_value();
-                    let divisor = divisor_unsigned.eject_value();
-
-                    // Wrapping operations are safe since unsigned division never overflows.
-                    let quotient_unsigned = Integer::<E, I::Dual>::new(
-                        Mode::Private,
-                        console::Integer::new(dividend.wrapping_div(&divisor)),
-                    );
-                    let remainder_unsigned = Integer::<E, I::Dual>::new(
-                        Mode::Private,
-                        console::Integer::new(dividend.wrapping_rem(&divisor)),
-                    );
-
-                    // Ensure that Euclidean division holds for these values in the base field.
-                    let remainder_field = remainder_unsigned.to_field();
-                    E::assert_eq(
-                        dividend_unsigned.to_field(),
-                        quotient_unsigned.to_field() * divisor_unsigned.to_field() + &remainder_field,
-                    );
-
-                    // Ensure that the remainder is less than the divisor.
-                    E::assert(remainder_unsigned.is_less_than(&divisor_unsigned));
+                    // Compute the quotient and remainder using wrapped, unsigned division.
+                    // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
+                    let (quotient_unsigned, remainder_field) = if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64
+                    {
+                        let (quotient_integer, remainder_integer) =
+                            dividend_unsigned.unsigned_division_via_witness(&divisor_unsigned);
+                        (quotient_integer, remainder_integer.to_field())
+                    } else {
+                        dividend_unsigned.unsigned_binary_long_division(&divisor_unsigned)
+                    };
 
                     // Note that quotient <= |console::Integer::MIN|, since the dividend <= |console::Integer::MIN| and 0 <= quotient <= dividend.
                     let quotient = Self { bits_le: quotient_unsigned.bits_le, phantom: Default::default() };

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -80,7 +80,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
                     let divisor_unsigned = shift_as_divisor.cast_as_dual();
 
                     // Compute the quotient and remainder using wrapped, unsigned division.
-                    // Note that do not invoke `div_wrapped` since we need the quotient AND the remainder.
+                    // Note that we do not invoke `div_wrapped` since we need the quotient AND the remainder.
                     // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
                     let (quotient_unsigned, remainder_field) = if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64
                     {


### PR DESCRIPTION
This PR uses binary long division as a subroutine for `shr` operations over `u128` and `i128`.
It formerly used "witnessed" binary long division, which is not safe if `2 * SIZE_OF_INT >= SIZE_OF_FIELD`.