### PR TITLE
Proposal: reduce the size of the BlockCoinbasePuzzleCommitmentMap

### DIFF
--- a/ledger/src/find.rs
+++ b/ledger/src/find.rs
@@ -25,7 +25,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.vm.block_store().find_block_hash(transaction_id)
     }
 
-    /// Returns the block hash that contains the given `puzzle commitment`.
+    /// Returns the block height that contains the given `puzzle commitment`.
     pub fn find_block_height_from_puzzle_commitment(
         &self,
         puzzle_commitment: &PuzzleCommitment<N>,

--- a/ledger/src/find.rs
+++ b/ledger/src/find.rs
@@ -26,11 +26,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns the block hash that contains the given `puzzle commitment`.
-    pub fn find_block_hash_from_puzzle_commitment(
+    pub fn find_block_height_from_puzzle_commitment(
         &self,
         puzzle_commitment: &PuzzleCommitment<N>,
-    ) -> Result<Option<N::BlockHash>> {
-        self.vm.block_store().find_block_hash_from_puzzle_commitment(puzzle_commitment)
+    ) -> Result<Option<u32>> {
+        self.vm.block_store().find_block_height_from_puzzle_commitment(puzzle_commitment)
     }
 
     /// Returns the transaction ID that contains the given `program ID`.

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -142,7 +142,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     /// The mapping of `block hash` to `block coinbase solution`.
     type CoinbaseSolutionMap: for<'a> Map<'a, N::BlockHash, Option<CoinbaseSolution<N>>>;
     /// The mapping of `puzzle commitment` to `block hash`.
-    type CoinbasePuzzleCommitmentMap: for<'a> Map<'a, PuzzleCommitment<N>, N::BlockHash>;
+    type CoinbasePuzzleCommitmentMap: for<'a> Map<'a, PuzzleCommitment<N>, u32>;
     /// The mapping of `block hash` to `block signature`.
     type SignatureMap: for<'a> Map<'a, N::BlockHash, Signature<N>>;
 
@@ -339,7 +339,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             // Store the block coinbase puzzle commitment.
             if let Some(coinbase) = block.coinbase() {
                 for puzzle_commitment in coinbase.partial_solutions().iter().map(|s| s.commitment()) {
-                    self.coinbase_puzzle_commitment_map().insert(puzzle_commitment, block.hash())?;
+                    self.coinbase_puzzle_commitment_map().insert(puzzle_commitment, block.height())?;
                 }
             }
 
@@ -437,12 +437,9 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     }
 
     /// Returns the block hash that contains the given `puzzle commitment`.
-    fn find_block_hash_from_puzzle_commitment(
-        &self,
-        puzzle_commitment: &PuzzleCommitment<N>,
-    ) -> Result<Option<N::BlockHash>> {
+    fn find_block_height_from_puzzle_commitment(&self, puzzle_commitment: &PuzzleCommitment<N>) -> Result<Option<u32>> {
         match self.coinbase_puzzle_commitment_map().get_confirmed(puzzle_commitment)? {
-            Some(block_hash) => Ok(Some(cow_to_copied!(block_hash))),
+            Some(block_height) => Ok(Some(cow_to_copied!(block_height))),
             None => Ok(None),
         }
     }
@@ -844,11 +841,11 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     }
 
     /// Returns the block hash that contains the given `puzzle commitment`.
-    pub fn find_block_hash_from_puzzle_commitment(
+    pub fn find_block_height_from_puzzle_commitment(
         &self,
         puzzle_commitment: &PuzzleCommitment<N>,
-    ) -> Result<Option<N::BlockHash>> {
-        self.storage.find_block_hash_from_puzzle_commitment(puzzle_commitment)
+    ) -> Result<Option<u32>> {
+        self.storage.find_block_height_from_puzzle_commitment(puzzle_commitment)
     }
 }
 

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -436,7 +436,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         }
     }
 
-    /// Returns the block hash that contains the given `puzzle commitment`.
+    /// Returns the block height that contains the given `puzzle commitment`.
     fn find_block_height_from_puzzle_commitment(&self, puzzle_commitment: &PuzzleCommitment<N>) -> Result<Option<u32>> {
         match self.coinbase_puzzle_commitment_map().get_confirmed(puzzle_commitment)? {
             Some(block_height) => Ok(Some(cow_to_copied!(block_height))),

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -141,7 +141,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     type RatificationsMap: for<'a> Map<'a, N::BlockHash, Vec<Ratify<N>>>;
     /// The mapping of `block hash` to `block coinbase solution`.
     type CoinbaseSolutionMap: for<'a> Map<'a, N::BlockHash, Option<CoinbaseSolution<N>>>;
-    /// The mapping of `puzzle commitment` to `block hash`.
+    /// The mapping of `puzzle commitment` to `block height`.
     type CoinbasePuzzleCommitmentMap: for<'a> Map<'a, PuzzleCommitment<N>, u32>;
     /// The mapping of `block hash` to `block signature`.
     type SignatureMap: for<'a> Map<'a, N::BlockHash, Signature<N>>;

--- a/synthesizer/src/store/block/mod.rs
+++ b/synthesizer/src/store/block/mod.rs
@@ -840,7 +840,7 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.find_block_hash(transaction_id)
     }
 
-    /// Returns the block hash that contains the given `puzzle commitment`.
+    /// Returns the block height that contains the given `puzzle commitment`.
     pub fn find_block_height_from_puzzle_commitment(
         &self,
         puzzle_commitment: &PuzzleCommitment<N>,

--- a/synthesizer/src/store/helpers/memory/block.rs
+++ b/synthesizer/src/store/helpers/memory/block.rs
@@ -49,7 +49,7 @@ pub struct BlockMemory<N: Network> {
     /// The coinbase solution map.
     coinbase_solution_map: MemoryMap<N::BlockHash, Option<CoinbaseSolution<N>>>,
     /// The coinbase puzzle commitment map.
-    coinbase_puzzle_commitment_map: MemoryMap<PuzzleCommitment<N>, N::BlockHash>,
+    coinbase_puzzle_commitment_map: MemoryMap<PuzzleCommitment<N>, u32>,
     /// The signature map.
     signature_map: MemoryMap<N::BlockHash, Signature<N>>,
 }
@@ -67,7 +67,7 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     type TransitionStorage = TransitionMemory<N>;
     type RatificationsMap = MemoryMap<N::BlockHash, Vec<Ratify<N>>>;
     type CoinbaseSolutionMap = MemoryMap<N::BlockHash, Option<CoinbaseSolution<N>>>;
-    type CoinbasePuzzleCommitmentMap = MemoryMap<PuzzleCommitment<N>, N::BlockHash>;
+    type CoinbasePuzzleCommitmentMap = MemoryMap<PuzzleCommitment<N>, u32>;
     type SignatureMap = MemoryMap<N::BlockHash, Signature<N>>;
 
     /// Initializes the block storage.

--- a/synthesizer/src/store/helpers/rocksdb/block.rs
+++ b/synthesizer/src/store/helpers/rocksdb/block.rs
@@ -55,7 +55,7 @@ pub struct BlockDB<N: Network> {
     /// The coinbase solution map.
     coinbase_solution_map: DataMap<N::BlockHash, Option<CoinbaseSolution<N>>>,
     /// The coinbase puzzle commitment map.
-    coinbase_puzzle_commitment_map: DataMap<PuzzleCommitment<N>, N::BlockHash>,
+    coinbase_puzzle_commitment_map: DataMap<PuzzleCommitment<N>, u32>,
     /// The signature map.
     signature_map: DataMap<N::BlockHash, Signature<N>>,
 }
@@ -73,7 +73,7 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
     type TransitionStorage = TransitionDB<N>;
     type RatificationsMap = DataMap<N::BlockHash, Vec<Ratify<N>>>;
     type CoinbaseSolutionMap = DataMap<N::BlockHash, Option<CoinbaseSolution<N>>>;
-    type CoinbasePuzzleCommitmentMap = DataMap<PuzzleCommitment<N>, N::BlockHash>;
+    type CoinbasePuzzleCommitmentMap = DataMap<PuzzleCommitment<N>, u32>;
     type SignatureMap = DataMap<N::BlockHash, Signature<N>>;
 
     /// Initializes the block storage.


### PR DESCRIPTION
One of the "heaviest" data sets in the ledger is the `BlockCoinbasePuzzleCommitmentMap`, which holds the largest (by an order of magnitude) number of records of all the maps. Due to that, and due to its values not being used in any hot site (at least not in snarkVM), I propose that the type of its value be changed from the block hash to the block height, reducing the size of every record by 28B (reducing the disk size of the map by ~30%). This would still allow us to trace the block to which the puzzle commitment belongs, and to obtain the hash with an additional query (if needed).

This is a breaking change.