### PR TITLE
Introduce complete abstractions for `Stack` and `Registers`

### DIFF
--- a/synthesizer/src/process/stack/evaluate.rs
+++ b/synthesizer/src/process/stack/evaluate.rs
@@ -16,13 +16,13 @@
 
 use super::*;
 
-impl<N: Network> Stack<N> {
+impl<N: Network> StackEvaluate<N> for Stack<N> {
     /// Evaluates a program closure on the given inputs.
     ///
     /// # Errors
     /// This method will halt if the given inputs are not the same length as the input statements.
     #[inline]
-    pub fn evaluate_closure<A: circuit::Aleo<Network = N>>(
+    fn evaluate_closure<A: circuit::Aleo<Network = N>>(
         &self,
         closure: &Closure<N>,
         inputs: &[Value<N>],
@@ -91,7 +91,7 @@ impl<N: Network> Stack<N> {
     /// # Errors
     /// This method will halt if the given inputs are not the same length as the input statements.
     #[inline]
-    pub fn evaluate_function<A: circuit::Aleo<Network = N>>(&self, call_stack: CallStack<N>) -> Result<Response<N>> {
+    fn evaluate_function<A: circuit::Aleo<Network = N>>(&self, call_stack: CallStack<N>) -> Result<Response<N>> {
         let timer = timer!("Stack::evaluate_function");
 
         // Retrieve the next request, based on the call stack mode.

--- a/synthesizer/src/process/stack/execute.rs
+++ b/synthesizer/src/process/stack/execute.rs
@@ -16,13 +16,13 @@
 
 use super::*;
 
-impl<N: Network> Stack<N> {
+impl<N: Network> StackExecute<N> for Stack<N> {
     /// Executes a program closure on the given inputs.
     ///
     /// # Errors
     /// This method will halt if the given inputs are not the same length as the input statements.
     #[inline]
-    pub fn execute_closure<A: circuit::Aleo<Network = N>>(
+    fn execute_closure<A: circuit::Aleo<Network = N>>(
         &self,
         closure: &Closure<N>,
         inputs: &[circuit::Value<A>],
@@ -122,7 +122,7 @@ impl<N: Network> Stack<N> {
     /// # Errors
     /// This method will halt if the given inputs are not the same length as the input statements.
     #[inline]
-    pub fn execute_function<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
+    fn execute_function<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
         &self,
         mut call_stack: CallStack<N>,
         rng: &mut R,
@@ -460,7 +460,9 @@ impl<N: Network> Stack<N> {
         // Return the response.
         Ok(response)
     }
+}
 
+impl<N: Network> Stack<N> {
     /// Prints the current state of the circuit.
     #[cfg(debug_assertions)]
     pub(crate) fn log_circuit<A: circuit::Aleo<Network = N>, S: Into<String>>(scope: S) {

--- a/synthesizer/src/process/stack/finalize_registers/load.rs
+++ b/synthesizer/src/process/stack/finalize_registers/load.rs
@@ -23,7 +23,7 @@ impl<N: Network> RegistersLoad<N> for FinalizeRegisters<N> {
     /// This method will halt if the register locator is not found.
     /// In the case of register members, this method will halt if the member is not found.
     #[inline]
-    fn load(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<Value<N>> {
+    fn load(&self, stack: &(impl StackMatches<N> + StackProgram<N>), operand: &Operand<N>) -> Result<Value<N>> {
         // Retrieve the register.
         let register = match operand {
             // If the operand is a literal, return the literal.

--- a/synthesizer/src/process/stack/finalize_registers/load.rs
+++ b/synthesizer/src/process/stack/finalize_registers/load.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<N: Network> Load<N> for FinalizeRegisters<N> {
+impl<N: Network> RegistersLoad<N> for FinalizeRegisters<N> {
     /// Loads the value of a given operand from the registers.
     ///
     /// # Errors

--- a/synthesizer/src/process/stack/finalize_registers/mod.rs
+++ b/synthesizer/src/process/stack/finalize_registers/mod.rs
@@ -18,7 +18,7 @@ mod load;
 mod store;
 
 use crate::{
-    process::{FinalizeTypes, RegistersLoad, RegistersStore, Stack},
+    process::{FinalizeTypes, RegistersLoad, RegistersStore, Stack, StackMatches, StackProgram},
     program::Operand,
 };
 use console::{

--- a/synthesizer/src/process/stack/finalize_registers/mod.rs
+++ b/synthesizer/src/process/stack/finalize_registers/mod.rs
@@ -18,7 +18,7 @@ mod load;
 mod store;
 
 use crate::{
-    process::{FinalizeTypes, RegistersLoad, RegistersStore, Stack, StackMatches, StackProgram},
+    process::{FinalizeTypes, RegistersLoad, RegistersStore, StackMatches, StackProgram},
     program::Operand,
 };
 use console::{

--- a/synthesizer/src/process/stack/finalize_registers/store.rs
+++ b/synthesizer/src/process/stack/finalize_registers/store.rs
@@ -24,7 +24,12 @@ impl<N: Network> RegistersStore<N> for FinalizeRegisters<N> {
     /// This method will halt if the given register is an input register.
     /// This method will halt if the register is already used.
     #[inline]
-    fn store(&mut self, stack: &Stack<N>, register: &Register<N>, stack_value: Value<N>) -> Result<()> {
+    fn store(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+        stack_value: Value<N>,
+    ) -> Result<()> {
         // Ensure that the stack value is a plaintext value.
         let plaintext_value = match stack_value {
             Value::Plaintext(plaintext) => plaintext,

--- a/synthesizer/src/process/stack/finalize_registers/store.rs
+++ b/synthesizer/src/process/stack/finalize_registers/store.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<N: Network> Store<N> for FinalizeRegisters<N> {
+impl<N: Network> RegistersStore<N> for FinalizeRegisters<N> {
     /// Assigns the given value to the given register, assuming the register is not already assigned.
     ///
     /// # Errors

--- a/synthesizer/src/process/stack/finalize_types/initialize.rs
+++ b/synthesizer/src/process/stack/finalize_types/initialize.rs
@@ -21,7 +21,10 @@ impl<N: Network> FinalizeTypes<N> {
     /// Initializes a new instance of `FinalizeTypes` for the given finalize.
     /// Checks that the given finalize is well-formed for the given stack.
     #[inline]
-    pub(super) fn initialize_finalize_types(stack: &Stack<N>, finalize: &Finalize<N>) -> Result<Self> {
+    pub(super) fn initialize_finalize_types(
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        finalize: &Finalize<N>,
+    ) -> Result<Self> {
         // Initialize a map of registers to their types.
         let mut finalize_types = Self { inputs: IndexMap::new(), destinations: IndexMap::new() };
 
@@ -96,7 +99,7 @@ impl<N: Network> FinalizeTypes<N> {
     #[inline]
     fn check_input(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         register: &Register<N>,
         plaintext_type: &PlaintextType<N>,
     ) -> Result<()> {
@@ -123,7 +126,12 @@ impl<N: Network> FinalizeTypes<N> {
 
     /// Ensures the given command is well-formed.
     #[inline]
-    fn check_command(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, command: &Command<N>) -> Result<()> {
+    fn check_command(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        finalize_name: &Identifier<N>,
+        command: &Command<N>,
+    ) -> Result<()> {
         match command {
             Command::Instruction(instruction) => self.check_instruction(stack, finalize_name, instruction)?,
             Command::Get(get) => self.check_get(stack, finalize_name, get)?,
@@ -135,7 +143,12 @@ impl<N: Network> FinalizeTypes<N> {
 
     /// Ensures the given `get` command is well-formed.
     #[inline]
-    fn check_get(&mut self, stack: &Stack<N>, finalize_name: &Identifier<N>, get: &Get<N>) -> Result<()> {
+    fn check_get(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        finalize_name: &Identifier<N>,
+        get: &Get<N>,
+    ) -> Result<()> {
         // Ensure the declared mapping in `get` is defined in the program.
         if !stack.program().contains_mapping(get.mapping_name()) {
             bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", get.mapping_name(), stack.program_id())
@@ -166,7 +179,7 @@ impl<N: Network> FinalizeTypes<N> {
     #[inline]
     fn check_get_or_init(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         finalize_name: &Identifier<N>,
         get_or_init: &GetOrInit<N>,
     ) -> Result<()> {
@@ -212,7 +225,12 @@ impl<N: Network> FinalizeTypes<N> {
 
     /// Ensures the given `set` command is well-formed.
     #[inline]
-    fn check_set(&self, stack: &Stack<N>, finalize_name: &Identifier<N>, set: &Set<N>) -> Result<()> {
+    fn check_set(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        finalize_name: &Identifier<N>,
+        set: &Set<N>,
+    ) -> Result<()> {
         // Ensure the declared mapping in `set` is defined in the program.
         if !stack.program().contains_mapping(set.mapping_name()) {
             bail!("Mapping '{}' in '{}/{finalize_name}' is not defined.", set.mapping_name(), stack.program_id())
@@ -245,7 +263,7 @@ impl<N: Network> FinalizeTypes<N> {
     #[inline]
     fn check_instruction(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         finalize_name: &Identifier<N>,
         instruction: &Instruction<N>,
     ) -> Result<()> {
@@ -285,7 +303,7 @@ impl<N: Network> FinalizeTypes<N> {
     #[inline]
     fn check_instruction_opcode(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         finalize_name: &Identifier<N>,
         instruction: &Instruction<N>,
     ) -> Result<()> {

--- a/synthesizer/src/process/stack/finalize_types/matches.rs
+++ b/synthesizer/src/process/stack/finalize_types/matches.rs
@@ -18,7 +18,12 @@ use super::*;
 
 impl<N: Network> FinalizeTypes<N> {
     /// Checks that the given operands matches the layout of the struct. The ordering of the operands matters.
-    pub fn matches_struct(&self, stack: &Stack<N>, operands: &[Operand<N>], struct_: &Struct<N>) -> Result<()> {
+    pub fn matches_struct(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operands: &[Operand<N>],
+        struct_: &Struct<N>,
+    ) -> Result<()> {
         // Retrieve the struct name.
         let struct_name = struct_.name();
         // Ensure the struct name is valid.

--- a/synthesizer/src/process/stack/finalize_types/mod.rs
+++ b/synthesizer/src/process/stack/finalize_types/mod.rs
@@ -18,7 +18,7 @@ mod initialize;
 mod matches;
 
 use crate::{
-    process::{Stack, StackMatches, StackProgram},
+    process::{StackMatches, StackProgram},
     program::{
         finalize::{Command, Finalize},
         Instruction,
@@ -48,7 +48,7 @@ impl<N: Network> FinalizeTypes<N> {
     /// Initializes a new instance of `FinalizeTypes` for the given finalize.
     /// Checks that the given finalize is well-formed for the given stack.
     #[inline]
-    pub fn from_finalize(stack: &Stack<N>, finalize: &Finalize<N>) -> Result<Self> {
+    pub fn from_finalize(stack: &(impl StackMatches<N> + StackProgram<N>), finalize: &Finalize<N>) -> Result<Self> {
         Self::initialize_finalize_types(stack, finalize)
     }
 
@@ -67,7 +67,11 @@ impl<N: Network> FinalizeTypes<N> {
     }
 
     /// Returns the type of the given operand.
-    pub fn get_type_from_operand(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<PlaintextType<N>> {
+    pub fn get_type_from_operand(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<PlaintextType<N>> {
         Ok(match operand {
             Operand::Literal(literal) => PlaintextType::from(literal.to_type()),
             Operand::Register(register) => self.get_type(stack, register)?,

--- a/synthesizer/src/process/stack/finalize_types/mod.rs
+++ b/synthesizer/src/process/stack/finalize_types/mod.rs
@@ -18,7 +18,7 @@ mod initialize;
 mod matches;
 
 use crate::{
-    process::Stack,
+    process::{Stack, StackMatches, StackProgram},
     program::{
         finalize::{Command, Finalize},
         Instruction,
@@ -77,7 +77,11 @@ impl<N: Network> FinalizeTypes<N> {
     }
 
     /// Returns the type of the given register.
-    pub fn get_type(&self, stack: &Stack<N>, register: &Register<N>) -> Result<PlaintextType<N>> {
+    pub fn get_type(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+    ) -> Result<PlaintextType<N>> {
         // Initialize a tracker for the type of the register.
         let mut plaintext_type = if self.is_input(register) {
             // Retrieve the input value type as a register type.

--- a/synthesizer/src/process/stack/helpers/matches.rs
+++ b/synthesizer/src/process/stack/helpers/matches.rs
@@ -16,9 +16,9 @@
 
 use super::*;
 
-impl<N: Network> Stack<N> {
+impl<N: Network> StackMatches<N> for Stack<N> {
     /// Checks that the given value matches the layout of the value type.
-    pub fn matches_value_type(&self, value: &Value<N>, value_type: &ValueType<N>) -> Result<()> {
+    fn matches_value_type(&self, value: &Value<N>, value_type: &ValueType<N>) -> Result<()> {
         // Ensure the value matches the declared value type in the register.
         match (value, value_type) {
             (Value::Plaintext(plaintext), ValueType::Constant(plaintext_type))
@@ -35,7 +35,7 @@ impl<N: Network> Stack<N> {
     }
 
     /// Checks that the given stack value matches the layout of the register type.
-    pub fn matches_register_type(&self, stack_value: &Value<N>, register_type: &RegisterType<N>) -> Result<()> {
+    fn matches_register_type(&self, stack_value: &Value<N>, register_type: &RegisterType<N>) -> Result<()> {
         match (stack_value, register_type) {
             (Value::Plaintext(plaintext), RegisterType::Plaintext(plaintext_type)) => {
                 self.matches_plaintext(plaintext, plaintext_type)
@@ -49,7 +49,7 @@ impl<N: Network> Stack<N> {
     }
 
     /// Checks that the given record matches the layout of the external record type.
-    pub fn matches_external_record(&self, record: &Record<N, Plaintext<N>>, locator: &Locator<N>) -> Result<()> {
+    fn matches_external_record(&self, record: &Record<N, Plaintext<N>>, locator: &Locator<N>) -> Result<()> {
         // Retrieve the record name.
         let record_name = locator.resource();
 
@@ -71,7 +71,7 @@ impl<N: Network> Stack<N> {
     }
 
     /// Checks that the given record matches the layout of the record type.
-    pub fn matches_record(&self, record: &Record<N, Plaintext<N>>, record_name: &Identifier<N>) -> Result<()> {
+    fn matches_record(&self, record: &Record<N, Plaintext<N>>, record_name: &Identifier<N>) -> Result<()> {
         // Ensure the record name is valid.
         ensure!(!Program::is_reserved_keyword(record_name), "Record name '{record_name}' is reserved");
 
@@ -90,7 +90,7 @@ impl<N: Network> Stack<N> {
     }
 
     /// Checks that the given plaintext matches the layout of the plaintext type.
-    pub fn matches_plaintext(&self, plaintext: &Plaintext<N>, plaintext_type: &PlaintextType<N>) -> Result<()> {
+    fn matches_plaintext(&self, plaintext: &Plaintext<N>, plaintext_type: &PlaintextType<N>) -> Result<()> {
         self.matches_plaintext_internal(plaintext, plaintext_type, 0)
     }
 }

--- a/synthesizer/src/process/stack/mod.rs
+++ b/synthesizer/src/process/stack/mod.rs
@@ -231,22 +231,24 @@ impl<N: Network> Stack<N> {
         // Return the stack.
         Stack::initialize(process, program)
     }
+}
 
+impl<N: Network> StackProgram<N> for Stack<N> {
     /// Returns the program.
     #[inline]
-    pub const fn program(&self) -> &Program<N> {
+    fn program(&self) -> &Program<N> {
         &self.program
     }
 
     /// Returns the program ID.
     #[inline]
-    pub const fn program_id(&self) -> &ProgramID<N> {
+    fn program_id(&self) -> &ProgramID<N> {
         self.program.id()
     }
 
     /// Returns `true` if the stack contains the external record.
     #[inline]
-    pub fn contains_external_record(&self, locator: &Locator<N>) -> bool {
+    fn contains_external_record(&self, locator: &Locator<N>) -> bool {
         // Retrieve the external program.
         match self.get_external_program(locator.program_id()) {
             // Return `true` if the external record exists.
@@ -258,14 +260,14 @@ impl<N: Network> Stack<N> {
 
     /// Returns the external stack for the given program ID.
     #[inline]
-    pub fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Stack<N>> {
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Stack<N>> {
         // Retrieve the external stack.
         self.external_stacks.get(program_id).ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
     }
 
     /// Returns the external program for the given program ID.
     #[inline]
-    pub fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>> {
+    fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>> {
         match self.program.id() == program_id {
             true => bail!("Attempted to get the main program '{}' as an external program", self.program.id()),
             // Retrieve the external stack, and return the external program.
@@ -275,7 +277,7 @@ impl<N: Network> Stack<N> {
 
     /// Returns `true` if the stack contains the external record.
     #[inline]
-    pub fn get_external_record(&self, locator: &Locator<N>) -> Result<RecordType<N>> {
+    fn get_external_record(&self, locator: &Locator<N>) -> Result<RecordType<N>> {
         // Retrieve the external program.
         let external_program = self.get_external_program(locator.program_id())?;
         // Return the external record, if it exists.
@@ -284,7 +286,7 @@ impl<N: Network> Stack<N> {
 
     /// Returns the function with the given function name.
     #[inline]
-    pub fn get_function(&self, function_name: &Identifier<N>) -> Result<Function<N>> {
+    fn get_function(&self, function_name: &Identifier<N>) -> Result<Function<N>> {
         // Ensure the function exists.
         match self.program.contains_function(function_name) {
             true => self.program.get_function(function_name),
@@ -294,7 +296,7 @@ impl<N: Network> Stack<N> {
 
     /// Returns the expected number of calls for the given function name.
     #[inline]
-    pub fn get_number_of_calls(&self, function_name: &Identifier<N>) -> Result<usize> {
+    fn get_number_of_calls(&self, function_name: &Identifier<N>) -> Result<usize> {
         // Determine the number of calls for this function (including the function itself).
         let mut num_calls = 1;
         for instruction in self.get_function(function_name)?.instructions() {
@@ -316,18 +318,20 @@ impl<N: Network> Stack<N> {
 
     /// Returns the register types for the given closure or function name.
     #[inline]
-    pub fn get_register_types(&self, name: &Identifier<N>) -> Result<&RegisterTypes<N>> {
+    fn get_register_types(&self, name: &Identifier<N>) -> Result<&RegisterTypes<N>> {
         // Retrieve the register types.
         self.register_types.get(name).ok_or_else(|| anyhow!("Register types for '{name}' do not exist"))
     }
 
     /// Returns the register types for the given finalize name.
     #[inline]
-    pub fn get_finalize_types(&self, name: &Identifier<N>) -> Result<&FinalizeTypes<N>> {
+    fn get_finalize_types(&self, name: &Identifier<N>) -> Result<&FinalizeTypes<N>> {
         // Retrieve the finalize types.
         self.finalize_types.get(name).ok_or_else(|| anyhow!("Finalize types for '{name}' do not exist"))
     }
+}
 
+impl<N: Network> Stack<N> {
     /// Returns `true` if the proving key for the given function name exists.
     #[inline]
     pub fn contains_proving_key(&self, function_name: &Identifier<N>) -> bool {

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -20,7 +20,10 @@ impl<N: Network> RegisterTypes<N> {
     /// Initializes a new instance of `RegisterTypes` for the given closure.
     /// Checks that the given closure is well-formed for the given stack.
     #[inline]
-    pub(super) fn initialize_closure_types(stack: &Stack<N>, closure: &Closure<N>) -> Result<Self> {
+    pub(super) fn initialize_closure_types(
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        closure: &Closure<N>,
+    ) -> Result<Self> {
         // Initialize a map of registers to their types.
         let mut register_types = Self { inputs: IndexMap::new(), destinations: IndexMap::new() };
 
@@ -56,7 +59,10 @@ impl<N: Network> RegisterTypes<N> {
     /// Initializes a new instance of `RegisterTypes` for the given function.
     /// Checks that the given function is well-formed for the given stack.
     #[inline]
-    pub(super) fn initialize_function_types(stack: &Stack<N>, function: &Function<N>) -> Result<Self> {
+    pub(super) fn initialize_function_types(
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        function: &Function<N>,
+    ) -> Result<Self> {
         // Initialize a map of registers to their types.
         let mut register_types = Self { inputs: IndexMap::new(), destinations: IndexMap::new() };
 
@@ -176,7 +182,12 @@ impl<N: Network> RegisterTypes<N> {
 impl<N: Network> RegisterTypes<N> {
     /// Ensure the given input register is well-formed.
     #[inline]
-    fn check_input(&mut self, stack: &Stack<N>, register: &Register<N>, register_type: &RegisterType<N>) -> Result<()> {
+    fn check_input(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+        register_type: &RegisterType<N>,
+    ) -> Result<()> {
         // Ensure the register type is defined in the program.
         match register_type {
             RegisterType::Plaintext(PlaintextType::Literal(..)) => (),
@@ -212,7 +223,12 @@ impl<N: Network> RegisterTypes<N> {
 
     /// Ensure the given output register is well-formed.
     #[inline]
-    fn check_output(&mut self, stack: &Stack<N>, operand: &Operand<N>, register_type: &RegisterType<N>) -> Result<()> {
+    fn check_output(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+        register_type: &RegisterType<N>,
+    ) -> Result<()> {
         match operand {
             // Inform the user the output operand is an input register, to ensure this is intended behavior.
             Operand::Register(register) if self.is_input(register) => {
@@ -264,7 +280,7 @@ impl<N: Network> RegisterTypes<N> {
     #[inline]
     fn check_instruction(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         closure_or_function_name: &Identifier<N>,
         instruction: &Instruction<N>,
     ) -> Result<()> {
@@ -299,7 +315,7 @@ impl<N: Network> RegisterTypes<N> {
     #[inline]
     fn check_instruction_opcode(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         closure_or_function_name: &Identifier<N>,
         instruction: &Instruction<N>,
     ) -> Result<()> {

--- a/synthesizer/src/process/stack/register_types/matches.rs
+++ b/synthesizer/src/process/stack/register_types/matches.rs
@@ -18,7 +18,12 @@ use super::*;
 
 impl<N: Network> RegisterTypes<N> {
     /// Checks that the given operands matches the layout of the struct. The ordering of the operands matters.
-    pub fn matches_struct(&self, stack: &Stack<N>, operands: &[Operand<N>], struct_: &Struct<N>) -> Result<()> {
+    pub fn matches_struct(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operands: &[Operand<N>],
+        struct_: &Struct<N>,
+    ) -> Result<()> {
         // Retrieve the struct name.
         let struct_name = struct_.name();
         // Ensure the struct name is valid.
@@ -93,7 +98,12 @@ impl<N: Network> RegisterTypes<N> {
     /// Checks that the given record matches the layout of the record type.
     /// Note: Ordering for `owner` **does** matter, however ordering
     /// for record data does **not** matter, as long as all defined members are present.
-    pub fn matches_record(&self, stack: &Stack<N>, operands: &[Operand<N>], record_type: &RecordType<N>) -> Result<()> {
+    pub fn matches_record(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operands: &[Operand<N>],
+        record_type: &RecordType<N>,
+    ) -> Result<()> {
         // Retrieve the record name.
         let record_name = record_type.name();
         // Ensure the record name is valid.

--- a/synthesizer/src/process/stack/register_types/mod.rs
+++ b/synthesizer/src/process/stack/register_types/mod.rs
@@ -17,7 +17,18 @@
 mod initialize;
 mod matches;
 
-use crate::{CallOperator, Closure, Function, Instruction, Opcode, Operand, Program, Stack};
+use crate::{
+    CallOperator,
+    Closure,
+    Function,
+    Instruction,
+    Opcode,
+    Operand,
+    Program,
+    Stack,
+    StackMatches,
+    StackProgram,
+};
 use console::{
     network::prelude::*,
     program::{
@@ -83,7 +94,11 @@ impl<N: Network> RegisterTypes<N> {
     }
 
     /// Returns the register type of the given register.
-    pub fn get_type(&self, stack: &Stack<N>, register: &Register<N>) -> Result<RegisterType<N>> {
+    pub fn get_type(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+    ) -> Result<RegisterType<N>> {
         // Initialize a tracker for the register type.
         let mut register_type = if self.is_input(register) {
             // Retrieve the input value type as a register type.

--- a/synthesizer/src/process/stack/register_types/mod.rs
+++ b/synthesizer/src/process/stack/register_types/mod.rs
@@ -17,18 +17,7 @@
 mod initialize;
 mod matches;
 
-use crate::{
-    CallOperator,
-    Closure,
-    Function,
-    Instruction,
-    Opcode,
-    Operand,
-    Program,
-    Stack,
-    StackMatches,
-    StackProgram,
-};
+use crate::{CallOperator, Closure, Function, Instruction, Opcode, Operand, Program, StackMatches, StackProgram};
 use console::{
     network::prelude::*,
     program::{
@@ -58,14 +47,14 @@ impl<N: Network> RegisterTypes<N> {
     /// Initializes a new instance of `RegisterTypes` for the given closure.
     /// Checks that the given closure is well-formed for the given stack.
     #[inline]
-    pub fn from_closure(stack: &Stack<N>, closure: &Closure<N>) -> Result<Self> {
+    pub fn from_closure(stack: &(impl StackMatches<N> + StackProgram<N>), closure: &Closure<N>) -> Result<Self> {
         Self::initialize_closure_types(stack, closure)
     }
 
     /// Initializes a new instance of `RegisterTypes` for the given function.
     /// Checks that the given function is well-formed for the given stack.
     #[inline]
-    pub fn from_function(stack: &Stack<N>, function: &Function<N>) -> Result<Self> {
+    pub fn from_function(stack: &(impl StackMatches<N> + StackProgram<N>), function: &Function<N>) -> Result<Self> {
         Self::initialize_function_types(stack, function)
     }
 
@@ -84,7 +73,11 @@ impl<N: Network> RegisterTypes<N> {
     }
 
     /// Returns the register type of the given operand.
-    pub fn get_type_from_operand(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<RegisterType<N>> {
+    pub fn get_type_from_operand(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<RegisterType<N>> {
         Ok(match operand {
             Operand::Literal(literal) => RegisterType::Plaintext(PlaintextType::from(literal.to_type())),
             Operand::Register(register) => self.get_type(stack, register)?,

--- a/synthesizer/src/process/stack/registers/call.rs
+++ b/synthesizer/src/process/stack/registers/call.rs
@@ -14,32 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-mod load;
-mod store;
+use super::*;
 
-use crate::{
-    process::{FinalizeTypes, RegistersLoad, RegistersStore, Stack},
-    program::Operand,
-};
-use console::{
-    network::prelude::*,
-    program::{Literal, Plaintext, Register, Value},
-};
-
-use indexmap::IndexMap;
-
-#[derive(Clone)]
-pub struct FinalizeRegisters<N: Network> {
-    /// The mapping of all registers to their defined types.
-    finalize_types: FinalizeTypes<N>,
-    /// The mapping of assigned registers to their values.
-    registers: IndexMap<u64, Plaintext<N>>,
-}
-
-impl<N: Network> FinalizeRegisters<N> {
-    /// Initializes a new set of registers, given the finalize types.
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCall<N> for Registers<N, A> {
+    /// Returns the current call stack.
     #[inline]
-    pub fn new(finalize_types: FinalizeTypes<N>) -> Self {
-        Self { finalize_types, registers: IndexMap::new() }
+    fn call_stack(&self) -> CallStack<N> {
+        self.call_stack.clone()
     }
 }

--- a/synthesizer/src/process/stack/registers/caller.rs
+++ b/synthesizer/src/process/stack/registers/caller.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCaller<N> for Registers<N, A> {
+    /// Returns the transition caller.
+    #[inline]
+    fn caller(&self) -> Result<Address<N>> {
+        self.caller.ok_or_else(|| anyhow!("Caller address (console) is not set in the registers."))
+    }
+
+    /// Sets the transition caller.
+    #[inline]
+    fn set_caller(&mut self, caller: Address<N>) {
+        self.caller = Some(caller);
+    }
+
+    /// Returns the transition view key.
+    #[inline]
+    fn tvk(&self) -> Result<Field<N>> {
+        self.tvk.ok_or_else(|| anyhow!("Transition view key (console) is not set in the registers."))
+    }
+
+    /// Sets the transition view key.
+    #[inline]
+    fn set_tvk(&mut self, tvk: Field<N>) {
+        self.tvk = Some(tvk);
+    }
+}
+
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCallerCircuit<N, A> for Registers<N, A> {
+    /// Returns the transition caller, as a circuit.
+    #[inline]
+    fn caller_circuit(&self) -> Result<circuit::Address<A>> {
+        self.caller_circuit.clone().ok_or_else(|| anyhow!("Caller address (circuit) is not set in the registers."))
+    }
+
+    /// Sets the transition caller, as a circuit.
+    #[inline]
+    fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>) {
+        self.caller_circuit = Some(caller_circuit);
+    }
+
+    /// Returns the transition view key, as a circuit.
+    #[inline]
+    fn tvk_circuit(&self) -> Result<circuit::Field<A>> {
+        self.tvk_circuit.clone().ok_or_else(|| anyhow!("Transition view key (circuit) is not set in the registers."))
+    }
+
+    /// Sets the transition view key, as a circuit.
+    #[inline]
+    fn set_tvk_circuit(&mut self, tvk_circuit: circuit::Field<A>) {
+        self.tvk_circuit = Some(tvk_circuit);
+    }
+}

--- a/synthesizer/src/process/stack/registers/load.rs
+++ b/synthesizer/src/process/stack/registers/load.rs
@@ -23,7 +23,7 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoad<N> for Registers<N
     /// This method will halt if the register locator is not found.
     /// In the case of register members, this method will halt if the member is not found.
     #[inline]
-    fn load(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<Value<N>> {
+    fn load(&self, stack: &(impl StackMatches<N> + StackProgram<N>), operand: &Operand<N>) -> Result<Value<N>> {
         // Retrieve the register.
         let register = match operand {
             // If the operand is a literal, return the literal.

--- a/synthesizer/src/process/stack/registers/load.rs
+++ b/synthesizer/src/process/stack/registers/load.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<N: Network, A: circuit::Aleo<Network = N>> Load<N> for Registers<N, A> {
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoad<N> for Registers<N, A> {
     /// Loads the value of a given operand from the registers.
     ///
     /// # Errors
@@ -73,7 +73,7 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Load<N> for Registers<N, A> {
     }
 }
 
-impl<N: Network, A: circuit::Aleo<Network = N>> LoadCircuit<N, A> for Registers<N, A> {
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoadCircuit<N, A> for Registers<N, A> {
     /// Loads the value of a given operand from the registers.
     ///
     /// # Errors

--- a/synthesizer/src/process/stack/registers/load.rs
+++ b/synthesizer/src/process/stack/registers/load.rs
@@ -80,7 +80,11 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoadCircuit<N, A> for R
     /// This method will halt if the register locator is not found.
     /// In the case of register members, this method will halt if the member is not found.
     #[inline]
-    fn load_circuit(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<circuit::Value<A>> {
+    fn load_circuit(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<circuit::Value<A>> {
         use circuit::Inject;
 
         // Retrieve the register.

--- a/synthesizer/src/process/stack/registers/mod.rs
+++ b/synthesizer/src/process/stack/registers/mod.rs
@@ -14,10 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
+mod call;
+mod caller;
 mod load;
 mod store;
 
-use crate::{CallStack, Load, LoadCircuit, Operand, RegisterTypes, Stack, Store, StoreCircuit};
+use crate::{
+    CallStack,
+    Operand,
+    RegisterTypes,
+    RegistersCall,
+    RegistersCaller,
+    RegistersCallerCircuit,
+    RegistersLoad,
+    RegistersLoadCircuit,
+    RegistersStore,
+    RegistersStoreCircuit,
+    Stack,
+};
 use console::{
     network::prelude::*,
     program::{Entry, Literal, Plaintext, Register, Value},
@@ -60,60 +74,6 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
             tvk: None,
             tvk_circuit: None,
         }
-    }
-
-    /// Returns the current call stack.
-    #[inline]
-    pub fn call_stack(&self) -> CallStack<N> {
-        self.call_stack.clone()
-    }
-
-    /// Returns the transition caller.
-    #[inline]
-    pub fn caller(&self) -> Result<Address<N>> {
-        self.caller.ok_or_else(|| anyhow!("Caller address (console) is not set in the registers."))
-    }
-
-    /// Returns the transition caller, as a circuit.
-    #[inline]
-    pub fn caller_circuit(&self) -> Result<circuit::Address<A>> {
-        self.caller_circuit.clone().ok_or_else(|| anyhow!("Caller address (circuit) is not set in the registers."))
-    }
-
-    /// Sets the transition caller.
-    #[inline]
-    pub fn set_caller(&mut self, caller: Address<N>) {
-        self.caller = Some(caller);
-    }
-
-    /// Sets the transition caller, as a circuit.
-    #[inline]
-    pub fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>) {
-        self.caller_circuit = Some(caller_circuit);
-    }
-
-    /// Returns the transition view key.
-    #[inline]
-    pub fn tvk(&self) -> Result<Field<N>> {
-        self.tvk.ok_or_else(|| anyhow!("Transition view key (console) is not set in the registers."))
-    }
-
-    /// Returns the transition view key, as a circuit.
-    #[inline]
-    pub fn tvk_circuit(&self) -> Result<circuit::Field<A>> {
-        self.tvk_circuit.clone().ok_or_else(|| anyhow!("Transition view key (circuit) is not set in the registers."))
-    }
-
-    /// Sets the transition view key.
-    #[inline]
-    pub fn set_tvk(&mut self, tvk: Field<N>) {
-        self.tvk = Some(tvk);
-    }
-
-    /// Sets the transition view key, as a circuit.
-    #[inline]
-    pub fn set_tvk_circuit(&mut self, tvk_circuit: circuit::Field<A>) {
-        self.tvk_circuit = Some(tvk_circuit);
     }
 
     /// Ensure the console and circuit registers match.

--- a/synthesizer/src/process/stack/registers/mod.rs
+++ b/synthesizer/src/process/stack/registers/mod.rs
@@ -30,7 +30,6 @@ use crate::{
     RegistersLoadCircuit,
     RegistersStore,
     RegistersStoreCircuit,
-    Stack,
     StackMatches,
     StackProgram,
 };

--- a/synthesizer/src/process/stack/registers/mod.rs
+++ b/synthesizer/src/process/stack/registers/mod.rs
@@ -31,6 +31,8 @@ use crate::{
     RegistersStore,
     RegistersStoreCircuit,
     Stack,
+    StackMatches,
+    StackProgram,
 };
 use console::{
     network::prelude::*,

--- a/synthesizer/src/process/stack/registers/store.rs
+++ b/synthesizer/src/process/stack/registers/store.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<N: Network, A: circuit::Aleo<Network = N>> Store<N> for Registers<N, A> {
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersStore<N> for Registers<N, A> {
     /// Assigns the given value to the given register, assuming the register is not already assigned.
     ///
     /// # Errors
@@ -58,7 +58,7 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Store<N> for Registers<N, A> {
     }
 }
 
-impl<N: Network, A: circuit::Aleo<Network = N>> StoreCircuit<N, A> for Registers<N, A> {
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersStoreCircuit<N, A> for Registers<N, A> {
     /// Assigns the given value to the given register, assuming the register is not already assigned.
     ///
     /// # Errors

--- a/synthesizer/src/process/stack/registers/store.rs
+++ b/synthesizer/src/process/stack/registers/store.rs
@@ -24,7 +24,12 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersStore<N> for Registers<
     /// This method will halt if the given register is an input register.
     /// This method will halt if the register is already used.
     #[inline]
-    fn store(&mut self, stack: &Stack<N>, register: &Register<N>, stack_value: Value<N>) -> Result<()> {
+    fn store(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+        stack_value: Value<N>,
+    ) -> Result<()> {
         match register {
             Register::Locator(locator) => {
                 // Ensure the register assignments are monotonically increasing.
@@ -68,7 +73,7 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersStoreCircuit<N, A> for 
     #[inline]
     fn store_circuit(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         register: &Register<N>,
         circuit_value: circuit::Value<A>,
     ) -> Result<()> {

--- a/synthesizer/src/process/stack/traits.rs
+++ b/synthesizer/src/process/stack/traits.rs
@@ -16,7 +16,40 @@
 
 use super::*;
 
-pub trait Load<N: Network> {
+pub trait RegistersCall<N: Network> {
+    /// Returns the current call stack.
+    fn call_stack(&self) -> CallStack<N>;
+}
+
+pub trait RegistersCaller<N: Network> {
+    /// Returns the transition caller.
+    fn caller(&self) -> Result<Address<N>>;
+
+    /// Sets the transition caller.
+    fn set_caller(&mut self, caller: Address<N>);
+
+    /// Returns the transition view key.
+    fn tvk(&self) -> Result<Field<N>>;
+
+    /// Sets the transition view key.
+    fn set_tvk(&mut self, tvk: Field<N>);
+}
+
+pub trait RegistersCallerCircuit<N: Network, A: circuit::Aleo<Network = N>> {
+    /// Returns the transition caller, as a circuit.
+    fn caller_circuit(&self) -> Result<circuit::Address<A>>;
+
+    /// Sets the transition caller, as a circuit.
+    fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>);
+
+    /// Returns the transition view key, as a circuit.
+    fn tvk_circuit(&self) -> Result<circuit::Field<A>>;
+
+    /// Sets the transition view key, as a circuit.
+    fn set_tvk_circuit(&mut self, tvk_circuit: circuit::Field<A>);
+}
+
+pub trait RegistersLoad<N: Network> {
     /// Loads the value of a given operand.
     ///
     /// # Errors
@@ -54,7 +87,7 @@ pub trait Load<N: Network> {
     }
 }
 
-pub trait LoadCircuit<N: Network, A: circuit::Aleo<Network = N>> {
+pub trait RegistersLoadCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     /// Loads the value of a given operand.
     ///
     /// # Errors
@@ -92,7 +125,7 @@ pub trait LoadCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     }
 }
 
-pub trait Store<N: Network> {
+pub trait RegistersStore<N: Network> {
     /// Assigns the given value to the given register, assuming the register is not already assigned.
     ///
     /// # Errors
@@ -113,7 +146,7 @@ pub trait Store<N: Network> {
     }
 }
 
-pub trait StoreCircuit<N: Network, A: circuit::Aleo<Network = N>> {
+pub trait RegistersStoreCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     /// Assigns the given value to the given register, assuming the register is not already assigned.
     ///
     /// # Errors

--- a/synthesizer/src/process/stack/traits.rs
+++ b/synthesizer/src/process/stack/traits.rs
@@ -113,7 +113,11 @@ pub trait RegistersLoad<N: Network> {
     /// This method should halt if the register locator is not found.
     /// In the case of register members, this method should halt if the member is not found.
     #[inline]
-    fn load_literal(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<Literal<N>> {
+    fn load_literal(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<Literal<N>> {
         match self.load(stack, operand)? {
             Value::Plaintext(Plaintext::Literal(literal, ..)) => Ok(literal),
             Value::Plaintext(Plaintext::Struct(..)) => bail!("Operand must be a literal"),
@@ -128,7 +132,11 @@ pub trait RegistersLoad<N: Network> {
     /// This method should halt if the register locator is not found.
     /// In the case of register members, this method should halt if the member is not found.
     #[inline]
-    fn load_plaintext(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<Plaintext<N>> {
+    fn load_plaintext(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<Plaintext<N>> {
         match self.load(stack, operand)? {
             Value::Plaintext(plaintext) => Ok(plaintext),
             Value::Record(..) => bail!("Operand must be a plaintext"),
@@ -142,7 +150,11 @@ pub trait RegistersLoadCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     /// # Errors
     /// This method should halt if the register locator is not found.
     /// In the case of register members, this method should halt if the member is not found.
-    fn load_circuit(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<circuit::Value<A>>;
+    fn load_circuit(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<circuit::Value<A>>;
 
     /// Loads the literal of a given operand.
     ///
@@ -151,7 +163,11 @@ pub trait RegistersLoadCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     /// This method should halt if the register locator is not found.
     /// In the case of register members, this method should halt if the member is not found.
     #[inline]
-    fn load_literal_circuit(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<circuit::Literal<A>> {
+    fn load_literal_circuit(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<circuit::Literal<A>> {
         match self.load_circuit(stack, operand)? {
             circuit::Value::Plaintext(circuit::Plaintext::Literal(literal, ..)) => Ok(literal),
             circuit::Value::Plaintext(circuit::Plaintext::Struct(..)) => bail!("Operand must be a literal"),
@@ -166,7 +182,11 @@ pub trait RegistersLoadCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     /// This method should halt if the register locator is not found.
     /// In the case of register members, this method should halt if the member is not found.
     #[inline]
-    fn load_plaintext_circuit(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<circuit::Plaintext<A>> {
+    fn load_plaintext_circuit(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        operand: &Operand<N>,
+    ) -> Result<circuit::Plaintext<A>> {
         match self.load_circuit(stack, operand)? {
             circuit::Value::Plaintext(plaintext) => Ok(plaintext),
             circuit::Value::Record(..) => bail!("Operand must be a plaintext"),

--- a/synthesizer/src/process/stack/traits.rs
+++ b/synthesizer/src/process/stack/traits.rs
@@ -16,6 +16,27 @@
 
 use super::*;
 
+pub trait StackEvaluate<N: Network>: Clone {
+    /// Evaluates a program closure on the given inputs.
+    ///
+    /// # Errors
+    /// This method will halt if the given inputs are not the same length as the input statements.
+    fn evaluate_closure<A: circuit::Aleo<Network = N>>(
+        &self,
+        closure: &Closure<N>,
+        inputs: &[Value<N>],
+        call_stack: CallStack<N>,
+        caller: Address<N>,
+        tvk: Field<N>,
+    ) -> Result<Vec<Value<N>>>;
+
+    /// Evaluates a program function on the given inputs.
+    ///
+    /// # Errors
+    /// This method will halt if the given inputs are not the same length as the input statements.
+    fn evaluate_function<A: circuit::Aleo<Network = N>>(&self, call_stack: CallStack<N>) -> Result<Response<N>>;
+}
+
 pub trait StackMatches<N: Network> {
     /// Checks that the given value matches the layout of the value type.
     fn matches_value_type(&self, value: &Value<N>, value_type: &ValueType<N>) -> Result<()>;

--- a/synthesizer/src/process/stack/traits.rs
+++ b/synthesizer/src/process/stack/traits.rs
@@ -37,6 +37,33 @@ pub trait StackEvaluate<N: Network>: Clone {
     fn evaluate_function<A: circuit::Aleo<Network = N>>(&self, call_stack: CallStack<N>) -> Result<Response<N>>;
 }
 
+pub trait StackExecute<N: Network> {
+    /// Executes a program closure on the given inputs.
+    ///
+    /// # Errors
+    /// This method will halt if the given inputs are not the same length as the input statements.
+    fn execute_closure<A: circuit::Aleo<Network = N>>(
+        &self,
+        closure: &Closure<N>,
+        inputs: &[circuit::Value<A>],
+        call_stack: CallStack<N>,
+        caller: circuit::Address<A>,
+        tvk: circuit::Field<A>,
+    ) -> Result<Vec<circuit::Value<A>>>;
+
+    /// Executes a program function on the given inputs.
+    ///
+    /// Note: To execute a transition, do **not** call this method. Instead, call `Process::execute`.
+    ///
+    /// # Errors
+    /// This method will halt if the given inputs are not the same length as the input statements.
+    fn execute_function<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
+        &self,
+        call_stack: CallStack<N>,
+        rng: &mut R,
+    ) -> Result<Response<N>>;
+}
+
 pub trait StackMatches<N: Network> {
     /// Checks that the given value matches the layout of the value type.
     fn matches_value_type(&self, value: &Value<N>, value_type: &ValueType<N>) -> Result<()>;

--- a/synthesizer/src/process/stack/traits.rs
+++ b/synthesizer/src/process/stack/traits.rs
@@ -181,7 +181,12 @@ pub trait RegistersStore<N: Network> {
     /// This method should halt if the given register is a register member.
     /// This method should halt if the given register is an input register.
     /// This method should halt if the register is already used.
-    fn store(&mut self, stack: &Stack<N>, register: &Register<N>, stack_value: Value<N>) -> Result<()>;
+    fn store(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+        stack_value: Value<N>,
+    ) -> Result<()>;
 
     /// Assigns the given literal to the given register, assuming the register is not already assigned.
     ///
@@ -190,7 +195,12 @@ pub trait RegistersStore<N: Network> {
     /// This method should halt if the given register is an input register.
     /// This method should halt if the register is already used.
     #[inline]
-    fn store_literal(&mut self, stack: &Stack<N>, register: &Register<N>, literal: Literal<N>) -> Result<()> {
+    fn store_literal(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+        literal: Literal<N>,
+    ) -> Result<()> {
         self.store(stack, register, Value::Plaintext(Plaintext::from(literal)))
     }
 }
@@ -202,8 +212,12 @@ pub trait RegistersStoreCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     /// This method should halt if the given register is a register member.
     /// This method should halt if the given register is an input register.
     /// This method should halt if the register is already used.
-    fn store_circuit(&mut self, stack: &Stack<N>, register: &Register<N>, stack_value: circuit::Value<A>)
-    -> Result<()>;
+    fn store_circuit(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        register: &Register<N>,
+        stack_value: circuit::Value<A>,
+    ) -> Result<()>;
 
     /// Assigns the given literal to the given register, assuming the register is not already assigned.
     ///
@@ -214,7 +228,7 @@ pub trait RegistersStoreCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     #[inline]
     fn store_literal_circuit(
         &mut self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         register: &Register<N>,
         literal: circuit::Literal<A>,
     ) -> Result<()> {

--- a/synthesizer/src/process/stack/traits.rs
+++ b/synthesizer/src/process/stack/traits.rs
@@ -16,6 +16,55 @@
 
 use super::*;
 
+pub trait StackMatches<N: Network> {
+    /// Checks that the given value matches the layout of the value type.
+    fn matches_value_type(&self, value: &Value<N>, value_type: &ValueType<N>) -> Result<()>;
+
+    /// Checks that the given stack value matches the layout of the register type.
+    fn matches_register_type(&self, stack_value: &Value<N>, register_type: &RegisterType<N>) -> Result<()>;
+
+    /// Checks that the given record matches the layout of the external record type.
+    fn matches_external_record(&self, record: &Record<N, Plaintext<N>>, locator: &Locator<N>) -> Result<()>;
+
+    /// Checks that the given record matches the layout of the record type.
+    fn matches_record(&self, record: &Record<N, Plaintext<N>>, record_name: &Identifier<N>) -> Result<()>;
+
+    /// Checks that the given plaintext matches the layout of the plaintext type.
+    fn matches_plaintext(&self, plaintext: &Plaintext<N>, plaintext_type: &PlaintextType<N>) -> Result<()>;
+}
+
+pub trait StackProgram<N: Network> {
+    /// Returns the program.
+    fn program(&self) -> &Program<N>;
+
+    /// Returns the program ID.
+    fn program_id(&self) -> &ProgramID<N>;
+
+    /// Returns `true` if the stack contains the external record.
+    fn contains_external_record(&self, locator: &Locator<N>) -> bool;
+
+    /// Returns the external stack for the given program ID.
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Self>;
+
+    /// Returns the external program for the given program ID.
+    fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>>;
+
+    /// Returns `true` if the stack contains the external record.
+    fn get_external_record(&self, locator: &Locator<N>) -> Result<RecordType<N>>;
+
+    /// Returns the function with the given function name.
+    fn get_function(&self, function_name: &Identifier<N>) -> Result<Function<N>>;
+
+    /// Returns the expected number of calls for the given function name.
+    fn get_number_of_calls(&self, function_name: &Identifier<N>) -> Result<usize>;
+
+    /// Returns the register types for the given closure or function name.
+    fn get_register_types(&self, name: &Identifier<N>) -> Result<&RegisterTypes<N>>;
+
+    /// Returns the register types for the given finalize name.
+    fn get_finalize_types(&self, name: &Identifier<N>) -> Result<&FinalizeTypes<N>>;
+}
+
 pub trait RegistersCall<N: Network> {
     /// Returns the current call stack.
     fn call_stack(&self) -> CallStack<N>;
@@ -55,7 +104,7 @@ pub trait RegistersLoad<N: Network> {
     /// # Errors
     /// This method should halt if the register locator is not found.
     /// In the case of register members, this method should halt if the member is not found.
-    fn load(&self, stack: &Stack<N>, operand: &Operand<N>) -> Result<Value<N>>;
+    fn load(&self, stack: &(impl StackMatches<N> + StackProgram<N>), operand: &Operand<N>) -> Result<Value<N>>;
 
     /// Loads the literal of a given operand.
     ///

--- a/synthesizer/src/program/finalize/command/finalize.rs
+++ b/synthesizer/src/program/finalize/command/finalize.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, Opcode, Operand, Stack};
+use crate::{Opcode, Operand, RegistersLoad, Stack};
 use console::{network::prelude::*, program::Register};
 
 /// Finalizes the operands on-chain.
@@ -63,7 +63,7 @@ impl<N: Network, const VARIANT: u8> FinalizeOperation<N, VARIANT> {
     pub fn evaluate<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &Stack<N>,
-        registers: &mut impl Load<N>,
+        registers: &mut impl RegistersLoad<N>,
     ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() > N::MAX_INPUTS {

--- a/synthesizer/src/program/finalize/command/get.rs
+++ b/synthesizer/src/program/finalize/command/get.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{FinalizeStorage, FinalizeStore, Load as LoadTrait, Opcode, Operand, Stack, Store};
+use crate::{FinalizeStorage, FinalizeStore, Opcode, Operand, RegistersLoad as LoadTrait, RegistersStore, Stack};
 use console::{
     network::prelude::*,
     program::{Identifier, Register, Value},
@@ -71,7 +71,7 @@ impl<N: Network> Get<N> {
         &self,
         stack: &Stack<N>,
         store: &FinalizeStore<N, P>,
-        registers: &mut (impl LoadTrait<N> + Store<N>),
+        registers: &mut (impl LoadTrait<N> + RegistersStore<N>),
     ) -> Result<()> {
         // Ensure the mapping exists in storage.
         if !store.contains_mapping_confirmed(stack.program_id(), &self.mapping)? {

--- a/synthesizer/src/program/finalize/command/get.rs
+++ b/synthesizer/src/program/finalize/command/get.rs
@@ -14,7 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{FinalizeStorage, FinalizeStore, Opcode, Operand, RegistersLoad as LoadTrait, RegistersStore, Stack};
+use crate::{
+    FinalizeStorage,
+    FinalizeStore,
+    Opcode,
+    Operand,
+    RegistersLoad as LoadTrait,
+    RegistersStore,
+    Stack,
+    StackProgram,
+};
 use console::{
     network::prelude::*,
     program::{Identifier, Register, Value},

--- a/synthesizer/src/program/finalize/command/get_or_init.rs
+++ b/synthesizer/src/program/finalize/command/get_or_init.rs
@@ -14,7 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{FinalizeOperation, FinalizeStorage, FinalizeStore, Load as LoadTrait, Opcode, Operand, Stack, Store};
+use crate::{
+    FinalizeOperation,
+    FinalizeStorage,
+    FinalizeStore,
+    Opcode,
+    Operand,
+    RegistersLoad as LoadTrait,
+    RegistersStore,
+    Stack,
+};
 use console::{
     network::prelude::*,
     program::{Identifier, Register, Value},
@@ -80,7 +89,7 @@ impl<N: Network> GetOrInit<N> {
         &self,
         stack: &Stack<N>,
         store: &FinalizeStore<N, P>,
-        registers: &mut (impl LoadTrait<N> + Store<N>),
+        registers: &mut (impl LoadTrait<N> + RegistersStore<N>),
     ) -> Result<Option<FinalizeOperation<N>>> {
         // Ensure the mapping exists in storage.
         if !store.contains_mapping_confirmed(stack.program_id(), &self.mapping)? {

--- a/synthesizer/src/program/finalize/command/get_or_init.rs
+++ b/synthesizer/src/program/finalize/command/get_or_init.rs
@@ -23,6 +23,7 @@ use crate::{
     RegistersLoad as LoadTrait,
     RegistersStore,
     Stack,
+    StackProgram,
 };
 use console::{
     network::prelude::*,

--- a/synthesizer/src/program/finalize/command/set.rs
+++ b/synthesizer/src/program/finalize/command/set.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{FinalizeOperation, FinalizeStorage, FinalizeStore, Opcode, Operand, RegistersLoad, Stack};
+use crate::{FinalizeOperation, FinalizeStorage, FinalizeStore, Opcode, Operand, RegistersLoad, Stack, StackProgram};
 use console::{
     network::prelude::*,
     program::{Identifier, Value},

--- a/synthesizer/src/program/finalize/command/set.rs
+++ b/synthesizer/src/program/finalize/command/set.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{FinalizeOperation, FinalizeStorage, FinalizeStore, Load, Opcode, Operand, Stack};
+use crate::{FinalizeOperation, FinalizeStorage, FinalizeStore, Opcode, Operand, RegistersLoad, Stack};
 use console::{
     network::prelude::*,
     program::{Identifier, Value},
@@ -71,7 +71,7 @@ impl<N: Network> Set<N> {
         &self,
         stack: &Stack<N>,
         store: &FinalizeStore<N, P>,
-        registers: &mut impl Load<N>,
+        registers: &mut impl RegistersLoad<N>,
     ) -> Result<FinalizeOperation<N>> {
         // Ensure the mapping exists in storage.
         if !store.contains_mapping_confirmed(stack.program_id(), &self.mapping)? {

--- a/synthesizer/src/program/instruction/mod.rs
+++ b/synthesizer/src/program/instruction/mod.rs
@@ -26,7 +26,7 @@ pub use operation::*;
 mod bytes;
 mod parse;
 
-use crate::{FinalizeRegisters, Registers, Stack, StackEvaluate, StackMatches, StackProgram};
+use crate::{FinalizeRegisters, Registers, StackEvaluate, StackExecute, StackMatches, StackProgram};
 use console::{
     network::{
         prelude::{
@@ -366,7 +366,7 @@ impl<N: Network> Instruction<N> {
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackEvaluate<N> + StackExecute<N> + StackMatches<N> + StackProgram<N>),
         registers: &mut Registers<N, A>,
     ) -> Result<()> {
         instruction!(self, |instruction| instruction.execute::<A>(stack, registers))

--- a/synthesizer/src/program/instruction/mod.rs
+++ b/synthesizer/src/program/instruction/mod.rs
@@ -26,7 +26,7 @@ pub use operation::*;
 mod bytes;
 mod parse;
 
-use crate::{FinalizeRegisters, Registers, Stack, StackProgram};
+use crate::{FinalizeRegisters, Registers, Stack, StackEvaluate, StackMatches, StackProgram};
 use console::{
     network::{
         prelude::{
@@ -356,7 +356,7 @@ impl<N: Network> Instruction<N> {
     #[inline]
     pub fn evaluate<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackEvaluate<N> + StackMatches<N> + StackProgram<N>),
         registers: &mut Registers<N, A>,
     ) -> Result<()> {
         instruction!(self, |instruction| instruction.evaluate(stack, registers))
@@ -374,7 +374,11 @@ impl<N: Network> Instruction<N> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &Stack<N>, registers: &mut FinalizeRegisters<N>) -> Result<()> {
+    pub fn finalize(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        registers: &mut FinalizeRegisters<N>,
+    ) -> Result<()> {
         instruction!(self, |instruction| instruction.finalize(stack, registers))
     }
 

--- a/synthesizer/src/program/instruction/mod.rs
+++ b/synthesizer/src/program/instruction/mod.rs
@@ -26,7 +26,7 @@ pub use operation::*;
 mod bytes;
 mod parse;
 
-use crate::{FinalizeRegisters, Registers, Stack};
+use crate::{FinalizeRegisters, Registers, Stack, StackProgram};
 use console::{
     network::{
         prelude::{
@@ -380,7 +380,11 @@ impl<N: Network> Instruction<N> {
 
     /// Returns the output type from the given input types.
     #[inline]
-    pub fn output_types(&self, stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         instruction!(self, |instruction| instruction.output_types(stack, input_types))
     }
 }

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, Stack};
+use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, Stack, StackProgram};
 use console::{
     network::prelude::*,
     program::{Register, RegisterType},
@@ -127,7 +127,11 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 
     /// Returns the output type from the given program and input types.
     #[inline]
-    pub fn output_types(&self, _stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        _stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         // Ensure the number of input types is correct.
         if input_types.len() != 2 {
             bail!("Instruction '{}' expects 2 inputs, found {} inputs", Self::opcode(), input_types.len())

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, Stack, StackProgram};
+use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, StackMatches, StackProgram};
 use console::{
     network::prelude::*,
     program::{Register, RegisterType},
@@ -67,7 +67,11 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
     /// Evaluates the instruction.
     #[inline]
-    pub fn evaluate(&self, stack: &Stack<N>, registers: &mut impl RegistersLoad<N>) -> Result<()> {
+    pub fn evaluate(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        registers: &mut impl RegistersLoad<N>,
+    ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
             bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
@@ -98,7 +102,7 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut impl RegistersLoadCircuit<N, A>,
     ) -> Result<()> {
         // Ensure the number of operands is correct.
@@ -121,7 +125,11 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &Stack<N>, registers: &mut impl RegistersLoad<N>) -> Result<()> {
+    pub fn finalize(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        registers: &mut impl RegistersLoad<N>,
+    ) -> Result<()> {
         self.evaluate(stack, registers)
     }
 
@@ -245,7 +253,7 @@ impl<N: Network, const VARIANT: u8> ToBytes for AssertInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::program::test_helpers::sample_registers;
+    use crate::{process::Stack, program::test_helpers::sample_registers};
     use circuit::AleoV0;
     use console::{
         network::Testnet3,

--- a/synthesizer/src/program/instruction/operation/assert.rs
+++ b/synthesizer/src/program/instruction/operation/assert.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, LoadCircuit, Opcode, Operand, Stack};
+use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, Stack};
 use console::{
     network::prelude::*,
     program::{Register, RegisterType},
@@ -67,7 +67,7 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
     /// Evaluates the instruction.
     #[inline]
-    pub fn evaluate(&self, stack: &Stack<N>, registers: &mut impl Load<N>) -> Result<()> {
+    pub fn evaluate(&self, stack: &Stack<N>, registers: &mut impl RegistersLoad<N>) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
             bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
@@ -99,7 +99,7 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &Stack<N>,
-        registers: &mut impl LoadCircuit<N, A>,
+        registers: &mut impl RegistersLoadCircuit<N, A>,
     ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
@@ -121,7 +121,7 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &Stack<N>, registers: &mut impl Load<N>) -> Result<()> {
+    pub fn finalize(&self, stack: &Stack<N>, registers: &mut impl RegistersLoad<N>) -> Result<()> {
         self.evaluate(stack, registers)
     }
 

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -27,6 +27,8 @@ use crate::{
     RegistersStore,
     RegistersStoreCircuit,
     Stack,
+    StackEvaluate,
+    StackMatches,
     StackProgram,
 };
 use console::{
@@ -179,7 +181,7 @@ impl<N: Network> Call<N> {
     #[inline]
     pub fn evaluate<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackEvaluate<N> + StackMatches<N> + StackProgram<N>),
         registers: &mut Registers<N, A>,
     ) -> Result<()> {
         // Load the operands values.
@@ -463,7 +465,11 @@ impl<N: Network> Call<N> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, _stack: &Stack<N>, _registers: &mut impl RegistersLoad<N>) -> Result<()> {
+    pub fn finalize(
+        &self,
+        _stack: &(impl StackMatches<N> + StackProgram<N>),
+        _registers: &mut impl RegistersLoad<N>,
+    ) -> Result<()> {
         bail!("Forbidden operation: Finalize cannot invoke a 'call'")
     }
 

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -161,7 +161,7 @@ impl<N: Network> Call<N> {
 impl<N: Network> Call<N> {
     /// Returns `true` if the instruction is a function call.
     #[inline]
-    pub fn is_function_call(&self, stack: &Stack<N>) -> Result<bool> {
+    pub fn is_function_call(&self, stack: &impl StackProgram<N>) -> Result<bool> {
         match self.operator() {
             // Check if the locator is for a function.
             CallOperator::Locator(locator) => {

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -14,7 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{CallStack, FinalizeRegisters, Load, LoadCircuit, Opcode, Operand, Registers, Stack, Store, StoreCircuit};
+use crate::{
+    CallStack,
+    Opcode,
+    Operand,
+    Registers,
+    RegistersCall,
+    RegistersCaller,
+    RegistersCallerCircuit,
+    RegistersLoad,
+    RegistersLoadCircuit,
+    RegistersStore,
+    RegistersStoreCircuit,
+    Stack,
+};
 use console::{
     network::prelude::*,
     program::{Identifier, Locator, Register, RegisterType, Request, ValueType},
@@ -234,7 +247,12 @@ impl<N: Network> Call<N> {
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &Stack<N>,
-        registers: &mut Registers<N, A>,
+        registers: &mut (
+                 impl RegistersCall<N>
+                 + RegistersCallerCircuit<N, A>
+                 + RegistersLoadCircuit<N, A>
+                 + RegistersStoreCircuit<N, A>
+             ),
     ) -> Result<()> {
         // Load the operands values.
         let inputs: Vec<_> =
@@ -444,7 +462,7 @@ impl<N: Network> Call<N> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, _stack: &Stack<N>, _registers: &mut FinalizeRegisters<N>) -> Result<()> {
+    pub fn finalize(&self, _stack: &Stack<N>, _registers: &mut impl RegistersLoad<N>) -> Result<()> {
         bail!("Forbidden operation: Finalize cannot invoke a 'call'")
     }
 

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -27,6 +27,7 @@ use crate::{
     RegistersStore,
     RegistersStoreCircuit,
     Stack,
+    StackProgram,
 };
 use console::{
     network::prelude::*,

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -26,8 +26,8 @@ use crate::{
     RegistersLoadCircuit,
     RegistersStore,
     RegistersStoreCircuit,
-    Stack,
     StackEvaluate,
+    StackExecute,
     StackMatches,
     StackProgram,
 };
@@ -249,7 +249,7 @@ impl<N: Network> Call<N> {
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackEvaluate<N> + StackExecute<N> + StackMatches<N> + StackProgram<N>),
         registers: &mut (
                  impl RegistersCall<N>
                  + RegistersCallerCircuit<N, A>

--- a/synthesizer/src/program/instruction/operation/call.rs
+++ b/synthesizer/src/program/instruction/operation/call.rs
@@ -469,7 +469,11 @@ impl<N: Network> Call<N> {
 
     /// Returns the output type from the given program and input types.
     #[inline]
-    pub fn output_types(&self, stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         // Retrieve the program and resource.
         let (is_external, program, resource) = match &self.operator {
             // Retrieve the program and resource from the locator.

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -431,7 +431,11 @@ impl<N: Network> Cast<N> {
 
     /// Returns the output type from the given program and input types.
     #[inline]
-    pub fn output_types(&self, stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         // Ensure the number of operands is correct.
         ensure!(
             input_types.len() == self.operands.len(),

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -24,6 +24,8 @@ use crate::{
     RegistersStore,
     RegistersStoreCircuit,
     Stack,
+    StackMatches,
+    StackProgram,
 };
 use console::{
     network::prelude::*,

--- a/synthesizer/src/program/instruction/operation/cast.rs
+++ b/synthesizer/src/program/instruction/operation/cast.rs
@@ -23,7 +23,6 @@ use crate::{
     RegistersLoadCircuit,
     RegistersStore,
     RegistersStoreCircuit,
-    Stack,
     StackMatches,
     StackProgram,
 };
@@ -90,7 +89,7 @@ impl<N: Network> Cast<N> {
     #[inline]
     pub fn evaluate(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersCaller<N> + RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         // Load the operands values.
@@ -221,7 +220,7 @@ impl<N: Network> Cast<N> {
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersCallerCircuit<N, A> + RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         use circuit::{Eject, Inject};
@@ -368,7 +367,7 @@ impl<N: Network> Cast<N> {
     #[inline]
     pub fn finalize(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         // Load the operands values.

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -14,7 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, RegistersStore, RegistersStoreCircuit, Stack};
+use crate::{
+    Opcode,
+    Operand,
+    RegistersLoad,
+    RegistersLoadCircuit,
+    RegistersStore,
+    RegistersStoreCircuit,
+    Stack,
+    StackProgram,
+};
 use console::{
     network::prelude::*,
     program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
@@ -172,7 +181,11 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
 
     /// Returns the output type from the given program and input types.
     #[inline]
-    pub fn output_types(&self, _stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        _stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         // Ensure the number of input types is correct.
         if input_types.len() != 2 {
             bail!("Instruction '{}' expects 2 inputs, found {} inputs", Self::opcode(), input_types.len())

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, LoadCircuit, Opcode, Operand, Stack, Store, StoreCircuit};
+use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, RegistersStore, RegistersStoreCircuit, Stack};
 use console::{
     network::prelude::*,
     program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
@@ -86,7 +86,11 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     /// Evaluates the instruction.
     #[inline]
-    pub fn evaluate(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn evaluate(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
             bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
@@ -120,7 +124,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &Stack<N>,
-        registers: &mut (impl LoadCircuit<N, A> + StoreCircuit<N, A>),
+        registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         use circuit::ToBits;
 
@@ -158,7 +162,11 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn finalize(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         self.evaluate(stack, registers)
     }
 

--- a/synthesizer/src/program/instruction/operation/commit.rs
+++ b/synthesizer/src/program/instruction/operation/commit.rs
@@ -21,7 +21,7 @@ use crate::{
     RegistersLoadCircuit,
     RegistersStore,
     RegistersStoreCircuit,
-    Stack,
+    StackMatches,
     StackProgram,
 };
 use console::{
@@ -97,7 +97,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     #[inline]
     pub fn evaluate(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
@@ -132,7 +132,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         use circuit::ToBits;
@@ -173,7 +173,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     #[inline]
     pub fn finalize(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         self.evaluate(stack, registers)

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -14,7 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, RegistersStore, RegistersStoreCircuit, Stack};
+use crate::{
+    Opcode,
+    Operand,
+    RegistersLoad,
+    RegistersLoadCircuit,
+    RegistersStore,
+    RegistersStoreCircuit,
+    Stack,
+    StackProgram,
+};
 use console::{
     network::prelude::*,
     program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
@@ -174,7 +183,11 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
 
     /// Returns the output type from the given program and input types.
     #[inline]
-    pub fn output_types(&self, _stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        _stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         // Ensure the number of input types is correct.
         if input_types.len() != 1 {
             bail!("Instruction '{}' expects 1 inputs, found {} inputs", Self::opcode(), input_types.len())

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, LoadCircuit, Opcode, Operand, Stack, Store, StoreCircuit};
+use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, RegistersStore, RegistersStoreCircuit, Stack};
 use console::{
     network::prelude::*,
     program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
@@ -99,7 +99,11 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     /// Evaluates the instruction.
     #[inline]
-    pub fn evaluate(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn evaluate(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 1 {
             bail!("Instruction '{}' expects 1 operands, found {} operands", Self::opcode(), self.operands.len())
@@ -128,7 +132,7 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &Stack<N>,
-        registers: &mut (impl LoadCircuit<N, A> + StoreCircuit<N, A>),
+        registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         use circuit::{ToBits, ToFields};
 
@@ -160,7 +164,11 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn finalize(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         self.evaluate(stack, registers)
     }
 

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -21,7 +21,7 @@ use crate::{
     RegistersLoadCircuit,
     RegistersStore,
     RegistersStoreCircuit,
-    Stack,
+    StackMatches,
     StackProgram,
 };
 use console::{
@@ -110,7 +110,7 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     #[inline]
     pub fn evaluate(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
@@ -140,7 +140,7 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         use circuit::{ToBits, ToFields};
@@ -175,7 +175,7 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     #[inline]
     pub fn finalize(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         self.evaluate(stack, registers)

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, LoadCircuit, Opcode, Operand, Stack, Store, StoreCircuit};
+use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, RegistersStore, RegistersStoreCircuit, Stack};
 use console::{
     network::prelude::*,
     program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
@@ -70,7 +70,11 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
     /// Evaluates the instruction.
     #[inline]
-    pub fn evaluate(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn evaluate(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
             bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
@@ -95,7 +99,7 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &Stack<N>,
-        registers: &mut (impl LoadCircuit<N, A> + StoreCircuit<N, A>),
+        registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
@@ -120,7 +124,11 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn finalize(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         self.evaluate(stack, registers)
     }
 

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -14,7 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Opcode, Operand, RegistersLoad, RegistersLoadCircuit, RegistersStore, RegistersStoreCircuit, Stack};
+use crate::{
+    Opcode,
+    Operand,
+    RegistersLoad,
+    RegistersLoadCircuit,
+    RegistersStore,
+    RegistersStoreCircuit,
+    Stack,
+    StackProgram,
+};
 use console::{
     network::prelude::*,
     program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
@@ -134,7 +143,11 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
 
     /// Returns the output type from the given program and input types.
     #[inline]
-    pub fn output_types(&self, _stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        _stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         // Ensure the number of input types is correct.
         if input_types.len() != 2 {
             bail!("Instruction '{}' expects 2 inputs, found {} inputs", Self::opcode(), input_types.len())

--- a/synthesizer/src/program/instruction/operation/is.rs
+++ b/synthesizer/src/program/instruction/operation/is.rs
@@ -21,7 +21,7 @@ use crate::{
     RegistersLoadCircuit,
     RegistersStore,
     RegistersStoreCircuit,
-    Stack,
+    StackMatches,
     StackProgram,
 };
 use console::{
@@ -81,7 +81,7 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
     #[inline]
     pub fn evaluate(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
@@ -107,7 +107,7 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
@@ -135,7 +135,7 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
     #[inline]
     pub fn finalize(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         self.evaluate(stack, registers)
@@ -274,7 +274,7 @@ impl<N: Network, const VARIANT: u8> ToBytes for IsInstruction<N, VARIANT> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::program::test_helpers::sample_registers;
+    use crate::{process::Stack, program::test_helpers::sample_registers};
     use circuit::AleoV0;
     use console::{network::Testnet3, program::Identifier};
     use snarkvm_synthesizer_snark::{ProvingKey, VerifyingKey};

--- a/synthesizer/src/program/instruction/operation/literals.rs
+++ b/synthesizer/src/program/instruction/operation/literals.rs
@@ -14,7 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Load, LoadCircuit, Opcode, Operand, Operation, Stack, Store, StoreCircuit};
+use crate::{
+    Opcode,
+    Operand,
+    Operation,
+    RegistersLoad,
+    RegistersLoadCircuit,
+    RegistersStore,
+    RegistersStoreCircuit,
+    Stack,
+};
 use console::{
     network::prelude::*,
     program::{Literal, LiteralType, PlaintextType, Register, RegisterType},
@@ -66,7 +75,11 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
 {
     /// Evaluates the instruction.
     #[inline]
-    pub fn evaluate(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn evaluate(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != NUM_OPERANDS {
             bail!("Instruction '{}' expects {NUM_OPERANDS} operands, found {} operands", O::OPCODE, self.operands.len())
@@ -105,7 +118,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &Stack<N>,
-        registers: &mut (impl LoadCircuit<N, A> + StoreCircuit<N, A>),
+        registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
         if self.operands.len() != NUM_OPERANDS {
@@ -137,7 +150,11 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &Stack<N>, registers: &mut (impl Load<N> + Store<N>)) -> Result<()> {
+    pub fn finalize(
+        &self,
+        stack: &Stack<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
         self.evaluate(stack, registers)
     }
 

--- a/synthesizer/src/program/instruction/operation/literals.rs
+++ b/synthesizer/src/program/instruction/operation/literals.rs
@@ -23,6 +23,7 @@ use crate::{
     RegistersStore,
     RegistersStoreCircuit,
     Stack,
+    StackProgram,
 };
 use console::{
     network::prelude::*,
@@ -160,7 +161,11 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
 
     /// Returns the output type from the given program and input types.
     #[inline]
-    pub fn output_types(&self, _stack: &Stack<N>, input_types: &[RegisterType<N>]) -> Result<Vec<RegisterType<N>>> {
+    pub fn output_types(
+        &self,
+        _stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
         // Ensure the number of input types is correct.
         if input_types.len() != NUM_OPERANDS {
             bail!("Instruction '{}' expects {NUM_OPERANDS} inputs, found {} inputs", O::OPCODE, input_types.len())

--- a/synthesizer/src/program/instruction/operation/literals.rs
+++ b/synthesizer/src/program/instruction/operation/literals.rs
@@ -22,7 +22,7 @@ use crate::{
     RegistersLoadCircuit,
     RegistersStore,
     RegistersStoreCircuit,
-    Stack,
+    StackMatches,
     StackProgram,
 };
 use console::{
@@ -78,7 +78,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
     #[inline]
     pub fn evaluate(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
@@ -118,7 +118,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         // Ensure the number of operands is correct.
@@ -153,7 +153,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
     #[inline]
     pub fn finalize(
         &self,
-        stack: &Stack<N>,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         self.evaluate(stack, registers)

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -773,7 +773,7 @@ crate::operation!(
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use super::*;
-    use crate::{Authorization, CallStack, Registers, Stack, Store, StoreCircuit};
+    use crate::{Authorization, CallStack, Registers, RegistersStore, RegistersStoreCircuit, Stack};
 
     use circuit::AleoV0;
     use console::{

--- a/synthesizer/src/program/instruction/operation/mod.rs
+++ b/synthesizer/src/program/instruction/operation/mod.rs
@@ -773,7 +773,7 @@ crate::operation!(
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use super::*;
-    use crate::{Authorization, CallStack, Registers, RegistersStore, RegistersStoreCircuit, Stack};
+    use crate::{Authorization, CallStack, Registers, RegistersStore, RegistersStoreCircuit, Stack, StackProgram};
 
     use circuit::AleoV0;
     use console::{

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -629,7 +629,7 @@ impl<N: Network> TypeName for Program<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CallStack, Execution, Inclusion, StackEvaluate};
+    use crate::{CallStack, Execution, Inclusion, StackEvaluate, StackExecute};
     use circuit::network::AleoV0;
     use console::{
         account::{Address, PrivateKey},

--- a/synthesizer/src/program/mod.rs
+++ b/synthesizer/src/program/mod.rs
@@ -629,7 +629,7 @@ impl<N: Network> TypeName for Program<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CallStack, Execution, Inclusion};
+    use crate::{CallStack, Execution, Inclusion, StackEvaluate};
     use circuit::network::AleoV0;
     use console::{
         account::{Address, PrivateKey},


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR builds upon #1546.

This PR introduces complete abstractions for `Stack` and `Registers`. By using `impl Trait` on types that the `Program` cannot access, we abstract the underlying types so that `Stack` and `Registers` can be introduced at a higher level.

