### PR TITLE
[Design] Renames `load` and `store` instructions to `get` and `put` respectively.

### DIFF
--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -1172,7 +1172,7 @@ function transfer:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_get_add_set() {
+    fn test_process_execute_and_finalize_get_add_put() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1194,7 +1194,7 @@ finalize compute:
     input r1 as u64.public;
     get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
-    set r3 into account[r0];
+    put r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1271,7 +1271,7 @@ finalize compute:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_increment_decrement_via_get_set() {
+    fn test_process_execute_and_finalize_increment_decrement_via_get_put() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1294,7 +1294,7 @@ finalize compute:
     get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
     sub r3 r1 into r4;
-    set r4 into account[r0];
+    put r4 into account[r0];
 ",
         )
         .unwrap();
@@ -1407,8 +1407,8 @@ finalize mint_public:
     get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Set `r3` into `account[r0]`.
-    set r3 into account[r0];
+    // Put `r3` into `account[r0]`.
+    put r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1525,8 +1525,8 @@ finalize mint_public:
     get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Set `r3` into `account[r0]`.
-    set r3 into account[r0];
+    // Put `r3` into `account[r0]`.
+    put r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1628,7 +1628,7 @@ function mint:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_get_set() {
+    fn test_process_execute_and_finalize_get_put() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1650,10 +1650,10 @@ finalize compute:
     input r1 as u64.public;
     get_or account[r0] 0u64 into r2;
     add r1 r2 into r3;
-    set r3 into account[r0];
+    put r3 into account[r0];
     get account[r0] into r4;
     add r1 r4 into r5;
-    set r5 into account[r0];
+    put r5 into account[r0];
 ",
         )
         .unwrap();

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -1172,7 +1172,7 @@ function transfer:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_load_add_store() {
+    fn test_process_execute_and_finalize_get_add_set() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1192,9 +1192,9 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
-    store r3 into account[r0];
+    set r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1271,7 +1271,7 @@ finalize compute:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_increment_decrement_via_load_store() {
+    fn test_process_execute_and_finalize_increment_decrement_via_get_set() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1291,10 +1291,10 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
     sub r3 r1 into r4;
-    store r4 into account[r0];
+    set r4 into account[r0];
 ",
         )
         .unwrap();
@@ -1403,12 +1403,12 @@ finalize mint_public:
     // Input the token amount.
     input r1 as u64.public;
 
-    // Load `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    load_or account[r0] 0u64 into r2;
+    // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
+    get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Store `r3` into `account[r0]`.
-    store r3 into account[r0];
+    // Set `r3` into `account[r0]`.
+    set r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1521,12 +1521,12 @@ finalize mint_public:
     // Input the token amount.
     input r1 as u64.public;
 
-    // Load `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    load_or account[r0] 0u64 into r2;
+    // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
+    get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Store `r3` into `account[r0]`.
-    store r3 into account[r0];
+    // Set `r3` into `account[r0]`.
+    set r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1628,7 +1628,7 @@ function mint:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_load_store() {
+    fn test_process_execute_and_finalize_get_set() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1648,12 +1648,12 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r1 r2 into r3;
-    store r3 into account[r0];
-    load account[r0] into r4;
+    set r3 into account[r0];
+    get account[r0] into r4;
     add r1 r4 into r5;
-    store r5 into account[r0];
+    set r5 into account[r0];
 ",
         )
         .unwrap();

--- a/synthesizer/src/process/stack/finalize_types/initialize.rs
+++ b/synthesizer/src/process/stack/finalize_types/initialize.rs
@@ -171,7 +171,7 @@ impl<N: Network> FinalizeTypes<N> {
             Command::Instruction(instruction) => self.check_instruction(stack, finalize_name, instruction)?,
             Command::Get(get) => self.check_get(stack, finalize_name, get)?,
             Command::GetOr(get_or) => self.check_get_or(stack, finalize_name, get_or)?,
-            Command::Set(set) => self.check_set(stack, finalize_name, set)?,
+            Command::Put(put) => self.check_put(stack, finalize_name, put)?,
         }
         Ok(())
     }
@@ -242,32 +242,32 @@ impl<N: Network> FinalizeTypes<N> {
         Ok(())
     }
 
-    /// Ensures the given `set` command is well-formed.
+    /// Ensures the given `put` command is well-formed.
     #[inline]
-    fn check_set(&self, stack: &Stack<N>, finalize_name: &Identifier<N>, set: &Set<N>) -> Result<()> {
-        // Ensure the declared mapping in `set` is defined in the program.
-        if !stack.program().contains_mapping(set.mapping_name()) {
-            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", set.mapping_name(), stack.program_id())
+    fn check_put(&self, stack: &Stack<N>, finalize_name: &Identifier<N>, put: &Put<N>) -> Result<()> {
+        // Ensure the declared mapping in `put` is defined in the program.
+        if !stack.program().contains_mapping(put.mapping_name()) {
+            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", put.mapping_name(), stack.program_id())
         }
         // Retrieve the mapping from the program.
         // Note that the unwrap is safe, as we have already checked the mapping exists.
-        let mapping = stack.program().get_mapping(set.mapping_name()).unwrap();
+        let mapping = stack.program().get_mapping(put.mapping_name()).unwrap();
         // Get the mapping key type.
         let mapping_key_type = mapping.key().plaintext_type();
         // Get the mapping value type.
         let mapping_value_type = mapping.value().plaintext_type();
         // Retrieve the register type of the key.
-        let key_type = self.get_type_from_operand(stack, set.key())?;
+        let key_type = self.get_type_from_operand(stack, put.key())?;
         // Check that the key type in the mapping matches the key type.
         if *mapping_key_type != key_type {
-            bail!("Key type in `set` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'.")
+            bail!("Key type in `put` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'.")
         }
         // Retrieve the type of the value.
-        let value_type = self.get_type_from_operand(stack, set.value())?;
+        let value_type = self.get_type_from_operand(stack, put.value())?;
         // Check that the value type in the mapping matches the type of the value.
         if *mapping_value_type != value_type {
             bail!(
-                "Value type in `set` '{value_type}' does not match the value type in the mapping '{mapping_value_type}'."
+                "Value type in `put` '{value_type}' does not match the value type in the mapping '{mapping_value_type}'."
             )
         }
         Ok(())

--- a/synthesizer/src/process/stack/finalize_types/initialize.rs
+++ b/synthesizer/src/process/stack/finalize_types/initialize.rs
@@ -15,7 +15,6 @@
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use crate::finalize::{Load, LoadOr, Store};
 
 impl<N: Network> FinalizeTypes<N> {
     /// Initializes a new instance of `FinalizeTypes` for the given finalize.
@@ -170,37 +169,35 @@ impl<N: Network> FinalizeTypes<N> {
     fn check_command(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, command: &Command<N>) -> Result<()> {
         match command {
             Command::Instruction(instruction) => self.check_instruction(stack, finalize_name, instruction)?,
-            Command::Load(load) => self.check_load(stack, finalize_name, load)?,
-            Command::LoadDefault(load_or) => self.check_load_or(stack, finalize_name, load_or)?,
-            Command::Store(store) => self.check_store(stack, finalize_name, store)?,
+            Command::Get(get) => self.check_get(stack, finalize_name, get)?,
+            Command::GetOr(get_or) => self.check_get_or(stack, finalize_name, get_or)?,
+            Command::Set(set) => self.check_set(stack, finalize_name, set)?,
         }
         Ok(())
     }
 
-    /// Ensures the given `load` command is well-formed.
+    /// Ensures the given `get` command is well-formed.
     #[inline]
-    fn check_load(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, load: &Load<N>) -> Result<()> {
-        // Ensure the declared mapping in `load` is defined in the program.
-        if !stack.program().contains_mapping(load.mapping_name()) {
-            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", load.mapping_name(), stack.program_id())
+    fn check_get(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, get: &Get<N>) -> Result<()> {
+        // Ensure the declared mapping in `get` is defined in the program.
+        if !stack.program().contains_mapping(get.mapping_name()) {
+            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", get.mapping_name(), stack.program_id())
         }
         // Retrieve the mapping from the program.
         // Note that the unwrap is safe, as we have already checked the mapping exists.
-        let mapping = stack.program().get_mapping(load.mapping_name()).unwrap();
+        let mapping = stack.program().get_mapping(get.mapping_name()).unwrap();
         // Get the mapping key type.
         let mapping_key_type = mapping.key().plaintext_type();
         // Get the mapping value type.
         let mapping_value_type = mapping.value().plaintext_type();
         // Retrieve the register type of the key.
-        let load_key_type = self.get_type_from_operand(stack, load.key())?;
-        // Check that the key type in the mapping matches the key type in the load.
-        if *mapping_key_type != load_key_type {
-            bail!(
-                "Key type in `load` '{load_key_type}' does not match the key type in the mapping '{mapping_key_type}'."
-            )
+        let key_type = self.get_type_from_operand(stack, get.key())?;
+        // Check that the key type in the mapping matches the key type in the instruction.
+        if *mapping_key_type != key_type {
+            bail!("Key type in `get` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'.")
         }
         // Get the destination register.
-        let destination = load.destination().clone();
+        let destination = get.destination().clone();
         // Ensure the destination register is a locator (and does not reference a member).
         ensure!(matches!(destination, Register::Locator(..)), "Destination '{destination}' must be a locator.");
         // Insert the destination register.
@@ -208,38 +205,36 @@ impl<N: Network> FinalizeTypes<N> {
         Ok(())
     }
 
-    /// Ensures the given `load_or` command is well-formed.
+    /// Ensures the given `get_or` command is well-formed.
     #[inline]
-    fn check_load_or(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, load_or: &LoadOr<N>) -> Result<()> {
-        // Ensure the declared mapping in `load_or` is defined in the program.
-        if !stack.program().contains_mapping(load_or.mapping_name()) {
-            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", load_or.mapping_name(), stack.program_id())
+    fn check_get_or(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, get_or: &GetOr<N>) -> Result<()> {
+        // Ensure the declared mapping in `get_or` is defined in the program.
+        if !stack.program().contains_mapping(get_or.mapping_name()) {
+            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", get_or.mapping_name(), stack.program_id())
         }
         // Retrieve the mapping from the program.
         // Note that the unwrap is safe, as we have already checked the mapping exists.
-        let mapping = stack.program().get_mapping(load_or.mapping_name()).unwrap();
+        let mapping = stack.program().get_mapping(get_or.mapping_name()).unwrap();
         // Get the mapping key type.
         let mapping_key_type = mapping.key().plaintext_type();
         // Get the mapping value type.
         let mapping_value_type = mapping.value().plaintext_type();
         // Retrieve the register type of the key.
-        let load_key_type = self.get_type_from_operand(stack, load_or.key())?;
-        // Check that the key type in the mapping matches the key type in the load.
-        if *mapping_key_type != load_key_type {
-            bail!(
-                "Key type in `load_or` '{load_key_type}' does not match the key type in the mapping '{mapping_key_type}'."
-            )
+        let key_type = self.get_type_from_operand(stack, get_or.key())?;
+        // Check that the key type in the mapping matches the key type.
+        if *mapping_key_type != key_type {
+            bail!("Key type in `get_or` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'.")
         }
         // Retrieve the register type of the default value.
-        let default_value_type = self.get_type_from_operand(stack, load_or.default())?;
-        // Check that the value type in the mapping matches the default value type in the load.
+        let default_value_type = self.get_type_from_operand(stack, get_or.default())?;
+        // Check that the value type in the mapping matches the default value type.
         if *mapping_value_type != default_value_type {
             bail!(
-                "Default value type in `load_or` '{default_value_type}' does not match the value type in the mapping '{mapping_value_type}'."
+                "Default value type in `get_or` '{default_value_type}' does not match the value type in the mapping '{mapping_value_type}'."
             )
         }
         // Get the destination register.
-        let destination = load_or.destination().clone();
+        let destination = get_or.destination().clone();
         // Ensure the destination register is a locator (and does not reference a member).
         ensure!(matches!(destination, Register::Locator(..)), "Destination '{destination}' must be a locator.");
         // Insert the destination register.
@@ -247,34 +242,32 @@ impl<N: Network> FinalizeTypes<N> {
         Ok(())
     }
 
-    /// Ensures the given `store` command is well-formed.
+    /// Ensures the given `set` command is well-formed.
     #[inline]
-    fn check_store(&self, stack: &Stack<N>, finalize_name: &Identifier<N>, store: &Store<N>) -> Result<()> {
-        // Ensure the declared mapping in `store` is defined in the program.
-        if !stack.program().contains_mapping(store.mapping_name()) {
-            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", store.mapping_name(), stack.program_id())
+    fn check_set(&self, stack: &Stack<N>, finalize_name: &Identifier<N>, set: &Set<N>) -> Result<()> {
+        // Ensure the declared mapping in `set` is defined in the program.
+        if !stack.program().contains_mapping(set.mapping_name()) {
+            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", set.mapping_name(), stack.program_id())
         }
         // Retrieve the mapping from the program.
         // Note that the unwrap is safe, as we have already checked the mapping exists.
-        let mapping = stack.program().get_mapping(store.mapping_name()).unwrap();
+        let mapping = stack.program().get_mapping(set.mapping_name()).unwrap();
         // Get the mapping key type.
         let mapping_key_type = mapping.key().plaintext_type();
         // Get the mapping value type.
         let mapping_value_type = mapping.value().plaintext_type();
         // Retrieve the register type of the key.
-        let store_key_type = self.get_type_from_operand(stack, store.key())?;
-        // Check that the key type in the mapping matches the key type in the store.
-        if *mapping_key_type != store_key_type {
-            bail!(
-                "Key type in `store` '{store_key_type}' does not match the key type in the mapping '{mapping_key_type}'."
-            )
+        let key_type = self.get_type_from_operand(stack, set.key())?;
+        // Check that the key type in the mapping matches the key type.
+        if *mapping_key_type != key_type {
+            bail!("Key type in `set` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'.")
         }
         // Retrieve the type of the value.
-        let store_value_type = self.get_type_from_operand(stack, store.value())?;
+        let value_type = self.get_type_from_operand(stack, set.value())?;
         // Check that the value type in the mapping matches the type of the value.
-        if *mapping_value_type != store_value_type {
+        if *mapping_value_type != value_type {
             bail!(
-                "Value type in `store` '{store_value_type}' does not match the value type in the mapping '{mapping_value_type}'."
+                "Value type in `set` '{value_type}' does not match the value type in the mapping '{mapping_value_type}'."
             )
         }
         Ok(())

--- a/synthesizer/src/process/stack/finalize_types/mod.rs
+++ b/synthesizer/src/process/stack/finalize_types/mod.rs
@@ -18,7 +18,7 @@ mod initialize;
 mod matches;
 
 use crate::{
-    finalize::{Command, Finalize},
+    finalize::{Command, Get, GetOr, Set, Finalize},
     Instruction,
     Opcode,
     Operand,

--- a/synthesizer/src/process/stack/finalize_types/mod.rs
+++ b/synthesizer/src/process/stack/finalize_types/mod.rs
@@ -18,7 +18,7 @@ mod initialize;
 mod matches;
 
 use crate::{
-    finalize::{Command, Get, GetOr, Set, Finalize},
+    finalize::{Command, Finalize, Get, GetOr, Put},
     Instruction,
     Opcode,
     Operand,

--- a/synthesizer/src/program/finalize/command/get.rs
+++ b/synthesizer/src/program/finalize/command/get.rs
@@ -14,35 +14,35 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, Opcode, Operand, ProgramStorage, ProgramStore, Stack};
+use crate::{Load as LoadTrait, Opcode, Operand, ProgramStorage, ProgramStore, Stack, Store};
 use console::{
     network::prelude::*,
-    program::{Identifier, Value},
+    program::{Identifier, Register, Value},
 };
 
-/// A store command, e.g. `store r1 into mapping[r0];`
-/// Stores the `value` operand into the `key` entry in `mapping`.
+/// A get command, e.g. `get accounts[r0] into r1;`.
+/// Gets the value stored at `operand` in `mapping` and stores the result in`destination`.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Store<N: Network> {
+pub struct Get<N: Network> {
     /// The mapping name.
     mapping: Identifier<N>,
     /// The key to access the mapping.
     key: Operand<N>,
-    /// The value to be stored.
-    value: Operand<N>,
+    /// The destination register.
+    destination: Register<N>,
 }
 
-impl<N: Network> Store<N> {
+impl<N: Network> Get<N> {
     /// Returns the opcode.
     #[inline]
     pub const fn opcode() -> Opcode {
-        Opcode::Command("store")
+        Opcode::Command("get")
     }
 
     /// Returns the operands in the operation.
     #[inline]
     pub fn operands(&self) -> Vec<Operand<N>> {
-        vec![self.value.clone(), self.key.clone()]
+        vec![self.key.clone()]
     }
 
     /// Returns the mapping name.
@@ -57,40 +57,46 @@ impl<N: Network> Store<N> {
         &self.key
     }
 
-    /// Returns the operand containing the value.
+    /// Returns the destination register.
     #[inline]
-    pub const fn value(&self) -> &Operand<N> {
-        &self.value
+    pub const fn destination(&self) -> &Register<N> {
+        &self.destination
     }
 }
 
-impl<N: Network> Store<N> {
+impl<N: Network> Get<N> {
     /// Evaluates the command.
     #[inline]
     pub fn evaluate_finalize<P: ProgramStorage<N>>(
         &self,
         stack: &Stack<N>,
         store: &ProgramStore<N, P>,
-        registers: &mut impl Load<N>,
+        registers: &mut (impl LoadTrait<N> + Store<N>),
     ) -> Result<()> {
         // Ensure the mapping exists in storage.
         if !store.contains_mapping(stack.program_id(), &self.mapping)? {
             bail!("Mapping '{}/{}' does not exist in storage", stack.program_id(), self.mapping);
         }
 
-        // Load the key operand as a plaintext.
+        // Load the operand as a plaintext.
         let key = registers.load_plaintext(stack, &self.key)?;
-        // Load the value operand as a plaintext.
-        let value = Value::Plaintext(registers.load_plaintext(stack, &self.value)?);
 
-        // Update the value in storage.
-        store.update_key_value(stack.program_id(), &self.mapping, key, value)?;
+        // Retrieve the value from storage as a literal.
+        let value = match store.get_value(stack.program_id(), &self.mapping, &key)? {
+            Some(Value::Plaintext(plaintext)) => Value::Plaintext(plaintext),
+            Some(Value::Record(..)) => bail!("Cannot 'get' a 'record'"),
+            // If a key does not exist, then bail.
+            None => bail!("Key '{}' does not exist in mapping '{}/{}'", key, stack.program_id(), self.mapping),
+        };
+
+        // Assign the value to the destination register.
+        registers.store(stack, &self.destination, value)?;
 
         Ok(())
     }
 }
 
-impl<N: Network> Parser for Store<N> {
+impl<N: Network> Parser for Get<N> {
     /// Parses a string into an operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
@@ -98,16 +104,6 @@ impl<N: Network> Parser for Store<N> {
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
-
-        // Parse the value operand from the string.
-        let (string, value) = Operand::parse(string)?;
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
-
-        // Parse the "into" keyword from the string.
-        let (string, _) = tag("into")(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
 
@@ -123,16 +119,26 @@ impl<N: Network> Parser for Store<N> {
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "]" from the string.
         let (string, _) = tag("]")(string)?;
+
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "into" keyword from the string.
+        let (string, _) = tag("into")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the destination register from the string.
+        let (string, destination) = Register::parse(string)?;
+
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the ";" from the string.
         let (string, _) = tag(";")(string)?;
 
-        Ok((string, Self { mapping, key, value }))
+        Ok((string, Self { mapping, key, destination }))
     }
 }
 
-impl<N: Network> FromStr for Store<N> {
+impl<N: Network> FromStr for Get<N> {
     type Err = Error;
 
     /// Parses a string into the command.
@@ -150,48 +156,48 @@ impl<N: Network> FromStr for Store<N> {
     }
 }
 
-impl<N: Network> Debug for Store<N> {
+impl<N: Network> Debug for Get<N> {
     /// Prints the command as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<N: Network> Display for Store<N> {
+impl<N: Network> Display for Get<N> {
     /// Prints the command to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Print the command.
         write!(f, "{} ", Self::opcode())?;
-        // Print the value operand.
-        write!(f, "{} into ", self.value)?;
         // Print the mapping and key operand.
-        write!(f, "{}[{}];", self.mapping, self.key)
+        write!(f, "{}[{}] into ", self.mapping, self.key)?;
+        // Print the destination register.
+        write!(f, "{};", self.destination)
     }
 }
 
-impl<N: Network> FromBytes for Store<N> {
+impl<N: Network> FromBytes for Get<N> {
     /// Reads the command from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the mapping name.
         let mapping = Identifier::read_le(&mut reader)?;
         // Read the key operand.
         let key = Operand::read_le(&mut reader)?;
-        // Read the value operand.
-        let value = Operand::read_le(&mut reader)?;
+        // Read the destination register.
+        let destination = Register::read_le(&mut reader)?;
         // Return the command.
-        Ok(Self { mapping, key, value })
+        Ok(Self { mapping, key, destination })
     }
 }
 
-impl<N: Network> ToBytes for Store<N> {
+impl<N: Network> ToBytes for Get<N> {
     /// Writes the operation to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the mapping name.
         self.mapping.write_le(&mut writer)?;
         // Write the key operand.
         self.key.write_le(&mut writer)?;
-        // Write the value operand.
-        self.value.write_le(&mut writer)
+        // Write the destination register.
+        self.destination.write_le(&mut writer)
     }
 }
 
@@ -204,11 +210,11 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, store) = Store::<CurrentNetwork>::parse("store r0 into account[r1];").unwrap();
+        let (string, get) = Get::<CurrentNetwork>::parse("get account[r0] into r1;").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(store.mapping, Identifier::from_str("account").unwrap());
-        assert_eq!(store.operands().len(), 2, "The number of operands is incorrect");
-        assert_eq!(store.value, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
-        assert_eq!(store.key, Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(get.mapping, Identifier::from_str("account").unwrap());
+        assert_eq!(get.operands().len(), 1, "The number of operands is incorrect");
+        assert_eq!(get.key, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+        assert_eq!(get.destination, Register::Locator(1), "The second operand is incorrect");
     }
 }

--- a/synthesizer/src/program/finalize/command/get_or.rs
+++ b/synthesizer/src/program/finalize/command/get_or.rs
@@ -20,29 +20,31 @@ use console::{
     program::{Identifier, Register, Value},
 };
 
-/// A load command, e.g. `load accounts[r0] into r1;`.
-/// Loads the value stored at `operand` in `mapping` into `destination`.
+/// A get command with a default value in case of failure, e.g. `get_or accounts[r0] r1 into r2;`.
+/// Gets the value stored at `operand` in `mapping` and stores the result in `destination`, using `default` if the entry does not exist.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Load<N: Network> {
+pub struct GetOr<N: Network> {
     /// The mapping name.
     mapping: Identifier<N>,
     /// The key to access the mapping.
     key: Operand<N>,
+    /// The default value.
+    default: Operand<N>,
     /// The destination register.
     destination: Register<N>,
 }
 
-impl<N: Network> Load<N> {
+impl<N: Network> GetOr<N> {
     /// Returns the opcode.
     #[inline]
     pub const fn opcode() -> Opcode {
-        Opcode::Command("load")
+        Opcode::Command("get_or")
     }
 
     /// Returns the operands in the operation.
     #[inline]
     pub fn operands(&self) -> Vec<Operand<N>> {
-        vec![self.key.clone()]
+        vec![self.key.clone(), self.default.clone()]
     }
 
     /// Returns the mapping name.
@@ -57,6 +59,12 @@ impl<N: Network> Load<N> {
         &self.key
     }
 
+    /// Returns the default value.
+    #[inline]
+    pub const fn default(&self) -> &Operand<N> {
+        &self.default
+    }
+
     /// Returns the destination register.
     #[inline]
     pub const fn destination(&self) -> &Register<N> {
@@ -64,7 +72,7 @@ impl<N: Network> Load<N> {
     }
 }
 
-impl<N: Network> Load<N> {
+impl<N: Network> GetOr<N> {
     /// Evaluates the command.
     #[inline]
     pub fn evaluate_finalize<P: ProgramStorage<N>>(
@@ -84,9 +92,9 @@ impl<N: Network> Load<N> {
         // Retrieve the value from storage as a literal.
         let value = match store.get_value(stack.program_id(), &self.mapping, &key)? {
             Some(Value::Plaintext(plaintext)) => Value::Plaintext(plaintext),
-            Some(Value::Record(..)) => bail!("Cannot 'load' a 'record'"),
-            // If a key does not exist, then bail.
-            None => bail!("Key '{}' does not exist in mapping '{}/{}'", key, stack.program_id(), self.mapping),
+            Some(Value::Record(..)) => bail!("Cannot 'get_or' a 'record'"),
+            // If a key does not exist, then use the default value.
+            None => Value::Plaintext(registers.load_plaintext(stack, &self.default)?),
         };
 
         // Assign the value to the destination register.
@@ -96,7 +104,7 @@ impl<N: Network> Load<N> {
     }
 }
 
-impl<N: Network> Parser for Load<N> {
+impl<N: Network> Parser for GetOr<N> {
     /// Parses a string into an operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
@@ -119,6 +127,10 @@ impl<N: Network> Parser for Load<N> {
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "]" from the string.
         let (string, _) = tag("]")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the default value from the string.
+        let (string, default) = Operand::parse(string)?;
 
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
@@ -134,11 +146,11 @@ impl<N: Network> Parser for Load<N> {
         // Parse the ";" from the string.
         let (string, _) = tag(";")(string)?;
 
-        Ok((string, Self { mapping, key, destination }))
+        Ok((string, Self { mapping, key, default, destination }))
     }
 }
 
-impl<N: Network> FromStr for Load<N> {
+impl<N: Network> FromStr for GetOr<N> {
     type Err = Error;
 
     /// Parses a string into the command.
@@ -156,46 +168,50 @@ impl<N: Network> FromStr for Load<N> {
     }
 }
 
-impl<N: Network> Debug for Load<N> {
+impl<N: Network> Debug for GetOr<N> {
     /// Prints the command as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<N: Network> Display for Load<N> {
+impl<N: Network> Display for GetOr<N> {
     /// Prints the command to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Print the command.
         write!(f, "{} ", Self::opcode())?;
         // Print the mapping and key operand.
-        write!(f, "{}[{}] into ", self.mapping, self.key)?;
+        write!(f, "{}[{}] {} into ", self.mapping, self.key, self.default)?;
         // Print the destination register.
         write!(f, "{};", self.destination)
     }
 }
 
-impl<N: Network> FromBytes for Load<N> {
+impl<N: Network> FromBytes for GetOr<N> {
     /// Reads the command from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the mapping name.
         let mapping = Identifier::read_le(&mut reader)?;
         // Read the key operand.
         let key = Operand::read_le(&mut reader)?;
+        // Read the default value.
+        let default = Operand::read_le(&mut reader)?;
         // Read the destination register.
         let destination = Register::read_le(&mut reader)?;
         // Return the command.
-        Ok(Self { mapping, key, destination })
+        Ok(Self { mapping, key, default, destination })
     }
 }
 
-impl<N: Network> ToBytes for Load<N> {
+impl<N: Network> ToBytes for GetOr<N> {
     /// Writes the operation to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the mapping name.
         self.mapping.write_le(&mut writer)?;
         // Write the key operand.
         self.key.write_le(&mut writer)?;
+        // Write the default value.
+        self.default.write_le(&mut writer)?;
         // Write the destination register.
         self.destination.write_le(&mut writer)
     }
@@ -210,11 +226,12 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, load) = Load::<CurrentNetwork>::parse("load account[r0] into r1;").unwrap();
+        let (string, get_or) = GetOr::<CurrentNetwork>::parse("get_or account[r0] r1 into r2;").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(load.mapping, Identifier::from_str("account").unwrap());
-        assert_eq!(load.operands().len(), 1, "The number of operands is incorrect");
-        assert_eq!(load.key, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
-        assert_eq!(load.destination, Register::Locator(1), "The second operand is incorrect");
+        assert_eq!(get_or.mapping, Identifier::from_str("account").unwrap());
+        assert_eq!(get_or.operands().len(), 2, "The number of operands is incorrect");
+        assert_eq!(get_or.key, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+        assert_eq!(get_or.default, Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(get_or.destination, Register::Locator(2), "The second operand is incorrect");
     }
 }

--- a/synthesizer/src/program/finalize/command/mod.rs
+++ b/synthesizer/src/program/finalize/command/mod.rs
@@ -17,14 +17,14 @@
 mod finalize;
 pub use finalize::*;
 
-mod load;
-pub use load::*;
+mod get;
+pub use get::*;
 
-mod load_or;
-pub use load_or::*;
+mod get_or;
+pub use get_or::*;
 
-mod store;
-pub use store::*;
+mod set;
+pub use set::*;
 
 use crate::{program::Instruction, FinalizeRegisters, ProgramStorage, ProgramStore, Stack};
 use console::network::prelude::*;
@@ -33,12 +33,12 @@ use console::network::prelude::*;
 pub enum Command<N: Network> {
     /// Evaluates the instruction.
     Instruction(Instruction<N>),
-    /// Loads the value stored at the `key` operand in `mapping` into `destination`.
-    Load(Load<N>),
-    /// Loads the value stored at the `key` operand in `mapping` into `destination`, using `default` if the key is not present.
-    LoadDefault(LoadOr<N>),
-    /// Stores the `value` operand into the `key` entry in `mapping`.
-    Store(Store<N>),
+    /// Gets the value stored at the `key` operand in `mapping` and stores the result into `destination`.
+    Get(Get<N>),
+    /// Gets the value stored at the `key` operand in `mapping` and stores the result into `destination`. The instruction uses `default` if the key is not present.
+    GetOr(GetOr<N>),
+    /// Sets the value stored at the `key` operand in the `mapping` to `value`.
+    Set(Set<N>),
 }
 
 impl<N: Network> Command<N> {
@@ -52,9 +52,9 @@ impl<N: Network> Command<N> {
     ) -> Result<()> {
         match self {
             Command::Instruction(instruction) => instruction.evaluate_finalize(stack, registers),
-            Command::Load(load) => load.evaluate_finalize(stack, program_store, registers),
-            Command::LoadDefault(load_or) => load_or.evaluate_finalize(stack, program_store, registers),
-            Command::Store(store) => store.evaluate_finalize(stack, program_store, registers),
+            Command::Get(get) => get.evaluate_finalize(stack, program_store, registers),
+            Command::GetOr(get_or) => get_or.evaluate_finalize(stack, program_store, registers),
+            Command::Set(set) => set.evaluate_finalize(stack, program_store, registers),
         }
     }
 }
@@ -67,12 +67,12 @@ impl<N: Network> FromBytes for Command<N> {
         match variant {
             // Read the instruction.
             0 => Ok(Self::Instruction(Instruction::read_le(&mut reader)?)),
-            // Read the load.
-            1 => Ok(Self::Load(Load::read_le(&mut reader)?)),
-            // Read the default load.
-            2 => Ok(Self::LoadDefault(LoadOr::read_le(&mut reader)?)),
-            // Read the store.
-            3 => Ok(Self::Store(Store::read_le(&mut reader)?)),
+            // Read the `get` operation.
+            1 => Ok(Self::Get(Get::read_le(&mut reader)?)),
+            // Read the defaulting `get` operation.
+            2 => Ok(Self::GetOr(GetOr::read_le(&mut reader)?)),
+            // Read the set operation.
+            3 => Ok(Self::Set(Set::read_le(&mut reader)?)),
             // Invalid variant.
             4.. => Err(error(format!("Invalid command variant: {variant}"))),
         }
@@ -89,23 +89,23 @@ impl<N: Network> ToBytes for Command<N> {
                 // Write the instruction.
                 instruction.write_le(&mut writer)
             }
-            Self::Load(load) => {
+            Self::Get(get) => {
                 // Write the variant.
                 1u8.write_le(&mut writer)?;
-                // Write the load.
-                load.write_le(&mut writer)
+                // Write the `get` operation.
+                get.write_le(&mut writer)
             }
-            Self::LoadDefault(load_or) => {
+            Self::GetOr(get_or) => {
                 // Write the variant.
                 2u8.write_le(&mut writer)?;
-                // Write the defaulting load.
-                load_or.write_le(&mut writer)
+                // Write the defaulting `get` operation.
+                get_or.write_le(&mut writer)
             }
-            Self::Store(store) => {
+            Self::Set(set) => {
                 // Write the variant.
                 3u8.write_le(&mut writer)?;
-                // Write the store.
-                store.write_le(&mut writer)
+                // Write the set.
+                set.write_le(&mut writer)
             }
         }
     }
@@ -118,9 +118,9 @@ impl<N: Network> Parser for Command<N> {
         // Parse the command.
         // Note that the order of the parsers is important.
         alt((
-            map(LoadOr::parse, |load_or| Self::LoadDefault(load_or)),
-            map(Load::parse, |load| Self::Load(load)),
-            map(Store::parse, |store| Self::Store(store)),
+            map(GetOr::parse, |get_or| Self::GetOr(get_or)),
+            map(Get::parse, |get| Self::Get(get)),
+            map(Set::parse, |set| Self::Set(set)),
             map(Instruction::parse, |instruction| Self::Instruction(instruction)),
         ))(string)
     }
@@ -156,9 +156,9 @@ impl<N: Network> Display for Command<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::Instruction(instruction) => Display::fmt(instruction, f),
-            Self::Load(load) => Display::fmt(load, f),
-            Self::LoadDefault(load_or) => Display::fmt(load_or, f),
-            Self::Store(store) => Display::fmt(store, f),
+            Self::Get(get) => Display::fmt(get, f),
+            Self::GetOr(get_or) => Display::fmt(get_or, f),
+            Self::Set(set) => Display::fmt(set, f),
         }
     }
 }
@@ -186,20 +186,20 @@ mod tests {
         let expected = "increment object[r0] by r1;";
         Command::<CurrentNetwork>::parse(expected).unwrap_err();
 
-        // Load
-        let expected = "load object[r0] into r1;";
+        // Get
+        let expected = "get object[r0] into r1;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
         let bytes = command.to_bytes_le().unwrap();
         assert_eq!(command, Command::from_bytes_le(&bytes).unwrap());
 
-        // Load default
-        let expected = "load_or object[r0] r1 into r2;";
+        // Defaulting Get
+        let expected = "get_or object[r0] r1 into r2;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
         let bytes = command.to_bytes_le().unwrap();
         assert_eq!(command, Command::from_bytes_le(&bytes).unwrap());
 
-        // Store
-        let expected = "store r0 into object[r1];";
+        // Set
+        let expected = "set r0 into object[r1];";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
         let bytes = command.to_bytes_le().unwrap();
         assert_eq!(command, Command::from_bytes_le(&bytes).unwrap());
@@ -221,22 +221,22 @@ mod tests {
         let expected = "increment object[r0] by r1;";
         Command::<CurrentNetwork>::parse(expected).unwrap_err();
 
-        // Load
-        let expected = "load object[r0] into r1;";
+        // Get
+        let expected = "get object[r0] into r1;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
-        assert_eq!(Command::Load(Load::from_str(expected).unwrap()), command);
+        assert_eq!(Command::Get(Get::from_str(expected).unwrap()), command);
         assert_eq!(expected, command.to_string());
 
-        // Load default
-        let expected = "load_or object[r0] r1 into r2;";
+        // Defaulting Get
+        let expected = "get_or object[r0] r1 into r2;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
-        assert_eq!(Command::LoadDefault(LoadOr::from_str(expected).unwrap()), command);
+        assert_eq!(Command::GetOr(GetOr::from_str(expected).unwrap()), command);
         assert_eq!(expected, command.to_string());
 
-        // Store
-        let expected = "store r0 into object[r1];";
+        // Set
+        let expected = "set r0 into object[r1];";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
-        assert_eq!(Command::Store(Store::from_str(expected).unwrap()), command);
+        assert_eq!(Command::Set(Set::from_str(expected).unwrap()), command);
         assert_eq!(expected, command.to_string());
     }
 }

--- a/synthesizer/src/program/finalize/command/put.rs
+++ b/synthesizer/src/program/finalize/command/put.rs
@@ -20,23 +20,23 @@ use console::{
     program::{Identifier, Value},
 };
 
-/// A set command, e.g. `set r1 into mapping[r0];`
-/// Sets the `key` entry as `value` in `mapping`.
+/// A put command, e.g. `put r1 into mapping[r0];`
+/// Puts the `key` entry as `value` in `mapping`.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Set<N: Network> {
+pub struct Put<N: Network> {
     /// The mapping name.
     mapping: Identifier<N>,
     /// The key to access the mapping.
     key: Operand<N>,
-    /// The value to be set.
+    /// The value to be put.
     value: Operand<N>,
 }
 
-impl<N: Network> Set<N> {
+impl<N: Network> Put<N> {
     /// Returns the opcode.
     #[inline]
     pub const fn opcode() -> Opcode {
-        Opcode::Command("set")
+        Opcode::Command("put")
     }
 
     /// Returns the operands in the operation.
@@ -64,7 +64,7 @@ impl<N: Network> Set<N> {
     }
 }
 
-impl<N: Network> Set<N> {
+impl<N: Network> Put<N> {
     /// Evaluates the command.
     #[inline]
     pub fn evaluate_finalize<P: ProgramStorage<N>>(
@@ -90,7 +90,7 @@ impl<N: Network> Set<N> {
     }
 }
 
-impl<N: Network> Parser for Set<N> {
+impl<N: Network> Parser for Put<N> {
     /// Parses a string into an operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
@@ -132,7 +132,7 @@ impl<N: Network> Parser for Set<N> {
     }
 }
 
-impl<N: Network> FromStr for Set<N> {
+impl<N: Network> FromStr for Put<N> {
     type Err = Error;
 
     /// Parses a string into the command.
@@ -150,14 +150,14 @@ impl<N: Network> FromStr for Set<N> {
     }
 }
 
-impl<N: Network> Debug for Set<N> {
+impl<N: Network> Debug for Put<N> {
     /// Prints the command as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<N: Network> Display for Set<N> {
+impl<N: Network> Display for Put<N> {
     /// Prints the command to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Print the command.
@@ -169,7 +169,7 @@ impl<N: Network> Display for Set<N> {
     }
 }
 
-impl<N: Network> FromBytes for Set<N> {
+impl<N: Network> FromBytes for Put<N> {
     /// Reads the command from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the mapping name.
@@ -183,7 +183,7 @@ impl<N: Network> FromBytes for Set<N> {
     }
 }
 
-impl<N: Network> ToBytes for Set<N> {
+impl<N: Network> ToBytes for Put<N> {
     /// Writes the operation to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the mapping name.
@@ -204,11 +204,11 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, set) = Set::<CurrentNetwork>::parse("set r0 into account[r1];").unwrap();
+        let (string, put) = Put::<CurrentNetwork>::parse("put r0 into account[r1];").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(set.mapping, Identifier::from_str("account").unwrap());
-        assert_eq!(set.operands().len(), 2, "The number of operands is incorrect");
-        assert_eq!(set.value, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
-        assert_eq!(set.key, Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(put.mapping, Identifier::from_str("account").unwrap());
+        assert_eq!(put.operands().len(), 2, "The number of operands is incorrect");
+        assert_eq!(put.value, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+        assert_eq!(put.key, Operand::Register(Register::Locator(1)), "The second operand is incorrect");
     }
 }

--- a/synthesizer/src/program/finalize/mod.rs
+++ b/synthesizer/src/program/finalize/mod.rs
@@ -141,14 +141,14 @@ impl<N: Network> Finalize<N> {
                     ensure!(matches!(register, Register::Locator(..)), "Destination register must be a locator");
                 }
             }
-            Command::Load(load) => {
+            Command::Get(get) => {
                 // Ensure the destination register is a locator.
-                ensure!(matches!(load.destination(), Register::Locator(..)), "Destination register must be a locator");
+                ensure!(matches!(get.destination(), Register::Locator(..)), "Destination register must be a locator");
             }
-            Command::LoadDefault(load_or) => {
+            Command::GetOr(get_or) => {
                 // Ensure the destination register is a locator.
                 ensure!(
-                    matches!(load_or.destination(), Register::Locator(..)),
+                    matches!(get_or.destination(), Register::Locator(..)),
                     "Destination register must be a locator"
                 );
             }

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -219,8 +219,8 @@ finalize mint_public:
     get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Set `r3` into `account[r0]`.
-    set r3 into account[r0];
+    // Put `r3` into `account[r0]`.
+    put r3 into account[r0];
 ",
         )
         .unwrap()

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -266,9 +266,9 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
-    store r3 into account[r0];
+    set r3 into account[r0];
     ",
         )
         .unwrap()

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -268,7 +268,7 @@ finalize compute:
     input r1 as u64.public;
     get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
-    set r3 into account[r0];
+    put r3 into account[r0];
     ",
         )
         .unwrap()

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -215,12 +215,12 @@ finalize mint_public:
     // Input the token amount.
     input r1 as u64.public;
 
-    // Load `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    load_or account[r0] 0u64 into r2;
+    // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
+    get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Store `r3` into `account[r0]`.
-    store r3 into account[r0];
+    // Set `r3` into `account[r0]`.
+    set r3 into account[r0];
 ",
         )
         .unwrap()

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -31,7 +31,7 @@ enum Variant {
     IsNeq,
 }
 
-/// Computes an equality operation on two operands, and stored the outcome in `destination`.
+/// Computes an equality operation on two operands, and stores the outcome in `destination`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct IsInstruction<N: Network, const VARIANT: u8> {
     /// The operands.


### PR DESCRIPTION
This PR, renames `load` and `store` instructions to `get` and `put` respectively.
The motivation is to reserve `load` and `store`for array operations.

Overloading loads/stores for array and mapping operations can minimize the instructions (but not by much).
However, this comes at the expense of clarity. 
A user is forced to disambiguate between a load/store on a mapping and one on an array.
Furthermore, loads/stores on mappings are not allowed in the off-chain component of the program. This requires a context-dependent check on each use of load/store.