### PR TITLE
Adds tx helpers

### DIFF
--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -142,20 +142,29 @@ impl<N: Network> Transaction<N> {
 }
 
 impl<N: Network> Transaction<N> {
+    /// Returns `Some(owner)` if the transaction is a deployment. Otherwise, returns `None`.
+    #[inline]
+    pub fn owner(&self) -> Option<&ProgramOwner<N>> {
+        match self {
+            Self::Deploy(_, owner, _, _) => Some(owner),
+            _ => None,
+        }
+    }
+
     /// Returns `Some(deployment)` if the transaction is a deployment. Otherwise, returns `None`.
     #[inline]
-    pub fn deployment(&self) -> Option<Deployment<N>> {
+    pub fn deployment(&self) -> Option<&Deployment<N>> {
         match self {
-            Self::Deploy(_, _, deployment, _) => Some(deployment.as_ref().clone()),
+            Self::Deploy(_, _, deployment, _) => Some(deployment.as_ref()),
             _ => None,
         }
     }
 
     /// Returns `Some(execution)` if the transaction is an execution. Otherwise, returns `None`.
     #[inline]
-    pub fn execution(&self) -> Option<Execution<N>> {
+    pub fn execution(&self) -> Option<&Execution<N>> {
         match self {
-            Self::Execute(_, execution, _) => Some(execution.clone()),
+            Self::Execute(_, execution, _) => Some(execution),
             _ => None,
         }
     }

--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -141,6 +141,26 @@ impl<N: Network> Transaction<N> {
     }
 }
 
+impl<N: Network> Transaction<N> {
+    /// Returns `Some(deployment)` if the transaction is a deployment. Otherwise, returns `None`.
+    #[inline]
+    pub fn deployment(&self) -> Option<Deployment<N>> {
+        match self {
+            Self::Deploy(_, _, deployment, _) => Some(deployment.as_ref().clone()),
+            _ => None,
+        }
+    }
+
+    /// Returns `Some(execution)` if the transaction is an execution. Otherwise, returns `None`.
+    #[inline]
+    pub fn execution(&self) -> Option<Execution<N>> {
+        match self {
+            Self::Execute(_, execution, _) => Some(execution.clone()),
+            _ => None,
+        }
+    }
+}
+
 /// A helper enum for iterators and consuming iterators over a transaction.
 enum IterWrap<T, I1: Iterator<Item = T>, I2: Iterator<Item = T>, I3: Iterator<Item = T>> {
     Deploy(I1),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds `Transaction::owner`, `Transaction::deployment`, and `Transaction::execution` helper methods to make accessing internal objects easier.