### PR TITLE
Ensure usize serialization in cryptographic contexts is always 64 bits

### DIFF
--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -150,7 +150,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, MM: MarlinMode> MarlinSNAR
     ) -> FS {
         let mut sponge = FS::new_with_parameters(fs_parameters);
         sponge.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME].unwrap());
-        sponge.absorb_bytes(&batch_size.to_le_bytes());
+        sponge.absorb_bytes(&(batch_size as u64).to_le_bytes());
         sponge.absorb_native_field_elements(circuit_commitments);
         for input in inputs {
             sponge.absorb_nonnative_field_elements(input.iter().copied());

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -150,7 +150,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, MM: MarlinMode> MarlinSNAR
     ) -> FS {
         let mut sponge = FS::new_with_parameters(fs_parameters);
         sponge.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME].unwrap());
-        sponge.absorb_bytes(&(batch_size as u64).to_le_bytes());
+        sponge.absorb_bytes(&(u64::try_from(batch_size).unwrap()).to_le_bytes());
         sponge.absorb_native_field_elements(circuit_commitments);
         for input in inputs {
             sponge.absorb_nonnative_field_elements(input.iter().copied());

--- a/utilities/src/serialize/error.rs
+++ b/utilities/src/serialize/error.rs
@@ -34,6 +34,9 @@ pub enum SerializationError {
     /// expected.
     #[error("the call expects empty flags")]
     UnexpectedFlags,
+    /// During serialization, the target was found to be incompatible
+    #[error("the file was serialized with a 64bit target and cannot be deserialized on a 32bit target")]
+    IncompatibleTarget,
 }
 
 impl From<SerializationError> for crate::io::Error {

--- a/utilities/src/serialize/error.rs
+++ b/utilities/src/serialize/error.rs
@@ -35,7 +35,7 @@ pub enum SerializationError {
     #[error("the call expects empty flags")]
     UnexpectedFlags,
     /// During serialization, the target was found to be incompatible
-    #[error("the file was serialized with a 64bit target and cannot be deserialized on a 32bit target")]
+    #[error("the value was serialized on a target that is incompatible with the current target")]
     IncompatibleTarget,
 }
 

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -152,7 +152,7 @@ impl_canonical_serialization_uint!(u64);
 impl CanonicalSerialize for usize {
     #[inline]
     fn serialize_with_mode<W: Write>(&self, mut writer: W, _compress: Compress) -> Result<(), SerializationError> {
-        let u64_value = *self as u64;
+        let u64_value = u64::try_from(*self).map_err(|_| SerializationError::IncompatibleTarget)?;
         Ok(writer.write_all(&u64_value.to_le_bytes())?)
     }
 

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -170,8 +170,8 @@ impl Valid for usize {
 
     #[inline]
     fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self>) -> Result<(), SerializationError>
-        where
-            Self: 'a,
+    where
+        Self: 'a,
     {
         Ok(())
     }

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -148,7 +148,46 @@ impl_canonical_serialization_uint!(u8);
 impl_canonical_serialization_uint!(u16);
 impl_canonical_serialization_uint!(u32);
 impl_canonical_serialization_uint!(u64);
-impl_canonical_serialization_uint!(usize);
+
+impl CanonicalSerialize for usize {
+    #[inline]
+    fn serialize_with_mode<W: Write>(&self, mut writer: W, _compress: Compress) -> Result<(), SerializationError> {
+        let u64_value = *self as u64;
+        Ok(writer.write_all(&u64_value.to_le_bytes())?)
+    }
+
+    #[inline]
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        8
+    }
+}
+
+impl Valid for usize {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+
+    #[inline]
+    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self>) -> Result<(), SerializationError>
+        where
+            Self: 'a,
+    {
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for usize {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let u64_value = u64::deserialize_compressed(&mut reader)?;
+        usize::try_from(u64_value).map_err(|_| SerializationError::IncompatibleTarget)
+    }
+}
 
 impl<T: CanonicalSerialize> CanonicalSerialize for Option<T> {
     #[inline]


### PR DESCRIPTION
## Motivation

There are 2 places in the code where `usize` integers are used in cryptographic contexts. 

1. [Absorption into the Poseidon Sponge during Marlin proofs](https://github.com/AleoHQ/snarkVM/blob/testnet3/algorithms/src/snark/marlin/marlin.rs#L153)
2. [Deserialization of the proving key](https://github.com/AleoHQ/snarkVM/blob/testnet3/utilities/src/serialize/impls.rs#L151)

In the sponge context, the proof only works if `usize` integers are represented as 8 bytes. If the Snark is run in a context where `usize` integers are represented without 8 bytes (such as a `wasm` context), the snark will generate an invalid proof.

Similarly, the deserialization within contexts where `usize` integers (again, in a `wasm` context) are represented as anything but 8 bytes leads to an incorrect proving key.

To ensure proof math computes correctly when using `usize` integers:
* `usize` integers are explicitly cast into 8 bytes before absorption into the sponge in the Marlin proofs
* `usize` integer serialization and deserialization is done explicitly in 8 bytes

This code was largely authored by Evan Marshall @ demox labs and modified by @iamalwaysuncomfortable - these serialization changes are currently in production enabling value transfers in the Leo wallet.

## Related PRs
This PR is a series of PRs to enable proving within `wasm` (and thus, within the browser). The following PRs are related to this effort:
Serial Flags: #1388 
[Enable Wasm Proofs in SnarkVM](https://github.com/demox-labs/snarkVM/pull/4)
