### PR TITLE
[Fix] Optimizes `u/i128` division.

### DIFF
--- a/circuit/types/integers/src/div_checked.rs
+++ b/circuit/types/integers/src/div_checked.rs
@@ -130,18 +130,21 @@ impl<E: Environment, I: IntegerType> Metrics<dyn DivChecked<Integer<E, I>, Outpu
     type Case = (Mode, Mode);
 
     fn count(case: &Self::Case) -> Count {
-        match I::is_signed() {
-            true => match (case.0, case.1) {
-                (Mode::Constant, Mode::Constant) => Count::is(2 * I::BITS, 0, 0, 0),
-                (Mode::Constant, _) | (_, Mode::Constant) => {
-                    Count::less_than(9 * I::BITS, 0, (8 * I::BITS) + 2, (8 * I::BITS) + 12)
+        match (case.0, case.1) {
+            (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
+            (Mode::Constant, _) | (_, Mode::Constant) => {
+                match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
+                    (true, true) => Count::less_than(7 * I::BITS + 1, 0, (9 * I::BITS) + 11, (9 * I::BITS) + 20),
+                    (true, false) => Count::less_than(7 * I::BITS + 1, 0, 1616, 1822),
+                    (false, true) => Count::less_than(I::BITS + 1, 0, (3 * I::BITS) + 2, (3 * I::BITS) + 5),
+                    (false, false) => Count::less_than(I::BITS + 1, 0, 839, 1039),
                 }
-                (_, _) => Count::is(8 * I::BITS, 0, (10 * I::BITS) + 15, (10 * I::BITS) + 27),
-            },
-            false => match (case.0, case.1) {
-                (Mode::Constant, Mode::Constant) => Count::is(2 * I::BITS, 0, 0, 0),
-                (_, Mode::Constant) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 1, (3 * I::BITS) + 4),
-                (Mode::Constant, _) | (_, _) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 4, (3 * I::BITS) + 9),
+            }
+            (_, _) => match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
+                (true, true) => Count::is(6 * I::BITS, 0, (9 * I::BITS) + 11, (9 * I::BITS) + 20),
+                (true, false) => Count::is(6 * I::BITS, 0, 1616, 1822),
+                (false, true) => Count::is(I::BITS, 0, (3 * I::BITS) + 2, (3 * I::BITS) + 5),
+                (false, false) => Count::is(I::BITS, 0, 839, 1039),
             },
         }
     }
@@ -185,8 +188,7 @@ mod tests {
                 Mode::Constant => check_operation_halts(&a, &b, Integer::div_checked),
                 _ => Circuit::scope(name, || {
                     let _candidate = a.div_checked(&b);
-                    // assert_count_fails!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
-                    assert!(!Circuit::is_satisfied_in_scope(), "(!is_satisfied_in_scope)");
+                    assert_count_fails!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
                 }),
             }
         } else {
@@ -195,16 +197,14 @@ mod tests {
                     let candidate = a.div_checked(&b);
                     assert_eq!(expected, *candidate.eject_value());
                     assert_eq!(console::Integer::new(expected), candidate.eject_value());
-                    // assert_count!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
-                    // assert_output_mode!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b), candidate);
-                    assert!(Circuit::is_satisfied_in_scope(), "(is_satisfied_in_scope)");
+                    assert_count!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
+                    assert_output_mode!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b), candidate);
                 }),
                 None => match (mode_a, mode_b) {
                     (Mode::Constant, Mode::Constant) => check_operation_halts(&a, &b, Integer::div_checked),
                     _ => Circuit::scope(name, || {
                         let _candidate = a.div_checked(&b);
-                        // assert_count_fails!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
-                        assert!(!Circuit::is_satisfied_in_scope(), "(!is_satisfied_in_scope)");
+                        assert_count_fails!(DivChecked(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
                     }),
                 },
             }

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -44,11 +44,6 @@ impl<E: Environment, I: IntegerType> DivWrapped<Self> for Integer<E, I> {
                     // Note that this expression handles the wrapping case, where the dividend is `I::MIN` and the divisor is `-1` and the result should be `I::MIN`.
                     Self::ternary(operands_same_sign, &signed_quotient, &Self::zero().sub_wrapped(&signed_quotient))
                 } else {
-                    // Ensure that `other` is not zero.
-                    // Note that all other implementations of `div_wrapped` and `div_checked` invoke this check.
-                    // TODO: This check is redundant. By checking that the remainder is less than `other` (divisor), we implicitly check that `other` is non-zero.
-                    E::assert_neq(other, &Self::zero());
-                    // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
                     self.unsigned_division_via_witness(other).0
                 }
             }
@@ -83,6 +78,7 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
         }
 
         // Ensure that the remainder is less than the divisor.
+        // Note that if this check is satisfied and `other` is an unsigned integer, then `other` is not zero.
         E::assert(remainder.is_less_than(other));
 
         // Return the quotient and remainder of `self` and `other`.

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -94,17 +94,17 @@ impl<E: Environment, I: IntegerType> Metrics<dyn DivWrapped<Integer<E, I>, Outpu
             (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
             (Mode::Constant, _) | (_, Mode::Constant) => {
                 match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
-                    (true, true) => Count::less_than(6 * I::BITS + 1, 0, (9 * I::BITS) + 7, (9 * I::BITS) + 13),
-                    (true, false) => Count::less_than(6 * I::BITS + 1, 0, 1612, 1815),
-                    (false, true) => Count::less_than(2 * I::BITS + 1, 0, (3 * I::BITS) + 3, (3 * I::BITS) + 6),
-                    (false, false) => Count::less_than(2 * I::BITS + 1, 0, 840, 1040),
+                    (true, true) => Count::less_than(5 * I::BITS + 1, 0, (9 * I::BITS) + 6, (9 * I::BITS) + 12),
+                    (true, false) => Count::less_than(5 * I::BITS + 1, 0, 1611, 1814),
+                    (false, true) => Count::less_than(I::BITS + 1, 0, (3 * I::BITS) + 2, (3 * I::BITS) + 5),
+                    (false, false) => Count::less_than(I::BITS + 1, 0, 839, 1039),
                 }
             }
             (_, _) => match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
-                (true, true) => Count::is(5 * I::BITS, 0, (9 * I::BITS) + 7, (9 * I::BITS) + 13),
-                (true, false) => Count::is(5 * I::BITS, 0, 1612, 1815),
-                (false, true) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 3, (3 * I::BITS) + 6),
-                (false, false) => Count::is(2 * I::BITS, 0, 840, 1040),
+                (true, true) => Count::is(4 * I::BITS, 0, (9 * I::BITS) + 6, (9 * I::BITS) + 12),
+                (true, false) => Count::is(4 * I::BITS, 0, 1611, 1814),
+                (false, true) => Count::is(I::BITS, 0, (3 * I::BITS) + 2, (3 * I::BITS) + 5),
+                (false, false) => Count::is(I::BITS, 0, 839, 1039),
             },
         }
     }
@@ -148,8 +148,7 @@ mod tests {
                 Mode::Constant => check_operation_halts(&a, &b, Integer::div_wrapped),
                 _ => Circuit::scope(name, || {
                     let _candidate = a.div_wrapped(&b);
-                    // assert_count_fails!(DivWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
-                    assert!(!Circuit::is_satisfied_in_scope(), "(!is_satisfied_in_scope)");
+                    assert_count_fails!(DivWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
                 }),
             }
         } else {

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -49,11 +49,7 @@ impl<E: Environment, I: IntegerType> DivWrapped<Self> for Integer<E, I> {
                     // TODO: This check is redundant. By checking that the remainder is less than `other` (divisor), we implicitly check that `other` is non-zero.
                     E::assert_neq(other, &Self::zero());
                     // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
-                    if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64 {
-                        self.unsigned_division_via_witness(other).0
-                    } else {
-                        self.unsigned_binary_long_division(other).0
-                    }
+                    self.unsigned_division_via_witness(other).0
                 }
             }
         }
@@ -78,49 +74,19 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
         let quotient = Integer::new(Mode::Private, console::Integer::new(dividend_value.wrapping_div(&divisor_value)));
         let remainder = Integer::new(Mode::Private, console::Integer::new(dividend_value.wrapping_rem(&divisor_value)));
 
-        // Ensure that Euclidean division holds for these values in the base field.
-        E::assert_eq(self.to_field(), quotient.to_field() * other.to_field() + remainder.to_field());
+        if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64 {
+            // Ensure that Euclidean division holds for these values in the base field.
+            E::assert_eq(self.to_field(), quotient.to_field() * other.to_field() + remainder.to_field());
+        } else {
+            // Ensure that Euclidean division holds for these values as integers.
+            E::assert_eq(self, quotient.mul_checked(other).add_checked(&remainder));
+        }
 
         // Ensure that the remainder is less than the divisor.
         E::assert(remainder.is_less_than(other));
 
-        // Return the quotient of `self` and `other`.
+        // Return the quotient and remainder of `self` and `other`.
         (quotient, remainder)
-    }
-
-    /// Divides `self` by `other`, using binary long division returning the quotient and remainder
-    /// See https://en.wikipedia.org/wiki/Division_algorithm under "Integer division (unsigned) with remainder".
-    /// Note that this method should be used when 2 * I::BITS >= E::BaseField::size_in_data_bits().
-    pub(super) fn unsigned_binary_long_division(&self, other: &Self) -> (Self, Field<E>) {
-        let divisor = other.to_field();
-        let max = Self::constant(console::Integer::MAX).to_field();
-
-        // The bits of the quotient in big-endian order.
-        let mut quotient_bits_be = Vec::with_capacity(I::BITS as usize);
-        let mut remainder: Field<E> = Field::zero();
-
-        for bit in self.to_bits_le().into_iter().rev() {
-            remainder = remainder.double();
-            remainder += Field::from_bits_le(&[bit]);
-
-            // Check that remainder is greater than or equal to divisor, via an unsigned overflow check.
-            //   - difference := I:MAX + (b - a).
-            //   - If difference > I::MAX, then b > a.
-            //   - If difference <= I::MAX, then a >= b.
-            //   - Note that difference > I::MAX if `carry_bit` is set.
-            let difference = &max + (&divisor - &remainder);
-            let bits = difference.to_lower_bits_le((I::BITS + 1) as usize);
-            // The `unwrap` is safe since we extract at least one bit from the difference.
-            let carry_bit = bits.last().unwrap();
-            let remainder_is_gte_divisor = carry_bit.not();
-
-            remainder = Field::ternary(&remainder_is_gte_divisor, &(&remainder - &divisor), &remainder);
-            quotient_bits_be.push(remainder_is_gte_divisor);
-        }
-
-        // Reverse and return the quotient bits.
-        quotient_bits_be.reverse();
-        (Self::from_bits_le(&quotient_bits_be), remainder)
     }
 }
 
@@ -133,16 +99,16 @@ impl<E: Environment, I: IntegerType> Metrics<dyn DivWrapped<Integer<E, I>, Outpu
             (Mode::Constant, _) | (_, Mode::Constant) => {
                 match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
                     (true, true) => Count::less_than(6 * I::BITS + 1, 0, (9 * I::BITS) + 7, (9 * I::BITS) + 13),
-                    (true, false) => Count::less_than(6 * I::BITS + 1, 0, 136 * I::BITS + 5, 137 * I::BITS + 8),
+                    (true, false) => Count::less_than(6 * I::BITS + 1, 0, 1612, 1815),
                     (false, true) => Count::less_than(2 * I::BITS + 1, 0, (3 * I::BITS) + 3, (3 * I::BITS) + 6),
-                    (false, false) => Count::less_than(2 * I::BITS + 1, 0, 130 * I::BITS + 1, 131 * I::BITS + 1),
+                    (false, false) => Count::less_than(2 * I::BITS + 1, 0, 840, 1040),
                 }
             }
             (_, _) => match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
                 (true, true) => Count::is(5 * I::BITS, 0, (9 * I::BITS) + 7, (9 * I::BITS) + 13),
-                (true, false) => Count::less_than(5 * I::BITS, 0, 136 * I::BITS + 5, 137 * I::BITS + 8),
+                (true, false) => Count::is(5 * I::BITS, 0, 1612, 1815),
                 (false, true) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 3, (3 * I::BITS) + 6),
-                (false, false) => Count::less_than(2 * I::BITS, 0, 130 * I::BITS + 1, 131 * I::BITS + 1),
+                (false, false) => Count::is(2 * I::BITS, 0, 840, 1040),
             },
         }
     }

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -46,6 +46,7 @@ impl<E: Environment, I: IntegerType> DivWrapped<Self> for Integer<E, I> {
                 } else {
                     // Ensure that `other` is not zero.
                     // Note that all other implementations of `div_wrapped` and `div_checked` invoke this check.
+                    // TODO: This check is redundant. By checking that the remainder is less than `other` (divisor), we implicitly check that `other` is non-zero.
                     E::assert_neq(other, &Self::zero());
                     // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
                     if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64 {

--- a/circuit/types/integers/src/helpers/from_bits.rs
+++ b/circuit/types/integers/src/helpers/from_bits.rs
@@ -86,10 +86,9 @@ mod tests {
                 assert_eq!(expected_size_in_bits, candidate.bits_le.len());
                 match mode.is_constant() {
                     true => assert_scope!(num_constants, num_public, num_private, num_constraints),
-                    // `num_private` gets 1 free excess bit, then is incremented by one for each excess bit.
                     // `num_constraints` is incremented by one for each excess bit.
                     false => {
-                        assert_scope!(num_constants, num_public, num_private + i.saturating_sub(1), num_constraints + i)
+                        assert_scope!(num_constants, num_public, num_private, num_constraints + i)
                     }
                 };
             });
@@ -127,10 +126,9 @@ mod tests {
                 assert_eq!(expected_size_in_bits, candidate.bits_le.len());
                 match mode.is_constant() {
                     true => assert_scope!(num_constants, num_public, num_private, num_constraints),
-                    // `num_private` gets 1 free excess bit, then is incremented by one for each excess bit.
                     // `num_constraints` is incremented by one for each excess bit.
                     false => {
-                        assert_scope!(num_constants, num_public, num_private + i.saturating_sub(1), num_constraints + i)
+                        assert_scope!(num_constants, num_public, num_private, num_constraints + i)
                     }
                 };
             });

--- a/circuit/types/integers/src/rem_wrapped.rs
+++ b/circuit/types/integers/src/rem_wrapped.rs
@@ -53,18 +53,21 @@ impl<E: Environment, I: IntegerType> Metrics<dyn RemWrapped<Integer<E, I>, Outpu
     type Case = (Mode, Mode);
 
     fn count(case: &Self::Case) -> Count {
-        match I::is_signed() {
-            true => match (case.0, case.1) {
-                (Mode::Constant, Mode::Constant) => Count::is(2 * I::BITS, 0, 0, 0),
-                (Mode::Constant, _) | (_, Mode::Constant) => {
-                    Count::less_than(9 * I::BITS, 0, (8 * I::BITS) + 2, (8 * I::BITS) + 12)
+        match (case.0, case.1) {
+            (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
+            (Mode::Constant, _) | (_, Mode::Constant) => {
+                match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
+                    (true, true) => Count::less_than(5 * I::BITS + 1, 0, (9 * I::BITS) + 5, (9 * I::BITS) + 11),
+                    (true, false) => Count::less_than(5 * I::BITS + 1, 0, 1610, 1813),
+                    (false, true) => Count::less_than(I::BITS + 1, 0, (3 * I::BITS) + 2, (3 * I::BITS) + 5),
+                    (false, false) => Count::less_than(I::BITS + 1, 0, 839, 1039),
                 }
-                (_, _) => Count::is(8 * I::BITS, 0, (10 * I::BITS) + 15, (10 * I::BITS) + 27),
-            },
-            false => match (case.0, case.1) {
-                (Mode::Constant, Mode::Constant) => Count::is(2 * I::BITS, 0, 0, 0),
-                (_, Mode::Constant) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 1, (3 * I::BITS) + 4),
-                (Mode::Constant, _) | (_, _) => Count::is(2 * I::BITS, 0, (3 * I::BITS) + 4, (3 * I::BITS) + 9),
+            }
+            (_, _) => match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
+                (true, true) => Count::is(4 * I::BITS, 0, (9 * I::BITS) + 5, (9 * I::BITS) + 11),
+                (true, false) => Count::is(4 * I::BITS, 0, 1610, 1813),
+                (false, true) => Count::is(I::BITS, 0, (3 * I::BITS) + 2, (3 * I::BITS) + 5),
+                (false, false) => Count::is(I::BITS, 0, 839, 1039),
             },
         }
     }
@@ -108,8 +111,7 @@ mod tests {
                 Mode::Constant => check_operation_halts(&a, &b, Integer::rem_wrapped),
                 _ => Circuit::scope(name, || {
                     let _candidate = a.rem_wrapped(&b);
-                    // assert_count_fails!(RemWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
-                    assert!(!Circuit::is_satisfied_in_scope(), "(!is_satisfied_in_scope)");
+                    assert_count_fails!(RemWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
                 }),
             }
         } else {
@@ -118,9 +120,8 @@ mod tests {
                 let candidate = a.rem_wrapped(&b);
                 assert_eq!(expected, *candidate.eject_value());
                 assert_eq!(console::Integer::new(expected), candidate.eject_value());
-                // assert_count!(RemWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
-                // assert_output_mode!(RemWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b), candidate);
-                assert!(Circuit::is_satisfied_in_scope(), "(is_satisfied_in_scope)");
+                assert_count!(RemWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b));
+                assert_output_mode!(RemWrapped(Integer<I>, Integer<I>) => Integer<I>, &(mode_a, mode_b), candidate);
             })
         }
         Circuit::reset();

--- a/circuit/types/integers/src/rem_wrapped.rs
+++ b/circuit/types/integers/src/rem_wrapped.rs
@@ -42,19 +42,7 @@ impl<E: Environment, I: IntegerType> RemWrapped<Self> for Integer<E, I> {
                     // The remainder takes on the same sign as `self` because the division operation rounds towards zero.
                     Self::ternary(&!self.msb(), &signed_remainder, &Self::zero().sub_wrapped(&signed_remainder))
                 } else {
-                    // Check that `other` is not zero.
-                    // Note that all other implementations of `rem_wrapped` and `rem_checked` invoke this check.
-                    E::assert_neq(other, &Self::zero());
-
-                    // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
-                    if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64 {
-                        self.unsigned_division_via_witness(other).1
-                    } else {
-                        Self {
-                            bits_le: self.unsigned_binary_long_division(other).1.to_lower_bits_le(I::BITS as usize),
-                            phantom: Default::default(),
-                        }
-                    }
+                    self.unsigned_division_via_witness(other).1
                 }
             }
         }

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -123,16 +123,16 @@ impl<E: Environment, I: IntegerType, M: Magnitude> Metrics<dyn ShrWrapped<Intege
             (Mode::Constant, _) => {
                 match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
                     (true, true) => Count::less_than(5 * I::BITS, 0, (10 * I::BITS) + (2 * index(I::BITS)) + 11, (10 * I::BITS) + (2 * index(I::BITS)) + 19),
-                    (true, false) => Count::less_than(5 * I::BITS, 0, (137 * I::BITS) + 17, (138 * I::BITS) + 22),
-                    (false, true) => Count::less_than(2 * I::BITS, 0, (4 * I::BITS) + (2 * index(I::BITS)) + 7, (4 * I::BITS) + (2 * index(I::BITS)) + 11),
-                    (false, false) => Count::less_than(2 * I::BITS, 0, (131 * I::BITS) + 13, (132 * I::BITS) + 14),
+                    (true, false) => Count::less_than(5 * I::BITS, 0, 1752, 1957),
+                    (false, true) => Count::less_than(I::BITS, 0, (4 * I::BITS) + (2 * index(I::BITS)) + 6, (4 * I::BITS) + (2 * index(I::BITS)) + 10),
+                    (false, false) => Count::less_than(I::BITS, 0, 979, 1180),
                 }
             }
             (_, _) => match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
                 (true, true) => Count::is(4 * I::BITS, 0, (10 * I::BITS) + (2 * index(I::BITS)) + 11, (10 * I::BITS) + (2 * index(I::BITS)) + 19),
-                (true, false) => Count::is(4 * I::BITS, 0, (137 * I::BITS) + 17, (138 * I::BITS) + 22),
-                (false, true) => Count::is(2 * I::BITS, 0, (4 * I::BITS) + (2 * index(I::BITS)) + 7, (4 * I::BITS) + (2 * index(I::BITS)) + 11),
-                (false, false) => Count::is(2 * I::BITS, 0, (131 * I::BITS) + 13, (132 * I::BITS) + 14),
+                (true, false) => Count::is(4 * I::BITS, 0, 1752, 1957),
+                (false, true) => Count::is(I::BITS, 0, (4 * I::BITS) + (2 * index(I::BITS)) + 6, (4 * I::BITS) + (2 * index(I::BITS)) + 10),
+                (false, false) => Count::is(I::BITS, 0, 979, 1180),
             },
         }
     }

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -75,29 +75,22 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
 
                 if I::is_signed() {
                     // Divide the absolute value of `self` and `shift` (as a divisor) in the base field.
-                    let dividend_unsigned = self.abs_wrapped().cast_as_dual();
-                    // Note that `divisor_unsigned` is greater than zero since `shift_in_field` is greater than zero.
-                    let divisor_unsigned = shift_as_divisor.cast_as_dual();
+                    let unsigned_divided = self.abs_wrapped().cast_as_dual();
+                    // Note that `unsigned_divisor` is greater than zero since `shift_in_field` is greater than zero.
+                    let unsigned_divisor = shift_as_divisor.cast_as_dual();
 
                     // Compute the quotient and remainder using wrapped, unsigned division.
                     // Note that we do not invoke `div_wrapped` since we need the quotient AND the remainder.
-                    // If the product of two unsigned integers can fit in the base field, then we can perform an optimized division operation.
-                    let (quotient_unsigned, remainder_field) = if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64
-                    {
-                        let (quotient_integer, remainder_integer) =
-                            dividend_unsigned.unsigned_division_via_witness(&divisor_unsigned);
-                        (quotient_integer, remainder_integer.to_field())
-                    } else {
-                        dividend_unsigned.unsigned_binary_long_division(&divisor_unsigned)
-                    };
+                    let (unsigned_quotient, unsigned_remainder) =
+                        unsigned_divided.unsigned_division_via_witness(&unsigned_divisor);
 
                     // Note that quotient <= |console::Integer::MIN|, since the dividend <= |console::Integer::MIN| and 0 <= quotient <= dividend.
-                    let quotient = Self { bits_le: quotient_unsigned.bits_le, phantom: Default::default() };
+                    let quotient = Self { bits_le: unsigned_quotient.bits_le, phantom: Default::default() };
                     let negated_quotient = &(!&quotient).add_wrapped(&Self::one());
 
                     // Arithmetic shift uses a different rounding mode than division.
                     let rounded_negated_quotient = Self::ternary(
-                        &remainder_field.is_equal(&Field::zero()),
+                        &unsigned_remainder.to_field().is_equal(&Field::zero()),
                         negated_quotient,
                         &(negated_quotient).sub_wrapped(&Self::one()),
                     );


### PR DESCRIPTION
This PR,
- optimizes the `u/i128` wrapped division by using a more efficient check via witnesses.
- removes a redundant zero check for the divisor.
The gadgets directly impacted are: `div_wrapped`, `div_checked`, `rem_wrapped`, `shr_wrapped`