### PR TITLE
Moves target computation to commitment

### DIFF
--- a/synthesizer/coinbase/src/helpers/partial_solution/mod.rs
+++ b/synthesizer/coinbase/src/helpers/partial_solution/mod.rs
@@ -17,7 +17,6 @@ mod serialize;
 mod string;
 
 use super::*;
-use snarkvm_algorithms::crypto_hash::sha256d_to_u64;
 
 /// The partial solution for the coinbase puzzle from a prover.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
@@ -61,7 +60,6 @@ impl<N: Network> PartialSolution<N> {
 
     /// Returns the target of the solution.
     pub fn to_target(&self) -> Result<u64> {
-        let hash_to_u64 = sha256d_to_u64(&self.commitment.to_bytes_le()?);
-        if hash_to_u64 == 0 { Ok(u64::MAX) } else { Ok(u64::MAX / hash_to_u64) }
+        self.commitment.to_target()
     }
 }

--- a/synthesizer/coinbase/src/helpers/puzzle_commitment/mod.rs
+++ b/synthesizer/coinbase/src/helpers/puzzle_commitment/mod.rs
@@ -32,6 +32,11 @@ impl<N: Network> PuzzleCommitment<N> {
         Self { commitment }
     }
 
+    /// Initializes a new instance of the puzzle commitment.
+    pub fn from_g1_affine(commitment: <<N as Environment>::PairingCurve as PairingEngine>::G1Affine) -> Self {
+        Self::from(KZGCommitment(commitment))
+    }
+
     /// Returns the proof target.
     pub fn to_target(&self) -> Result<u64> {
         let hash_to_u64 = sha256d_to_u64(&self.commitment.to_bytes_le()?);

--- a/synthesizer/coinbase/src/helpers/puzzle_commitment/mod.rs
+++ b/synthesizer/coinbase/src/helpers/puzzle_commitment/mod.rs
@@ -17,6 +17,7 @@ mod serialize;
 mod string;
 
 use super::*;
+use snarkvm_algorithms::crypto_hash::sha256d_to_u64;
 
 /// A coinbase puzzle commitment to a polynomial.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
@@ -29,6 +30,12 @@ impl<N: Network> PuzzleCommitment<N> {
     /// Initializes a new instance of the puzzle commitment.
     pub const fn new(commitment: KZGCommitment<<N as Environment>::PairingCurve>) -> Self {
         Self { commitment }
+    }
+
+    /// Returns the proof target.
+    pub fn to_target(&self) -> Result<u64> {
+        let hash_to_u64 = sha256d_to_u64(&self.commitment.to_bytes_le()?);
+        if hash_to_u64 == 0 { Ok(u64::MAX) } else { Ok(u64::MAX / hash_to_u64) }
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This refactor PR:
- Moves target computation to commitment, so that it is accessible from a lower level.
- Adds a G1 affine constructor for the commitment