### PR TITLE
[Feature] Add `open_testing` method to the storage traits.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ jobs:
     resource_class: 2xlarge
     steps:
       - run_serial:
-          flags: --features=rocks
+          flags: --features=rocks,testing
           workspace_member: synthesizer
           cache_key: snarkvm-synthesizer-cache
 

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -52,6 +52,7 @@ serial = [
   "snarkvm-utilities/serial"
 ]
 setup = [ ]
+testing = [ ]
 timer = [ "aleo-std/timer" ]
 wasm = [ ]
 

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -149,8 +149,8 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     /// Initializes the block storage.
     fn open(dev: Option<u16>) -> Result<Self>;
 
-    #[cfg(feature = "testing")]
     /// Initializes the block storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self>;
 
     /// Returns the state root map.
@@ -674,7 +674,8 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         Ok(Self { storage, tree })
     }
 
-    /// Initializes the block store for testign
+    /// Initializes the block store for testing.
+    #[cfg(feature = "testing")]
     pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the block storage.
         let storage = B::open_testing(path)?;

--- a/synthesizer/src/store/consensus/mod.rs
+++ b/synthesizer/src/store/consensus/mod.rs
@@ -117,7 +117,7 @@ impl<N: Network, C: ConsensusStorage<N>> ConsensusStore<N, C> {
         // Initialize the consensus storage.
         let storage = C::open(dev)?;
         // Return the consensus store.
-        Ok(Self { storage, _phantom: PhantomData })
+        Ok(Self::from(storage))
     }
 
     /// Initializes the consensus store for testing.
@@ -126,7 +126,7 @@ impl<N: Network, C: ConsensusStorage<N>> ConsensusStore<N, C> {
         // Initialize the consensus storage.
         let storage = C::open_testing(path)?;
         // Return the consensus store.
-        Ok(Self { storage, _phantom: PhantomData })
+        Ok(Self::from(storage))
     }
 
     /// Initializes a consensus store from storage.

--- a/synthesizer/src/store/consensus/mod.rs
+++ b/synthesizer/src/store/consensus/mod.rs
@@ -43,6 +43,10 @@ pub trait ConsensusStorage<N: Network>: 'static + Clone + Send + Sync {
     /// Initializes the consensus storage.
     fn open(dev: Option<u16>) -> Result<Self>;
 
+    #[cfg(feature = "testing")]
+    /// Initializes the consensus storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self>;
+
     /// Returns the finalize storage.
     fn finalize_store(&self) -> &FinalizeStore<N, Self::FinalizeStorage>;
     /// Returns the block storage.
@@ -112,6 +116,15 @@ impl<N: Network, C: ConsensusStorage<N>> ConsensusStore<N, C> {
     pub fn open(dev: Option<u16>) -> Result<Self> {
         // Initialize the consensus storage.
         let storage = C::open(dev)?;
+        // Return the consensus store.
+        Ok(Self { storage, _phantom: PhantomData })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the consensus storage for testing.
+    pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize the consensus storage.
+        let storage = C::open_testing(path)?;
         // Return the consensus store.
         Ok(Self { storage, _phantom: PhantomData })
     }

--- a/synthesizer/src/store/consensus/mod.rs
+++ b/synthesizer/src/store/consensus/mod.rs
@@ -120,7 +120,7 @@ impl<N: Network, C: ConsensusStorage<N>> ConsensusStore<N, C> {
         Ok(Self { storage, _phantom: PhantomData })
     }
 
-    /// Initializes the consensus storage for testing.
+    /// Initializes the consensus store for testing.
     #[cfg(feature = "testing")]
     pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the consensus storage.

--- a/synthesizer/src/store/consensus/mod.rs
+++ b/synthesizer/src/store/consensus/mod.rs
@@ -43,8 +43,8 @@ pub trait ConsensusStorage<N: Network>: 'static + Clone + Send + Sync {
     /// Initializes the consensus storage.
     fn open(dev: Option<u16>) -> Result<Self>;
 
-    #[cfg(feature = "testing")]
     /// Initializes the consensus storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self>;
 
     /// Returns the finalize storage.
@@ -120,8 +120,8 @@ impl<N: Network, C: ConsensusStorage<N>> ConsensusStore<N, C> {
         Ok(Self { storage, _phantom: PhantomData })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the consensus storage for testing.
+    #[cfg(feature = "testing")]
     pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the consensus storage.
         let storage = C::open_testing(path)?;

--- a/synthesizer/src/store/helpers/memory/block.rs
+++ b/synthesizer/src/store/helpers/memory/block.rs
@@ -91,6 +91,29 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the block storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize the transition store.
+        let transition_store = TransitionStore::<N, TransitionMemory<N>>::open_testing(path.clone())?;
+        // Initialize the transaction store.
+        let transaction_store = TransactionStore::<N, TransactionMemory<N>>::open_testing(path, transition_store)?;
+        // Return the block storage.
+        Ok(Self {
+            state_root_map: MemoryMap::default(),
+            reverse_state_root_map: MemoryMap::default(),
+            id_map: MemoryMap::default(),
+            reverse_id_map: MemoryMap::default(),
+            header_map: MemoryMap::default(),
+            transactions_map: MemoryMap::default(),
+            reverse_transactions_map: MemoryMap::default(),
+            transaction_store,
+            coinbase_solution_map: MemoryMap::default(),
+            coinbase_puzzle_commitment_map: MemoryMap::default(),
+            signature_map: MemoryMap::default(),
+        })
+    }
+
     /// Returns the state root map.
     fn state_root_map(&self) -> &Self::StateRootMap {
         &self.state_root_map

--- a/synthesizer/src/store/helpers/memory/block.rs
+++ b/synthesizer/src/store/helpers/memory/block.rs
@@ -91,8 +91,8 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the block storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the transition store.
         let transition_store = TransitionStore::<N, TransitionMemory<N>>::open_testing(path.clone())?;

--- a/synthesizer/src/store/helpers/memory/block.rs
+++ b/synthesizer/src/store/helpers/memory/block.rs
@@ -106,7 +106,7 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
             reverse_id_map: MemoryMap::default(),
             header_map: MemoryMap::default(),
             transactions_map: MemoryMap::default(),
-            reverse_transactions_map: MemoryMap::default(),
+            confirmed_transactions_map: MemoryMap::default(),
             transaction_store,
             coinbase_solution_map: MemoryMap::default(),
             coinbase_puzzle_commitment_map: MemoryMap::default(),

--- a/synthesizer/src/store/helpers/memory/block.rs
+++ b/synthesizer/src/store/helpers/memory/block.rs
@@ -93,11 +93,11 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
 
     /// Initializes the block storage for testing.
     #[cfg(feature = "testing")]
-    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+    fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the transition store.
-        let transition_store = TransitionStore::<N, TransitionMemory<N>>::open_testing(path.clone())?;
+        let transition_store = TransitionStore::<N, TransitionMemory<N>>::open_testing(None)?;
         // Initialize the transaction store.
-        let transaction_store = TransactionStore::<N, TransactionMemory<N>>::open_testing(path, transition_store)?;
+        let transaction_store = TransactionStore::<N, TransactionMemory<N>>::open_testing(None, transition_store)?;
         // Return the block storage.
         Ok(Self {
             state_root_map: MemoryMap::default(),

--- a/synthesizer/src/store/helpers/memory/consensus.rs
+++ b/synthesizer/src/store/helpers/memory/consensus.rs
@@ -53,11 +53,11 @@ impl<N: Network> ConsensusStorage<N> for ConsensusMemory<N> {
 
     /// Initializes the consensus storage for testing.
     #[cfg(feature = "testing")]
-    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+    fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the finalize store.
-        let finalize_store = FinalizeStore::<N, FinalizeMemory<N>>::open_testing(path.clone())?;
+        let finalize_store = FinalizeStore::<N, FinalizeMemory<N>>::open_testing(None)?;
         // Initialize the block store.
-        let block_store = BlockStore::<N, BlockMemory<N>>::open_testing(path)?;
+        let block_store = BlockStore::<N, BlockMemory<N>>::open_testing(None)?;
         // Return the consensus storage.
         Ok(Self {
             finalize_store,

--- a/synthesizer/src/store/helpers/memory/consensus.rs
+++ b/synthesizer/src/store/helpers/memory/consensus.rs
@@ -51,6 +51,20 @@ impl<N: Network> ConsensusStorage<N> for ConsensusMemory<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the consensus storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize the finalize store.
+        let finalize_store = FinalizeStore::<N, FinalizeMemory<N>>::open_testing(path.clone())?;
+        // Initialize the block store.
+        let block_store = BlockStore::<N, BlockMemory<N>>::open_testing(path)?;
+        // Return the consensus storage.
+        Ok(Self {
+            finalize_store,
+            block_store,
+        })
+    }
+
     /// Returns the finalize store.
     fn finalize_store(&self) -> &FinalizeStore<N, Self::FinalizeStorage> {
         &self.finalize_store

--- a/synthesizer/src/store/helpers/memory/consensus.rs
+++ b/synthesizer/src/store/helpers/memory/consensus.rs
@@ -51,8 +51,8 @@ impl<N: Network> ConsensusStorage<N> for ConsensusMemory<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the consensus storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the finalize store.
         let finalize_store = FinalizeStore::<N, FinalizeMemory<N>>::open_testing(path.clone())?;

--- a/synthesizer/src/store/helpers/memory/program.rs
+++ b/synthesizer/src/store/helpers/memory/program.rs
@@ -60,6 +60,13 @@ impl<N: Network> FinalizeStorage<N> for FinalizeMemory<N> {
         })
     }
 
+
+    /// Initializes the program state storage for testing.
+    #[cfg(feature = "testing")]
+    fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
+        Self::open(None)
+    }
+
     /// Returns the program ID map.
     fn program_id_map(&self) -> &Self::ProgramIDMap {
         &self.program_id_map

--- a/synthesizer/src/store/helpers/memory/transaction.rs
+++ b/synthesizer/src/store/helpers/memory/transaction.rs
@@ -68,6 +68,17 @@ impl<N: Network> TransactionStorage<N> for TransactionMemory<N> {
         Ok(Self { id_map: MemoryMap::default(), deployment_store, execution_store, fee_store })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transaction storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
+        // Initialize the deployment store.
+        let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::open_testing(path.clone(), transition_store.clone())?;
+        // Initialize the execution store.
+        let execution_store = ExecutionStore::<N, ExecutionMemory<N>>::open_testing(path, transition_store)?;
+        // Return the transaction storage.
+        Ok(Self { id_map: MemoryMap::default(), deployment_store, execution_store })
+    }
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap {
         &self.id_map
@@ -134,6 +145,12 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
             certificate_map: MemoryMap::default(),
             fee_store,
         })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the deployment storage for testing.
+    fn open_testing(_: Option<std::path::PathBuf>, fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self> {
+        Self::open(fee_store)
     }
 
     /// Returns the ID map.
@@ -208,6 +225,12 @@ impl<N: Network> ExecutionStorage<N> for ExecutionMemory<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the execution storage for testing.
+    fn open_testing(_: Option<std::path::PathBuf>, fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self> {
+        Self::open(fee_store)
+    }
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap {
         &self.id_map
@@ -256,6 +279,12 @@ impl<N: Network> FeeStorage<N> for FeeMemory<N> {
         })
     }
 
+    /// Initializes the fee storage for testing.
+    #[cfg(feature = "testing")]
+    fn open_testing(_: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
+        Self::open(transition_store)
+    }
+
     /// Returns the fee map.
     fn fee_map(&self) -> &Self::FeeMap {
         &self.fee_map
@@ -271,3 +300,4 @@ impl<N: Network> FeeStorage<N> for FeeMemory<N> {
         &self.transition_store
     }
 }
+

--- a/synthesizer/src/store/helpers/memory/transaction.rs
+++ b/synthesizer/src/store/helpers/memory/transaction.rs
@@ -71,12 +71,14 @@ impl<N: Network> TransactionStorage<N> for TransactionMemory<N> {
     /// Initializes the transaction storage for testing.
     #[cfg(feature = "testing")]
     fn open_testing(_: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
+        // Initialize the fee store.
+        let fee_store = FeeStore::<N, FeeMemory<N>>::open_testing(None, transition_store)?;
         // Initialize the deployment store.
-        let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::open_testing(None, transition_store.clone())?;
+        let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::open_testing(None, fee_store.clone())?;
         // Initialize the execution store.
-        let execution_store = ExecutionStore::<N, ExecutionMemory<N>>::open_testing(None, transition_store)?;
+        let execution_store = ExecutionStore::<N, ExecutionMemory<N>>::open_testing(None, fee_store.clone())?;
         // Return the transaction storage.
-        Ok(Self { id_map: MemoryMap::default(), deployment_store, execution_store })
+        Ok(Self { id_map: MemoryMap::default(), deployment_store, execution_store, fee_store })
     }
 
     /// Returns the ID map.

--- a/synthesizer/src/store/helpers/memory/transaction.rs
+++ b/synthesizer/src/store/helpers/memory/transaction.rs
@@ -70,11 +70,11 @@ impl<N: Network> TransactionStorage<N> for TransactionMemory<N> {
 
     /// Initializes the transaction storage for testing.
     #[cfg(feature = "testing")]
-    fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
+    fn open_testing(_: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
         // Initialize the deployment store.
-        let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::open_testing(path.clone(), transition_store.clone())?;
+        let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::open_testing(None, transition_store.clone())?;
         // Initialize the execution store.
-        let execution_store = ExecutionStore::<N, ExecutionMemory<N>>::open_testing(path, transition_store)?;
+        let execution_store = ExecutionStore::<N, ExecutionMemory<N>>::open_testing(None, transition_store)?;
         // Return the transaction storage.
         Ok(Self { id_map: MemoryMap::default(), deployment_store, execution_store })
     }

--- a/synthesizer/src/store/helpers/memory/transaction.rs
+++ b/synthesizer/src/store/helpers/memory/transaction.rs
@@ -68,8 +68,8 @@ impl<N: Network> TransactionStorage<N> for TransactionMemory<N> {
         Ok(Self { id_map: MemoryMap::default(), deployment_store, execution_store, fee_store })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transaction storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
         // Initialize the deployment store.
         let deployment_store = DeploymentStore::<N, DeploymentMemory<N>>::open_testing(path.clone(), transition_store.clone())?;
@@ -147,8 +147,8 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the deployment storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(_: Option<std::path::PathBuf>, fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self> {
         Self::open(fee_store)
     }
@@ -300,4 +300,3 @@ impl<N: Network> FeeStorage<N> for FeeMemory<N> {
         &self.transition_store
     }
 }
-

--- a/synthesizer/src/store/helpers/memory/transition.rs
+++ b/synthesizer/src/store/helpers/memory/transition.rs
@@ -74,6 +74,12 @@ impl<N: Network> TransitionStorage<N> for TransitionMemory<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transition storage for testing.
+    fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
+        Self::open(None)
+    }
+
     /// Returns the transition program IDs and function names.
     fn locator_map(&self) -> &Self::LocatorMap {
         &self.locator_map
@@ -167,6 +173,12 @@ impl<N: Network> InputStorage<N> for InputMemory<N> {
             external_record: MemoryMap::default(),
             dev,
         })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transition input storage for testing.
+    fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
+        Self::open(None)
     }
 
     /// Returns the ID map.
@@ -263,6 +275,12 @@ impl<N: Network> OutputStorage<N> for OutputMemory<N> {
             external_record: Default::default(),
             dev,
         })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transition output storage for testing.
+    fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
+        Self::open(None)
     }
 
     /// Returns the ID map.

--- a/synthesizer/src/store/helpers/memory/transition.rs
+++ b/synthesizer/src/store/helpers/memory/transition.rs
@@ -74,8 +74,8 @@ impl<N: Network> TransitionStorage<N> for TransitionMemory<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transition storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
         Self::open(None)
     }
@@ -175,8 +175,8 @@ impl<N: Network> InputStorage<N> for InputMemory<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transition input storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
         Self::open(None)
     }
@@ -277,8 +277,8 @@ impl<N: Network> OutputStorage<N> for OutputMemory<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transition output storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(_: Option<std::path::PathBuf>) -> Result<Self> {
         Self::open(None)
     }

--- a/synthesizer/src/store/helpers/rocksdb/block.rs
+++ b/synthesizer/src/store/helpers/rocksdb/block.rs
@@ -97,8 +97,8 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the block storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the transition store.
         let transition_store = TransitionStore::<N, TransitionDB<N>>::open_testing(path.clone())?;

--- a/synthesizer/src/store/helpers/rocksdb/block.rs
+++ b/synthesizer/src/store/helpers/rocksdb/block.rs
@@ -97,6 +97,29 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the block storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize the transition store.
+        let transition_store = TransitionStore::<N, TransitionDB<N>>::open_testing(path.clone())?;
+        // Initialize the transaction store.
+        let transaction_store = TransactionStore::<N, TransactionDB<N>>::open_testing(path.clone(), transition_store)?;
+        // Return the block storage.
+        Ok(Self {
+            state_root_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::StateRoot))?,
+            reverse_state_root_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::ReverseStateRoot))?,
+            id_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::ID))?,
+            reverse_id_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::ReverseID))?,
+            header_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::Header))?,
+            transactions_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::Transactions))?,
+            reverse_transactions_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::ReverseTransactions))?,
+            transaction_store,
+            coinbase_solution_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::CoinbaseSolution))?,
+            coinbase_puzzle_commitment_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::CoinbasePuzzleCommitment))?,
+            signature_map: internal::RocksDB::open_map_testing(path, MapID::Block(BlockMap::Signature))?,
+        })
+    }
+
     /// Returns the state root map.
     fn state_root_map(&self) -> &Self::StateRootMap {
         &self.state_root_map

--- a/synthesizer/src/store/helpers/rocksdb/block.rs
+++ b/synthesizer/src/store/helpers/rocksdb/block.rs
@@ -112,7 +112,7 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
             reverse_id_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::ReverseID))?,
             header_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::Header))?,
             transactions_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::Transactions))?,
-            reverse_transactions_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::ReverseTransactions))?,
+            confirmed_transactions_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::ConfirmedTransactions))?,
             transaction_store,
             coinbase_solution_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::CoinbaseSolution))?,
             coinbase_puzzle_commitment_map: internal::RocksDB::open_map_testing(path.clone(), MapID::Block(BlockMap::CoinbasePuzzleCommitment))?,

--- a/synthesizer/src/store/helpers/rocksdb/consensus.rs
+++ b/synthesizer/src/store/helpers/rocksdb/consensus.rs
@@ -51,6 +51,20 @@ impl<N: Network> ConsensusStorage<N> for ConsensusDB<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the consensus storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize the finalize store.
+        let finalize_store = FinalizeStore::<N, FinalizeDB<N>>::open_testing(path.clone())?;
+        // Initialize the block store.
+        let block_store = BlockStore::<N, BlockDB<N>>::open_testing(path)?;
+        // Return the consensus storage.
+        Ok(Self {
+            finalize_store,
+            block_store,
+        })
+    }
+
     /// Returns the finalize store.
     fn finalize_store(&self) -> &FinalizeStore<N, Self::FinalizeStorage> {
         &self.finalize_store

--- a/synthesizer/src/store/helpers/rocksdb/consensus.rs
+++ b/synthesizer/src/store/helpers/rocksdb/consensus.rs
@@ -51,8 +51,8 @@ impl<N: Network> ConsensusStorage<N> for ConsensusDB<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the consensus storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the finalize store.
         let finalize_store = FinalizeStore::<N, FinalizeDB<N>>::open_testing(path.clone())?;

--- a/synthesizer/src/store/helpers/rocksdb/internal/map.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/map.rs
@@ -329,6 +329,7 @@ impl<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> fmt::Debu
 }
 
 #[cfg(test)]
+#[cfg(features = "testing")]
 mod tests {
     use super::*;
     use crate::{

--- a/synthesizer/src/store/helpers/rocksdb/internal/map.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/map.rs
@@ -89,7 +89,7 @@ impl<
     ///
     fn start_atomic(&self) {
         // Set the atomic batch flag to `true`.
-        self.batch_in_progress.store(true, Ordering::SeqCst);
+        self.batch_in_progress.store(true, Ordering::Relaxed);
         // Ensure that the atomic batch is empty.
         assert!(self.atomic_batch.lock().is_empty());
     }
@@ -100,7 +100,7 @@ impl<
     /// if they are already part of a larger one.
     ///
     fn is_atomic_in_progress(&self) -> bool {
-        self.batch_in_progress.load(Ordering::SeqCst)
+        self.batch_in_progress.load(Ordering::Acquire)
     }
 
     ///
@@ -141,7 +141,7 @@ impl<
         // Clear the checkpoint stack.
         *self.checkpoint.lock() = Default::default();
         // Set the atomic batch flag to `false`.
-        self.batch_in_progress.store(false, Ordering::SeqCst);
+        self.batch_in_progress.store(false, Ordering::Release);
     }
 
     ///
@@ -185,7 +185,7 @@ impl<
         // Clear the checkpoint stack.
         *self.checkpoint.lock() = Default::default();
         // Set the atomic batch flag to `false`.
-        self.batch_in_progress.store(false, Ordering::SeqCst);
+        self.batch_in_progress.store(false, Ordering::Release);
 
         Ok(())
     }
@@ -354,7 +354,7 @@ mod tests {
 
         // Initialize a map.
         let map: DataMap<Address<CurrentNetwork>, ()> =
-            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
+            RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMap::Test)).expect("Failed to open data map");
         map.insert(address, ()).expect("Failed to insert into data map");
         assert!(map.contains_key_confirmed(&address).unwrap());
     }
@@ -365,7 +365,7 @@ mod tests {
     fn test_insert_and_get_speculative() {
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
+            RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter_confirmed().next().is_none());
@@ -418,7 +418,7 @@ mod tests {
     fn test_remove_and_get_speculative() {
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
+            RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter_confirmed().next().is_none());
@@ -481,7 +481,7 @@ mod tests {
 
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
+            RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter_confirmed().next().is_none());
@@ -542,7 +542,7 @@ mod tests {
 
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
+            RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter_confirmed().next().is_none());

--- a/synthesizer/src/store/helpers/rocksdb/internal/map.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/map.rs
@@ -89,7 +89,7 @@ impl<
     ///
     fn start_atomic(&self) {
         // Set the atomic batch flag to `true`.
-        self.batch_in_progress.store(true, Ordering::Relaxed);
+        self.batch_in_progress.store(true, Ordering::SeqCst);
         // Ensure that the atomic batch is empty.
         assert!(self.atomic_batch.lock().is_empty());
     }
@@ -100,7 +100,7 @@ impl<
     /// if they are already part of a larger one.
     ///
     fn is_atomic_in_progress(&self) -> bool {
-        self.batch_in_progress.load(Ordering::Acquire)
+        self.batch_in_progress.load(Ordering::SeqCst)
     }
 
     ///
@@ -141,7 +141,7 @@ impl<
         // Clear the checkpoint stack.
         *self.checkpoint.lock() = Default::default();
         // Set the atomic batch flag to `false`.
-        self.batch_in_progress.store(false, Ordering::Release);
+        self.batch_in_progress.store(false, Ordering::SeqCst);
     }
 
     ///
@@ -185,7 +185,7 @@ impl<
         // Clear the checkpoint stack.
         *self.checkpoint.lock() = Default::default();
         // Set the atomic batch flag to `false`.
-        self.batch_in_progress.store(false, Ordering::Release);
+        self.batch_in_progress.store(false, Ordering::SeqCst);
 
         Ok(())
     }

--- a/synthesizer/src/store/helpers/rocksdb/internal/mod.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/mod.rs
@@ -28,13 +28,11 @@ mod tests;
 
 use anyhow::{bail, Result};
 use core::{fmt::Debug, hash::Hash};
-use indexmap::IndexMap;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::{OnceCell};
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
-    borrow::{Borrow, BorrowMut},
-    collections::HashMap,
+    borrow::{Borrow},
     marker::PhantomData,
     ops::Deref,
     sync::{atomic::AtomicBool, Arc},

--- a/synthesizer/src/store/helpers/rocksdb/internal/mod.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/mod.rs
@@ -28,11 +28,11 @@ mod tests;
 
 use anyhow::{bail, Result};
 use core::{fmt::Debug, hash::Hash};
-use once_cell::sync::{OnceCell};
+use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
-    borrow::{Borrow},
+    borrow::Borrow,
     marker::PhantomData,
     ops::Deref,
     sync::{atomic::AtomicBool, Arc},
@@ -139,6 +139,9 @@ impl Database for RocksDB {
 impl RocksDB {
     /// Opens the test database.
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        use once_cell::sync::Lazy;
+        use std::collections::HashMap;
+
         // A global mapping of test databases.
         static DATABASES: Lazy<Mutex<HashMap<std::path::PathBuf, RocksDB>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 

--- a/synthesizer/src/store/helpers/rocksdb/internal/tests.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/tests.rs
@@ -41,13 +41,13 @@ pub(crate) fn temp_dir() -> std::path::PathBuf {
 #[test]
 #[serial]
 fn test_open() {
-    let _storage = RocksDB::open_testing(temp_dir(), None).expect("Failed to open storage");
+    let _storage = RocksDB::open_testing(Some(temp_dir())).expect("Failed to open storage");
 }
 
 #[test]
 #[serial]
 fn test_open_map() {
-    let _map = RocksDB::open_map_testing::<u32, String, _>(temp_dir(), None, MapID::Test(TestMapID::Test))
+    let _map = RocksDB::open_map_testing::<u32, String, _>(Some(temp_dir()), MapID::Test(TestMapID::Test))
         .expect("Failed to open data map");
 }
 
@@ -55,7 +55,7 @@ fn test_open_map() {
 #[serial]
 fn test_insert_and_contains_key() {
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     assert!(map.contains_key_confirmed(&123456789).expect("Failed to call contains key"));
@@ -66,7 +66,7 @@ fn test_insert_and_contains_key() {
 #[serial]
 fn test_insert_and_get() {
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     assert_eq!(
@@ -81,7 +81,7 @@ fn test_insert_and_get() {
 #[serial]
 fn test_insert_and_remove() {
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     assert_eq!(
@@ -97,7 +97,7 @@ fn test_insert_and_remove() {
 #[serial]
 fn test_insert_and_iter() {
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
 
@@ -110,7 +110,7 @@ fn test_insert_and_iter() {
 #[serial]
 fn test_insert_and_keys() {
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
 
@@ -123,7 +123,7 @@ fn test_insert_and_keys() {
 #[serial]
 fn test_insert_and_values() {
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
 
@@ -137,13 +137,13 @@ fn test_insert_and_values() {
 fn test_reopen() {
     let directory = temp_dir();
     {
-        let map = RocksDB::open_map_testing(directory.clone(), None, MapID::Test(TestMapID::Test))
+        let map = RocksDB::open_map_testing(Some(directory.clone()), MapID::Test(TestMapID::Test))
             .expect("Failed to open data map");
         map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     }
     {
         let map: TestMap =
-            RocksDB::open_map_testing(directory, None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+            RocksDB::open_map_testing(Some(directory), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
         match map.get_confirmed(&123456789).expect("Failed to get") {
             Some(Cow::Borrowed(value)) => assert_eq!(value.to_string(), "123456789".to_string()),
             Some(Cow::Owned(value)) => assert_eq!(value, "123456789".to_string()),
@@ -186,7 +186,7 @@ fn test_scalar_mul() {
     const ITERATIONS: u32 = 1_000_000u32;
 
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     // Sample `ITERATION` random field elements to store.
     for i in 0..ITERATIONS {
@@ -209,7 +209,7 @@ fn test_scalar_mul() {
 #[serial]
 fn test_iterator_ordering() {
     let map =
-        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
+        RocksDB::open_map_testing(Some(temp_dir()), MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     // Insert values into the map.
     map.insert(5, "d".to_string()).expect("Failed to insert");

--- a/synthesizer/src/store/helpers/rocksdb/internal/tests.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/tests.rs
@@ -16,8 +16,9 @@
 
 #![cfg(feature = "testing")]
 
-use crate::store::helpers::{
-    rocksdb::{DataMap, MapID, RocksDB, TestMap as TestMapID},
+use crate::{
+    helpers::{Map, MapRead},
+    store::helpers::rocksdb::{DataMap, MapID, RocksDB, TestMap as TestMapID},
 };
 use console::{
     network::{Network, Testnet3},

--- a/synthesizer/src/store/helpers/rocksdb/internal/tests.rs
+++ b/synthesizer/src/store/helpers/rocksdb/internal/tests.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+#![cfg(feature = "testing")]
+
 use crate::store::helpers::{
     rocksdb::{DataMap, MapID, RocksDB, TestMap as TestMapID},
-    Map,
-    MapRead,
 };
 use console::{
     network::{Network, Testnet3},

--- a/synthesizer/src/store/helpers/rocksdb/program.rs
+++ b/synthesizer/src/store/helpers/rocksdb/program.rs
@@ -63,6 +63,20 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Opens the test database.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        Ok(Self {
+            program_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::ProgramID))?,
+            program_index_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::ProgramIndex))?,
+            mapping_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::MappingID))?,
+            key_value_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::KeyValueID))?,
+            key_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::Key))?,
+            value_map: rocksdb::RocksDB::open_map_testing(path, MapID::Program(ProgramMap::Value))?,
+            dev: None,
+        })
+    }
+
     /// Returns the program ID map.
     fn program_id_map(&self) -> &Self::ProgramIDMap {
         &self.program_id_map

--- a/synthesizer/src/store/helpers/rocksdb/program.rs
+++ b/synthesizer/src/store/helpers/rocksdb/program.rs
@@ -68,7 +68,6 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         Ok(Self {
             program_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::ProgramID))?,
-            program_index_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::ProgramIndex))?,
             mapping_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::MappingID))?,
             key_value_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::KeyValueID))?,
             key_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::Key))?,

--- a/synthesizer/src/store/helpers/rocksdb/program.rs
+++ b/synthesizer/src/store/helpers/rocksdb/program.rs
@@ -63,8 +63,8 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Opens the test database.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         Ok(Self {
             program_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Program(ProgramMap::ProgramID))?,

--- a/synthesizer/src/store/helpers/rocksdb/transaction.rs
+++ b/synthesizer/src/store/helpers/rocksdb/transaction.rs
@@ -78,6 +78,17 @@ impl<N: Network> TransactionStorage<N> for TransactionDB<N> {
         Ok(Self { id_map: rocksdb::RocksDB::open_map(N::ID, execution_store.dev(), MapID::Transaction(TransactionMap::ID))?, deployment_store, execution_store, fee_store })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transaction storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
+        // Initialize the deployment store.
+        let deployment_store = DeploymentStore::<N, DeploymentDB<N>>::open_testing(path.clone(), transition_store.clone())?;
+        // Initialize the execution store.
+        let execution_store = ExecutionStore::<N, ExecutionDB<N>>::open_testing(path.clone(), transition_store)?;
+        // Return the transaction storage.
+        Ok(Self { id_map: rocksdb::RocksDB::open_map_testing(path, MapID::Transaction(TransactionMap::ID))?, deployment_store, execution_store })
+    }
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap {
         &self.id_map
@@ -144,6 +155,21 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
             program_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::Program))?,
             verifying_key_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::VerifyingKey))?,
             certificate_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::Certificate))?,
+            fee_store,
+        })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the deployment storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>, fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self> {
+        Ok(Self {
+            id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Deployment(DeploymentMap::ID))?,
+            edition_map: rocksdb::RocksDB::open_map_testing(path.clone(),  MapID::Deployment(DeploymentMap::Edition))?,
+            reverse_id_map: rocksdb::RocksDB::open_map_testing(path.clone(),  MapID::Deployment(DeploymentMap::ReverseID))?,
+            owner_map: rocksdb::RocksDB::open_map_testing(path.clone(),  MapID::Deployment(DeploymentMap::Owner))?,
+            program_map: rocksdb::RocksDB::open_map_testing(path.clone(),  MapID::Deployment(DeploymentMap::Program))?,
+            verifying_key_map: rocksdb::RocksDB::open_map_testing(path.clone(),  MapID::Deployment(DeploymentMap::VerifyingKey))?,
+            certificate_map: rocksdb::RocksDB::open_map_testing(path,  MapID::Deployment(DeploymentMap::Certificate))?,
             fee_store,
         })
     }
@@ -222,6 +248,17 @@ impl<N: Network> ExecutionStorage<N> for ExecutionDB<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the execution storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>, fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self> {
+        Ok(Self {
+            id_map: rocksdb::RocksDB::open_map_testing(path.clone(), N::ID, MapID::Execution(ExecutionMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), N::ID, MapID::Execution(ExecutionMap::ReverseID))?,
+            inclusion_map: rocksdb::RocksDB::open_map_testing(path, N::ID, MapID::Execution(ExecutionMap::Inclusion))?,
+            fee_store,
+        })
+    }
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap {
         &self.id_map
@@ -268,6 +305,16 @@ impl<N: Network> FeeStorage<N> for FeeDB<N> {
         Ok(Self {
             fee_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Fee(FeeMap::Fee))?,
             reverse_fee_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Fee(FeeMap::ReverseFee))?,
+            transition_store,
+        })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the execution storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
+        Ok(Self {
+            fee_map: rocksdb::RocksDB::open_map_testing(path.clone(), N::ID, MapID::Fee(FeeMap::Fee))?,
+            reverse_fee_map: rocksdb::RocksDB::open_map_testing(path, N::ID, MapID::Fee(FeeMap::ReverseFee))?,
             transition_store,
         })
     }

--- a/synthesizer/src/store/helpers/rocksdb/transaction.rs
+++ b/synthesizer/src/store/helpers/rocksdb/transaction.rs
@@ -78,8 +78,8 @@ impl<N: Network> TransactionStorage<N> for TransactionDB<N> {
         Ok(Self { id_map: rocksdb::RocksDB::open_map(N::ID, execution_store.dev(), MapID::Transaction(TransactionMap::ID))?, deployment_store, execution_store, fee_store })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transaction storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self> {
         // Initialize the deployment store.
         let deployment_store = DeploymentStore::<N, DeploymentDB<N>>::open_testing(path.clone(), transition_store.clone())?;
@@ -159,8 +159,8 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the deployment storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>, fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self> {
         Ok(Self {
             id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Deployment(DeploymentMap::ID))?,

--- a/synthesizer/src/store/helpers/rocksdb/transition.rs
+++ b/synthesizer/src/store/helpers/rocksdb/transition.rs
@@ -81,6 +81,22 @@ impl<N: Network> TransitionStorage<N> for TransitionDB<N> {
         })
     }
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transition storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        Ok(Self {
+            locator_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Transition(TransitionMap::Locator))?,
+            input_store: InputStore::open_testing(path.clone())?,
+            output_store: OutputStore::open_testing(path.clone())?,
+            finalize_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Transition(TransitionMap::Finalize))?,
+            proof_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Transition(TransitionMap::Proof))?,
+            tpk_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Transition(TransitionMap::TPK))?,
+            reverse_tpk_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Transition(TransitionMap::ReverseTPK))?,
+            tcm_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Transition(TransitionMap::TCM))?,
+            reverse_tcm_map: rocksdb::RocksDB::open_map_testing(path, MapID::Transition(TransitionMap::ReverseTCM))?,
+        })
+    }
+
     /// Returns the transition program IDs and function names.
     fn locator_map(&self) -> &Self::LocatorMap {
         &self.locator_map
@@ -173,6 +189,22 @@ impl<N: Network> InputStorage<N> for InputDB<N> {
             record_tag: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::RecordTag))?,
             external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::ExternalRecord))?,
             dev,
+        })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transition input storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        Ok(Self {
+            id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::ReverseID))?,
+            constant: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::Constant))?,
+            public: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::Public))?,
+            private: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::Private))?,
+            record: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::Record))?,
+            record_tag: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::RecordTag))?,
+            external_record: rocksdb::RocksDB::open_map_testing(path, MapID::TransitionInput(TransitionInputMap::ExternalRecord))?,
+            dev: None,
         })
     }
 
@@ -269,6 +301,22 @@ impl<N: Network> OutputStorage<N> for OutputDB<N> {
             record_nonce: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::RecordNonce))?,
             external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::ExternalRecord))?,
             dev,
+        })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transition output storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        Ok(Self {
+            id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::ReverseID))?,
+            constant: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::Constant))?,
+            public: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::Public))?,
+            private: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::Private))?,
+            record: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::Record))?,
+            record_nonce: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::RecordNonce))?,
+            external_record: rocksdb::RocksDB::open_map_testing(path, MapID::TransitionOutput(TransitionOutputMap::ExternalRecord))?,
+            dev: None,
         })
     }
 

--- a/synthesizer/src/store/helpers/rocksdb/transition.rs
+++ b/synthesizer/src/store/helpers/rocksdb/transition.rs
@@ -81,8 +81,8 @@ impl<N: Network> TransitionStorage<N> for TransitionDB<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transition storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         Ok(Self {
             locator_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::Transition(TransitionMap::Locator))?,
@@ -192,8 +192,8 @@ impl<N: Network> InputStorage<N> for InputDB<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transition input storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         Ok(Self {
             id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionInput(TransitionInputMap::ID))?,
@@ -304,8 +304,8 @@ impl<N: Network> OutputStorage<N> for OutputDB<N> {
         })
     }
 
-    #[cfg(feature = "testing")]
     /// Initializes the transition output storage for testing.
+    #[cfg(feature = "testing")]
     fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         Ok(Self {
             id_map: rocksdb::RocksDB::open_map_testing(path.clone(), MapID::TransitionOutput(TransitionOutputMap::ID))?,

--- a/synthesizer/src/store/program/finalize.rs
+++ b/synthesizer/src/store/program/finalize.rs
@@ -553,12 +553,7 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
     #[cfg(feature = "testing")]
     /// Initializes a finalize store for testing.
     pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
-        // Initialize the finalize storage.
-        let storage = P::open_testing(path)?;
-        // Compute the finalize tree.
-        let tree = Arc::new(RwLock::new(storage.to_finalize_tree()?));
-
-        Ok(Self { storage, tree, is_speculate: Default::default(), _phantom: PhantomData })
+        Self::from(P::open_testing(path)?)
     }
 
     /// Initializes a finalize store from storage.

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -59,6 +59,13 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the deployment storage.
     fn open(fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self>;
 
+    #[cfg(feature = "testing")]
+    /// Initializes the deployment storage for testing.
+    fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, Self::TransitionStorage>,
+    ) -> Result<Self>;
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
     /// Returns the edition map.
@@ -442,6 +449,18 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     pub fn open(fee_store: FeeStore<N, D::FeeStorage>) -> Result<Self> {
         // Initialize the deployment storage.
         let storage = D::open(fee_store)?;
+        // Return the deployment store.
+        Ok(Self { storage, _phantom: PhantomData })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the deployment storage for testing.
+    pub fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, D::TransitionStorage>,
+    ) -> Result<Self> {
+        // Initialize the deployment storage.
+        let storage = D::open_testing(path, transition_store)?;
         // Return the deployment store.
         Ok(Self { storage, _phantom: PhantomData })
     }

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -61,10 +61,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     #[cfg(feature = "testing")]
     /// Initializes the deployment storage for testing.
-    fn open_testing(
-        path: Option<std::path::PathBuf>,
-        transition_store: TransitionStore<N, Self::TransitionStorage>,
-    ) -> Result<Self>;
+    fn open_testing(path: Option<std::path::PathBuf>, transition_store: FeeStore<N, Self::FeeStorage>) -> Result<Self>;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -455,12 +452,9 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
 
     #[cfg(feature = "testing")]
     /// Initializes the deployment store for testing.
-    pub fn open_testing(
-        path: Option<std::path::PathBuf>,
-        transition_store: TransitionStore<N, D::TransitionStorage>,
-    ) -> Result<Self> {
+    pub fn open_testing(path: Option<std::path::PathBuf>, fee_store: FeeStore<N, D::FeeStorage>) -> Result<Self> {
         // Initialize the deployment storage.
-        let storage = D::open_testing(path, transition_store)?;
+        let storage = D::open_testing(path, fee_store)?;
         // Return the deployment store.
         Ok(Self::from(storage))
     }

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -454,7 +454,7 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     }
 
     #[cfg(feature = "testing")]
-    /// Initializes the deployment storage for testing.
+    /// Initializes the deployment store for testing.
     pub fn open_testing(
         path: Option<std::path::PathBuf>,
         transition_store: TransitionStore<N, D::TransitionStorage>,

--- a/synthesizer/src/store/transaction/deployment.rs
+++ b/synthesizer/src/store/transaction/deployment.rs
@@ -450,7 +450,7 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
         // Initialize the deployment storage.
         let storage = D::open(fee_store)?;
         // Return the deployment store.
-        Ok(Self { storage, _phantom: PhantomData })
+        Ok(Self::from(storage))
     }
 
     #[cfg(feature = "testing")]
@@ -462,7 +462,7 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
         // Initialize the deployment storage.
         let storage = D::open_testing(path, transition_store)?;
         // Return the deployment store.
-        Ok(Self { storage, _phantom: PhantomData })
+        Ok(Self::from(storage))
     }
 
     /// Initializes a deployment store from storage.

--- a/synthesizer/src/store/transaction/execution.rs
+++ b/synthesizer/src/store/transaction/execution.rs
@@ -50,10 +50,7 @@ pub trait ExecutionStorage<N: Network>: Clone + Send + Sync {
 
     #[cfg(feature = "testing")]
     /// Initializes the execution storage for testing.
-    fn open_testing(
-        path: Option<std::path::PathBuf>,
-        fee_store: FeeStore<N, Self::FeeStorage>,
-    ) -> Result<Self>;
+    fn open_testing(path: Option<std::path::PathBuf>, fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self>;
 
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
@@ -309,10 +306,7 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
 
     #[cfg(feature = "testing")]
     /// Initializes the execution store for testing.
-    pub fn open_testing(
-        path: Option<std::path::PathBuf>,
-        fee_store: FeeStore<N, E::FeeStorage>,
-    ) -> Result<Self> {
+    pub fn open_testing(path: Option<std::path::PathBuf>, fee_store: FeeStore<N, E::FeeStorage>) -> Result<Self> {
         // Initialize the execution storage.
         let storage = E::open_testing(path, fee_store)?;
         // Return the execution store.

--- a/synthesizer/src/store/transaction/execution.rs
+++ b/synthesizer/src/store/transaction/execution.rs
@@ -308,7 +308,7 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
     }
 
     #[cfg(feature = "testing")]
-    /// Initializes the execution storage for testing.
+    /// Initializes the execution store for testing.
     pub fn open_testing(
         path: Option<std::path::PathBuf>,
         fee_store: FeeStore<N, E::FeeStorage>,

--- a/synthesizer/src/store/transaction/execution.rs
+++ b/synthesizer/src/store/transaction/execution.rs
@@ -52,7 +52,7 @@ pub trait ExecutionStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the execution storage for testing.
     fn open_testing(
         path: Option<std::path::PathBuf>,
-        transition_store: TransitionStore<N, Self::TransitionStorage>,
+        fee_store: FeeStore<N, Self::FeeStorage>,
     ) -> Result<Self>;
 
     /// Returns the ID map.
@@ -304,19 +304,19 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
         // Initialize the execution storage.
         let storage = E::open(fee_store)?;
         // Return the execution store.
-        Ok(Self { storage, _phantom: PhantomData })
+        Ok(Self::from(storage))
     }
 
     #[cfg(feature = "testing")]
     /// Initializes the execution storage for testing.
     pub fn open_testing(
         path: Option<std::path::PathBuf>,
-        transition_store: TransitionStore<N, E::TransitionStorage>,
+        fee_store: FeeStore<N, E::FeeStorage>,
     ) -> Result<Self> {
         // Initialize the execution storage.
-        let storage = E::open_testing(path, transition_store)?;
+        let storage = E::open_testing(path, fee_store)?;
         // Return the execution store.
-        Ok(Self { storage, _phantom: PhantomData })
+        Ok(Self::from(storage))
     }
 
     /// Initializes an execution store from storage.

--- a/synthesizer/src/store/transaction/execution.rs
+++ b/synthesizer/src/store/transaction/execution.rs
@@ -48,6 +48,13 @@ pub trait ExecutionStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the execution storage.
     fn open(fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self>;
 
+    #[cfg(feature = "testing")]
+    /// Initializes the execution storage for testing.
+    fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, Self::TransitionStorage>,
+    ) -> Result<Self>;
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
     /// Returns the reverse ID map.
@@ -296,6 +303,18 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
     pub fn open(fee_store: FeeStore<N, E::FeeStorage>) -> Result<Self> {
         // Initialize the execution storage.
         let storage = E::open(fee_store)?;
+        // Return the execution store.
+        Ok(Self { storage, _phantom: PhantomData })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the execution storage for testing.
+    pub fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, E::TransitionStorage>,
+    ) -> Result<Self> {
+        // Initialize the execution storage.
+        let storage = E::open_testing(path, transition_store)?;
         // Return the execution store.
         Ok(Self { storage, _phantom: PhantomData })
     }

--- a/synthesizer/src/store/transaction/fee.rs
+++ b/synthesizer/src/store/transaction/fee.rs
@@ -46,7 +46,10 @@ pub trait FeeStorage<N: Network>: Clone + Send + Sync {
 
     /// Initializes the fee storage for testing.
     #[cfg(feature = "testing")]
-    fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self>;
+    fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, Self::TransitionStorage>,
+    ) -> Result<Self>;
 
     /// Returns the fee map.
     fn fee_map(&self) -> &Self::FeeMap;
@@ -186,7 +189,10 @@ impl<N: Network, F: FeeStorage<N>> FeeStore<N, F> {
 
     /// Initializes the fee store for testing.
     #[cfg(feature = "testing")]
-    pub fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, F::TransitionStorage>) -> Result<Self> {
+    pub fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, F::TransitionStorage>,
+    ) -> Result<Self> {
         // Initialize the fee storage.
         let storage = F::open_testing(path, transition_store)?;
         // Return the fee store.

--- a/synthesizer/src/store/transaction/fee.rs
+++ b/synthesizer/src/store/transaction/fee.rs
@@ -44,6 +44,10 @@ pub trait FeeStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the fee storage.
     fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self>;
 
+    /// Initializes the fee storage for testing.
+    #[cfg(feature = "testing")]
+    fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self>;
+
     /// Returns the fee map.
     fn fee_map(&self) -> &Self::FeeMap;
     /// Returns the reverse fee map.
@@ -177,7 +181,16 @@ impl<N: Network, F: FeeStorage<N>> FeeStore<N, F> {
         // Initialize the fee storage.
         let storage = F::open(transition_store)?;
         // Return the fee store.
-        Ok(Self { storage, _phantom: PhantomData })
+        Ok(Self::from(storage))
+    }
+
+    /// Initializes the fee store for testing.
+    #[cfg(feature = "testing")]
+    pub fn open_testing(path: Option<std::path::PathBuf>, transition_store: TransitionStore<N, F::TransitionStorage>) -> Result<Self> {
+        // Initialize the fee storage.
+        let storage = F::open_testing(path, transition_store)?;
+        // Return the fee store.
+        Ok(Self::from(storage))
     }
 
     /// Initializes a fee store from storage.

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -247,7 +247,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
         // Initialize the transaction storage.
         let storage = T::open(transition_store)?;
         // Return the transaction store.
-        Ok(Self { transaction_ids: storage.id_map().clone(), storage })
+        Ok(Self::from(storage))
     }
 
     #[cfg(feature = "testing")]
@@ -259,7 +259,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
         // Initialize the transaction storage.
         let storage = T::open_testing(path, transition_store)?;
         // Return the transaction store.
-        Ok(Self { transaction_ids: storage.id_map().clone(), storage })
+        Ok(Self::from(storage))
     }
 
     /// Initializes a transaction store from storage.

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -251,7 +251,7 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     }
 
     #[cfg(feature = "testing")]
-    /// Initializes the transaction storage for testing.
+    /// Initializes the transaction store for testing.
     pub fn open_testing(
         path: Option<std::path::PathBuf>,
         transition_store: TransitionStore<N, T::TransitionStorage>,

--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -71,6 +71,13 @@ pub trait TransactionStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the transaction storage.
     fn open(transition_store: TransitionStore<N, Self::TransitionStorage>) -> Result<Self>;
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transaction storage for testing.
+    fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, Self::TransitionStorage>,
+    ) -> Result<Self>;
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
     /// Returns the deployment store.
@@ -239,6 +246,18 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     pub fn open(transition_store: TransitionStore<N, T::TransitionStorage>) -> Result<Self> {
         // Initialize the transaction storage.
         let storage = T::open(transition_store)?;
+        // Return the transaction store.
+        Ok(Self { transaction_ids: storage.id_map().clone(), storage })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transaction storage for testing.
+    pub fn open_testing(
+        path: Option<std::path::PathBuf>,
+        transition_store: TransitionStore<N, T::TransitionStorage>,
+    ) -> Result<Self> {
+        // Initialize the transaction storage.
+        let storage = T::open_testing(path, transition_store)?;
         // Return the transaction store.
         Ok(Self { transaction_ids: storage.id_map().clone(), storage })
     }

--- a/synthesizer/src/store/transition/input.rs
+++ b/synthesizer/src/store/transition/input.rs
@@ -50,6 +50,10 @@ pub trait InputStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the transition input storage.
     fn open(dev: Option<u16>) -> Result<Self>;
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transition input storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self>;
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
     /// Returns the reverse ID map.
@@ -298,6 +302,23 @@ impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
     pub fn open(dev: Option<u16>) -> Result<Self> {
         // Initialize a new transition input storage.
         let storage = I::open(dev)?;
+        // Return the transition input store.
+        Ok(Self {
+            constant: storage.constant_map().clone(),
+            public: storage.public_map().clone(),
+            private: storage.private_map().clone(),
+            record: storage.record_map().clone(),
+            record_tag: storage.record_tag_map().clone(),
+            external_record: storage.external_record_map().clone(),
+            storage,
+        })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transition input store.
+    pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize a new transition input storage.
+        let storage = I::open_testing(path)?;
         // Return the transition input store.
         Ok(Self {
             constant: storage.constant_map().clone(),

--- a/synthesizer/src/store/transition/input.rs
+++ b/synthesizer/src/store/transition/input.rs
@@ -303,15 +303,7 @@ impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
         // Initialize a new transition input storage.
         let storage = I::open(dev)?;
         // Return the transition input store.
-        Ok(Self {
-            constant: storage.constant_map().clone(),
-            public: storage.public_map().clone(),
-            private: storage.private_map().clone(),
-            record: storage.record_map().clone(),
-            record_tag: storage.record_tag_map().clone(),
-            external_record: storage.external_record_map().clone(),
-            storage,
-        })
+        Ok(Self::from(storage))
     }
 
     #[cfg(feature = "testing")]
@@ -320,15 +312,7 @@ impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
         // Initialize a new transition input storage.
         let storage = I::open_testing(path)?;
         // Return the transition input store.
-        Ok(Self {
-            constant: storage.constant_map().clone(),
-            public: storage.public_map().clone(),
-            private: storage.private_map().clone(),
-            record: storage.record_map().clone(),
-            record_tag: storage.record_tag_map().clone(),
-            external_record: storage.external_record_map().clone(),
-            storage,
-        })
+        Ok(Self::from(storage))
     }
 
     /// Initializes a transition input store from storage.

--- a/synthesizer/src/store/transition/mod.rs
+++ b/synthesizer/src/store/transition/mod.rs
@@ -308,18 +308,7 @@ impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {
         // Initialize the transition storage.
         let storage = T::open(dev)?;
         // Return the transition store.
-        Ok(Self {
-            locator: storage.locator_map().clone(),
-            inputs: (*storage.input_store()).clone(),
-            outputs: (*storage.output_store()).clone(),
-            finalize: storage.finalize_map().clone(),
-            proof: storage.proof_map().clone(),
-            tpk: storage.tpk_map().clone(),
-            reverse_tpk: storage.reverse_tpk_map().clone(),
-            tcm: storage.tcm_map().clone(),
-            reverse_tcm: storage.reverse_tcm_map().clone(),
-            storage,
-        })
+        Ok(Self::from(storage))
     }
 
     #[cfg(feature = "testing")]
@@ -328,18 +317,7 @@ impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {
         // Initialize the transition storage.
         let storage = T::open_testing(path)?;
         // Return the transition store.
-        Ok(Self {
-            locator: storage.locator_map().clone(),
-            inputs: (*storage.input_store()).clone(),
-            outputs: (*storage.output_store()).clone(),
-            finalize: storage.finalize_map().clone(),
-            proof: storage.proof_map().clone(),
-            tpk: storage.tpk_map().clone(),
-            reverse_tpk: storage.reverse_tpk_map().clone(),
-            tcm: storage.tcm_map().clone(),
-            reverse_tcm: storage.reverse_tcm_map().clone(),
-            storage,
-        })
+        Ok(Self::from(storage))
     }
 
     /// Initializes a transition store from storage.

--- a/synthesizer/src/store/transition/mod.rs
+++ b/synthesizer/src/store/transition/mod.rs
@@ -61,6 +61,10 @@ pub trait TransitionStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the transition storage.
     fn open(dev: Option<u16>) -> Result<Self>;
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transition storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self>;
+
     /// Returns the transition program IDs and function names.
     fn locator_map(&self) -> &Self::LocatorMap;
     /// Returns the transition input store.
@@ -303,6 +307,26 @@ impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {
     pub fn open(dev: Option<u16>) -> Result<Self> {
         // Initialize the transition storage.
         let storage = T::open(dev)?;
+        // Return the transition store.
+        Ok(Self {
+            locator: storage.locator_map().clone(),
+            inputs: (*storage.input_store()).clone(),
+            outputs: (*storage.output_store()).clone(),
+            finalize: storage.finalize_map().clone(),
+            proof: storage.proof_map().clone(),
+            tpk: storage.tpk_map().clone(),
+            reverse_tpk: storage.reverse_tpk_map().clone(),
+            tcm: storage.tcm_map().clone(),
+            reverse_tcm: storage.reverse_tcm_map().clone(),
+            storage,
+        })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transition storage for testing.
+    pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize the transition storage.
+        let storage = T::open_testing(path)?;
         // Return the transition store.
         Ok(Self {
             locator: storage.locator_map().clone(),

--- a/synthesizer/src/store/transition/mod.rs
+++ b/synthesizer/src/store/transition/mod.rs
@@ -323,7 +323,7 @@ impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {
     }
 
     #[cfg(feature = "testing")]
-    /// Initializes the transition storage for testing.
+    /// Initializes the transition store for testing.
     pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize the transition storage.
         let storage = T::open_testing(path)?;

--- a/synthesizer/src/store/transition/output.rs
+++ b/synthesizer/src/store/transition/output.rs
@@ -50,6 +50,10 @@ pub trait OutputStorage<N: Network>: Clone + Send + Sync {
     /// Initializes the transition output storage.
     fn open(dev: Option<u16>) -> Result<Self>;
 
+    #[cfg(feature = "testing")]
+    /// Initializes the transition output storage for testing.
+    fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self>;
+
     /// Returns the ID map.
     fn id_map(&self) -> &Self::IDMap;
     /// Returns the reverse ID map.
@@ -302,6 +306,23 @@ impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
     pub fn open(dev: Option<u16>) -> Result<Self> {
         // Initialize a new transition output storage.
         let storage = O::open(dev)?;
+        // Return the transition output store.
+        Ok(Self {
+            constant: storage.constant_map().clone(),
+            public: storage.public_map().clone(),
+            private: storage.private_map().clone(),
+            record: storage.record_map().clone(),
+            record_nonce: storage.record_nonce_map().clone(),
+            external_record: storage.external_record_map().clone(),
+            storage,
+        })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Initializes the transition output storage for testing.
+    pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
+        // Initialize a new transition output storage.
+        let storage = O::open_testing(path)?;
         // Return the transition output store.
         Ok(Self {
             constant: storage.constant_map().clone(),

--- a/synthesizer/src/store/transition/output.rs
+++ b/synthesizer/src/store/transition/output.rs
@@ -319,7 +319,7 @@ impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
     }
 
     #[cfg(feature = "testing")]
-    /// Initializes the transition output storage for testing.
+    /// Initializes the transition output store for testing.
     pub fn open_testing(path: Option<std::path::PathBuf>) -> Result<Self> {
         // Initialize a new transition output storage.
         let storage = O::open_testing(path)?;

--- a/synthesizer/src/store/transition/output.rs
+++ b/synthesizer/src/store/transition/output.rs
@@ -307,15 +307,7 @@ impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
         // Initialize a new transition output storage.
         let storage = O::open(dev)?;
         // Return the transition output store.
-        Ok(Self {
-            constant: storage.constant_map().clone(),
-            public: storage.public_map().clone(),
-            private: storage.private_map().clone(),
-            record: storage.record_map().clone(),
-            record_nonce: storage.record_nonce_map().clone(),
-            external_record: storage.external_record_map().clone(),
-            storage,
-        })
+        Ok(Self::from(storage))
     }
 
     #[cfg(feature = "testing")]
@@ -324,15 +316,7 @@ impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
         // Initialize a new transition output storage.
         let storage = O::open_testing(path)?;
         // Return the transition output store.
-        Ok(Self {
-            constant: storage.constant_map().clone(),
-            public: storage.public_map().clone(),
-            private: storage.private_map().clone(),
-            record: storage.record_map().clone(),
-            record_nonce: storage.record_nonce_map().clone(),
-            external_record: storage.external_record_map().clone(),
-            storage,
-        })
+        Ok(Self::from(storage))
     }
 
     /// Initializes a transition output store from storage.


### PR DESCRIPTION
This PR,
- adds the `open_testing` method to the storage traits, feature guarding them under the `"testing"` feature flag.
- updates the `RockDB::open_testing` to cache DB handles (better for benchmarks)
