### PR TITLE
[Fix] Execution of nested external calls.

### DIFF
--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -95,7 +95,14 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         // Retrieve the next request, based on the call stack mode.
         let (request, call_stack) = match &call_stack {
             CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
-            CallStack::Execute(authorization, ..) => (authorization.peek_next()?, call_stack.replicate()),
+            // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
+            // This is done to ensure that evaluation during execution is performed consistently.
+            CallStack::Execute(authorization, _, _, _) => {
+                let authorization = authorization.replicate();
+                let request = authorization.next()?;
+                let call_stack = CallStack::Evaluate(authorization);
+                (request, call_stack)
+            }
             _ => bail!("Illegal operation: call stack must be `Evaluate` or `Execute` in `evaluate_function`."),
         };
         lap!(timer, "Retrieve the next request");

--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -97,7 +97,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
             CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
             // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
             // This is done to ensure that evaluation during execution is performed consistently.
-            CallStack::Execute(authorization, _, _, _) => {
+            CallStack::Execute(authorization, _) => {
                 let authorization = authorization.replicate();
                 let request = authorization.next()?;
                 let call_stack = CallStack::Evaluate(authorization);

--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -1447,6 +1447,21 @@ function a:
     assert_eq!(output, candidate[0]);
 
     process.verify_execution::<false>(&execution).unwrap();
+
+    // Construct the expected transition order.
+    let expected_order = [
+        (program0.id(), Identifier::<Testnet3>::from_str("b").unwrap()),
+        (program1.id(), Identifier::from_str("c").unwrap()),
+        (program2.id(), Identifier::from_str("a").unwrap()),
+    ];
+
+    // Check the expected transition order.
+    for (transition, (expected_program_id, expected_function_name)) in
+        execution.transitions().zip_eq(expected_order.iter())
+    {
+        assert_eq!(transition.program_id(), *expected_program_id);
+        assert_eq!(transition.function_name(), expected_function_name);
+    }
 }
 
 #[test]
@@ -1604,6 +1619,8 @@ fn test_complex_execution_order() {
     let candidate = response.outputs();
     assert_eq!(1, candidate.len());
     assert_eq!(output, candidate[0]);
+
+    process.verify_execution::<false>(&execution).unwrap();
 
     // Construct the expected execution order.
     let expected_order = [

--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -1446,12 +1446,10 @@ function a:
     assert_eq!(1, candidate.len());
     assert_eq!(output, candidate[0]);
 
-    process.verify_execution::<false>(&execution).unwrap();
-
     // Construct the expected transition order.
     let expected_order = [
-        (program0.id(), Identifier::<Testnet3>::from_str("b").unwrap()),
-        (program1.id(), Identifier::from_str("c").unwrap()),
+        (program0.id(), Identifier::<Testnet3>::from_str("c").unwrap()),
+        (program1.id(), Identifier::from_str("b").unwrap()),
         (program2.id(), Identifier::from_str("a").unwrap()),
     ];
 
@@ -1462,6 +1460,9 @@ function a:
         assert_eq!(transition.program_id(), *expected_program_id);
         assert_eq!(transition.function_name(), expected_function_name);
     }
+
+    // Check that the execution is valid.
+    process.verify_execution::<false>(&execution).unwrap();
 }
 
 #[test]
@@ -1620,8 +1621,6 @@ fn test_complex_execution_order() {
     assert_eq!(1, candidate.len());
     assert_eq!(output, candidate[0]);
 
-    process.verify_execution::<false>(&execution).unwrap();
-
     // Construct the expected execution order.
     let expected_order = [
         (program0.id(), Identifier::<Testnet3>::from_str("c").unwrap()),
@@ -1641,6 +1640,9 @@ fn test_complex_execution_order() {
         assert_eq!(transition.program_id(), *expected_program_id);
         assert_eq!(transition.function_name(), expected_function_name);
     }
+
+    // Check that the execution is valid.
+    process.verify_execution::<false>(&execution).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This PR,
- fixes execution for nested external calls.
- adds tests using nested external calls and checks their execution order (the order of transitions in an `Execution`).

### What is the correct order?
Suppose that we have the following programs:
- `C`, with transition `c`.
- `B`, with transition `b`.
- `A`, which imports `B` and `C`, and contains transition `a` which invokes `B/b` and `C/c`.
Suppose that the call graph looks like:
```
A::a
  --> B::b
  --> C::c
```
Then the finalize blocks need to evaluated in the following order: `
```
B::b, C::c, A::a
```
In other words, **finalize blocks are evaluated in order of the transition that finished first**.


For a more complex example,
Suppose we have the following call graph, where each call is an external call.
```
A::a
--> B::b
       --> C::c
       --> D::d
--> E::e
       --> B::b
              --> C::c
              --> D::d"
       --> D::d
       --> C::c
```
The finalize blocks need to be evaluated in the following order: 
```
C::c, D::d, B::b, C::c, D::d, B::b, D::d, C::c, E::e, A::a
```
