### PR TITLE
Adds additional checks to `check_next_block`

### DIFF
--- a/ledger/src/check.rs
+++ b/ledger/src/check.rs
@@ -204,47 +204,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
         }
 
-        for transaction_id in block.transaction_ids() {
-            // Ensure the transaction in the block do not already exist.
-            if self.contains_transaction_id(transaction_id)? {
-                bail!("Transaction '{transaction_id}' already exists in the ledger")
-            }
-        }
-
-        /* Input */
-
-        // Ensure the ledger does not already contain a given serial numbers.
-        for serial_number in block.serial_numbers() {
-            if self.contains_serial_number(serial_number)? {
-                bail!("Serial number '{serial_number}' already exists in the ledger")
-            }
-        }
-
-        /* Output */
-
-        // Ensure the ledger does not already contain a given commitments.
-        for commitment in block.commitments() {
-            if self.contains_commitment(commitment)? {
-                bail!("Commitment '{commitment}' already exists in the ledger")
-            }
-        }
-
-        // Ensure the ledger does not already contain a given nonces.
-        for nonce in block.nonces() {
-            if self.contains_nonce(nonce)? {
-                bail!("Nonce '{nonce}' already exists in the ledger")
-            }
-        }
-
-        /* Metadata */
-
-        // Ensure the ledger does not already contain a given transition public keys.
-        for tpk in block.transition_public_keys() {
-            if self.contains_tpk(tpk)? {
-                bail!("Transition public key '{tpk}' already exists in the ledger")
-            }
-        }
-
         /* Block Header */
 
         // If the block is the genesis block, check that it is valid.

--- a/ledger/src/check.rs
+++ b/ledger/src/check.rs
@@ -212,7 +212,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         /* Input */
 
         // Ensure there are no duplicate input IDs.
-        if has_duplicates(block.transitions().flat_map(|t| t.input_ids())) {
+        if has_duplicates(block.input_ids()) {
             bail!("Found duplicate input IDs in the block");
         }
 
@@ -229,7 +229,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         /* Output */
 
         // Ensure there are no duplicate output IDs.
-        if has_duplicates(block.transitions().flat_map(|t| t.output_ids())) {
+        if has_duplicates(block.output_ids()) {
             bail!("Found duplicate output IDs in the block");
         }
 

--- a/ledger/src/check.rs
+++ b/ledger/src/check.rs
@@ -204,6 +204,57 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
         }
 
+        // Ensure there are no duplicate transition IDs.
+        if has_duplicates(block.transition_ids()) {
+            bail!("Found duplicate transition in the block");
+        }
+
+        /* Input */
+
+        // Ensure there are no duplicate input IDs.
+        if has_duplicates(block.transitions().flat_map(|t| t.input_ids())) {
+            bail!("Found duplicate input IDs in the block");
+        }
+
+        // Ensure there are no duplicate serial numbers.
+        if has_duplicates(block.serial_numbers()) {
+            bail!("Found duplicate serial numbers in the block");
+        }
+
+        // Ensure there are no duplicate tags.
+        if has_duplicates(block.tags()) {
+            bail!("Found duplicate tags in the block");
+        }
+
+        /* Output */
+
+        // Ensure there are no duplicate output IDs.
+        if has_duplicates(block.transitions().flat_map(|t| t.output_ids())) {
+            bail!("Found duplicate output IDs in the block");
+        }
+
+        // Ensure there are no duplicate commitments.
+        if has_duplicates(block.commitments()) {
+            bail!("Found duplicate commitments in the block");
+        }
+
+        // Ensure there are no duplicate nonces.
+        if has_duplicates(block.nonces()) {
+            bail!("Found duplicate nonces in the block");
+        }
+
+        /* Metadata */
+
+        // Ensure there are no duplicate transition public keys.
+        if has_duplicates(block.transition_public_keys()) {
+            bail!("Found duplicate transition public keys in the block");
+        }
+
+        // Ensure there are no duplicate transition commitments.
+        if has_duplicates(block.transition_commitments()) {
+            bail!("Found duplicate transition commitments in the block");
+        }
+
         /* Block Header */
 
         // If the block is the genesis block, check that it is valid.

--- a/synthesizer/src/block/mod.rs
+++ b/synthesizer/src/block/mod.rs
@@ -304,6 +304,11 @@ impl<N: Network> Block<N> {
         self.transactions.transition_public_keys()
     }
 
+    /// Returns an iterator over the transition commitments, for all transactions.
+    pub fn transition_commitments(&self) -> impl '_ + Iterator<Item = &Field<N>> {
+        self.transactions.transition_commitments()
+    }
+
     /// Returns an iterator over the tags, for all transition inputs that are records.
     pub fn tags(&self) -> impl '_ + Iterator<Item = &Field<N>> {
         self.transactions.tags()

--- a/synthesizer/src/block/mod.rs
+++ b/synthesizer/src/block/mod.rs
@@ -314,9 +314,19 @@ impl<N: Network> Block<N> {
         self.transactions.tags()
     }
 
+    /// Returns an iterator over the input IDs, for all transition inputs that are records.
+    pub fn input_ids(&self) -> impl '_ + Iterator<Item = &Field<N>> {
+        self.transactions.input_ids()
+    }
+
     /// Returns an iterator over the serial numbers, for all transition inputs that are records.
     pub fn serial_numbers(&self) -> impl '_ + Iterator<Item = &Field<N>> {
         self.transactions.serial_numbers()
+    }
+
+    /// Returns an iterator over the output IDs, for all transition inputs that are records.
+    pub fn output_ids(&self) -> impl '_ + Iterator<Item = &Field<N>> {
+        self.transactions.output_ids()
     }
 
     /// Returns an iterator over the commitments, for all transition outputs that are records.

--- a/synthesizer/src/block/transactions/mod.rs
+++ b/synthesizer/src/block/transactions/mod.rs
@@ -205,9 +205,19 @@ impl<N: Network> Transactions<N> {
         self.iter().flat_map(|tx| tx.tags())
     }
 
+    /// Returns an iterator over the input IDs, for all transition inputs that are records.
+    pub fn input_ids(&self) -> impl '_ + Iterator<Item = &Field<N>> {
+        self.iter().flat_map(|tx| tx.input_ids())
+    }
+
     /// Returns an iterator over the serial numbers, for all transition inputs that are records.
     pub fn serial_numbers(&self) -> impl '_ + Iterator<Item = &Field<N>> {
         self.iter().flat_map(|tx| tx.serial_numbers())
+    }
+
+    /// Returns an iterator over the output IDs, for all transition inputs that are records.
+    pub fn output_ids(&self) -> impl '_ + Iterator<Item = &Field<N>> {
+        self.iter().flat_map(|tx| tx.output_ids())
     }
 
     /// Returns an iterator over the commitments, for all transition outputs that are records.

--- a/synthesizer/src/block/transactions/mod.rs
+++ b/synthesizer/src/block/transactions/mod.rs
@@ -195,6 +195,11 @@ impl<N: Network> Transactions<N> {
         self.iter().flat_map(|tx| tx.transition_public_keys())
     }
 
+    /// Returns an iterator over the transition commitments, for all transactions.
+    pub fn transition_commitments(&self) -> impl '_ + Iterator<Item = &Field<N>> {
+        self.iter().flat_map(|tx| tx.transition_commitments())
+    }
+
     /// Returns an iterator over the tags, for all transition inputs that are records.
     pub fn tags(&self) -> impl '_ + Iterator<Item = &Field<N>> {
         self.iter().flat_map(|tx| tx.tags())


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds additional `has_duplicate` checks to the block level in `check_next_block`. 

Additionally, redundant `self.contains_*` checks were removed from `check_next_block`, as they are already done further down in the `check_transaction_basic` calls.
