### PR TITLE
Add a test case for cli argument parsing

### DIFF
--- a/vm/cli/cli.rs
+++ b/vm/cli/cli.rs
@@ -62,3 +62,32 @@ impl Command {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A test case recommended by clap (https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html#testing).
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        CLI::command().debug_assert()
+    }
+
+    #[test]
+    fn clap_snarkvm_run() {
+        use crate::prelude::{Identifier, Value};
+
+        let arg_vec = vec!["snarkvm", "run", "hello", "1u32", "2u32", "--endpoint", "ENDPOINT", "--offline"];
+        let cli = CLI::parse_from(&arg_vec);
+
+        if let Command::Run(run) = cli.command {
+            assert_eq!(run.function(), Identifier::try_from(arg_vec[2]).unwrap());
+            assert_eq!(run.inputs(), vec![Value::try_from(arg_vec[3]).unwrap(), Value::try_from(arg_vec[4]).unwrap()]);
+            assert_eq!(run.endpoint(), Some("ENDPOINT"));
+            assert!(run.offline());
+        } else {
+            panic!("Unexpected result of clap parsing!");
+        }
+    }
+}

--- a/vm/cli/commands/run.rs
+++ b/vm/cli/commands/run.rs
@@ -106,4 +106,24 @@ impl Run {
 
         Ok(format!("✅ Executed '{}' {}", locator.to_string().bold(), path_string.dimmed()))
     }
+
+    #[cfg(test)]
+    pub fn function(&self) -> Identifier<CurrentNetwork> {
+        self.function
+    }
+
+    #[cfg(test)]
+    pub fn inputs(&self) -> &[Value<CurrentNetwork>] {
+        &self.inputs
+    }
+
+    #[cfg(test)]
+    pub fn endpoint(&self) -> Option<&str> {
+        self.endpoint.as_deref()
+    }
+
+    #[cfg(test)]
+    pub fn offline(&self) -> bool {
+        self.offline
+    }
 }


### PR DESCRIPTION
This will help us ensure that any future breaking `clap` changes (some of which are not necessarily included in the CHANGELOG) don't result in unexpected behavior.

For now I only added one officially recommended test case and one for the following command:
```
snarkvm run hello 1u32 2u32 --endpoint ENDPOINT --offline
```

Happy to include more if desirable. I'll include a similar test case (or more) in the snarkOS clap update PR.