### PR TITLE
Verify transition output limit using correct constant

### DIFF
--- a/synthesizer/src/process/verify_execution.rs
+++ b/synthesizer/src/process/verify_execution.rs
@@ -64,7 +64,7 @@ impl<N: Network> Process<N> {
             // Ensure the number of inputs is within the allowed range.
             ensure!(transition.inputs().len() <= N::MAX_INPUTS, "Transition exceeded maximum number of inputs");
             // Ensure the number of outputs is within the allowed range.
-            ensure!(transition.outputs().len() <= N::MAX_INPUTS, "Transition exceeded maximum number of outputs");
+            ensure!(transition.outputs().len() <= N::MAX_OUTPUTS, "Transition exceeded maximum number of outputs");
 
             // Compute the function ID as `Hash(network_id, program_id, function_name)`.
             let function_id = N::hash_bhp1024(


### PR DESCRIPTION
This PR changes the transition output limit verification to compare against correct constant. 

As both `MAX_INPUTS` and `MAX_OUTPUTS` are currently the same, this doesn't functionally change anything. 