### PR TITLE
Adds `Transition::is_coinbase` and `Transition::is_split`

### DIFF
--- a/synthesizer/src/block/transaction/mod.rs
+++ b/synthesizer/src/block/transaction/mod.rs
@@ -99,45 +99,23 @@ impl<N: Network> Transaction<N> {
     /// Returns `true` if this is a coinbase transaction.
     #[inline]
     pub fn is_coinbase(&self) -> bool {
-        // Case 1 - The transaction contains 1 transition, which calls 'credits.aleo/mint'.
-        if let Self::Execute(_, execution, _) = self {
-            // Ensure there is 1 transition.
-            if execution.len() == 1 {
-                // Retrieve the transition.
-                if let Ok(transition) = execution.get(0) {
-                    // Check if it calls 'credits.aleo/mint'.
-                    if transition.program_id().to_string() == "credits.aleo"
-                        && transition.function_name().to_string() == "mint"
-                    {
-                        return true;
-                    }
-                }
-            }
+        match self {
+            // Case 1 - The transaction contains a transition that calls 'credits.aleo/mint'.
+            Transaction::Execute(_, execution, _) => execution.transitions().any(|transition| transition.is_coinbase()),
+            // Otherwise, return 'false'.
+            _ => false,
         }
-        // Otherwise, return 'false'.
-        false
     }
 
     /// Returns `true` if this is a `split` transaction.
     #[inline]
     pub fn is_split(&self) -> bool {
-        // Case 1 - The transaction contains 1 transition, which calls 'credits.aleo/split'.
-        if let Self::Execute(_, execution, _) = self {
-            // Ensure there is 1 transition.
-            if execution.len() == 1 {
-                // Retrieve the transition.
-                if let Ok(transition) = execution.get(0) {
-                    // Check if it calls 'credits.aleo/split'.
-                    if transition.program_id().to_string() == "credits.aleo"
-                        && transition.function_name().to_string() == "split"
-                    {
-                        return true;
-                    }
-                }
-            }
+        match self {
+            // Case 1 - The transaction contains a transition that calls 'credits.aleo/split'.
+            Transaction::Execute(_, execution, _) => execution.transitions().any(|transition| transition.is_split()),
+            // Otherwise, return 'false'.
+            _ => false,
         }
-        // Otherwise, return 'false'.
-        false
     }
 }
 

--- a/synthesizer/src/block/transition/mod.rs
+++ b/synthesizer/src/block/transition/mod.rs
@@ -306,6 +306,30 @@ impl<N: Network> Transition<N> {
 }
 
 impl<N: Network> Transition<N> {
+    /// Returns `true` if this is a coinbase transaction.
+    #[inline]
+    pub fn is_coinbase(&self) -> bool {
+        // Case 1: The transition calls 'credits.aleo/mint'.
+        if self.program_id.to_string() == "credits.aleo" && self.function_name.to_string() == "mint" {
+            return true;
+        }
+        // Otherwise, return 'false'.
+        false
+    }
+
+    /// Returns `true` if this is a `split` transaction.
+    #[inline]
+    pub fn is_split(&self) -> bool {
+        // Case 1 - The transition calls 'credits.aleo/split'.
+        if self.program_id.to_string() == "credits.aleo" && self.function_name.to_string() == "split" {
+            return true;
+        }
+        // Otherwise, return 'false'.
+        false
+    }
+}
+
+impl<N: Network> Transition<N> {
     /// Returns `true` if the transition contains the given serial number.
     pub fn contains_serial_number(&self, serial_number: &Field<N>) -> bool {
         self.inputs.iter().any(|input| match input {

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -124,7 +124,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 }
                 // TODO (raychu86): Remove `is_split` check once batch executions are supported.
                 // Ensure the fee is present, if the transaction is not a coinbase or split.
-                if !transaction.is_coinbase() && !transaction.is_split() && fee.is_none() {
+                if !(transaction.is_coinbase() || (transaction.is_split() && execution.len() == 1)) && fee.is_none() {
                     bail!("Transaction is missing a fee (execution)");
                 }
                 // Verify the fee.

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -124,7 +124,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 }
                 // TODO (raychu86): Remove `is_split` check once batch executions are supported.
                 // Ensure the fee is present, if the transaction is not a coinbase or split.
-                if !(transaction.is_coinbase() || (transaction.is_split() && execution.len() == 1)) && fee.is_none() {
+                if !((transaction.is_coinbase() || transaction.is_split()) && execution.len() == 1) && fee.is_none() {
                     bail!("Transaction is missing a fee (execution)");
                 }
                 // Verify the fee.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds `Transition::is_coinbase` and `Transition::is_split` methods.


