### PR TITLE
Use `BTreeMap` in `MerkleTree::update_many` to enforce uniqueness

### DIFF
--- a/console/collections/src/merkle_tree/mod.rs
+++ b/console/collections/src/merkle_tree/mod.rs
@@ -309,12 +309,10 @@ impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>
         // Check that there are updates to perform.
         ensure!(!updates.is_empty(), "There must be at least one leaf to update in the Merkle tree");
 
-        // Note that this unwrap is safe since updates is guaranteed to be non-empty.
-        let last = updates.last_key_value().unwrap();
-
         // Check that the latest leaf index is less than number of leaves in the Merkle tree.
+        // Note: This unwrap is safe since updates is guaranteed to be non-empty.
         ensure!(
-            *last.0 < self.number_of_leaves,
+            *updates.last_key_value().unwrap().0 < self.number_of_leaves,
             "Leaf index must be less than the number of leaves in the Merkle tree"
         );
 

--- a/synthesizer/src/store/program/speculate.rs
+++ b/synthesizer/src/store/program/speculate.rs
@@ -386,8 +386,8 @@ impl<N: Network> Speculate<N> {
             match vm.finalize_store().contains_program(program_id)? {
                 true => match vm.finalize_store().get_program_index(program_id)? {
                     Some(index) => {
-                        if updates.insert(usize::try_from(index)?, leaf).is_none() {
-                            bail!("Failed to insert update index: {index}");
+                        if updates.insert(usize::try_from(index)?, leaf).is_some() {
+                            bail!("Can't insert multiple leaves in the same index: {index}");
                         }
                     }
                     None => bail!("No index found for program_id: {program_id}"),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR replaces `&[(usize, LH::Leaf)]` with `&BTreeMap<usize, LH::Leaf>` in `MerkleTree::update_many` to enforce ordering during the update. 

`update_many` requires the leaf indices to be sorted in descending order and be unique, so using a `BTreeMap` covers both cases.
