### PR TITLE
Fix program fetching in cost function

### DIFF
--- a/synthesizer/src/block/transaction/execution/cost.rs
+++ b/synthesizer/src/block/transaction/execution/cost.rs
@@ -25,10 +25,7 @@ impl<N: Network> Execution<N> {
             .transitions()
             .map(|transition| {
                 let program_id = transition.program_id();
-                Ok((
-                    *program_id,
-                    vm.transaction_store().get_program(program_id)?.ok_or(anyhow!("Program {program_id} not found"))?,
-                ))
+                Ok((*program_id, vm.process().read().get_program(program_id)?.clone()))
             })
             .collect::<Result<HashMap<_, _>>>()?;
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

In `snarkos developer` context, we don't really have a transaction storage; programs are added to `Process` directly. This will cause executing to fail as the `cost` function can't find the program in the non-existent storage. This PR makes the `cost` function read the program directly from the `Process` instead of the consensus storage to make executing work again.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Well, there really should be a test case for this but I didn't write one...

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM and https://github.com/AleoHQ/protocol-docs,
    and link to your PR here.
-->

<sub>(What's that `protocol-docs` repo? Seems it's private.)</sub>
