### PR TITLE
[Feature] Permutation Assignment.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2400,7 @@ name = "snarkvm-circuit-algorithms"
 version = "0.11.2"
 dependencies = [
  "anyhow",
+ "rand",
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
  "snarkvm-curves",
@@ -2579,6 +2596,8 @@ dependencies = [
  "criterion",
  "expect-test",
  "hex",
+ "petgraph",
+ "rand",
  "serde",
  "serde_json",
  "smallvec",

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -32,6 +32,9 @@ default-features = false
 [dev-dependencies.anyhow]
 version = "1.0.71"
 
+[dev-dependencies.rand]
+version = "0.8.5"
+
 [features]
 default = [ "enable_console" ]
 enable_console = [ "console" ]

--- a/circuit/algorithms/src/waksman/check.rs
+++ b/circuit/algorithms/src/waksman/check.rs
@@ -29,3 +29,115 @@ impl<E: Environment> ASWaksman<E> {
         output.iter().zip_eq(second).fold(Boolean::constant(true), |acc, (a, b)| acc & a.is_equal(b))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use snarkvm_circuit_types::environment::Circuit;
+    use snarkvm_utilities::{TestRng, Uniform};
+
+    use rand::seq::SliceRandom;
+    use std::iter;
+
+    const ITERATIONS: usize = 10;
+
+    type CurrentEnvironment = Circuit;
+
+    #[test]
+    fn test_check_permutation() {
+        // A helper function to check that `check_permutation` returns the expected result.
+        fn run_test(n: usize, iterations: usize, rng: &mut TestRng) {
+            for mode in [Mode::Constant, Mode::Public, Mode::Private] {
+                for i in 0..iterations {
+                    // Sample a random permutation.
+                    let mut permutation: Vec<usize> = (0..n).collect();
+                    permutation.shuffle(rng);
+                    // Compute the inverse permutation.
+                    let inverse_permutation = permutation
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &j)| (j, i))
+                        .sorted()
+                        .map(|(_, i)| i)
+                        .collect::<Vec<_>>();
+                    // Sample a random sequence of inputs.
+                    let inputs: Vec<console::Field<<CurrentEnvironment as Environment>::Network>> =
+                        iter::repeat_with(|| Uniform::rand(rng)).take(n).collect();
+                    // Instantiate the Waksman network.
+                    let network = console::ASWaksman::<_>::new(n);
+                    // Compute the selectors.
+                    let selectors = network.assign_selectors(&permutation);
+                    assert_eq!(selectors.len(), network.num_selectors());
+                    // Apply the permutation to the inputs.
+                    let mut outputs = Vec::with_capacity(n);
+                    for i in 0..inputs.len() {
+                        outputs.push(inputs[inverse_permutation[i]]);
+                    }
+                    // Check the permutation.
+                    assert!(*network.check_permutation(&inputs, &outputs, &selectors));
+
+                    // Inject the inputs.
+                    let inputs = inputs
+                        .into_iter()
+                        .map(|input| Field::<CurrentEnvironment>::new(mode, input))
+                        .collect::<Vec<_>>();
+                    // Inject the selectors.
+                    let selectors = selectors
+                        .into_iter()
+                        .map(|selector| Boolean::<CurrentEnvironment>::new(mode, *selector))
+                        .collect::<Vec<_>>();
+                    // Inject the outputs.
+                    let outputs = outputs
+                        .into_iter()
+                        .map(|output| Field::<CurrentEnvironment>::new(mode, output))
+                        .collect::<Vec<_>>();
+                    // Initialize the network.
+                    let network = ASWaksman::<_>::new(n);
+                    CurrentEnvironment::scope(format!("TestCheckPermutation(Mode: {mode}, Iteration: {i})"), || {
+                        let is_satisfied = network.check_permutation(&inputs, &outputs, &selectors);
+                        assert!(is_satisfied.eject_value());
+                        assert!(Circuit::is_satisfied());
+                    });
+                    Circuit::reset();
+                }
+            }
+        }
+
+        let mut rng = TestRng::default();
+
+        run_test(1, ITERATIONS, &mut rng);
+        run_test(2, ITERATIONS, &mut rng);
+        run_test(3, ITERATIONS, &mut rng);
+        run_test(4, ITERATIONS, &mut rng);
+        run_test(5, ITERATIONS, &mut rng);
+        run_test(6, ITERATIONS, &mut rng);
+        run_test(7, ITERATIONS, &mut rng);
+        run_test(8, ITERATIONS, &mut rng);
+        run_test(9, ITERATIONS, &mut rng);
+        run_test(10, ITERATIONS, &mut rng);
+        run_test(11, ITERATIONS, &mut rng);
+        run_test(12, ITERATIONS, &mut rng);
+        run_test(13, ITERATIONS, &mut rng);
+        run_test(14, ITERATIONS, &mut rng);
+        run_test(15, ITERATIONS, &mut rng);
+        run_test(16, ITERATIONS, &mut rng);
+        run_test(17, ITERATIONS, &mut rng);
+        run_test(32, ITERATIONS, &mut rng);
+        run_test(33, ITERATIONS, &mut rng);
+        run_test(64, ITERATIONS, &mut rng);
+        run_test(65, ITERATIONS, &mut rng);
+        run_test(128, ITERATIONS, &mut rng);
+        run_test(129, ITERATIONS, &mut rng);
+        run_test(256, ITERATIONS, &mut rng);
+        run_test(257, ITERATIONS, &mut rng);
+        run_test(512, ITERATIONS, &mut rng);
+        run_test(513, ITERATIONS, &mut rng);
+        run_test(1024, ITERATIONS, &mut rng);
+        run_test(1025, ITERATIONS, &mut rng);
+        run_test(2048, ITERATIONS, &mut rng);
+        run_test(2049, ITERATIONS, &mut rng);
+        run_test(4096, ITERATIONS, &mut rng);
+        run_test(4097, ITERATIONS, &mut rng);
+    }
+}

--- a/circuit/algorithms/src/waksman/mod.rs
+++ b/circuit/algorithms/src/waksman/mod.rs
@@ -186,11 +186,104 @@ mod test {
     use snarkvm_circuit_types::environment::{assert_scope, Circuit};
     use snarkvm_utilities::{TestRng, Uniform};
 
+    use rand::seq::SliceRandom;
     use std::iter;
 
     const ITERATIONS: usize = 10;
 
     type CurrentEnvironment = Circuit;
+
+    #[test]
+    fn test_random_networks() {
+        // A helper function to run a test that samples random permutations, assigns selectors, and checks that the Waksman network computes the correct permutation.
+        fn run_test(n: usize, iterations: usize, rng: &mut TestRng) {
+            for mode in [Mode::Constant, Mode::Public, Mode::Private] {
+                for i in 0..iterations {
+                    // Sample a random permutation.
+                    let mut permutation: Vec<usize> = (0..n).collect();
+                    permutation.shuffle(rng);
+                    // Compute the inverse permutation.
+                    let inverse_permutation = permutation
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &j)| (j, i))
+                        .sorted()
+                        .map(|(_, i)| i)
+                        .collect::<Vec<_>>();
+                    // Sample a random sequence of inputs.
+                    let inputs: Vec<console::Field<<CurrentEnvironment as Environment>::Network>> =
+                        iter::repeat_with(|| Uniform::rand(rng)).take(n).collect();
+                    // Instantiate the Waksman network.
+                    let network = console::ASWaksman::<<CurrentEnvironment as Environment>::Network>::new(n);
+                    // Compute the selectors.
+                    let selectors = network.assign_selectors(&permutation);
+                    assert_eq!(selectors.len(), network.num_selectors());
+                    // Apply the permutation to the inputs.
+                    let mut expected_outputs = Vec::with_capacity(n);
+                    for i in 0..inputs.len() {
+                        expected_outputs.push(inputs[inverse_permutation[i]]);
+                    }
+                    // Inject the inputs.
+                    let inputs = inputs
+                        .into_iter()
+                        .map(|input| Field::<CurrentEnvironment>::new(mode, input))
+                        .collect::<Vec<_>>();
+                    // Inject the selectors.
+                    let selectors = selectors
+                        .into_iter()
+                        .map(|selector| Boolean::<CurrentEnvironment>::new(mode, *selector))
+                        .collect::<Vec<_>>();
+                    // Initialize the network.
+                    let network = ASWaksman::<_>::new(n);
+                    CurrentEnvironment::scope(format!("TestRandomRun(Mode: {mode}, Iteration: {i})"), || {
+                        let outputs = network.run(&inputs, &selectors);
+                        // Check that the outputs are correct.
+                        for (expected, actual) in expected_outputs.iter().zip_eq(outputs.iter()) {
+                            assert_eq!(*expected, actual.eject_value());
+                        }
+                        assert!(Circuit::is_satisfied());
+                    });
+                    Circuit::reset();
+                }
+            }
+        }
+
+        let mut rng = TestRng::default();
+
+        run_test(1, ITERATIONS, &mut rng);
+        run_test(2, ITERATIONS, &mut rng);
+        run_test(3, ITERATIONS, &mut rng);
+        run_test(4, ITERATIONS, &mut rng);
+        run_test(5, ITERATIONS, &mut rng);
+        run_test(6, ITERATIONS, &mut rng);
+        run_test(7, ITERATIONS, &mut rng);
+        run_test(8, ITERATIONS, &mut rng);
+        run_test(9, ITERATIONS, &mut rng);
+        run_test(10, ITERATIONS, &mut rng);
+        run_test(11, ITERATIONS, &mut rng);
+        run_test(12, ITERATIONS, &mut rng);
+        run_test(13, ITERATIONS, &mut rng);
+        run_test(14, ITERATIONS, &mut rng);
+        run_test(15, ITERATIONS, &mut rng);
+        run_test(16, ITERATIONS, &mut rng);
+        run_test(17, ITERATIONS, &mut rng);
+        run_test(32, ITERATIONS, &mut rng);
+        run_test(33, ITERATIONS, &mut rng);
+        run_test(64, ITERATIONS, &mut rng);
+        run_test(65, ITERATIONS, &mut rng);
+        run_test(128, ITERATIONS, &mut rng);
+        run_test(129, ITERATIONS, &mut rng);
+        run_test(256, ITERATIONS, &mut rng);
+        run_test(257, ITERATIONS, &mut rng);
+        run_test(512, ITERATIONS, &mut rng);
+        run_test(513, ITERATIONS, &mut rng);
+        run_test(1024, ITERATIONS, &mut rng);
+        run_test(1025, ITERATIONS, &mut rng);
+        run_test(2048, ITERATIONS, &mut rng);
+        run_test(2049, ITERATIONS, &mut rng);
+        run_test(4096, ITERATIONS, &mut rng);
+        run_test(4097, ITERATIONS, &mut rng);
+    }
 
     #[test]
     #[should_panic]
@@ -228,6 +321,7 @@ mod test {
                             ),
                         }
                     });
+                    Circuit::reset();
                 }
             }
         }
@@ -319,6 +413,7 @@ mod test {
                             ),
                         }
                     });
+                    Circuit::reset();
                 }
             }
         }

--- a/console/algorithms/Cargo.toml
+++ b/console/algorithms/Cargo.toml
@@ -34,6 +34,9 @@ version = "=0.11.2"
 [dependencies.blake2s_simd]
 version = "1.0"
 
+[dependencies.petgraph]
+version = "0.6.3"
+
 [dependencies.smallvec]
 version = "1.10"
 default-features = false
@@ -51,6 +54,9 @@ version = "1.4"
 
 [dev-dependencies.hex]
 version = "0.4"
+
+[dev-dependencies.rand]
+version = "0.8.5"
 
 [dev-dependencies.serde]
 version = "1.0"

--- a/console/algorithms/src/waksman/assign.rs
+++ b/console/algorithms/src/waksman/assign.rs
@@ -1,18 +1,16 @@
 // Copyright (C) 2019-2023 Aleo Systems Inc.
 // This file is part of the snarkVM library.
 
-// The snarkVM library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
 
-// The snarkVM library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use super::*;
 

--- a/console/algorithms/src/waksman/assign.rs
+++ b/console/algorithms/src/waksman/assign.rs
@@ -1,0 +1,291 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use petgraph::{
+    algo::{condensation, toposort},
+    Directed,
+    Graph,
+};
+use std::collections::{BTreeMap, HashSet};
+
+impl<E: Environment> ASWaksman<E> {
+    /// Returns the sequence of selector bits that implements the given `permutation`.
+    /// `permutation[i] = k` indicates the permutation maps the element in the `i`th position of the input to the `k`th position of the output.
+    pub fn assign_selectors(&self, permutation: &[usize]) -> Vec<Boolean<E>> {
+        // Check that the size of the permutation correct.
+        if permutation.len() != self.num_inputs {
+            return E::halt(format!("The size of the permutation must be exactly {}.", self.num_inputs));
+        }
+
+        // Check that the `permutation` is valid.
+        // For the `permutation` to be valid, the elements must be unique and the largest element must be less than the number of inputs.
+        // Note that this unwrap is safe since `self.num_inputs` is always greater than zero.
+        let mut permutation_vec = permutation.to_vec();
+        permutation_vec.dedup();
+        if !(permutation.len() == permutation_vec.len() && permutation.iter().max().unwrap() < &self.num_inputs) {
+            return E::halt("Invalid permutation.");
+        }
+
+        let selectors = match permutation.len() {
+            // Base Case #1: The network has exactly one input.
+            // In this case, the network is a single wire, and there are no selectors.
+            1 => vec![],
+            // Base Case #2: The network has exactly two inputs.
+            // In this case, the network is a single switch, and there is exactly one selector.
+            2 => vec![Boolean::new(permutation[0] == 1)],
+            _ => {
+                let mut selectors = Vec::with_capacity(self.num_selectors());
+                // Assign inputs to the upper and lower subnetworks, while satisfying the constraints given by the topology of the network.
+                // Note that `assign_to_upper_subnet[i] == true` indicates that the i-th input is assigned to the upper subnetwork.
+                // By definition, `assign_to_upper_subnet[2i] != assign_to_upper_subnet[2i + 1]`.
+                let assign_to_upper_subnet = assign_to_subnets::<E>(permutation);
+                // From the assignment, compute the input selectors.
+                // For all i, if `assign_to_upper_subnet[2i] == true`, then the selector for the switch must be false.
+                selectors.extend(
+                    assign_to_upper_subnet.iter().take(permutation.len() / 2 * 2).step_by(2).map(|&b| Boolean::new(!b)),
+                );
+
+                // Construct the permutation for the upper and lower subnetworks.
+                let mut upper_permutation = Vec::with_capacity(permutation.len() / 2);
+                let mut lower_permutation = Vec::with_capacity(permutation.len() - upper_permutation.len());
+                for (i, &b) in assign_to_upper_subnet.iter().enumerate() {
+                    if b {
+                        upper_permutation.push(permutation[i] / 2);
+                    } else {
+                        lower_permutation.push(permutation[i] / 2);
+                    }
+                }
+
+                // Compute the selectors for the upper subnetwork.
+                selectors.extend(ASWaksman::new(upper_permutation.len()).assign_selectors(&upper_permutation));
+
+                // Compute the selectors for the lower subnetwork.
+                selectors.extend(ASWaksman::new(lower_permutation.len()).assign_selectors(&lower_permutation));
+
+                // Compute the inverse of the permutation.
+                let inverse_permutation = invert_permutation(permutation);
+                // Compute the selectors for the output switches.
+                // For all i, except the last, if `assign_to_upper_subnet[inverse_permutation[2i]] == true`, then the selector for the switch must be false.
+                for i in 0..((inverse_permutation.len() - 1) / 2) {
+                    selectors.push(Boolean::new(!assign_to_upper_subnet[inverse_permutation[2 * i]]));
+                }
+                selectors
+            }
+        };
+
+        // If the computed number of selectors does not match the expected number, then halt.
+        if selectors.len() != self.num_selectors() {
+            return E::halt(format!(
+                "The number of selectors is incorrect. Expected {}, found {}.",
+                self.num_selectors(),
+                selectors.len()
+            ));
+        }
+
+        selectors
+    }
+}
+
+/// A helper function that takes a `permutation` and returns a vector of booleans, indicating the subnetwork to which each input is assigned.
+/// If `result[i] == true`, then the i-th input is assigned to the upper subnetwork.
+/// If `result[i] == false`, then the i-th input is assigned to the lower subnetwork.
+fn assign_to_subnets<E: Environment>(permutation: &[usize]) -> Vec<bool> {
+    // The assignment to subnetworks is computed by encoding the network topology and desired permutation as an instance of the 2-SAT problem.
+    //
+    // First,
+    // - Let `N` be the number of inputs.
+    // - Let `x_i` be a boolean variable for each input `i`, indicating whether or not the input is assigned to the upper subnetwork.
+    // - Let `inv: usize -> usize` be the inverse of the permutation, s.t `permutation[i] == j` iff `inv[j] == i`.
+    //
+    // The encoding is as follows:
+    // 1. For each `i` in `0..(N / 2)`, add the clauses:  ( x_{2i} | x_{2i + 1} ) & ( ~x_{2i} | ~x_{2i + 1} ).
+    //   These clauses ensure that for every pair of inputs assigned to the same input switch, exactly one of the inputs is assigned to the upper subnetwork.
+    // 2. For each `i` in `0..((N - 1)) / 2)`, add the clauses:  ( x_{inv(2i)} | x_{inv(2i + 1)} ) & ( ~x_{inv(2i)} | ~x_{inv(2i + 1)} ).
+    //   These clauses ensure that for every pair of outputs assigned to the same output switch, exactly one of the outputs is produced by the upper subnetwork.
+    // 3. Add the clause:  ( ~x_{inv(N - 1)} | false )
+    //   This clause ensures that the last output is produced by the lower subnetwork.
+    // 4. If `N` is even, add the clause:  ( x_{inv(N - 2)} | false )
+    //   In the case where the number of inputs is even, this clause ensures that the second-to-last output is produced by the upper subnetwork.
+    //
+    // The 2-SAT instance is encoded as an implication graph.
+    // That is, for each clause `(a | b)` in the 2-SAT instance, the implication graph must have the edges `~b ==> a` and `~a ==> b`.
+    // See https://en.wikipedia.org/wiki/2-satisfiability for more details on the graph encoding and how a satisfying assignment is produced.
+
+    // Compute the inverse of the permutation.
+    let inverse_permutation = invert_permutation(permutation);
+
+    // Instantiate the implication graph.
+    let mut implication_graph =
+        Graph::<usize, usize, Directed>::with_capacity(permutation.len() * 2, permutation.len() * 2);
+
+    // Initialize the nodes.
+    // Note that the implication graph has `2N` vertices, one for each boolean variable and its negation.
+    // Note that `x_i` is represented by the vertex `2i`, and `~x_i` is represented by the vertex `2i + 1`.
+    let mut node_indices = Vec::with_capacity(permutation.len() * 2);
+    let num_variables = permutation.len() * 2;
+    for i in 0..num_variables {
+        node_indices.push(implication_graph.add_node(i));
+    }
+
+    // Helpers for indexing into the nodes.
+    let index = |i: usize| node_indices[2 * i];
+    let not_index = |i: usize| node_indices[2 * i + 1];
+
+    // Add clauses for Step 1, as described above.
+    for i in 0..(permutation.len() / 2) {
+        // Add an edge for the clause:  ( x_{2i} | x_{2i + 1} ).
+        // This corresponds to the implications: ~x_{2i + 1} ==> x_{2i} and ~x_{2i} ==> x_{2i + 1}.
+        implication_graph.add_edge(not_index(2 * i + 1), index(2 * i), 0);
+        implication_graph.add_edge(not_index(2 * i), index(2 * i + 1), 0);
+        // Add an edge for the clause:  ( ~x_{2i} | ~x_{2i + 1} ).
+        // This corresponds to the implications: x_{2i + 1} ==> ~x_{2i} and x_{2i} ==> ~x_{2i + 1}.
+        implication_graph.add_edge(index(2 * i + 1), not_index(2 * i), 0);
+        implication_graph.add_edge(index(2 * i), not_index(2 * i + 1), 0);
+    }
+
+    // Add clauses for Step 2, as described above.
+    for i in 0..((permutation.len() - 1) / 2) {
+        // Add an edge for the clause:  ( x_{inv(2i)} | x_{inv(2i + 1)} ).
+        // This corresponds to the implications: ~x_{inv(2i + 1)} ==> x_{inv(2i)} and ~x_{inv(2i)} ==> x_{inv(2i + 1)}.
+        implication_graph.add_edge(not_index(inverse_permutation[2 * i + 1]), index(inverse_permutation[2 * i]), 0);
+        implication_graph.add_edge(not_index(inverse_permutation[2 * i]), index(inverse_permutation[2 * i + 1]), 0);
+        // Add an edge for the clause:  ( ~x_{inv(2i)} | ~x_{inv(2i + 1)} ).
+        // This corresponds to the implications: x_{inv(2i + 1)} ==> ~x_{inv(2i)} and x_{inv(2i)} ==> ~x_{inv(2i + 1)}.
+        implication_graph.add_edge(index(inverse_permutation[2 * i + 1]), not_index(inverse_permutation[2 * i]), 0);
+        implication_graph.add_edge(index(inverse_permutation[2 * i]), not_index(inverse_permutation[2 * i + 1]), 0);
+    }
+
+    // Add clauses for Step 3, as described above.
+    // Add an edge for the clause:  ( ~x_{inv(N - 1)} | ~x_{inv(N - 1)} )
+    // This corresponds to the implication: x_{inv(N - 1)} ==> ~x_{inv(N - 1)}
+    let last_element_index = inverse_permutation[permutation.len() - 1];
+    implication_graph.add_edge(index(last_element_index), not_index(last_element_index), 0);
+
+    // Add clauses for Step 4, as described above.
+    if permutation.len() % 2 == 0 {
+        // Add an edge for the clause:  ( x_{inv(N - 2)} | x_{inv(N - 2)} )
+        // This corresponds to the implications: ~x_{inv(N - 2)} ==> x_{inv(N - 2)}
+        let second_last_element_index = inverse_permutation[permutation.len() - 2];
+        implication_graph.add_edge(not_index(second_last_element_index), index(second_last_element_index), 0);
+    }
+
+    // Compute the condensation of the implication graph.
+    let condensation = condensation(implication_graph, true);
+    // Get the topological ordering of the condensation.
+    // Note that the unwrap is safe since the condensation is guaranteed to be acyclic.
+    let topological_order = toposort(&condensation, None).unwrap();
+
+    // A helper function to get the complement of a variable.
+    let complement = |i: usize| if i % 2 == 0 { i + 1 } else { i - 1 };
+
+    // An assignment to the variables in the 2-SAT instance.
+    let mut assignment = BTreeMap::new();
+    // Process each element of the condensation in reverse topological order, check that 2-SAT instance is satisfiable, and construct the satisfying assignment.
+    for condensation_index in topological_order.iter().rev() {
+        // Check that a variable and its complement are not in the same node in the condensation.
+        // Note that the unwrap is safe since `condensation_index` is in the topological ordering of `condensation`.
+        let component = condensation.node_weight(*condensation_index).unwrap();
+        // Store each variable seen in the component in a set.
+        let mut seen = HashSet::with_capacity(component.len());
+        for index in component {
+            if seen.contains(&complement(*index)) {
+                // The 2-SAT instance is not satisfiable.
+                return E::halt("Could not find a satisfying assignment for the given permutation.");
+            } else {
+                // Mark the variable as seen.
+                seen.insert(*index);
+                // If the variable does not have an assignment, assign it `true`.
+                if assignment.get(index).is_some() {
+                    // The variable already has an assignment.
+                    continue;
+                } else {
+                    // Assign the variable `true`.
+                    assignment.insert(*index, true);
+                    // Assign its complement `false`.
+                    assignment.insert(complement(*index), false);
+                }
+            }
+        }
+    }
+    // Return the assignment, ignoring the negations of variables.
+    let assignment: Vec<bool> = assignment.into_values().step_by(2).collect();
+    assignment
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    type CurrentEnvironment = Console;
+
+    // A helper function to test that selectors are computed correctly.
+    fn test_selectors(permutation: &[usize], expected_selectors: &[bool]) {
+        let waksman = ASWaksman::<CurrentEnvironment>::new(permutation.len());
+        let selectors = waksman.assign_selectors(permutation);
+        assert_eq!(&selectors.into_iter().map(|b| *b).collect_vec(), expected_selectors);
+    }
+
+    #[test]
+    fn test_assign_selectors_one() {
+        test_selectors(&[0], &[]);
+    }
+
+    #[test]
+    fn test_assign_selectors_two() {
+        test_selectors(&[0, 1], &[false]);
+        test_selectors(&[1, 0], &[true]);
+    }
+
+    #[test]
+    fn test_assign_selectors_three() {
+        test_selectors(&[0, 1, 2], &[true, false, true]);
+        test_selectors(&[0, 2, 1], &[false, true, false]);
+        test_selectors(&[1, 0, 2], &[true, false, false]);
+        test_selectors(&[1, 2, 0], &[false, true, true]);
+        test_selectors(&[2, 0, 1], &[true, true, false]);
+        test_selectors(&[2, 1, 0], &[true, true, true]);
+    }
+
+    #[test]
+    fn test_assign_selectors_four() {
+        test_selectors(&[0, 1, 2, 3], &[true, false, false, false, true]);
+        test_selectors(&[0, 1, 3, 2], &[true, true, false, false, true]);
+        test_selectors(&[0, 2, 1, 3], &[true, false, true, false, true]);
+        test_selectors(&[0, 2, 3, 1], &[true, true, true, false, true]);
+        test_selectors(&[0, 3, 1, 2], &[false, true, false, true, false]);
+        test_selectors(&[0, 3, 2, 1], &[false, false, false, true, false]);
+        test_selectors(&[1, 0, 2, 3], &[true, false, false, false, false]);
+        test_selectors(&[1, 0, 3, 2], &[true, true, false, false, false]);
+        test_selectors(&[1, 2, 0, 3], &[true, false, true, false, false]);
+        test_selectors(&[1, 2, 3, 0], &[true, true, true, false, false]);
+        test_selectors(&[1, 3, 0, 2], &[false, true, false, true, true]);
+        test_selectors(&[1, 3, 2, 0], &[false, false, false, true, true]);
+        test_selectors(&[2, 0, 1, 3], &[false, false, true, false, true]);
+        test_selectors(&[2, 0, 3, 1], &[false, true, true, false, true]);
+        test_selectors(&[2, 1, 0, 3], &[false, false, true, false, false]);
+        test_selectors(&[2, 1, 3, 0], &[false, true, true, false, false]);
+        test_selectors(&[2, 3, 0, 1], &[false, true, true, true, true]);
+        test_selectors(&[2, 3, 1, 0], &[false, true, true, true, false]);
+        test_selectors(&[3, 0, 1, 2], &[true, true, false, true, false]);
+        test_selectors(&[3, 0, 2, 1], &[true, false, false, true, false]);
+        test_selectors(&[3, 1, 0, 2], &[true, true, false, true, true]);
+        test_selectors(&[3, 1, 2, 0], &[true, false, false, true, true]);
+        test_selectors(&[3, 2, 0, 1], &[true, true, true, true, true]);
+        test_selectors(&[3, 2, 1, 0], &[true, true, true, true, false]);
+    }
+}

--- a/console/algorithms/src/waksman/assign.rs
+++ b/console/algorithms/src/waksman/assign.rs
@@ -235,8 +235,8 @@ mod test {
 
     // A helper function to test that selectors are computed correctly.
     fn test_selectors(permutation: &[usize], expected_selectors: &[bool]) {
-        let waksman = ASWaksman::<CurrentEnvironment>::new(permutation.len());
-        let selectors = waksman.assign_selectors(permutation);
+        let network = ASWaksman::<CurrentEnvironment>::new(permutation.len());
+        let selectors = network.assign_selectors(permutation);
         assert_eq!(&selectors.into_iter().map(|b| *b).collect_vec(), expected_selectors);
     }
 

--- a/console/algorithms/src/waksman/check.rs
+++ b/console/algorithms/src/waksman/check.rs
@@ -29,3 +29,90 @@ impl<E: Environment> ASWaksman<E> {
         output.iter().zip_eq(second).fold(Boolean::new(true), |acc, (a, b)| acc & a.is_equal(b))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use snarkvm_utilities::{TestRng, Uniform};
+
+    use rand::seq::SliceRandom;
+    use std::iter;
+
+    const ITERATIONS: usize = 100;
+
+    type CurrentEnvironment = Console;
+
+    #[test]
+    fn test_check_permutation() {
+        // A helper function to check that `check_permutation` returns the expected result.
+        fn run_test(n: usize, iterations: usize, rng: &mut TestRng) {
+            for _ in 0..iterations {
+                // Sample a random permutation.
+                let mut permutation: Vec<usize> = (0..n).collect();
+                permutation.shuffle(rng);
+                // Compute the inverse permutation.
+                let inverse_permutation = invert_permutation(&permutation);
+                // Sample a random sequence of inputs.
+                let inputs: Vec<Field<CurrentEnvironment>> = iter::repeat_with(|| Uniform::rand(rng)).take(n).collect();
+                // Instantiate the Waksman network.
+                let network = ASWaksman::<CurrentEnvironment>::new(n);
+                // Compute the selectors.
+                let selectors = network.assign_selectors(&permutation);
+                assert_eq!(selectors.len(), network.num_selectors());
+                // Apply the permutation to the inputs.
+                let mut outputs = Vec::with_capacity(n);
+                for i in 0..inputs.len() {
+                    outputs.push(inputs[inverse_permutation[i]]);
+                }
+                // Check the permutation.
+                assert!(*network.check_permutation(&inputs, &outputs, &selectors));
+                // Check that a randomly sampled set of selectors does not work, as long as the selectors produce a different output.
+                // Note that there are multiple sets of selectors that produce the same output.
+                let mut bad_selectors = Vec::with_capacity(n);
+                for _ in 0..selectors.len() {
+                    bad_selectors.push(Boolean::rand(rng));
+                }
+                if network.run(&inputs, &bad_selectors) != outputs {
+                    assert!(!*network.check_permutation(&inputs, &outputs, &bad_selectors));
+                }
+            }
+        }
+
+        let mut rng = TestRng::default();
+
+        run_test(1, ITERATIONS, &mut rng);
+        run_test(2, ITERATIONS, &mut rng);
+        run_test(3, ITERATIONS, &mut rng);
+        run_test(4, ITERATIONS, &mut rng);
+        run_test(5, ITERATIONS, &mut rng);
+        run_test(6, ITERATIONS, &mut rng);
+        run_test(7, ITERATIONS, &mut rng);
+        run_test(8, ITERATIONS, &mut rng);
+        run_test(9, ITERATIONS, &mut rng);
+        run_test(10, ITERATIONS, &mut rng);
+        run_test(11, ITERATIONS, &mut rng);
+        run_test(12, ITERATIONS, &mut rng);
+        run_test(13, ITERATIONS, &mut rng);
+        run_test(14, ITERATIONS, &mut rng);
+        run_test(15, ITERATIONS, &mut rng);
+        run_test(16, ITERATIONS, &mut rng);
+        run_test(17, ITERATIONS, &mut rng);
+        run_test(32, ITERATIONS, &mut rng);
+        run_test(33, ITERATIONS, &mut rng);
+        run_test(64, ITERATIONS, &mut rng);
+        run_test(65, ITERATIONS, &mut rng);
+        run_test(128, ITERATIONS, &mut rng);
+        run_test(129, ITERATIONS, &mut rng);
+        run_test(256, ITERATIONS, &mut rng);
+        run_test(257, ITERATIONS, &mut rng);
+        run_test(512, ITERATIONS, &mut rng);
+        run_test(513, ITERATIONS, &mut rng);
+        run_test(1024, ITERATIONS, &mut rng);
+        run_test(1025, ITERATIONS, &mut rng);
+        run_test(2048, ITERATIONS, &mut rng);
+        run_test(2049, ITERATIONS, &mut rng);
+        run_test(4096, ITERATIONS, &mut rng);
+        run_test(4097, ITERATIONS, &mut rng);
+    }
+}

--- a/console/algorithms/src/waksman/mod.rs
+++ b/console/algorithms/src/waksman/mod.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod assign;
 mod check;
+mod sort;
 mod switch;
 
 use snarkvm_console_types::prelude::*;
@@ -179,22 +181,95 @@ impl<E: Environment> ASWaksman<E> {
     }
 }
 
+/// A helper function to invert a permutation.
+/// `inverse[i] = j` indicates `permutation` maps the element in the i-th position of the j-th position.
+fn invert_permutation(permutation: &[usize]) -> Vec<usize> {
+    permutation.iter().enumerate().map(|(i, &j)| (j, i)).sorted().map(|(_, i)| i).collect()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
     use snarkvm_utilities::{TestRng, Uniform};
 
+    use rand::seq::SliceRandom;
     use std::iter;
 
-    const ITERATIONS: usize = 10;
+    const ITERATIONS: usize = 100;
 
     type CurrentEnvironment = Console;
 
     #[test]
-    #[should_panic]
-    fn test_zero_size_network_fails() {
-        ASWaksman::<CurrentEnvironment>::new(0);
+    fn test_random_networks() {
+        // A helper function to run a test that samples random permutations, assigns selectors, and checks that the Waksman network computes the correct permutation.
+        fn run_test(n: usize, iterations: usize, rng: &mut TestRng) {
+            for i in 0..iterations {
+                // Sample a random permutation.
+                let mut permutation: Vec<usize> = (0..n).collect();
+                permutation.shuffle(rng);
+                // Compute the inverse permutation.
+                let inverse_permutation = invert_permutation(&permutation);
+                // Sample a random sequence of inputs.
+                let inputs: Vec<Field<CurrentEnvironment>> = iter::repeat_with(|| Uniform::rand(rng)).take(n).collect();
+                // Instantiate the Waksman network.
+                let waskman = ASWaksman::<CurrentEnvironment>::new(n);
+                // Compute the selectors.
+                let selectors = waskman.assign_selectors(&permutation);
+                assert_eq!(selectors.len(), waskman.num_selectors());
+                // Apply the permutation to the inputs.
+                let mut expected_outputs = Vec::with_capacity(n);
+                for i in 0..inputs.len() {
+                    expected_outputs.push(inputs[inverse_permutation[i]]);
+                }
+                // Run the Waksman network.
+                let actual_outputs = waskman.run(&inputs, &selectors);
+                // Check that the outputs are correct.
+                assert_eq!(
+                    actual_outputs,
+                    expected_outputs,
+                    "AssignSelectors(Iteration: {}, Inputs: {})",
+                    i,
+                    inputs.len()
+                )
+            }
+        }
+
+        let mut rng = TestRng::default();
+
+        run_test(1, ITERATIONS, &mut rng);
+        run_test(2, ITERATIONS, &mut rng);
+        run_test(3, ITERATIONS, &mut rng);
+        run_test(4, ITERATIONS, &mut rng);
+        run_test(5, ITERATIONS, &mut rng);
+        run_test(6, ITERATIONS, &mut rng);
+        run_test(7, ITERATIONS, &mut rng);
+        run_test(8, ITERATIONS, &mut rng);
+        run_test(9, ITERATIONS, &mut rng);
+        run_test(10, ITERATIONS, &mut rng);
+        run_test(11, ITERATIONS, &mut rng);
+        run_test(12, ITERATIONS, &mut rng);
+        run_test(13, ITERATIONS, &mut rng);
+        run_test(14, ITERATIONS, &mut rng);
+        run_test(15, ITERATIONS, &mut rng);
+        run_test(16, ITERATIONS, &mut rng);
+        run_test(17, ITERATIONS, &mut rng);
+        run_test(32, ITERATIONS, &mut rng);
+        run_test(33, ITERATIONS, &mut rng);
+        run_test(64, ITERATIONS, &mut rng);
+        run_test(65, ITERATIONS, &mut rng);
+        run_test(128, ITERATIONS, &mut rng);
+        run_test(129, ITERATIONS, &mut rng);
+        run_test(256, ITERATIONS, &mut rng);
+        run_test(257, ITERATIONS, &mut rng);
+        run_test(512, ITERATIONS, &mut rng);
+        run_test(513, ITERATIONS, &mut rng);
+        run_test(1024, ITERATIONS, &mut rng);
+        run_test(1025, ITERATIONS, &mut rng);
+        run_test(2048, ITERATIONS, &mut rng);
+        run_test(2049, ITERATIONS, &mut rng);
+        run_test(4096, ITERATIONS, &mut rng);
+        run_test(4097, ITERATIONS, &mut rng);
     }
 
     #[test]
@@ -255,27 +330,6 @@ mod test {
 
     #[test]
     fn test_reverse_network() {
-        fn compute_selectors(num_inputs: usize) -> Vec<Boolean<CurrentEnvironment>> {
-            match num_inputs {
-                0 => panic!("num_inputs must be greater than 0"),
-                1 => vec![],
-                2 => vec![Boolean::new(true)],
-                _ => {
-                    let mut input_selectors = vec![Boolean::new(true); num_inputs / 2];
-                    let upper_selectors = compute_selectors(num_inputs / 2);
-                    let lower_selectors = compute_selectors(num_inputs - num_inputs / 2);
-                    let output_selectors = match num_inputs % 2 == 0 {
-                        true => vec![Boolean::new(false); num_inputs / 2 - 1],
-                        false => vec![Boolean::new(true); (num_inputs - 1) / 2],
-                    };
-                    input_selectors.extend(upper_selectors);
-                    input_selectors.extend(lower_selectors);
-                    input_selectors.extend(output_selectors);
-                    input_selectors
-                }
-            }
-        }
-
         fn run_test(num_inputs: usize, rng: &mut TestRng) {
             for _ in 0..ITERATIONS {
                 let network = ASWaksman::new(num_inputs);
@@ -283,7 +337,7 @@ mod test {
                 let inputs = iter::repeat_with(|| Field::<CurrentEnvironment>::new(Uniform::rand(rng)))
                     .take(num_inputs)
                     .collect::<Vec<_>>();
-                let selectors = compute_selectors(num_inputs);
+                let selectors = network.assign_selectors(&(0..num_inputs).rev().collect::<Vec<_>>());
 
                 let outputs = network.run(&inputs, &selectors);
                 for (input, output) in inputs.iter().zip_eq(outputs.iter().rev()) {
@@ -327,5 +381,11 @@ mod test {
         run_test(2049, &mut rng);
         run_test(4096, &mut rng);
         run_test(4097, &mut rng);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_zero_size_network_fails() {
+        ASWaksman::<CurrentEnvironment>::new(0);
     }
 }

--- a/console/algorithms/src/waksman/mod.rs
+++ b/console/algorithms/src/waksman/mod.rs
@@ -213,17 +213,17 @@ mod test {
                 // Sample a random sequence of inputs.
                 let inputs: Vec<Field<CurrentEnvironment>> = iter::repeat_with(|| Uniform::rand(rng)).take(n).collect();
                 // Instantiate the Waksman network.
-                let waskman = ASWaksman::<CurrentEnvironment>::new(n);
+                let network = ASWaksman::<CurrentEnvironment>::new(n);
                 // Compute the selectors.
-                let selectors = waskman.assign_selectors(&permutation);
-                assert_eq!(selectors.len(), waskman.num_selectors());
+                let selectors = network.assign_selectors(&permutation);
+                assert_eq!(selectors.len(), network.num_selectors());
                 // Apply the permutation to the inputs.
                 let mut expected_outputs = Vec::with_capacity(n);
                 for i in 0..inputs.len() {
                     expected_outputs.push(inputs[inverse_permutation[i]]);
                 }
                 // Run the Waksman network.
-                let actual_outputs = waskman.run(&inputs, &selectors);
+                let actual_outputs = network.run(&inputs, &selectors);
                 // Check that the outputs are correct.
                 assert_eq!(
                     actual_outputs,

--- a/console/algorithms/src/waksman/sort.rs
+++ b/console/algorithms/src/waksman/sort.rs
@@ -1,18 +1,16 @@
 // Copyright (C) 2019-2023 Aleo Systems Inc.
 // This file is part of the snarkVM library.
 
-// The snarkVM library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
 
-// The snarkVM library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use super::*;
 

--- a/console/algorithms/src/waksman/sort.rs
+++ b/console/algorithms/src/waksman/sort.rs
@@ -1,0 +1,122 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// The snarkVM library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkVM library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkVM library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use std::collections::HashMap;
+
+impl<E: Environment> ASWaksman<E> {
+    /// Returns the sorted `inputs` sequence and the associated `selectors` for the switches in the network.
+    pub fn sort(&self, inputs: &[Field<E>]) -> (Vec<Field<E>>, Vec<Boolean<E>>) {
+        // Check that the number of inputs is correct.
+        if inputs.len() != self.num_inputs {
+            return E::halt(format!("The number of inputs must be exactly {}.", self.num_inputs));
+        }
+
+        // TODO: Condense sorting logic
+        // Sort the inputs.
+        let mut sorted = inputs.to_vec();
+        sorted.sort();
+
+        // Map each element in the sorted sequence to its index in the sorted sequence, accounting for duplicates.
+        let mut element_counts = HashMap::new();
+        let mut indexes = HashMap::new();
+        for (i, element) in sorted.iter().enumerate() {
+            let count = *element_counts.entry(element).and_modify(|count| *count += 1).or_insert(0usize);
+            indexes.insert((element, count), i);
+        }
+
+        // Construct a vector representing the permutation.
+        let mut element_counts = HashMap::new();
+        let mut permutation = Vec::with_capacity(self.num_inputs);
+        for input in inputs.iter() {
+            let count = *element_counts.entry(input).and_modify(|count| *count += 1).or_insert(0usize);
+            permutation.push(indexes[&(input, count)]);
+        }
+
+        // Construct the selectors for the switches in the network.
+        let selectors = self.assign_selectors(&permutation);
+
+        (sorted, selectors)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::iter;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: usize = 100;
+
+    #[test]
+    fn test_sort() {
+        // A helper function to run a test that samples a random set of inputs, computes the , and checks that the Waksman network computes the correct permutation.
+        fn run_test(n: usize, iterations: usize, rng: &mut TestRng) {
+            for i in 0..iterations {
+                // Sample a random sequence of inputs.
+                let inputs: Vec<Field<CurrentEnvironment>> = iter::repeat_with(|| Uniform::rand(rng)).take(n).collect();
+                // Instantiate the Waksman network.
+                let network = ASWaksman::<CurrentEnvironment>::new(n);
+                // Use the network to sort the inputs.
+                let (sorted, selectors) = network.sort(&inputs);
+                // Check that the sorted sequence is correct.
+                let expected_outputs: Vec<Field<CurrentEnvironment>> = inputs.iter().cloned().sorted().collect();
+                assert_eq!(sorted, expected_outputs, "Sort(Iteration: {}, Inputs: {})", i, inputs.len());
+                // Check that the network "checks" the permutation correctly.
+                assert!(*network.check_permutation(&inputs, &sorted, &selectors));
+            }
+        }
+
+        let mut rng = TestRng::default();
+
+        run_test(1, ITERATIONS, &mut rng);
+        run_test(2, ITERATIONS, &mut rng);
+        run_test(3, ITERATIONS, &mut rng);
+        run_test(4, ITERATIONS, &mut rng);
+        run_test(5, ITERATIONS, &mut rng);
+        run_test(6, ITERATIONS, &mut rng);
+        run_test(7, ITERATIONS, &mut rng);
+        run_test(8, ITERATIONS, &mut rng);
+        run_test(9, ITERATIONS, &mut rng);
+        run_test(10, ITERATIONS, &mut rng);
+        run_test(11, ITERATIONS, &mut rng);
+        run_test(12, ITERATIONS, &mut rng);
+        run_test(13, ITERATIONS, &mut rng);
+        run_test(14, ITERATIONS, &mut rng);
+        run_test(15, ITERATIONS, &mut rng);
+        run_test(16, ITERATIONS, &mut rng);
+        run_test(17, ITERATIONS, &mut rng);
+        run_test(32, ITERATIONS, &mut rng);
+        run_test(33, ITERATIONS, &mut rng);
+        run_test(64, ITERATIONS, &mut rng);
+        run_test(65, ITERATIONS, &mut rng);
+        run_test(128, ITERATIONS, &mut rng);
+        run_test(129, ITERATIONS, &mut rng);
+        run_test(256, ITERATIONS, &mut rng);
+        run_test(257, ITERATIONS, &mut rng);
+        run_test(512, ITERATIONS, &mut rng);
+        run_test(513, ITERATIONS, &mut rng);
+        run_test(1024, ITERATIONS, &mut rng);
+        run_test(1025, ITERATIONS, &mut rng);
+        run_test(2048, ITERATIONS, &mut rng);
+        run_test(2049, ITERATIONS, &mut rng);
+        run_test(4096, ITERATIONS, &mut rng);
+        run_test(4097, ITERATIONS, &mut rng);
+    }
+}


### PR DESCRIPTION
This PR adds functionality to compute the assignment to the switches of an arbitrary-size Waksman network, such that the network implements the desired permutation.

Depends on #1586.
