### PR TITLE
Updates hash opcode implementation

### DIFF
--- a/circuit/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/circuit/algorithms/src/poseidon/hash_to_scalar.rs
@@ -24,10 +24,9 @@ impl<E: Environment, const RATE: usize> HashToScalar for Poseidon<E, RATE> {
     fn hash_to_scalar(&self, input: &[Self::Input]) -> Self::Scalar {
         // Hash the input to the base field.
         let output = self.hash(input);
-
-        // Truncate the output to the size in data bits (1 bit less than the MODULUS) of the scalar.
-        // Slicing here is safe as the base field is larger than the scalar field.
-        Scalar::from_bits_le(&output.to_bits_le()[..E::ScalarField::size_in_data_bits()])
+        // Convert the output to the scalar field,
+        // truncating to the size in data bits (1 bit less than the MODULUS) of the scalar.
+        Scalar::from_field_lossy(output)
     }
 }
 

--- a/circuit/program/src/data/literal/downcast.rs
+++ b/circuit/program/src/data/literal/downcast.rs
@@ -1,0 +1,135 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<A: Aleo> Literal<A> {
+    /// Downcasts the literal to the given literal type.
+    ///
+    /// This method checks that the downcast does not lose any bits of information,
+    /// and returns an error if it does.
+    ///
+    /// The hierarchy of downcasting is as follows:
+    ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
+    ///  - `String` (currently not supported)
+    pub fn downcast(&self, to_type: LiteralType) -> Result<Self> {
+        match self {
+            Self::Address(address) => downcast_group_to_type(address.to_group(), to_type),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Field(field) => downcast_field_to_type(field.clone(), to_type),
+            Self::Group(group) => downcast_group_to_type(group.clone(), to_type),
+            Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
+            Self::I16(..) => bail!("Cannot downcast an i16 literal to another type (yet)."),
+            Self::I32(..) => bail!("Cannot downcast an i32 literal to another type (yet)."),
+            Self::I64(..) => bail!("Cannot downcast an i64 literal to another type (yet)."),
+            Self::I128(..) => bail!("Cannot downcast an i128 literal to another type (yet)."),
+            Self::U8(..) => bail!("Cannot downcast a u8 literal to another type (yet)."),
+            Self::U16(..) => bail!("Cannot downcast a u16 literal to another type (yet)."),
+            Self::U32(..) => bail!("Cannot downcast a u32 literal to another type (yet)."),
+            Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
+            Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
+            Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+        }
+    }
+
+    /// Downcasts the literal to the given literal type, with lossy truncation.
+    ///
+    /// This method makes a *best-effort* attempt to preserve upcasting back
+    /// to the original literal type, but it is not guaranteed to do so.
+    ///
+    /// The hierarchy of downcasting is as follows:
+    ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
+    ///  - `String` (currently not supported)
+    pub fn downcast_lossy(&self, to_type: LiteralType) -> Result<Self> {
+        match self {
+            Self::Address(address) => downcast_lossy_group_to_type(address.to_group(), to_type),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Field(field) => downcast_lossy_field_to_type(field.clone(), to_type),
+            Self::Group(group) => downcast_lossy_group_to_type(group.clone(), to_type),
+            Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
+            Self::I16(..) => bail!("Cannot downcast an i16 literal to another type (yet)."),
+            Self::I32(..) => bail!("Cannot downcast an i32 literal to another type (yet)."),
+            Self::I64(..) => bail!("Cannot downcast an i64 literal to another type (yet)."),
+            Self::I128(..) => bail!("Cannot downcast an i128 literal to another type (yet)."),
+            Self::U8(..) => bail!("Cannot downcast a u8 literal to another type (yet)."),
+            Self::U16(..) => bail!("Cannot downcast a u16 literal to another type (yet)."),
+            Self::U32(..) => bail!("Cannot downcast a u32 literal to another type (yet)."),
+            Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
+            Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
+            Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+        }
+    }
+}
+
+/// Downcasts a field literal to the given literal type.
+fn downcast_field_to_type<A: Aleo>(field: Field<A>, to_type: LiteralType) -> Result<Literal<A>> {
+    match to_type {
+        LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Field => Ok(Literal::Field(field)),
+        LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
+        LiteralType::I8 => Ok(Literal::I8(I8::from_field(field))),
+        LiteralType::I16 => Ok(Literal::I16(I16::from_field(field))),
+        LiteralType::I32 => Ok(Literal::I32(I32::from_field(field))),
+        LiteralType::I64 => Ok(Literal::I64(I64::from_field(field))),
+        LiteralType::I128 => Ok(Literal::I128(I128::from_field(field))),
+        LiteralType::U8 => Ok(Literal::U8(U8::from_field(field))),
+        LiteralType::U16 => Ok(Literal::U16(U16::from_field(field))),
+        LiteralType::U32 => Ok(Literal::U32(U32::from_field(field))),
+        LiteralType::U64 => Ok(Literal::U64(U64::from_field(field))),
+        LiteralType::U128 => Ok(Literal::U128(U128::from_field(field))),
+        LiteralType::Scalar => Ok(Literal::Scalar(Scalar::from_field(field))),
+        LiteralType::String => bail!("Cannot downcast a field literal to a string type."),
+    }
+}
+
+/// Downcasts a field literal to the given literal type, with lossy truncation.
+fn downcast_lossy_field_to_type<A: Aleo>(field: Field<A>, to_type: LiteralType) -> Result<Literal<A>> {
+    match to_type {
+        LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Field => Ok(Literal::Field(field)),
+        LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
+        LiteralType::I8 => Ok(Literal::I8(I8::from_field_lossy(field))),
+        LiteralType::I16 => Ok(Literal::I16(I16::from_field_lossy(field))),
+        LiteralType::I32 => Ok(Literal::I32(I32::from_field_lossy(field))),
+        LiteralType::I64 => Ok(Literal::I64(I64::from_field_lossy(field))),
+        LiteralType::I128 => Ok(Literal::I128(I128::from_field_lossy(field))),
+        LiteralType::U8 => Ok(Literal::U8(U8::from_field_lossy(field))),
+        LiteralType::U16 => Ok(Literal::U16(U16::from_field_lossy(field))),
+        LiteralType::U32 => Ok(Literal::U32(U32::from_field_lossy(field))),
+        LiteralType::U64 => Ok(Literal::U64(U64::from_field_lossy(field))),
+        LiteralType::U128 => Ok(Literal::U128(U128::from_field_lossy(field))),
+        LiteralType::Scalar => Ok(Literal::Scalar(Scalar::from_field_lossy(field))),
+        LiteralType::String => bail!("Cannot downcast a field literal to a string type."),
+    }
+}
+
+/// Downcasts a group literal to the given literal type.
+fn downcast_group_to_type<A: Aleo>(group: Group<A>, to_type: LiteralType) -> Result<Literal<A>> {
+    match to_type {
+        LiteralType::Address => Ok(Literal::Address(Address::from_group(group))),
+        _ => downcast_field_to_type(group.to_x_coordinate(), to_type),
+    }
+}
+
+/// Downcasts a group literal to the given literal type, with lossy truncation.
+fn downcast_lossy_group_to_type<A: Aleo>(group: Group<A>, to_type: LiteralType) -> Result<Literal<A>> {
+    match to_type {
+        LiteralType::Address => Ok(Literal::Address(Address::from_group(group))),
+        _ => downcast_lossy_field_to_type(group.to_x_coordinate(), to_type),
+    }
+}

--- a/circuit/program/src/data/literal/downcast.rs
+++ b/circuit/program/src/data/literal/downcast.rs
@@ -22,11 +22,11 @@ impl<A: Aleo> Literal<A> {
     ///
     /// The hierarchy of downcasting is as follows:
     ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
-    ///  - `String` (currently not supported)
+    ///  - `String` (not supported)
     pub fn downcast(&self, to_type: LiteralType) -> Result<Self> {
         match self {
             Self::Address(address) => downcast_group_to_type(address.to_group(), to_type),
-            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type."),
             Self::Field(field) => downcast_field_to_type(field.clone(), to_type),
             Self::Group(group) => downcast_group_to_type(group.clone(), to_type),
             Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
@@ -40,7 +40,7 @@ impl<A: Aleo> Literal<A> {
             Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
             Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
             Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
-            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type."),
         }
     }
 
@@ -51,11 +51,11 @@ impl<A: Aleo> Literal<A> {
     ///
     /// The hierarchy of downcasting is as follows:
     ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
-    ///  - `String` (currently not supported)
+    ///  - `String` (not supported)
     pub fn downcast_lossy(&self, to_type: LiteralType) -> Result<Self> {
         match self {
             Self::Address(address) => downcast_lossy_group_to_type(address.to_group(), to_type),
-            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type."),
             Self::Field(field) => downcast_lossy_field_to_type(field.clone(), to_type),
             Self::Group(group) => downcast_lossy_group_to_type(group.clone(), to_type),
             Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
@@ -69,7 +69,7 @@ impl<A: Aleo> Literal<A> {
             Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
             Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
             Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
-            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type."),
         }
     }
 }
@@ -78,7 +78,7 @@ impl<A: Aleo> Literal<A> {
 fn downcast_field_to_type<A: Aleo>(field: Field<A>, to_type: LiteralType) -> Result<Literal<A>> {
     match to_type {
         LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
-        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type (yet)."),
         LiteralType::Field => Ok(Literal::Field(field)),
         LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
         LiteralType::I8 => Ok(Literal::I8(I8::from_field(field))),
@@ -100,7 +100,7 @@ fn downcast_field_to_type<A: Aleo>(field: Field<A>, to_type: LiteralType) -> Res
 fn downcast_lossy_field_to_type<A: Aleo>(field: Field<A>, to_type: LiteralType) -> Result<Literal<A>> {
     match to_type {
         LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
-        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type (yet)."),
         LiteralType::Field => Ok(Literal::Field(field)),
         LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
         LiteralType::I8 => Ok(Literal::I8(I8::from_field_lossy(field))),
@@ -122,6 +122,7 @@ fn downcast_lossy_field_to_type<A: Aleo>(field: Field<A>, to_type: LiteralType) 
 fn downcast_group_to_type<A: Aleo>(group: Group<A>, to_type: LiteralType) -> Result<Literal<A>> {
     match to_type {
         LiteralType::Address => Ok(Literal::Address(Address::from_group(group))),
+        LiteralType::Group => Ok(Literal::Group(group)),
         _ => downcast_field_to_type(group.to_x_coordinate(), to_type),
     }
 }
@@ -130,6 +131,7 @@ fn downcast_group_to_type<A: Aleo>(group: Group<A>, to_type: LiteralType) -> Res
 fn downcast_lossy_group_to_type<A: Aleo>(group: Group<A>, to_type: LiteralType) -> Result<Literal<A>> {
     match to_type {
         LiteralType::Address => Ok(Literal::Address(Address::from_group(group))),
+        LiteralType::Group => Ok(Literal::Group(group)),
         _ => downcast_lossy_field_to_type(group.to_x_coordinate(), to_type),
     }
 }

--- a/circuit/program/src/data/literal/mod.rs
+++ b/circuit/program/src/data/literal/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod downcast;
 mod equal;
 mod from_bits;
 mod size_in_bits;
@@ -20,6 +21,7 @@ mod to_fields;
 mod to_type;
 mod variant;
 
+use console::LiteralType;
 use snarkvm_circuit_network::Aleo;
 use snarkvm_circuit_types::prelude::*;
 

--- a/circuit/types/integers/src/helpers/from_field_lossy.rs
+++ b/circuit/types/integers/src/helpers/from_field_lossy.rs
@@ -1,0 +1,164 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment, I: IntegerType> Integer<E, I> {
+    /// Casts an integer from a base field, with lossy truncation.
+    ///
+    /// This method is commonly-used by hash-to-integer algorithms,
+    /// where the hash output does not need to preserve the full base field.
+    pub fn from_field_lossy(field: Field<E>) -> Self {
+        // Note: We are reconstituting the integer from the base field.
+        // This is safe as the number of bits in the integer is less than the base field modulus,
+        // and thus will always fit within a single base field element.
+        debug_assert!(I::BITS < E::BaseField::size_in_bits() as u64);
+
+        // Truncate the field to the size in bits of the integer.
+        // Slicing here is safe as the base field is larger than the integer domain.
+        Self { bits_le: field.to_bits_le()[..I::BITS as usize].to_vec(), phantom: Default::default() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_circuit_environment::Circuit;
+
+    const ITERATIONS: u64 = 128;
+
+    fn check_from_field_lossy<I: IntegerType>(mode: Mode, rng: &mut TestRng) {
+        for i in 0..ITERATIONS {
+            // Sample a random integer.
+            let expected = Uniform::rand(rng);
+            let candidate = Integer::<Circuit, I>::new(mode, expected).to_field();
+
+            Circuit::scope(format!("{mode} {expected} {i}"), || {
+                // Perform the operation.
+                let candidate = Integer::from_field_lossy(candidate);
+                assert_eq!(expected, candidate.eject_value());
+                match mode {
+                    Mode::Constant => assert_scope!(0, 0, 0, 0),
+                    _ => assert_scope!(0, 0, 0, 0),
+                }
+            });
+            Circuit::reset();
+
+            // Sample a random field.
+            let expected = Field::<Circuit>::new(mode, Uniform::rand(rng));
+            // Perform the operation.
+            Integer::<_, I>::from_field_lossy(expected); // This should not fail.
+        }
+    }
+
+    #[test]
+    fn test_u8_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = u8;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_i8_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = i8;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_u16_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = u16;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_i16_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = i16;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_u32_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = u32;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_i32_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = i32;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_u64_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = u64;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_i64_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = i64;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_u128_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = u128;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+
+    #[test]
+    fn test_i128_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        type I = i128;
+        check_from_field_lossy::<I>(Mode::Constant, &mut rng);
+        check_from_field_lossy::<I>(Mode::Public, &mut rng);
+        check_from_field_lossy::<I>(Mode::Private, &mut rng);
+    }
+}

--- a/circuit/types/integers/src/helpers/mod.rs
+++ b/circuit/types/integers/src/helpers/mod.rs
@@ -16,6 +16,7 @@ use super::*;
 
 pub mod from_bits;
 pub mod from_field;
+pub mod from_field_lossy;
 pub mod msb;
 pub mod one;
 pub mod to_bits;

--- a/circuit/types/scalar/src/helpers/from_field.rs
+++ b/circuit/types/scalar/src/helpers/from_field.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> FromField for Scalar<E> {
+    type Field = Field<E>;
+
+    /// Casts a scalar from a base field element.
+    ///
+    /// This method guarantees the following:
+    ///   1. If the field element is larger than the scalar field modulus, then the operation will fail.
+    ///   2. If the field element is smaller than the scalar field modulus, then the operation will succeed.
+    ///     - This is particularly useful for the case where a user called, `Scalar::from_field(scalar.to_field())`,
+    ///       and the scalar bit representation is between `size_in_data_bits < bits.len() < size_in_bits`.
+    fn from_field(field: Self::Field) -> Self {
+        // Note: We are reconstituting the integer from the base field.
+        // This is safe as the number of bits in the integer is less than the base field modulus,
+        // and thus will always fit within a single base field element.
+        debug_assert!(E::ScalarField::size_in_bits() < E::BaseField::size_in_bits());
+
+        // Do not truncate the field bits, which provides the following features:
+        //   1. If the field element is larger than the scalar field modulus, then the operation will fail.
+        //   2. If the field element is smaller than the scalar field modulus, then the operation will succeed.
+        //     - This is particularly useful for the case where a user called, `Scalar::from_field(scalar.to_field())`,
+        //       and the scalar bit representation is between `size_in_data_bits < bits.len() < size_in_bits`.
+        Scalar::from_bits_le(&field.to_bits_le())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_circuit_environment::Circuit;
+
+    const ITERATIONS: u64 = 128;
+
+    fn check_from_field(mode: Mode, rng: &mut TestRng) {
+        for i in 0..ITERATIONS {
+            // Sample a random scalar.
+            let expected = Uniform::rand(rng);
+            let candidate = Scalar::<Circuit>::new(mode, expected).to_field();
+
+            Circuit::scope(format!("{mode} {expected} {i}"), || {
+                // Perform the operation.
+                let candidate = Scalar::<Circuit>::from_field(candidate);
+                assert_eq!(expected, candidate.eject_value());
+                match mode {
+                    Mode::Constant => assert_scope!(253, 0, 0, 0),
+                    _ => assert_scope!(0, 0, 755, 760),
+                }
+            });
+            Circuit::reset();
+
+            // Sample a random field.
+            let expected = Field::<Circuit>::new(mode, Uniform::rand(rng));
+            // Filter for field elements that exceed the scalar field modulus.
+            if expected.eject_value()
+                > console::ToField::to_field(&-console::Scalar::<<Circuit as Environment>::Network>::one()).unwrap()
+            {
+                // Perform the operation.
+                let result = std::panic::catch_unwind(|| {
+                    Scalar::from_field(expected); // This should fail.
+                });
+                assert!(result.is_err() || !Circuit::is_satisfied());
+            } else {
+                // Perform the operation.
+                Scalar::from_field(expected); // This should not fail.
+            }
+
+            Circuit::reset();
+        }
+    }
+
+    #[test]
+    fn test_from_field() {
+        let mut rng = TestRng::default();
+
+        check_from_field(Mode::Constant, &mut rng);
+        check_from_field(Mode::Public, &mut rng);
+        check_from_field(Mode::Private, &mut rng);
+    }
+}

--- a/circuit/types/scalar/src/helpers/from_field_lossy.rs
+++ b/circuit/types/scalar/src/helpers/from_field_lossy.rs
@@ -52,7 +52,7 @@ mod tests {
                 assert_eq!(expected, candidate.eject_value());
                 match mode {
                     Mode::Constant => assert_scope!(253, 0, 0, 0),
-                    _ => assert_scope!(0, 0, 755, 758),
+                    _ => assert_scope!(0, 0, 505, 507),
                 }
             });
             Circuit::reset();

--- a/circuit/types/scalar/src/helpers/from_field_lossy.rs
+++ b/circuit/types/scalar/src/helpers/from_field_lossy.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> Scalar<E> {
+    /// Casts a scalar from a base field, with lossy truncation.
+    ///
+    /// This method is commonly-used by hash-to-scalar algorithms,
+    /// where the hash output does not need to preserve the full base field.
+    pub fn from_field_lossy(field: Field<E>) -> Self {
+        // Note: We are reconstituting the integer from the base field.
+        // This is safe as the number of bits in the integer is less than the base field modulus,
+        // and thus will always fit within a single base field element.
+        debug_assert!(E::ScalarField::size_in_bits() < E::BaseField::size_in_bits());
+
+        // Truncate the output to the size in data bits (1 bit less than the MODULUS) of the scalar.
+        // Slicing here is safe as the base field is larger than the scalar field.
+        Scalar::from_bits_le(&field.to_bits_le()[..E::ScalarField::size_in_data_bits()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_circuit_environment::Circuit;
+
+    const ITERATIONS: u64 = 128;
+
+    fn check_from_field_lossy(mode: Mode, rng: &mut TestRng) {
+        for i in 0..ITERATIONS {
+            // Sample a random scalar.
+            let size_in_data_bits = console::Scalar::<<Circuit as Environment>::Network>::size_in_data_bits();
+            let prepare = console::Scalar::<<Circuit as Environment>::Network>::rand(rng);
+            let expected = console::Scalar::from_bits_le(&prepare.to_bits_le()[..size_in_data_bits]).unwrap();
+            let candidate = Scalar::<Circuit>::new(mode, expected).to_field();
+
+            Circuit::scope(format!("{mode} {expected} {i}"), || {
+                // Perform the operation.
+                let candidate = Scalar::<Circuit>::from_field_lossy(candidate);
+                assert_eq!(expected, candidate.eject_value());
+                match mode {
+                    Mode::Constant => assert_scope!(253, 0, 0, 0),
+                    _ => assert_scope!(0, 0, 755, 758),
+                }
+            });
+            Circuit::reset();
+
+            // Sample a random field element.
+            let expected = Field::<Circuit>::new(mode, Uniform::rand(rng));
+            // Perform the operation.
+            Scalar::from_field_lossy(expected); // This should not fail.
+
+            Circuit::reset();
+        }
+    }
+
+    #[test]
+    fn test_from_field_lossy() {
+        let mut rng = TestRng::default();
+
+        check_from_field_lossy(Mode::Constant, &mut rng);
+        check_from_field_lossy(Mode::Public, &mut rng);
+        check_from_field_lossy(Mode::Private, &mut rng);
+    }
+}

--- a/circuit/types/scalar/src/helpers/mod.rs
+++ b/circuit/types/scalar/src/helpers/mod.rs
@@ -15,6 +15,8 @@
 use super::*;
 
 pub mod from_bits;
+pub mod from_field;
+pub mod from_field_lossy;
 pub mod one;
 pub mod to_bits;
 pub mod to_field;

--- a/console/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/console/algorithms/src/poseidon/hash_to_scalar.rs
@@ -22,19 +22,10 @@ impl<E: Environment, const RATE: usize> HashToScalar for Poseidon<E, RATE> {
     /// This method uses truncation (up to data bits) to project onto the scalar field.
     #[inline]
     fn hash_to_scalar(&self, input: &[Self::Input]) -> Result<Self::Output> {
-        // Note: We are reconstituting the base field into a scalar field.
-        // This is safe as the scalar field modulus is less than the base field modulus,
-        // and thus will always fit within a single base field element.
-        debug_assert!(Scalar::<E>::size_in_bits() < Field::<E>::size_in_bits());
-
         // Hash the input to the base field.
         let output = self.hash(input)?;
-
-        // Truncate the output to the size in data bits (1 bit less than the MODULUS) of the scalar.
-        // Slicing here is safe as the base field is larger than the scalar field.
-        let bits = &output.to_bits_le()[..Scalar::<E>::size_in_data_bits()];
-
-        // Output the scalar.
-        Scalar::from_bits_le(bits)
+        // Convert the output to the scalar field,
+        // truncating to the size in data bits (1 bit less than the MODULUS) of the scalar.
+        Self::Output::from_field_lossy(&output)
     }
 }

--- a/console/program/src/data/literal/downcast.rs
+++ b/console/program/src/data/literal/downcast.rs
@@ -22,11 +22,11 @@ impl<N: Network> Literal<N> {
     ///
     /// The hierarchy of downcasting is as follows:
     ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
-    ///  - `String` (currently not supported)
+    ///  - `String` (not supported)
     pub fn downcast(&self, to_type: LiteralType) -> Result<Self> {
         match self {
             Self::Address(address) => downcast_group_to_type(address.to_group(), to_type),
-            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type."),
             Self::Field(field) => downcast_field_to_type(field, to_type),
             Self::Group(group) => downcast_group_to_type(group, to_type),
             Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
@@ -40,7 +40,7 @@ impl<N: Network> Literal<N> {
             Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
             Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
             Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
-            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type."),
         }
     }
 
@@ -51,11 +51,11 @@ impl<N: Network> Literal<N> {
     ///
     /// The hierarchy of downcasting is as follows:
     ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
-    ///  - `String` (currently not supported)
+    ///  - `String` (not supported)
     pub fn downcast_lossy(&self, to_type: LiteralType) -> Result<Self> {
         match self {
             Self::Address(address) => downcast_lossy_group_to_type(address.to_group(), to_type),
-            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type."),
             Self::Field(field) => downcast_lossy_field_to_type(field, to_type),
             Self::Group(group) => downcast_lossy_group_to_type(group, to_type),
             Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
@@ -69,7 +69,7 @@ impl<N: Network> Literal<N> {
             Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
             Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
             Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
-            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type."),
         }
     }
 }
@@ -78,7 +78,7 @@ impl<N: Network> Literal<N> {
 fn downcast_field_to_type<N: Network>(field: &Field<N>, to_type: LiteralType) -> Result<Literal<N>> {
     match to_type {
         LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
-        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type (yet)."),
         LiteralType::Field => Ok(Literal::Field(*field)),
         LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
         LiteralType::I8 => Ok(Literal::I8(I8::from_field(field)?)),
@@ -100,7 +100,7 @@ fn downcast_field_to_type<N: Network>(field: &Field<N>, to_type: LiteralType) ->
 fn downcast_lossy_field_to_type<N: Network>(field: &Field<N>, to_type: LiteralType) -> Result<Literal<N>> {
     match to_type {
         LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
-        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type (yet)."),
         LiteralType::Field => Ok(Literal::Field(*field)),
         LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
         LiteralType::I8 => Ok(Literal::I8(I8::from_field_lossy(field)?)),
@@ -122,6 +122,7 @@ fn downcast_lossy_field_to_type<N: Network>(field: &Field<N>, to_type: LiteralTy
 fn downcast_group_to_type<N: Network>(group: &Group<N>, to_type: LiteralType) -> Result<Literal<N>> {
     match to_type {
         LiteralType::Address => Ok(Literal::Address(Address::new(*group))),
+        LiteralType::Group => Ok(Literal::Group(*group)),
         _ => downcast_field_to_type(&group.to_x_coordinate(), to_type),
     }
 }
@@ -130,6 +131,7 @@ fn downcast_group_to_type<N: Network>(group: &Group<N>, to_type: LiteralType) ->
 fn downcast_lossy_group_to_type<N: Network>(group: &Group<N>, to_type: LiteralType) -> Result<Literal<N>> {
     match to_type {
         LiteralType::Address => Ok(Literal::Address(Address::new(*group))),
+        LiteralType::Group => Ok(Literal::Group(*group)),
         _ => downcast_lossy_field_to_type(&group.to_x_coordinate(), to_type),
     }
 }

--- a/console/program/src/data/literal/downcast.rs
+++ b/console/program/src/data/literal/downcast.rs
@@ -1,0 +1,135 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Literal<N> {
+    /// Downcasts the literal to the given literal type.
+    ///
+    /// This method checks that the downcast does not lose any bits of information,
+    /// and returns an error if it does.
+    ///
+    /// The hierarchy of downcasting is as follows:
+    ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
+    ///  - `String` (currently not supported)
+    pub fn downcast(&self, to_type: LiteralType) -> Result<Self> {
+        match self {
+            Self::Address(address) => downcast_group_to_type(address.to_group(), to_type),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Field(field) => downcast_field_to_type(field, to_type),
+            Self::Group(group) => downcast_group_to_type(group, to_type),
+            Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
+            Self::I16(..) => bail!("Cannot downcast an i16 literal to another type (yet)."),
+            Self::I32(..) => bail!("Cannot downcast an i32 literal to another type (yet)."),
+            Self::I64(..) => bail!("Cannot downcast an i64 literal to another type (yet)."),
+            Self::I128(..) => bail!("Cannot downcast an i128 literal to another type (yet)."),
+            Self::U8(..) => bail!("Cannot downcast a u8 literal to another type (yet)."),
+            Self::U16(..) => bail!("Cannot downcast a u16 literal to another type (yet)."),
+            Self::U32(..) => bail!("Cannot downcast a u32 literal to another type (yet)."),
+            Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
+            Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
+            Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+        }
+    }
+
+    /// Downcasts the literal to the given literal type, with lossy truncation.
+    ///
+    /// This method makes a *best-effort* attempt to preserve upcasting back
+    /// to the original literal type, but it is not guaranteed to do so.
+    ///
+    /// The hierarchy of downcasting is as follows:
+    ///  - (`Address`, `Group`) -> `Field` -> `Scalar` -> `Integer` -> `Boolean`
+    ///  - `String` (currently not supported)
+    pub fn downcast_lossy(&self, to_type: LiteralType) -> Result<Self> {
+        match self {
+            Self::Address(address) => downcast_lossy_group_to_type(address.to_group(), to_type),
+            Self::Boolean(..) => bail!("Cannot downcast a boolean literal to another type (yet)."),
+            Self::Field(field) => downcast_lossy_field_to_type(field, to_type),
+            Self::Group(group) => downcast_lossy_group_to_type(group, to_type),
+            Self::I8(..) => bail!("Cannot downcast an i8 literal to another type (yet)."),
+            Self::I16(..) => bail!("Cannot downcast an i16 literal to another type (yet)."),
+            Self::I32(..) => bail!("Cannot downcast an i32 literal to another type (yet)."),
+            Self::I64(..) => bail!("Cannot downcast an i64 literal to another type (yet)."),
+            Self::I128(..) => bail!("Cannot downcast an i128 literal to another type (yet)."),
+            Self::U8(..) => bail!("Cannot downcast a u8 literal to another type (yet)."),
+            Self::U16(..) => bail!("Cannot downcast a u16 literal to another type (yet)."),
+            Self::U32(..) => bail!("Cannot downcast a u32 literal to another type (yet)."),
+            Self::U64(..) => bail!("Cannot downcast a u64 literal to another type (yet)."),
+            Self::U128(..) => bail!("Cannot downcast a u128 literal to another type (yet)."),
+            Self::Scalar(..) => bail!("Cannot downcast a scalar literal to another type (yet)."),
+            Self::String(..) => bail!("Cannot downcast a string literal to another type (yet)."),
+        }
+    }
+}
+
+/// Downcasts a field literal to the given literal type.
+fn downcast_field_to_type<N: Network>(field: &Field<N>, to_type: LiteralType) -> Result<Literal<N>> {
+    match to_type {
+        LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Field => Ok(Literal::Field(*field)),
+        LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
+        LiteralType::I8 => Ok(Literal::I8(I8::from_field(field)?)),
+        LiteralType::I16 => Ok(Literal::I16(I16::from_field(field)?)),
+        LiteralType::I32 => Ok(Literal::I32(I32::from_field(field)?)),
+        LiteralType::I64 => Ok(Literal::I64(I64::from_field(field)?)),
+        LiteralType::I128 => Ok(Literal::I128(I128::from_field(field)?)),
+        LiteralType::U8 => Ok(Literal::U8(U8::from_field(field)?)),
+        LiteralType::U16 => Ok(Literal::U16(U16::from_field(field)?)),
+        LiteralType::U32 => Ok(Literal::U32(U32::from_field(field)?)),
+        LiteralType::U64 => Ok(Literal::U64(U64::from_field(field)?)),
+        LiteralType::U128 => Ok(Literal::U128(U128::from_field(field)?)),
+        LiteralType::Scalar => Ok(Literal::Scalar(Scalar::from_field(field)?)),
+        LiteralType::String => bail!("Cannot downcast a field literal to a string type."),
+    }
+}
+
+/// Downcasts a field literal to the given literal type, with lossy truncation.
+fn downcast_lossy_field_to_type<N: Network>(field: &Field<N>, to_type: LiteralType) -> Result<Literal<N>> {
+    match to_type {
+        LiteralType::Address => bail!("Cannot downcast a field literal to an address type."),
+        LiteralType::Boolean => bail!("Cannot downcast a field literal to a boolean type."),
+        LiteralType::Field => Ok(Literal::Field(*field)),
+        LiteralType::Group => bail!("Cannot downcast a field literal to a group type."),
+        LiteralType::I8 => Ok(Literal::I8(I8::from_field_lossy(field)?)),
+        LiteralType::I16 => Ok(Literal::I16(I16::from_field_lossy(field)?)),
+        LiteralType::I32 => Ok(Literal::I32(I32::from_field_lossy(field)?)),
+        LiteralType::I64 => Ok(Literal::I64(I64::from_field_lossy(field)?)),
+        LiteralType::I128 => Ok(Literal::I128(I128::from_field_lossy(field)?)),
+        LiteralType::U8 => Ok(Literal::U8(U8::from_field_lossy(field)?)),
+        LiteralType::U16 => Ok(Literal::U16(U16::from_field_lossy(field)?)),
+        LiteralType::U32 => Ok(Literal::U32(U32::from_field_lossy(field)?)),
+        LiteralType::U64 => Ok(Literal::U64(U64::from_field_lossy(field)?)),
+        LiteralType::U128 => Ok(Literal::U128(U128::from_field_lossy(field)?)),
+        LiteralType::Scalar => Ok(Literal::Scalar(Scalar::from_field_lossy(field)?)),
+        LiteralType::String => bail!("Cannot downcast a field literal to a string type."),
+    }
+}
+
+/// Downcasts a group literal to the given literal type.
+fn downcast_group_to_type<N: Network>(group: &Group<N>, to_type: LiteralType) -> Result<Literal<N>> {
+    match to_type {
+        LiteralType::Address => Ok(Literal::Address(Address::new(*group))),
+        _ => downcast_field_to_type(&group.to_x_coordinate(), to_type),
+    }
+}
+
+/// Downcasts a group literal to the given literal type, with lossy truncation.
+fn downcast_lossy_group_to_type<N: Network>(group: &Group<N>, to_type: LiteralType) -> Result<Literal<N>> {
+    match to_type {
+        LiteralType::Address => Ok(Literal::Address(Address::new(*group))),
+        _ => downcast_lossy_field_to_type(&group.to_x_coordinate(), to_type),
+    }
+}

--- a/console/program/src/data/literal/mod.rs
+++ b/console/program/src/data/literal/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod bytes;
+mod downcast;
 mod equal;
 mod from_bits;
 mod parse;

--- a/console/types/address/src/lib.rs
+++ b/console/types/address/src/lib.rs
@@ -27,6 +27,7 @@ mod size_in_bytes;
 mod to_bits;
 mod to_field;
 mod to_fields;
+mod to_group;
 
 pub use snarkvm_console_network_environment::prelude::*;
 pub use snarkvm_console_types_boolean::Boolean;

--- a/console/types/address/src/to_group.rs
+++ b/console/types/address/src/to_group.rs
@@ -1,0 +1,50 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> Address<E> {
+    /// Returns the address as a group element.
+    pub const fn to_group(&self) -> &Group<E> {
+        &self.address
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network_environment::Console;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: u64 = 10_000;
+
+    #[test]
+    fn test_to_group() -> Result<()> {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            // Sample a random value.
+            let address = Address::<CurrentEnvironment>::new(Uniform::rand(&mut rng));
+
+            let candidate = address.to_group();
+
+            let expected = address.to_bits_le();
+            for (index, candidate_bit) in candidate.to_bits_le().iter().enumerate() {
+                assert_eq!(expected[index], *candidate_bit);
+            }
+        }
+        Ok(())
+    }
+}

--- a/console/types/integers/src/from_field_lossy.rs
+++ b/console/types/integers/src/from_field_lossy.rs
@@ -1,0 +1,121 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment, I: IntegerType> Integer<E, I> {
+    /// Casts an integer from a base field, with lossy truncation.
+    ///
+    /// This method is commonly-used by hash-to-integer algorithms,
+    /// where the hash output does not need to preserve the full base field.
+    pub fn from_field_lossy(field: &Field<E>) -> Result<Self> {
+        // Note: We are reconstituting the integer from the base field.
+        // This is safe as the number of bits in the integer is less than the base field modulus,
+        // and thus will always fit within a single base field element.
+        debug_assert!(I::BITS < Field::<E>::size_in_bits() as u64);
+
+        // Truncate the field to the size of the integer domain.
+        // Slicing here is safe as the base field is larger than the integer domain.
+        Self::from_bits_le(&field.to_bits_le()[..usize::try_from(I::BITS)?])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network_environment::Console;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: u64 = 10_000;
+
+    fn check_from_field_lossy<I: IntegerType>() -> Result<()> {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            // Sample a random integer.
+            let expected = Integer::<CurrentEnvironment, I>::rand(&mut rng);
+
+            // Perform the operation.
+            let candidate = Integer::from_field_lossy(&expected.to_field()?)?;
+            assert_eq!(expected, candidate);
+
+            // Sample a random field.
+            let expected = Field::<CurrentEnvironment>::rand(&mut rng);
+            // Perform the operation.
+            assert!(Integer::<_, I>::from_field_lossy(&expected).is_ok());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_u8_from_field_lossy() -> Result<()> {
+        type I = u8;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_i8_from_field_lossy() -> Result<()> {
+        type I = i8;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_u16_from_field_lossy() -> Result<()> {
+        type I = u16;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_i16_from_field_lossy() -> Result<()> {
+        type I = i16;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_u32_from_field_lossy() -> Result<()> {
+        type I = u32;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_i32_from_field_lossy() -> Result<()> {
+        type I = i32;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_u64_from_field_lossy() -> Result<()> {
+        type I = u64;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_i64_from_field_lossy() -> Result<()> {
+        type I = i64;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_u128_from_field_lossy() -> Result<()> {
+        type I = u128;
+        check_from_field_lossy::<I>()
+    }
+
+    #[test]
+    fn test_i128_from_field_lossy() -> Result<()> {
+        type I = i128;
+        check_from_field_lossy::<I>()
+    }
+}

--- a/console/types/integers/src/lib.rs
+++ b/console/types/integers/src/lib.rs
@@ -21,6 +21,7 @@ mod bytes;
 mod compare;
 mod from_bits;
 mod from_field;
+mod from_field_lossy;
 mod from_fields;
 mod one;
 mod parse;

--- a/console/types/scalar/src/from_field.rs
+++ b/console/types/scalar/src/from_field.rs
@@ -1,0 +1,75 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> FromField for Scalar<E> {
+    type Field = Field<E>;
+
+    /// Casts a scalar from a base field element.
+    ///
+    /// This method guarantees the following:
+    ///   1. If the field element is larger than the scalar field modulus, then the operation will fail.
+    ///   2. If the field element is smaller than the scalar field modulus, then the operation will succeed.
+    ///     - This is particularly useful for the case where a user called, `Scalar::from_field(scalar.to_field())`,
+    ///       and the scalar bit representation is between `size_in_data_bits < bits.len() < size_in_bits`.
+    fn from_field(field: &Self::Field) -> Result<Self> {
+        // Note: We are reconstituting the base field into a scalar field.
+        // This is safe as the scalar field modulus is less than the base field modulus,
+        // and thus will always fit within a single base field element.
+        debug_assert!(Scalar::<E>::size_in_bits() < Field::<E>::size_in_bits());
+
+        // Do not truncate the field bits, which provides the following features:
+        //   1. If the field element is larger than the scalar field modulus, then the operation will fail.
+        //   2. If the field element is smaller than the scalar field modulus, then the operation will succeed.
+        //     - This is particularly useful for the case where a user called, `Scalar::from_field(scalar.to_field())`,
+        //       and the scalar bit representation is between `size_in_data_bits < bits.len() < size_in_bits`.
+        Self::from_bits_le(&field.to_bits_le())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network_environment::Console;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: u64 = 10_000;
+
+    #[test]
+    fn test_from_field() -> Result<()> {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            // Sample a random scalar.
+            let expected = Scalar::<CurrentEnvironment>::rand(&mut rng);
+            // Perform the operation.
+            let candidate = Scalar::from_field(&expected.to_field()?)?;
+            assert_eq!(expected, candidate);
+
+            // Sample a random field.
+            let expected = Field::<CurrentEnvironment>::rand(&mut rng);
+            // Filter for field elements that exceed the scalar field modulus.
+            if expected > (-Scalar::<CurrentEnvironment>::one()).to_field()? {
+                // Perform the operation.
+                assert!(Scalar::from_field(&expected).is_err());
+            } else {
+                // Perform the operation.
+                assert!(Scalar::from_field(&expected).is_ok());
+            }
+        }
+        Ok(())
+    }
+}

--- a/console/types/scalar/src/from_field_lossy.rs
+++ b/console/types/scalar/src/from_field_lossy.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> Scalar<E> {
+    /// Casts a scalar from a base field, with lossy truncation.
+    ///
+    /// This method is commonly-used by hash-to-scalar algorithms,
+    /// where the hash output does not need to preserve the full base field.
+    pub fn from_field_lossy(field: &Field<E>) -> Result<Self> {
+        // Note: We are reconstituting the base field into a scalar field.
+        // This is safe as the scalar field modulus is less than the base field modulus,
+        // and thus will always fit within a single base field element.
+        debug_assert!(Scalar::<E>::size_in_bits() < Field::<E>::size_in_bits());
+
+        // Truncate the field to the size in data bits (1 bit less than the MODULUS) of the scalar.
+        // Slicing here is safe as the base field is larger than the scalar field.
+        Self::from_bits_le(&field.to_bits_le()[..Scalar::<E>::size_in_data_bits()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network_environment::Console;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: u64 = 10_000;
+
+    #[test]
+    fn test_from_field() -> Result<()> {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            // Sample a random scalar.
+            let size_in_data_bits = Scalar::<CurrentEnvironment>::size_in_data_bits();
+            let prepare = &Scalar::<CurrentEnvironment>::rand(&mut rng).to_bits_le()[0..size_in_data_bits];
+            let expected = Scalar::<CurrentEnvironment>::from_bits_le(prepare)?;
+            // Perform the operation.
+            let candidate = Scalar::from_field_lossy(&expected.to_field()?)?;
+            assert_eq!(expected, candidate);
+
+            // Sample a random field.
+            let expected = Field::<CurrentEnvironment>::rand(&mut rng);
+            // Perform the operation.
+            assert!(Scalar::from_field_lossy(&expected).is_ok());
+        }
+        Ok(())
+    }
+}

--- a/console/types/scalar/src/lib.rs
+++ b/console/types/scalar/src/lib.rs
@@ -20,6 +20,8 @@ mod bitwise;
 mod bytes;
 mod compare;
 mod from_bits;
+mod from_field;
+mod from_field_lossy;
 mod one;
 mod parse;
 mod random;

--- a/synthesizer/benches/instruction.rs
+++ b/synthesizer/benches/instruction.rs
@@ -110,6 +110,24 @@ fn bench_instructions(c: &mut Criterion) {
                 });
             };
         };
+        // Benchmark a unary instruction, with the given sampling method.
+        ($samples:tt, $instruction:ident { $input:ident , }, $as_type:expr) => {
+            {
+                use snarkvm_synthesizer::$instruction;
+                let name = concat!(stringify!($instruction), "/", stringify!($input));
+                let instruction = Instruction::<Testnet3>::$instruction($instruction::from_str(&format!("{} r0 into r1 as {}", $instruction::<Testnet3>::opcode().to_string(), $as_type)).unwrap());
+                c.bench_function(&format!("{name}/instruction"), |b| {
+                    b.iter_batched(
+                        || {
+                            let arg = $samples.next().unwrap();
+                            setup_finalize_registers(stack, instruction.to_string(), &[Value::from_str(&arg.to_string()).unwrap()])
+                        },
+                        |mut finalize_registers| instruction.finalize(stack, &mut finalize_registers).unwrap(),
+                        BatchSize::PerIteration,
+                    )
+                });
+            };
+        };
         // Benchmark a binary instruction, with the given sampling method.
         ($samples:tt, $instruction:ident { ($input_a:ident, $input_b:ident) , }) => {
             {
@@ -494,19 +512,19 @@ fn bench_instructions(c: &mut Criterion) {
     macro_rules! bench_ped64_hash_instruction {
         ($instruction:tt) => {
             let mut samples = iter::repeat_with(|| { Boolean::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { Boolean, });
+            bench_instruction!(samples, $instruction { Boolean, }, "group");
             let mut samples = iter::repeat_with(|| { I8::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { I8, });
+            bench_instruction!(samples, $instruction { I8, }, "group");
             let mut samples = iter::repeat_with(|| { I16::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { I16, });
+            bench_instruction!(samples, $instruction { I16, }, "group");
             let mut samples = iter::repeat_with(|| { I32::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { I32, });
+            bench_instruction!(samples, $instruction { I32, }, "group");
             let mut samples = iter::repeat_with(|| { U8::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { U8, });
+            bench_instruction!(samples, $instruction { U8, }, "group");
             let mut samples = iter::repeat_with(|| { U16::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { U16, });
+            bench_instruction!(samples, $instruction { U16, }, "group");
             let mut samples = iter::repeat_with(|| { U32::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { U32, });
+            bench_instruction!(samples, $instruction { U32, }, "group");
         }
     }
 
@@ -514,19 +532,19 @@ fn bench_instructions(c: &mut Criterion) {
         ($instruction:tt) => {
             bench_ped64_hash_instruction!($instruction);
             let mut samples = iter::repeat_with(|| { Field::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { Field, });
+            bench_instruction!(samples, $instruction { Field, }, "group");
             let mut samples = iter::repeat_with(|| { Group::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { Group, });
+            bench_instruction!(samples, $instruction { Group, }, "group");
             let mut samples = iter::repeat_with(|| { I64::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { I64, });
+            bench_instruction!(samples, $instruction { I64, }, "group");
             let mut samples = iter::repeat_with(|| { I128::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { I128, });
+            bench_instruction!(samples, $instruction { I128, }, "group");
             let mut samples = iter::repeat_with(|| { U64::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { U64, });
+            bench_instruction!(samples, $instruction { U64, }, "group");
             let mut samples = iter::repeat_with(|| { U128::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { U128, });
+            bench_instruction!(samples, $instruction { U128, }, "group");
             let mut samples = iter::repeat_with(|| { Scalar::<Testnet3>::rand(rng) });
-            bench_instruction!(samples, $instruction { Scalar, });
+            bench_instruction!(samples, $instruction { Scalar, }, "group");
         }
     }
 
@@ -539,32 +557,13 @@ fn bench_instructions(c: &mut Criterion) {
 
     bench_ped64_hash_instruction!(HashPED128);
     let mut samples = iter::repeat_with(|| { I64::<Testnet3>::rand(rng) });
-    bench_instruction!(samples, HashPED128 { I64, });
+    bench_instruction!(samples, HashPED128 { I64, }, "group");
     let mut samples = iter::repeat_with(|| { U64::<Testnet3>::rand(rng) });
-    bench_instruction!(samples, HashPED128 { U64, });
+    bench_instruction!(samples, HashPED128 { U64, }, "group");
 
     bench_hash_instruction!(HashPSD2);
     bench_hash_instruction!(HashPSD4);
     bench_hash_instruction!(HashPSD8);
-    bench_hash_instruction!(HashToGroupBHP256);
-    bench_hash_instruction!(HashToGroupBHP512);
-    bench_hash_instruction!(HashToGroupBHP768);
-    bench_hash_instruction!(HashToGroupBHP1024);
-
-    bench_ped64_hash_instruction!(HashToGroupPED64);
-
-    bench_ped64_hash_instruction!(HashToGroupPED128);
-    let mut samples = iter::repeat_with(|| { I64::<Testnet3>::rand(rng) });
-    bench_instruction!(samples, HashToGroupPED128 { I64, });
-    let mut samples = iter::repeat_with(|| { U64::<Testnet3>::rand(rng) });
-    bench_instruction!(samples, HashToGroupPED128 { U64, });
-
-    bench_hash_instruction!(HashToGroupPSD2);
-    bench_hash_instruction!(HashToGroupPSD4);
-    bench_hash_instruction!(HashToGroupPSD8);
-    bench_hash_instruction!(HashToScalarPSD2);
-    bench_hash_instruction!(HashToScalarPSD4);
-    bench_hash_instruction!(HashToScalarPSD8);
 
     use console::prelude::Inverse;
     bench_instruction_with_default!(inverse?, Inv { Field, });

--- a/synthesizer/src/process/stack/register_types/initialize.rs
+++ b/synthesizer/src/process/stack/register_types/initialize.rs
@@ -573,18 +573,6 @@ impl<N: Network> RegisterTypes<N> {
             "hash_many.psd2",
             "hash_many.psd4",
             "hash_many.psd8",
-            "hash_to_group.bhp256",
-            "hash_to_group.bhp512",
-            "hash_to_group.bhp768",
-            "hash_to_group.bhp1024",
-            "hash_to_group.ped64",
-            "hash_to_group.ped128",
-            "hash_to_group.psd2",
-            "hash_to_group.psd4",
-            "hash_to_group.psd8",
-            "hash_to_scalar.psd2",
-            "hash_to_scalar.psd4",
-            "hash_to_scalar.psd8",
         ]
         .contains(&opcode)
         {
@@ -638,54 +626,6 @@ impl<N: Network> RegisterTypes<N> {
             ),
             "hash_many.psd8" => ensure!(
                 matches!(instruction, Instruction::HashManyPSD8(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.bhp256" => ensure!(
-                matches!(instruction, Instruction::HashToGroupBHP256(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.bhp512" => ensure!(
-                matches!(instruction, Instruction::HashToGroupBHP512(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.bhp768" => ensure!(
-                matches!(instruction, Instruction::HashToGroupBHP768(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.bhp1024" => ensure!(
-                matches!(instruction, Instruction::HashToGroupBHP1024(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.ped64" => ensure!(
-                matches!(instruction, Instruction::HashToGroupPED64(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.ped128" => ensure!(
-                matches!(instruction, Instruction::HashToGroupPED128(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.psd2" => ensure!(
-                matches!(instruction, Instruction::HashToGroupPSD2(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.psd4" => ensure!(
-                matches!(instruction, Instruction::HashToGroupPSD4(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_group.psd8" => ensure!(
-                matches!(instruction, Instruction::HashToGroupPSD8(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_scalar.psd2" => ensure!(
-                matches!(instruction, Instruction::HashToScalarPSD2(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_scalar.psd4" => ensure!(
-                matches!(instruction, Instruction::HashToScalarPSD4(..)),
-                "Instruction '{instruction}' is not for opcode '{opcode}'."
-            ),
-            "hash_to_scalar.psd8" => ensure!(
-                matches!(instruction, Instruction::HashToScalarPSD8(..)),
                 "Instruction '{instruction}' is not for opcode '{opcode}'."
             ),
             _ => bail!("Instruction '{instruction}' is not for opcode '{opcode}'."),

--- a/synthesizer/src/program/instruction/mod.rs
+++ b/synthesizer/src/program/instruction/mod.rs
@@ -133,30 +133,6 @@ pub enum Instruction<N: Network> {
     HashManyPSD4(HashManyPSD4<N>),
     /// Performs a Poseidon hash with an input rate of 8.
     HashManyPSD8(HashManyPSD8<N>),
-    /// Performs a BHP hash on inputs of 256-bit chunks.
-    HashToGroupBHP256(HashToGroupBHP256<N>),
-    /// Performs a BHP hash on inputs of 512-bit chunks.
-    HashToGroupBHP512(HashToGroupBHP512<N>),
-    /// Performs a BHP hash on inputs of 768-bit chunks.
-    HashToGroupBHP768(HashToGroupBHP768<N>),
-    /// Performs a BHP hash on inputs of 1024-bit chunks.
-    HashToGroupBHP1024(HashToGroupBHP1024<N>),
-    /// Performs a Pedersen hash on up to a 64-bit input.
-    HashToGroupPED64(HashToGroupPED64<N>),
-    /// Performs a Pedersen hash on up to a 128-bit input.
-    HashToGroupPED128(HashToGroupPED128<N>),
-    /// Performs a Poseidon hash with an input rate of 2.
-    HashToGroupPSD2(HashToGroupPSD2<N>),
-    /// Performs a Poseidon hash with an input rate of 4.
-    HashToGroupPSD4(HashToGroupPSD4<N>),
-    /// Performs a Poseidon hash with an input rate of 8.
-    HashToGroupPSD8(HashToGroupPSD8<N>),
-    /// Performs a Poseidon hash with an input rate of 2.
-    HashToScalarPSD2(HashToScalarPSD2<N>),
-    /// Performs a Poseidon hash with an input rate of 4.
-    HashToScalarPSD4(HashToScalarPSD4<N>),
-    /// Performs a Poseidon hash with an input rate of 8.
-    HashToScalarPSD8(HashToScalarPSD8<N>),
     /// Computes the multiplicative inverse of `first`, storing the outcome in `destination`.
     Inv(Inv<N>),
     /// Computes whether `first` equals `second` as a boolean, storing the outcome in `destination`.
@@ -280,18 +256,6 @@ macro_rules! instruction {
             HashManyPSD2,
             HashManyPSD4,
             HashManyPSD8,
-            HashToGroupBHP256,
-            HashToGroupBHP512,
-            HashToGroupBHP768,
-            HashToGroupBHP1024,
-            HashToGroupPED64,
-            HashToGroupPED128,
-            HashToGroupPSD2,
-            HashToGroupPSD4,
-            HashToGroupPSD8,
-            HashToScalarPSD2,
-            HashToScalarPSD4,
-            HashToScalarPSD8,
             Inv,
             IsEq,
             IsNeq,

--- a/synthesizer/src/program/instruction/mod.rs
+++ b/synthesizer/src/program/instruction/mod.rs
@@ -443,7 +443,7 @@ mod tests {
     fn test_opcodes() {
         // Sanity check the number of instructions is unchanged.
         assert_eq!(
-            77,
+            65,
             Instruction::<CurrentNetwork>::OPCODES.len(),
             "Update me if the number of instructions changes."
         );

--- a/synthesizer/src/program/instruction/operation/hash.rs
+++ b/synthesizer/src/program/instruction/operation/hash.rs
@@ -167,11 +167,17 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
             (3, _) => Literal::Group(N::hash_to_group_bhp1024(&input.to_bits_le())?),
             (4, _) => Literal::Group(N::hash_to_group_ped64(&input.to_bits_le())?),
             (5, _) => Literal::Group(N::hash_to_group_ped128(&input.to_bits_le())?),
-            (6, LiteralType::Group) => Literal::Group(N::hash_to_group_psd2(&input.to_fields()?)?),
+            (6, LiteralType::Address) | (6, LiteralType::Group) => {
+                Literal::Group(N::hash_to_group_psd2(&input.to_fields()?)?)
+            }
             (6, _) => Literal::Field(N::hash_psd2(&input.to_fields()?)?),
-            (7, LiteralType::Group) => Literal::Group(N::hash_to_group_psd4(&input.to_fields()?)?),
+            (7, LiteralType::Address) | (7, LiteralType::Group) => {
+                Literal::Group(N::hash_to_group_psd4(&input.to_fields()?)?)
+            }
             (7, _) => Literal::Field(N::hash_psd4(&input.to_fields()?)?),
-            (8, LiteralType::Group) => Literal::Group(N::hash_to_group_psd8(&input.to_fields()?)?),
+            (8, LiteralType::Address) | (8, LiteralType::Group) => {
+                Literal::Group(N::hash_to_group_psd8(&input.to_fields()?)?)
+            }
             (8, _) => Literal::Field(N::hash_psd8(&input.to_fields()?)?),
             (9, _) => bail!("'hash_many' is not yet implemented"),
             (10, _) => bail!("'hash_many' is not yet implemented"),

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -791,7 +791,7 @@ finalize transfer_public:
         for finalize_logic in &[
             "finalize ped_hash:
     input r0 as u128.public;
-    hash.ped64 r0 into r1;
+    hash.ped64 r0 into r1 as field;
     set r1 into hashes[r0];",
             "finalize ped_hash:
     input r0 as u128.public;
@@ -824,7 +824,7 @@ mapping hashes:
 
 function ped_hash:
     input r0 as u128.public;
-    // hash.ped64 r0 into r1; // <--- This will cause a E::halt.
+    // hash.ped64 r0 into r1 as field; // <--- This will cause a E::halt.
     finalize r0;
 
 {finalize_logic}"


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes the following opcodes:
```ts
"hash_to_group.bhp256",
"hash_to_group.bhp512",
"hash_to_group.bhp768",
"hash_to_group.bhp1024",
"hash_to_group.ped64",
"hash_to_group.ped128",
"hash_to_group.psd2",
"hash_to_group.psd4",
"hash_to_group.psd8",
"hash_to_scalar.psd2",
"hash_to_scalar.psd4",
"hash_to_scalar.psd8",
```

In its place, the following syntax is introduced:
```ts
hash.bhp256 r0 into r1 as address;
hash.bhp256 r0 into r1 as field;
hash.bhp256 r0 into r1 as group;
hash.bhp256 r0 into r1 as i8;
hash.bhp256 r0 into r1 as i16;
hash.bhp256 r0 into r1 as i32;
hash.bhp256 r0 into r1 as i64;
hash.bhp256 r0 into r1 as i128;
hash.bhp256 r0 into r1 as u8;
hash.bhp256 r0 into r1 as u16;
hash.bhp256 r0 into r1 as u32;
hash.bhp256 r0 into r1 as u64;
hash.bhp256 r0 into r1 as u128;
hash.bhp256 r0 into r1 as scalar;
hash.bhp512 ...;
hash.bhp768 ...;
hash.bhp1024 ...;
hash.ped64 ...;
hash.ped128 ...;
hash.psd2 ...;
hash.psd4 ...;
hash.psd8 ...;
```
This applies for all `hash` variants.

## Changes

- Adds `Integer::from_field_lossy`
- Adds `Scalar::from_field`
- Adds `Scalar::from_field_lossy`
- Adds `Literal::downcast`
- Adds `Literal::downcast_lossy`
