### PR TITLE
Reduce sizes in `merkle_tree` benchmarks

### DIFF
--- a/console/collections/benches/merkle_tree.rs
+++ b/console/collections/benches/merkle_tree.rs
@@ -28,9 +28,9 @@ use std::collections::BTreeMap;
 const DEPTH: u8 = 32;
 const MAX_INSTANTIATED_DEPTH: u8 = 16;
 
-const NUM_LEAVES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000, 1_000_000];
-const APPEND_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000, 1_000_000];
-const UPDATE_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000, 1_000_000];
+const NUM_LEAVES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000 /*{ 1_000_000 }*/];
+const APPEND_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000 /*{ 1_000_000 }*/];
+const UPDATE_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000 /*{ 100_000, 1_000_000 }*/];
 
 /// Generates the specified number of random Merkle tree leaves.
 macro_rules! generate_leaves {

--- a/console/collections/benches/merkle_tree.rs
+++ b/console/collections/benches/merkle_tree.rs
@@ -28,9 +28,9 @@ use std::collections::BTreeMap;
 const DEPTH: u8 = 32;
 const MAX_INSTANTIATED_DEPTH: u8 = 16;
 
-const NUM_LEAVES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000 /*{ 1_000_000 }*/];
-const APPEND_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000 /*{ 1_000_000 }*/];
-const UPDATE_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000 /*{ 100_000, 1_000_000 }*/];
+const NUM_LEAVES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000];
+const APPEND_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000, 100_000];
+const UPDATE_SIZES: &[usize] = &[1, 10, 100, 1_000, 10_000];
 
 /// Generates the specified number of random Merkle tree leaves.
 macro_rules! generate_leaves {


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR reduces the number of leaves run in the `merkle_tree` benchmarks to ensure the CI completes reasonably. 

