### PR TITLE
Fix `Map` leniency

### DIFF
--- a/console/network/src/helpers/id.rs
+++ b/console/network/src/helpers/id.rs
@@ -23,7 +23,6 @@ use std::borrow::Borrow;
 
 pub trait Bech32ID<F: FieldTrait>:
     From<F>
-    + Borrow<F>
     + Deref<Target = F>
     + Into<Vec<F>>
     + Uniform

--- a/console/network/src/helpers/object.rs
+++ b/console/network/src/helpers/object.rs
@@ -23,7 +23,6 @@ use std::borrow::Borrow;
 
 pub trait Bech32Object<T: Clone + Debug + ToBytes + FromBytes + PartialEq + Eq + Sync + Send>:
     From<T>
-    + Borrow<T>
     + Deref<Target = T>
     + Clone
     + Debug

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -359,7 +359,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         let block_path = block_tree.prove(block.height() as usize, &block.hash().to_bits_le())?;
 
         // Ensure the global state root exists in storage.
-        if !self.reverse_state_root_map().contains_key(&global_state_root)? {
+        if !self.reverse_state_root_map().contains_key(&global_state_root.into())? {
             bail!("The global state root '{global_state_root}' for commitment '{commitment}' is missing in storage");
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR handles the `Map` leniency described here - https://github.com/AleoHQ/snarkVM/issues/1353. This is done by removing `Borrow<F>` trait requirement from `Bech32ID` and `Bech32Object`.

This leniency allowed map functions to take in generic fields by input instead of their wrapper, Bech32ID. In other words, a map would consider `N::StateRoot`, `N::BlockHash`, `N::TransactionID`, and `N::TransitionID` all the same (as fields), instead of their wrapper types. This leads to possible errors in the map operations like the one fixed in https://github.com/AleoHQ/snarkVM/pull/1345.

Alternative solutions are welcome, as this adds (minor) restrictions to the updated traits.

