### PR TITLE
[Fix] Check for well-formed booleans.

### DIFF
--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -87,7 +87,6 @@ impl<F: PrimeField> LinearCombination<F> {
     /// 1. Either `constant` or `terms` is utilized, however never both.
     /// 2. Every individual variable in the linear combination must always be either `0` or `1`.
     /// 3. The value of the linear combination must always be either `0` or `1`.
-    ///
     pub fn is_boolean_type(&self) -> bool {
         // Constant case (enforce Property 1)
         if self.terms.is_empty() {
@@ -96,7 +95,8 @@ impl<F: PrimeField> LinearCombination<F> {
         // Public and private cases (enforce Property 1)
         else if self.constant.is_zero() {
             // Enforce property 2.
-            if self.terms.iter().all(|(v, _)| !(v.value().is_zero() || v.value().is_one())) {
+            // Note: This branch is triggered if ANY term is not (zero or one).
+            if self.terms.iter().any(|(v, _)| !(v.value().is_zero() || v.value().is_one())) {
                 eprintln!("Property 2 of the `Boolean` type was violated in {self}");
                 return false;
             }


### PR DESCRIPTION
This PR fixes a check that a boolean - encoded as a linear combination - is well-formed.