### PR TITLE
Add `get_confirmed_transaction` to Ledger

### DIFF
--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -149,6 +149,15 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
     }
 
+    /// Returns the confirmed transaction for the given transaction ID.
+    pub fn get_confirmed_transaction(&self, transaction_id: N::TransactionID) -> Result<ConfirmedTransaction<N>> {
+        // Retrieve the confirmed transaction.
+        match self.vm.block_store().get_confirmed_transaction(&transaction_id)? {
+            Some(confirmed_transaction) => Ok(confirmed_transaction),
+            None => bail!("Missing confirmed transaction for ID {transaction_id}"),
+        }
+    }
+
     /// Returns the program for the given program ID.
     pub fn get_program(&self, program_id: ProgramID<N>) -> Result<Program<N>> {
         match self.vm.transaction_store().get_program(&program_id)? {

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -34,7 +34,7 @@ use console::{
     types::{Field, Group},
 };
 use synthesizer::{
-    block::{Block, Header, Transaction, Transactions},
+    block::{Block, ConfirmedTransaction, Header, Transaction, Transactions},
     coinbase_puzzle::{CoinbaseSolution, EpochChallenge, PuzzleCommitment},
     process::Query,
     program::Program,

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -860,6 +860,14 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.get_block(block_hash)
     }
 
+    /// Returns the confirmed transaction for the given `transaction ID`.
+    pub fn get_confirmed_transaction(
+        &self,
+        transaction_id: &N::TransactionID,
+    ) -> Result<Option<ConfirmedTransaction<N>>> {
+        self.storage.get_confirmed_transaction(*transaction_id)
+    }
+
     /// Returns the program for the given `program ID`.
     pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
         self.storage.transaction_store().get_program(program_id)


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds the getter function `get_confirmed_transaction` to Ledger. This will enable snarkOS to fetch additional information about each transaction directly from the ledger. 