### PR TITLE
[Feature] Allow passing a `struct` as arguments to `finalize`.

### DIFF
--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -341,13 +341,7 @@ impl<N: Network> Stack<N> {
                     // Ensure the value is a literal (for now).
                     match value {
                         circuit::Value::Plaintext(circuit::Plaintext::Literal(..)) => (),
-                        circuit::Value::Plaintext(circuit::Plaintext::Struct(..)) => {
-                            bail!(
-                                "'{}/{}' attempts to pass an 'struct' into 'finalize'",
-                                self.program_id(),
-                                function.name()
-                            );
-                        }
+                        circuit::Value::Plaintext(circuit::Plaintext::Struct(..)) => (),
                         circuit::Value::Record(..) => {
                             bail!(
                                 "'{}/{}' attempts to pass a 'record' into 'finalize'",

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -338,7 +338,7 @@ impl<N: Network> Stack<N> {
                     let value = registers.load_circuit(self, operand)?;
                     // TODO (howardwu): Expand the scope of 'finalize' to support other register types.
                     //  See `RegisterTypes::initialize_function_types()` for the same set of checks.
-                    // Ensure the value is a literal (for now).
+                    // Ensure the value is a literal or a struct.
                     match value {
                         circuit::Value::Plaintext(circuit::Plaintext::Literal(..)) => (),
                         circuit::Value::Plaintext(circuit::Plaintext::Struct(..)) => (),

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -336,9 +336,8 @@ impl<N: Network> Stack<N> {
                 for operand in command.operands() {
                     // Retrieve the finalize input.
                     let value = registers.load_circuit(self, operand)?;
-                    // TODO (howardwu): Expand the scope of 'finalize' to support other register types.
-                    //  See `RegisterTypes::initialize_function_types()` for the same set of checks.
                     // Ensure the value is a literal or a struct.
+                    // See `RegisterTypes::initialize_function_types()` for the same set of checks.
                     match value {
                         circuit::Value::Plaintext(circuit::Plaintext::Literal(..)) => (),
                         circuit::Value::Plaintext(circuit::Plaintext::Struct(..)) => (),

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -65,7 +65,7 @@ impl<N: Network> RegisterTypes<N> {
             // TODO (howardwu): In order to support constant inputs, update `Self::deploy()` to allow
             //  the caller to provide optional constant inputs (instead of sampling random constants).
             //  Then, this check can be removed to enable support for constant inputs in functions.
-            ensure!(!matches!(input.value_type(), ValueType::Constant(..)), "Constant inputs are not supported (yet)");
+            ensure!(!matches!(input.value_type(), ValueType::Constant(..)), "Constant inputs are not supported");
 
             // Check the input register type.
             register_types.check_input(stack, input.register(), &RegisterType::from(*input.value_type()))?;
@@ -96,9 +96,8 @@ impl<N: Network> RegisterTypes<N> {
             for operand in command.operands() {
                 // Retrieve the register type from the operand.
                 let register_type = register_types.get_type_from_operand(stack, operand)?;
-                // TODO (howardwu): Expand the scope of 'finalize' to support other register types.
-                //  See `Stack::execute_function()` for the same set of checks.
-                // Ensure the register type is a literal (for now).
+                // Ensure the register type is a literal or a struct.
+                // See `Stack::execute_function()` for the same set of checks.
                 match register_type {
                     RegisterType::Plaintext(PlaintextType::Literal(..)) => (),
                     RegisterType::Plaintext(PlaintextType::Struct(..)) => (),

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -101,13 +101,7 @@ impl<N: Network> RegisterTypes<N> {
                 // Ensure the register type is a literal (for now).
                 match register_type {
                     RegisterType::Plaintext(PlaintextType::Literal(..)) => (),
-                    RegisterType::Plaintext(PlaintextType::Struct(..)) => {
-                        bail!(
-                            "'{}/{}' attempts to pass an 'struct' into 'finalize'",
-                            stack.program_id(),
-                            function.name()
-                        );
-                    }
+                    RegisterType::Plaintext(PlaintextType::Struct(..)) => (),
                     RegisterType::Record(..) => {
                         bail!(
                             "'{}/{}' attempts to pass a 'record' into 'finalize'",

--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -1354,6 +1354,11 @@ finalize compute:
     add r1.data r2.data into r4;
     cast r3 r4 into r5 as entry;
     set r5 into entries[r0];
+    get entries[r0] into r6;
+    add r6.count r1.count into r7;
+    add r6.data r1.data into r8;
+    cast r7 r8 into r9 as entry;
+    set r9 into entries[r0];
 ",
     )
     .unwrap();
@@ -1423,10 +1428,10 @@ finalize compute:
     // Now, finalize the execution.
     process.finalize_execution(&store, &execution).unwrap();
 
-    // Check that the account balance is now 8.
+    // Check that the struct is stored as expected.
     let candidate = store
         .get_value_speculative(program_id, &mapping_name, &Plaintext::from(Literal::Address(caller)))
         .unwrap()
         .unwrap();
-    assert_eq!(candidate, Value::from_str("{ count: 2u8, data: 4u8 }").unwrap());
+    assert_eq!(candidate, Value::from_str("{ count: 3u8, data: 6u8 }").unwrap());
 }

--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -1324,3 +1324,109 @@ finalize compute:
         .unwrap();
     assert_eq!(candidate, Value::from_str("16u64").unwrap());
 }
+
+#[test]
+fn test_process_execute_and_finalize_get_set_with_struct() {
+    // Initialize a new program.
+    let (string, program) = Program::<CurrentNetwork>::parse(
+        r"
+program testing.aleo;
+
+struct entry:
+    count as u8;
+    data as u8;
+
+mapping entries:
+    key owner as address.public;
+    value entry as entry.public;
+
+function compute:
+    input r0 as u8.public;
+    input r1 as u8.public;
+    cast r0 r1 into r2 as entry;
+    finalize self.caller r2;
+
+finalize compute:
+    input r0 as address.public;
+    input r1 as entry.public;
+    get.or_init entries[r0] r1 into r2;
+    add r1.count r2.count into r3;
+    add r1.data r2.data into r4;
+    cast r3 r4 into r5 as entry;
+    set r5 into entries[r0];
+",
+    )
+    .unwrap();
+    assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+    // Declare the program ID.
+    let program_id = program.id();
+    // Declare the mapping.
+    let mapping_name = Identifier::from_str("entries").unwrap();
+    // Declare the function name.
+    let function_name = Identifier::from_str("compute").unwrap();
+
+    // Initialize the RNG.
+    let rng = &mut TestRng::default();
+
+    // Construct the process.
+    let process = super::test_helpers::sample_process(&program);
+    // Check that the circuit key can be synthesized.
+    process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
+
+    // Reset the process.
+    let mut process = Process::load().unwrap();
+
+    // Initialize a new finalize store.
+    let store = FinalizeStore::<_, FinalizeMemory<_>>::open(None).unwrap();
+
+    // Add the program to the process.
+    let deployment = process.deploy::<CurrentAleo, _>(&program, rng).unwrap();
+    // Check that the deployment verifies.
+    process.verify_deployment::<CurrentAleo, _>(&deployment, rng).unwrap();
+    // Finalize the deployment.
+    let (stack, _) = process.finalize_deployment(&store, &deployment).unwrap();
+    // Add the stack *manually* to the process.
+    process.add_stack(stack);
+
+    // Initialize a new caller account.
+    let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let _caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
+    let caller = Address::try_from(&caller_private_key).unwrap();
+
+    // Declare the input value.
+    let r0 = Value::<CurrentNetwork>::from_str("1u8").unwrap();
+    let r1 = Value::<CurrentNetwork>::from_str("2u8").unwrap();
+
+    // Authorize the function call.
+    let authorization = process
+        .authorize::<CurrentAleo, _>(&caller_private_key, program.id(), function_name, [r0, r1].iter(), rng)
+        .unwrap();
+    assert_eq!(authorization.len(), 1);
+
+    // Compute the output value.
+    let response = process.evaluate::<CurrentAleo>(authorization.replicate()).unwrap();
+    let candidate = response.outputs();
+    assert_eq!(0, candidate.len());
+
+    // Check again to make sure we didn't modify the authorization after calling `evaluate`.
+    assert_eq!(authorization.len(), 1);
+
+    // Execute the request.
+    let (response, execution, _inclusion, _metrics) = process.execute::<CurrentAleo, _>(authorization, rng).unwrap();
+    let candidate = response.outputs();
+    assert_eq!(0, candidate.len());
+
+    // Verify the execution.
+    process.verify_execution::<true>(&execution).unwrap();
+
+    // Now, finalize the execution.
+    process.finalize_execution(&store, &execution).unwrap();
+
+    // Check that the account balance is now 8.
+    let candidate = store
+        .get_value_speculative(program_id, &mapping_name, &Plaintext::from(Literal::Address(caller)))
+        .unwrap()
+        .unwrap();
+    assert_eq!(candidate, Value::from_str("{ count: 2u8, data: 4u8 }").unwrap());
+}


### PR DESCRIPTION
This PR removes a restriction, allowing users to pass registers containing `structs` into `finalize` command.
