### PR TITLE
[Feature] `get.or_use`

### DIFF
--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -764,7 +764,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     add r2 r1 into r3;
     set r3 into account[r0];
 ",
@@ -873,7 +873,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     add r2 r1 into r3;
     sub r3 r1 into r4;
     set r4 into account[r0];
@@ -996,7 +996,7 @@ finalize mint_public:
     input r1 as u64.public;
 
     // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
     // Set `r3` into `account[r0]`.
@@ -1124,7 +1124,7 @@ finalize mint_public:
     input r1 as u64.public;
 
     // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
     // Set `r3` into `account[r0]`.
@@ -1260,7 +1260,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     add r1 r2 into r3;
     set r3 into account[r0];
     get account[r0] into r4;
@@ -1375,7 +1375,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as entry.public;
-    get.or_init entries[r0] r1 into r2;
+    get.or_use entries[r0] r1 into r2;
     add r1.count r2.count into r3;
     add r1.data r2.data into r4;
     cast r3 r4 into r5 as entry;

--- a/synthesizer/src/program/finalize/command/get_or_use.rs
+++ b/synthesizer/src/program/finalize/command/get_or_use.rs
@@ -28,11 +28,11 @@ use console::{
     program::{Identifier, Register, Value},
 };
 
-/// A get command that initializes the mapping in case of failure, e.g. `get.or_init accounts[r0] r1 into r2;`.
+/// A get command that uses the provided operand in case of failure, e.g. `get.or_use accounts[r0] r1 into r2;`.
 /// Gets the value stored at `operand` in `mapping` and stores the result in `destination`.
-/// If the key is not present, `default` is stored in `mapping` and stored in `destination`.
+/// If the key is not present, `default` is stored in `destination`.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct GetOrInit<N: Network> {
+pub struct GetOrUse<N: Network> {
     /// The mapping name.
     mapping: Identifier<N>,
     /// The key to access the mapping.
@@ -43,11 +43,11 @@ pub struct GetOrInit<N: Network> {
     destination: Register<N>,
 }
 
-impl<N: Network> GetOrInit<N> {
+impl<N: Network> GetOrUse<N> {
     /// Returns the opcode.
     #[inline]
     pub const fn opcode() -> Opcode {
-        Opcode::Command("get.or_init")
+        Opcode::Command("get.or_use")
     }
 
     /// Returns the operands in the operation.
@@ -81,7 +81,7 @@ impl<N: Network> GetOrInit<N> {
     }
 }
 
-impl<N: Network> GetOrInit<N> {
+impl<N: Network> GetOrUse<N> {
     /// Finalizes the command.
     #[inline]
     pub fn finalize<P: FinalizeStorage<N>>(
@@ -101,14 +101,9 @@ impl<N: Network> GetOrInit<N> {
         // Retrieve the value from storage as a literal.
         let (value, finalize_operation) = match store.get_value_speculative(stack.program_id(), &self.mapping, &key)? {
             Some(Value::Plaintext(plaintext)) => (Value::Plaintext(plaintext), None),
-            Some(Value::Record(..)) => bail!("Cannot 'get.or_init' a 'record'"),
-            // If a key does not exist, then store the default value into the mapping and return it.
-            None => {
-                // Store the default value into the mapping.
-                let default = Value::Plaintext(registers.load_plaintext(stack, &self.default)?);
-                // Return the default value and finalize operation.
-                (default.clone(), Some(store.update_key_value(stack.program_id(), &self.mapping, key, default)?))
-            }
+            Some(Value::Record(..)) => bail!("Cannot 'get.or_use' a 'record'"),
+            // If a key does not exist, then use the default value.
+            None => (Value::Plaintext(registers.load_plaintext(stack, &self.default)?), None),
         };
 
         // Assign the value to the destination register.
@@ -119,7 +114,7 @@ impl<N: Network> GetOrInit<N> {
     }
 }
 
-impl<N: Network> Parser for GetOrInit<N> {
+impl<N: Network> Parser for GetOrUse<N> {
     /// Parses a string into an operation.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
@@ -165,7 +160,7 @@ impl<N: Network> Parser for GetOrInit<N> {
     }
 }
 
-impl<N: Network> FromStr for GetOrInit<N> {
+impl<N: Network> FromStr for GetOrUse<N> {
     type Err = Error;
 
     /// Parses a string into the command.
@@ -183,14 +178,14 @@ impl<N: Network> FromStr for GetOrInit<N> {
     }
 }
 
-impl<N: Network> Debug for GetOrInit<N> {
+impl<N: Network> Debug for GetOrUse<N> {
     /// Prints the command as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<N: Network> Display for GetOrInit<N> {
+impl<N: Network> Display for GetOrUse<N> {
     /// Prints the command to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Print the command.
@@ -202,7 +197,7 @@ impl<N: Network> Display for GetOrInit<N> {
     }
 }
 
-impl<N: Network> FromBytes for GetOrInit<N> {
+impl<N: Network> FromBytes for GetOrUse<N> {
     /// Reads the command from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the mapping name.
@@ -218,7 +213,7 @@ impl<N: Network> FromBytes for GetOrInit<N> {
     }
 }
 
-impl<N: Network> ToBytes for GetOrInit<N> {
+impl<N: Network> ToBytes for GetOrUse<N> {
     /// Writes the operation to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the mapping name.
@@ -241,12 +236,12 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let (string, get_or_init) = GetOrInit::<CurrentNetwork>::parse("get.or_init account[r0] r1 into r2;").unwrap();
+        let (string, get_or_use) = GetOrUse::<CurrentNetwork>::parse("get.or_use account[r0] r1 into r2;").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(get_or_init.mapping, Identifier::from_str("account").unwrap());
-        assert_eq!(get_or_init.operands().len(), 2, "The number of operands is incorrect");
-        assert_eq!(get_or_init.key, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
-        assert_eq!(get_or_init.default, Operand::Register(Register::Locator(1)), "The second operand is incorrect");
-        assert_eq!(get_or_init.destination, Register::Locator(2), "The second operand is incorrect");
+        assert_eq!(get_or_use.mapping, Identifier::from_str("account").unwrap());
+        assert_eq!(get_or_use.operands().len(), 2, "The number of operands is incorrect");
+        assert_eq!(get_or_use.key, Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+        assert_eq!(get_or_use.default, Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(get_or_use.destination, Register::Locator(2), "The second operand is incorrect");
     }
 }

--- a/synthesizer/src/program/finalize/command/get_or_use.rs
+++ b/synthesizer/src/program/finalize/command/get_or_use.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::{
-    FinalizeOperation,
     FinalizeStorage,
     FinalizeStore,
     Opcode,

--- a/synthesizer/src/program/finalize/command/mod.rs
+++ b/synthesizer/src/program/finalize/command/mod.rs
@@ -18,8 +18,8 @@ pub use finalize::*;
 mod get;
 pub use get::*;
 
-mod get_or_init;
-pub use get_or_init::*;
+mod get_or_use;
+pub use get_or_use::*;
 
 mod set;
 pub use set::*;
@@ -34,8 +34,8 @@ pub enum Command<N: Network> {
     /// Gets the value stored at the `key` operand in `mapping` and stores the result into `destination`.
     Get(Get<N>),
     /// Gets the value stored at the `key` operand in `mapping` and stores the result into `destination`.
-    /// If the key is not present, `default` is stored at the `key` operand in the `mapping` and stored in `destination`.
-    GetOrInit(GetOrInit<N>),
+    /// If the key is not present, `default` is stored `destination`.
+    GetOrUse(GetOrUse<N>),
     /// Sets the value stored at the `key` operand in the `mapping` to `value`.
     Set(Set<N>),
 }
@@ -54,8 +54,8 @@ impl<N: Network> Command<N> {
             Command::Instruction(instruction) => instruction.finalize(stack, registers).map(|_| None),
             // Finalize the 'get' command, and return no finalize operation.
             Command::Get(get) => get.finalize(stack, store, registers).map(|_| None),
-            // Finalize the 'get.or_init' command, and return the (optional) finalize operation.
-            Command::GetOrInit(get_or_init) => get_or_init.finalize(stack, store, registers),
+            // Finalize the 'get.or_use' command, and return the (optional) finalize operation.
+            Command::GetOrUse(get_or_use) => get_or_use.finalize(stack, store, registers),
             // Finalize the 'set' command, and return the finalize operation.
             Command::Set(set) => set.finalize(stack, store, registers).map(Some),
         }
@@ -72,8 +72,8 @@ impl<N: Network> FromBytes for Command<N> {
             0 => Ok(Self::Instruction(Instruction::read_le(&mut reader)?)),
             // Read the `get` operation.
             1 => Ok(Self::Get(Get::read_le(&mut reader)?)),
-            // Read the `get.or_init` operation.
-            2 => Ok(Self::GetOrInit(GetOrInit::read_le(&mut reader)?)),
+            // Read the `get.or_use` operation.
+            2 => Ok(Self::GetOrUse(GetOrUse::read_le(&mut reader)?)),
             // Read the `set` operation.
             3 => Ok(Self::Set(Set::read_le(&mut reader)?)),
             // Invalid variant.
@@ -98,11 +98,11 @@ impl<N: Network> ToBytes for Command<N> {
                 // Write the `get` operation.
                 get.write_le(&mut writer)
             }
-            Self::GetOrInit(get_or_init) => {
+            Self::GetOrUse(get_or_use) => {
                 // Write the variant.
                 2u8.write_le(&mut writer)?;
                 // Write the defaulting `get` operation.
-                get_or_init.write_le(&mut writer)
+                get_or_use.write_le(&mut writer)
             }
             Self::Set(set) => {
                 // Write the variant.
@@ -121,7 +121,7 @@ impl<N: Network> Parser for Command<N> {
         // Parse the command.
         // Note that the order of the parsers is important.
         alt((
-            map(GetOrInit::parse, |get_or_init| Self::GetOrInit(get_or_init)),
+            map(GetOrUse::parse, |get_or_use| Self::GetOrUse(get_or_use)),
             map(Get::parse, |get| Self::Get(get)),
             map(Set::parse, |set| Self::Set(set)),
             map(Instruction::parse, |instruction| Self::Instruction(instruction)),
@@ -160,7 +160,7 @@ impl<N: Network> Display for Command<N> {
         match self {
             Self::Instruction(instruction) => Display::fmt(instruction, f),
             Self::Get(get) => Display::fmt(get, f),
-            Self::GetOrInit(get_or_init) => Display::fmt(get_or_init, f),
+            Self::GetOrUse(get_or_use) => Display::fmt(get_or_use, f),
             Self::Set(set) => Display::fmt(set, f),
         }
     }
@@ -196,7 +196,7 @@ mod tests {
         assert_eq!(command, Command::from_bytes_le(&bytes).unwrap());
 
         // GetOr
-        let expected = "get.or_init object[r0] r1 into r2;";
+        let expected = "get.or_use object[r0] r1 into r2;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
         let bytes = command.to_bytes_le().unwrap();
         assert_eq!(command, Command::from_bytes_le(&bytes).unwrap());
@@ -231,9 +231,9 @@ mod tests {
         assert_eq!(expected, command.to_string());
 
         // GetOr
-        let expected = "get.or_init object[r0] r1 into r2;";
+        let expected = "get.or_use object[r0] r1 into r2;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
-        assert_eq!(Command::GetOrInit(GetOrInit::from_str(expected).unwrap()), command);
+        assert_eq!(Command::GetOrUse(GetOrUse::from_str(expected).unwrap()), command);
         assert_eq!(expected, command.to_string());
 
         // Set

--- a/synthesizer/src/program/finalize/command/mod.rs
+++ b/synthesizer/src/program/finalize/command/mod.rs
@@ -55,7 +55,7 @@ impl<N: Network> Command<N> {
             // Finalize the 'get' command, and return no finalize operation.
             Command::Get(get) => get.finalize(stack, store, registers).map(|_| None),
             // Finalize the 'get.or_use' command, and return the (optional) finalize operation.
-            Command::GetOrUse(get_or_use) => get_or_use.finalize(stack, store, registers),
+            Command::GetOrUse(get_or_use) => get_or_use.finalize(stack, store, registers).map(|_| None),
             // Finalize the 'set' command, and return the finalize operation.
             Command::Set(set) => set.finalize(stack, store, registers).map(Some),
         }

--- a/synthesizer/src/program/finalize/mod.rs
+++ b/synthesizer/src/program/finalize/mod.rs
@@ -108,13 +108,9 @@ impl<N: Network> Finalize<N> {
         // Ensure the maximum number of commands has not been exceeded.
         ensure!(self.commands.len() < N::MAX_COMMANDS, "Cannot add more than {} commands", N::MAX_COMMANDS);
         // Ensure the number of write commands has not been exceeded.
-        ensure!(
-            self.num_writes < N::MAX_WRITES,
-            "Cannot add more than {} 'get.or_use' and 'set' commands",
-            N::MAX_WRITES
-        );
+        ensure!(self.num_writes < N::MAX_WRITES, "Cannot add more than {} 'set' commands", N::MAX_WRITES);
 
-        // If the command is an instruction, `get` command, or `get.or_use` command, perform additional checks.
+        // Perform additional checks on the command.
         match &command {
             Command::Instruction(instruction) => {
                 match instruction {

--- a/synthesizer/src/program/finalize/mod.rs
+++ b/synthesizer/src/program/finalize/mod.rs
@@ -110,11 +110,11 @@ impl<N: Network> Finalize<N> {
         // Ensure the number of write commands has not been exceeded.
         ensure!(
             self.num_writes < N::MAX_WRITES,
-            "Cannot add more than {} 'get.or_init' and 'set' commands",
+            "Cannot add more than {} 'get.or_use' and 'set' commands",
             N::MAX_WRITES
         );
 
-        // If the command is an instruction, `get` command, or `get.or_init` command, perform additional checks.
+        // If the command is an instruction, `get` command, or `get.or_use` command, perform additional checks.
         match &command {
             Command::Instruction(instruction) => {
                 match instruction {
@@ -135,14 +135,12 @@ impl<N: Network> Finalize<N> {
                 // Ensure the destination register is a locator.
                 ensure!(matches!(get.destination(), Register::Locator(..)), "Destination register must be a locator");
             }
-            Command::GetOrInit(get_or_init) => {
+            Command::GetOrUse(get_or_use) => {
                 // Ensure the destination register is a locator.
                 ensure!(
-                    matches!(get_or_init.destination(), Register::Locator(..)),
+                    matches!(get_or_use.destination(), Register::Locator(..)),
                     "Destination register must be a locator"
                 );
-                // Increment the number of write commands.
-                self.num_writes += 1;
             }
             Command::Set(_) => {
                 // Increment the number of write commands.

--- a/synthesizer/src/program/function/parse.rs
+++ b/synthesizer/src/program/function/parse.rs
@@ -214,7 +214,7 @@ finalize mint_public:
     input r1 as u64.public;
 
     // Get `account[r0]` into `r2`, defaulting to 0u64 if the entry does not exist.
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     // Add `r1` to `r2`. If the operation overflows, `mint_public` is reverted.
     add r2 r1 into r3;
     // Set `r3` into `account[r0]`.
@@ -264,7 +264,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u64.public;
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     add r2 r1 into r3;
     set r3 into account[r0];
     ",

--- a/synthesizer/src/program/resources/credits.aleo
+++ b/synthesizer/src/program/resources/credits.aleo
@@ -51,15 +51,15 @@ finalize transfer_public:
     // Input the amount.
     input r2 as u64.public;
     // Decrements `account[r0]` by `r2`.
-    // If `account[r0]` does not exist, it will be created.
+    // If `account[r0]` does not exist, 0u64 is used.
     // If `account[r0] - r2` underflows, `transfer_public` is reverted.
-    get.or_init account[r0] 0u64 into r3;
+    get.or_use account[r0] 0u64 into r3;
     sub r3 r2 into r4;
     set r4 into account[r0];
     // Increments `account[r1]` by `r2`.
-    // If `account[r1]` does not exist, it will be created.
+    // If `account[r1]` does not exist, 0u64 is used.
     // If `account[r1] + r2` overflows, `transfer_public` is reverted.
-    get.or_init account[r1] 0u64 into r5;
+    get.or_use account[r1] 0u64 into r5;
     add r5 r2 into r6;
     set r6 into account[r1];
 
@@ -116,8 +116,8 @@ finalize transfer_private_to_public:
     // Input the amount.
     input r1 as u64.public;
     // Retrieve the balance of the sender.
-    // If `account[r0]` does not exist, it will be created.
-    get.or_init account[r0] 0u64 into r2;
+    // If `account[r0]` does not exist, 0u64 is used.
+    get.or_use account[r0] 0u64 into r2;
     // Increments `account[r0]` by `r1`.
     // If `r1 + r2` overflows, `transfer_private_to_public` is reverted.
     add r1 r2 into r3;
@@ -147,8 +147,8 @@ finalize transfer_public_to_private:
     // Input the amount.
     input r1 as u64.public;
     // Retrieve the balance of the sender.
-    // If `account[r0]` does not exist, it will be created.
-    get.or_init account[r0] 0u64 into r2;
+    // If `account[r0]` does not exist, 0u64 is used.
+    get.or_use account[r0] 0u64 into r2;
     // Decrements `account[r0]` by `r1`.
     // If `r2 - r1` underflows, `transfer_public_to_private` is reverted.
     sub r2 r1 into r3;

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -372,7 +372,7 @@ finalize mint_public:
     input r0 as address.public;
     input r1 as u64.public;
 
-    get.or_init account[r0] 0u64 into r2;
+    get.or_use account[r0] 0u64 into r2;
     add r2 r1 into r3;
     set r3 into account[r0];
 
@@ -387,8 +387,8 @@ finalize transfer_public:
     input r1 as address.public;
     input r2 as u64.public;
 
-    get.or_init account[r0] 0u64 into r3;
-    get.or_init account[r1] 0u64 into r4;
+    get.or_use account[r0] 0u64 into r3;
+    get.or_use account[r1] 0u64 into r4;
 
     sub r3 r2 into r5;
     add r4 r2 into r6;
@@ -919,7 +919,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as u8.public;
-    get.or_init entries[r0] r1 into r2;
+    get.or_use entries[r0] r1 into r2;
     add r1 r2 into r3;
     set r3 into entries[r0];
     get entries[r0] into r4;

--- a/synthesizer/tests/tests/parser/program/finalize_entry.aleo
+++ b/synthesizer/tests/tests/parser/program/finalize_entry.aleo
@@ -18,7 +18,7 @@ function compute:
 finalize compute:
     input r0 as address.public;
     input r1 as entry.public;
-    get.or_init entries[r0] r1 into r2;
+    get.or_use entries[r0] r1 into r2;
     add r1.count r2.count into r3;
     add r1.data r2.data into r4;
     cast r3 r4 into r5 as entry;


### PR DESCRIPTION
This PR, removes `get.or_init` and introduces `get.or_use`. 
If the entry does not exist in the mapping, the default operand is loaded and stored into the destination register.