### PR TITLE
fix comment about number of constraints

### DIFF
--- a/circuit/types/field/src/equal.rs
+++ b/circuit/types/field/src/equal.rs
@@ -22,7 +22,7 @@ impl<E: Environment> Equal<Self> for Field<E> {
     ///
     /// Returns `true` if `self` and `other` are equal.
     ///
-    /// This method costs 3 constraints.
+    /// This method costs 2 constraints.
     ///
     fn is_equal(&self, other: &Self) -> Self::Output {
         !self.is_not_equal(other)
@@ -34,7 +34,7 @@ impl<E: Environment> Equal<Self> for Field<E> {
     /// This method constructs a boolean that indicates if
     /// `self` and `other ` are *not* equal to each other.
     ///
-    /// This method costs 3 constraints.
+    /// This method costs 2 constraints.
     ///
     fn is_not_equal(&self, other: &Self) -> Self::Output {
         match (self.is_constant(), other.is_constant()) {


### PR DESCRIPTION
It seems there're only 2 constraints in [`Field.is_not_equal`](https://github.com/AleoHQ/snarkVM/blob/e8466f87e4ed6f9709524df700a1279e34d59972/circuit/types/field/src/equal.rs#L39)?