### PR TITLE
[Design] Use canonical identifiers for opcodes.

### DIFF
--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -930,7 +930,7 @@ closure execute:
 closure check_not_equal:
     input r0 as field;
     input r1 as field;
-    assert.neq r0 r1;
+    assert_neq r0 r1;
 
 function compute:
     input r0 as field.private;
@@ -1056,7 +1056,7 @@ function produce_magic_number:
 
 function check_magic_number:
     input r0 as u64.private;
-    assert.eq r0 1234u64;
+    assert_eq r0 1234u64;
 
 function noop:
 

--- a/synthesizer/src/process/stack/finalize_types/initialize.rs
+++ b/synthesizer/src/process/stack/finalize_types/initialize.rs
@@ -363,16 +363,16 @@ impl<N: Network> FinalizeTypes<N> {
             }
             Opcode::Assert(opcode) => {
                 // Ensure the instruction belongs to the defined set.
-                if !["assert.eq", "assert.neq"].contains(&opcode) {
+                if !["assert_eq", "assert_neq"].contains(&opcode) {
                     bail!("Instruction '{instruction}' is not for opcode '{opcode}'.");
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "assert.eq" => ensure!(
+                    "assert_eq" => ensure!(
                         matches!(instruction, Instruction::AssertEq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "assert.neq" => ensure!(
+                    "assert_neq" => ensure!(
                         matches!(instruction, Instruction::AssertNeq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
@@ -432,12 +432,12 @@ impl<N: Network> FinalizeTypes<N> {
             Opcode::Commit(opcode) => {
                 // Ensure the instruction belongs to the defined set.
                 if ![
-                    "commit.bhp256",
-                    "commit.bhp512",
-                    "commit.bhp768",
-                    "commit.bhp1024",
-                    "commit.ped64",
-                    "commit.ped128",
+                    "commit_bhp256",
+                    "commit_bhp512",
+                    "commit_bhp768",
+                    "commit_bhp1024",
+                    "commit_ped64",
+                    "commit_ped128",
                 ]
                 .contains(&opcode)
                 {
@@ -445,27 +445,27 @@ impl<N: Network> FinalizeTypes<N> {
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "commit.bhp256" => ensure!(
+                    "commit_bhp256" => ensure!(
                         matches!(instruction, Instruction::CommitBHP256(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.bhp512" => ensure!(
+                    "commit_bhp512" => ensure!(
                         matches!(instruction, Instruction::CommitBHP512(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.bhp768" => ensure!(
+                    "commit_bhp768" => ensure!(
                         matches!(instruction, Instruction::CommitBHP768(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.bhp1024" => ensure!(
+                    "commit_bhp1024" => ensure!(
                         matches!(instruction, Instruction::CommitBHP1024(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.ped64" => ensure!(
+                    "commit_ped64" => ensure!(
                         matches!(instruction, Instruction::CommitPED64(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.ped128" => ensure!(
+                    "commit_ped128" => ensure!(
                         matches!(instruction, Instruction::CommitPED128(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
@@ -478,15 +478,15 @@ impl<N: Network> FinalizeTypes<N> {
             Opcode::Hash(opcode) => {
                 // Ensure the instruction belongs to the defined set.
                 if ![
-                    "hash.bhp256",
-                    "hash.bhp512",
-                    "hash.bhp768",
-                    "hash.bhp1024",
-                    "hash.ped64",
-                    "hash.ped128",
-                    "hash.psd2",
-                    "hash.psd4",
-                    "hash.psd8",
+                    "hash_bhp256",
+                    "hash_bhp512",
+                    "hash_bhp768",
+                    "hash_bhp1024",
+                    "hash_ped64",
+                    "hash_ped128",
+                    "hash_psd2",
+                    "hash_psd4",
+                    "hash_psd8",
                 ]
                 .contains(&opcode)
                 {
@@ -494,39 +494,39 @@ impl<N: Network> FinalizeTypes<N> {
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "hash.bhp256" => ensure!(
+                    "hash_bhp256" => ensure!(
                         matches!(instruction, Instruction::HashBHP256(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.bhp512" => ensure!(
+                    "hash_bhp512" => ensure!(
                         matches!(instruction, Instruction::HashBHP512(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.bhp768" => ensure!(
+                    "hash_bhp768" => ensure!(
                         matches!(instruction, Instruction::HashBHP768(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.bhp1024" => ensure!(
+                    "hash_bhp1024" => ensure!(
                         matches!(instruction, Instruction::HashBHP1024(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.ped64" => ensure!(
+                    "hash_ped64" => ensure!(
                         matches!(instruction, Instruction::HashPED64(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.ped128" => ensure!(
+                    "hash_ped128" => ensure!(
                         matches!(instruction, Instruction::HashPED128(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.psd2" => ensure!(
+                    "hash_psd2" => ensure!(
                         matches!(instruction, Instruction::HashPSD2(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.psd4" => ensure!(
+                    "hash_psd4" => ensure!(
                         matches!(instruction, Instruction::HashPSD4(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.psd8" => ensure!(
+                    "hash_psd8" => ensure!(
                         matches!(instruction, Instruction::HashPSD8(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
@@ -535,16 +535,16 @@ impl<N: Network> FinalizeTypes<N> {
             }
             Opcode::Is(opcode) => {
                 // Ensure the instruction belongs to the defined set.
-                if !["is.eq", "is.neq"].contains(&opcode) {
+                if !["is_eq", "is_neq"].contains(&opcode) {
                     bail!("Instruction '{instruction}' is not for opcode '{opcode}'.");
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "is.eq" => ensure!(
+                    "is_eq" => ensure!(
                         matches!(instruction, Instruction::IsEq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "is.neq" => ensure!(
+                    "is_neq" => ensure!(
                         matches!(instruction, Instruction::IsNeq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -324,16 +324,16 @@ impl<N: Network> RegisterTypes<N> {
             }
             Opcode::Assert(opcode) => {
                 // Ensure the instruction belongs to the defined set.
-                if !["assert.eq", "assert.neq"].contains(&opcode) {
+                if !["assert_eq", "assert_neq"].contains(&opcode) {
                     bail!("Instruction '{instruction}' is not for opcode '{opcode}'.");
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "assert.eq" => ensure!(
+                    "assert_eq" => ensure!(
                         matches!(instruction, Instruction::AssertEq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "assert.neq" => ensure!(
+                    "assert_neq" => ensure!(
                         matches!(instruction, Instruction::AssertNeq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
@@ -442,12 +442,12 @@ impl<N: Network> RegisterTypes<N> {
             Opcode::Commit(opcode) => {
                 // Ensure the instruction belongs to the defined set.
                 if ![
-                    "commit.bhp256",
-                    "commit.bhp512",
-                    "commit.bhp768",
-                    "commit.bhp1024",
-                    "commit.ped64",
-                    "commit.ped128",
+                    "commit_bhp256",
+                    "commit_bhp512",
+                    "commit_bhp768",
+                    "commit_bhp1024",
+                    "commit_ped64",
+                    "commit_ped128",
                 ]
                 .contains(&opcode)
                 {
@@ -455,27 +455,27 @@ impl<N: Network> RegisterTypes<N> {
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "commit.bhp256" => ensure!(
+                    "commit_bhp256" => ensure!(
                         matches!(instruction, Instruction::CommitBHP256(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.bhp512" => ensure!(
+                    "commit_bhp512" => ensure!(
                         matches!(instruction, Instruction::CommitBHP512(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.bhp768" => ensure!(
+                    "commit_bhp768" => ensure!(
                         matches!(instruction, Instruction::CommitBHP768(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.bhp1024" => ensure!(
+                    "commit_bhp1024" => ensure!(
                         matches!(instruction, Instruction::CommitBHP1024(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.ped64" => ensure!(
+                    "commit_ped64" => ensure!(
                         matches!(instruction, Instruction::CommitPED64(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "commit.ped128" => ensure!(
+                    "commit_ped128" => ensure!(
                         matches!(instruction, Instruction::CommitPED128(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
@@ -492,15 +492,15 @@ impl<N: Network> RegisterTypes<N> {
             Opcode::Hash(opcode) => {
                 // Ensure the instruction belongs to the defined set.
                 if ![
-                    "hash.bhp256",
-                    "hash.bhp512",
-                    "hash.bhp768",
-                    "hash.bhp1024",
-                    "hash.ped64",
-                    "hash.ped128",
-                    "hash.psd2",
-                    "hash.psd4",
-                    "hash.psd8",
+                    "hash_bhp256",
+                    "hash_bhp512",
+                    "hash_bhp768",
+                    "hash_bhp1024",
+                    "hash_ped64",
+                    "hash_ped128",
+                    "hash_psd2",
+                    "hash_psd4",
+                    "hash_psd8",
                 ]
                 .contains(&opcode)
                 {
@@ -508,39 +508,39 @@ impl<N: Network> RegisterTypes<N> {
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "hash.bhp256" => ensure!(
+                    "hash_bhp256" => ensure!(
                         matches!(instruction, Instruction::HashBHP256(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.bhp512" => ensure!(
+                    "hash_bhp512" => ensure!(
                         matches!(instruction, Instruction::HashBHP512(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.bhp768" => ensure!(
+                    "hash_bhp768" => ensure!(
                         matches!(instruction, Instruction::HashBHP768(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.bhp1024" => ensure!(
+                    "hash_bhp1024" => ensure!(
                         matches!(instruction, Instruction::HashBHP1024(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.ped64" => ensure!(
+                    "hash_ped64" => ensure!(
                         matches!(instruction, Instruction::HashPED64(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.ped128" => ensure!(
+                    "hash_ped128" => ensure!(
                         matches!(instruction, Instruction::HashPED128(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.psd2" => ensure!(
+                    "hash_psd2" => ensure!(
                         matches!(instruction, Instruction::HashPSD2(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.psd4" => ensure!(
+                    "hash_psd4" => ensure!(
                         matches!(instruction, Instruction::HashPSD4(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "hash.psd8" => ensure!(
+                    "hash_psd8" => ensure!(
                         matches!(instruction, Instruction::HashPSD8(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
@@ -549,16 +549,16 @@ impl<N: Network> RegisterTypes<N> {
             }
             Opcode::Is(opcode) => {
                 // Ensure the instruction belongs to the defined set.
-                if !["is.eq", "is.neq"].contains(&opcode) {
+                if !["is_eq", "is_neq"].contains(&opcode) {
                     bail!("Instruction '{instruction}' is not for opcode '{opcode}'.");
                 }
                 // Ensure the instruction is the correct one.
                 match opcode {
-                    "is.eq" => ensure!(
+                    "is_eq" => ensure!(
                         matches!(instruction, Instruction::IsEq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),
-                    "is.neq" => ensure!(
+                    "is_neq" => ensure!(
                         matches!(instruction, Instruction::IsNeq(..)),
                         "Instruction '{instruction}' is not for opcode '{opcode}'."
                     ),

--- a/synthesizer/src/program/instruction/opcode/mod.rs
+++ b/synthesizer/src/program/instruction/opcode/mod.rs
@@ -27,13 +27,13 @@ pub enum Opcode {
     Cast,
     /// The opcode is for a finalize command (i.e. `increment`).
     Command(&'static str),
-    /// The opcode is for a commit operation (i.e. `commit.psd4`).
+    /// The opcode is for a commit operation (i.e. `commit_psd4`).
     Commit(&'static str),
     /// The opcode is for a finalize operation (i.e. `finalize`).
     Finalize(&'static str),
-    /// The opcode is for a hash operation (i.e. `hash.psd4`).
+    /// The opcode is for a hash operation (i.e. `hash_psd4`).
     Hash(&'static str),
-    /// The opcode for an 'is' operation (i.e. `is.eq`).
+    /// The opcode for an 'is' operation (i.e. `is_eq`).
     Is(&'static str),
     /// The opcode is for a literal operation (i.e. `add`).
     Literal(&'static str),

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -42,8 +42,8 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
     #[inline]
     pub const fn opcode() -> Opcode {
         match VARIANT {
-            0 => Opcode::Assert("assert.eq"),
-            1 => Opcode::Assert("assert.neq"),
+            0 => Opcode::Assert("assert_eq"),
+            1 => Opcode::Assert("assert_neq"),
             _ => panic!("Invalid 'assert' instruction opcode"),
         }
     }
@@ -605,13 +605,13 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, assert) = AssertEq::<CurrentNetwork>::parse("assert.eq r0 r1").unwrap();
+        let (string, assert) = AssertEq::<CurrentNetwork>::parse("assert_eq r0 r1").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(assert.operands.len(), 2, "The number of operands is incorrect");
         assert_eq!(assert.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");
         assert_eq!(assert.operands[1], Operand::Register(Register::Locator(1)), "The second operand is incorrect");
 
-        let (string, assert) = AssertNeq::<CurrentNetwork>::parse("assert.neq r0 r1").unwrap();
+        let (string, assert) = AssertNeq::<CurrentNetwork>::parse("assert_neq r0 r1").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(assert.operands.len(), 2, "The number of operands is incorrect");
         assert_eq!(assert.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -57,12 +57,12 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     #[inline]
     pub const fn opcode() -> Opcode {
         match VARIANT {
-            0 => Opcode::Commit("commit.bhp256"),
-            1 => Opcode::Commit("commit.bhp512"),
-            2 => Opcode::Commit("commit.bhp768"),
-            3 => Opcode::Commit("commit.bhp1024"),
-            4 => Opcode::Commit("commit.ped64"),
-            5 => Opcode::Commit("commit.ped128"),
+            0 => Opcode::Commit("commit_bhp256"),
+            1 => Opcode::Commit("commit_bhp512"),
+            2 => Opcode::Commit("commit_bhp768"),
+            3 => Opcode::Commit("commit_bhp1024"),
+            4 => Opcode::Commit("commit_ped64"),
+            5 => Opcode::Commit("commit_ped128"),
             _ => panic!("Invalid 'commit' instruction opcode"),
         }
     }
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, commit) = CommitBHP512::<CurrentNetwork>::parse("commit.bhp512 r0 r1 into r2").unwrap();
+        let (string, commit) = CommitBHP512::<CurrentNetwork>::parse("commit_bhp512 r0 r1 into r2").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(commit.operands.len(), 2, "The number of operands is incorrect");
         assert_eq!(commit.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -67,15 +67,15 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     #[inline]
     pub const fn opcode() -> Opcode {
         match VARIANT {
-            0 => Opcode::Hash("hash.bhp256"),
-            1 => Opcode::Hash("hash.bhp512"),
-            2 => Opcode::Hash("hash.bhp768"),
-            3 => Opcode::Hash("hash.bhp1024"),
-            4 => Opcode::Hash("hash.ped64"),
-            5 => Opcode::Hash("hash.ped128"),
-            6 => Opcode::Hash("hash.psd2"),
-            7 => Opcode::Hash("hash.psd4"),
-            8 => Opcode::Hash("hash.psd8"),
+            0 => Opcode::Hash("hash_bhp256"),
+            1 => Opcode::Hash("hash_bhp512"),
+            2 => Opcode::Hash("hash_bhp768"),
+            3 => Opcode::Hash("hash_bhp1024"),
+            4 => Opcode::Hash("hash_ped64"),
+            5 => Opcode::Hash("hash_ped128"),
+            6 => Opcode::Hash("hash_psd2"),
+            7 => Opcode::Hash("hash_psd4"),
+            8 => Opcode::Hash("hash_psd8"),
             _ => panic!("Invalid 'hash' instruction opcode"),
         }
     }
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, hash) = HashBHP512::<CurrentNetwork>::parse("hash.bhp512 r0 into r1").unwrap();
+        let (string, hash) = HashBHP512::<CurrentNetwork>::parse("hash_bhp512 r0 into r1").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(hash.operands.len(), 1, "The number of operands is incorrect");
         assert_eq!(hash.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -45,8 +45,8 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
     #[inline]
     pub const fn opcode() -> Opcode {
         match VARIANT {
-            0 => Opcode::Is("is.eq"),
-            1 => Opcode::Is("is.neq"),
+            0 => Opcode::Is("is_eq"),
+            1 => Opcode::Is("is_neq"),
             _ => panic!("Invalid 'is' instruction opcode"),
         }
     }
@@ -651,14 +651,14 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, is) = IsEq::<CurrentNetwork>::parse("is.eq r0 r1 into r2").unwrap();
+        let (string, is) = IsEq::<CurrentNetwork>::parse("is_eq r0 r1 into r2").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(is.operands.len(), 2, "The number of operands is incorrect");
         assert_eq!(is.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");
         assert_eq!(is.operands[1], Operand::Register(Register::Locator(1)), "The second operand is incorrect");
         assert_eq!(is.destination, Register::Locator(2), "The destination register is incorrect");
 
-        let (string, is) = IsNeq::<CurrentNetwork>::parse("is.neq r0 r1 into r2").unwrap();
+        let (string, is) = IsNeq::<CurrentNetwork>::parse("is_neq r0 r1 into r2").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(is.operands.len(), 2, "The number of operands is incorrect");
         assert_eq!(is.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");

--- a/synthesizer/src/program/instruction/operation/macros.rs
+++ b/synthesizer/src/program/instruction/operation/macros.rs
@@ -704,7 +704,7 @@ mod tests {
 
                     // Determine the number of iterations to run, based on the opcode.
                     let num_iterations: u64 = match *<$operation as $crate::Operation<_, _, _, 2>>::OPCODE {
-                        "pow" | "pow.w" => 10,
+                        "pow" | "pow_w" => 10,
                         _ => 100
                     };
 

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -73,7 +73,7 @@ crate::operation!(
 pub type AbsWrapped<N> = UnaryLiteral<N, AbsWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct AbsWrappedOperation<console::prelude::AbsWrapped, circuit::prelude::AbsWrapped, abs_wrapped, "abs.w"> {
+    pub struct AbsWrappedOperation<console::prelude::AbsWrapped, circuit::prelude::AbsWrapped, abs_wrapped, "abs_w"> {
         I8 => I8,
         I16 => I16,
         I32 => I32,
@@ -107,7 +107,7 @@ crate::operation!(
 pub type AddWrapped<N> = BinaryLiteral<N, AddWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct AddWrappedOperation<console::prelude::AddWrapped, circuit::prelude::AddWrapped, add_wrapped, "add.w"> {
+    pub struct AddWrappedOperation<console::prelude::AddWrapped, circuit::prelude::AddWrapped, add_wrapped, "add_w"> {
         (I8, I8) => I8,
         (I16, I16) => I16,
         (I32, I32) => I32,
@@ -164,7 +164,7 @@ crate::operation!(
 pub type DivWrapped<N> = BinaryLiteral<N, DivWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct DivWrappedOperation<console::prelude::DivWrapped, circuit::prelude::DivWrapped, div_wrapped, "div.w"> {
+    pub struct DivWrappedOperation<console::prelude::DivWrapped, circuit::prelude::DivWrapped, div_wrapped, "div_w"> {
         (I8, I8) => I8 ("ensure divide by zero halts"),
         (I16, I16) => I16 ("ensure divide by zero halts"),
         (I32, I32) => I32 ("ensure divide by zero halts"),
@@ -320,7 +320,7 @@ crate::operation!(
 pub type MulWrapped<N> = BinaryLiteral<N, MulWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct MulWrappedOperation<console::prelude::MulWrapped, circuit::prelude::MulWrapped, mul_wrapped, "mul.w"> {
+    pub struct MulWrappedOperation<console::prelude::MulWrapped, circuit::prelude::MulWrapped, mul_wrapped, "mul_w"> {
         (I8, I8) => I8,
         (I16, I16) => I16,
         (I32, I32) => I32,
@@ -448,7 +448,7 @@ crate::operation!(
 pub type PowWrapped<N> = BinaryLiteral<N, PowWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct PowWrappedOperation<console::prelude::PowWrapped, circuit::prelude::PowWrapped, pow_wrapped, "pow.w"> {
+    pub struct PowWrappedOperation<console::prelude::PowWrapped, circuit::prelude::PowWrapped, pow_wrapped, "pow_w"> {
         (I8, U8) => I8,
         (I8, U16) => I8,
         (I8, U32) => I8,
@@ -504,7 +504,7 @@ crate::operation!(
 pub type RemWrapped<N> = BinaryLiteral<N, RemWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct RemWrappedOperation<console::prelude::RemWrapped, circuit::prelude::RemWrapped, rem_wrapped, "rem.w"> {
+    pub struct RemWrappedOperation<console::prelude::RemWrapped, circuit::prelude::RemWrapped, rem_wrapped, "rem_w"> {
         (I8, I8) => I8 ("ensure divide by zero halts"),
         (I16, I16) => I16 ("ensure divide by zero halts"),
         (I32, I32) => I32 ("ensure divide by zero halts"),
@@ -560,7 +560,7 @@ crate::operation!(
 pub type ShlWrapped<N> = BinaryLiteral<N, ShlWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct ShlWrappedOperation<console::prelude::ShlWrapped, circuit::prelude::ShlWrapped, shl_wrapped, "shl.w"> {
+    pub struct ShlWrappedOperation<console::prelude::ShlWrapped, circuit::prelude::ShlWrapped, shl_wrapped, "shl_w"> {
         (I8, U8) => I8,
         (I8, U16) => I8,
         (I8, U32) => I8,
@@ -636,7 +636,7 @@ crate::operation!(
 pub type ShrWrapped<N> = BinaryLiteral<N, ShrWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct ShrWrappedOperation<console::prelude::ShrWrapped, circuit::prelude::ShrWrapped, shr_wrapped, "shr.w"> {
+    pub struct ShrWrappedOperation<console::prelude::ShrWrapped, circuit::prelude::ShrWrapped, shr_wrapped, "shr_w"> {
         (I8, U8) => I8,
         (I8, U16) => I8,
         (I8, U32) => I8,
@@ -713,7 +713,7 @@ crate::operation!(
 pub type SubWrapped<N> = BinaryLiteral<N, SubWrappedOperation<N>>;
 
 crate::operation!(
-    pub struct SubWrappedOperation<console::prelude::SubWrapped, circuit::prelude::SubWrapped, sub_wrapped, "sub.w"> {
+    pub struct SubWrappedOperation<console::prelude::SubWrapped, circuit::prelude::SubWrapped, sub_wrapped, "sub_w"> {
         (I8, I8) => I8,
         (I16, I16) => I16,
         (I32, I32) => I32,

--- a/vm/package/is_build_required.rs
+++ b/vm/package/is_build_required.rs
@@ -115,7 +115,7 @@ record token:
 
 function compute:
     input r0 as token.record;
-    add.w r0.token_amount r0.token_amount into r1;
+    add_w r0.token_amount r0.token_amount into r1;
     output r1 as u64.private;"
         )
     }


### PR DESCRIPTION
Currently, our opcodes use "dot" syntax to denote variants, e.g `add.w`.
This PR, renames opcodes such that each opcode is a canonical identifier (`[a-zA-Z][_a-zA-Z0-9]*`).
This simplifies the formal grammar, making it easier to support inline assembly in Leo.
While this changes the syntax for Aleo instructions, the difference between using `.` and `_` is minimal. We can also help users migrate existing programs with a script.

