### PR TITLE
Fix a few imports

### DIFF
--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -41,7 +41,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> CommitUncompr
 mod tests {
     use super::*;
     use snarkvm_circuit_types::environment::Circuit;
-    use snarkvm_curves::ProjectiveCurve;
+    use snarkvm_curves::{AffineCurve, ProjectiveCurve};
     use snarkvm_utilities::{TestRng, Uniform};
 
     use anyhow::Result;

--- a/circuit/algorithms/src/bhp/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hash_uncompressed.rs
@@ -67,7 +67,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
 mod tests {
     use super::*;
     use snarkvm_circuit_types::environment::Circuit;
-    use snarkvm_curves::ProjectiveCurve;
+    use snarkvm_curves::{AffineCurve, ProjectiveCurve};
     use snarkvm_utilities::{TestRng, Uniform};
 
     use anyhow::Result;

--- a/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -172,7 +172,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
 mod tests {
     use super::*;
     use snarkvm_circuit_types::environment::Circuit;
-    use snarkvm_curves::ProjectiveCurve;
+    use snarkvm_curves::{AffineCurve, ProjectiveCurve};
     use snarkvm_utilities::{TestRng, Uniform};
 
     use anyhow::Result;

--- a/synthesizer/src/process/stack/inclusion/mod.rs
+++ b/synthesizer/src/process/stack/inclusion/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(debug_assertions)]
+use crate::Stack;
 use crate::{
     BlockStorage,
     BlockStore,
@@ -24,7 +26,6 @@ use crate::{
     Program,
     Proof,
     ProvingKey,
-    Stack,
     Transaction,
     Transition,
     VerifyingKey,


### PR DESCRIPTION
I encountered this when running some tests. With these tweaks in place, one can run `cargo check --release --workspace --all-targets` for the whole repo without errors or warnings.