### PR TITLE
Enable Insertion of Proving Keys from External Contexts

### DIFF
--- a/synthesizer/src/process/execute.rs
+++ b/synthesizer/src/process/execute.rs
@@ -85,7 +85,7 @@ impl<N: Network> Process<N> {
 
         // Ensure the inclusion proof is valid.
         if VERIFY_INCLUSION {
-            Inclusion::verify_execution(execution)?;
+            Inclusion::verify_execution(execution, None)?;
             lap!(timer, "Verify the inclusion proof");
         }
 

--- a/synthesizer/src/process/execute_fee.rs
+++ b/synthesizer/src/process/execute_fee.rs
@@ -137,7 +137,7 @@ impl<N: Network> Process<N> {
         ensure!(fee.fee() >= &0, "The fee must be zero or positive");
 
         // Ensure the inclusion proof is valid.
-        Inclusion::verify_fee(fee)?;
+        Inclusion::verify_fee(fee, None)?;
         lap!(timer, "Verify the inclusion proof");
 
         // Compute the x- and y-coordinate of `tpk`.

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -149,6 +149,25 @@ impl<N: Network> Process<N> {
         Ok(process)
     }
 
+    /// Initializes a new process without downloading the credits.aleo proving keys
+    #[inline]
+    pub fn load_offline() -> Result<Self> {
+        // Initialize the process.
+        let mut process = Self { universal_srs: Arc::new(UniversalSRS::load()?), stacks: IndexMap::new() };
+
+        // Initialize the 'credits.aleo' program so that a conflicting program named `credits.aleo` can't be added
+        let program = Program::credits()?;
+
+        // Compute the 'credits.aleo' program stack.
+        let stack = Stack::new(&process, &program)?;
+
+        // Add the stack to the process.
+        process.stacks.insert(*program.id(), stack);
+
+        // Return the process.
+        Ok(process)
+    }
+
     /// Initializes a new process with a cache of previously used keys. This version is suitable for tests
     /// (which often use nested loops that keep reusing those), as their deserialization is slow.
     #[cfg(test)]

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -44,17 +44,17 @@ pub enum Query<N: Network, B: BlockStorage<N>> {
     /// Base URL of the node to fetch inclusion proof data
     REST(String),
     /// Inclusion proof data fetched from an outside environment
-    External(N::StateRoot, HashMap<Field<N>, StatePath<N>>),
+    LOCAL(N::StateRoot, HashMap<Field<N>, StatePath<N>>),
 }
 
 impl<N: Network, B: BlockStorage<N>> TryFrom<(&str, &str)> for Query<N, B> {
     type Error = anyhow::Error;
 
     fn try_from(inclusion_data: (&str, &str)) -> std::result::Result<Self, Self::Error> {
-        let (state_root, commitments) = inclusion_data;
-        Ok(Self::External(
+        let (state_root, commitment_map) = inclusion_data;
+        Ok(Self::LOCAL(
             N::StateRoot::from_str(state_root).map_err(|_| anyhow!("Invalid state root"))?,
-            serde_json::from_str(commitments).map_err(|_| anyhow!("Invalid state path"))?,
+            serde_json::from_str(commitment_map).map_err(|_| anyhow!("Invalid state path"))?,
         ))
     }
 }
@@ -62,7 +62,7 @@ impl<N: Network, B: BlockStorage<N>> TryFrom<(&str, &str)> for Query<N, B> {
 impl<N: Network, B: BlockStorage<N>> From<(N::StateRoot, HashMap<Field<N>, StatePath<N>>)> for Query<N, B> {
     fn from(inclusion_data: (N::StateRoot, HashMap<Field<N>, StatePath<N>>)) -> Self {
         let (state_root, commitments) = inclusion_data;
-        Self::External(state_root, commitments)
+        Self::LOCAL(state_root, commitments)
     }
 }
 
@@ -121,7 +121,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 3 => Ok(Self::get_request(&format!("{url}/testnet3/latest/stateRoot"))?.into_json()?),
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
-            Self::External(state_root, _) => Ok(*state_root),
+            Self::LOCAL(state_root, _) => Ok(*state_root),
             #[cfg(feature = "wasm")]
             _ => bail!("REST queries not supported in wasm environments"),
         }
@@ -136,7 +136,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 3 => Ok(Self::get_request(&format!("{url}/testnet3/statePath/{commitment}"))?.into_json()?),
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
-            Self::External(_, commitments) => {
+            Self::LOCAL(_, commitments) => {
                 let state_path =
                     commitments.get(commitment).ok_or_else(|| anyhow!("Commitment not found in inclusion query"))?;
                 Ok(state_path.clone())
@@ -681,17 +681,43 @@ impl<N: Network> InclusionAssignment<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        cast_ref,
+        vm::test_helpers::{sample_deployment_transaction, sample_execution_transaction},
+        Authorization,
+        BlockMemory,
+        CallMetrics,
+        Process,
+    };
+    use console::{
+        account::PrivateKey,
+        program::{Response, Value},
+    };
     use snarkvm_utilities::TestRng;
+
+    type CurrentNetwork = console::network::Testnet3;
+    type CurrentAleo = circuit::network::AleoV0;
+    const COMMITMENT: &str = r"4874757399230654999279876063378939895075480265760505926730283954993786291609field";
+    const COMMITMENT_MAP: &str = r#"{"4874757399230654999279876063378939895075480265760505926730283954993786291609field": "path1qqqzcvgx7n7y4sgjyzdkdlhn7ew4gydwshtlty84hul59jk3zyqvuzfkqqqqqqqqqqq2nxkl6lnue70g7khz72x76f3np35mkdkjvczz5ya3d4lf7fnx7plr64ptwy0wz4xe6sex2aw3hpunh8vnz6ce4rsnjf333k0vqn3lpx5exr9auj7lx536yxrn0zy54tu5e38kmgyvmfqj2shuksx7jvepy6u3998xzrgmd59hy9pz75p6l683jhjg2p95gly0x8v523ker8qzhva8uy3tas82wwa7ymzwr92ysn2w7lm3r3tdm45wfwve6ssqruppfq0sn69ud8a2c554tnazt3trper5h02yufw8r45r7x6l2293vragtjlkeacu0nuqhpuw4wmclwplzg9ruecw3mavaans537jd44qp6tvwxpffjnlzzg924uaf8snpat4ve95mzl4u9nlxc09unpsuqjqjr8ygw29xdhsc2h5sdvgh0d8lw3ex0tas8m7jd0mme4vagtw6psqm2nurmm8kd28hp4k2r7xatvrw7rw7qghc0wmn0mrqvs8wx2wf59d7x6vtav05l6z8lp3xvdcfkyd90ztluda6nrnm7pp3lny8dvlzzvfmfmh5tvlsdrvldn2fd3hqsvrndm5vm3curxq8amx3kazcvgaz2zpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qj8hdgqzvtea2t4ry8hnc4d63th6y29tdvjta48rtpxkl8zfej5qmjj5ayyy7ac22w79ttzztuhyvf3zna90hl70t54nk9ala3499qsvx954sr3e6dek8v6dd4mrxayyah6u7cdvwqvapnvs2dye8y8wcvgszqqqqqqqqqqqm55t50ma732h5s9s785pxrkdz5c9xdm3t5vd9xxqyqvdjg93wyfx8ce6fm5jhhfup3as6eg7m95h7hhd38f2m2e8w582lwzj253rkp8742hl94rvs9qas6ef6r4mxt4ssdswwykh9rhr79gexf3wrsprqqq65qzm6ea2vduhs450n0dzp9da07dr4ndfhxktacv98h500v9xjqcqqqqqqqqqqqqgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pqjr4zcfvlxmmrnv535p5fyje2qt6muy3rzr3mya4pu543cv5m0qcqqqqqqqqqqqqyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzqzqqqdzndt6u5ra2x52ze36ahgggzz2mfnh45lsw9cpu3qc9ea72n9yxsxqqqqqqqqqqq0rryangqmqe4m0ecrjxrp20yy2xfm4n9ww5r0a9kvpdg2d5rq5r3zm3zks4dspjw6d69fzta9rsekv5jluwg7ajpcj2sate23xngjrkw5uhg30e6ufy3r03p69y900vselx9ah7ra9tcv0gyua9m5s32p6zpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqgqqrqvqfnpdu9wtdcfu6c3ke43e3cjxy3h5rr75h44l3qyddmz2g6ypuwzsfapyfp"}"#;
+    const STATE_PATH: &str = r"path1qqqzcvgx7n7y4sgjyzdkdlhn7ew4gydwshtlty84hul59jk3zyqvuzfkqqqqqqqqqqq2nxkl6lnue70g7khz72x76f3np35mkdkjvczz5ya3d4lf7fnx7plr64ptwy0wz4xe6sex2aw3hpunh8vnz6ce4rsnjf333k0vqn3lpx5exr9auj7lx536yxrn0zy54tu5e38kmgyvmfqj2shuksx7jvepy6u3998xzrgmd59hy9pz75p6l683jhjg2p95gly0x8v523ker8qzhva8uy3tas82wwa7ymzwr92ysn2w7lm3r3tdm45wfwve6ssqruppfq0sn69ud8a2c554tnazt3trper5h02yufw8r45r7x6l2293vragtjlkeacu0nuqhpuw4wmclwplzg9ruecw3mavaans537jd44qp6tvwxpffjnlzzg924uaf8snpat4ve95mzl4u9nlxc09unpsuqjqjr8ygw29xdhsc2h5sdvgh0d8lw3ex0tas8m7jd0mme4vagtw6psqm2nurmm8kd28hp4k2r7xatvrw7rw7qghc0wmn0mrqvs8wx2wf59d7x6vtav05l6z8lp3xvdcfkyd90ztluda6nrnm7pp3lny8dvlzzvfmfmh5tvlsdrvldn2fd3hqsvrndm5vm3curxq8amx3kazcvgaz2zpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qj8hdgqzvtea2t4ry8hnc4d63th6y29tdvjta48rtpxkl8zfej5qmjj5ayyy7ac22w79ttzztuhyvf3zna90hl70t54nk9ala3499qsvx954sr3e6dek8v6dd4mrxayyah6u7cdvwqvapnvs2dye8y8wcvgszqqqqqqqqqqqm55t50ma732h5s9s785pxrkdz5c9xdm3t5vd9xxqyqvdjg93wyfx8ce6fm5jhhfup3as6eg7m95h7hhd38f2m2e8w582lwzj253rkp8742hl94rvs9qas6ef6r4mxt4ssdswwykh9rhr79gexf3wrsprqqq65qzm6ea2vduhs450n0dzp9da07dr4ndfhxktacv98h500v9xjqcqqqqqqqqqqqqgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzgg9v7559gaxswfjytkkhslq44kvj8ld2pj29xvvqdlsn6zez45pqjr4zcfvlxmmrnv535p5fyje2qt6muy3rzr3mya4pu543cv5m0qcqqqqqqqqqqqqyyzk022z5wng8yez9mttc0s26mxfrlk4qe9znxxqxlcfapv326qjzpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqfpq4n6js4r56pexg3w667ruzkkejgla4gxfg5e3sph7z0gty2ksyss2eafg236dqunyghdd0p7pttvey0765ry52vccqmlp859j9tgzqzqqqdzndt6u5ra2x52ze36ahgggzz2mfnh45lsw9cpu3qc9ea72n9yxsxqqqqqqqqqqq0rryangqmqe4m0ecrjxrp20yy2xfm4n9ww5r0a9kvpdg2d5rq5r3zm3zks4dspjw6d69fzta9rsekv5jluwg7ajpcj2sate23xngjrkw5uhg30e6ufy3r03p69y900vselx9ah7ra9tcv0gyua9m5s32p6zpt849p28f5rjv3za44u8c9ddny3lm2svj3fnrqr0uy7skg4dqgqqrqvqfnpdu9wtdcfu6c3ke43e3cjxy3h5rr75h44l3qyddmz2g6ypuwzsfapyfp";
+    const STATE_ROOT: &str = r"ar19scsda8uftq3ygymvml08aja2sg6apwh7kg0t0elgt9dzygqecys8m9c4g";
 
     #[test]
     fn test_inclusion_verify_execution() {
         let rng = &mut TestRng::default();
         // Fetch an execution transaction.
-        let execution_transaction = crate::vm::test_helpers::sample_execution_transaction(rng);
+        let execution_transaction = sample_execution_transaction(rng);
+
+        // Get verifying key as if it were being passed in from an external context.
+        let verifying_key = VerifyingKey::<CurrentNetwork>::new(CurrentNetwork::inclusion_verifying_key().clone());
 
         match execution_transaction {
             Transaction::Execute(_, execution, _) => {
+                // Assert stateful verification passes.
                 assert!(Inclusion::verify_execution(&execution, None).is_ok());
+
+                // Assert stateless verification passes.
+                assert!(Inclusion::verify_execution(&execution, Some(verifying_key)).is_ok());
             }
             _ => panic!("Expected an execution transaction"),
         }
@@ -701,13 +727,178 @@ mod tests {
     fn test_inclusion_verify_fee() {
         let rng = &mut TestRng::default();
         // Fetch a deployment transaction.
-        let deployment_transaction = crate::vm::test_helpers::sample_deployment_transaction(rng);
+        let deployment_transaction = sample_deployment_transaction(rng);
+
+        // Get verifying key as if it were being passed in from an external context.
+        let verifying_key = VerifyingKey::<CurrentNetwork>::new(CurrentNetwork::inclusion_verifying_key().clone());
 
         match deployment_transaction {
             Transaction::Deploy(_, _, fee) => {
+                // Assert stateful verification passes.
                 assert!(Inclusion::verify_fee(&fee, None).is_ok());
+
+                // Assert stateless verification passes.
+                assert!(Inclusion::verify_fee(&fee, Some(verifying_key)).is_ok());
             }
             _ => panic!("Expected a deployment transaction"),
         }
+    }
+
+    #[test]
+    fn test_local_query_variant_serialization() {
+        // Commitments and state roots fetched from testnet3 api
+        let program_id = ProgramID::<CurrentNetwork>::from_str("hello.aleo").unwrap();
+
+        // Convert the state root to a field element
+        let commitment = Field::<CurrentNetwork>::from_str(COMMITMENT).unwrap();
+        let commitment_map: HashMap<Field<CurrentNetwork>, StatePath<CurrentNetwork>> =
+            serde_json::from_str(COMMITMENT_MAP).unwrap();
+        let state_root = <CurrentNetwork as Network>::StateRoot::from_str(STATE_ROOT).unwrap();
+        let state_path = StatePath::<CurrentNetwork>::from_str(STATE_PATH).unwrap();
+
+        // Ensure queries can be constructed from both structs and strings
+        let query_from_struct =
+            Query::<CurrentNetwork, BlockMemory<CurrentNetwork>>::from((state_root, commitment_map));
+        let query_from_str =
+            Query::<CurrentNetwork, BlockMemory<CurrentNetwork>>::try_from((STATE_ROOT, COMMITMENT_MAP)).unwrap();
+
+        // Ensure associated methods return the correct values
+        assert_eq!(query_from_struct.get_state_path_for_commitment(&commitment).unwrap(), state_path);
+        assert_eq!(query_from_str.get_state_path_for_commitment(&commitment).unwrap(), state_path);
+        assert_eq!(query_from_struct.current_state_root().unwrap(), state_root);
+        assert_eq!(query_from_str.current_state_root().unwrap(), state_root);
+        assert!(query_from_struct.get_program(&program_id).is_err());
+        assert!(query_from_str.get_program(&program_id).is_err());
+    }
+
+    #[test]
+    fn test_wasm_execution_flow_with_inclusion_proof() {
+        // Test an inclusion proof in the way it would be done in webassembly context.
+
+        //----------- DATA ASSUMED TO BE SUPPLIED BY THE PROVER FROM OUTSIDE WASM -----------
+        let inclusion_proving_key = ProvingKey::<CurrentNetwork>::new(CurrentNetwork::inclusion_proving_key().clone());
+        let inclusion_verifying_key =
+            VerifyingKey::<CurrentNetwork>::new(CurrentNetwork::inclusion_verifying_key().clone());
+        let credits_proving_key = ProvingKey::<CurrentNetwork>::new(
+            CurrentNetwork::get_credits_proving_key("transfer".to_string()).unwrap().clone(),
+        );
+
+        // Initialize a new caller account.
+        let caller_private_key =
+            PrivateKey::from_str("APrivateKey1zkpJNtSFD3LfsSHhuUgUVfdtHqSrm2wjWLRqUkHALUBw4Lb").unwrap();
+
+        let record_string = r"{owner: aleo1f3wd9pvw2z9mrwl9s6v7c0tdp4yw4et0304ltq6lp65d45x095psmj9wd4.private,  gates: 50200000u64.private,  _nonce: 3456560291181264315715430728275848162867086452732010598924408047526149762526group.public}";
+        let r0 = Value::<CurrentNetwork>::from_str(record_string).unwrap();
+        let r1 = Value::<CurrentNetwork>::from_str(r"aleo1f3wd9pvw2z9mrwl9s6v7c0tdp4yw4et0304ltq6lp65d45x095psmj9wd4")
+            .unwrap();
+        let r2 = Value::<CurrentNetwork>::from_str("50000u64").unwrap();
+
+        //----------- FUNCTIONS ASSUMED TO BE COMPILED INTO WEBASSEMBLY -----------
+        // Create an authorization for the given function & get input commitments needed to find state-paths
+        fn authorize_offline(
+            caller_private_key: &PrivateKey<CurrentNetwork>,
+            program_id: impl TryInto<ProgramID<CurrentNetwork>>,
+            function_name: impl TryInto<Identifier<CurrentNetwork>>,
+            inputs: impl ExactSizeIterator<Item = impl TryInto<Value<CurrentNetwork>>>,
+        ) -> Result<(Authorization<CurrentNetwork>, Vec<Field<CurrentNetwork>>)> {
+            let rng = &mut TestRng::default();
+            let process = Process::<CurrentNetwork>::load_offline()?;
+            let authorization =
+                process.authorize::<CurrentAleo, _>(caller_private_key, program_id, function_name, inputs, rng)?;
+            let commitments = authorization
+                .to_vec_deque()
+                .iter()
+                .flat_map(|request| request.input_ids())
+                .filter_map(|input| if let InputID::Record(commitment, ..) = input { Some(*commitment) } else { None })
+                .collect();
+            Ok((authorization, commitments))
+        }
+
+        // Execute a program with necessary data inserted from external environment
+        fn execute_program(
+            program_id: &str,
+            function_name: &str,
+            authorization: Authorization<CurrentNetwork>,
+            state_root: &str,
+            commitment_map: &str,
+            program_proving_key: ProvingKey<CurrentNetwork>,
+            inclusion_proving_key: ProvingKey<CurrentNetwork>,
+        ) -> Result<(
+            Response<CurrentNetwork>,
+            Execution<CurrentNetwork>,
+            Inclusion<CurrentNetwork>,
+            Vec<CallMetrics<CurrentNetwork>>,
+        )> {
+            let rng = &mut TestRng::default();
+            let program_id = ProgramID::<CurrentNetwork>::from_str(program_id)?;
+            let function_name = Identifier::<CurrentNetwork>::from_str(function_name)?;
+
+            // Load the process
+            let process = Process::<CurrentNetwork>::load_offline()?;
+            process.insert_proving_key(&program_id, &function_name, program_proving_key)?;
+
+            // Execute the call.
+            let (response, execution, inclusion, metrics) = process.execute::<CurrentAleo, _>(authorization, rng)?;
+
+            let query = Query::<CurrentNetwork, BlockMemory<CurrentNetwork>>::try_from((state_root, commitment_map))?;
+            // Prepare the assignments.
+            let (assignments, global_state_root) = {
+                let execution = cast_ref!(execution as Execution<CurrentNetwork>);
+                let inclusion = cast_ref!(inclusion as Inclusion<CurrentNetwork>);
+                inclusion.prepare_execution(execution, query)?
+            };
+            let assignments = cast_ref!(assignments as Vec<InclusionAssignment<CurrentNetwork>>);
+            let global_state_root = *cast_ref!((*global_state_root) as Field<CurrentNetwork>);
+
+            // Compute the inclusion proof and update the execution.
+            let execution = inclusion.prove_execution::<CurrentAleo, _>(
+                execution,
+                assignments,
+                global_state_root.into(),
+                Some(inclusion_proving_key),
+                rng,
+            )?;
+
+            // Prepare the return.
+            let response = cast_ref!(response as Response<CurrentNetwork>).clone();
+            let execution = cast_ref!(execution as Execution<CurrentNetwork>).clone();
+            let metrics = cast_ref!(metrics as Vec<CallMetrics<CurrentNetwork>>).clone();
+
+            // Return the response, execution, and metrics.
+            Ok((response, execution, inclusion, metrics))
+        }
+
+        //----------- FUNCTIONS ASSUMED TO BE EXECUTED OUTSIDE OF WEBASSEMBLY -----------
+        // This function would be non-wasm function (most likely in javascript that takes the
+        // "commitments" output from get_authorization_offline and use it to make a call in
+        // the outside environment to the Aleo API to get the state roots and state paths
+        fn get_inclusion_proof_data(_commitments: &[Field<CurrentNetwork>]) -> (&str, &str) {
+            (STATE_ROOT, COMMITMENT_MAP)
+        }
+
+        //----------- SAMPLE WEB PROVING PROGRAM FLOW -----------
+        // This program execution flow would be executed from javascript
+
+        // ENTER WASM: Get authorization and commitments
+        let (authorization, commitments) =
+            authorize_offline(&caller_private_key, "credits.aleo", "transfer", [r0, r1, r2].into_iter()).unwrap();
+
+        // LEAVE WASM: Get this data from the web (not in rust)
+        let (state_root, commitment_map) = get_inclusion_proof_data(&commitments); // This would be inserted into the main
+
+        // ENTER WASM: Execute the program in wasm with data supplied from an outside environment
+        let (_, execution, _, _) = execute_program(
+            "credits.aleo",
+            "transfer",
+            authorization,
+            state_root,
+            commitment_map,
+            credits_proving_key,
+            inclusion_proving_key,
+        )
+        .unwrap();
+
+        // ENTER WASM: Verify the execution
+        assert!(Inclusion::verify_execution(&execution, Some(inclusion_verifying_key)).is_ok());
     }
 }

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -58,8 +58,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the inclusion proof and update the execution.
-                let execution =
-                    inclusion.prove_execution::<$aleo, _>(execution, assignments, global_state_root.into(), rng)?;
+                let execution = inclusion.prove_execution::<$aleo, _>(
+                    execution,
+                    assignments,
+                    global_state_root.into(),
+                    None,
+                    rng,
+                )?;
                 lap!(timer, "Compute the inclusion proof");
 
                 // Prepare the return.
@@ -122,7 +127,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the inclusion proof and construct the fee.
-                let fee = inclusion.prove_fee::<$aleo, _>(fee_transition, assignments, rng)?;
+                let fee = inclusion.prove_fee::<$aleo, _>(fee_transition, assignments, None, rng)?;
                 lap!(timer, "Compute the inclusion proof and construct the fee");
 
                 // Prepare the return.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -421,7 +421,7 @@ function compute:
                 let (_response, fee, _metrics) = vm.execute_fee(&caller_private_key, record, 1u64, None, rng).unwrap();
                 // Verify.
                 assert!(vm.verify_fee(&fee));
-                assert!(Inclusion::verify_fee(&fee).is_ok());
+                assert!(Inclusion::verify_fee(&fee, None).is_ok());
                 // Return the fee.
                 fee
             })

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -280,7 +280,7 @@ mod tests {
                 // Ensure the inclusion proof exists.
                 assert!(execution.inclusion_proof().is_some());
                 // Verify the inclusion.
-                assert!(Inclusion::verify_execution(&execution).is_ok());
+                assert!(Inclusion::verify_execution(&execution, None).is_ok());
                 // Verify the execution.
                 assert!(vm.check_execution(&execution).is_ok());
                 assert!(vm.verify_execution(&execution));


### PR DESCRIPTION
## Motivation

Webassembly does not allow blocking operations to be performed. Network calls can be performed via the `fetch` operation but currently only on javascript microtasks which wait for the event loop to complete before making the network calls resulting in parameter fetching happening after webassembly code completes.  

Addtionally, asynchronous network calls aren't easily possible given Aleo's fetching of key material happens almost entirely in a synchronous context.

This PR add the ability for key material to be fetched from an external context and inserted in Aleo's inclusion proof flow.

This approach was initially researched by @evanmarshall and several other developers at Demox Labs. It includes some modification of approach to stay with the existing query model and make the code more concise.

## Test Plan
* Test to ensure executions & inclusion proving work with both externall inserted values & via downloads
* Test mock flow of proving within the web
