### PR TITLE
[Test] Equivalence tests for `assert`.

### DIFF
--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -241,7 +241,11 @@ impl<N: Network, const VARIANT: u8> ToBytes for AssertInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{program::test_helpers::sample_registers, ProvingKey, VerifyingKey};
+    use crate::{
+        program::test_helpers::{sample_finalize_registers, sample_registers},
+        ProvingKey,
+        VerifyingKey,
+    };
 
     use circuit::AleoV0;
     use console::{
@@ -253,6 +257,8 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
     type CurrentAleo = AleoV0;
+
+    const ITERATIONS: usize = 100;
 
     /// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
     fn sample_stack(
@@ -281,6 +287,12 @@ mod tests {
             function {function_name}:
                 input {r0} as {type_a}.{mode_a};
                 input {r1} as {type_b}.{mode_b};
+                {opcode} {r0} {r1};
+                finalize {r0} {r1};
+
+            finalize {function_name}:
+                input {r0} as {type_a}.public;
+                input {r1} as {type_b}.public;
                 {opcode} {r0} {r1};
         "
         ))?;
@@ -316,7 +328,7 @@ mod tests {
         let (stack, operands) = sample_stack(opcode, type_a, type_b, *mode_a, *mode_b, cache).unwrap();
         // Initialize the operation.
         let operation = operation(operands);
-        // Construct the function name.
+        // Initialize the function name.
         let function_name = Identifier::from_str("run").unwrap();
 
         /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
@@ -369,6 +381,20 @@ mod tests {
 
             // Reset the circuit.
             <CurrentAleo as circuit::Environment>::reset();
+
+            // Attempt to finalize the valid operand case.
+            let mut registers = sample_finalize_registers(&stack, &function_name, &[literal_a, literal_a]).unwrap();
+            let result_c = operation.finalize(&stack, &mut registers);
+
+            // Ensure the result is correct.
+            match VARIANT {
+                0 => assert!(result_c.is_ok(), "Instruction '{operation}' failed (console): {literal_a} {literal_a}"),
+                1 => assert!(
+                    result_c.is_err(),
+                    "Instruction '{operation}' should have failed (console): {literal_a} {literal_a}"
+                ),
+                _ => panic!("Found an invalid 'assert' variant in the test"),
+            }
         }
         /* Next, check the mismatching literals *fail*. */
         if literal_a != literal_b {
@@ -420,6 +446,20 @@ mod tests {
 
             // Reset the circuit.
             <CurrentAleo as circuit::Environment>::reset();
+
+            // Attempt to finalize the valid operand case.
+            let mut registers = sample_finalize_registers(&stack, &function_name, &[literal_a, literal_b]).unwrap();
+            let result_c = operation.finalize(&stack, &mut registers);
+
+            // Ensure the result is correct.
+            match VARIANT {
+                0 => assert!(
+                    result_c.is_err(),
+                    "Instruction '{operation}' should have failed (console): {literal_a} {literal_b}"
+                ),
+                1 => assert!(result_c.is_ok(), "Instruction '{operation}' failed (console): {literal_a} {literal_b}"),
+                _ => panic!("Found an invalid 'assert' variant in the test"),
+            }
         }
     }
 
@@ -455,19 +495,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
-        let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+        let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
-            for mode_a in &modes_a {
-                for mode_b in &modes_b {
-                    // Check the operation.
-                    check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        // Check the operation.
+                        check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
                 }
             }
         }
@@ -482,21 +524,23 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
-        let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+        let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                            }
                         }
                     }
                 }
@@ -515,19 +559,21 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
-        let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+        let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
-            for mode_a in &modes_a {
-                for mode_b in &modes_b {
-                    // Check the operation.
-                    check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for (literal_a, literal_b) in literals_a.iter().zip_eq(literals_b.iter()) {
+                for mode_a in &modes_a {
+                    for mode_b in &modes_b {
+                        // Check the operation.
+                        check_assert(operation, opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                    }
                 }
             }
         }
@@ -542,21 +588,23 @@ mod tests {
         let mut rng = TestRng::default();
 
         // Prepare the test.
-        let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
-        let modes_a = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
-        let modes_b = [/* circuit::Mode::Constant, */ circuit::Mode::Public, circuit::Mode::Private];
+        let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+        let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
 
         // Prepare the key cache.
         let mut cache = Default::default();
 
-        for literal_a in &literals_a {
-            for literal_b in &literals_b {
-                if literal_a.to_type() != literal_b.to_type() {
-                    for mode_a in &modes_a {
-                        for mode_b in &modes_b {
-                            // Check the operation fails.
-                            check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+        for _ in 0..ITERATIONS {
+            let literals_a = crate::sample_literals!(CurrentNetwork, &mut rng);
+            let literals_b = crate::sample_literals!(CurrentNetwork, &mut rng);
+            for literal_a in &literals_a {
+                for literal_b in &literals_b {
+                    if literal_a.to_type() != literal_b.to_type() {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                // Check the operation fails.
+                                check_assert_fails(opcode, literal_a, literal_b, mode_a, mode_b, &mut cache);
+                            }
                         }
                     }
                 }

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -389,7 +389,8 @@ mod tests {
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
         // Attempt to finalize the valid operand case.
-        let mut finalize_registers = sample_finalize_registers(&stack, &[literal_a, literal_b]).unwrap();
+        let mut finalize_registers =
+            sample_finalize_registers(&stack, &function_name, &[literal_a, literal_b]).unwrap();
         let result_c = operation.finalize(&stack, &mut finalize_registers);
 
         // Check that either all operations failed, or all operations succeeded.

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -371,7 +371,7 @@ mod tests {
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
         // Attempt to finalize the valid operand case.
-        let mut finalize_registers = sample_finalize_registers(&stack, &[literal]).unwrap();
+        let mut finalize_registers = sample_finalize_registers(&stack, &function_name, &[literal]).unwrap();
         let result_c = operation.finalize(&stack, &mut finalize_registers);
 
         // Check that either all operations failed, or all operations succeeded.

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -823,7 +823,6 @@ pub(crate) mod test_helpers {
         function_name: &Identifier<CurrentNetwork>,
         literals: &[&Literal<CurrentNetwork>],
     ) -> Result<FinalizeRegisters<CurrentNetwork>> {
-
         // Initialize the registers.
         let mut finalize_registers =
             FinalizeRegisters::<CurrentNetwork>::new(stack.get_finalize_types(function_name)?.clone());

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -822,6 +822,7 @@ pub(crate) mod test_helpers {
         stack: &Stack<CurrentNetwork>,
         literals: &[&Literal<CurrentNetwork>],
     ) -> Result<FinalizeRegisters<CurrentNetwork>> {
+
         // Initialize the function name.
         let function_name = Identifier::from_str("run")?;
 

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -820,15 +820,13 @@ pub(crate) mod test_helpers {
     /// Samples the finalize registers. Note: Do not replicate this for real program use, it is insecure.
     pub(crate) fn sample_finalize_registers(
         stack: &Stack<CurrentNetwork>,
+        function_name: &Identifier<CurrentNetwork>,
         literals: &[&Literal<CurrentNetwork>],
     ) -> Result<FinalizeRegisters<CurrentNetwork>> {
 
-        // Initialize the function name.
-        let function_name = Identifier::from_str("run")?;
-
         // Initialize the registers.
         let mut finalize_registers =
-            FinalizeRegisters::<CurrentNetwork>::new(stack.get_finalize_types(&function_name)?.clone());
+            FinalizeRegisters::<CurrentNetwork>::new(stack.get_finalize_types(function_name)?.clone());
 
         // For each literal,
         for (index, literal) in literals.iter().enumerate() {


### PR DESCRIPTION
This PR,
- generalizes `sample_finalize_registers` to accept any function name.
-  adds equivalence tests (between `evaluate`, `execute`, and `finalize`) for the `assert` operation.

Depends on #1534.