### PR TITLE
Moves `Transaction` executors to `VM`

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -347,6 +347,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let fee = Some((fee_record, priority_fee_in_microcredits));
 
         // Create a new execute transaction.
-        Transaction::execute(&self.vm, private_key, ("credits.aleo", "transfer"), inputs.iter(), fee, query, rng)
+        self.vm.execute(private_key, ("credits.aleo", "transfer"), inputs.iter(), fee, query, rng)
     }
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -313,7 +313,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let fee = (fee_record, priority_fee_in_microcredits);
 
         // Create a new deploy transaction.
-        Transaction::deploy(&self.vm, private_key, program, fee, query, rng)
+        self.vm.deploy(private_key, program, fee, query, rng)
     }
 
     /// Creates a transfer transaction.

--- a/synthesizer/benches/transaction.rs
+++ b/synthesizer/benches/transaction.rs
@@ -115,8 +115,7 @@ fn execute(c: &mut Criterion) {
 
     c.bench_function("Transaction - execution (transfer)", |b| {
         b.iter(|| {
-            Transaction::execute_authorization(
-                &vm,
+            vm.execute_authorization(
                 Authorization::new(&authorization.to_vec_deque().into_iter().collect::<Vec<_>>()),
                 None,
                 None,
@@ -127,14 +126,14 @@ fn execute(c: &mut Criterion) {
     });
 
     c.bench_function("Transaction verify - execution (transfer)", |b| {
-        let transaction = Transaction::execute_authorization(
-            &vm,
-            Authorization::new(&authorization.to_vec_deque().into_iter().collect::<Vec<_>>()),
-            None,
-            None,
-            rng,
-        )
-        .unwrap();
+        let transaction = vm
+            .execute_authorization(
+                Authorization::new(&authorization.to_vec_deque().into_iter().collect::<Vec<_>>()),
+                None,
+                None,
+                rng,
+            )
+            .unwrap();
         b.iter(|| assert!(vm.verify_transaction(&transaction)))
     });
 }

--- a/synthesizer/benches/transaction.rs
+++ b/synthesizer/benches/transaction.rs
@@ -83,12 +83,11 @@ function hello:
     .unwrap();
 
     c.bench_function("Transaction - deploy", |b| {
-        b.iter(|| Transaction::deploy(&vm, &private_key, &program, (record.clone(), 600000), None, rng).unwrap())
+        b.iter(|| vm.deploy(&private_key, &program, (record.clone(), 600000), None, rng).unwrap())
     });
 
     c.bench_function("Transaction verify - deployment", |b| {
-        let transaction =
-            Transaction::deploy(&vm, &private_key, &program, (record.clone(), 600000), None, rng).unwrap();
+        let transaction = vm.deploy(&private_key, &program, (record.clone(), 600000), None, rng).unwrap();
         b.iter(|| assert!(vm.verify_transaction(&transaction)))
     });
 }

--- a/synthesizer/benches/transaction.rs
+++ b/synthesizer/benches/transaction.rs
@@ -28,7 +28,6 @@ use snarkvm_synthesizer::{
     Block,
     ConsensusStore,
     Program,
-    Transaction,
     Transition,
     VM,
 };

--- a/synthesizer/src/block/genesis.rs
+++ b/synthesizer/src/block/genesis.rs
@@ -40,7 +40,7 @@ impl<N: Network> Block<N> {
         let transactions = (0u32..Self::NUM_GENESIS_TRANSACTIONS as u32)
             .map(|index| {
                 // Execute the mint function.
-                let transaction = Transaction::execute(vm, private_key, locator, inputs.iter(), None, None, rng)?;
+                let transaction = vm.execute(private_key, locator, inputs.iter(), None, None, rng)?;
                 // Prepare the confirmed transaction.
                 ConfirmedTransaction::accepted_execute(index, transaction, vec![])
             })

--- a/synthesizer/src/block/mod.rs
+++ b/synthesizer/src/block/mod.rs
@@ -420,8 +420,7 @@ pub(crate) mod test_helpers {
                 let inputs = [address.to_string(), "1_u64".to_string()].into_iter();
 
                 // Construct the transaction.
-                let transaction =
-                    Transaction::execute(&vm, &private_key, ("credits.aleo", "mint"), inputs, None, None, rng).unwrap();
+                let transaction = vm.execute(&private_key, ("credits.aleo", "mint"), inputs, None, None, rng).unwrap();
                 // Construct the transactions.
                 let transactions =
                     Transactions::from(&[

--- a/synthesizer/src/block/transaction/merkle.rs
+++ b/synthesizer/src/block/transaction/merkle.rs
@@ -17,6 +17,9 @@
 use super::*;
 
 impl<N: Network> Transaction<N> {
+    /// The maximum number of transitions allowed in a transaction.
+    const MAX_TRANSITIONS: usize = usize::pow(2, TRANSACTION_DEPTH as u32);
+
     /// Returns the transaction root, by computing the root for a Merkle tree of the transition IDs.
     pub fn to_root(&self) -> Result<Field<N>> {
         Ok(*self.to_tree()?.root())

--- a/synthesizer/src/block/transaction/merkle.rs
+++ b/synthesizer/src/block/transaction/merkle.rs
@@ -97,7 +97,7 @@ impl<N: Network> Transaction<N> {
 
 impl<N: Network> Transaction<N> {
     /// Returns the Merkle tree for the given deployment.
-    pub(super) fn deployment_tree(deployment: &Deployment<N>, fee: &Fee<N>) -> Result<TransactionTree<N>> {
+    pub fn deployment_tree(deployment: &Deployment<N>, fee: &Fee<N>) -> Result<TransactionTree<N>> {
         // Ensure the number of leaves is within the Merkle tree size.
         Self::check_deployment_size(deployment)?;
         // Retrieve the program.

--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -28,7 +28,7 @@ mod merkle;
 mod serialize;
 mod string;
 
-use crate::{block::Transition, process::Authorization, vm::VM, ConsensusStorage, Query};
+use crate::block::Transition;
 use console::{
     network::prelude::*,
     program::{Ciphertext, ProgramOwner, Record, TransactionLeaf, TransactionPath, TransactionTree, TRANSACTION_DEPTH},
@@ -76,25 +76,6 @@ impl<N: Network> Transaction<N> {
         let id = *Self::fee_tree(&fee)?.root();
         // Construct the execution transaction.
         Ok(Self::Fee(id.into(), fee))
-    }
-}
-
-impl<N: Network> Transaction<N> {
-    /// The maximum number of transitions allowed in a transaction.
-    const MAX_TRANSITIONS: usize = usize::pow(2, TRANSACTION_DEPTH as u32);
-
-    /// Initializes a new execution transaction from an authorization.
-    pub fn execute_authorization<C: ConsensusStorage<N>, R: Rng + CryptoRng>(
-        vm: &VM<N, C>,
-        authorization: Authorization<N>,
-        fee: Option<Fee<N>>,
-        query: Option<Query<N, C::BlockStorage>>,
-        rng: &mut R,
-    ) -> Result<Self> {
-        // Compute the execution.
-        let (_response, execution, _metrics) = vm.execute_authorization(authorization, query, rng)?;
-        // Initialize the transaction.
-        Self::from_execution(execution, fee)
     }
 }
 

--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -120,7 +120,7 @@ impl<N: Network> Transaction<N> {
             .ok_or_else(|| anyhow!("Fee overflowed for a deployment transaction"))?;
 
         // Compute the fee.
-        let (_, fee, _) = vm.execute_fee(private_key, fee_record, fee_in_microcredits, query, rng)?;
+        let (_, fee, _) = vm.execute_fee_raw(private_key, fee_record, fee_in_microcredits, query, rng)?;
 
         // Construct the owner.
         let id = *Self::deployment_tree(&deployment, &fee)?.root();
@@ -156,23 +156,11 @@ impl<N: Network> Transaction<N> {
                     .checked_add(priority_fee_in_microcredits)
                     .ok_or_else(|| anyhow!("Fee overflowed for an execution transaction"))?;
                 // Compute the fee.
-                Some(vm.execute_fee(private_key, credits, fee_in_microcredits, query, rng)?.1)
+                Some(vm.execute_fee_raw(private_key, credits, fee_in_microcredits, query, rng)?.1)
             }
         };
         // Initialize the transaction.
         Self::from_execution(execution, fee)
-    }
-
-    /// Initializes a new fee.
-    pub fn execute_fee<C: ConsensusStorage<N>, R: Rng + CryptoRng>(
-        vm: &VM<N, C>,
-        private_key: &PrivateKey<N>,
-        credits: Record<N, Plaintext<N>>,
-        fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
-        rng: &mut R,
-    ) -> Result<Fee<N>> {
-        Ok(vm.execute_fee(private_key, credits, fee_in_microcredits, query, rng)?.1)
     }
 
     /// Initializes a new execution transaction from an authorization.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -77,98 +77,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Process the logic.
         process!(self, logic)
     }
-
-    /// Executes a fee for the given private key, fee record, and fee amount (in microcredits).
-    /// Returns the fee transaction.
-    #[inline]
-    pub fn execute_fee<R: Rng + CryptoRng>(
-        &self,
-        private_key: &PrivateKey<N>,
-        fee_record: Record<N, Plaintext<N>>,
-        fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
-        rng: &mut R,
-    ) -> Result<Transaction<N>> {
-        // Compute the fee.
-        let fee = self.execute_fee_raw(private_key, fee_record, fee_in_microcredits, query, rng)?.1;
-        // Return the fee transaction.
-        Transaction::from_fee(fee)
-    }
-
-    /// Executes a fee for the given private key, fee record, and fee amount (in microcredits).
-    /// Returns the response, fee, and call metrics.
-    #[inline]
-    pub fn execute_fee_raw<R: Rng + CryptoRng>(
-        &self,
-        private_key: &PrivateKey<N>,
-        fee_record: Record<N, Plaintext<N>>,
-        fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
-        rng: &mut R,
-    ) -> Result<(Response<N>, Fee<N>, Vec<CallMetrics<N>>)> {
-        let timer = timer!("VM::execute_fee_raw");
-
-        // Prepare the query.
-        let query = match query {
-            Some(query) => query,
-            None => Query::VM(self.block_store().clone()),
-        };
-        lap!(timer, "Prepare the query");
-
-        // TODO (raychu86): Ensure that the fee record is associated with the `credits.aleo` program
-        // Ensure that the record has enough balance to pay the fee.
-        match fee_record.find(&[Identifier::from_str("microcredits")?]) {
-            Ok(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => {
-                if *amount < fee_in_microcredits {
-                    bail!("Fee record does not have enough balance to pay the fee")
-                }
-            }
-            _ => bail!("Fee record does not have microcredits"),
-        }
-
-        // Compute the core logic.
-        macro_rules! logic {
-            ($process:expr, $network:path, $aleo:path) => {{
-                type RecordPlaintext<NetworkMacro> = Record<NetworkMacro, Plaintext<NetworkMacro>>;
-
-                // Prepare the private key and fee record.
-                let private_key = cast_ref!(&private_key as PrivateKey<$network>);
-                let fee_record = cast_ref!(fee_record as RecordPlaintext<$network>);
-                lap!(timer, "Prepare the private key and fee record");
-
-                // Execute the call to fee.
-                let (response, fee_transition, inclusion, metrics) =
-                    $process.execute_fee::<$aleo, _>(private_key, fee_record.clone(), fee_in_microcredits, rng)?;
-                lap!(timer, "Execute the call to fee");
-
-                // Prepare the assignments.
-                let assignments = {
-                    let fee_transition = cast_ref!(fee_transition as Transition<N>);
-                    let inclusion = cast_ref!(inclusion as Inclusion<N>);
-                    inclusion.prepare_fee(fee_transition, query)?
-                };
-                let assignments = cast_ref!(assignments as Vec<InclusionAssignment<$network>>);
-                lap!(timer, "Prepare the assignments");
-
-                // Compute the inclusion proof and construct the fee.
-                let fee = inclusion.prove_fee::<$aleo, _>(fee_transition, assignments, rng)?;
-                lap!(timer, "Compute the inclusion proof and construct the fee");
-
-                // Prepare the return.
-                let response = cast_ref!(response as Response<N>).clone();
-                let fee = cast_ref!(fee as Fee<N>).clone();
-                let metrics = cast_ref!(metrics as Vec<CallMetrics<N>>).clone();
-                lap!(timer, "Prepare the response, fee, and metrics");
-
-                finish!(timer);
-
-                // Return the response, fee, metrics.
-                Ok((response, fee, metrics))
-            }};
-        }
-        // Process the logic.
-        process!(self, logic)
-    }
 }
 
 #[cfg(test)]
@@ -349,27 +257,5 @@ mod tests {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
             assert_eq!(2457, execution_size_in_bytes, "Update me if serialization has changed");
         }
-    }
-
-    #[test]
-    fn test_fee_transition_size() {
-        let rng = &mut TestRng::default();
-
-        // Initialize a new caller.
-        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
-        let caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
-
-        // Prepare the VM and records.
-        let (vm, records) = prepare_vm(rng).unwrap();
-
-        // Fetch the unspent record.
-        let record = records.values().next().unwrap().decrypt(&caller_view_key).unwrap();
-
-        // Execute.
-        let (_, fee, _) = vm.execute_fee_raw(&caller_private_key, record, 1, None, rng).unwrap();
-
-        // Assert the size of the transition.
-        let fee_size_in_bytes = fee.to_bytes_le().unwrap().len();
-        assert_eq!(2247, fee_size_in_bytes, "Update me if serialization has changed");
     }
 }

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -106,7 +106,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         query: Option<Query<N, C::BlockStorage>>,
         rng: &mut R,
     ) -> Result<(Response<N>, Fee<N>, Vec<CallMetrics<N>>)> {
-        let timer = timer!("VM::execute_fee");
+        let timer = timer!("VM::execute_fee_raw");
 
         // Prepare the query.
         let query = match query {

--- a/synthesizer/src/vm/execute_fee.rs
+++ b/synthesizer/src/vm/execute_fee.rs
@@ -1,0 +1,167 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
+    /// Executes a fee for the given private key, fee record, and fee amount (in microcredits).
+    /// Returns the fee transaction.
+    #[inline]
+    pub fn execute_fee<R: Rng + CryptoRng>(
+        &self,
+        private_key: &PrivateKey<N>,
+        fee_record: Record<N, Plaintext<N>>,
+        fee_in_microcredits: u64,
+        query: Option<Query<N, C::BlockStorage>>,
+        rng: &mut R,
+    ) -> Result<Transaction<N>> {
+        // Compute the fee.
+        let fee = self.execute_fee_raw(private_key, fee_record, fee_in_microcredits, query, rng)?.1;
+        // Return the fee transaction.
+        Transaction::from_fee(fee)
+    }
+
+    /// Executes a fee for the given private key, fee record, and fee amount (in microcredits).
+    /// Returns the response, fee, and call metrics.
+    #[inline]
+    pub fn execute_fee_raw<R: Rng + CryptoRng>(
+        &self,
+        private_key: &PrivateKey<N>,
+        fee_record: Record<N, Plaintext<N>>,
+        fee_in_microcredits: u64,
+        query: Option<Query<N, C::BlockStorage>>,
+        rng: &mut R,
+    ) -> Result<(Response<N>, Fee<N>, Vec<CallMetrics<N>>)> {
+        let timer = timer!("VM::execute_fee_raw");
+
+        // Prepare the query.
+        let query = match query {
+            Some(query) => query,
+            None => Query::VM(self.block_store().clone()),
+        };
+        lap!(timer, "Prepare the query");
+
+        // TODO (raychu86): Ensure that the fee record is associated with the `credits.aleo` program
+        // Ensure that the record has enough balance to pay the fee.
+        match fee_record.find(&[Identifier::from_str("microcredits")?]) {
+            Ok(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => {
+                if *amount < fee_in_microcredits {
+                    bail!("Fee record does not have enough balance to pay the fee")
+                }
+            }
+            _ => bail!("Fee record does not have microcredits"),
+        }
+
+        // Compute the core logic.
+        macro_rules! logic {
+            ($process:expr, $network:path, $aleo:path) => {{
+                type RecordPlaintext<NetworkMacro> = Record<NetworkMacro, Plaintext<NetworkMacro>>;
+
+                // Prepare the private key and fee record.
+                let private_key = cast_ref!(&private_key as PrivateKey<$network>);
+                let fee_record = cast_ref!(fee_record as RecordPlaintext<$network>);
+                lap!(timer, "Prepare the private key and fee record");
+
+                // Execute the call to fee.
+                let (response, fee_transition, inclusion, metrics) =
+                    $process.execute_fee::<$aleo, _>(private_key, fee_record.clone(), fee_in_microcredits, rng)?;
+                lap!(timer, "Execute the call to fee");
+
+                // Prepare the assignments.
+                let assignments = {
+                    let fee_transition = cast_ref!(fee_transition as Transition<N>);
+                    let inclusion = cast_ref!(inclusion as Inclusion<N>);
+                    inclusion.prepare_fee(fee_transition, query)?
+                };
+                let assignments = cast_ref!(assignments as Vec<InclusionAssignment<$network>>);
+                lap!(timer, "Prepare the assignments");
+
+                // Compute the inclusion proof and construct the fee.
+                let fee = inclusion.prove_fee::<$aleo, _>(fee_transition, assignments, rng)?;
+                lap!(timer, "Compute the inclusion proof and construct the fee");
+
+                // Prepare the return.
+                let response = cast_ref!(response as Response<N>).clone();
+                let fee = cast_ref!(fee as Fee<N>).clone();
+                let metrics = cast_ref!(metrics as Vec<CallMetrics<N>>).clone();
+                lap!(timer, "Prepare the response, fee, and metrics");
+
+                finish!(timer);
+
+                // Return the response, fee, metrics.
+                Ok((response, fee, metrics))
+            }};
+        }
+        // Process the logic.
+        process!(self, logic)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::helpers::memory::ConsensusMemory;
+    use console::{account::ViewKey, network::Testnet3, program::Ciphertext};
+
+    use indexmap::IndexMap;
+
+    type CurrentNetwork = Testnet3;
+
+    fn prepare_vm(
+        rng: &mut TestRng,
+    ) -> Result<(
+        VM<CurrentNetwork, ConsensusMemory<CurrentNetwork>>,
+        IndexMap<Field<CurrentNetwork>, Record<CurrentNetwork, Ciphertext<CurrentNetwork>>>,
+    )> {
+        // Initialize the genesis block.
+        let genesis = crate::vm::test_helpers::sample_genesis_block(rng);
+
+        // Fetch the unspent records.
+        let records = genesis.transitions().cloned().flat_map(Transition::into_records).collect::<IndexMap<_, _>>();
+
+        // Initialize the genesis block.
+        let genesis = crate::vm::test_helpers::sample_genesis_block(rng);
+
+        // Initialize the VM.
+        let vm = crate::vm::test_helpers::sample_vm();
+        // Update the VM.
+        vm.add_next_block(&genesis).unwrap();
+
+        Ok((vm, records))
+    }
+
+    #[test]
+    fn test_fee_transition_size() {
+        let rng = &mut TestRng::default();
+
+        // Initialize a new caller.
+        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+        let caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
+
+        // Prepare the VM and records.
+        let (vm, records) = prepare_vm(rng).unwrap();
+
+        // Fetch the unspent record.
+        let record = records.values().next().unwrap().decrypt(&caller_view_key).unwrap();
+
+        // Execute.
+        let (_, fee, _) = vm.execute_fee_raw(&caller_private_key, record, 1, None, rng).unwrap();
+
+        // Assert the size of the transition.
+        let fee_size_in_bytes = fee.to_bytes_le().unwrap().len();
+        assert_eq!(2247, fee_size_in_bytes, "Update me if serialization has changed");
+    }
+}

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -405,7 +405,7 @@ finalize transfer_public:
         let additional_fee = (credits, 10);
 
         // Deploy.
-        let transaction = Transaction::deploy(vm, private_key, &program, additional_fee, None, rng)?;
+        let transaction = vm.deploy(private_key, &program, additional_fee, None, rng)?;
 
         // Construct the new block.
         let next_block = sample_next_block(vm, private_key, &[transaction], previous_block, unspent_records, rng)?;
@@ -838,8 +838,7 @@ function ped_hash:
             let additional_fee = (credits, 10);
 
             // Deploy the program.
-            let deployment_transaction =
-                Transaction::deploy(&vm, &caller_private_key, &program, additional_fee, None, rng).unwrap();
+            let deployment_transaction = vm.deploy(&caller_private_key, &program, additional_fee, None, rng).unwrap();
 
             // Construct the deployment block.
             let deployment_block = sample_next_block(

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -490,8 +490,7 @@ finalize transfer_public:
             .into_iter();
 
             // Execute.
-            let transaction =
-                Transaction::execute(vm, private_key, ("credits.aleo", "split"), inputs, None, None, rng).unwrap();
+            let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs, None, None, rng).unwrap();
 
             transactions.push(transaction);
         }
@@ -518,16 +517,16 @@ finalize transfer_public:
         let additional_fee = (credits, 1);
 
         // Execute.
-        let transaction = Transaction::execute(
-            vm,
-            &caller_private_key,
-            (program_id, function_name),
-            inputs.into_iter(),
-            Some(additional_fee),
-            None,
-            rng,
-        )
-        .unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                (program_id, function_name),
+                inputs.into_iter(),
+                Some(additional_fee),
+                None,
+                rng,
+            )
+            .unwrap();
         // Verify.
         assert!(vm.verify_transaction(&transaction));
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -499,16 +499,16 @@ function compute:
         vm.add_next_block(&genesis).unwrap();
 
         // Split once.
-        let transaction = Transaction::execute(
-            &vm,
-            &caller_private_key,
-            ("credits.aleo", "split"),
-            [Value::Record(record), Value::from_str("1000000000u64").unwrap()].iter(), // 1000 credits
-            None,
-            None,
-            rng,
-        )
-        .unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "split"),
+                [Value::Record(record), Value::from_str("1000000000u64").unwrap()].iter(), // 1000 credits
+                None,
+                None,
+                rng,
+            )
+            .unwrap();
         let records = transaction.records().collect_vec();
         let first_record = records[0].1.clone().decrypt(&caller_view_key).unwrap();
         let second_record = records[1].1.clone().decrypt(&caller_view_key).unwrap();
@@ -517,31 +517,31 @@ function compute:
 
         // Split again.
         let mut transactions = Vec::new();
-        let transaction = Transaction::execute(
-            &vm,
-            &caller_private_key,
-            ("credits.aleo", "split"),
-            [Value::Record(first_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
-            None,
-            None,
-            rng,
-        )
-        .unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "split"),
+                [Value::Record(first_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
+                None,
+                None,
+                rng,
+            )
+            .unwrap();
         let records = transaction.records().collect_vec();
         let first_record = records[0].1.clone().decrypt(&caller_view_key).unwrap();
         let third_record = records[1].1.clone().decrypt(&caller_view_key).unwrap();
         transactions.push(transaction);
         // Split again.
-        let transaction = Transaction::execute(
-            &vm,
-            &caller_private_key,
-            ("credits.aleo", "split"),
-            [Value::Record(second_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
-            None,
-            None,
-            rng,
-        )
-        .unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "split"),
+                [Value::Record(second_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
+                None,
+                None,
+                rng,
+            )
+            .unwrap();
         let records = transaction.records().collect_vec();
         let second_record = records[0].1.clone().decrypt(&caller_view_key).unwrap();
         let fourth_record = records[1].1.clone().decrypt(&caller_view_key).unwrap();
@@ -590,26 +590,26 @@ finalize getter:
         vm.add_next_block(&deployment_block).unwrap();
 
         // Execute the programs.
-        let first_execution = Transaction::execute(
-            &vm,
-            &caller_private_key,
-            ("test_1.aleo", "init"),
-            Vec::<Value<Testnet3>>::new().iter(),
-            Some((third_record, 1)),
-            None,
-            rng,
-        )
-        .unwrap();
-        let second_execution = Transaction::execute(
-            &vm,
-            &caller_private_key,
-            ("test_2.aleo", "init"),
-            Vec::<Value<Testnet3>>::new().iter(),
-            Some((fourth_record, 1)),
-            None,
-            rng,
-        )
-        .unwrap();
+        let first_execution = vm
+            .execute(
+                &caller_private_key,
+                ("test_1.aleo", "init"),
+                Vec::<Value<Testnet3>>::new().iter(),
+                Some((third_record, 1)),
+                None,
+                rng,
+            )
+            .unwrap();
+        let second_execution = vm
+            .execute(
+                &caller_private_key,
+                ("test_2.aleo", "init"),
+                Vec::<Value<Testnet3>>::new().iter(),
+                Some((fourth_record, 1)),
+                None,
+                rng,
+            )
+            .unwrap();
         let execution_block =
             sample_next_block(&vm, &caller_private_key, &[first_execution, second_execution], rng).unwrap();
         vm.add_next_block(&execution_block).unwrap();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -328,7 +328,7 @@ function compute:
                 assert_eq!(authorization.len(), 1);
 
                 // Execute.
-                let transaction = Transaction::execute_authorization(&vm, authorization, None, None, rng).unwrap();
+                let transaction = vm.execute_authorization(authorization, None, None, rng).unwrap();
                 // Verify.
                 assert!(!vm.verify_transaction(&transaction));
                 // Return the transaction.
@@ -377,7 +377,7 @@ function compute:
                 let fee = vm.execute_fee_raw(&caller_private_key, record, 100, None, rng).unwrap().1;
 
                 // Execute.
-                let transaction = Transaction::execute_authorization(&vm, authorization, Some(fee), None, rng).unwrap();
+                let transaction = vm.execute_authorization(authorization, Some(fee), None, rng).unwrap();
                 // Verify.
                 assert!(vm.verify_transaction(&transaction));
                 // Return the transaction.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -373,7 +373,7 @@ function compute:
                 assert_eq!(authorization.len(), 1);
 
                 // Execute the fee.
-                let fee = Transaction::execute_fee(&vm, &caller_private_key, record, 100, None, rng).unwrap();
+                let fee = vm.execute_fee_raw(&caller_private_key, record, 100, None, rng).unwrap().1;
 
                 // Execute.
                 let transaction = Transaction::execute_authorization(&vm, authorization, Some(fee), None, rng).unwrap();
@@ -410,7 +410,8 @@ function compute:
                 vm.add_next_block(&genesis).unwrap();
 
                 // Execute.
-                let (_response, fee, _metrics) = vm.execute_fee(&caller_private_key, record, 1u64, None, rng).unwrap();
+                let (_response, fee, _metrics) =
+                    vm.execute_fee_raw(&caller_private_key, record, 1u64, None, rng).unwrap();
                 // Verify.
                 assert!(vm.verify_fee(&fee));
                 assert!(Inclusion::verify_fee(&fee).is_ok());

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -19,6 +19,7 @@ mod helpers;
 mod authorize;
 mod deploy;
 mod execute;
+mod execute_fee;
 mod finalize;
 mod verify;
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -37,7 +37,7 @@ use crate::{
 use console::{
     account::PrivateKey,
     network::prelude::*,
-    program::{Entry, Identifier, Literal, Plaintext, ProgramID, Record, Response, Value},
+    program::{Entry, Identifier, Literal, Plaintext, ProgramID, ProgramOwner, Record, Response, Value},
     types::Field,
 };
 
@@ -280,7 +280,7 @@ function compute:
                 vm.add_next_block(&genesis).unwrap();
 
                 // Deploy.
-                let transaction = Transaction::deploy(&vm, &caller_private_key, &program, fee, None, rng).unwrap();
+                let transaction = vm.deploy(&caller_private_key, &program, fee, None, rng).unwrap();
                 // Verify.
                 assert!(vm.verify_transaction(&transaction));
                 // Return the transaction.
@@ -578,24 +578,12 @@ function getter:
 finalize getter:
     get map_0[0field] into r0;
         ";
-        let first_deployment = Transaction::deploy(
-            &vm,
-            &caller_private_key,
-            &Program::from_str(first_program).unwrap(),
-            (first_record, 1),
-            None,
-            rng,
-        )
-        .unwrap();
-        let second_deployment = Transaction::deploy(
-            &vm,
-            &caller_private_key,
-            &Program::from_str(second_program).unwrap(),
-            (second_record, 1),
-            None,
-            rng,
-        )
-        .unwrap();
+        let first_deployment = vm
+            .deploy(&caller_private_key, &Program::from_str(first_program).unwrap(), (first_record, 1), None, rng)
+            .unwrap();
+        let second_deployment = vm
+            .deploy(&caller_private_key, &Program::from_str(second_program).unwrap(), (second_record, 1), None, rng)
+            .unwrap();
         let deployment_block =
             sample_next_block(&vm, &caller_private_key, &[first_deployment, second_deployment], rng).unwrap();
         vm.add_next_block(&deployment_block).unwrap();

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -443,7 +443,7 @@ mod tests {
         assert_eq!(authorization.len(), 1);
 
         // Execute.
-        let transaction = Transaction::execute_authorization(&vm, authorization, Some(fee), None, rng).unwrap();
+        let transaction = vm.execute_authorization(authorization, Some(fee), None, rng).unwrap();
 
         // Verify.
         assert!(vm.check_transaction(&transaction).is_ok());

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -264,7 +264,7 @@ mod tests {
         let program = crate::vm::test_helpers::sample_program();
 
         // Deploy the program.
-        let deployment = vm.deploy(&program, rng).unwrap();
+        let deployment = vm.deploy_raw(&program, rng).unwrap();
 
         // Ensure the deployment is valid.
         assert!(vm.check_deployment(&deployment).is_ok());
@@ -385,7 +385,7 @@ mod tests {
 
         // Deploy.
         let program = crate::vm::test_helpers::sample_program();
-        let deployment_transaction = Transaction::deploy(&vm, &caller_private_key, &program, fee, None, rng).unwrap();
+        let deployment_transaction = vm.deploy(&caller_private_key, &program, fee, None, rng).unwrap();
 
         // Construct the new block header.
         let transactions = vm.speculate([deployment_transaction].iter()).unwrap();

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -429,7 +429,7 @@ mod tests {
         let fee_in_microcredits = 10;
 
         // Execute the fee.
-        let fee = Transaction::execute_fee(&vm, &caller_private_key, credits, fee_in_microcredits, None, rng).unwrap();
+        let fee = vm.execute_fee_raw(&caller_private_key, credits, fee_in_microcredits, None, rng).unwrap().1;
 
         // Prepare the inputs.
         let inputs = [


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR builds upon #1544.

This PR moves the `Transaction` executors to `VM`, unifying their contexts and preparing the `block` folder for separation into a subcrate.

## Migration

The following is the change to syntax for construction a `Transaction`.
```rs
Before: Transaction::deploy(vm, ...)
After: vm.deploy(...)
```
```rs
Before: Transaction::execute(vm, ...)
After: vm.execute(...)
```
```rs
Before: Transaction::execute_fee(vm, ...)
After: vm.execute_fee(...)
```

