### PR TITLE
Extend test framework to parsing commands.

### DIFF
--- a/synthesizer/tests/expectations/parser/command/command_fail.out
+++ b/synthesizer/tests/expectations/parser/command/command_fail.out
@@ -1,0 +1,13 @@
+- |+
+  0: at line 1, in Tag:
+  branch.lt r0 r1 to destination;
+  ^
+
+  1: at line 1, in Alt:
+  branch.lt r0 r1 to destination;
+  ^
+
+  2: at line 1, in Alt:
+  branch.lt r0 r1 to destination;
+  ^
+

--- a/synthesizer/tests/expectations/parser/command/command_pass.out
+++ b/synthesizer/tests/expectations/parser/command/command_pass.out
@@ -1,0 +1,1 @@
+- Parsing was successful.

--- a/synthesizer/tests/test_command_parse.rs
+++ b/synthesizer/tests/test_command_parse.rs
@@ -1,0 +1,40 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod utilities;
+use utilities::*;
+
+use console::network::prelude::*;
+use snarkvm_synthesizer::Command;
+
+use rayon::prelude::*;
+
+#[test]
+fn test_command_parse() {
+    // Load the tests.
+    let tests = load_tests::<_, LineParseTest>("./tests/parser/command", "./expectations/parser/command");
+    // Run each test and compare it against its corresponding expectation.
+    tests.par_iter().for_each(|test| {
+        // Run the parser on each of the test strings.
+        let outputs = test
+            .test_strings()
+            .iter()
+            .map(|test_string| convert_result(Command::<CurrentNetwork>::parse(test_string), test_string))
+            .collect::<Vec<_>>();
+        // Check against the expected output.
+        test.check(&outputs).unwrap();
+        // Save the output.
+        test.save(&outputs).unwrap();
+    });
+}

--- a/synthesizer/tests/tests/parser/command/command_fail.aleo
+++ b/synthesizer/tests/tests/parser/command/command_fail.aleo
@@ -1,0 +1,1 @@
+branch.lt r0 r1 to destination;

--- a/synthesizer/tests/tests/parser/command/command_pass.aleo
+++ b/synthesizer/tests/tests/parser/command/command_pass.aleo
@@ -1,0 +1,1 @@
+branch.eq r0 r1 to destination;


### PR DESCRIPTION
The addition is similar, and modeled after, the code to test instruction parsing.

Also add one succeeding test and one failing test to check that this new addition is working.
