### PR TITLE
Use a fixed rng seed for `test_load_deployments_with_imports`

### DIFF
--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -712,7 +712,7 @@ finalize getter:
 
     #[test]
     fn test_load_deployments_with_imports() {
-        let rng = &mut TestRng::default();
+        let rng = &mut TestRng::fixed(123456789);
 
         // Initialize a new caller.
         let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -712,7 +712,8 @@ finalize getter:
 
     #[test]
     fn test_load_deployments_with_imports() {
-        let rng = &mut TestRng::fixed(123456789);
+        // NOTE: This seed was chosen for the CI's RNG to ensure that the test passes.
+        let rng = &mut TestRng::fixed(987654321);
 
         // Initialize a new caller.
         let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR uses a fixed rng seed for `test_load_deployments_with_imports` in order to ensure that the `deployment_transaction_ids()` lexicographical ordering is different for the sequential deployment transactions. This allows us to test the recursive loading of import programs before parent programs.
