### PR TITLE
[Doc] Add note indicating why `benches/instruction.rs` was commented out.

### DIFF
--- a/synthesizer/benches/instruction.rs
+++ b/synthesizer/benches/instruction.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//
+// Note: The code needs to be commented out to minimize build/clippy times.
+//
 // #[macro_use]
 // extern crate criterion;
 //


### PR DESCRIPTION
^
