### PR TITLE
[Design] Renames `load` and `store` instructions to `get` and `set` respectively.

### DIFF
--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -1192,7 +1192,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get_or account[r0] 0u64 into r2;
+    get.or_init account[r0] 0u64 into r2;
     add r2 r1 into r3;
     set r3 into account[r0];
 ",
@@ -1291,7 +1291,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get_or account[r0] 0u64 into r2;
+    get.or_init account[r0] 0u64 into r2;
     add r2 r1 into r3;
     sub r3 r1 into r4;
     set r4 into account[r0];
@@ -1404,7 +1404,7 @@ finalize mint_public:
     input r1 as u64.public;
 
     // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    get_or account[r0] 0u64 into r2;
+    get.or_init account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
     // Set `r3` into `account[r0]`.
@@ -1522,7 +1522,7 @@ finalize mint_public:
     input r1 as u64.public;
 
     // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    get_or account[r0] 0u64 into r2;
+    get.or_init account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
     // Set `r3` into `account[r0]`.
@@ -1648,7 +1648,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get_or account[r0] 0u64 into r2;
+    get.or_init account[r0] 0u64 into r2;
     add r1 r2 into r3;
     set r3 into account[r0];
     get account[r0] into r4;

--- a/synthesizer/src/process/mod.rs
+++ b/synthesizer/src/process/mod.rs
@@ -1172,7 +1172,7 @@ function transfer:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_load_add_store() {
+    fn test_process_execute_and_finalize_get_add_set() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1192,9 +1192,9 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
-    store r3 into account[r0];
+    set r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1271,7 +1271,7 @@ finalize compute:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_increment_decrement_via_load_store() {
+    fn test_process_execute_and_finalize_increment_decrement_via_get_set() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1291,10 +1291,10 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
     sub r3 r1 into r4;
-    store r4 into account[r0];
+    set r4 into account[r0];
 ",
         )
         .unwrap();
@@ -1403,12 +1403,12 @@ finalize mint_public:
     // Input the token amount.
     input r1 as u64.public;
 
-    // Load `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    load_or account[r0] 0u64 into r2;
+    // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
+    get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Store `r3` into `account[r0]`.
-    store r3 into account[r0];
+    // Set `r3` into `account[r0]`.
+    set r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1521,12 +1521,12 @@ finalize mint_public:
     // Input the token amount.
     input r1 as u64.public;
 
-    // Load `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    load_or account[r0] 0u64 into r2;
+    // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
+    get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Store `r3` into `account[r0]`.
-    store r3 into account[r0];
+    // Set `r3` into `account[r0]`.
+    set r3 into account[r0];
 ",
         )
         .unwrap();
@@ -1628,7 +1628,7 @@ function mint:
     }
 
     #[test]
-    fn test_process_execute_and_finalize_load_store() {
+    fn test_process_execute_and_finalize_get_set() {
         // Initialize a new program.
         let (string, program) = Program::<CurrentNetwork>::parse(
             r"
@@ -1648,12 +1648,12 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r1 r2 into r3;
-    store r3 into account[r0];
-    load account[r0] into r4;
+    set r3 into account[r0];
+    get account[r0] into r4;
     add r1 r4 into r5;
-    store r5 into account[r0];
+    set r5 into account[r0];
 ",
         )
         .unwrap();

--- a/synthesizer/src/process/stack/finalize_types/initialize.rs
+++ b/synthesizer/src/process/stack/finalize_types/initialize.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-use crate::finalize::{Get, GetOr, Set};
+use crate::finalize::{Get, GetOrInit, Set};
 
 impl<N: Network> FinalizeTypes<N> {
     /// Initializes a new instance of `FinalizeTypes` for the given finalize.
@@ -172,7 +172,7 @@ impl<N: Network> FinalizeTypes<N> {
         match command {
             Command::Instruction(instruction) => self.check_instruction(stack, finalize_name, instruction)?,
             Command::Get(get) => self.check_get(stack, finalize_name, get)?,
-            Command::GetOr(get_or) => self.check_get_or(stack, finalize_name, get_or)?,
+            Command::GetOrInit(get_or_init) => self.check_get_or_init(stack, finalize_name, get_or_init)?,
             Command::Set(set) => self.check_set(stack, finalize_name, set)?,
         }
         Ok(())
@@ -207,36 +207,47 @@ impl<N: Network> FinalizeTypes<N> {
         Ok(())
     }
 
-    /// Ensures the given `get_or` command is well-formed.
+    /// Ensures the given `get.or_init` command is well-formed.
     #[inline]
-    fn check_get_or(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, get_or: &GetOr<N>) -> Result<()> {
-        // Ensure the declared mapping in `get_or` is defined in the program.
-        if !stack.program().contains_mapping(get_or.mapping_name()) {
-            bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", get_or.mapping_name(), stack.program_id())
+    fn check_get_or_init(
+        &mut self,
+        stack: &Stack<N>,
+        finalize_name: &Identifier<N>,
+        get_or_init: &GetOrInit<N>,
+    ) -> Result<()> {
+        // Ensure the declared mapping in `get.or_init` is defined in the program.
+        if !stack.program().contains_mapping(get_or_init.mapping_name()) {
+            bail!(
+                "Mapping '{}' in '{}/{finalize_name}' is not defined.",
+                get_or_init.mapping_name(),
+                stack.program_id()
+            )
         }
         // Retrieve the mapping from the program.
         // Note that the unwrap is safe, as we have already checked the mapping exists.
-        let mapping = stack.program().get_mapping(get_or.mapping_name()).unwrap();
+        let mapping = stack.program().get_mapping(get_or_init.mapping_name()).unwrap();
         // Get the mapping key type.
         let mapping_key_type = mapping.key().plaintext_type();
         // Get the mapping value type.
         let mapping_value_type = mapping.value().plaintext_type();
         // Retrieve the register type of the key.
-        let key_type = self.get_type_from_operand(stack, get_or.key())?;
+        let key_type = self.get_type_from_operand(stack, get_or_init.key())?;
         // Check that the key type in the mapping matches the key type.
         if *mapping_key_type != key_type {
-            bail!("Key type in `get_or` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'.")
+            bail!(
+                "Key type in `get.or_init` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'."
+            )
         }
         // Retrieve the register type of the default value.
-        let default_value_type = self.get_type_from_operand(stack, get_or.default())?;
+        let default_value_type = self.get_type_from_operand(stack, get_or_init.default())?;
         // Check that the value type in the mapping matches the default value type.
         if *mapping_value_type != default_value_type {
             bail!(
-                "Default value type in `get_or` '{default_value_type}' does not match the value type in the mapping '{mapping_value_type}'."
+                "Default value type in `get.or_init` '{default_value_type}' does not match the value type in the mapping '{mapping_value_type}'."
             )
         }
         // Get the destination register.
-        let destination = get_or.destination().clone();
+        let destination = get_or_init.destination().clone();
         // Ensure the destination register is a locator (and does not reference a member).
         ensure!(matches!(destination, Register::Locator(..)), "Destination '{destination}' must be a locator.");
         // Insert the destination register.

--- a/synthesizer/src/process/stack/finalize_types/initialize.rs
+++ b/synthesizer/src/process/stack/finalize_types/initialize.rs
@@ -181,7 +181,6 @@ impl<N: Network> FinalizeTypes<N> {
     /// Ensures the given `get` command is well-formed.
     #[inline]
     fn check_get(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, get: &Get<N>) -> Result<()> {
-        println!("Checking get command: {:#?}", get);
         // Ensure the declared mapping in `get` is defined in the program.
         if !stack.program().contains_mapping(get.mapping_name()) {
             bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", get.mapping_name(), stack.program_id())

--- a/synthesizer/src/program/finalize/command/get.rs
+++ b/synthesizer/src/program/finalize/command/get.rs
@@ -14,35 +14,35 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, Opcode, Operand, ProgramStorage, ProgramStore, Stack};
+use crate::{Load as LoadTrait, Opcode, Operand, ProgramStorage, ProgramStore, Stack, Store};
 use console::{
     network::prelude::*,
-    program::{Identifier, Value},
+    program::{Identifier, Register, Value},
 };
 
-/// A store command, e.g. `store r1 into mapping[r0];`
-/// Stores the `value` operand into the `key` entry in `mapping`.
+/// A get command, e.g. `get accounts[r0] into r1;`.
+/// Gets the value stored at `operand` in `mapping` and stores the result in`destination`.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Store<N: Network> {
+pub struct Get<N: Network> {
     /// The mapping name.
     mapping: Identifier<N>,
     /// The key to access the mapping.
     key: Operand<N>,
-    /// The value to be stored.
-    value: Operand<N>,
+    /// The destination register.
+    destination: Register<N>,
 }
 
-impl<N: Network> Store<N> {
+impl<N: Network> Get<N> {
     /// Returns the opcode.
     #[inline]
     pub const fn opcode() -> Opcode {
-        Opcode::Command("store")
+        Opcode::Command("get")
     }
 
     /// Returns the operands in the operation.
     #[inline]
     pub fn operands(&self) -> Vec<Operand<N>> {
-        vec![self.value.clone(), self.key.clone()]
+        vec![self.key.clone()]
     }
 
     /// Returns the mapping name.
@@ -57,40 +57,46 @@ impl<N: Network> Store<N> {
         &self.key
     }
 
-    /// Returns the operand containing the value.
+    /// Returns the destination register.
     #[inline]
-    pub const fn value(&self) -> &Operand<N> {
-        &self.value
+    pub const fn destination(&self) -> &Register<N> {
+        &self.destination
     }
 }
 
-impl<N: Network> Store<N> {
+impl<N: Network> Get<N> {
     /// Evaluates the command.
     #[inline]
     pub fn evaluate_finalize<P: ProgramStorage<N>>(
         &self,
         stack: &Stack<N>,
         store: &ProgramStore<N, P>,
-        registers: &mut impl Load<N>,
+        registers: &mut (impl LoadTrait<N> + Store<N>),
     ) -> Result<()> {
         // Ensure the mapping exists in storage.
         if !store.contains_mapping(stack.program_id(), &self.mapping)? {
             bail!("Mapping '{}/{}' does not exist in storage", stack.program_id(), self.mapping);
         }
 
-        // Load the key operand as a plaintext.
+        // Load the operand as a plaintext.
         let key = registers.load_plaintext(stack, &self.key)?;
-        // Load the value operand as a plaintext.
-        let value = Value::Plaintext(registers.load_plaintext(stack, &self.value)?);
 
-        // Update the value in storage.
-        store.update_key_value(stack.program_id(), &self.mapping, key, value)?;
+        // Retrieve the value from storage as a literal.
+        let value = match store.get_value(stack.program_id(), &self.mapping, &key)? {
+            Some(Value::Plaintext(plaintext)) => Value::Plaintext(plaintext),
+            Some(Value::Record(..)) => bail!("Cannot 'get' a 'record'"),
+            // If a key does not exist, then bail.
+            None => bail!("Key '{}' does not exist in mapping '{}/{}'", key, stack.program_id(), self.mapping),
+        };
+
+        // Assign the value to the destination register.
+        registers.store(stack, &self.destination, value)?;
 
         Ok(())
     }
 }
 
-impl<N: Network> Parser for Store<N> {
+impl<N: Network> Parser for Get<N> {
     /// Parses a string into an operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
@@ -98,16 +104,6 @@ impl<N: Network> Parser for Store<N> {
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
-
-        // Parse the value operand from the string.
-        let (string, value) = Operand::parse(string)?;
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
-
-        // Parse the "into" keyword from the string.
-        let (string, _) = tag("into")(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
 
@@ -123,16 +119,26 @@ impl<N: Network> Parser for Store<N> {
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "]" from the string.
         let (string, _) = tag("]")(string)?;
+
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "into" keyword from the string.
+        let (string, _) = tag("into")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the destination register from the string.
+        let (string, destination) = Register::parse(string)?;
+
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the ";" from the string.
         let (string, _) = tag(";")(string)?;
 
-        Ok((string, Self { mapping, key, value }))
+        Ok((string, Self { mapping, key, destination }))
     }
 }
 
-impl<N: Network> FromStr for Store<N> {
+impl<N: Network> FromStr for Get<N> {
     type Err = Error;
 
     /// Parses a string into the command.
@@ -150,48 +156,48 @@ impl<N: Network> FromStr for Store<N> {
     }
 }
 
-impl<N: Network> Debug for Store<N> {
+impl<N: Network> Debug for Get<N> {
     /// Prints the command as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<N: Network> Display for Store<N> {
+impl<N: Network> Display for Get<N> {
     /// Prints the command to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Print the command.
         write!(f, "{} ", Self::opcode())?;
-        // Print the value operand.
-        write!(f, "{} into ", self.value)?;
         // Print the mapping and key operand.
-        write!(f, "{}[{}];", self.mapping, self.key)
+        write!(f, "{}[{}] into ", self.mapping, self.key)?;
+        // Print the destination register.
+        write!(f, "{};", self.destination)
     }
 }
 
-impl<N: Network> FromBytes for Store<N> {
+impl<N: Network> FromBytes for Get<N> {
     /// Reads the command from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the mapping name.
         let mapping = Identifier::read_le(&mut reader)?;
         // Read the key operand.
         let key = Operand::read_le(&mut reader)?;
-        // Read the value operand.
-        let value = Operand::read_le(&mut reader)?;
+        // Read the destination register.
+        let destination = Register::read_le(&mut reader)?;
         // Return the command.
-        Ok(Self { mapping, key, value })
+        Ok(Self { mapping, key, destination })
     }
 }
 
-impl<N: Network> ToBytes for Store<N> {
+impl<N: Network> ToBytes for Get<N> {
     /// Writes the operation to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the mapping name.
         self.mapping.write_le(&mut writer)?;
         // Write the key operand.
         self.key.write_le(&mut writer)?;
-        // Write the value operand.
-        self.value.write_le(&mut writer)
+        // Write the destination register.
+        self.destination.write_le(&mut writer)
     }
 }
 
@@ -204,11 +210,11 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, store) = Store::<CurrentNetwork>::parse("store r0 into account[r1];").unwrap();
+        let (string, get) = Get::<CurrentNetwork>::parse("get account[r0] into r1;").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(store.mapping, Identifier::from_str("account").unwrap());
-        assert_eq!(store.operands().len(), 2, "The number of operands is incorrect");
-        assert_eq!(store.value, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
-        assert_eq!(store.key, Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(get.mapping, Identifier::from_str("account").unwrap());
+        assert_eq!(get.operands().len(), 1, "The number of operands is incorrect");
+        assert_eq!(get.key, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+        assert_eq!(get.destination, Register::Locator(1), "The second operand is incorrect");
     }
 }

--- a/synthesizer/src/program/finalize/mod.rs
+++ b/synthesizer/src/program/finalize/mod.rs
@@ -141,14 +141,14 @@ impl<N: Network> Finalize<N> {
                     ensure!(matches!(register, Register::Locator(..)), "Destination register must be a locator");
                 }
             }
-            Command::Load(load) => {
+            Command::Get(get) => {
                 // Ensure the destination register is a locator.
-                ensure!(matches!(load.destination(), Register::Locator(..)), "Destination register must be a locator");
+                ensure!(matches!(get.destination(), Register::Locator(..)), "Destination register must be a locator");
             }
-            Command::LoadDefault(load_or) => {
+            Command::GetOr(get_or) => {
                 // Ensure the destination register is a locator.
                 ensure!(
-                    matches!(load_or.destination(), Register::Locator(..)),
+                    matches!(get_or.destination(), Register::Locator(..)),
                     "Destination register must be a locator"
                 );
             }

--- a/synthesizer/src/program/finalize/mod.rs
+++ b/synthesizer/src/program/finalize/mod.rs
@@ -145,10 +145,10 @@ impl<N: Network> Finalize<N> {
                 // Ensure the destination register is a locator.
                 ensure!(matches!(get.destination(), Register::Locator(..)), "Destination register must be a locator");
             }
-            Command::GetOr(get_or) => {
+            Command::GetOrInit(get_or_init) => {
                 // Ensure the destination register is a locator.
                 ensure!(
-                    matches!(get_or.destination(), Register::Locator(..)),
+                    matches!(get_or_init.destination(), Register::Locator(..)),
                     "Destination register must be a locator"
                 );
             }

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -216,7 +216,7 @@ finalize mint_public:
     input r1 as u64.public;
 
     // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    get_or account[r0] 0u64 into r2;
+    get.or_init account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
     // Set `r3` into `account[r0]`.
@@ -266,7 +266,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get_or account[r0] 0u64 into r2;
+    get.or_init account[r0] 0u64 into r2;
     add r2 r1 into r3;
     set r3 into account[r0];
     ",

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -266,9 +266,9 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    load_or account[r0] 0u64 into r2;
+    get_or account[r0] 0u64 into r2;
     add r2 r1 into r3;
-    store r3 into account[r0];
+    set r3 into account[r0];
     ",
         )
         .unwrap()

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -215,12 +215,12 @@ finalize mint_public:
     // Input the token amount.
     input r1 as u64.public;
 
-    // Load `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    load_or account[r0] 0u64 into r2;
+    // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
+    get_or account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
-    // Store `r3` into `account[r0]`.
-    store r3 into account[r0];
+    // Set `r3` into `account[r0]`.
+    set r3 into account[r0];
 ",
         )
         .unwrap()

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -31,7 +31,7 @@ enum Variant {
     IsNeq,
 }
 
-/// Computes an equality operation on two operands, and stored the outcome in `destination`.
+/// Computes an equality operation on two operands, and stores the outcome in `destination`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct IsInstruction<N: Network, const VARIANT: u8> {
     /// The operands.


### PR DESCRIPTION
This PR, renames load and store instructions to get and put respectively.
See #1436 for prior discussion.
