### PR TITLE
Fix serialization of parameter version

### DIFF
--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -161,9 +161,9 @@ impl Network for Testnet3 {
     fn inclusion_proving_key() -> &'static Arc<MarlinProvingKey<Self>> {
         static INSTANCE: OnceCell<Arc<MarlinProvingKey<Console>>> = OnceCell::new();
         INSTANCE.get_or_init(|| {
-            // Skipping the first 2 bytes, which is the encoded version.
+            // Skipping the first byte, which is the encoded version.
             Arc::new(
-                CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet3::INCLUSION_PROVING_KEY[2..])
+                CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet3::INCLUSION_PROVING_KEY[1..])
                     .expect("Failed to load inclusion proving key."),
             )
         })
@@ -173,9 +173,9 @@ impl Network for Testnet3 {
     fn inclusion_verifying_key() -> &'static Arc<MarlinVerifyingKey<Self>> {
         static INSTANCE: OnceCell<Arc<MarlinVerifyingKey<Console>>> = OnceCell::new();
         INSTANCE.get_or_init(|| {
-            // Skipping the first 2 bytes, which is the encoded version.
+            // Skipping the first byte, which is the encoded version.
             Arc::new(
-                CircuitVerifyingKey::from_bytes_le(&snarkvm_parameters::testnet3::INCLUSION_VERIFYING_KEY[2..])
+                CircuitVerifyingKey::from_bytes_le(&snarkvm_parameters::testnet3::INCLUSION_VERIFYING_KEY[1..])
                     .expect("Failed to load inclusion verifying key."),
             )
         })

--- a/parameters/src/testnet3/mod.rs
+++ b/parameters/src/testnet3/mod.rs
@@ -96,7 +96,7 @@ macro_rules! insert_key {
         // Load the circuit key bytes.
         let key_bytes: Vec<u8> = $circuit_key.expect(&format!("Failed to load {} bytes", $string));
         // Recover the circuit key.
-        let key = $type::<$network>::from_bytes_le(&key_bytes[2..]).expect(&format!("Failed to recover {}", $string));
+        let key = $type::<$network>::from_bytes_le(&key_bytes[1..]).expect(&format!("Failed to recover {}", $string));
         // Insert the circuit key.
         $map.insert($name.to_string(), std::sync::Arc::new(key));
     }};

--- a/parameters/src/testnet3/resources/fee.metadata
+++ b/parameters/src/testnet3/resources/fee.metadata
@@ -1,6 +1,6 @@
 {
-  "prover_checksum": "91da75ab29a5d79140ac5d1501c029729e8a86f3ecc7d2735a0182ab7d8bb743",
-  "prover_size": 145760986,
-  "verifier_checksum": "d080b7ea6a4cfcc9067fc37e9cbb89c233c85e7d2d17680fb00bc3154d1e6626",
-  "verifier_size": 3787
+  "prover_checksum": "0bfc24fb28cd147e4a0c29bb118a96975b0e23878bfffe631137c4d08503f92b",
+  "prover_size": 145760985,
+  "verifier_checksum": "44783e85701fde1fd07aa94f94b5c19b501eef2a656c1c8cb0b5ac6f5715260d",
+  "verifier_size": 3786
 }

--- a/parameters/src/testnet3/resources/inclusion.metadata
+++ b/parameters/src/testnet3/resources/inclusion.metadata
@@ -1,6 +1,6 @@
 {
-  "prover_checksum": "32343fd8b4aa6eaf80261f909c758634c4d3830e7c71413c1e40f54bec8bccca",
-  "prover_size": 488475009,
-  "verifier_checksum": "7d325e5355b08ee7ab40353b3efcd5c8bbd4a9a39eeae90c0a79bc5b67309b20",
-  "verifier_size": 3787
+  "prover_checksum": "1bc806e2648167d2a457943875144983aa306f563d725460b7dc3d2fefe5400c",
+  "prover_size": 488475008,
+  "verifier_checksum": "26082d5ce07aa0af38a71a54666c98145f31cb2e73a43751e81675dcc7405d26",
+  "verifier_size": 3786
 }

--- a/parameters/src/testnet3/resources/join.metadata
+++ b/parameters/src/testnet3/resources/join.metadata
@@ -1,6 +1,6 @@
 {
-  "prover_checksum": "fd30c75792e3b046626f784d8f9797a9780684466082300b8b38fd3464ef5959",
-  "prover_size": 208625449,
-  "verifier_checksum": "92cea66303a4239d19e6270ac8baa9e4779e9a7721e2cc106d7201b6937fbca9",
-  "verifier_size": 3787
+  "prover_checksum": "6856be2b5db64fcbc6346a0c10a4e0663f4b8b0a03a83a2c2569623f040909e4",
+  "prover_size": 208625448,
+  "verifier_checksum": "9c946a39f555e88714d32fe96221353a5c1040de896d69678dd71687c63d2375",
+  "verifier_size": 3786
 }

--- a/parameters/src/testnet3/resources/mint.metadata
+++ b/parameters/src/testnet3/resources/mint.metadata
@@ -1,6 +1,6 @@
 {
-  "prover_checksum": "65722a4a229641f4a666f8aa8f6a9b449657e898ddcd846beed8c85373d593c4",
-  "prover_size": 138814114,
-  "verifier_checksum": "ee3c84cb586b58ebd403afc36a7b5fa60c4ba57e58934c0e0ba8883329c67235",
-  "verifier_size": 3787
+  "prover_checksum": "a4d517a23e6f60f33809fa8244213b9c91877ef11785a3cf3966582aab3cc64f",
+  "prover_size": 138814113,
+  "verifier_checksum": "1a0d61ab88759647aabf30a7125c117a63a2184e5452da407410974bffe46d37",
+  "verifier_size": 3786
 }

--- a/parameters/src/testnet3/resources/split.metadata
+++ b/parameters/src/testnet3/resources/split.metadata
@@ -1,6 +1,6 @@
 {
-  "prover_checksum": "7f93327c0bd4e07a9660a3d0640e554fdb421f9fea12199fe75801ff0068aa09",
-  "prover_size": 209147577,
-  "verifier_checksum": "8f54648043fd943449942522e86e6553d479fa049c996e8dcd1f502ee7a6ffcf",
-  "verifier_size": 3787
+  "prover_checksum": "8469bca8d54ff8230759f727845fadd0c32b79c584312ee546dbc8e4058ef0b4",
+  "prover_size": 209147576,
+  "verifier_checksum": "ba3bdd9df2cd531958bc66ec8c06841ef725e4b162ae21db1eb1f69f130c19a5",
+  "verifier_size": 3786
 }

--- a/parameters/src/testnet3/resources/transfer.metadata
+++ b/parameters/src/testnet3/resources/transfer.metadata
@@ -1,6 +1,6 @@
 {
-  "prover_checksum": "d0ae9df57acf20a6b428f1150514a779d62666aef4f34a8177267fccbeb93846",
-  "prover_size": 277215274,
-  "verifier_checksum": "13b2d49b264cf3b8665ff3c97a4aa72417ac032692bb4c33f0b7bec2d28c03fa",
-  "verifier_size": 3787
+  "prover_checksum": "c3bcd1ae7c0d2c7b7f3358869a08614d9a2cdd16caae2487af8489d66899f8c7",
+  "prover_size": 277215273,
+  "verifier_checksum": "2192afd86546924447561152b74eb0cf6d3220c00e6f3f72611b39e2f5cdf178",
+  "verifier_size": 3786
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR addresses #1528 by updating the serialization of the stored `credis.aleo` and `inclusion` keys. This change is required to match the unification of version types (u8). In this particular case, an extra byte was removed from each of the stored parameters, because we went from u16 to u8.

Thanks to @weikengchen and @vicsn for finding this discrepancy.


