### PR TITLE
[Test] Equivalence tests for `hash`.

### DIFF
--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -317,12 +317,13 @@ mod tests {
         // Initialize the operation.
         let operation = operation(operands);
         // Construct the function name.
-        let fn_name = Identifier::from_str("run").unwrap();
+        let function_name = Identifier::from_str("run").unwrap();
 
         /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
         {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_a, None)]).unwrap();
+            let values = [(literal_a, None), (literal_a, None)];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             let result_a = operation.evaluate(&stack, &mut registers);
 
             // Ensure the result is correct.
@@ -336,8 +337,8 @@ mod tests {
             }
 
             // Attempt to compute the valid operand case.
-            let mut registers =
-                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_a, Some(*mode_a))]).unwrap();
+            let values = [(literal_a, Some(*mode_a)), (literal_a, Some(*mode_a))];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             let result_b = operation.execute::<CurrentAleo>(&stack, &mut registers);
 
             // Ensure the result is correct.
@@ -372,7 +373,8 @@ mod tests {
         /* Next, check the mismatching literals *fail*. */
         if literal_a != literal_b {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_b, None)]).unwrap();
+            let values = [(literal_a, None), (literal_b, None)];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             let result_a = operation.evaluate(&stack, &mut registers);
 
             // Ensure the result is correct.
@@ -386,8 +388,8 @@ mod tests {
             }
 
             // Attempt to compute the valid operand case.
-            let mut registers =
-                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))]).unwrap();
+            let values = [(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             let result_b = operation.execute::<CurrentAleo>(&stack, &mut registers);
 
             // Ensure the result is correct.

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -322,7 +322,7 @@ mod tests {
         /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
         {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, literal_a, literal_a, None, None).unwrap();
+            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_a, None)]).unwrap();
             let result_a = operation.evaluate(&stack, &mut registers);
 
             // Ensure the result is correct.
@@ -337,7 +337,7 @@ mod tests {
 
             // Attempt to compute the valid operand case.
             let mut registers =
-                sample_registers(&stack, &fn_name, literal_a, literal_a, Some(*mode_a), Some(*mode_a)).unwrap();
+                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_a, Some(*mode_a))]).unwrap();
             let result_b = operation.execute::<CurrentAleo>(&stack, &mut registers);
 
             // Ensure the result is correct.
@@ -372,7 +372,7 @@ mod tests {
         /* Next, check the mismatching literals *fail*. */
         if literal_a != literal_b {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, literal_a, literal_b, None, None).unwrap();
+            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_b, None)]).unwrap();
             let result_a = operation.evaluate(&stack, &mut registers);
 
             // Ensure the result is correct.
@@ -387,7 +387,7 @@ mod tests {
 
             // Attempt to compute the valid operand case.
             let mut registers =
-                sample_registers(&stack, &fn_name, literal_a, literal_b, Some(*mode_a), Some(*mode_b)).unwrap();
+                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))]).unwrap();
             let result_b = operation.execute::<CurrentAleo>(&stack, &mut registers);
 
             // Ensure the result is correct.

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -305,7 +305,6 @@ mod tests {
         cache: &mut HashMap<String, (ProvingKey<CurrentNetwork>, VerifyingKey<CurrentNetwork>)>,
     ) -> Result<(Stack<CurrentNetwork>, Vec<Operand<CurrentNetwork>>, Register<CurrentNetwork>)> {
         use crate::{Process, Program};
-        use console::program::Identifier;
 
         // Initialize the opcode.
         let opcode = opcode.to_string();

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -279,9 +279,246 @@ impl<N: Network, const VARIANT: u8> ToBytes for HashInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
+
+    use crate::{
+        program::test_helpers::{sample_finalize_registers, sample_registers},
+        ProvingKey,
+        VerifyingKey,
+    };
+
+    use circuit::{AleoV0, Eject};
+    use console::{network::Testnet3, program::Identifier};
+
+    use std::collections::HashMap;
 
     type CurrentNetwork = Testnet3;
+    type CurrentAleo = AleoV0;
+
+    const ITERATIONS: usize = 100;
+
+    /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
+    #[allow(clippy::type_complexity)]
+    fn sample_stack(
+        opcode: Opcode,
+        type_: LiteralType,
+        mode: circuit::Mode,
+        cache: &mut HashMap<String, (ProvingKey<CurrentNetwork>, VerifyingKey<CurrentNetwork>)>,
+    ) -> Result<(Stack<CurrentNetwork>, Vec<Operand<CurrentNetwork>>, Register<CurrentNetwork>)> {
+        use crate::{Process, Program};
+        use console::program::Identifier;
+
+        // Initialize the opcode.
+        let opcode = opcode.to_string();
+
+        // Initialize the function name.
+        let function_name = Identifier::<CurrentNetwork>::from_str("run")?;
+
+        // Initialize the registers.
+        let r0 = Register::Locator(0);
+        let r1 = Register::Locator(1);
+
+        // Initialize the program.
+        let program = Program::from_str(&format!(
+            "program testing.aleo;
+            function {function_name}:
+                input {r0} as {type_}.{mode};
+                {opcode} {r0} into {r1};
+                finalize {r0};
+            finalize {function_name}:
+                input {r0} as {type_}.public;
+                {opcode} {r0} into {r1};
+        "
+        ))?;
+
+        // Initialize the operands.
+        let operands = vec![Operand::Register(r0)];
+
+        // Initialize the stack.
+        let stack = Stack::new(&Process::load_with_cache(cache)?, &program)?;
+
+        Ok((stack, operands, r1))
+    }
+
+    fn check_hash<const VARIANT: u8>(
+        operation: impl FnOnce(
+            Vec<Operand<CurrentNetwork>>,
+            Register<CurrentNetwork>,
+        ) -> HashInstruction<CurrentNetwork, VARIANT>,
+        opcode: Opcode,
+        literal: &Literal<CurrentNetwork>,
+        mode: &circuit::Mode,
+        cache: &mut HashMap<String, (ProvingKey<CurrentNetwork>, VerifyingKey<CurrentNetwork>)>,
+    ) {
+        println!("Checking '{opcode}' for '{literal}.{mode}'");
+
+        // Initialize the types.
+        let type_ = literal.to_type();
+
+        // Initialize the stack.
+        let (stack, operands, destination) = sample_stack(opcode, type_, *mode, cache).unwrap();
+
+        // Initialize the operation.
+        let operation = operation(operands, destination.clone());
+        // Initialize the function name.
+        let function_name = Identifier::from_str("run").unwrap();
+        // Initialize a destination operand.
+        let destination_operand = Operand::Register(destination);
+
+        // Attempt to evaluate the valid operand case.
+        let mut evaluate_registers = sample_registers(&stack, &function_name, &[(literal, None)]).unwrap();
+        let result_a = operation.evaluate(&stack, &mut evaluate_registers);
+
+        // Attempt to execute the valid operand case.
+        let mut execute_registers = sample_registers(&stack, &function_name, &[(literal, Some(*mode))]).unwrap();
+        let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
+
+        // Attempt to finalize the valid operand case.
+        let mut finalize_registers = sample_finalize_registers(&stack, &[literal]).unwrap();
+        let result_c = operation.finalize(&stack, &mut finalize_registers);
+
+        // Check that either all operations failed, or all operations succeeded.
+        let all_failed = result_a.is_err() && result_b.is_err() && result_c.is_err();
+        let all_succeeded = result_a.is_ok() && result_b.is_ok() && result_c.is_ok();
+        assert!(
+            all_failed || all_succeeded,
+            "The results of the evaluation, execution, and finalization should either all succeed or all fail"
+        );
+
+        // If all operations succeeded, check that the outputs are consistent.
+        if all_succeeded {
+            // Retrieve the output of evaluation.
+            let output_a = evaluate_registers.load(&stack, &destination_operand).unwrap();
+
+            // Retrieve the output of execution.
+            let output_b = execute_registers.load_circuit(&stack, &destination_operand).unwrap();
+
+            // Retrieve the output of finalization.
+            let output_c = finalize_registers.load(&stack, &destination_operand).unwrap();
+
+            // Check that the outputs are consistent.
+            assert_eq!(
+                output_a,
+                output_b.eject_value(),
+                "The results of the evaluation and execution are inconsistent"
+            );
+            assert_eq!(output_a, output_c, "The results of the evaluation and finalization are inconsistent");
+        }
+
+        // Reset the circuit.
+        <CurrentAleo as circuit::Environment>::reset();
+    }
+
+    macro_rules! test_hash {
+        ($name: tt, $hash:ident) => {
+            paste::paste! {
+                #[test]
+                fn [<test _ $name _ is _ consistent>]() {
+                    // Initialize the operation.
+                    let operation = |operands, destination| $hash::<CurrentNetwork> { operands, destination };
+                    // Initialize the opcode.
+                    let opcode = $hash::<CurrentNetwork>::opcode();
+
+                    // Prepare the rng.
+                    let mut rng = TestRng::default();
+
+                    // Prepare the test.
+                    let modes = [circuit::Mode::Public, circuit::Mode::Private];
+
+                    // Prepare the key cache.
+                    let mut cache = Default::default();
+
+                    for _ in 0..ITERATIONS {
+                        let literals = crate::sample_literals!(CurrentNetwork, &mut rng);
+                        for literal in literals.iter() {
+                            for mode in modes.iter() {
+                                check_hash(operation, opcode, literal, mode, &mut cache);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    test_hash!(hash_bhp256, HashBHP256);
+    test_hash!(hash_bhp512, HashBHP512);
+    test_hash!(hash_bhp768, HashBHP768);
+    test_hash!(hash_bhp1024, HashBHP1024);
+    test_hash!(hash_psd2, HashPSD2);
+    test_hash!(hash_psd4, HashPSD4);
+    test_hash!(hash_psd8, HashPSD8);
+
+    // Note this test must be explicitly written, instead of using the macro, because HashPED64 fails on certain input types.
+    #[test]
+    fn test_hash_ped64_is_consistent() {
+        // Initialize the operation.
+        let operation = |operands, destination| HashPED64::<CurrentNetwork> { operands, destination };
+        // Initialize the opcode.
+        let opcode = HashPED64::<CurrentNetwork>::opcode();
+
+        // Prepare the rng.
+        let mut rng = TestRng::default();
+
+        // Prepare the test.
+        let modes = [circuit::Mode::Public, circuit::Mode::Private];
+
+        // Prepare the key cache.
+        let mut cache = Default::default();
+
+        for _ in 0..ITERATIONS {
+            let literals = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+            ];
+            for literal in literals.iter() {
+                for mode in modes.iter() {
+                    check_hash(operation, opcode, literal, mode, &mut cache);
+                }
+            }
+        }
+    }
+
+    // Note this test must be explicitly written, instead of using the macro, because HashPED128 fails on certain input types.
+    #[test]
+    fn test_hash_ped128_is_consistent() {
+        // Initialize the operation.
+        let operation = |operands, destination| HashPED128::<CurrentNetwork> { operands, destination };
+        // Initialize the opcode.
+        let opcode = HashPED128::<CurrentNetwork>::opcode();
+
+        // Prepare the rng.
+        let mut rng = TestRng::default();
+
+        // Prepare the test.
+        let modes = [circuit::Mode::Public, circuit::Mode::Private];
+
+        // Prepare the key cache.
+        let mut cache = Default::default();
+
+        for _ in 0..ITERATIONS {
+            let literals = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::I64(console::types::I64::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+                Literal::U64(console::types::U64::rand(&mut rng)),
+            ];
+            for literal in literals.iter() {
+                for mode in modes.iter() {
+                    check_hash(operation, opcode, literal, mode, &mut cache);
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_parse() {

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -279,7 +279,6 @@ impl<N: Network, const VARIANT: u8> ToBytes for HashInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::{
         program::test_helpers::{sample_finalize_registers, sample_registers},
         ProvingKey,

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -333,14 +333,15 @@ mod tests {
         // Initialize the operation.
         let operation = operation(operands, destination.clone());
         // Initialize the function name.
-        let fn_name = Identifier::from_str("run").unwrap();
+        let function_name = Identifier::from_str("run").unwrap();
         // Initialize a destination operand.
         let destination_operand = Operand::Register(destination);
 
         /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
         {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_a, None)]).unwrap();
+            let values = [(literal_a, None), (literal_a, None)];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             operation.evaluate(&stack, &mut registers).unwrap();
 
             // Retrieve the output.
@@ -361,8 +362,8 @@ mod tests {
             }
 
             // Attempt to compute the valid operand case.
-            let mut registers =
-                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_a, Some(*mode_a))]).unwrap();
+            let values = [(literal_a, Some(*mode_a)), (literal_a, Some(*mode_a))];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
             // Retrieve the output.
@@ -404,7 +405,8 @@ mod tests {
         /* Next, check the mismatching literals *fail*. */
         if literal_a != literal_b {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_b, None)]).unwrap();
+            let values = [(literal_a, None), (literal_b, None)];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             operation.evaluate(&stack, &mut registers).unwrap();
 
             // Retrieve the output.
@@ -425,8 +427,8 @@ mod tests {
             }
 
             // Attempt to compute the valid operand case.
-            let mut registers =
-                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))]).unwrap();
+            let values = [(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))];
+            let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
             operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
             // Retrieve the output.

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -340,7 +340,7 @@ mod tests {
         /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
         {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, literal_a, literal_a, None, None).unwrap();
+            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_a, None)]).unwrap();
             operation.evaluate(&stack, &mut registers).unwrap();
 
             // Retrieve the output.
@@ -362,7 +362,7 @@ mod tests {
 
             // Attempt to compute the valid operand case.
             let mut registers =
-                sample_registers(&stack, &fn_name, literal_a, literal_a, Some(*mode_a), Some(*mode_a)).unwrap();
+                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_a, Some(*mode_a))]).unwrap();
             operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
             // Retrieve the output.
@@ -404,7 +404,7 @@ mod tests {
         /* Next, check the mismatching literals *fail*. */
         if literal_a != literal_b {
             // Attempt to compute the valid operand case.
-            let mut registers = sample_registers(&stack, &fn_name, literal_a, literal_b, None, None).unwrap();
+            let mut registers = sample_registers(&stack, &fn_name, &[(literal_a, None), (literal_b, None)]).unwrap();
             operation.evaluate(&stack, &mut registers).unwrap();
 
             // Retrieve the output.
@@ -426,7 +426,7 @@ mod tests {
 
             // Attempt to compute the valid operand case.
             let mut registers =
-                sample_registers(&stack, &fn_name, literal_a, literal_b, Some(*mode_a), Some(*mode_b)).unwrap();
+                sample_registers(&stack, &fn_name, &[(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))]).unwrap();
             operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
             // Retrieve the output.

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -822,8 +822,6 @@ pub(crate) mod test_helpers {
         stack: &Stack<CurrentNetwork>,
         literals: &[&Literal<CurrentNetwork>],
     ) -> Result<FinalizeRegisters<CurrentNetwork>> {
-        use console::program::{Identifier, Plaintext, Value};
-
         // Initialize the function name.
         let function_name = Identifier::from_str("run")?;
 

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -788,10 +788,7 @@ pub(crate) mod test_helpers {
     pub fn sample_registers(
         stack: &Stack<CurrentNetwork>,
         function_name: &Identifier<CurrentNetwork>,
-        literal_a: &Literal<CurrentNetwork>,
-        literal_b: &Literal<CurrentNetwork>,
-        mode_a: Option<circuit::Mode>,
-        mode_b: Option<circuit::Mode>,
+        values: &[(&Literal<CurrentNetwork>, Option<circuit::Mode>)],
     ) -> Result<Registers<CurrentNetwork, CurrentAleo>> {
         // Initialize the registers.
         let mut registers = Registers::<CurrentNetwork, CurrentAleo>::new(
@@ -799,30 +796,24 @@ pub(crate) mod test_helpers {
             stack.get_register_types(function_name)?.clone(),
         );
 
-        // Initialize the registers.
-        let r0 = Register::Locator(0);
-        let r1 = Register::Locator(1);
+        // For each value,
+        for (index, (literal, mode)) in values.iter().enumerate() {
+            // Initialize the register
+            let register = Register::Locator(index as u64);
+            // Initialize the console value.
+            let value = Value::Plaintext(Plaintext::from(*literal));
+            // Store the value in the console registers.
+            registers.store(stack, &register, value.clone())?;
+            // If the mode is not `None`,
+            if let Some(mode) = mode {
+                use circuit::Inject;
 
-        // Initialize the console values.
-        let value_a = Value::Plaintext(Plaintext::from(literal_a));
-        let value_b = Value::Plaintext(Plaintext::from(literal_b));
-
-        // Store the values in the console registers.
-        registers.store(stack, &r0, value_a.clone())?;
-        registers.store(stack, &r1, value_b.clone())?;
-
-        if let (Some(mode_a), Some(mode_b)) = (mode_a, mode_b) {
-            use circuit::Inject;
-
-            // Initialize the circuit values.
-            let circuit_a = circuit::Value::new(mode_a, value_a);
-            let circuit_b = circuit::Value::new(mode_b, value_b);
-
-            // Store the values in the circuit registers.
-            registers.store_circuit(stack, &r0, circuit_a)?;
-            registers.store_circuit(stack, &r1, circuit_b)?;
+                // Initialize the circuit value.
+                let circuit_value = circuit::Value::new(*mode, value);
+                // Store the value in the circuit registers.
+                registers.store_circuit(stack, &register, circuit_value)?;
+            }
         }
-
         Ok(registers)
     }
 }

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -773,7 +773,7 @@ crate::operation!(
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use super::*;
-    use crate::{Authorization, CallStack, Registers, Stack, Store, StoreCircuit};
+    use crate::{Authorization, CallStack, FinalizeRegisters, Registers, Stack, Store, StoreCircuit};
 
     use circuit::AleoV0;
     use console::{
@@ -815,5 +815,32 @@ pub(crate) mod test_helpers {
             }
         }
         Ok(registers)
+    }
+
+    /// Samples the finalize registers. Note: Do not replicate this for real program use, it is insecure.
+    pub(crate) fn sample_finalize_registers(
+        stack: &Stack<CurrentNetwork>,
+        literals: &[&Literal<CurrentNetwork>],
+    ) -> Result<FinalizeRegisters<CurrentNetwork>> {
+        use console::program::{Identifier, Plaintext, Value};
+
+        // Initialize the function name.
+        let function_name = Identifier::from_str("run")?;
+
+        // Initialize the registers.
+        let mut finalize_registers =
+            FinalizeRegisters::<CurrentNetwork>::new(stack.get_finalize_types(&function_name)?.clone());
+
+        // For each literal,
+        for (index, literal) in literals.iter().enumerate() {
+            // Initialize the register
+            let register = Register::Locator(index as u64);
+            // Initialize the console value.
+            let value = Value::Plaintext(Plaintext::from(*literal));
+            // Store the value in the console registers.
+            finalize_registers.store(stack, &register, value)?;
+        }
+
+        Ok(finalize_registers)
     }
 }

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -796,9 +796,9 @@ pub(crate) mod test_helpers {
             stack.get_register_types(function_name)?.clone(),
         );
 
-        // For each value,
+        // For each value, store the register and value.
         for (index, (literal, mode)) in values.iter().enumerate() {
-            // Initialize the register
+            // Initialize the register.
             let register = Register::Locator(index as u64);
             // Initialize the console value.
             let value = Value::Plaintext(Plaintext::from(*literal));


### PR DESCRIPTION
This PR,
- updates the definition of `sample_registers` to allow any number of initial values.
- introduces `sample_finalize_registers`.
- adds equivalence tests (between `evaluate`, `execute`, and `finalize`) for the `hash` operation.
- updates the use of `sample_registers` in `is.rs` and `assert.rs`.

Depends on #1532.
