### PR TITLE
Remove fee check for `credits.aleo/split` calls

### DIFF
--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -179,6 +179,28 @@ impl<N: Network> Transaction<N> {
         // Otherwise, return 'false'.
         false
     }
+
+    /// Returns `true` if this is a `split` transaction.
+    #[inline]
+    pub fn is_split(&self) -> bool {
+        // Case 1 - The transaction contains 1 transition, which calls 'credits.aleo/split'.
+        if let Self::Execute(_, execution, _) = self {
+            // Ensure there is 1 transition.
+            if execution.len() == 1 {
+                // Retrieve the transition.
+                if let Ok(transition) = execution.get(0) {
+                    // Check if it calls 'credits.aleo/split'.
+                    if transition.program_id().to_string() == "credits.aleo"
+                        && transition.function_name().to_string() == "split"
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        // Otherwise, return 'false'.
+        false
+    }
 }
 
 /// A helper enum for iterators and consuming iterators over a transaction.

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -137,8 +137,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 if let Err(error) = Transaction::check_execution_size(execution) {
                     bail!("Invalid transaction size (execution): {error}");
                 }
-                // Ensure the fee is present, if the transaction is not a coinbase.
-                if !transaction.is_coinbase() && fee.is_none() {
+                // TODO (raychu86): Remove `is_split` check once batch executions are supported.
+                // Ensure the fee is present, if the transaction is not a coinbase or split.
+                if !transaction.is_coinbase() && !transaction.is_split() && fee.is_none() {
                     bail!("Transaction is missing a fee (execution)");
                 }
                 // Verify the fee.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes the fee requirement from `credits.aleo/split` calls. The intention for this is so that users can start creating transactions without having to initially own 2+ records. 

This rule will be removed once batched executions are introduced, because fees can be baked into the Tx.
