### PR TITLE
[Test] Equivalence tests for `commit`.

### DIFF
--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -285,9 +285,276 @@ impl<N: Network, const VARIANT: u8> ToBytes for CommitInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
+
+    use crate::{
+        program::test_helpers::{sample_finalize_registers, sample_registers},
+        ProvingKey,
+        VerifyingKey,
+    };
+
+    use circuit::{AleoV0, Eject};
+    use console::{network::Testnet3, program::Identifier};
+
+    use std::collections::HashMap;
 
     type CurrentNetwork = Testnet3;
+    type CurrentAleo = AleoV0;
+
+    const ITERATIONS: usize = 100;
+
+    /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
+    #[allow(clippy::type_complexity)]
+    fn sample_stack(
+        opcode: Opcode,
+        type_a: LiteralType,
+        type_b: LiteralType,
+        mode_a: circuit::Mode,
+        mode_b: circuit::Mode,
+        cache: &mut HashMap<String, (ProvingKey<CurrentNetwork>, VerifyingKey<CurrentNetwork>)>,
+    ) -> Result<(Stack<CurrentNetwork>, Vec<Operand<CurrentNetwork>>, Register<CurrentNetwork>)> {
+        use crate::{Process, Program};
+
+        // Initialize the opcode.
+        let opcode = opcode.to_string();
+
+        // Initialize the function name.
+        let function_name = Identifier::<CurrentNetwork>::from_str("run")?;
+
+        // Initialize the registers.
+        let r0 = Register::Locator(0);
+        let r1 = Register::Locator(1);
+        let r2 = Register::Locator(2);
+
+        // Initialize the program.
+        let program = Program::from_str(&format!(
+            "program testing.aleo;
+            function {function_name}:
+                input {r0} as {type_a}.{mode_a};
+                input {r1} as {type_b}.{mode_b};
+                {opcode} {r0} {r1} into {r2};
+                finalize {r0} {r1};
+
+            finalize {function_name}:
+                input {r0} as {type_a}.public;
+                input {r1} as {type_b}.public;
+                {opcode} {r0} {r1} into {r2};
+        "
+        ))?;
+
+        // Initialize the operands.
+        let operand_a = Operand::Register(r0);
+        let operand_b = Operand::Register(r1);
+        let operands = vec![operand_a, operand_b];
+
+        // Initialize the stack.
+        let stack = Stack::new(&Process::load_with_cache(cache)?, &program)?;
+
+        Ok((stack, operands, r2))
+    }
+
+    fn check_commit<const VARIANT: u8>(
+        operation: impl FnOnce(
+            Vec<Operand<CurrentNetwork>>,
+            Register<CurrentNetwork>,
+        ) -> CommitInstruction<CurrentNetwork, VARIANT>,
+        opcode: Opcode,
+        literal_a: &Literal<CurrentNetwork>,
+        literal_b: &Literal<CurrentNetwork>,
+        mode_a: &circuit::Mode,
+        mode_b: &circuit::Mode,
+        cache: &mut HashMap<String, (ProvingKey<CurrentNetwork>, VerifyingKey<CurrentNetwork>)>,
+    ) {
+        println!("Checking '{opcode}' for '{literal_a}.{mode_a}' and '{literal_b}.{mode_b}'");
+
+        // Initialize the types.
+        let type_a = literal_a.to_type();
+        let type_b = literal_b.to_type();
+
+        // Initialize the stack.
+        let (stack, operands, destination) = sample_stack(opcode, type_a, type_b, *mode_a, *mode_b, cache).unwrap();
+        // Initialize the operation.
+        let operation = operation(operands, destination.clone());
+        // Initialize the function name.
+        let function_name = Identifier::from_str("run").unwrap();
+        // Initialize a destination operand.
+        let destination_operand = Operand::Register(destination);
+
+        // Attempt to evaluate the valid operand case.
+        let mut evaluate_registers =
+            sample_registers(&stack, &function_name, &[(literal_a, None), (literal_b, None)]).unwrap();
+        let result_a = operation.evaluate(&stack, &mut evaluate_registers);
+
+        // Attempt to execute the valid operand case.
+        let mut execute_registers =
+            sample_registers(&stack, &function_name, &[(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))])
+                .unwrap();
+        let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
+
+        // Attempt to finalize the valid operand case.
+        let mut finalize_registers = sample_finalize_registers(&stack, &[literal_a, literal_b]).unwrap();
+        let result_c = operation.finalize(&stack, &mut finalize_registers);
+
+        // Check that either all operations failed, or all operations succeeded.
+        let all_failed = result_a.is_err() && result_b.is_err() && result_c.is_err();
+        let all_succeeded = result_a.is_ok() && result_b.is_ok() && result_c.is_ok();
+        assert!(
+            all_failed || all_succeeded,
+            "The results of the evaluation, execution, and finalization should either all succeed or all fail"
+        );
+
+        // If all operations succeeded, check that the outputs are consistent.
+        if all_succeeded {
+            // Retrieve the output of evaluation.
+            let output_a = evaluate_registers.load(&stack, &destination_operand).unwrap();
+
+            // Retrieve the output of execution.
+            let output_b = execute_registers.load_circuit(&stack, &destination_operand).unwrap();
+
+            // Retrieve the output of finalization.
+            let output_c = finalize_registers.load(&stack, &destination_operand).unwrap();
+
+            // Check that the outputs are consistent.
+            assert_eq!(
+                output_a,
+                output_b.eject_value(),
+                "The results of the evaluation and execution are inconsistent"
+            );
+            assert_eq!(output_a, output_c, "The results of the evaluation and finalization are inconsistent");
+        }
+
+        // Reset the circuit.
+        <CurrentAleo as circuit::Environment>::reset();
+    }
+
+    macro_rules! test_commit {
+        ($name: tt, $commit:ident) => {
+            paste::paste! {
+                #[test]
+                fn [<test _ $name _ is _ consistent>]() {
+                    // Initialize the operation.
+                    let operation = |operands, destination| $commit::<CurrentNetwork> { operands, destination };
+                    // Initialize the opcode.
+                    let opcode = $commit::<CurrentNetwork>::opcode();
+
+                    // Prepare the rng.
+                    let mut rng = TestRng::default();
+
+                   // Prepare the test.
+                    let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+                    let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
+
+                    // Prepare the key cache.
+                    let mut cache = Default::default();
+
+                    for _ in 0..ITERATIONS {
+                        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+                        let literals_b = vec![console::program::Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+
+                        for literal_a in &literals_a {
+                            for literal_b in &literals_b {
+                                for mode_a in &modes_a {
+                                    for mode_b in &modes_b {
+                                        check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    test_commit!(commit_bhp256, CommitBHP256);
+    test_commit!(commit_bhp512, CommitBHP512);
+    test_commit!(commit_bhp768, CommitBHP768);
+    test_commit!(commit_bhp1024, CommitBHP1024);
+
+    // Note this test must be explicitly written, instead of using the macro, because CommitPED64 fails on certain input types.
+    #[test]
+    fn test_hash_ped64_is_consistent() {
+        // Initialize the operation.
+        let operation = |operands, destination| CommitPED64::<CurrentNetwork> { operands, destination };
+        // Initialize the opcode.
+        let opcode = CommitPED128::<CurrentNetwork>::opcode();
+
+        // Prepare the rng.
+        let mut rng = TestRng::default();
+
+        // Prepare the test.
+        let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
+
+        // Prepare the key cache.
+        let mut cache = Default::default();
+
+        for _ in 0..ITERATIONS {
+            let literals_a = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+            ];
+            let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
+                            check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Note this test must be explicitly written, instead of using the macro, because CommitPED128 fails on certain input types.
+    #[test]
+    fn test_hash_ped128_is_consistent() {
+        // Initialize the operation.
+        let operation = |operands, destination| CommitPED128::<CurrentNetwork> { operands, destination };
+        // Initialize the opcode.
+        let opcode = CommitPED128::<CurrentNetwork>::opcode();
+
+        // Prepare the rng.
+        let mut rng = TestRng::default();
+
+        // Prepare the test.
+        let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
+
+        // Prepare the key cache.
+        let mut cache = Default::default();
+
+        for _ in 0..ITERATIONS {
+            let literals_a = [
+                Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                Literal::I8(console::types::I8::rand(&mut rng)),
+                Literal::I16(console::types::I16::rand(&mut rng)),
+                Literal::I32(console::types::I32::rand(&mut rng)),
+                Literal::I64(console::types::I64::rand(&mut rng)),
+                Literal::U8(console::types::U8::rand(&mut rng)),
+                Literal::U16(console::types::U16::rand(&mut rng)),
+                Literal::U32(console::types::U32::rand(&mut rng)),
+                Literal::U64(console::types::U64::rand(&mut rng)),
+            ];
+            let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
+                            check_commit(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_parse() {

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -285,7 +285,6 @@ impl<N: Network, const VARIANT: u8> ToBytes for CommitInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::{
         program::test_helpers::{sample_finalize_registers, sample_registers},
         ProvingKey,
@@ -380,14 +379,13 @@ mod tests {
         let destination_operand = Operand::Register(destination);
 
         // Attempt to evaluate the valid operand case.
-        let mut evaluate_registers =
-            sample_registers(&stack, &function_name, &[(literal_a, None), (literal_b, None)]).unwrap();
+        let values = [(literal_a, None), (literal_b, None)];
+        let mut evaluate_registers = sample_registers(&stack, &function_name, &values).unwrap();
         let result_a = operation.evaluate(&stack, &mut evaluate_registers);
 
         // Attempt to execute the valid operand case.
-        let mut execute_registers =
-            sample_registers(&stack, &function_name, &[(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))])
-                .unwrap();
+        let values = [(literal_a, Some(*mode_a)), (literal_b, Some(*mode_b))];
+        let mut execute_registers = sample_registers(&stack, &function_name, &values).unwrap();
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
         // Attempt to finalize the valid operand case.

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -822,8 +822,6 @@ pub(crate) mod test_helpers {
         stack: &Stack<CurrentNetwork>,
         literals: &[&Literal<CurrentNetwork>],
     ) -> Result<FinalizeRegisters<CurrentNetwork>> {
-        use console::program::{Identifier, Plaintext, Value};
-
         // Initialize the function name.
         let function_name = Identifier::from_str("run")?;
 

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -822,6 +822,8 @@ pub(crate) mod test_helpers {
         stack: &Stack<CurrentNetwork>,
         literals: &[&Literal<CurrentNetwork>],
     ) -> Result<FinalizeRegisters<CurrentNetwork>> {
+        use console::program::{Identifier, Plaintext, Value};
+
         // Initialize the function name.
         let function_name = Identifier::from_str("run")?;
 


### PR DESCRIPTION
This PR, adds equivalence tests (between `evaluate`, `execute`, and `finalize`) for the `commit` operation.

Depends on #1533.