### PR TITLE
remove required cli flags, support multiple arguments, update readme

### DIFF
--- a/vm/cli/commands/run.rs
+++ b/vm/cli/commands/run.rs
@@ -20,10 +20,8 @@ pub const LOCALE: &num_format::Locale = &num_format::Locale::en;
 #[derive(Debug, Parser)]
 pub struct Run {
     /// The function name.
-    #[clap(long)]
     function: Identifier<CurrentNetwork>,
     /// The function inputs.
-    #[clap(long)]
     inputs: Vec<Value<CurrentNetwork>>,
     /// Uses the specified endpoint.
     #[clap(long)]

--- a/vm/file/readme_file.rs
+++ b/vm/file/readme_file.rs
@@ -45,7 +45,12 @@ impl README {
 
 To compile this Aleo program, run:
 ```bash
-aleo build
+snarkvm build
+```
+
+To execute this Aleo program, run:
+```bash
+snarkvm run hello
 ```
 "
         );


### PR DESCRIPTION
The CLI changes merged in https://github.com/AleoHQ/snarkVM/pull/1583 require that the `--function` and `--inputs` long flags be present when calling the `run` command of the CLI. In addition, clap does not support multiple arguments by default so you cannot pass multiple `inputs` arguments to the CLI at all right now. https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html#options

The fix is very simple - remove the attributes. This supports the previous and intended syntax to run a program as well as multiple inputs.
```bash
snarkvm run hello 1u32 2u32
```