### PR TITLE
Load program imports before the program itself

### DIFF
--- a/synthesizer/src/store/transaction/mod.rs
+++ b/synthesizer/src/store/transaction/mod.rs
@@ -263,6 +263,11 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
         self.storage.remove(transaction_id)
     }
 
+    /// Returns the deployment store.
+    pub fn deployment_store(&self) -> &DeploymentStore<N, T::DeploymentStorage> {
+        self.storage.deployment_store()
+    }
+
     /// Returns the transition store.
     pub fn transition_store(&self) -> &TransitionStore<N, T::TransitionStorage> {
         self.storage.transition_store()

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -91,12 +91,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Add the imports to the process if does not exist yet.
                 if !process.contains_program(import_program_id) {
                     // Fetch the deployment transaction id.
-                    let transaction_id = match transaction_store
+                    let Some(transaction_id) = transaction_store
                         .deployment_store()
                         .find_transaction_id_from_program_id(import_program_id)?
-                    {
-                        Some(id) => id,
-                        None => bail!("Transaction id for '{program_id}' is not found in storage."),
+                    else {
+                        bail!("Transaction id for '{program_id}' is not found in storage.");
                     };
 
                     // Recursively load the deployment and its imports.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -789,10 +789,13 @@ function a:
         vm.add_next_block(&deployment_block).unwrap();
 
         // Check that the iterator ordering is not the same as the deployment ordering.
-        let deployment_transaction_ids = vm.transaction_store().deployment_transaction_ids().collect::<Vec<_>>();
-        assert_eq!(*deployment_transaction_ids[0], first_deployment.id());
-        assert_eq!(*deployment_transaction_ids[1], third_deployment.id());
-        assert_eq!(*deployment_transaction_ids[2], second_deployment.id());
+        let deployment_transaction_ids =
+            vm.transaction_store().deployment_transaction_ids().map(|id| *id).collect::<Vec<_>>();
+        assert_ne!(deployment_transaction_ids, vec![
+            first_deployment.id(),
+            second_deployment.id(),
+            third_deployment.id()
+        ]);
 
         // Enforce that the VM can load properly with the imports.
         assert!(VM::from(vm.store.clone()).is_ok());

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -86,6 +86,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             let program = deployment.program();
             let program_id = program.id();
 
+            // Return early if the program is already loaded.
+            if process.contains_program(program_id) {
+                return Ok(());
+            }
+
             // Iterate through the program imports.
             for import_program_id in program.imports().keys() {
                 // Add the imports to the process if does not exist yet.
@@ -790,6 +795,8 @@ function a:
         // Check that the iterator ordering is not the same as the deployment ordering.
         let deployment_transaction_ids =
             vm.transaction_store().deployment_transaction_ids().map(|id| *id).collect::<Vec<_>>();
+        // This `assert_ne` check is here to ensure that we are properly loading imports even though any order will work for `VM::from`.
+        // Note: `deployment_transaction_ids` is sorted lexicographically by transaction id, so the order may change if we update internal methods.
         assert_ne!(deployment_transaction_ids, vec![
             first_deployment.id(),
             second_deployment.id(),

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -788,6 +788,12 @@ function a:
         let deployment_block = sample_next_block(&vm, &caller_private_key, &[third_deployment.clone()], rng).unwrap();
         vm.add_next_block(&deployment_block).unwrap();
 
+        // Check that the iterator ordering is not the same as the deployment ordering.
+        let deployment_transaction_ids = vm.transaction_store().deployment_transaction_ids().collect::<Vec<_>>();
+        assert_eq!(*deployment_transaction_ids[0], first_deployment.id());
+        assert_eq!(*deployment_transaction_ids[1], third_deployment.id());
+        assert_eq!(*deployment_transaction_ids[2], second_deployment.id());
+
         // Enforce that the VM can load properly with the imports.
         assert!(VM::from(vm.store.clone()).is_ok());
     }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR addresses this [issue](https://github.com/AleoHQ/snarkOS/issues/2306) that prevented the VM from loading properly when loading programs from storage. The issue what that since the iterator is lexicographical, the node may try to load a program before its import. 

The solution here is to recursively load program imports prior to loading the program itself.

## Test Plan

A test has been added to check that the VM imports the program's imports before processing the program itself. This is done by creating three programs (each importing the previous) and checking that loading a new VM from storage works correctly.