### PR TITLE
[Feature] Increase limits for `Finalize`.

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -133,7 +133,7 @@ pub trait Network:
     /// The maximum number of instructions in a closure or function.
     const MAX_INSTRUCTIONS: usize = u16::MAX as usize;
     /// The maximum number of commands in finalize.
-    const MAX_COMMANDS: usize = u8::MAX as usize;
+    const MAX_COMMANDS: usize = u16::MAX as usize;
 
     /// The maximum number of inputs per transition.
     const MAX_INPUTS: usize = 16;

--- a/synthesizer/src/program/closure/mod.rs
+++ b/synthesizer/src/program/closure/mod.rs
@@ -109,7 +109,7 @@ impl<N: Network> Closure<N> {
 
         // Ensure the maximum number of instructions has not been exceeded.
         ensure!(
-            self.instructions.len() <= N::MAX_INSTRUCTIONS,
+            self.instructions.len() < N::MAX_INSTRUCTIONS,
             "Cannot add more than {} instructions",
             N::MAX_INSTRUCTIONS
         );
@@ -131,7 +131,7 @@ impl<N: Network> Closure<N> {
     #[inline]
     fn add_output(&mut self, output: Output<N>) -> Result<()> {
         // Ensure the maximum number of outputs has not been exceeded.
-        ensure!(self.outputs.len() <= N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
+        ensure!(self.outputs.len() < N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
 
         // Ensure the closure output register is not a record.
         ensure!(!matches!(output.register_type(), RegisterType::Record(..)), "Output register cannot be a record");

--- a/synthesizer/src/program/finalize/mod.rs
+++ b/synthesizer/src/program/finalize/mod.rs
@@ -102,7 +102,7 @@ impl<N: Network> Finalize<N> {
     #[inline]
     pub fn add_command(&mut self, command: Command<N>) -> Result<()> {
         // Ensure the maximum number of commands has not been exceeded.
-        ensure!(self.commands.len() <= N::MAX_COMMANDS, "Cannot add more than {} commands", N::MAX_COMMANDS);
+        ensure!(self.commands.len() < N::MAX_COMMANDS, "Cannot add more than {} commands", N::MAX_COMMANDS);
 
         // If the command is an instruction, `get` command, or `get.or_init` command, perform additional checks.
         match &command {

--- a/synthesizer/src/program/function/mod.rs
+++ b/synthesizer/src/program/function/mod.rs
@@ -116,7 +116,7 @@ impl<N: Network> Function<N> {
         ensure!(self.outputs.is_empty(), "Cannot add inputs after outputs have been added");
 
         // Ensure the maximum number of inputs has not been exceeded.
-        ensure!(self.inputs.len() <= N::MAX_INPUTS, "Cannot add more than {} inputs", N::MAX_INPUTS);
+        ensure!(self.inputs.len() < N::MAX_INPUTS, "Cannot add more than {} inputs", N::MAX_INPUTS);
         // Ensure the input statement was not previously added.
         ensure!(!self.inputs.contains(&input), "Cannot add duplicate input statement");
 
@@ -144,7 +144,7 @@ impl<N: Network> Function<N> {
 
         // Ensure the maximum number of instructions has not been exceeded.
         ensure!(
-            self.instructions.len() <= N::MAX_INSTRUCTIONS,
+            self.instructions.len() < N::MAX_INSTRUCTIONS,
             "Cannot add more than {} instructions",
             N::MAX_INSTRUCTIONS
         );
@@ -170,7 +170,7 @@ impl<N: Network> Function<N> {
     #[inline]
     fn add_output(&mut self, output: Output<N>) -> Result<()> {
         // Ensure the maximum number of outputs has not been exceeded.
-        ensure!(self.outputs.len() <= N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
+        ensure!(self.outputs.len() < N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
         // Ensure the output statement was not previously added.
         ensure!(!self.outputs.contains(&output), "Cannot add duplicate output statement");
 


### PR DESCRIPTION
This PR,
- increases the number of commands allowed in a `Finalize` block.
- fixes off-by-one errors in allowed program size.