### PR TITLE
reuse compute_key for Request.sign

### DIFF
--- a/console/account/src/view_key/try_from.rs
+++ b/console/account/src/view_key/try_from.rs
@@ -42,8 +42,7 @@ impl<N: Network> TryFrom<(&PrivateKey<N>, &ComputeKey<N>)> for ViewKey<N> {
     type Error = Error;
 
     /// Initializes a new account view key from an account private key.
-    fn try_from(private_and_compute_key: (&PrivateKey<N>, &ComputeKey<N>)) -> Result<Self, Self::Error> {
-        let (private_key, compute_key) = private_and_compute_key;
+    fn try_from((private_key, compute_key): (&PrivateKey<N>, &ComputeKey<N>)) -> Result<Self, Self::Error> {
         // Compute view_key := sk_sig + r_sig + sk_prf.
         Ok(Self(private_key.sk_sig() + private_key.r_sig() + compute_key.sk_prf()))
     }

--- a/console/account/src/view_key/try_from.rs
+++ b/console/account/src/view_key/try_from.rs
@@ -37,6 +37,18 @@ impl<N: Network> TryFrom<&PrivateKey<N>> for ViewKey<N> {
     }
 }
 
+#[cfg(feature = "private_key")]
+impl<N: Network> TryFrom<(&PrivateKey<N>, &ComputeKey<N>)> for ViewKey<N> {
+    type Error = Error;
+
+    /// Initializes a new account view key from an account private key.
+    fn try_from(private_and_compute_key: (&PrivateKey<N>, &ComputeKey<N>)) -> Result<Self, Self::Error> {
+        let (private_key, compute_key) = private_and_compute_key;
+        // Compute view_key := sk_sig + r_sig + sk_prf.
+        Ok(Self(private_key.sk_sig() + private_key.r_sig() + compute_key.sk_prf()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -60,6 +72,9 @@ mod tests {
             // Compute view_key := sk_sig + r_sig + sk_prf.
             let candidate = ViewKey(private_key.sk_sig() + private_key.r_sig() + compute_key.sk_prf());
             assert_eq!(view_key, candidate);
+
+            let view_key2 = ViewKey::try_from((&private_key, &compute_key))?;
+            assert_eq!(view_key2, candidate);
         }
         Ok(())
     }

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -40,17 +40,17 @@ impl<N: Network> Request<N> {
         // Retrieve `sk_sig`.
         let sk_sig = private_key.sk_sig();
 
-        // Derive the view key.
-        let view_key = ViewKey::try_from(private_key)?;
-        // Derive `sk_tag` from the graph key.
-        let sk_tag = GraphKey::try_from(view_key)?.sk_tag();
-
         // Derive the compute key.
         let compute_key = ComputeKey::try_from(private_key)?;
         // Retrieve `pk_sig`.
         let pk_sig = compute_key.pk_sig();
         // Retrieve `pr_sig`.
         let pr_sig = compute_key.pr_sig();
+
+        // Derive the view key.
+        let view_key = ViewKey::try_from((private_key, &compute_key))?;
+        // Derive `sk_tag` from the graph key.
+        let sk_tag = GraphKey::try_from(view_key)?.sk_tag();
 
         // Sample a random nonce.
         let nonce = Field::<N>::rand(rng);


### PR DESCRIPTION
This PR saves recalculation of `ComputeKey` during `Request.sign`.