### PR TITLE
Catch instruction panics for `Speculate`

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -47,7 +47,10 @@ use snarkvm_curves::PairingEngine;
 
 use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
-use std::sync::Arc;
+use std::{
+    panic::{RefUnwindSafe, UnwindSafe},
+    sync::Arc,
+};
 
 /// A helper type for the BHP Merkle tree.
 pub type BHPMerkleTree<N, const DEPTH: u8> = MerkleTree<N, BHP1024<N>, BHP512<N>, DEPTH>;
@@ -77,6 +80,8 @@ pub trait Network:
     + for<'a> Deserialize<'a>
     + Send
     + Sync
+    + UnwindSafe
+    + RefUnwindSafe
 {
     /// The network ID.
     const ID: u16;

--- a/curves/src/traits/group.rs
+++ b/curves/src/traits/group.rs
@@ -23,6 +23,7 @@ use core::{
     hash::Hash,
     iter,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    panic::{RefUnwindSafe, UnwindSafe},
 };
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -59,6 +60,8 @@ pub trait ProjectiveCurve:
     + ToBytes
     + iter::Sum
     + From<<Self as ProjectiveCurve>::Affine>
+    + UnwindSafe
+    + RefUnwindSafe
 {
     type Affine: AffineCurve<Projective = Self, ScalarField = Self::ScalarField> + From<Self> + Into<Self>;
     type BaseField: Field;

--- a/fields/src/traits/field.rs
+++ b/fields/src/traits/field.rs
@@ -31,10 +31,11 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
-use std::{
+use core::{
     fmt::{Debug, Display},
     hash::Hash,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    panic::{RefUnwindSafe, UnwindSafe},
 };
 
 use serde::{Deserialize, Serialize};
@@ -91,6 +92,8 @@ pub trait Field:
     + CanonicalDeserializeWithFlags
     + Serialize
     + for<'a> Deserialize<'a>
+    + UnwindSafe
+    + RefUnwindSafe
 {
     type BasePrimeField: PrimeField;
 

--- a/fields/src/traits/field_parameters.rs
+++ b/fields/src/traits/field_parameters.rs
@@ -16,8 +16,10 @@
 
 use crate::traits::{FftParameters, PoseidonDefaultParameters};
 
+use core::panic::{RefUnwindSafe, UnwindSafe};
+
 /// A trait that defines parameters for a prime field.
-pub trait FieldParameters: 'static + FftParameters + PoseidonDefaultParameters {
+pub trait FieldParameters: 'static + FftParameters + PoseidonDefaultParameters + UnwindSafe + RefUnwindSafe {
     /// The modulus of the field.
     const MODULUS: Self::BigInteger;
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Built on #1445.

This PR catches instruction panics caused by `O::evaluate` in `Literals::evaluate` and returns an error. This is used to catch the `E::halt` panic calls from Literal operations - example [here](https://github.com/AleoHQ/snarkVM/blob/8695df3717a54cd8f7b29989171f005da0342eab/console/types/integers/src/arithmetic.rs#L72). 

This catch is required because `Speculate` needs to determine if a transaction execution will fail without dropping the entire process with a panic. 

This is a preliminary solution to the `panic` problem, however I am unsure if the `catch_unwind` approach is safe for production.


## Test Plan

Running `test_speculate_many` will run into the cases where panic handling is necessary. 
