### PR TITLE
Feature-gate the MemoryMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-curves",
  "snarkvm-fields",
+ "snarkvm-synthesizer",
  "snarkvm-utilities",
  "tracing",
  "ureq",

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -106,6 +106,7 @@ path = "../console"
 
 [dev-dependencies.snarkvm-synthesizer]
 path = "../synthesizer"
+features = [ "memory-map" ]
 
 [dev-dependencies.curl]
 version = "0.4.34"

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -43,6 +43,7 @@ harness = false
 default = [ ]
 aleo-cli = [ ]
 cuda = [ "snarkvm-algorithms/cuda" ]
+memory-map = [ "dep:bincode" ]
 serial = [
   "console/serial",
   "snarkvm-algorithms/serial",
@@ -90,6 +91,7 @@ version = "1.0.70"
 
 [dependencies.bincode]
 version = "1"
+optional = true
 
 [dependencies.blake2]
 version = "0.10"
@@ -139,8 +141,10 @@ package = "snarkvm-console"
 path = "../console"
 features = [ "test" ]
 
-[dev-dependencies.bincode]
-version = "1.3"
+[dev-dependencies.synthesizer]
+package = "snarkvm-synthesizer"
+path = "."
+features = [ "memory-map" ]
 
 [dev-dependencies.criterion]
 version = "0.4.0"

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
+use crate::store::{helpers::memory_map::MemoryMap, TransactionMemory, TransitionMemory};
 use crate::{
     atomic_write_batch,
     block::{Block, Header, Transactions},
@@ -21,11 +23,9 @@ use crate::{
     cow_to_cloned,
     cow_to_copied,
     store::{
-        helpers::{memory_map::MemoryMap, Map, MapRead},
-        TransactionMemory,
+        helpers::{Map, MapRead},
         TransactionStorage,
         TransactionStore,
-        TransitionMemory,
         TransitionStorage,
         TransitionStore,
     },
@@ -521,6 +521,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
 }
 
 /// An in-memory block storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 pub struct BlockMemory<N: Network> {
     /// The mapping of `block height` to `state root`.
@@ -547,6 +548,7 @@ pub struct BlockMemory<N: Network> {
     signature_map: MemoryMap<N::BlockHash, Signature<N>>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     type StateRootMap = MemoryMap<u32, N::StateRoot>;

--- a/synthesizer/src/store/consensus/mod.rs
+++ b/synthesizer/src/store/consensus/mod.rs
@@ -14,17 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
+use crate::store::{BlockMemory, ProgramMemory, TransactionMemory, TransitionMemory};
 use crate::store::{
-    BlockMemory,
     BlockStorage,
     BlockStore,
-    ProgramMemory,
     ProgramStorage,
     ProgramStore,
-    TransactionMemory,
     TransactionStorage,
     TransactionStore,
-    TransitionMemory,
     TransitionStorage,
     TransitionStore,
 };
@@ -91,6 +89,7 @@ pub trait ConsensusStorage<N: Network>: 'static + Clone + Send + Sync {
 }
 
 /// An in-memory consensus storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 pub struct ConsensusMemory<N: Network> {
     /// The program store.
@@ -99,6 +98,7 @@ pub struct ConsensusMemory<N: Network> {
     block_store: BlockStore<N, BlockMemory<N>>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> ConsensusStorage<N> for ConsensusMemory<N> {
     type ProgramStorage = ProgramMemory<N>;

--- a/synthesizer/src/store/helpers/mod.rs
+++ b/synthesizer/src/store/helpers/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
 pub mod memory_map;
 
 use console::network::prelude::*;

--- a/synthesizer/src/store/program/mod.rs
+++ b/synthesizer/src/store/program/mod.rs
@@ -14,11 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
+use crate::store::helpers::memory_map::MemoryMap;
 use crate::{
     atomic_write_batch,
     cow_to_cloned,
     cow_to_copied,
-    store::helpers::{memory_map::MemoryMap, Map, MapRead},
+    store::helpers::{Map, MapRead},
 };
 use console::{
     network::prelude::*,
@@ -536,6 +538,7 @@ pub trait ProgramStorage<N: Network>: 'static + Clone + Send + Sync {
 }
 
 /// An in-memory program state storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 pub struct ProgramMemory<N: Network> {
     /// The program ID map.
@@ -554,6 +557,7 @@ pub struct ProgramMemory<N: Network> {
     dev: Option<u16>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> ProgramStorage<N> for ProgramMemory<N> {
     type ProgramIDMap = MemoryMap<ProgramID<N>, IndexSet<Identifier<N>>>;
@@ -580,7 +584,7 @@ impl<N: Network> ProgramStorage<N> for ProgramMemory<N> {
     fn program_id_map(&self) -> &Self::ProgramIDMap {
         &self.program_id_map
     }
-    
+
     /// Returns the program index map.
     fn program_index_map(&self) -> &Self::ProgramIndexMap {
         &self.program_index_map

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
+use crate::store::{helpers::memory_map::MemoryMap, TransitionMemory};
 use crate::{
     atomic_write_batch,
     block::Transaction,
@@ -23,8 +25,7 @@ use crate::{
     program::Program,
     snark::{Certificate, Proof, VerifyingKey},
     store::{
-        helpers::{memory_map::MemoryMap, Map, MapRead},
-        TransitionMemory,
+        helpers::{Map, MapRead},
         TransitionStorage,
         TransitionStore,
     },
@@ -456,6 +457,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 }
 
 /// An in-memory deployment storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub struct DeploymentMemory<N: Network> {
@@ -481,6 +483,7 @@ pub struct DeploymentMemory<N: Network> {
     transition_store: TransitionStore<N, TransitionMemory<N>>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
     type IDMap = MemoryMap<N::TransactionID, ProgramID<N>>;

--- a/synthesizer/src/store/transaction/execution.rs
+++ b/synthesizer/src/store/transaction/execution.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
+use crate::store::{helpers::memory_map::MemoryMap, TransitionMemory};
 use crate::{
     atomic_write_batch,
     block::{Transaction, Transition},
@@ -22,8 +24,7 @@ use crate::{
     process::{Execution, Fee},
     snark::Proof,
     store::{
-        helpers::{memory_map::MemoryMap, Map, MapRead},
-        TransitionMemory,
+        helpers::{Map, MapRead},
         TransitionStorage,
         TransitionStore,
     },
@@ -293,6 +294,7 @@ pub trait ExecutionStorage<N: Network>: Clone + Send + Sync {
 }
 
 /// An in-memory execution storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub struct ExecutionMemory<N: Network> {
@@ -308,6 +310,7 @@ pub struct ExecutionMemory<N: Network> {
     fee_map: MemoryMap<N::TransactionID, (N::StateRoot, Option<Proof<N>>)>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> ExecutionStorage<N> for ExecutionMemory<N> {
     type IDMap = MemoryMap<N::TransactionID, (Vec<N::TransitionID>, Option<N::TransitionID>)>;

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -20,6 +20,8 @@ pub use deployment::*;
 mod execution;
 pub use execution::*;
 
+#[cfg(feature = "memory-map")]
+use crate::store::{helpers::memory_map::MemoryMap, TransitionMemory};
 use crate::{
     atomic_write_batch,
     block::Transaction,
@@ -28,8 +30,7 @@ use crate::{
     program::Program,
     snark::{Certificate, VerifyingKey},
     store::{
-        helpers::{memory_map::MemoryMap, Map, MapRead},
-        TransitionMemory,
+        helpers::{Map, MapRead},
         TransitionStorage,
         TransitionStore,
     },
@@ -190,6 +191,7 @@ pub trait TransactionStorage<N: Network>: Clone + Send + Sync {
 }
 
 /// An in-memory transaction storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 pub struct TransactionMemory<N: Network> {
     /// The mapping of `transaction ID` to `transaction type`.
@@ -200,6 +202,7 @@ pub struct TransactionMemory<N: Network> {
     execution_store: ExecutionStore<N, ExecutionMemory<N>>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> TransactionStorage<N> for TransactionMemory<N> {
     type IDMap = MemoryMap<N::TransactionID, TransactionType>;

--- a/synthesizer/src/store/transition/input.rs
+++ b/synthesizer/src/store/transition/input.rs
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
+use crate::store::helpers::memory_map::MemoryMap;
 use crate::{
     atomic_write_batch,
     block::Input,
-    store::helpers::{memory_map::MemoryMap, Map, MapRead},
+    store::helpers::{Map, MapRead},
 };
 use console::{
     network::prelude::*,
@@ -255,6 +257,7 @@ pub trait InputStorage<N: Network>: Clone + Send + Sync {
 }
 
 /// An in-memory transition input storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 pub struct InputMemory<N: Network> {
     /// The mapping of `transition ID` to `input IDs`.
@@ -277,6 +280,7 @@ pub struct InputMemory<N: Network> {
     dev: Option<u16>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> InputStorage<N> for InputMemory<N> {
     type IDMap = MemoryMap<N::TransitionID, Vec<Field<N>>>;

--- a/synthesizer/src/store/transition/mod.rs
+++ b/synthesizer/src/store/transition/mod.rs
@@ -20,13 +20,15 @@ pub use input::*;
 mod output;
 pub use output::*;
 
+#[cfg(feature = "memory-map")]
+use crate::store::helpers::memory_map::MemoryMap;
 use crate::{
     atomic_write_batch,
     block::{Input, Output, Transition},
     cow_to_cloned,
     cow_to_copied,
     snark::Proof,
-    store::helpers::{memory_map::MemoryMap, Map, MapRead},
+    store::helpers::{Map, MapRead},
 };
 use console::{
     network::prelude::*,
@@ -252,6 +254,7 @@ pub trait TransitionStorage<N: Network>: Clone + Send + Sync {
 }
 
 /// An in-memory transition storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 pub struct TransitionMemory<N: Network> {
     /// The transition program IDs and function names.
@@ -274,6 +277,7 @@ pub struct TransitionMemory<N: Network> {
     reverse_tcm_map: MemoryMap<Field<N>, N::TransitionID>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> TransitionStorage<N> for TransitionMemory<N> {
     type LocatorMap = MemoryMap<N::TransitionID, (ProgramID<N>, Identifier<N>)>;

--- a/synthesizer/src/store/transition/output.rs
+++ b/synthesizer/src/store/transition/output.rs
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "memory-map")]
+use crate::store::helpers::memory_map::MemoryMap;
 use crate::{
     atomic_write_batch,
     block::Output,
-    store::helpers::{memory_map::MemoryMap, Map, MapRead},
+    store::helpers::{Map, MapRead},
 };
 use console::{
     network::prelude::*,
@@ -259,6 +261,7 @@ pub trait OutputStorage<N: Network>: Clone + Send + Sync {
 }
 
 /// An in-memory transition output storage.
+#[cfg(feature = "memory-map")]
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub struct OutputMemory<N: Network> {
@@ -282,6 +285,7 @@ pub struct OutputMemory<N: Network> {
     dev: Option<u16>,
 }
 
+#[cfg(feature = "memory-map")]
 #[rustfmt::skip]
 impl<N: Network> OutputStorage<N> for OutputMemory<N> {
     type IDMap = MemoryMap<N::TransitionID, Vec<Field<N>>>;


### PR DESCRIPTION
We're only using it in tests, so we don't need to compile it outside of them.

This PR can be merged at any point in time, and contrary to what I have expected at first, it should be simple enough to rebase it (mostly due to the test self-dependency trick).