### PR TITLE
Use a BTreeMap instead of IndexMap in MemoryMap

### DIFF
--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -88,6 +88,9 @@ default-features = false
 [dependencies.anyhow]
 version = "1.0.70"
 
+[dependencies.bincode]
+version = "1"
+
 [dependencies.blake2]
 version = "0.10"
 default-features = false

--- a/synthesizer/src/store/helpers/memory_map.rs
+++ b/synthesizer/src/store/helpers/memory_map.rs
@@ -35,7 +35,7 @@ pub struct MemoryMap<
     V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > {
     // The reason for using BTreeMap with binary keys is for the order of items to be the same as
-    // the one in the RocksDB-backed DataMap in snarkOS; if not for that, it could be any map
+    // the one in the RocksDB-backed DataMap; if not for that, it could be any map
     // with fast lookups and the keys could be typed (i.e. just `K` instead of `Vec<u8>`).
     map: Arc<RwLock<BTreeMap<Vec<u8>, V>>>,
     batch_in_progress: Arc<AtomicBool>,


### PR DESCRIPTION
This purpose of this PR is to make the test conditions in snarkVM more aligned with those typical for snarkOS.

As stated in the newly added comment:
> The reason for using BTreeMap with binary keys is for the order of items to be the same as the one in the RocksDB-backed DataMap in snarkOS; if not for that, it could be any map with fast lookups and the keys could be typed (i.e. just `K` instead of `Vec<u8>`).