### PR TITLE
Prevent addition overflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ snarkVM is a big project, so (non-)adherence to best practices related to perfor
 - if possible, reuse collections; an example would be a loop that needs a clean vector on each iteration: instead of creating and allocating it over and over, create it _before_ the loop and use `.clear()` on every iteration instead
 - try to keep the sizes of `enum` variants uniform; use `Box<T>` on ones that are large
 
+### Cross-platform consistency
+- types which contain consensus- or cryptographic logic should have a consistent size across platforms. Their serialized output should not contain `usize`, and at times it may be worth it to avoid using `usize` in the types themselves for clarity.
+
 ### Misc. performance
 
 - avoid the `format!()` macro; if it is used only to convert a single value to a `String`, use `.to_string()` instead, which is also available to all the implementors of `Display`

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -387,6 +387,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
         optimization_type: OptimizationType,
     ) -> SmallVec<[F; 10]> {
         let params = get_params(TargetField::size_in_bits(), F::size_in_bits(), optimization_type);
+        assert!(params.bits_per_limb <= u32::MAX as usize);
 
         // Push the lower limbs first
         let mut limbs: SmallVec<[F; 10]> = SmallVec::new();

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -379,6 +379,8 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
         Self::get_limbs_representations_from_big_integer::<TargetField>(&elem.to_bigint(), optimization_type)
     }
 
+    // params.bits_per_limb is safe to cast as u32 because it will be less than `max_limb_size`
+    #[allow(clippy::cast_possible_truncation)]
     /// Obtain the limbs directly from a big int
     pub fn get_limbs_representations_from_big_integer<TargetField: PrimeField>(
         elem: &<TargetField as PrimeField>::BigInteger,

--- a/algorithms/src/errors.rs
+++ b/algorithms/src/errors.rs
@@ -22,29 +22,35 @@ pub enum SNARKError {
     #[error("{}", _0)]
     AnyhowError(#[from] anyhow::Error),
 
+    #[error("Batch size was different between public input and proof")]
+    BatchSizeMismatch,
+
+    #[error("Circuit not found")]
+    CircuitNotFound,
+
     #[error("{}", _0)]
     ConstraintFieldError(#[from] ConstraintFieldError),
 
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 
+    #[error("Batch size was zero; must be at least 1")]
+    EmptyBatch,
+
     #[error("Expected a circuit-specific SRS in SNARK")]
     ExpectedCircuitSpecificSRS,
+
+    #[error(transparent)]
+    IntError(#[from] std::num::TryFromIntError),
 
     #[error("{}", _0)]
     Message(String),
 
+    #[error(transparent)]
+    ParseIntError(#[from] std::num::ParseIntError),
+
     #[error("{}", _0)]
     SynthesisError(SynthesisError),
-
-    #[error("Batch size was zero; must be at least 1")]
-    EmptyBatch,
-
-    #[error("Batch size was different between public input and proof")]
-    BatchSizeMismatch,
-
-    #[error("Circuit not found")]
-    CircuitNotFound,
 
     #[error("terminated")]
     Terminated,

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -116,7 +116,7 @@ impl<F: FftField> EvaluationDomain<F> {
     /// having `num_coeffs` coefficients.
     pub fn new(num_coeffs: usize) -> Option<Self> {
         // Compute the size of our evaluation domain
-        let size = num_coeffs.checked_next_power_of_two()? as u64;
+        let size = num_coeffs.checked_next_power_of_two()?;
         let log_size_of_group = size.trailing_zeros();
 
         // libfqfft uses > https://github.com/scipr-lab/libfqfft/blob/e0183b2cef7d4c5deb21a6eaf3fe3b586d738fe0/libfqfft/evaluation_domain/domains/basic_radix2_domain.tcc#L33
@@ -126,7 +126,8 @@ impl<F: FftField> EvaluationDomain<F> {
 
         // Compute the generator for the multiplicative subgroup.
         // It should be the 2^(log_size_of_group) root of unity.
-        let group_gen = F::get_root_of_unity(size as usize)?;
+        let group_gen = F::get_root_of_unity(size)?;
+        let size = size as u64;
 
         // Check that it is indeed the 2^(log_size_of_group) root of unity.
         debug_assert_eq!(group_gen.pow([size]), F::one());
@@ -152,6 +153,8 @@ impl<F: FftField> EvaluationDomain<F> {
         if size.trailing_zeros() <= F::FftParameters::TWO_ADICITY { Some(size) } else { None }
     }
 
+    // casting to usize is safe because it is originally a usize in self.new()
+    #[allow(clippy::cast_possible_truncation)]
     /// Return the size of `self`.
     pub fn size(&self) -> usize {
         self.size as usize
@@ -256,7 +259,7 @@ impl<F: FftField> EvaluationDomain<F> {
     /// `tau`.
     pub fn evaluate_all_lagrange_coefficients(&self, tau: F) -> Vec<F> {
         // Evaluate all Lagrange polynomials
-        let size = self.size as usize;
+        let size = self.size();
         let t_size = tau.pow([self.size]);
         let one = F::one();
         if t_size.is_one() {
@@ -375,7 +378,7 @@ impl<F: FftField> EvaluationDomain<F> {
         // SNP TODO: how to set threshold and check that the type is Fr
         if self.size >= 32 && std::mem::size_of::<T>() == 32 {
             let result = snarkvm_algorithms_cuda::NTT(
-                self.size as usize,
+                self.size(),
                 x_s,
                 snarkvm_algorithms_cuda::NTTInputOutputOrder::NN,
                 snarkvm_algorithms_cuda::NTTDirection::Forward,
@@ -404,7 +407,7 @@ impl<F: FftField> EvaluationDomain<F> {
         // SNP TODO: how to set threshold
         if self.size >= 32 && std::mem::size_of::<T>() == 32 {
             let result = snarkvm_algorithms_cuda::NTT(
-                self.size as usize,
+                self.size(),
                 x_s,
                 snarkvm_algorithms_cuda::NTTInputOutputOrder::NN,
                 snarkvm_algorithms_cuda::NTTDirection::Inverse,
@@ -425,7 +428,7 @@ impl<F: FftField> EvaluationDomain<F> {
         // SNP TODO: how to set threshold
         if self.size >= 32 && std::mem::size_of::<T>() == 32 {
             let result = snarkvm_algorithms_cuda::NTT(
-                self.size as usize,
+                self.size(),
                 x_s,
                 snarkvm_algorithms_cuda::NTTInputOutputOrder::NN,
                 snarkvm_algorithms_cuda::NTTDirection::Inverse,
@@ -452,7 +455,7 @@ impl<F: FftField> EvaluationDomain<F> {
         // SNP TODO: how to set threshold
         if self.size >= 32 && std::mem::size_of::<T>() == 32 {
             let result = snarkvm_algorithms_cuda::NTT(
-                self.size as usize,
+                self.size(),
                 x_s,
                 snarkvm_algorithms_cuda::NTTInputOutputOrder::NN,
                 snarkvm_algorithms_cuda::NTTDirection::Forward,
@@ -483,7 +486,7 @@ impl<F: FftField> EvaluationDomain<F> {
         // SNP TODO: how to set threshold
         if self.size >= 32 && std::mem::size_of::<T>() == 32 {
             let result = snarkvm_algorithms_cuda::NTT(
-                self.size as usize,
+                self.size(),
                 x_s,
                 snarkvm_algorithms_cuda::NTTInputOutputOrder::NN,
                 snarkvm_algorithms_cuda::NTTDirection::Inverse,
@@ -517,7 +520,7 @@ impl<F: FftField> EvaluationDomain<F> {
         // SNP TODO: how to set threshold
         if self.size >= 32 && std::mem::size_of::<T>() == 32 {
             let result = snarkvm_algorithms_cuda::NTT(
-                self.size as usize,
+                self.size(),
                 x_s,
                 snarkvm_algorithms_cuda::NTTInputOutputOrder::NN,
                 snarkvm_algorithms_cuda::NTTDirection::Inverse,
@@ -585,17 +588,17 @@ impl<F: FftField> EvaluationDomain<F> {
     // [1, g, g^2, ..., g^{(n/2) - 1}]
     #[cfg(feature = "serial")]
     pub fn roots_of_unity(&self, root: F) -> Vec<F> {
-        compute_powers_serial((self.size as usize) / 2, root)
+        compute_powers_serial((self.size()) / 2, root)
     }
 
     /// Computes the first `self.size / 2` roots of unity.
     #[cfg(not(feature = "serial"))]
     pub fn roots_of_unity(&self, root: F) -> Vec<F> {
         // TODO: check if this method can replace parallel compute powers.
-        let log_size = log2(self.size as usize);
+        let log_size = log2(self.size());
         // early exit for short inputs
         if log_size <= LOG_ROOTS_OF_UNITY_PARALLEL_SIZE {
-            compute_powers_serial((self.size as usize) / 2, root)
+            compute_powers_serial((self.size()) / 2, root)
         } else {
             let mut temp = root;
             // w, w^2, w^4, w^8, ..., w^(2^(log_size - 1))
@@ -793,6 +796,8 @@ pub(crate) fn derange<T>(xi: &mut [T]) {
     derange_helper(xi, log2(xi.len()))
 }
 
+// casting to usize is safe because xi.len() is at most domain.size() which uses usize in self.new()
+#[allow(clippy::cast_possible_truncation)]
 fn derange_helper<T>(xi: &mut [T], log_len: u32) {
     for idx in 1..(xi.len() as u64 - 1) {
         let ridx = bitrev(idx, log_len);

--- a/algorithms/src/fft/polynomial/sparse.rs
+++ b/algorithms/src/fft/polynomial/sparse.rs
@@ -18,12 +18,11 @@
 
 use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
 use snarkvm_fields::{Field, PrimeField};
-use snarkvm_utilities::serialize::*;
 
 use std::{collections::BTreeMap, fmt};
 
 /// Stores a sparse polynomial in coefficient form.
-#[derive(Clone, PartialEq, Eq, Hash, Default, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Default)]
 #[must_use]
 pub struct SparsePolynomial<F: Field> {
     /// The coefficient a_i of `x^i` is stored as (i, a_i) in `self.coeffs`.

--- a/algorithms/src/lib.rs
+++ b/algorithms/src/lib.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::type_complexity)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
+#![warn(clippy::cast_possible_truncation)]
 
 #[cfg(feature = "wasm")]
 #[macro_use]

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -181,6 +181,7 @@ pub(super) fn batch_add<G: AffineCurve>(
 ) -> Vec<G> {
     // assert_eq!(bases.len(), bucket_positions.len());
     assert!(!bases.is_empty());
+    assert!(num_buckets <= u32::MAX as usize);
 
     // Fetch the ideal batch size for the number of bases.
     let batch_size = batch_size(bases.len());
@@ -335,6 +336,8 @@ fn batched_window<G: AffineCurve>(
     w_start: usize,
     c: usize,
 ) -> (G::Projective, usize) {
+    assert!(w_start <= u32::MAX as usize);
+    assert!(c <= u32::MAX as usize);
     // We don't need the "zero" bucket, so we only have 2^c - 1 buckets
     let window_size = if (w_start % c) != 0 { w_start % c } else { c };
     let num_buckets = (1 << window_size) - 1;

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -172,6 +172,8 @@ fn batch_add_write<G: AffineCurve>(
 }
 
 #[inline]
+// It is safe to cast num_buckets to u32 because it was small enough earlier in the callchain
+#[allow(clippy::cast_possible_truncation)]
 pub(super) fn batch_add<G: AffineCurve>(
     num_buckets: usize,
     bases: &[G],
@@ -325,6 +327,8 @@ pub(super) fn batch_add<G: AffineCurve>(
 }
 
 #[inline]
+// It is safe to cast w_start and c to u32 because they were small enough earlier in the callchain
+#[allow(clippy::cast_possible_truncation)]
 fn batched_window<G: AffineCurve>(
     bases: &[G],
     scalars: &[<G::ScalarField as PrimeField>::BigInteger],

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -21,6 +21,9 @@ use snarkvm_utilities::{cfg_into_iter, BigInteger};
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 
+// It is safe to cast w_start to u32 because it was small enough earlier in the callchain
+// It is safe to cast scalar to usize because it is mod c, which is usize
+#[allow(clippy::cast_possible_truncation)]
 fn update_buckets<G: AffineCurve>(
     base: &G,
     mut scalar: <G::ScalarField as PrimeField>::BigInteger,

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -31,6 +31,7 @@ fn update_buckets<G: AffineCurve>(
     c: usize,
     buckets: &mut [G::Projective],
 ) {
+    assert!(w_start <= u32::MAX as usize);
     // We right-shift by w_start, thus getting rid of the lower bits.
     scalar.divn(w_start as u32);
 

--- a/algorithms/src/polycommit/error.rs
+++ b/algorithms/src/polycommit/error.rs
@@ -94,6 +94,9 @@ pub enum PCError {
         label: String,
     },
 
+    /// Could not convert from int.
+    IntError(std::num::TryFromIntError),
+
     Terminated,
 }
 
@@ -102,6 +105,12 @@ impl snarkvm_utilities::error::Error for PCError {}
 impl From<anyhow::Error> for PCError {
     fn from(other: anyhow::Error) -> Self {
         Self::AnyhowError(other)
+    }
+}
+
+impl From<std::num::TryFromIntError> for PCError {
+    fn from(other: std::num::TryFromIntError) -> Self {
+        Self::IntError(other)
     }
 }
 
@@ -150,6 +159,7 @@ impl core::fmt::Display for PCError {
                  (having degree {poly_degree:?}) is greater than the maximum \
                  supported degree ({supported_degree:?})"
             ),
+            Self::IntError(error) => write!(f, "{error}"),
             Self::Terminated => write!(f, "terminated"),
         }
     }

--- a/algorithms/src/polycommit/kzg10/data_structures.rs
+++ b/algorithms/src/polycommit/kzg10/data_structures.rs
@@ -131,6 +131,8 @@ impl<E: PairingEngine> FromBytes for UniversalParams<E> {
     }
 }
 
+// It is safe to cast `supported_degree_bounds.len()` and individual bounds to a `u32` because they are read and used as u32
+#[allow(clippy::cast_possible_truncation)]
 impl<E: PairingEngine> ToBytes for UniversalParams<E> {
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
         // Serialize powers.
@@ -352,7 +354,7 @@ impl<E: PairingEngine> ToBytes for KZGCommitment<E> {
 }
 
 impl<E: PairingEngine> ToMinimalBits for KZGCommitment<E> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
         self.0.to_minimal_bits()
     }
 }

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -83,7 +83,7 @@ pub struct CommitterKey<E: PairingEngine> {
     pub enforced_degree_bounds: Option<Vec<usize>>,
 
     /// The maximum degree supported by the `UniversalParams` from which `self` was derived
-    pub max_degree: usize,
+    pub max_degree: u32,
 }
 
 impl<E: PairingEngine> FromBytes for CommitterKey<E> {
@@ -217,12 +217,14 @@ impl<E: PairingEngine> FromBytes for CommitterKey<E> {
             shifted_powers_of_beta_g,
             shifted_powers_of_beta_times_gamma_g,
             enforced_degree_bounds,
-            max_degree: max_degree as usize,
+            max_degree,
         })
     }
 }
 
 impl<E: PairingEngine> ToBytes for CommitterKey<E> {
+    // Values are safe to cast to u32 because they are read as u32.
+    #[allow(clippy::cast_possible_truncation)]
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
         // Serialize `powers`.
         (self.powers_of_beta_g.len() as u32).write_le(&mut writer)?;
@@ -258,10 +260,10 @@ impl<E: PairingEngine> ToBytes for CommitterKey<E> {
         self.shifted_powers_of_beta_times_gamma_g.is_some().write_le(&mut writer)?;
         if let Some(shifted_powers_of_beta_times_gamma_g) = &self.shifted_powers_of_beta_times_gamma_g {
             (shifted_powers_of_beta_times_gamma_g.len() as u32).write_le(&mut writer)?;
-            for (key, shifted_powers_of_beta_g) in shifted_powers_of_beta_times_gamma_g {
+            for (key, shifted_powers_of_beta_times_gamma_g) in shifted_powers_of_beta_times_gamma_g {
                 (*key as u32).write_le(&mut writer)?;
-                (shifted_powers_of_beta_g.len() as u32).write_le(&mut writer)?;
-                for shifted_power in shifted_powers_of_beta_g {
+                (shifted_powers_of_beta_times_gamma_g.len() as u32).write_le(&mut writer)?;
+                for shifted_power in shifted_powers_of_beta_times_gamma_g {
                     shifted_power.write_le(&mut writer)?;
                 }
             }
@@ -277,7 +279,7 @@ impl<E: PairingEngine> ToBytes for CommitterKey<E> {
         }
 
         // Serialize `max_degree`.
-        (self.max_degree as u32).write_le(&mut writer)?;
+        self.max_degree.write_le(&mut writer)?;
 
         // Construct the hash of the group elements.
         let mut hash_input = self.powers_of_beta_g.to_bytes_le().map_err(|_| error("Could not serialize powers"))?;
@@ -343,7 +345,7 @@ pub struct CommitterUnionKey<'a, E: PairingEngine> {
     pub enforced_degree_bounds: Option<Vec<usize>>,
 
     /// The maximum degree supported by the `UniversalParams` from which `self` was derived
-    pub max_degree: usize,
+    pub max_degree: u32,
 }
 
 impl<'a, E: PairingEngine> CommitterUnionKey<'a, E> {
@@ -389,7 +391,7 @@ impl<'a, E: PairingEngine> CommitterUnionKey<'a, E> {
         })
     }
 
-    pub fn max_degree(&self) -> usize {
+    pub fn max_degree(&self) -> u32 {
         self.max_degree
     }
 

--- a/algorithms/src/snark/marlin/ahp/ahp.rs
+++ b/algorithms/src/snark/marlin/ahp/ahp.rs
@@ -279,17 +279,18 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         end_timer!(v_X_at_beta_time);
 
         let z_b_s_at_beta = z_b_s
-            .iter()
-            .map(|(circuit_id, z_b_i)| {
-                let z_b_i_s = z_b_i.iter().map(|z_b| evals.get_lc_eval(z_b, beta).unwrap()).collect::<Vec<F>>();
-                (*circuit_id, z_b_i_s)
+            .values()
+            .map(|z_b_i| {
+                let z_b_i_s = z_b_i.iter().map(|z_b| evals.get_lc_eval(z_b, beta)).collect::<Result<Vec<F>, _>>();
+                z_b_i_s
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<Result<Vec<_>, _>>()?;
+
         let batch_z_b_s_at_beta = z_b_s_at_beta
             .iter()
-            .zip_eq(batch_combiners.values())
+            .zip_eq(batch_combiners.iter())
             .zip_eq(r_alpha_at_beta_s.values())
-            .map(|(((circuit_id, z_b_i_at_beta), combiners), &r_alpha_at_beta)| {
+            .map(|((z_b_i_at_beta, (circuit_id, combiners)), &r_alpha_at_beta)| {
                 let z_b_at_beta = z_b_i_at_beta
                     .iter()
                     .zip_eq(&combiners.instance_combiners)
@@ -324,13 +325,13 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             if MM::ZK {
                 lincheck_sumcheck.add(F::one(), "mask_poly");
             }
-            for (id, c) in batch_combiners.iter() {
+            for (i, (id, c)) in batch_combiners.iter().enumerate() {
                 let mut circuit_term = LinearCombination::empty(format!("lincheck_sumcheck term {id}"));
                 for (j, instance_combiner) in c.instance_combiners.iter().enumerate() {
                     let z_a_j = witness_label(*id, "z_a", j);
                     let w_j = witness_label(*id, "w", j);
                     circuit_term
-                        .add(r_alpha_at_beta_s[id] * instance_combiner * (eta_a + eta_c * z_b_s_at_beta[id][j]), z_a_j)
+                        .add(r_alpha_at_beta_s[id] * instance_combiner * (eta_a + eta_c * z_b_s_at_beta[i][j]), z_a_j)
                         .add(-t_at_beta_s[id] * v_X_at_beta[id] * instance_combiner, w_j);
                 }
                circuit_term

--- a/algorithms/src/snark/marlin/ahp/errors.rs
+++ b/algorithms/src/snark/marlin/ahp/errors.rs
@@ -23,6 +23,8 @@ pub enum AHPError {
     ConstraintSystemError(snarkvm_r1cs::errors::SynthesisError),
     /// The instance generated during proving does not match that in the index.
     InstanceDoesNotMatchIndex,
+    /// Could not convert from int.
+    IntError(std::num::TryFromIntError),
     /// The number of public inputs is incorrect.
     InvalidPublicInputLength,
     /// During verification, a required evaluation is missing
@@ -36,5 +38,11 @@ pub enum AHPError {
 impl From<snarkvm_r1cs::errors::SynthesisError> for AHPError {
     fn from(other: snarkvm_r1cs::errors::SynthesisError) -> Self {
         AHPError::ConstraintSystemError(other)
+    }
+}
+
+impl From<std::num::TryFromIntError> for AHPError {
+    fn from(other: std::num::TryFromIntError) -> Self {
+        Self::IntError(other)
     }
 }

--- a/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
@@ -115,7 +115,7 @@ impl<F: PrimeField, MM: MarlinMode> Circuit<F, MM> {
     }
 
     /// The maximum degree required to represent polynomials of this index.
-    pub fn max_degree(&self) -> usize {
+    pub fn max_degree(&self) -> u32 {
         self.index_info.max_degree::<MM>()
     }
 

--- a/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
@@ -160,15 +160,14 @@ impl<F: PrimeField, MM: MarlinMode> CanonicalSerialize for Circuit<F, MM> {
 
     #[allow(unused_mut, unused_variables)]
     fn serialized_size(&self, mode: Compress) -> usize {
-        let mut size = 0;
-        size += self.index_info.serialized_size(mode);
-        size += self.a.serialized_size(mode);
-        size += self.b.serialized_size(mode);
-        size += self.c.serialized_size(mode);
-        size += self.a_arith.serialized_size(mode);
-        size += self.b_arith.serialized_size(mode);
-        size += self.c_arith.serialized_size(mode);
-        size
+        0usize
+            .saturating_add(self.index_info.serialized_size(mode))
+            .saturating_add(self.a.serialized_size(mode))
+            .saturating_add(self.b.serialized_size(mode))
+            .saturating_add(self.c.serialized_size(mode))
+            .saturating_add(self.a_arith.serialized_size(mode))
+            .saturating_add(self.b_arith.serialized_size(mode))
+            .saturating_add(self.c_arith.serialized_size(mode))
     }
 }
 

--- a/algorithms/src/snark/marlin/ahp/indexer/circuit_info.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/circuit_info.rs
@@ -45,7 +45,7 @@ pub struct CircuitInfo<F: Sync + Send> {
 
 impl<F: PrimeField> CircuitInfo<F> {
     /// The maximum degree of polynomial required to represent this index in the AHP.
-    pub fn max_degree<MM: MarlinMode>(&self) -> usize {
+    pub fn max_degree<MM: MarlinMode>(&self) -> u32 {
         let max_non_zero = self.num_non_zero_a.max(self.num_non_zero_b).max(self.num_non_zero_c);
         AHPForR1CS::<F, MM>::max_degree(self.num_constraints, self.num_variables, max_non_zero).unwrap()
     }

--- a/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
@@ -136,7 +136,7 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
 
         let padding_time = start_timer!(|| "Padding matrices to make them square");
         crate::snark::marlin::ahp::matrices::pad_input_for_indexer_and_prover(&mut ics);
-        ics.make_matrices_square();
+        ics.make_matrices_square()?;
 
         let a = ics.a_matrix();
         let b = ics.b_matrix();

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/first.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/first.rs
@@ -51,9 +51,9 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
 
     /// Output the degree bounds of oracles in the first round.
     pub fn first_round_polynomial_info<'a>(
-        circuits: impl Iterator<Item = (&'a CircuitId, &'a usize)>,
+        batch_sizes: impl Iterator<Item = (&'a CircuitId, &'a usize)>,
     ) -> BTreeMap<PolynomialLabel, PolynomialInfo> {
-        let mut polynomials = circuits
+        let mut polynomials = batch_sizes
             .flat_map(|(&circuit_id, &batch_size)| {
                 (0..batch_size).flat_map(move |i| {
                     [
@@ -74,13 +74,14 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     #[allow(clippy::type_complexity)]
     pub fn prover_first_round<'a, R: RngCore>(
         mut state: prover::State<'a, F, MM>,
+        batch_sizes: impl Iterator<Item = (&'a CircuitId, &'a usize)>,
         rng: &mut R,
     ) -> Result<prover::State<'a, F, MM>, AHPError> {
         let round_time = start_timer!(|| "AHP::Prover::FirstRound");
         let mut r_b_s = Vec::with_capacity(state.circuit_specific_states.len());
-        let mut job_pool = snarkvm_utilities::ExecutionPool::with_capacity(3 * state.total_instances);
+        let mut job_pool = snarkvm_utilities::ExecutionPool::with_capacity((3 * state.total_instances).try_into()?);
         for (circuit, circuit_state) in state.circuit_specific_states.iter_mut() {
-            let batch_size = circuit_state.batch_size;
+            let batch_size = usize::try_from(circuit_state.batch_size)?;
 
             let z_a = circuit_state.z_a.take().unwrap();
             let z_b = circuit_state.z_b.take().unwrap();
@@ -123,20 +124,18 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
                 prover::SingleEntry { z_a, z_b, w_poly, z_a_poly, z_b_poly }
             })
             .collect::<Vec<_>>();
-        assert_eq!(batches.len(), state.total_instances);
+        assert_eq!(batches.len(), usize::try_from(state.total_instances)?);
 
         let mut circuit_specific_batches = BTreeMap::new();
         for ((circuit, state), r_b_s) in state.circuit_specific_states.iter_mut().zip(r_b_s) {
-            let batches = batches.drain(0..state.batch_size).collect_vec();
+            let batches = batches.drain(0..state.batch_size.try_into()?).collect_vec();
             circuit_specific_batches.insert(circuit.id, batches);
             state.mz_poly_randomizer = MM::ZK.then_some(r_b_s);
             end_timer!(round_time);
         }
         let mask_poly = Self::calculate_mask_poly(state.max_constraint_domain, rng);
         let oracles = prover::FirstOracles { batches: circuit_specific_batches, mask_poly };
-        assert!(oracles.matches_info(&Self::first_round_polynomial_info(
-            state.circuit_specific_states.iter().map(|(c, s)| (&c.id, &s.batch_size))
-        )));
+        assert!(oracles.matches_info(&Self::first_round_polynomial_info(batch_sizes)));
         state.first_round_oracles = Some(Arc::new(oracles));
         Ok(state)
     }

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/mod.rs
@@ -64,7 +64,7 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
                             circuit.id
                         ));
                         crate::snark::marlin::ahp::matrices::pad_input_for_indexer_and_prover(&mut pcs);
-                        pcs.make_matrices_square();
+                        pcs.make_matrices_square()?;
                         end_timer!(padding_time);
 
                         let prover::ConstraintSystem {

--- a/algorithms/src/snark/marlin/ahp/prover/state.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/state.rs
@@ -32,7 +32,7 @@ pub struct CircuitSpecificState<F: PrimeField> {
     pub(super) non_zero_c_domain: EvaluationDomain<F>,
 
     /// The number of instances being proved in this batch.
-    pub(in crate::snark) batch_size: usize,
+    pub(in crate::snark) batch_size: u32,
 
     /// The list of public inputs for each instance in the batch.
     /// The length of this list must be equal to the batch size.
@@ -76,7 +76,7 @@ pub struct State<'a, F: PrimeField, MM: MarlinMode> {
     /// The largest constraint domain of all circuits in the batch.
     pub(in crate::snark) max_constraint_domain: EvaluationDomain<F>,
     /// The total number of instances we're proving in the batch.
-    pub(in crate::snark) total_instances: usize,
+    pub(in crate::snark) total_instances: u32,
 }
 
 /// The public inputs for a single instance.
@@ -114,13 +114,14 @@ impl<'a, F: PrimeField, MM: MarlinMode> State<'a, F, MM> {
 
                 let first_padded_public_inputs = &variable_assignments[0].0;
                 let input_domain = EvaluationDomain::new(first_padded_public_inputs.len()).unwrap();
-                let batch_size = variable_assignments.len();
+                let batch_size = variable_assignments.len().try_into()?;
                 total_instances += batch_size;
-                let mut z_as = Vec::with_capacity(batch_size);
-                let mut z_bs = Vec::with_capacity(batch_size);
-                let mut x_polys = Vec::with_capacity(batch_size);
-                let mut padded_public_variables = Vec::with_capacity(batch_size);
-                let mut private_variables = Vec::with_capacity(batch_size);
+                let batch_size_usize = batch_size as usize;
+                let mut z_as = Vec::with_capacity(batch_size_usize);
+                let mut z_bs = Vec::with_capacity(batch_size_usize);
+                let mut x_polys = Vec::with_capacity(batch_size_usize);
+                let mut padded_public_variables = Vec::with_capacity(batch_size_usize);
+                let mut private_variables = Vec::with_capacity(batch_size_usize);
 
                 for Assignments(padded_public_input, private_input, z_a, z_b) in variable_assignments {
                     z_as.push(z_a);
@@ -165,7 +166,7 @@ impl<'a, F: PrimeField, MM: MarlinMode> State<'a, F, MM> {
     }
 
     /// Get the batch size for a given circuit.
-    pub fn batch_size(&self, circuit: &Circuit<F, MM>) -> Option<usize> {
+    pub fn batch_size(&self, circuit: &Circuit<F, MM>) -> Option<u32> {
         self.circuit_specific_states.get(circuit).map(|s| s.batch_size)
     }
 

--- a/algorithms/src/snark/marlin/ahp/prover/state.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/state.rs
@@ -101,7 +101,7 @@ impl<'a, F: PrimeField, MM: MarlinMode> State<'a, F, MM> {
     ) -> Result<Self, AHPError> {
         let mut max_constraint_domain: Option<EvaluationDomain<F>> = None;
         let mut max_non_zero_domain: Option<EvaluationDomain<F>> = None;
-        let mut total_instances = 0;
+        let mut total_instances: u32 = 0;
         let circuit_specific_states = indices_and_assignments
             .into_iter()
             .map(|(circuit, variable_assignments)| {
@@ -115,7 +115,8 @@ impl<'a, F: PrimeField, MM: MarlinMode> State<'a, F, MM> {
                 let first_padded_public_inputs = &variable_assignments[0].0;
                 let input_domain = EvaluationDomain::new(first_padded_public_inputs.len()).unwrap();
                 let batch_size = variable_assignments.len().try_into()?;
-                total_instances += batch_size;
+                total_instances =
+                    total_instances.checked_add(batch_size).ok_or_else(|| anyhow::anyhow!("Batch size too large"))?;
                 let batch_size_usize = batch_size as usize;
                 let mut z_as = Vec::with_capacity(batch_size_usize);
                 let mut z_bs = Vec::with_capacity(batch_size_usize);

--- a/algorithms/src/snark/marlin/ahp/verifier/messages.rs
+++ b/algorithms/src/snark/marlin/ahp/verifier/messages.rs
@@ -18,7 +18,7 @@ use snarkvm_fields::PrimeField;
 
 use crate::snark::marlin::{witness_label, CircuitId, MarlinMode};
 use itertools::Itertools;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, num::TryFromIntError};
 
 /// Randomizers used to combine circuit-specific and instance-specific elements in the AHP sumchecks
 #[derive(Clone, Debug)]
@@ -82,7 +82,7 @@ pub struct QuerySet<F: PrimeField> {
 }
 
 impl<F: PrimeField> QuerySet<F> {
-    pub fn new<MM: MarlinMode>(state: &super::State<F, MM>) -> Self {
+    pub fn new<MM: MarlinMode>(state: &super::State<F, MM>) -> Result<Self, TryFromIntError> {
         let beta = state.second_round_message.unwrap().beta;
         let gamma = state.gamma.unwrap();
         // For the first linear combination
@@ -93,8 +93,12 @@ impl<F: PrimeField> QuerySet<F> {
         // Note that z is the interpolation of x || w, so it equals x + v_X * w
         // We also use an optimization: instead of explicitly calculating z_c, we
         // use the "virtual oracle" z_a * z_b
-        Self {
-            batch_sizes: state.circuit_specific_states.iter().map(|(c, s)| (*c, s.batch_size)).collect(),
+        Ok(Self {
+            batch_sizes: state
+                .circuit_specific_states
+                .iter()
+                .map(|(c, s)| Ok::<_, TryFromIntError>((*c, usize::try_from(s.batch_size)?)))
+                .try_collect()?,
             g_1_query: ("beta".into(), beta),
             z_b_query: ("beta".into(), beta),
             lincheck_sumcheck_query: ("beta".into(), beta),
@@ -103,7 +107,7 @@ impl<F: PrimeField> QuerySet<F> {
             g_b_query: ("gamma".into(), gamma),
             g_c_query: ("gamma".into(), gamma),
             matrix_sumcheck_query: ("gamma".into(), gamma),
-        }
+        })
     }
 
     /// Returns a `BTreeSet` containing elements of the form

--- a/algorithms/src/snark/marlin/ahp/verifier/state.rs
+++ b/algorithms/src/snark/marlin/ahp/verifier/state.rs
@@ -37,7 +37,7 @@ pub struct CircuitSpecificState<F: PrimeField> {
     pub(crate) non_zero_c_domain: EvaluationDomain<F>,
 
     /// The number of instances being proved in this batch.
-    pub(in crate::snark::marlin) batch_size: usize,
+    pub(in crate::snark::marlin) batch_size: u32,
 }
 /// State of the AHP verifier.
 #[derive(Debug)]

--- a/algorithms/src/snark/marlin/ahp/verifier/verifier.rs
+++ b/algorithms/src/snark/marlin/ahp/verifier/verifier.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 use smallvec::SmallVec;
 use snarkvm_fields::PrimeField;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, num::TryFromIntError};
 
 impl<TargetField: PrimeField, MM: MarlinMode> AHPForR1CS<TargetField, MM> {
     /// Output the first message and next round state.
@@ -104,7 +104,7 @@ impl<TargetField: PrimeField, MM: MarlinMode> AHPForR1CS<TargetField, MM> {
                 non_zero_a_domain,
                 non_zero_b_domain,
                 non_zero_c_domain,
-                batch_size: *batch_size,
+                batch_size: (*batch_size).try_into()?,
             };
             circuit_specific_states.insert(*circuit_id, circuit_specific_state);
         }
@@ -184,7 +184,9 @@ impl<TargetField: PrimeField, MM: MarlinMode> AHPForR1CS<TargetField, MM> {
     }
 
     /// Output the query state and next round state.
-    pub fn verifier_query_set(state: State<TargetField, MM>) -> (QuerySet<TargetField>, State<TargetField, MM>) {
-        (QuerySet::new(&state), state)
+    pub fn verifier_query_set(
+        state: State<TargetField, MM>,
+    ) -> Result<(QuerySet<TargetField>, State<TargetField, MM>), TryFromIntError> {
+        Ok((QuerySet::new(&state)?, state))
     }
 }

--- a/algorithms/src/snark/marlin/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/marlin/data_structures/circuit_verifying_key.rs
@@ -97,7 +97,7 @@ impl<E: PairingEngine, MM: MarlinMode> From<PreparedCircuitVerifyingKey<E, MM>> 
 }
 
 impl<E: PairingEngine, MM: MarlinMode> ToMinimalBits for CircuitVerifyingKey<E, MM> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
         let constraint_domain = EvaluationDomain::<E::Fr>::new(self.circuit_info.num_constraints)
             .ok_or(SynthesisError::PolynomialDegreeTooLarge)
             .unwrap();
@@ -111,15 +111,10 @@ impl<E: PairingEngine, MM: MarlinMode> ToMinimalBits for CircuitVerifyingKey<E, 
             .ok_or(SynthesisError::PolynomialDegreeTooLarge)
             .unwrap();
 
-        assert!(constraint_domain.size() < u64::MAX as usize);
-        assert!(non_zero_domain_a.size() < u64::MAX as usize);
-        assert!(non_zero_domain_b.size() < u64::MAX as usize);
-        assert!(non_zero_domain_c.size() < u64::MAX as usize);
-
-        let constraint_domain_size = constraint_domain.size() as u64;
-        let non_zero_domain_a_size = non_zero_domain_a.size() as u64;
-        let non_zero_domain_b_size = non_zero_domain_b.size() as u64;
-        let non_zero_domain_c_size = non_zero_domain_c.size() as u64;
+        let constraint_domain_size = u64::try_from(constraint_domain.size())?;
+        let non_zero_domain_a_size = u64::try_from(non_zero_domain_a.size())?;
+        let non_zero_domain_b_size = u64::try_from(non_zero_domain_b.size())?;
+        let non_zero_domain_c_size = u64::try_from(non_zero_domain_c.size())?;
 
         let constraint_domain_size_bits = constraint_domain_size
             .to_le_bytes()
@@ -142,16 +137,16 @@ impl<E: PairingEngine, MM: MarlinMode> ToMinimalBits for CircuitVerifyingKey<E, 
             .flat_map(|&byte| (0..8).map(move |i| (byte >> i) & 1u8 == 1u8))
             .collect::<Vec<bool>>();
 
-        let circuit_commitments_bits = self.circuit_commitments.to_minimal_bits();
+        let circuit_commitments_bits = self.circuit_commitments.to_minimal_bits()?;
 
-        [
+        Ok([
             constraint_domain_size_bits,
             non_zero_domain_size_a_bits,
             non_zero_domain_size_b_bits,
             non_zero_domain_size_c_bits,
             circuit_commitments_bits,
         ]
-        .concat()
+        .concat())
     }
 }
 

--- a/algorithms/src/snark/marlin/data_structures/proof.rs
+++ b/algorithms/src/snark/marlin/data_structures/proof.rs
@@ -374,6 +374,7 @@ impl<E: PairingEngine> FromBytes for Proof<E> {
 }
 
 #[cfg(test)]
+#[allow(clippy::cast_possible_truncation)]
 mod test {
     #![allow(non_camel_case_types)]
 

--- a/algorithms/src/snark/marlin/data_structures/test_circuit.rs
+++ b/algorithms/src/snark/marlin/data_structures/test_circuit.rs
@@ -67,11 +67,16 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for TestCircuit<Cons
 
         let mul_constraints = self.mul_depth - 1;
         for i in 0..(self.num_constraints - mul_constraints) {
-            cs.enforce(|| format!("constraint {i}"), |lc| lc + a, |lc| lc + b, |lc| lc + mul_vars[0]);
+            cs.enforce(|| format!("constraint {i}"), |lc| lc + a, |lc| lc + b, |lc| lc + mul_vars[0])?;
         }
 
         for i in 0..mul_constraints {
-            cs.enforce(|| format!("constraint_mul {i}"), |lc| lc + mul_vars[i], |lc| lc + b, |lc| lc + mul_vars[i + 1]);
+            cs.enforce(
+                || format!("constraint_mul {i}"),
+                |lc| lc + mul_vars[i],
+                |lc| lc + b,
+                |lc| lc + mul_vars[i + 1],
+            )?;
         }
 
         Ok(())

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -887,7 +887,7 @@ where
                 }
                 let eval = proof
                     .evaluations
-                    .get(circuit_index as usize, &label)?
+                    .get(usize::try_from(circuit_index)?, &label)?
                     .ok_or_else(|| AHPError::MissingEval(label.clone()))?;
                 evaluations.insert((label, q), eval);
             }

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -391,7 +391,7 @@ where
         let mut batch_sizes = BTreeMap::new();
         let mut circuit_infos = BTreeMap::new();
         let mut inputs_and_batch_sizes = BTreeMap::new();
-        let mut total_instances = 0;
+        let mut total_instances = 0u32;
         let mut public_inputs = BTreeMap::new(); // inputs need to live longer than the rest of prover_state
         let mut circuit_ids = Vec::with_capacity(keys_to_constraints.len());
         for pk in keys_to_constraints.keys() {
@@ -404,7 +404,7 @@ where
             circuit_infos.insert(circuit_id, &pk.circuit_verifying_key.circuit_info);
             inputs_and_batch_sizes.insert(circuit_id, (batch_size, padded_public_input));
             public_inputs.insert(circuit_id, public_input);
-            total_instances += batch_size;
+            total_instances = total_instances.saturating_add(batch_size);
 
             let batch_size = usize::try_from(batch_size)?;
             batch_sizes.insert(circuit_id, batch_size);

--- a/algorithms/src/traits/algebraic_sponge.rs
+++ b/algorithms/src/traits/algebraic_sponge.rs
@@ -68,7 +68,7 @@ pub trait AlgebraicSponge<F: PrimeField, const RATE: usize>: Clone + Debug {
         self.absorb_native_field_elements(&elements);
     }
 
-    /// Takes in field elements.
+    /// Takes out field elements.
     fn squeeze_native_field_elements(&mut self, num: usize) -> SmallVec<[F; 10]>;
 
     /// Takes out field elements.

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -206,7 +206,7 @@ impl<F: PrimeField> snarkvm_r1cs::ConstraintSynthesizer<F> for Assignment<F> {
                 |lc| lc + convert_linear_combination(a),
                 |lc| lc + convert_linear_combination(b),
                 |lc| lc + convert_linear_combination(c),
-            );
+            )?;
         }
 
         // Ensure the given `cs` matches in size with the first system.

--- a/circuit/environment/src/helpers/converter.rs
+++ b/circuit/environment/src/helpers/converter.rs
@@ -150,7 +150,7 @@ impl<F: PrimeField> R1CS<F> {
                 |lc| lc + convert_linear_combination(a),
                 |lc| lc + convert_linear_combination(b),
                 |lc| lc + convert_linear_combination(c),
-            );
+            )?;
         }
 
         // Ensure the given `cs` matches in size with the first system.

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -265,11 +265,11 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
         let mut res_bits = self.x.to_bits_le();
         res_bits.push(*self.y.to_bits_le().first().unwrap());
         res_bits.push(self.infinity);
-        res_bits
+        Ok(res_bits)
     }
 }
 

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -258,8 +258,8 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
-        self.x.to_bits_le()
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
+        Ok(self.x.to_bits_le())
     }
 }
 

--- a/r1cs/src/constraint_system.rs
+++ b/r1cs/src/constraint_system.rs
@@ -60,7 +60,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     /// Enforce that `A` * `B` = `C`. The `annotation` function is invoked in
     /// testing contexts in order to derive a unique name for the constraint
     /// in the current namespace.
-    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
+    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC) -> Result<(), SynthesisError>
     where
         A: FnOnce() -> AR,
         AR: AsRef<str>,
@@ -138,7 +138,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for &mut CS {
     }
 
     #[inline]
-    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
+    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC) -> Result<(), SynthesisError>
     where
         A: FnOnce() -> AR,
         AR: AsRef<str>,

--- a/r1cs/src/errors.rs
+++ b/r1cs/src/errors.rs
@@ -31,24 +31,27 @@ pub enum SynthesisError {
     /// During synthesis, we divided by zero.
     #[error("Division by zero during synthesis")]
     DivisionByZero,
-    /// During synthesis, we constructed an unsatisfiable constraint system.
-    #[error("Unsatisfiable constraint system")]
-    Unsatisfiable,
-    /// During synthesis, our polynomials ended up being too high of degree
-    #[error("Polynomial degree is too large")]
-    PolynomialDegreeTooLarge,
-    /// During proof generation, we encountered an identity in the CRS
-    #[error("Encountered an identity element in the CRS")]
-    UnexpectedIdentity,
+    /// During synthesis, we could not recover our desired int.
+    #[error(transparent)]
+    IntError(#[from] std::num::TryFromIntError),
     /// During proof generation, we encountered an I/O error with the CRS
     #[error("Encountered an I/O error")]
     IoError(std::io::Error),
     /// During verification, our verifying key was malformed.
     #[error("Malformed verifying key, public input count was {} but expected {}", _0, _1)]
     MalformedVerifyingKey(usize, usize),
+    /// During synthesis, our polynomials ended up being too high of degree
+    #[error("Polynomial degree is too large")]
+    PolynomialDegreeTooLarge,
     /// During CRS generation, we observed an unconstrained auxiliary variable
     #[error("Auxiliary variable was unconstrained")]
     UnconstrainedVariable,
+    /// During proof generation, we encountered an identity in the CRS
+    #[error("Encountered an identity element in the CRS")]
+    UnexpectedIdentity,
+    /// During synthesis, we constructed an unsatisfiable constraint system.
+    #[error("Unsatisfiable constraint system")]
+    Unsatisfiable,
 }
 
 impl From<std::io::Error> for SynthesisError {

--- a/r1cs/src/namespace.rs
+++ b/r1cs/src/namespace.rs
@@ -52,7 +52,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for Namespace<'_, F,
     }
 
     #[inline]
-    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
+    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC) -> Result<(), SynthesisError>
     where
         A: FnOnce() -> AR,
         AR: AsRef<str>,

--- a/r1cs/src/test_constraint_system.rs
+++ b/r1cs/src/test_constraint_system.rs
@@ -409,7 +409,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         Ok(var)
     }
 
-    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
+    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC) -> Result<(), SynthesisError>
     where
         A: FnOnce() -> AR,
         AR: AsRef<str>,
@@ -438,6 +438,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         let c = intern_fields(c(LinearCombination::zero()).0);
 
         self.constraints.insert(TestConstraint { interned_path, a, b, c });
+        Ok(())
     }
 
     fn push_namespace<NR: AsRef<str>, N: FnOnce() -> NR>(&mut self, name_fn: N) {

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -214,13 +214,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(1385, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(1383, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(1350, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(1348, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -254,13 +254,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2590, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2587, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2555, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2552, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -289,13 +289,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2475, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2472, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2440, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2437, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -323,13 +323,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2487, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2484, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2452, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2449, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -352,6 +352,6 @@ mod tests {
 
         // Assert the size of the transition.
         let fee_size_in_bytes = fee.to_bytes_le().unwrap().len();
-        assert_eq!(2242, fee_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2239, fee_size_in_bytes, "Update me if serialization has changed");
     }
 }

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -214,13 +214,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(1387, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(1385, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(1352, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(1350, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -254,13 +254,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2595, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2590, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2560, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2555, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -289,13 +289,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2480, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2475, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2445, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2440, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -323,13 +323,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2492, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2487, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2457, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2452, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -352,6 +352,6 @@ mod tests {
 
         // Assert the size of the transition.
         let fee_size_in_bytes = fee.to_bytes_le().unwrap().len();
-        assert_eq!(2247, fee_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2242, fee_size_in_bytes, "Update me if serialization has changed");
     }
 }

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -36,16 +36,16 @@ pub trait FromBits: Sized {
 
 pub trait ToMinimalBits: Sized {
     /// Returns `self` as a minimal boolean array.
-    fn to_minimal_bits(&self) -> Vec<bool>;
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError>;
 }
 
 impl<T: ToMinimalBits> ToMinimalBits for Vec<T> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
         let mut res_bits = vec![];
         for elem in self.iter() {
-            res_bits.extend(elem.to_minimal_bits());
+            res_bits.extend(elem.to_minimal_bits()?);
         }
-        res_bits
+        Ok(res_bits)
     }
 }
 


### PR DESCRIPTION
## Motivation

We should avoid panics, this PR adds checking if additions are allowed in snarkVM. I could not find problematic subtraction cases.

For this, we should agree on the attack surface. I can imagine the following attack vectors:
- an attacker lets different nodes misinterpret a serialized object, which can happen if our flags are serialized last. Fortunately I haven't seen this anywhere.
- an attacker's frontend lets an honest user serialize a giant object so their local node panics, I don't think this is a huge issue
- an attacker lets an honest node deserialize a giant object so it panics. This might kill the network so we should prevent this. Nodes already seem to have a [maximum message size](https://github.com/AleoHQ/snarkOS/blob/1ec292b8d3d71013f43084f663e4e7b926e8c170/node/messages/src/helpers/codec.rs#L26), but as defense in depth I use `saturating_add` in `serialized_size`. Using `checked_add` there is tricky as it will change the `serialized_size` trait function signature all over the codebase, including in macros and for types which we know have a fixed size.

## Test Plan

Our usual test suite

## Related PRs

Merging into https://github.com/AleoHQ/snarkVM/pull/1499