### PR TITLE
[Fix] Reorder evaluation of `finalize` transitions.

### DIFF
--- a/synthesizer/src/process/finalize.rs
+++ b/synthesizer/src/process/finalize.rs
@@ -138,7 +138,7 @@ impl<N: Network> Process<N> {
             // TODO (howardwu): This is a temporary approach. We should create a "CallStack" and recurse through the stack.
             //  Currently this loop assumes a linearly execution stack.
             // Finalize each transition, starting from the last one.
-            for transition in execution.transitions().rev() {
+            for transition in execution.transitions() {
                 #[cfg(debug_assertions)]
                 println!("Finalizing transition for {}/{}...", transition.program_id(), transition.function_name());
 

--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -1314,3 +1314,111 @@ finalize compute:
         .unwrap();
     assert_eq!(candidate, Value::from_str("16u64").unwrap());
 }
+
+#[test]
+fn test_execution_order_with_two_external_calls() {
+    // Initialize a new program.
+    let (string, program0) = Program::<CurrentNetwork>::parse(
+        r"
+program foo.aleo;
+
+function b:
+    input r0 as u8.private;
+    input r1 as u8.private;
+    add r0 r1 into r2;
+    output r2 as u8.private;",
+    )
+    .unwrap();
+    assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+    // Construct the process.
+    let mut process = super::test_helpers::sample_process(&program0);
+
+    // Initialize another program.
+    let (string, program1) = Program::<CurrentNetwork>::parse(
+        r"
+program bar.aleo;
+
+function c:
+    input r0 as u8.private;
+    input r1 as u8.private;
+    add r0 r1 into r2;
+    output r2 as u8.private;",
+    )
+    .unwrap();
+    assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+    // Add the program to the process.
+    process.add_program(&program1).unwrap();
+
+    // Initialize another program.
+    let (string, program2) = Program::<CurrentNetwork>::parse(
+        r"
+import foo.aleo;
+import bar.aleo;
+
+program baz.aleo;
+
+function a:
+    input r0 as u8.private;
+    input r1 as u8.private;
+    call foo.aleo/b r0 r1 into r2;
+    call bar.aleo/c r1 r2 into r3;
+    output r3 as u8.private;",
+    )
+    .unwrap();
+    assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+    // Add the program to the process.
+    process.add_program(&program2).unwrap();
+
+    // Initialize the RNG.
+    let rng = &mut TestRng::default();
+
+    // Initialize caller.
+    let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+
+    // Declare the function name.
+    let function_name = Identifier::from_str("a").unwrap();
+
+    // Declare the input value.
+    let r0 = Value::<CurrentNetwork>::from_str("1u8").unwrap();
+    let r1 = Value::<CurrentNetwork>::from_str("2u8").unwrap();
+
+    // Authorize the function call.
+    let authorization = process
+        .authorize::<CurrentAleo, _>(&caller_private_key, program2.id(), function_name, [r0, r1].iter(), rng)
+        .unwrap();
+    assert_eq!(authorization.len(), 3);
+    println!("\nAuthorize\n{:#?}\n\n", authorization.to_vec_deque());
+
+    let output = Value::<CurrentNetwork>::from_str("5u8").unwrap();
+
+    // Check again to make sure we didn't modify the authorization before calling `evaluate`.
+    assert_eq!(authorization.len(), 3);
+
+    // Compute the output value.
+    let response = process.evaluate::<CurrentAleo>(authorization.replicate()).unwrap();
+    let candidate = response.outputs();
+    assert_eq!(1, candidate.len());
+    assert_eq!(output, candidate[0]);
+
+    // Check again to make sure we didn't modify the authorization after calling `evaluate`.
+    assert_eq!(authorization.len(), 3);
+
+    // Execute the request.
+    let (_, execution, _, _) = process.execute::<CurrentAleo, _>(authorization, rng).unwrap();
+
+    // Construct the expected transition order.
+    let expected_order = [
+        (program0.id(), Identifier::<Testnet3>::from_str("b").unwrap()),
+        (program1.id(), Identifier::from_str("c").unwrap()),
+        (program2.id(), Identifier::from_str("a").unwrap()),
+    ];
+    for (transition, (expected_program_id, expected_function_name)) in
+        execution.transitions().zip_eq(expected_order.iter())
+    {
+        assert_eq!(transition.program_id(), *expected_program_id);
+        assert_eq!(transition.function_name(), expected_function_name);
+    }
+}

--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -1316,7 +1316,7 @@ finalize compute:
 }
 
 #[test]
-fn test_execution_order_with_two_external_calls() {
+fn test_execution_order() {
     // Initialize a new program.
     let (string, program0) = Program::<CurrentNetwork>::parse(
         r"
@@ -1392,18 +1392,7 @@ function a:
     assert_eq!(authorization.len(), 3);
     println!("\nAuthorize\n{:#?}\n\n", authorization.to_vec_deque());
 
-    let output = Value::<CurrentNetwork>::from_str("5u8").unwrap();
-
     // Check again to make sure we didn't modify the authorization before calling `evaluate`.
-    assert_eq!(authorization.len(), 3);
-
-    // Compute the output value.
-    let response = process.evaluate::<CurrentAleo>(authorization.replicate()).unwrap();
-    let candidate = response.outputs();
-    assert_eq!(1, candidate.len());
-    assert_eq!(output, candidate[0]);
-
-    // Check again to make sure we didn't modify the authorization after calling `evaluate`.
     assert_eq!(authorization.len(), 3);
 
     // Execute the request.
@@ -1421,4 +1410,167 @@ function a:
         assert_eq!(transition.program_id(), *expected_program_id);
         assert_eq!(transition.function_name(), expected_function_name);
     }
+
+    // TODO: Enable once nested calls (beyond depth 1) are supported.
+    //     #[test]
+    //     fn test_complex_execution_order() {
+    //         // This test checks that the execution order is correct.
+    //         // The functions are invoked in the following order:
+    //         // "four::a"
+    //         //   --> "two::b"
+    //         //        --> "zero::c"
+    //         //        --> "one::d"
+    //         //   --> "three::e"
+    //         //        --> "two::b"
+    //         //             --> "zero::c"
+    //         //             --> "one::d"
+    //         //        --> "one::d"
+    //         //        --> "zero::c"
+    //         // The linearized order is:
+    //         //  - [a, b, c, d, e, b, c, d, d, c]
+    //         // The transitions must be included in the execution in the order they finish.
+    //         // The execution order is:
+    //         //  - [c, d, b, c, d, b, d, c, e, a]
+    //
+    //         // Initialize a new program.
+    //         let (string, program0) = Program::<CurrentNetwork>::parse(
+    //             r"
+    // program zero.aleo;
+    //
+    // function c:
+    //     input r0 as u8.private;
+    //     input r1 as u8.private;
+    //     add r0 r1 into r2;
+    //     output r2 as u8.private;",
+    //         )
+    //             .unwrap();
+    //         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+    //
+    //         // Construct the process.
+    //         let mut process = super::test_helpers::sample_process(&program0);
+    //
+    //         // Initialize another program.
+    //         let (string, program1) = Program::<CurrentNetwork>::parse(
+    //             r"
+    // program one.aleo;
+    //
+    // function d:
+    //     input r0 as u8.private;
+    //     input r1 as u8.private;
+    //     add r0 r1 into r2;
+    //     output r2 as u8.private;",
+    //         )
+    //             .unwrap();
+    //         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+    //
+    //         // Add the program to the process.
+    //         process.add_program(&program1).unwrap();
+    //
+    //         // Initialize another program.
+    //         let (string, program2) = Program::<CurrentNetwork>::parse(
+    //             r"
+    // import zero.aleo;
+    // import one.aleo;
+    //
+    // program two.aleo;
+    //
+    // function b:
+    //     input r0 as u8.private;
+    //     input r1 as u8.private;
+    //     call zero.aleo/c r0 r1 into r2;
+    //     call one.aleo/d r1 r2 into r3;
+    //     output r3 as u8.private;",
+    //         )
+    //             .unwrap();
+    //         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+    //
+    //         // Add the program to the process.
+    //         process.add_program(&program2).unwrap();
+    //
+    //         // Initialize another program.
+    //         let (string, program3) = Program::<CurrentNetwork>::parse(
+    //             r"
+    // import zero.aleo;
+    // import one.aleo;
+    // import two.aleo;
+    //
+    // program three.aleo;
+    //
+    // function e:
+    //     input r0 as u8.private;
+    //     input r1 as u8.private;
+    //     call two.aleo/b r0 r1 into r2;
+    //     call one.aleo/d r1 r2 into r3;
+    //     call zero.aleo/c r1 r2 into r4;
+    //     output r4 as u8.private;",
+    //         )
+    //             .unwrap();
+    //         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+    //
+    //         // Add the program to the process.
+    //         process.add_program(&program3).unwrap();
+    //
+    //         // Initialize another program.
+    //         let (string, program4) = Program::<CurrentNetwork>::parse(
+    //             r"
+    // import two.aleo;
+    // import three.aleo;
+    //
+    // program four.aleo;
+    //
+    // function a:
+    //     input r0 as u8.private;
+    //     input r1 as u8.private;
+    //     call two.aleo/b r0 r1 into r2;
+    //     call three.aleo/e r1 r2 into r3;
+    //     output r3 as u8.private;",
+    //         )
+    //             .unwrap();
+    //         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+    //
+    //         // Add the program to the process.
+    //         process.add_program(&program4).unwrap();
+    //
+    //         // Initialize the RNG.
+    //         let rng = &mut TestRng::default();
+    //
+    //         // Initialize caller.
+    //         let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    //
+    //         // Declare the function name.
+    //         let function_name = Identifier::from_str("a").unwrap();
+    //
+    //         // Declare the input value.
+    //         let r0 = Value::<CurrentNetwork>::from_str("1u8").unwrap();
+    //         let r1 = Value::<CurrentNetwork>::from_str("2u8").unwrap();
+    //
+    //         // Authorize the function call.
+    //         let authorization = process
+    //             .authorize::<CurrentAleo, _>(&caller_private_key, program4.id(), function_name, [r0, r1].iter(), rng)
+    //             .unwrap();
+    //         assert_eq!(authorization.len(), 10);
+    //
+    //         // Execute the request.
+    //         let (_, execution, _, _) = process.execute::<CurrentAleo, _>(authorization, rng).unwrap();
+    //
+    //         // Construct the expected execution order.
+    //         let expected_order = [
+    //             (program0.id(), Identifier::<Testnet3>::from_str("c").unwrap()),
+    //             (program1.id(), Identifier::<Testnet3>::from_str("d").unwrap()),
+    //             (program2.id(), Identifier::<Testnet3>::from_str("b").unwrap()),
+    //             (program0.id(), Identifier::<Testnet3>::from_str("c").unwrap()),
+    //             (program1.id(), Identifier::<Testnet3>::from_str("d").unwrap()),
+    //             (program2.id(), Identifier::<Testnet3>::from_str("b").unwrap()),
+    //             (program1.id(), Identifier::<Testnet3>::from_str("d").unwrap()),
+    //             (program0.id(), Identifier::<Testnet3>::from_str("c").unwrap()),
+    //             (program3.id(), Identifier::<Testnet3>::from_str("e").unwrap()),
+    //             (program4.id(), Identifier::<Testnet3>::from_str("a").unwrap()),
+    //         ];
+    //         for (transition, (expected_program_id, expected_function_name)) in
+    //         execution.transitions().zip_eq(expected_order.iter())
+    //         {
+    //             assert_eq!(transition.program_id(), *expected_program_id);
+    //             assert_eq!(transition.function_name(), expected_function_name);
+    //         }
+    //     }
 }


### PR DESCRIPTION
This PR reorders the evaluation of transitions when finalizing an `Execution`.
This is necessary to ensure correct semantics when finalize transactions that contain external calls.

Suppose that we have the following programs:
- `C`, with transition `c`.
- `B`, with transition `b`.
- `A`, which imports `B` and `C`, and contains transition `a` which invokes `B/b` and `C/c`.
Suppose that the call graph looks like:
```
A::a
  --> B::b
  --> C::c
```
Then the finalize blocks need to evaluated in the following order: `
```
B::b, C::c, A::a
```
In other words, **finalize blocks are evaluated in order of the transition that finished first**.


For a more complex example,
Suppose we have the following call graph, where each call is an external call.
```
A::a
--> B::b
       --> C::c
       --> D::d
--> E::e
       --> B::b
              --> C::c
              --> D::d"
       --> D::d
       --> C::c
```
The finalize blocks need to be evaluated in the following order: 
```
C::c, D::d, B::b, C::c, D::d, B::b, D::d, C::c, E::e, A::a
```