### PR TITLE
fix: pass bullshark committee

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -185,6 +185,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         Ok(ledger)
     }
 
+    pub fn add_authorized_account(&self, address: Address<N>) {
+        self.current_committee.write().insert(address);
+    }
+
     /// Returns the VM.
     pub const fn vm(&self) -> &VM<N, C> {
         &self.vm

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -185,7 +185,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         Ok(ledger)
     }
 
-    pub fn add_authorized_account(&self, address: Address<N>) {
+    /// TODO: Delete this after testing for snarkOS team.
+    pub fn insert_committee_member(&self, address: Address<N>) {
         self.current_committee.write().insert(address);
     }
 


### PR DESCRIPTION
The ledger only accepts blocks from the genesis address right now. This gives problems when blocks can be signed by all validators in the committee. This PR adds a method to pass in allowed validator account addresses. This will be done from the handshake code in snarkOS node (after checking that the account is actually in the committee).