### PR TITLE
[Test] Equivalence tests for `evaluate`, `execute` and `finalize`

### DIFF
--- a/synthesizer/src/program/finalize/command/finalize.rs
+++ b/synthesizer/src/program/finalize/command/finalize.rs
@@ -354,6 +354,7 @@ mod tests {
     //     // Prepare the test.
     //     let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
     //     let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+    //     // TODO: Enable once constant inputs to programs are supported.
     //     let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
     //     let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
     //
@@ -379,6 +380,7 @@ mod tests {
     //     // Prepare the test.
     //     let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
     //     let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+    //     // TODO: Enable once constant inputs to programs are supported.
     //     let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
     //     let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
     //

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -257,6 +257,8 @@ mod tests {
     type CurrentNetwork = Testnet3;
     type CurrentAleo = AleoV0;
 
+    const ITERATIONS: usize = 100;
+
     /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
     fn sample_stack(
         opcode: Opcode,
@@ -489,19 +491,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
-            for mode_a in &modes_a {
-                for mode_b in &modes_b {
-                    // Check the operation.
-                    check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        // Check the operation.
+                        check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
                 }
             }
         }
@@ -516,21 +520,23 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                            }
                         }
                     }
                 }
@@ -549,19 +555,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
-            for mode_a in &modes_a {
-                for mode_b in &modes_b {
-                    // Check the operation.
-                    check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        // Check the operation.
+                        check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
                 }
             }
         }
@@ -576,21 +584,23 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                            }
                         }
                     }
                 }

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -491,6 +491,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -520,6 +521,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -555,6 +557,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -584,6 +587,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -475,13 +475,11 @@ impl<N: Network> Cast<N> {
         // Initialize the struct members.
         let mut members = IndexMap::new();
         for (member, (member_name, member_type)) in inputs.iter().zip_eq(struct_.members()) {
-            // Compute the register type.
-            let register_type = RegisterType::Plaintext(*member_type);
             // Retrieve the plaintext value from the entry.
             let plaintext = match member {
                 Value::Plaintext(plaintext) => {
-                    // Ensure the member matches the register type.
-                    stack.matches_register_type(&Value::Plaintext(plaintext.clone()), &register_type)?;
+                    // Ensure the plaintext matches the member type.
+                    stack.matches_plaintext(plaintext, member_type)?;
                     // Output the plaintext.
                     plaintext.clone()
                 }

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -34,6 +34,7 @@ use console::{
     types::Field,
 };
 
+use console::program::Identifier;
 use indexmap::IndexMap;
 
 /// Casts the operands into the declared type.
@@ -87,48 +88,7 @@ impl<N: Network> Cast<N> {
         match self.register_type {
             RegisterType::Plaintext(PlaintextType::Literal(..)) => bail!("Casting to literal is currently unsupported"),
             RegisterType::Plaintext(PlaintextType::Struct(struct_name)) => {
-                // Ensure the operands length is at least the minimum.
-                if inputs.len() < N::MIN_STRUCT_ENTRIES {
-                    bail!("Casting to a struct requires at least {} operand", N::MIN_STRUCT_ENTRIES)
-                }
-
-                // Retrieve the struct and ensure it is defined in the program.
-                let struct_ = stack.program().get_struct(&struct_name)?;
-
-                // Ensure that the number of operands is equal to the number of struct members.
-                if inputs.len() != struct_.members().len() {
-                    bail!(
-                        "Casting to the struct {} requires {} operands, but {} were provided",
-                        struct_.name(),
-                        struct_.members().len(),
-                        inputs.len()
-                    )
-                }
-
-                // Initialize the struct members.
-                let mut members = IndexMap::new();
-                for (member, (member_name, member_type)) in inputs.iter().zip_eq(struct_.members()) {
-                    // Compute the register type.
-                    let register_type = RegisterType::Plaintext(*member_type);
-                    // Retrieve the plaintext value from the entry.
-                    let plaintext = match member {
-                        Value::Plaintext(plaintext) => {
-                            // Ensure the member matches the register type.
-                            stack.matches_register_type(&Value::Plaintext(plaintext.clone()), &register_type)?;
-                            // Output the plaintext.
-                            plaintext.clone()
-                        }
-                        // Ensure the struct member is not a record.
-                        Value::Record(..) => bail!("Casting a record into a struct member is illegal"),
-                    };
-                    // Append the member to the struct members.
-                    members.insert(*member_name, plaintext);
-                }
-
-                // Construct the struct.
-                let struct_ = Plaintext::Struct(members, Default::default());
-                // Store the struct.
-                registers.store(stack, &self.destination, Value::Plaintext(struct_))
+                self.cast_to_struct(stack, registers, struct_name, inputs)
             }
             RegisterType::Record(record_name) => {
                 // Ensure the operands length is at least the minimum.
@@ -361,48 +321,7 @@ impl<N: Network> Cast<N> {
         match self.register_type {
             RegisterType::Plaintext(PlaintextType::Literal(..)) => bail!("Casting to literal is currently unsupported"),
             RegisterType::Plaintext(PlaintextType::Struct(struct_name)) => {
-                // Ensure the operands length is at least the minimum.
-                if inputs.len() < N::MIN_STRUCT_ENTRIES {
-                    bail!("Casting to a struct requires at least {} operand", N::MIN_STRUCT_ENTRIES)
-                }
-
-                // Retrieve the struct and ensure it is defined in the program.
-                let struct_ = stack.program().get_struct(&struct_name)?;
-
-                // Ensure that the number of operands is equal to the number of struct members.
-                if inputs.len() != struct_.members().len() {
-                    bail!(
-                        "Casting to the struct {} requires {} operands, but {} were provided",
-                        struct_.name(),
-                        struct_.members().len(),
-                        inputs.len()
-                    )
-                }
-
-                // Initialize the struct members.
-                let mut members = IndexMap::new();
-                for (member, (member_name, member_type)) in inputs.iter().zip_eq(struct_.members()) {
-                    // Compute the register type.
-                    let register_type = RegisterType::Plaintext(*member_type);
-                    // Retrieve the plaintext value from the entry.
-                    let plaintext = match member {
-                        Value::Plaintext(plaintext) => {
-                            // Ensure the member matches the register type.
-                            stack.matches_register_type(&Value::Plaintext(plaintext.clone()), &register_type)?;
-                            // Output the plaintext.
-                            plaintext.clone()
-                        }
-                        // Ensure the struct member is not a record.
-                        Value::Record(..) => bail!("Casting a record into a struct member is illegal"),
-                    };
-                    // Append the member to the struct members.
-                    members.insert(*member_name, plaintext);
-                }
-
-                // Construct the struct.
-                let struct_ = Plaintext::Struct(members, Default::default());
-                // Store the struct.
-                registers.store(stack, &self.destination, Value::Plaintext(struct_))
+                self.cast_to_struct(stack, registers, struct_name, inputs)
             }
             RegisterType::Record(_record_name) => {
                 bail!("Illegal operation: Cannot cast to a record in a finalize block.")
@@ -523,6 +442,60 @@ impl<N: Network> Cast<N> {
         }
 
         Ok(vec![self.register_type])
+    }
+}
+
+impl<N: Network> Cast<N> {
+    /// A helper method to handle casting to a struct.
+    fn cast_to_struct(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut impl Store<N>,
+        struct_name: Identifier<N>,
+        inputs: Vec<Value<N>>,
+    ) -> Result<()> {
+        // Ensure the operands length is at least the minimum.
+        if inputs.len() < N::MIN_STRUCT_ENTRIES {
+            bail!("Casting to a struct requires at least {} operand", N::MIN_STRUCT_ENTRIES)
+        }
+
+        // Retrieve the struct and ensure it is defined in the program.
+        let struct_ = stack.program().get_struct(&struct_name)?;
+
+        // Ensure that the number of operands is equal to the number of struct members.
+        if inputs.len() != struct_.members().len() {
+            bail!(
+                "Casting to the struct {} requires {} operands, but {} were provided",
+                struct_.name(),
+                struct_.members().len(),
+                inputs.len()
+            )
+        }
+
+        // Initialize the struct members.
+        let mut members = IndexMap::new();
+        for (member, (member_name, member_type)) in inputs.iter().zip_eq(struct_.members()) {
+            // Compute the register type.
+            let register_type = RegisterType::Plaintext(*member_type);
+            // Retrieve the plaintext value from the entry.
+            let plaintext = match member {
+                Value::Plaintext(plaintext) => {
+                    // Ensure the member matches the register type.
+                    stack.matches_register_type(&Value::Plaintext(plaintext.clone()), &register_type)?;
+                    // Output the plaintext.
+                    plaintext.clone()
+                }
+                // Ensure the struct member is not a record.
+                Value::Record(..) => bail!("Casting a record into a struct member is illegal"),
+            };
+            // Append the member to the struct members.
+            members.insert(*member_name, plaintext);
+        }
+
+        // Construct the struct.
+        let struct_ = Plaintext::Struct(members, Default::default());
+        // Store the struct.
+        registers.store(stack, &self.destination, Value::Plaintext(struct_))
     }
 }
 

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -435,6 +435,7 @@ mod tests {
                     let mut rng = TestRng::default();
 
                    // Prepare the test.
+                    // TODO: Enable once constant inputs to programs are supported.
                     let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
                     let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -476,6 +477,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -517,6 +519,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -298,6 +298,8 @@ mod tests {
     type CurrentNetwork = Testnet3;
     type CurrentAleo = AleoV0;
 
+    const ITERATIONS: usize = 100;
+
     /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
     #[allow(clippy::type_complexity)]
     fn sample_stack(
@@ -433,19 +435,22 @@ mod tests {
                     let mut rng = TestRng::default();
 
                    // Prepare the test.
-                    let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-                    let literals_b = vec![console::program::Literal::Scalar(console::types::Scalar::rand(&mut rng))];
                     let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
                     let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
                     // Prepare the key cache.
                     let mut cache = Default::default();
 
-                    for literal_a in &literals_a {
-                        for literal_b in &literals_b {
-                            for mode_a in &modes_a {
-                                for mode_b in &modes_b {
-                                    check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    for _ in 0..ITERATIONS {
+                        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+                        let literals_b = vec![console::program::Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+
+                        for literal_a in &literals_a {
+                            for literal_b in &literals_b {
+                                for mode_a in &modes_a {
+                                    for mode_b in &modes_b {
+                                        check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                                    }
                                 }
                             }
                         }
@@ -471,27 +476,30 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = [
-            Literal::Boolean(console::types::Boolean::rand(&mut rng)),
-            Literal::I8(console::types::I8::rand(&mut rng)),
-            Literal::I16(console::types::I16::rand(&mut rng)),
-            Literal::I32(console::types::I32::rand(&mut rng)),
-            Literal::U8(console::types::U8::rand(&mut rng)),
-            Literal::U16(console::types::U16::rand(&mut rng)),
-            Literal::U32(console::types::U32::rand(&mut rng)),
-        ];
-        let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                for mode_a in &modes_a {
-                    for mode_b in &modes_b {
-                        check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+            ];
+            let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
+                            check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                        }
                     }
                 }
             }
@@ -509,29 +517,32 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = [
-            Literal::Boolean(console::types::Boolean::rand(&mut rng)),
-            Literal::I8(console::types::I8::rand(&mut rng)),
-            Literal::I16(console::types::I16::rand(&mut rng)),
-            Literal::I32(console::types::I32::rand(&mut rng)),
-            Literal::I64(console::types::I64::rand(&mut rng)),
-            Literal::U8(console::types::U8::rand(&mut rng)),
-            Literal::U16(console::types::U16::rand(&mut rng)),
-            Literal::U32(console::types::U32::rand(&mut rng)),
-            Literal::U64(console::types::U64::rand(&mut rng)),
-        ];
-        let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                for mode_a in &modes_a {
-                    for mode_b in &modes_b {
-                        check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::I64(console::types::I64::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+                Literal::U64(console::types::U64::rand(&mut rng)),
+            ];
+            let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
+                            check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                        }
                     }
                 }
             }

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -285,9 +285,331 @@ impl<N: Network, const VARIANT: u8> ToBytes for CommitInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{FinalizeRegisters, ProvingKey, Registers, VerifyingKey};
+    use circuit::{AleoV0, Eject};
     use console::network::Testnet3;
 
+    use std::collections::HashMap;
+
     type CurrentNetwork = Testnet3;
+    type CurrentAleo = AleoV0;
+
+    /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
+    #[allow(clippy::type_complexity)]
+    fn sample_stack(
+        opcode: Opcode,
+        type_a: LiteralType,
+        type_b: LiteralType,
+        mode_a: circuit::Mode,
+        mode_b: circuit::Mode,
+        cache: &mut HashMap<String, (ProvingKey<CurrentNetwork>, VerifyingKey<CurrentNetwork>)>,
+    ) -> Result<(Stack<CurrentNetwork>, Vec<Operand<CurrentNetwork>>, Register<CurrentNetwork>)> {
+        use crate::{Process, Program};
+        use console::program::Identifier;
+
+        // Initialize the opcode.
+        let opcode = opcode.to_string();
+
+        // Initialize the function name.
+        let function_name = Identifier::<CurrentNetwork>::from_str("run")?;
+
+        // Initialize the registers.
+        let r0 = Register::Locator(0);
+        let r1 = Register::Locator(1);
+        let r2 = Register::Locator(2);
+
+        // Initialize the program.
+        let program = Program::from_str(&format!(
+            "program testing.aleo;
+            function {function_name}:
+                input {r0} as {type_a}.{mode_a};
+                input {r1} as {type_b}.{mode_b};
+                {opcode} {r0} {r1} into {r2};
+                finalize {r0} {r1};
+
+            finalize {function_name}:
+                input {r0} as {type_a}.public;
+                input {r1} as {type_b}.public;
+                {opcode} {r0} {r1} into {r2};
+        "
+        ))?;
+
+        // Initialize the operands.
+        let operand_a = Operand::Register(r0);
+        let operand_b = Operand::Register(r1);
+        let operands = vec![operand_a, operand_b];
+
+        // Initialize the stack.
+        let stack = Stack::new(&Process::load_with_cache(cache)?, &program)?;
+
+        Ok((stack, operands, r2))
+    }
+
+    /// Samples the registers. Note: Do not replicate this for real program use, it is insecure.
+    fn sample_registers(
+        stack: &Stack<CurrentNetwork>,
+        literal_a: &Literal<CurrentNetwork>,
+        literal_b: &Literal<CurrentNetwork>,
+        mode_a: Option<circuit::Mode>,
+        mode_b: Option<circuit::Mode>,
+    ) -> Result<Registers<CurrentNetwork, CurrentAleo>> {
+        use crate::{Authorization, CallStack};
+        use console::program::Identifier;
+
+        // Initialize the function name.
+        let function_name = Identifier::from_str("run")?;
+
+        // Initialize the registers.
+        let mut registers = Registers::<CurrentNetwork, CurrentAleo>::new(
+            CallStack::evaluate(Authorization::new(&[]))?,
+            stack.get_register_types(&function_name)?.clone(),
+        );
+
+        // Initialize the registers.
+        let r0 = Register::Locator(0);
+        let r1 = Register::Locator(1);
+
+        // Initialize the console values.
+        let value_a = Value::Plaintext(Plaintext::from(literal_a));
+        let value_b = Value::Plaintext(Plaintext::from(literal_b));
+
+        // Store the values in the console registers.
+        registers.store(stack, &r0, value_a.clone())?;
+        registers.store(stack, &r1, value_b.clone())?;
+
+        if let (Some(mode_a), Some(mode_b)) = (mode_a, mode_b) {
+            use circuit::Inject;
+
+            // Initialize the circuit values.
+            let circuit_a = circuit::Value::new(mode_a, value_a);
+            let circuit_b = circuit::Value::new(mode_b, value_b);
+
+            // Store the values in the circuit registers.
+            registers.store_circuit(stack, &r0, circuit_a)?;
+            registers.store_circuit(stack, &r1, circuit_b)?;
+        }
+
+        Ok(registers)
+    }
+
+    /// Samples the finalize registers. Note: Do not replicate this for real program use, it is insecure.
+    fn sample_finalize_registers(
+        stack: &Stack<CurrentNetwork>,
+        literal_a: &Literal<CurrentNetwork>,
+        literal_b: &Literal<CurrentNetwork>,
+    ) -> Result<FinalizeRegisters<CurrentNetwork>> {
+        use console::program::Identifier;
+
+        // Initialize the function name.
+        let function_name = Identifier::from_str("run")?;
+
+        // Initialize the registers.
+        let mut finalize_registers =
+            FinalizeRegisters::<CurrentNetwork>::new(stack.get_finalize_types(&function_name)?.clone());
+
+        // Initialize the registers.
+        let r0 = Register::Locator(0);
+        let r1 = Register::Locator(1);
+
+        // Initialize the console values.
+        let value_a = Value::Plaintext(Plaintext::from(literal_a));
+        let value_b = Value::Plaintext(Plaintext::from(literal_b));
+
+        // Store the values in the console registers.
+        finalize_registers.store(stack, &r0, value_a)?;
+        finalize_registers.store(stack, &r1, value_b)?;
+
+        Ok(finalize_registers)
+    }
+
+    fn check_commit<const VARIANT: u8>(
+        operation: impl FnOnce(
+            Vec<Operand<CurrentNetwork>>,
+            Register<CurrentNetwork>,
+        ) -> CommitInstruction<CurrentNetwork, VARIANT>,
+        opcode: Opcode,
+        literal_a: &Literal<CurrentNetwork>,
+        literal_b: &Literal<CurrentNetwork>,
+        mode_a: &circuit::Mode,
+        mode_b: &circuit::Mode,
+        cache: &mut HashMap<String, (ProvingKey<CurrentNetwork>, VerifyingKey<CurrentNetwork>)>,
+    ) {
+        println!("Checking '{opcode}' for '{literal_a}.{mode_a}' and '{literal_b}.{mode_b}'");
+
+        // Initialize the types.
+        let type_a = literal_a.to_type();
+        let type_b = literal_b.to_type();
+
+        // Initialize the stack.
+        let (stack, operands, destination) = sample_stack(opcode, type_a, type_b, *mode_a, *mode_b, cache).unwrap();
+        // Initialize the operation.
+        let operation = operation(operands, destination.clone());
+        // Initialize a destination operand.
+        let destination_operand = Operand::Register(destination);
+
+        // Attempt to evaluate the valid operand case.
+        let mut evaluate_registers = sample_registers(&stack, literal_a, literal_b, None, None).unwrap();
+        let result_a = operation.evaluate(&stack, &mut evaluate_registers);
+
+        // Attempt to execute the valid operand case.
+        let mut execute_registers =
+            sample_registers(&stack, literal_a, literal_b, Some(*mode_a), Some(*mode_b)).unwrap();
+        let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
+
+        // Attempt to finalize the valid operand case.
+        let mut finalize_registers = sample_finalize_registers(&stack, literal_a, literal_b).unwrap();
+        let result_c = operation.finalize(&stack, &mut finalize_registers);
+
+        // Check that either all operations failed, or all operations succeeded.
+        let all_failed = result_a.is_err() && result_b.is_err() && result_c.is_err();
+        let all_succeeded = result_a.is_ok() && result_b.is_ok() && result_c.is_ok();
+        assert!(
+            all_failed || all_succeeded,
+            "The results of the evaluation, execution, and finalization should either all succeed or all fail"
+        );
+
+        // If all operations succeeded, check that the outputs are consistent.
+        if all_succeeded {
+            // Retrieve the output of evaluation.
+            let output_a = evaluate_registers.load(&stack, &destination_operand).unwrap();
+
+            // Retrieve the output of execution.
+            let output_b = execute_registers.load_circuit(&stack, &destination_operand).unwrap();
+
+            // Retrieve the output of finalization.
+            let output_c = finalize_registers.load(&stack, &destination_operand).unwrap();
+
+            // Check that the outputs are consistent.
+            assert_eq!(
+                output_a,
+                output_b.eject_value(),
+                "The results of the evaluation and execution are inconsistent"
+            );
+            assert_eq!(output_a, output_c, "The results of the evaluation and finalization are inconsistent");
+        }
+
+        // Reset the circuit.
+        <CurrentAleo as circuit::Environment>::reset();
+    }
+
+    macro_rules! test_commit {
+        ($name: tt, $commit:ident) => {
+            paste::paste! {
+                #[test]
+                fn [<test _ $name _ is _ consistent>]() {
+                    // Initialize the operation.
+                    let operation = |operands, destination| $commit::<CurrentNetwork> { operands, destination };
+                    // Initialize the opcode.
+                    let opcode = $commit::<CurrentNetwork>::opcode();
+
+                    // Prepare the rng.
+                    let mut rng = TestRng::default();
+
+                   // Prepare the test.
+                    let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+                    let literals_b = vec![console::program::Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+                    let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+                    let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+
+                    // Prepare the key cache.
+                    let mut cache = Default::default();
+
+                    for literal_a in &literals_a {
+                        for literal_b in &literals_b {
+                            for mode_a in &modes_a {
+                                for mode_b in &modes_b {
+                                    check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    test_commit!(commit_bhp256, CommitBHP256);
+    test_commit!(commit_bhp512, CommitBHP512);
+    test_commit!(commit_bhp768, CommitBHP768);
+    test_commit!(commit_bhp1024, CommitBHP1024);
+
+    #[test]
+    fn test_hash_ped64_is_consistent() {
+        // Initialize the operation.
+        let operation = |operands, destination| CommitPED64::<CurrentNetwork> { operands, destination };
+        // Initialize the opcode.
+        let opcode = CommitPED128::<CurrentNetwork>::opcode();
+
+        // Prepare the rng.
+        let mut rng = TestRng::default();
+
+        // Prepare the test.
+        let literals_a = [
+            Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+            Literal::I8(console::types::I8::rand(&mut rng)),
+            Literal::I16(console::types::I16::rand(&mut rng)),
+            Literal::I32(console::types::I32::rand(&mut rng)),
+            Literal::U8(console::types::U8::rand(&mut rng)),
+            Literal::U16(console::types::U16::rand(&mut rng)),
+            Literal::U32(console::types::U32::rand(&mut rng)),
+        ];
+        let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+        let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+
+        // Prepare the key cache.
+        let mut cache = Default::default();
+
+        for literal_a in &literals_a {
+            for literal_b in &literals_b {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_hash_ped128_is_consistent() {
+        // Initialize the operation.
+        let operation = |operands, destination| CommitPED128::<CurrentNetwork> { operands, destination };
+        // Initialize the opcode.
+        let opcode = CommitPED128::<CurrentNetwork>::opcode();
+
+        // Prepare the rng.
+        let mut rng = TestRng::default();
+
+        // Prepare the test.
+        let literals_a = [
+            Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+            Literal::I8(console::types::I8::rand(&mut rng)),
+            Literal::I16(console::types::I16::rand(&mut rng)),
+            Literal::I32(console::types::I32::rand(&mut rng)),
+            Literal::I64(console::types::I64::rand(&mut rng)),
+            Literal::U8(console::types::U8::rand(&mut rng)),
+            Literal::U16(console::types::U16::rand(&mut rng)),
+            Literal::U32(console::types::U32::rand(&mut rng)),
+            Literal::U64(console::types::U64::rand(&mut rng)),
+        ];
+        let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+        let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+
+        // Prepare the key cache.
+        let mut cache = Default::default();
+
+        for literal_a in &literals_a {
+            for literal_b in &literals_b {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_parse() {

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -285,7 +285,11 @@ impl<N: Network, const VARIANT: u8> ToBytes for CommitInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FinalizeRegisters, ProvingKey, Registers, VerifyingKey};
+    use crate::{
+        program::instruction::operation::tests::{sample_finalize_registers, sample_registers},
+        ProvingKey,
+        VerifyingKey,
+    };
     use circuit::{AleoV0, Eject};
     use console::network::Testnet3;
 
@@ -345,83 +349,6 @@ mod tests {
         Ok((stack, operands, r2))
     }
 
-    /// Samples the registers. Note: Do not replicate this for real program use, it is insecure.
-    fn sample_registers(
-        stack: &Stack<CurrentNetwork>,
-        literal_a: &Literal<CurrentNetwork>,
-        literal_b: &Literal<CurrentNetwork>,
-        mode_a: Option<circuit::Mode>,
-        mode_b: Option<circuit::Mode>,
-    ) -> Result<Registers<CurrentNetwork, CurrentAleo>> {
-        use crate::{Authorization, CallStack};
-        use console::program::Identifier;
-
-        // Initialize the function name.
-        let function_name = Identifier::from_str("run")?;
-
-        // Initialize the registers.
-        let mut registers = Registers::<CurrentNetwork, CurrentAleo>::new(
-            CallStack::evaluate(Authorization::new(&[]))?,
-            stack.get_register_types(&function_name)?.clone(),
-        );
-
-        // Initialize the registers.
-        let r0 = Register::Locator(0);
-        let r1 = Register::Locator(1);
-
-        // Initialize the console values.
-        let value_a = Value::Plaintext(Plaintext::from(literal_a));
-        let value_b = Value::Plaintext(Plaintext::from(literal_b));
-
-        // Store the values in the console registers.
-        registers.store(stack, &r0, value_a.clone())?;
-        registers.store(stack, &r1, value_b.clone())?;
-
-        if let (Some(mode_a), Some(mode_b)) = (mode_a, mode_b) {
-            use circuit::Inject;
-
-            // Initialize the circuit values.
-            let circuit_a = circuit::Value::new(mode_a, value_a);
-            let circuit_b = circuit::Value::new(mode_b, value_b);
-
-            // Store the values in the circuit registers.
-            registers.store_circuit(stack, &r0, circuit_a)?;
-            registers.store_circuit(stack, &r1, circuit_b)?;
-        }
-
-        Ok(registers)
-    }
-
-    /// Samples the finalize registers. Note: Do not replicate this for real program use, it is insecure.
-    fn sample_finalize_registers(
-        stack: &Stack<CurrentNetwork>,
-        literal_a: &Literal<CurrentNetwork>,
-        literal_b: &Literal<CurrentNetwork>,
-    ) -> Result<FinalizeRegisters<CurrentNetwork>> {
-        use console::program::Identifier;
-
-        // Initialize the function name.
-        let function_name = Identifier::from_str("run")?;
-
-        // Initialize the registers.
-        let mut finalize_registers =
-            FinalizeRegisters::<CurrentNetwork>::new(stack.get_finalize_types(&function_name)?.clone());
-
-        // Initialize the registers.
-        let r0 = Register::Locator(0);
-        let r1 = Register::Locator(1);
-
-        // Initialize the console values.
-        let value_a = Value::Plaintext(Plaintext::from(literal_a));
-        let value_b = Value::Plaintext(Plaintext::from(literal_b));
-
-        // Store the values in the console registers.
-        finalize_registers.store(stack, &r0, value_a)?;
-        finalize_registers.store(stack, &r1, value_b)?;
-
-        Ok(finalize_registers)
-    }
-
     fn check_commit<const VARIANT: u8>(
         operation: impl FnOnce(
             Vec<Operand<CurrentNetwork>>,
@@ -448,16 +375,16 @@ mod tests {
         let destination_operand = Operand::Register(destination);
 
         // Attempt to evaluate the valid operand case.
-        let mut evaluate_registers = sample_registers(&stack, literal_a, literal_b, None, None).unwrap();
+        let mut evaluate_registers = sample_registers(&stack, &[(literal_a, None), (literal_b, None)]).unwrap();
         let result_a = operation.evaluate(&stack, &mut evaluate_registers);
 
         // Attempt to execute the valid operand case.
         let mut execute_registers =
-            sample_registers(&stack, literal_a, literal_b, Some(*mode_a), Some(*mode_b)).unwrap();
+            sample_registers(&stack, &[(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))]).unwrap();
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
         // Attempt to finalize the valid operand case.
-        let mut finalize_registers = sample_finalize_registers(&stack, literal_a, literal_b).unwrap();
+        let mut finalize_registers = sample_finalize_registers(&stack, &[literal_a, literal_b]).unwrap();
         let result_c = operation.finalize(&stack, &mut finalize_registers);
 
         // Check that either all operations failed, or all operations succeeded.

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -419,6 +419,7 @@ mod tests {
                     let mut rng = TestRng::default();
 
                     // Prepare the test.
+                    // TODO: Enable once constant inputs to programs are supported.
                     let modes = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
                     // Prepare the key cache.
@@ -456,6 +457,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
@@ -490,6 +492,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -292,6 +292,8 @@ mod tests {
     type CurrentNetwork = Testnet3;
     type CurrentAleo = AleoV0;
 
+    const ITERATIONS: usize = 100;
+
     /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
     #[allow(clippy::type_complexity)]
     fn sample_stack(
@@ -417,15 +419,17 @@ mod tests {
                     let mut rng = TestRng::default();
 
                     // Prepare the test.
-                    let literals = crate::sample_literals!(CurrentNetwork, &mut rng);
                     let modes = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
                     // Prepare the key cache.
                     let mut cache = Default::default();
 
-                    for literal in literals.iter() {
-                        for mode in modes.iter() {
-                            check_hash(operation, opcode, literal, mode, &mut cache);
+                    for _ in 0..ITERATIONS {
+                        let literals = crate::sample_literals!(CurrentNetwork, &mut rng);
+                        for literal in literals.iter() {
+                            for mode in modes.iter() {
+                                check_hash(operation, opcode, literal, mode, &mut cache);
+                            }
                         }
                     }
                 }
@@ -452,23 +456,25 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals = [
-            Literal::Boolean(console::types::Boolean::rand(&mut rng)),
-            Literal::I8(console::types::I8::rand(&mut rng)),
-            Literal::I16(console::types::I16::rand(&mut rng)),
-            Literal::I32(console::types::I32::rand(&mut rng)),
-            Literal::U8(console::types::U8::rand(&mut rng)),
-            Literal::U16(console::types::U16::rand(&mut rng)),
-            Literal::U32(console::types::U32::rand(&mut rng)),
-        ];
         let modes = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal in literals.iter() {
-            for mode in modes.iter() {
-                check_hash(operation, opcode, literal, mode, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+            ];
+            for literal in literals.iter() {
+                for mode in modes.iter() {
+                    check_hash(operation, opcode, literal, mode, &mut cache);
+                }
             }
         }
     }
@@ -484,25 +490,27 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals = [
-            Literal::Boolean(console::types::Boolean::rand(&mut rng)),
-            Literal::I8(console::types::I8::rand(&mut rng)),
-            Literal::I16(console::types::I16::rand(&mut rng)),
-            Literal::I32(console::types::I32::rand(&mut rng)),
-            Literal::I64(console::types::I64::rand(&mut rng)),
-            Literal::U8(console::types::U8::rand(&mut rng)),
-            Literal::U16(console::types::U16::rand(&mut rng)),
-            Literal::U32(console::types::U32::rand(&mut rng)),
-            Literal::U64(console::types::U64::rand(&mut rng)),
-        ];
         let modes = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal in literals.iter() {
-            for mode in modes.iter() {
-                check_hash(operation, opcode, literal, mode, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::I64(console::types::I64::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+                Literal::U64(console::types::U64::rand(&mut rng)),
+            ];
+            for literal in literals.iter() {
+                for mode in modes.iter() {
+                    check_hash(operation, opcode, literal, mode, &mut cache);
+                }
             }
         }
     }

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -266,6 +266,8 @@ mod tests {
     type CurrentNetwork = Testnet3;
     type CurrentAleo = AleoV0;
 
+    const ITERATIONS: usize = 100;
+
     /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
     #[allow(clippy::type_complexity)]
     fn sample_stack(
@@ -549,19 +551,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
-            for mode_a in &modes_a {
-                for mode_b in &modes_b {
-                    // Check the operation.
-                    check_is(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        // Check the operation.
+                        check_is(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
                 }
             }
         }
@@ -576,21 +580,23 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                            }
                         }
                     }
                 }
@@ -609,19 +615,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
-            for mode_a in &modes_a {
-                for mode_b in &modes_b {
-                    // Check the operation.
-                    check_is(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        // Check the operation.
+                        check_is(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
                 }
             }
         }
@@ -636,21 +644,23 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_is_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                            }
                         }
                     }
                 }

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -551,6 +551,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -580,6 +581,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -615,6 +617,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 
@@ -644,6 +647,7 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
+        // TODO: Enable once constant inputs to programs are supported.
         let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
         let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
 

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -253,7 +253,7 @@ impl<N: Network, const VARIANT: u8> ToBytes for IsInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ProvingKey, Registers, VerifyingKey};
+    use crate::{FinalizeRegisters, ProvingKey, Registers, VerifyingKey};
     use circuit::AleoV0;
     use console::network::Testnet3;
 
@@ -292,6 +292,12 @@ mod tests {
             function {function_name}:
                 input {r0} as {type_a}.{mode_a};
                 input {r1} as {type_b}.{mode_b};
+                {opcode} {r0} {r1} into {r2};
+                finalize {r0} {r1};
+
+            finalize {function_name}:
+                input {r0} as {type_a}.public;
+                input {r1} as {type_b}.public;
                 {opcode} {r0} {r1} into {r2};
         "
         ))?;
@@ -354,6 +360,36 @@ mod tests {
         Ok(registers)
     }
 
+    /// Samples the finalize registers. Note: Do not replicate this for real program use, it is insecure.
+    fn sample_finalize_registers(
+        stack: &Stack<CurrentNetwork>,
+        literal_a: &Literal<CurrentNetwork>,
+        literal_b: &Literal<CurrentNetwork>,
+    ) -> Result<FinalizeRegisters<CurrentNetwork>> {
+        use console::program::Identifier;
+
+        // Initialize the function name.
+        let function_name = Identifier::from_str("run")?;
+
+        // Initialize the registers.
+        let mut finalize_registers =
+            FinalizeRegisters::<CurrentNetwork>::new(stack.get_finalize_types(&function_name)?.clone());
+
+        // Initialize the registers.
+        let r0 = Register::Locator(0);
+        let r1 = Register::Locator(1);
+
+        // Initialize the console values.
+        let value_a = Value::Plaintext(Plaintext::from(literal_a));
+        let value_b = Value::Plaintext(Plaintext::from(literal_b));
+
+        // Store the values in the console registers.
+        finalize_registers.store(stack, &r0, value_a)?;
+        finalize_registers.store(stack, &r1, value_b)?;
+
+        Ok(finalize_registers)
+    }
+
     fn check_is<const VARIANT: u8>(
         operation: impl FnOnce(
             Vec<Operand<CurrentNetwork>>,
@@ -384,7 +420,7 @@ mod tests {
 
         /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
         {
-            // Attempt to compute the valid operand case.
+            // Attempt to evaluate the valid operand case.
             let mut registers = sample_registers(&stack, literal_a, literal_a, None, None).unwrap();
             operation.evaluate(&stack, &mut registers).unwrap();
 
@@ -405,7 +441,7 @@ mod tests {
                 panic!("The output must be a boolean (console)");
             }
 
-            // Attempt to compute the valid operand case.
+            // Attempt to execute the valid operand case.
             let mut registers = sample_registers(&stack, literal_a, literal_a, Some(*mode_a), Some(*mode_a)).unwrap();
             operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
@@ -444,10 +480,31 @@ mod tests {
 
             // Reset the circuit.
             <CurrentAleo as circuit::Environment>::reset();
+
+            // Attempt to finalize the valid operand case.
+            let mut registers = sample_finalize_registers(&stack, literal_a, literal_a).unwrap();
+            operation.finalize(&stack, &mut registers).unwrap();
+
+            // Retrieve the output.
+            let output_c = registers.load_literal(&stack, &destination_operand).unwrap();
+
+            // Ensure the output is correct.
+            if let Literal::Boolean(output_c) = output_c {
+                match VARIANT {
+                    0 => assert!(*output_c, "Instruction '{operation}' failed (finalize): {literal_a} {literal_a}"),
+                    1 => assert!(
+                        !*output_c,
+                        "Instruction '{operation}' should have failed (finalize): {literal_a} {literal_a}"
+                    ),
+                    _ => panic!("Found an invalid 'is' variant in the test"),
+                }
+            } else {
+                panic!("The output must be a boolean (finalize)");
+            }
         }
         /* Next, check the mismatching literals *fail*. */
         if literal_a != literal_b {
-            // Attempt to compute the valid operand case.
+            // Attempt to evaluate the valid operand case.
             let mut registers = sample_registers(&stack, literal_a, literal_b, None, None).unwrap();
             operation.evaluate(&stack, &mut registers).unwrap();
 
@@ -468,7 +525,7 @@ mod tests {
                 panic!("The output must be a boolean (console)");
             }
 
-            // Attempt to compute the valid operand case.
+            // Attempt to execute the valid operand case.
             let mut registers = sample_registers(&stack, literal_a, literal_b, Some(*mode_a), Some(*mode_b)).unwrap();
             operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
@@ -507,6 +564,27 @@ mod tests {
 
             // Reset the circuit.
             <CurrentAleo as circuit::Environment>::reset();
+
+            // Attempt to finalize the valid operand case.
+            let mut registers = sample_finalize_registers(&stack, literal_a, literal_b).unwrap();
+            operation.finalize(&stack, &mut registers).unwrap();
+
+            // Retrieve the output.
+            let output_c = registers.load_literal(&stack, &destination_operand).unwrap();
+
+            // Ensure the output is correct.
+            if let Literal::Boolean(output_c) = output_c {
+                match VARIANT {
+                    0 => assert!(
+                        !*output_c,
+                        "Instruction '{operation}' should have failed (finalize): {literal_a} {literal_b}"
+                    ),
+                    1 => assert!(*output_c, "Instruction '{operation}' failed (finalize): {literal_a} {literal_b}"),
+                    _ => panic!("Found an invalid 'is' variant in the test"),
+                }
+            } else {
+                panic!("The output must be a boolean (finalize)");
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds tests checking that the results of `evaluate`, `execute` and `finalize` for `assert`, `is`, `commit`, and `hash` instructions are consistent/equivalent.