### PR TITLE
Adds the deployment fee multiplier

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -97,6 +97,8 @@ pub trait Network:
 
     /// The starting supply of Aleo credits.
     const STARTING_SUPPLY: u64 = 1_500_000_000_000_000; // 1.5B credits
+    /// The cost in microcredits per byte for the deployment transaction.
+    const DEPLOYMENT_FEE_MULTIPLIER: u64 = 1_000; // 1 millicredit per byte
 
     /// The anchor time per block in seconds, which must be greater than the round time per block.
     const ANCHOR_TIME: u16 = 25;

--- a/synthesizer/src/process/stack/deployment/mod.rs
+++ b/synthesizer/src/process/stack/deployment/mod.rs
@@ -98,6 +98,11 @@ impl<N: Network> Deployment<N> {
         Ok(())
     }
 
+    /// Returns the size in bytes.
+    pub fn size_in_bytes(&self) -> Result<u64> {
+        Ok(u64::try_from(self.to_bytes_le()?.len())?)
+    }
+
     /// Returns the edition.
     pub const fn edition(&self) -> u16 {
         self.edition

--- a/synthesizer/src/process/stack/execution/mod.rs
+++ b/synthesizer/src/process/stack/execution/mod.rs
@@ -54,6 +54,11 @@ impl<N: Network> Execution<N> {
         Ok(execution)
     }
 
+    /// Returns the size in bytes.
+    pub fn size_in_bytes(&self) -> Result<u64> {
+        Ok(u64::try_from(self.to_bytes_le()?.len())?)
+    }
+
     /// Returns the global state root.
     pub const fn global_state_root(&self) -> N::StateRoot {
         self.global_state_root

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -97,6 +97,17 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         };
         lap!(timer, "Prepare the query");
 
+        // TODO (raychu86): Ensure that the fee record is associated with the `credits.aleo` program
+        // Ensure that the record has enough balance to pay the fee.
+        match fee_record.find(&[Identifier::from_str("microcredits")?]) {
+            Ok(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => {
+                if *amount < fee_in_microcredits {
+                    bail!("Fee record does not have enough balance to pay the fee")
+                }
+            }
+            _ => bail!("Fee record does not have microcredits"),
+        }
+
         // Compute the core logic.
         macro_rules! logic {
             ($process:expr, $network:path, $aleo:path) => {{

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -78,12 +78,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         process!(self, logic)
     }
 
-    /// Executes a fee for the given private key, credits record, and fee amount (in microcredits).
+    /// Executes a fee for the given private key, fee record, and fee amount (in microcredits).
     #[inline]
     pub fn execute_fee<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
-        credits: Record<N, Plaintext<N>>,
+        fee_record: Record<N, Plaintext<N>>,
         fee_in_microcredits: u64,
         query: Option<Query<N, C::BlockStorage>>,
         rng: &mut R,
@@ -102,14 +102,14 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             ($process:expr, $network:path, $aleo:path) => {{
                 type RecordPlaintext<NetworkMacro> = Record<NetworkMacro, Plaintext<NetworkMacro>>;
 
-                // Prepare the private key and credits record.
+                // Prepare the private key and fee record.
                 let private_key = cast_ref!(&private_key as PrivateKey<$network>);
-                let credits = cast_ref!(credits as RecordPlaintext<$network>);
-                lap!(timer, "Prepare the private key and credits record");
+                let fee_record = cast_ref!(fee_record as RecordPlaintext<$network>);
+                lap!(timer, "Prepare the private key and fee record");
 
                 // Execute the call to fee.
                 let (response, fee_transition, inclusion, metrics) =
-                    $process.execute_fee::<$aleo, _>(private_key, credits.clone(), fee_in_microcredits, rng)?;
+                    $process.execute_fee::<$aleo, _>(private_key, fee_record.clone(), fee_in_microcredits, rng)?;
                 lap!(timer, "Execute the call to fee");
 
                 // Prepare the assignments.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -317,8 +317,8 @@ finalize transfer_public:
             let record = unspent_records.pop().unwrap().decrypt(&view_key)?;
 
             // Fetch the record balance and divide it in half.
-            let split_balance = match record.data().get(&Identifier::from_str("microcredits")?) {
-                Some(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => **amount / 2,
+            let split_balance = match record.find(&[Identifier::from_str("microcredits")?]) {
+                Ok(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => *amount / 2,
                 _ => bail!("fee record does not contain a microcredits entry"),
             };
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -316,10 +316,18 @@ finalize transfer_public:
         while !unspent_records.is_empty() {
             let record = unspent_records.pop().unwrap().decrypt(&view_key)?;
 
+            // Fetch the record balance and divide it in half.
+            let split_balance = match record.data().get(&Identifier::from_str("microcredits")?) {
+                Some(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => **amount / 2,
+                _ => bail!("fee record does not contain a microcredits entry"),
+            };
+
             // Prepare the inputs.
-            let inputs =
-                [Value::<CurrentNetwork>::Record(record), Value::<CurrentNetwork>::from_str("100u64").unwrap()]
-                    .into_iter();
+            let inputs = [
+                Value::<CurrentNetwork>::Record(record),
+                Value::<CurrentNetwork>::from_str(&format!("{split_balance}u64")).unwrap(),
+            ]
+            .into_iter();
 
             // Execute.
             let transaction =

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -38,7 +38,7 @@ use crate::{
 use console::{
     account::PrivateKey,
     network::prelude::*,
-    program::{Identifier, Plaintext, ProgramID, Record, Response, Value},
+    program::{Entry, Identifier, Literal, Plaintext, ProgramID, Record, Response, Value},
     types::Field,
 };
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -490,7 +490,7 @@ function compute:
             &vm,
             &caller_private_key,
             ("credits.aleo", "split"),
-            [Value::Record(record), Value::from_str("10000000u64").unwrap()].iter(),
+            [Value::Record(record), Value::from_str("1000000000u64").unwrap()].iter(), // 1000 credits
             None,
             None,
             rng,
@@ -508,7 +508,7 @@ function compute:
             &vm,
             &caller_private_key,
             ("credits.aleo", "split"),
-            [Value::Record(first_record), Value::from_str("1000000u64").unwrap()].iter(),
+            [Value::Record(first_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
             None,
             None,
             rng,
@@ -523,7 +523,7 @@ function compute:
             &vm,
             &caller_private_key,
             ("credits.aleo", "split"),
-            [Value::Record(second_record), Value::from_str("1000000u64").unwrap()].iter(),
+            [Value::Record(second_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
             None,
             None,
             rng,
@@ -570,7 +570,7 @@ finalize getter:
             &vm,
             &caller_private_key,
             &Program::from_str(first_program).unwrap(),
-            (first_record, 1000000),
+            (first_record, 1),
             None,
             rng,
         )
@@ -579,7 +579,7 @@ finalize getter:
             &vm,
             &caller_private_key,
             &Program::from_str(second_program).unwrap(),
-            (second_record, 1000000),
+            (second_record, 1),
             None,
             rng,
         )
@@ -594,7 +594,7 @@ finalize getter:
             &caller_private_key,
             ("test_1.aleo", "init"),
             Vec::<Value<Testnet3>>::new().iter(),
-            Some((third_record, 1000000)),
+            Some((third_record, 1)),
             None,
             rng,
         )
@@ -604,7 +604,7 @@ finalize getter:
             &caller_private_key,
             ("test_2.aleo", "init"),
             Vec::<Value<Testnet3>>::new().iter(),
-            Some((fourth_record, 1000000)),
+            Some((fourth_record, 1)),
             None,
             rng,
         )


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR primarily introduces the deployment fee multiplier into the `Network` trait. The multiplier is set to `1000` microcredits per byte.

This PR also ports over a legacy `create_deploy` method, and updates the usage of `Transaction::deploy` and `Transaction::execute` to automatically compute the deployment fee and execution fee.

Note: The execution fee in this PR does **not** account for the finalize fee currently. This is to be added in the future.
