### PR TITLE
Refactors `snarkvm-ledger` testing, removing `once_cell` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,6 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap",
- "once_cell",
  "parking_lot",
  "rand 0.8.5",
  "rayon",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -42,9 +42,6 @@ version = "1.0.70"
 version = "1.9"
 features = [ "rayon" ]
 
-[dependencies.once_cell]
-version = "1.18"
-
 [dependencies.parking_lot]
 version = "0.12"
 

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -201,7 +201,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::test_helpers::CurrentLedger;
+    use crate::test_helpers::CurrentLedger;
     use console::network::Testnet3;
 
     type CurrentNetwork = Testnet3;

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -366,3 +366,37 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.vm.execute(private_key, ("credits.aleo", "transfer_private"), inputs.iter(), fee, query, rng)
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use crate::Ledger;
+    use console::{account::PrivateKey, network::Testnet3, prelude::*};
+    use synthesizer::{
+        block::Block,
+        store::{helpers::memory::ConsensusMemory, ConsensusStore},
+        vm::VM,
+    };
+
+    pub(crate) type CurrentNetwork = Testnet3;
+    pub(crate) type CurrentLedger = Ledger<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
+
+    pub(crate) fn sample_genesis_block() -> Block<CurrentNetwork> {
+        Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap()
+    }
+
+    pub(crate) fn sample_ledger(
+        private_key: PrivateKey<CurrentNetwork>,
+        rng: &mut (impl Rng + CryptoRng),
+    ) -> CurrentLedger {
+        // Initialize the store.
+        let store = ConsensusStore::<_, ConsensusMemory<_>>::open(None).unwrap();
+        // Create a genesis block.
+        let genesis = VM::from(store).unwrap().genesis(&private_key, rng).unwrap();
+        // Initialize the ledger with the genesis block.
+        let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
+        // Ensure the genesis block is correct.
+        assert_eq!(genesis, ledger.get_block(0).unwrap());
+        // Return the ledger.
+        ledger
+    }
+}

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -370,7 +370,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use crate::Ledger;
-    use console::{account::PrivateKey, network::Testnet3, prelude::*};
+    use console::{
+        account::{Address, PrivateKey, ViewKey},
+        network::Testnet3,
+        prelude::*,
+    };
     use synthesizer::{
         block::Block,
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
@@ -379,6 +383,25 @@ pub(crate) mod test_helpers {
 
     pub(crate) type CurrentNetwork = Testnet3;
     pub(crate) type CurrentLedger = Ledger<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
+
+    #[allow(dead_code)]
+    pub(crate) struct TestEnv {
+        pub ledger: CurrentLedger,
+        pub private_key: PrivateKey<CurrentNetwork>,
+        pub view_key: ViewKey<CurrentNetwork>,
+        pub address: Address<CurrentNetwork>,
+    }
+
+    pub(crate) fn sample_test_env(rng: &mut (impl Rng + CryptoRng)) -> TestEnv {
+        // Sample the genesis private key.
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        let view_key = ViewKey::try_from(&private_key).unwrap();
+        let address = Address::try_from(&private_key).unwrap();
+        // Sample the ledger.
+        let ledger = sample_ledger(private_key, rng);
+        // Return the test environment.
+        TestEnv { ledger, private_key, view_key, address }
+    }
 
     pub(crate) fn sample_genesis_block() -> Block<CurrentNetwork> {
         Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap()

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -17,7 +17,7 @@ use crate::{
     RecordsFilter,
 };
 use console::{
-    account::{PrivateKey, ViewKey},
+    account::PrivateKey,
     network::prelude::*,
     program::{Entry, Identifier, Literal, Plaintext, Value},
 };
@@ -86,12 +86,8 @@ fn test_state_path() {
 fn test_insufficient_finalize_fees() {
     let rng = &mut TestRng::default();
 
-    // Sample the genesis private key.
-    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
-    let view_key = ViewKey::try_from(&private_key).unwrap();
-
-    // Initialize the ledger.
-    let ledger = crate::test_helpers::sample_ledger(private_key, rng);
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, private_key, view_key, .. } = crate::test_helpers::sample_test_env(rng);
 
     // Deploy a test program to the ledger.
     let program = Program::<CurrentNetwork>::from_str(

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -12,50 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{tests::test_helpers::CurrentLedger, Ledger, RecordsFilter};
+use crate::{
+    test_helpers::{CurrentLedger, CurrentNetwork},
+    RecordsFilter,
+};
 use console::{
-    account::ViewKey,
-    network::{prelude::*, Testnet3},
+    account::{PrivateKey, ViewKey},
+    network::prelude::*,
     program::{Entry, Identifier, Literal, Plaintext, Value},
 };
 use synthesizer::{
-    block::Block,
     store::{helpers::memory::ConsensusMemory, ConsensusStore},
     vm::VM,
     Program,
 };
-
-type CurrentNetwork = Testnet3;
-
-#[cfg(test)]
-pub(crate) mod test_helpers {
-    use super::*;
-    use console::{account::PrivateKey, network::Testnet3, prelude::TestRng};
-
-    use once_cell::sync::OnceCell;
-
-    type CurrentNetwork = Testnet3;
-    pub(crate) type CurrentLedger = Ledger<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
-
-    pub(crate) fn sample_genesis_private_key(rng: &mut TestRng) -> PrivateKey<CurrentNetwork> {
-        static INSTANCE: OnceCell<PrivateKey<CurrentNetwork>> = OnceCell::new();
-        *INSTANCE.get_or_init(|| {
-            // Initialize a new caller.
-            PrivateKey::<CurrentNetwork>::new(rng).unwrap()
-        })
-    }
-}
-
-fn sample_genesis_block() -> Block<CurrentNetwork> {
-    Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap()
-}
 
 #[test]
 fn test_load() {
     let rng = &mut TestRng::default();
 
     // Sample the genesis private key.
-    let private_key = crate::tests::test_helpers::sample_genesis_private_key(rng);
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     // Initialize the store.
     let store = ConsensusStore::<_, ConsensusMemory<_>>::open(None).unwrap();
     // Create a genesis block.
@@ -72,7 +49,7 @@ fn test_load() {
 #[test]
 fn test_load_unchecked() {
     // Load the genesis block.
-    let genesis = sample_genesis_block();
+    let genesis = crate::test_helpers::sample_genesis_block();
 
     // Initialize the ledger without checks.
     let ledger = CurrentLedger::load_unchecked(genesis.clone(), None).unwrap();
@@ -91,13 +68,12 @@ fn test_load_unchecked() {
 
 #[test]
 fn test_state_path() {
-    // Load the genesis block.
-    let genesis = sample_genesis_block();
-    // Initialize the ledger with the genesis block.
-    let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
+    let rng = &mut TestRng::default();
+
+    // Initialize the ledger.
+    let ledger = crate::test_helpers::sample_ledger(PrivateKey::<CurrentNetwork>::new(rng).unwrap(), rng);
     // Retrieve the genesis block.
     let block = ledger.get_block(0).unwrap();
-    assert_eq!(genesis, block);
 
     // Construct the state path.
     let commitments = block.transactions().commitments().collect::<Vec<_>>();
@@ -111,14 +87,11 @@ fn test_insufficient_finalize_fees() {
     let rng = &mut TestRng::default();
 
     // Sample the genesis private key.
-    let private_key = test_helpers::sample_genesis_private_key(rng);
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     let view_key = ViewKey::try_from(&private_key).unwrap();
-    // Initialize the store.
-    let store = ConsensusStore::<_, ConsensusMemory<_>>::open(None).unwrap();
-    // Create a genesis block.
-    let genesis = VM::from(store).unwrap().genesis(&private_key, rng).unwrap();
-    // Initialize the ledger with the genesis block.
-    let ledger = CurrentLedger::load(genesis, None).unwrap();
+
+    // Initialize the ledger.
+    let ledger = crate::test_helpers::sample_ledger(private_key, rng);
 
     // Deploy a test program to the ledger.
     let program = Program::<CurrentNetwork>::from_str(
@@ -148,13 +121,12 @@ finalize foo:
 
     // Fetch the unspent records.
     let records = find_records();
-
     // Prepare the additional fee.
     let credits = records.values().next().unwrap().clone();
     let additional_fee = (credits, 6466000);
 
     // Deploy.
-    let transaction = ledger.vm().deploy(&private_key, &program, additional_fee, None, rng).unwrap();
+    let transaction = ledger.vm.deploy(&private_key, &program, additional_fee, None, rng).unwrap();
     // Verify.
     assert!(ledger.vm().verify_transaction(&transaction, None));
 
@@ -168,32 +140,29 @@ finalize foo:
     // Execute the test program, without providing enough fees for finalize, and ensure that the ledger deems the transaction invalid.
     // Fetch the unspent records.
     let records = find_records();
-
     // Select a record to spend.
     let record = records.values().next().unwrap().clone();
-
-    // Retrieve the VM.
-    let vm = ledger.vm();
 
     // Prepare the inputs.
     let inputs = [Value::<CurrentNetwork>::from_str("1u8").unwrap()].into_iter();
 
     // Execute.
-    let transaction = vm
+    let transaction = ledger
+        .vm
         .execute(&private_key, ("dummy.aleo", "foo"), inputs.clone(), Some((record.clone(), 1_000)), None, rng)
         .unwrap();
     // Verify.
-    assert!(vm.verify_transaction(&transaction, None));
-
+    assert!(ledger.vm.verify_transaction(&transaction, None));
     // Ensure that the ledger deems the transaction invalid.
     assert!(ledger.check_transaction_basic(&transaction, None).is_err());
 
     // Execute with enough fees.
-    let transaction =
-        vm.execute(&private_key, ("dummy.aleo", "foo"), inputs, Some((record, 2_000_000_000)), None, rng).unwrap();
+    let transaction = ledger
+        .vm
+        .execute(&private_key, ("dummy.aleo", "foo"), inputs, Some((record, 2_000_000_000)), None, rng)
+        .unwrap();
     // Verify.
-    assert!(vm.verify_transaction(&transaction, None));
-
+    assert!(ledger.vm.verify_transaction(&transaction, None));
     // Ensure that the ledger deems the transaction valid.
     assert!(ledger.check_transaction_basic(&transaction, None).is_ok());
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR refactors `snarkvm-ledger` testing, removing `once_cell` usage. This means that each test will be responsible with sampling its own initial state, and may lead to performance overheads, but introduces better reproducibility via deterministic testing.
