### PR TITLE
Introduce formal `Rejected` wrapper

### DIFF
--- a/ledger/src/check.rs
+++ b/ledger/src/check.rs
@@ -401,10 +401,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             // Construct the rejected ID.
             let rejected_id = match transaction {
                 ConfirmedTransaction::AcceptedDeploy(..) | ConfirmedTransaction::AcceptedExecute(..) => None,
-                ConfirmedTransaction::RejectedDeploy(_, _, rejected) => {
-                    Some(rejected.deployment()?.to_deployment_id()?)
-                }
-                ConfirmedTransaction::RejectedExecute(_, _, rejected) => Some(rejected.execution()?.to_execution_id()?),
+                ConfirmedTransaction::RejectedDeploy(_, _, rejected) => Some(rejected.to_id()?),
+                ConfirmedTransaction::RejectedExecute(_, _, rejected) => Some(rejected.to_id()?),
             };
 
             self.check_transaction_basic(transaction, rejected_id)

--- a/ledger/src/check.rs
+++ b/ledger/src/check.rs
@@ -420,7 +420,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             block.previous_hash(),
         )?;
 
-        // Extract the unconfirmed deployment and execution transactions.
+        // Reproduce the unconfirmed deployment and execution transactions.
         let unconfirmed_transactions = block
             .transactions()
             .iter()

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -26,7 +26,7 @@ use synthesizer::{
     vm::VM,
     ConfirmedTransaction,
     Program,
-    Reject,
+    Rejected,
     Transaction,
 };
 
@@ -263,7 +263,7 @@ finalize failed_assert:
     if let Transaction::Execute(_, execution, fee) = failed_assert_transaction {
         let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
         let expected_confirmed_transaction =
-            ConfirmedTransaction::RejectedExecute(0, fee_transaction, Reject::new_execution(execution));
+            ConfirmedTransaction::RejectedExecute(0, fee_transaction, Rejected::new_execution(execution));
 
         assert_eq!(confirmed_transaction, &expected_confirmed_transaction);
     }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -26,7 +26,7 @@ use synthesizer::{
     vm::VM,
     ConfirmedTransaction,
     Program,
-    Rejected,
+    Reject,
     Transaction,
 };
 
@@ -263,7 +263,7 @@ finalize failed_assert:
     if let Transaction::Execute(_, execution, fee) = failed_assert_transaction {
         let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
         let expected_confirmed_transaction =
-            ConfirmedTransaction::RejectedExecute(0, fee_transaction, Rejected(execution));
+            ConfirmedTransaction::RejectedExecute(0, fee_transaction, Reject::new_execution(execution));
 
         assert_eq!(confirmed_transaction, &expected_confirmed_transaction);
     }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -24,7 +24,10 @@ use console::{
 use synthesizer::{
     store::{helpers::memory::ConsensusMemory, ConsensusStore},
     vm::VM,
+    ConfirmedTransaction,
     Program,
+    Rejected,
+    Transaction,
 };
 
 #[test]
@@ -182,4 +185,92 @@ finalize foo:
     assert!(ledger.vm.verify_transaction(&transaction, None));
     // Ensure that the ledger deems the transaction valid.
     assert!(ledger.check_transaction_basic(&transaction, None).is_ok());
+}
+
+#[test]
+fn test_rejected_execution() {
+    let rng = &mut TestRng::default();
+
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, private_key, view_key, .. } = crate::test_helpers::sample_test_env(rng);
+
+    // Deploy a test program to the ledger.
+    let program_id = "test_rejected_execute.aleo";
+    let program = Program::<CurrentNetwork>::from_str(&format!(
+        "
+program {program_id};
+
+function failed_assert:
+    finalize;
+
+finalize failed_assert:
+    assert.eq false true;"
+    ))
+    .unwrap();
+
+    // A helper function to find records.
+    let find_records = || {
+        let microcredits = Identifier::from_str("microcredits").unwrap();
+        ledger
+            .find_records(&view_key, RecordsFilter::SlowUnspent(private_key))
+            .unwrap()
+            .filter(|(_, record)| match record.data().get(&microcredits) {
+                Some(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => !amount.is_zero(),
+                _ => false,
+            })
+            .collect::<indexmap::IndexMap<_, _>>()
+    };
+
+    // Fetch the unspent records.
+    let records = find_records();
+    let record_1 = records[0].clone();
+    let record_2 = records[1].clone();
+
+    // Deploy the program.
+    let deployment_transaction = ledger.vm().deploy(&private_key, &program, (record_1, 0), None, rng).unwrap();
+
+    // Construct the deployment block.
+    let deployment_block =
+        ledger.prepare_advance_to_next_block(&private_key, vec![deployment_transaction], None, rng).unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&deployment_block).unwrap();
+
+    // Add the deployment block to the ledger.
+    ledger.advance_to_next_block(&deployment_block).unwrap();
+
+    // Construct a transaction that will cause error from an assert call in `finalize`.
+    let failed_assert_transaction = ledger
+        .vm()
+        .execute(
+            &private_key,
+            (program_id, "failed_assert"),
+            Vec::<Value<_>>::new().into_iter(),
+            Some((record_2, 0)),
+            None,
+            rng,
+        )
+        .unwrap();
+
+    // Construct the next block containing the new transaction.
+    let next_block =
+        ledger.prepare_advance_to_next_block(&private_key, vec![failed_assert_transaction.clone()], None, rng).unwrap();
+
+    // Check that the block contains 1 rejected execution.
+    assert_eq!(next_block.transactions().len(), 1);
+    let confirmed_transaction = next_block.transactions().iter().next().unwrap();
+    assert!(confirmed_transaction.is_rejected());
+    if let Transaction::Execute(_, execution, fee) = failed_assert_transaction {
+        let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
+        let expected_confirmed_transaction =
+            ConfirmedTransaction::RejectedExecute(0, fee_transaction, Rejected(execution));
+
+        assert_eq!(confirmed_transaction, &expected_confirmed_transaction);
+    }
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&next_block).unwrap();
+
+    // Add the block with the rejected transaction to the ledger.
+    ledger.advance_to_next_block(&next_block).unwrap();
 }

--- a/synthesizer/src/block/transactions/confirmed/bytes.rs
+++ b/synthesizer/src/block/transactions/confirmed/bytes.rs
@@ -51,7 +51,7 @@ impl<N: Network> FromBytes for ConfirmedTransaction<N> {
                 // Read the transaction.
                 let transaction = Transaction::<N>::read_le(&mut reader)?;
                 // Read the rejected deployment.
-                let rejected = Deployment::<N>::read_le(&mut reader)?;
+                let rejected = Reject::<N>::read_le(&mut reader)?;
                 // Return the confirmed transaction.
                 Self::rejected_deploy(index, transaction, rejected).map_err(|e| error(e.to_string()))
             }
@@ -61,7 +61,7 @@ impl<N: Network> FromBytes for ConfirmedTransaction<N> {
                 // Read the transaction.
                 let transaction = Transaction::<N>::read_le(&mut reader)?;
                 // Read the rejected execution.
-                let rejected = Execution::<N>::read_le(&mut reader)?;
+                let rejected = Reject::<N>::read_le(&mut reader)?;
                 // Return the confirmed transaction.
                 Self::rejected_execute(index, transaction, rejected).map_err(|e| error(e.to_string()))
             }

--- a/synthesizer/src/block/transactions/confirmed/bytes.rs
+++ b/synthesizer/src/block/transactions/confirmed/bytes.rs
@@ -51,7 +51,7 @@ impl<N: Network> FromBytes for ConfirmedTransaction<N> {
                 // Read the transaction.
                 let transaction = Transaction::<N>::read_le(&mut reader)?;
                 // Read the rejected deployment.
-                let rejected = Reject::<N>::read_le(&mut reader)?;
+                let rejected = Rejected::<N>::read_le(&mut reader)?;
                 // Return the confirmed transaction.
                 Self::rejected_deploy(index, transaction, rejected).map_err(|e| error(e.to_string()))
             }
@@ -61,7 +61,7 @@ impl<N: Network> FromBytes for ConfirmedTransaction<N> {
                 // Read the transaction.
                 let transaction = Transaction::<N>::read_le(&mut reader)?;
                 // Read the rejected execution.
-                let rejected = Reject::<N>::read_le(&mut reader)?;
+                let rejected = Rejected::<N>::read_le(&mut reader)?;
                 // Return the confirmed transaction.
                 Self::rejected_execute(index, transaction, rejected).map_err(|e| error(e.to_string()))
             }

--- a/synthesizer/src/block/transactions/confirmed/mod.rs
+++ b/synthesizer/src/block/transactions/confirmed/mod.rs
@@ -16,7 +16,7 @@ mod bytes;
 mod serialize;
 mod string;
 
-use crate::block::{rejected::Reject, FinalizeOperation, Transaction};
+use crate::block::{rejected::Rejected, FinalizeOperation, Transaction};
 use console::network::prelude::*;
 
 pub type NumFinalizeSize = u16;
@@ -29,9 +29,9 @@ pub enum ConfirmedTransaction<N: Network> {
     /// The accepted execute transaction is composed of `(index, execute_transaction, finalize_operations)`.
     AcceptedExecute(u32, Transaction<N>, Vec<FinalizeOperation<N>>),
     /// The rejected deploy transaction is composed of `(index, fee_transaction, rejected_deployment)`.
-    RejectedDeploy(u32, Transaction<N>, Reject<N>),
+    RejectedDeploy(u32, Transaction<N>, Rejected<N>),
     /// The rejected execute transaction is composed of `(index, fee_transaction, rejected_execution)`.
-    RejectedExecute(u32, Transaction<N>, Reject<N>),
+    RejectedExecute(u32, Transaction<N>, Rejected<N>),
 }
 
 impl<N: Network> ConfirmedTransaction<N> {
@@ -93,7 +93,7 @@ impl<N: Network> ConfirmedTransaction<N> {
     }
 
     /// Returns a new instance of a rejected deploy transaction.
-    pub fn rejected_deploy(index: u32, transaction: Transaction<N>, rejected: Reject<N>) -> Result<Self> {
+    pub fn rejected_deploy(index: u32, transaction: Transaction<N>, rejected: Rejected<N>) -> Result<Self> {
         ensure!(rejected.is_deployment(), "Rejected deployment is not a deployment");
 
         // Ensure the transaction is a fee transaction.
@@ -104,7 +104,7 @@ impl<N: Network> ConfirmedTransaction<N> {
     }
 
     /// Returns a new instance of a rejected execute transaction.
-    pub fn rejected_execute(index: u32, transaction: Transaction<N>, rejected: Reject<N>) -> Result<Self> {
+    pub fn rejected_execute(index: u32, transaction: Transaction<N>, rejected: Rejected<N>) -> Result<Self> {
         ensure!(rejected.is_execution(), "Rejected execution is not an execution");
 
         // Ensure the transaction is a fee transaction.

--- a/synthesizer/src/block/transactions/confirmed/mod.rs
+++ b/synthesizer/src/block/transactions/confirmed/mod.rs
@@ -16,23 +16,10 @@ mod bytes;
 mod serialize;
 mod string;
 
-use crate::block::{Deployment, Execution, FinalizeOperation, Transaction};
+use crate::block::{rejected::Reject, FinalizeOperation, Transaction};
 use console::network::prelude::*;
 
 pub type NumFinalizeSize = u16;
-
-/// A safety wrapper around a rejected type.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Rejected<T: Clone + Debug + PartialEq + Eq + ToBytes>(pub T);
-
-impl<T: Clone + Debug + PartialEq + Eq + ToBytes> Deref for Rejected<T> {
-    type Target = T;
-
-    /// Returns a reference to the rejected type.
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 /// The confirmed transaction.
 #[derive(Clone, PartialEq, Eq)]
@@ -42,9 +29,9 @@ pub enum ConfirmedTransaction<N: Network> {
     /// The accepted execute transaction is composed of `(index, execute_transaction, finalize_operations)`.
     AcceptedExecute(u32, Transaction<N>, Vec<FinalizeOperation<N>>),
     /// The rejected deploy transaction is composed of `(index, fee_transaction, rejected_deployment)`.
-    RejectedDeploy(u32, Transaction<N>, Box<Rejected<Deployment<N>>>),
+    RejectedDeploy(u32, Transaction<N>, Reject<N>),
     /// The rejected execute transaction is composed of `(index, fee_transaction, rejected_execution)`.
-    RejectedExecute(u32, Transaction<N>, Rejected<Execution<N>>),
+    RejectedExecute(u32, Transaction<N>, Reject<N>),
 }
 
 impl<N: Network> ConfirmedTransaction<N> {
@@ -106,23 +93,23 @@ impl<N: Network> ConfirmedTransaction<N> {
     }
 
     /// Returns a new instance of a rejected deploy transaction.
-    pub fn rejected_deploy(
-        index: u32,
-        transaction: Transaction<N>,
-        rejected_deployment: Deployment<N>,
-    ) -> Result<Self> {
+    pub fn rejected_deploy(index: u32, transaction: Transaction<N>, rejected: Reject<N>) -> Result<Self> {
+        ensure!(rejected.is_deployment(), "Rejected deployment is not a deployment");
+
         // Ensure the transaction is a fee transaction.
         match transaction.is_fee() {
-            true => Ok(Self::RejectedDeploy(index, transaction, Box::new(Rejected(rejected_deployment)))),
+            true => Ok(Self::RejectedDeploy(index, transaction, rejected)),
             false => bail!("Transaction '{}' is not a fee transaction", transaction.id()),
         }
     }
 
     /// Returns a new instance of a rejected execute transaction.
-    pub fn rejected_execute(index: u32, transaction: Transaction<N>, rejected_execution: Execution<N>) -> Result<Self> {
+    pub fn rejected_execute(index: u32, transaction: Transaction<N>, rejected: Reject<N>) -> Result<Self> {
+        ensure!(rejected.is_execution(), "Rejected execution is not an execution");
+
         // Ensure the transaction is a fee transaction.
         match transaction.is_fee() {
-            true => Ok(Self::RejectedExecute(index, transaction, Rejected(rejected_execution))),
+            true => Ok(Self::RejectedExecute(index, transaction, rejected)),
             false => bail!("Transaction '{}' is not a fee transaction", transaction.id()),
         }
     }
@@ -230,14 +217,11 @@ pub(crate) mod test_helpers {
         // Sample a fee transaction.
         let fee_transaction = crate::vm::test_helpers::sample_fee_transaction(rng);
 
-        // Extract the deployment.
-        let deploy = match crate::vm::test_helpers::sample_deployment_transaction(rng) {
-            Transaction::Deploy(_, _, deploy, _) => (*deploy).clone(),
-            _ => unreachable!(),
-        };
+        // Extract the rejected deployment.
+        let rejected = crate::rejected::test_helpers::sample_rejected_deployment(rng);
 
         // Return the confirmed transaction.
-        ConfirmedTransaction::rejected_deploy(index, fee_transaction, deploy).unwrap()
+        ConfirmedTransaction::rejected_deploy(index, fee_transaction, rejected).unwrap()
     }
 
     /// Samples a rejected execute transaction at the given index.
@@ -245,14 +229,11 @@ pub(crate) mod test_helpers {
         // Sample a fee transaction.
         let fee_transaction = crate::vm::test_helpers::sample_fee_transaction(rng);
 
-        // Extract the execution.
-        let execute = match crate::vm::test_helpers::sample_execution_transaction_with_fee(rng) {
-            Transaction::Execute(_, execute, _) => execute,
-            _ => unreachable!(),
-        };
+        // Extract the rejected execution.
+        let rejected = crate::rejected::test_helpers::sample_rejected_execution(rng);
 
         // Return the confirmed transaction.
-        ConfirmedTransaction::rejected_execute(index, fee_transaction, execute).unwrap()
+        ConfirmedTransaction::rejected_execute(index, fee_transaction, rejected).unwrap()
     }
 
     /// Sample a list of randomly confirmed transactions.

--- a/synthesizer/src/block/transactions/confirmed/serialize.rs
+++ b/synthesizer/src/block/transactions/confirmed/serialize.rs
@@ -45,7 +45,7 @@ impl<N: Network> Serialize for ConfirmedTransaction<N> {
                     object.serialize_field("type", "deploy")?;
                     object.serialize_field("index", index)?;
                     object.serialize_field("transaction", transaction)?;
-                    object.serialize_field("rejected", &rejected_deployment.0)?;
+                    object.serialize_field("rejected", &rejected_deployment)?;
                     object.end()
                 }
                 Self::RejectedExecute(index, transaction, rejected_execution) => {
@@ -54,7 +54,7 @@ impl<N: Network> Serialize for ConfirmedTransaction<N> {
                     object.serialize_field("type", "execute")?;
                     object.serialize_field("index", index)?;
                     object.serialize_field("transaction", transaction)?;
-                    object.serialize_field("rejected", &rejected_execution.0)?;
+                    object.serialize_field("rejected", &rejected_execution)?;
                     object.end()
                 }
             },
@@ -96,13 +96,13 @@ impl<'de, N: Network> Deserialize<'de> for ConfirmedTransaction<N> {
                     }
                     (Some("rejected"), Some("deploy")) => {
                         // Parse the rejected deployment.
-                        let rejected: Deployment<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
+                        let rejected: Reject<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
                         // Return the rejected deploy transaction.
                         Self::rejected_deploy(index, transaction, rejected).map_err(de::Error::custom)
                     }
                     (Some("rejected"), Some("execute")) => {
                         // Parse the rejected execution.
-                        let rejected: Execution<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
+                        let rejected: Reject<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
                         // Return the rejected execute transaction.
                         Self::rejected_execute(index, transaction, rejected).map_err(de::Error::custom)
                     }

--- a/synthesizer/src/block/transactions/confirmed/serialize.rs
+++ b/synthesizer/src/block/transactions/confirmed/serialize.rs
@@ -96,13 +96,13 @@ impl<'de, N: Network> Deserialize<'de> for ConfirmedTransaction<N> {
                     }
                     (Some("rejected"), Some("deploy")) => {
                         // Parse the rejected deployment.
-                        let rejected: Reject<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
+                        let rejected: Rejected<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
                         // Return the rejected deploy transaction.
                         Self::rejected_deploy(index, transaction, rejected).map_err(de::Error::custom)
                     }
                     (Some("rejected"), Some("execute")) => {
                         // Parse the rejected execution.
-                        let rejected: Reject<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
+                        let rejected: Rejected<N> = DeserializeExt::take_from_value::<D>(&mut object, "rejected")?;
                         // Return the rejected execute transaction.
                         Self::rejected_execute(index, transaction, rejected).map_err(de::Error::custom)
                     }

--- a/synthesizer/src/block/transactions/mod.rs
+++ b/synthesizer/src/block/transactions/mod.rs
@@ -15,6 +15,9 @@
 pub mod confirmed;
 pub use confirmed::*;
 
+pub mod rejected;
+pub use rejected::*;
+
 mod finalize_operation;
 pub use finalize_operation::*;
 
@@ -26,7 +29,15 @@ mod string;
 use crate::block::{Transaction, Transition};
 use console::{
     network::prelude::*,
-    program::{Ciphertext, Record, TransactionsPath, TransactionsTree, FINALIZE_OPERATIONS_DEPTH, TRANSACTIONS_DEPTH},
+    program::{
+        Ciphertext,
+        ProgramOwner,
+        Record,
+        TransactionsPath,
+        TransactionsTree,
+        FINALIZE_OPERATIONS_DEPTH,
+        TRANSACTIONS_DEPTH,
+    },
     types::{Field, Group, U64},
 };
 

--- a/synthesizer/src/block/transactions/rejected/bytes.rs
+++ b/synthesizer/src/block/transactions/rejected/bytes.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-impl<N: Network> FromBytes for Reject<N> {
+impl<N: Network> FromBytes for Rejected<N> {
     /// Reads the rejected transaction from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let variant = u8::read_le(&mut reader)?;
@@ -38,7 +38,7 @@ impl<N: Network> FromBytes for Reject<N> {
     }
 }
 
-impl<N: Network> ToBytes for Reject<N> {
+impl<N: Network> ToBytes for Rejected<N> {
     /// Writes the rejected transaction to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         match self {
@@ -72,8 +72,8 @@ mod tests {
         for expected in crate::block::transactions::rejected::test_helpers::sample_rejected_transactions() {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
-            assert_eq!(expected, Reject::read_le(&expected_bytes[..]).unwrap());
-            assert!(Reject::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
+            assert_eq!(expected, Rejected::read_le(&expected_bytes[..]).unwrap());
+            assert!(Rejected::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/synthesizer/src/block/transactions/rejected/bytes.rs
+++ b/synthesizer/src/block/transactions/rejected/bytes.rs
@@ -1,0 +1,79 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for Reject<N> {
+    /// Reads the rejected transaction from a buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let variant = u8::read_le(&mut reader)?;
+        match variant {
+            0 => {
+                // Read the program owner.
+                let program_owner = ProgramOwner::read_le(&mut reader)?;
+                // Read the deployment.
+                let deployment = Deployment::read_le(&mut reader)?;
+                // Return the rejected deployment.
+                Ok(Self::new_deployment(program_owner, deployment))
+            }
+            1 => {
+                // Read the execution.
+                let execution = Execution::read_le(&mut reader)?;
+                // Return the rejected execution.
+                Ok(Self::new_execution(execution))
+            }
+            2.. => Err(error(format!("Failed to decode rejected transaction variant {variant}"))),
+        }
+    }
+}
+
+impl<N: Network> ToBytes for Reject<N> {
+    /// Writes the rejected transaction to a buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        match self {
+            Self::Deployment(program_owner, deployment) => {
+                // Write the variant.
+                0u8.write_le(&mut writer)?;
+                // Write the program owner.
+                program_owner.write_le(&mut writer)?;
+                // Write the deployment.
+                deployment.write_le(&mut writer)
+            }
+            Self::Execution(execution) => {
+                // Write the variant.
+                1u8.write_le(&mut writer)?;
+                // Write the execution.
+                execution.write_le(&mut writer)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_bytes() {
+        for expected in crate::block::transactions::rejected::test_helpers::sample_rejected_transactions() {
+            // Check the byte representation.
+            let expected_bytes = expected.to_bytes_le().unwrap();
+            assert_eq!(expected, Reject::read_le(&expected_bytes[..]).unwrap());
+            assert!(Reject::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
+        }
+    }
+}

--- a/synthesizer/src/block/transactions/rejected/mod.rs
+++ b/synthesizer/src/block/transactions/rejected/mod.rs
@@ -71,6 +71,14 @@ impl<N: Network> Rejected<N> {
             _ => bail!("Rejected transaction is not an execution"),
         }
     }
+
+    /// Returns the rejected ID.
+    pub fn to_id(&self) -> Result<Field<N>> {
+        match self {
+            Self::Deployment(_, deployment) => deployment.to_deployment_id(),
+            Self::Execution(execution) => execution.to_execution_id(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/synthesizer/src/block/transactions/rejected/mod.rs
+++ b/synthesizer/src/block/transactions/rejected/mod.rs
@@ -22,12 +22,12 @@ use crate::block::{Deployment, Execution};
 
 /// A wrapper around the rejected deployment or execution.
 #[derive(Clone, PartialEq, Eq)]
-pub enum Reject<N: Network> {
+pub enum Rejected<N: Network> {
     Deployment(ProgramOwner<N>, Box<Deployment<N>>),
     Execution(Execution<N>),
 }
 
-impl<N: Network> Reject<N> {
+impl<N: Network> Rejected<N> {
     /// Initializes a rejected deployment.
     pub fn new_deployment(program_owner: ProgramOwner<N>, deployment: Deployment<N>) -> Self {
         Self::Deployment(program_owner, Box::new(deployment))
@@ -81,7 +81,7 @@ pub(crate) mod test_helpers {
     type CurrentNetwork = Testnet3;
 
     /// Samples a rejected deployment.
-    pub(crate) fn sample_rejected_deployment(rng: &mut TestRng) -> Reject<CurrentNetwork> {
+    pub(crate) fn sample_rejected_deployment(rng: &mut TestRng) -> Rejected<CurrentNetwork> {
         // Sample a deploy transaction.
         let deployment = match crate::vm::test_helpers::sample_deployment_transaction(rng) {
             Transaction::Deploy(_, _, deployment, _) => (*deployment).clone(),
@@ -94,11 +94,11 @@ pub(crate) mod test_helpers {
         let program_owner = ProgramOwner::new(&private_key, deployment_id, rng).unwrap();
 
         // Return the rejected deployment.
-        Reject::new_deployment(program_owner, deployment)
+        Rejected::new_deployment(program_owner, deployment)
     }
 
     /// Samples a rejected execution.
-    pub(crate) fn sample_rejected_execution(rng: &mut TestRng) -> Reject<CurrentNetwork> {
+    pub(crate) fn sample_rejected_execution(rng: &mut TestRng) -> Rejected<CurrentNetwork> {
         // Sample an execute transaction.
         let execution = match crate::vm::test_helpers::sample_execution_transaction_with_fee(rng) {
             Transaction::Execute(_, execution, _) => execution,
@@ -106,11 +106,11 @@ pub(crate) mod test_helpers {
         };
 
         // Return the rejected execution.
-        Reject::new_execution(execution)
+        Rejected::new_execution(execution)
     }
 
     /// Sample a list of randomly rejected transactions.
-    pub(crate) fn sample_rejected_transactions() -> Vec<Reject<CurrentNetwork>> {
+    pub(crate) fn sample_rejected_transactions() -> Vec<Rejected<CurrentNetwork>> {
         let rng = &mut TestRng::default();
 
         vec![sample_rejected_deployment(rng), sample_rejected_execution(rng)]

--- a/synthesizer/src/block/transactions/rejected/mod.rs
+++ b/synthesizer/src/block/transactions/rejected/mod.rs
@@ -1,0 +1,118 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod serialize;
+mod string;
+
+use super::*;
+
+use crate::block::{Deployment, Execution};
+
+/// A wrapper around the rejected deployment or execution.
+#[derive(Clone, PartialEq, Eq)]
+pub enum Reject<N: Network> {
+    Deployment(ProgramOwner<N>, Box<Deployment<N>>),
+    Execution(Execution<N>),
+}
+
+impl<N: Network> Reject<N> {
+    /// Initializes a rejected deployment.
+    pub fn new_deployment(program_owner: ProgramOwner<N>, deployment: Deployment<N>) -> Self {
+        Self::Deployment(program_owner, Box::new(deployment))
+    }
+
+    /// Initializes a rejected execution.
+    pub fn new_execution(execution: Execution<N>) -> Self {
+        Self::Execution(execution)
+    }
+
+    /// Returns true if the rejected transaction is a deployment.
+    pub fn is_deployment(&self) -> bool {
+        matches!(self, Self::Deployment(..))
+    }
+
+    /// Returns true if the rejected transaction is an execution.
+    pub fn is_execution(&self) -> bool {
+        matches!(self, Self::Execution(..))
+    }
+
+    /// Returns the program owner of the rejected deployment.
+    pub fn program_owner(&self) -> Result<&ProgramOwner<N>> {
+        match self {
+            Self::Deployment(program_owner, _) => Ok(program_owner),
+            _ => bail!("Rejected transaction is not a deployment"),
+        }
+    }
+
+    /// Returns the rejected deployment.
+    pub fn deployment(&self) -> Result<&Deployment<N>> {
+        match self {
+            Self::Deployment(_, deployment) => Ok(deployment),
+            _ => bail!("Rejected transaction is not a deployment"),
+        }
+    }
+
+    /// Returns the rejected execution.
+    pub fn execution(&self) -> Result<&Execution<N>> {
+        match self {
+            Self::Execution(execution) => Ok(execution),
+            _ => bail!("Rejected transaction is not an execution"),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use super::*;
+    use console::{account::PrivateKey, network::Testnet3};
+
+    type CurrentNetwork = Testnet3;
+
+    /// Samples a rejected deployment.
+    pub(crate) fn sample_rejected_deployment(rng: &mut TestRng) -> Reject<CurrentNetwork> {
+        // Sample a deploy transaction.
+        let deployment = match crate::vm::test_helpers::sample_deployment_transaction(rng) {
+            Transaction::Deploy(_, _, deployment, _) => (*deployment).clone(),
+            _ => unreachable!(),
+        };
+
+        // Sample a new program owner.
+        let private_key = PrivateKey::new(rng).unwrap();
+        let deployment_id = deployment.to_deployment_id().unwrap();
+        let program_owner = ProgramOwner::new(&private_key, deployment_id, rng).unwrap();
+
+        // Return the rejected deployment.
+        Reject::new_deployment(program_owner, deployment)
+    }
+
+    /// Samples a rejected execution.
+    pub(crate) fn sample_rejected_execution(rng: &mut TestRng) -> Reject<CurrentNetwork> {
+        // Sample an execute transaction.
+        let execution = match crate::vm::test_helpers::sample_execution_transaction_with_fee(rng) {
+            Transaction::Execute(_, execution, _) => execution,
+            _ => unreachable!(),
+        };
+
+        // Return the rejected execution.
+        Reject::new_execution(execution)
+    }
+
+    /// Sample a list of randomly rejected transactions.
+    pub(crate) fn sample_rejected_transactions() -> Vec<Reject<CurrentNetwork>> {
+        let rng = &mut TestRng::default();
+
+        vec![sample_rejected_deployment(rng), sample_rejected_execution(rng)]
+    }
+}

--- a/synthesizer/src/block/transactions/rejected/mod.rs
+++ b/synthesizer/src/block/transactions/rejected/mod.rs
@@ -49,26 +49,26 @@ impl<N: Network> Rejected<N> {
     }
 
     /// Returns the program owner of the rejected deployment.
-    pub fn program_owner(&self) -> Result<&ProgramOwner<N>> {
+    pub fn program_owner(&self) -> Option<&ProgramOwner<N>> {
         match self {
-            Self::Deployment(program_owner, _) => Ok(program_owner),
-            _ => bail!("Rejected transaction is not a deployment"),
+            Self::Deployment(program_owner, _) => Some(program_owner),
+            Self::Execution(_) => None,
         }
     }
 
     /// Returns the rejected deployment.
-    pub fn deployment(&self) -> Result<&Deployment<N>> {
+    pub fn deployment(&self) -> Option<&Deployment<N>> {
         match self {
-            Self::Deployment(_, deployment) => Ok(deployment),
-            _ => bail!("Rejected transaction is not a deployment"),
+            Self::Deployment(_, deployment) => Some(deployment),
+            Self::Execution(_) => None,
         }
     }
 
     /// Returns the rejected execution.
-    pub fn execution(&self) -> Result<&Execution<N>> {
+    pub fn execution(&self) -> Option<&Execution<N>> {
         match self {
-            Self::Execution(execution) => Ok(execution),
-            _ => bail!("Rejected transaction is not an execution"),
+            Self::Deployment(_, _) => None,
+            Self::Execution(execution) => Some(execution),
         }
     }
 

--- a/synthesizer/src/block/transactions/rejected/serialize.rs
+++ b/synthesizer/src/block/transactions/rejected/serialize.rs
@@ -1,0 +1,132 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+use snarkvm_utilities::DeserializeExt;
+
+impl<N: Network> Serialize for Reject<N> {
+    /// Serializes the rejected transaction into string or bytes.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => match self {
+                Self::Deployment(program_owner, deployment) => {
+                    let mut object = serializer.serialize_struct("Rejected", 3)?;
+                    object.serialize_field("type", "deployment")?;
+                    object.serialize_field("program_owner", program_owner)?;
+                    object.serialize_field("deployment", deployment)?;
+                    object.end()
+                }
+                Self::Execution(execution) => {
+                    let mut object = serializer.serialize_struct("Rejected", 2)?;
+                    object.serialize_field("type", "execution")?;
+                    object.serialize_field("execution", execution)?;
+                    object.end()
+                }
+            },
+            false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
+        }
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for Reject<N> {
+    /// Deserializes the confirmed transaction from a string or bytes.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => {
+                // Parse the rejected transaction from a string into a value.
+                let mut object = serde_json::Value::deserialize(deserializer)?;
+
+                // Parse the type.
+                let type_ = object.get("type").and_then(|t| t.as_str());
+
+                // Recover the rejected transaction.
+                match type_ {
+                    Some("deployment") => {
+                        // Parse the program owner.
+                        let program_owner: ProgramOwner<N> =
+                            DeserializeExt::take_from_value::<D>(&mut object, "program_owner")?;
+                        // Parse the deployment.
+                        let deployment: Deployment<N> =
+                            DeserializeExt::take_from_value::<D>(&mut object, "deployment")?;
+                        // Return the rejected deployment.
+                        Ok(Self::new_deployment(program_owner, deployment))
+                    }
+                    Some("execution") => {
+                        // Parse the execution.
+                        let execution: Execution<N> = DeserializeExt::take_from_value::<D>(&mut object, "execution")?;
+                        // Return the rejected execution.
+                        Ok(Self::new_execution(execution))
+                    }
+                    _ => Err(de::Error::custom("Invalid rejected transaction type")),
+                }
+            }
+            false => {
+                FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "confirmed transaction")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check_serde_json<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_string = expected.to_string();
+        let candidate_string = serde_json::to_string(&expected).unwrap();
+        let candidate = serde_json::from_str::<T>(&candidate_string).unwrap();
+        assert_eq!(expected, candidate);
+        assert_eq!(expected_string, candidate_string);
+        assert_eq!(expected_string, candidate.to_string());
+
+        // Deserialize
+        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
+        assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+    }
+
+    fn check_bincode<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_bytes = expected.to_bytes_le().unwrap();
+        let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(expected, T::read_le(&expected_bytes[..]).unwrap());
+        assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json() {
+        for rejected in crate::block::transactions::rejected::test_helpers::sample_rejected_transactions() {
+            check_serde_json(rejected);
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        for rejected in crate::block::transactions::rejected::test_helpers::sample_rejected_transactions() {
+            check_bincode(rejected);
+        }
+    }
+}

--- a/synthesizer/src/block/transactions/rejected/serialize.rs
+++ b/synthesizer/src/block/transactions/rejected/serialize.rs
@@ -16,7 +16,7 @@ use super::*;
 
 use snarkvm_utilities::DeserializeExt;
 
-impl<N: Network> Serialize for Reject<N> {
+impl<N: Network> Serialize for Rejected<N> {
     /// Serializes the rejected transaction into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
@@ -40,7 +40,7 @@ impl<N: Network> Serialize for Reject<N> {
     }
 }
 
-impl<'de, N: Network> Deserialize<'de> for Reject<N> {
+impl<'de, N: Network> Deserialize<'de> for Rejected<N> {
     /// Deserializes the confirmed transaction from a string or bytes.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {

--- a/synthesizer/src/block/transactions/rejected/string.rs
+++ b/synthesizer/src/block/transactions/rejected/string.rs
@@ -1,0 +1,38 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromStr for Reject<N> {
+    type Err = Error;
+
+    /// Initializes the rejected transaction from a JSON-string.
+    fn from_str(status: &str) -> Result<Self, Self::Err> {
+        Ok(serde_json::from_str(status)?)
+    }
+}
+
+impl<N: Network> Debug for Reject<N> {
+    /// Prints the rejected transaction as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for Reject<N> {
+    /// Displays the rejected transaction as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).map_err::<fmt::Error, _>(ser::Error::custom)?)
+    }
+}

--- a/synthesizer/src/block/transactions/rejected/string.rs
+++ b/synthesizer/src/block/transactions/rejected/string.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 
-impl<N: Network> FromStr for Reject<N> {
+impl<N: Network> FromStr for Rejected<N> {
     type Err = Error;
 
     /// Initializes the rejected transaction from a JSON-string.
@@ -23,14 +23,14 @@ impl<N: Network> FromStr for Reject<N> {
     }
 }
 
-impl<N: Network> Debug for Reject<N> {
+impl<N: Network> Debug for Rejected<N> {
     /// Prints the rejected transaction as a JSON-string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<N: Network> Display for Reject<N> {
+impl<N: Network> Display for Rejected<N> {
     /// Displays the rejected transaction as a JSON-string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", serde_json::to_string(self).map_err::<fmt::Error, _>(ser::Error::custom)?)

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -276,7 +276,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             return Err("Mismatch in rejected deploy transaction index".to_string());
                         }
                         // Extract the rejected deployment.
-                        let Ok(deployment) = rejected.deployment() else {
+                        let Some(deployment) = rejected.deployment() else {
                             // Note: This will abort the entire atomic batch.
                             return Err("Expected rejected deployment".to_string());
                         };
@@ -295,7 +295,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             return Err("Mismatch in rejected execute transaction index".to_string());
                         }
                         // Extract the rejected execution.
-                        let Ok(execution) = rejected.execution() else {
+                        let Some(execution) = rejected.execution() else {
                             // Note: This will abort the entire atomic batch.
                             return Err("Expected rejected execution".to_string());
                         };

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -123,7 +123,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             // Construct the fee transaction.
                             // Note: On failure, this will abort the entire atomic batch.
                             let fee_tx = Transaction::from_fee(fee.clone()).map_err(|e| e.to_string())?;
-                            // Construct the rejected execution.
+                            // Construct the rejected deployment.
                             let rejected = Rejected::new_deployment(*program_owner, *deployment.clone());
                             // Construct the rejected deploy transaction.
                             ConfirmedTransaction::rejected_deploy(index, fee_tx, rejected).map_err(|e| e.to_string())

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -282,6 +282,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         };
                         // TODO (howardwu): Ensure this fee corresponds to the deployment.
                         // Attempt to finalize the deployment, which should fail.
+                        #[cfg(debug_assertions)]
                         if let Ok(..) = process.finalize_deployment(store, deployment) {
                             // Note: This will abort the entire atomic batch.
                             return Err("Failed to reject a rejected deploy transaction".to_string());
@@ -301,6 +302,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         };
                         // TODO (howardwu): Ensure this fee corresponds to the execution.
                         // Attempt to finalize the execution, which should fail.
+                        #[cfg(debug_assertions)]
                         if let Ok(..) = process.finalize_execution(state, store, execution) {
                             // Note: This will abort the entire atomic batch.
                             return Err("Failed to reject a rejected execute transaction".to_string());

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::{ConfirmedTransaction, Transactions};
+use crate::{ConfirmedTransaction, Reject, Transactions};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FinalizeMode {
@@ -115,7 +115,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 let outcome = match transaction {
                     // The finalize operation here involves appending the 'stack',
                     // and adding the program to the finalize tree.
-                    Transaction::Deploy(_, _, deployment, fee) => match process.finalize_deployment(store, deployment) {
+                    Transaction::Deploy(_, program_owner, deployment, fee) => match process.finalize_deployment(store, deployment) {
                         // Construct the accepted deploy transaction.
                         Ok((_, finalize)) => ConfirmedTransaction::accepted_deploy(index, transaction.clone(), finalize).map_err(|e| e.to_string()),
                         // Construct the rejected deploy transaction.
@@ -123,8 +123,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             // Construct the fee transaction.
                             // Note: On failure, this will abort the entire atomic batch.
                             let fee_tx = Transaction::from_fee(fee.clone()).map_err(|e| e.to_string())?;
+                            // Construct the rejected execution.
+                            let rejected = Reject::new_deployment(*program_owner, *deployment.clone());
                             // Construct the rejected deploy transaction.
-                            ConfirmedTransaction::rejected_deploy(index, fee_tx, *deployment.clone()).map_err(|e| e.to_string())
+                            ConfirmedTransaction::rejected_deploy(index, fee_tx, rejected).map_err(|e| e.to_string())
                         }
                     }
                     // The finalize operation here involves calling 'update_key_value',
@@ -138,8 +140,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                 // Construct the fee transaction.
                                 // Note: On failure, this will abort the entire atomic batch.
                                 let fee_tx = Transaction::from_fee(fee.clone()).map_err(|e| e.to_string())?;
+                                // Construct the rejected execution.
+                                let rejected = Reject::new_execution(execution.clone());
                                 // Construct the rejected execute transaction.
-                                ConfirmedTransaction::rejected_execute(index, fee_tx, execution.clone()).map_err(|e| e.to_string())
+                                ConfirmedTransaction::rejected_execute(index, fee_tx, rejected).map_err(|e| e.to_string())
                             },
                             // This is a foundational bug - the caller is violating protocol rules.
                             // Note: This will abort the entire atomic batch.
@@ -265,12 +269,17 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         }
                         Ok(())
                     }
-                    ConfirmedTransaction::RejectedDeploy(idx, _fee_transaction, deployment) => {
+                    ConfirmedTransaction::RejectedDeploy(idx, _fee_transaction, rejected) => {
                         // Ensure the index matches the expected index.
                         if index != *idx {
                             // Note: This will abort the entire atomic batch.
                             return Err("Mismatch in rejected deploy transaction index".to_string());
                         }
+                        // Extract the rejected deployment.
+                        let Ok(deployment) = rejected.deployment() else {
+                            // Note: This will abort the entire atomic batch.
+                            return Err("Expected rejected deployment".to_string());
+                        };
                         // TODO (howardwu): Ensure this fee corresponds to the deployment.
                         // Attempt to finalize the deployment, which should fail.
                         if let Ok(..) = process.finalize_deployment(store, deployment) {
@@ -279,12 +288,17 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         }
                         Ok(())
                     }
-                    ConfirmedTransaction::RejectedExecute(idx, _fee_transaction, execution) => {
+                    ConfirmedTransaction::RejectedExecute(idx, _fee_transaction, rejected) => {
                         // Ensure the index matches the expected index.
                         if index != *idx {
                             // Note: This will abort the entire atomic batch.
                             return Err("Mismatch in rejected execute transaction index".to_string());
                         }
+                        // Extract the rejected execution.
+                        let Ok(execution) = rejected.execution() else {
+                            // Note: This will abort the entire atomic batch.
+                            return Err("Expected rejected execution".to_string());
+                        };
                         // TODO (howardwu): Ensure this fee corresponds to the execution.
                         // Attempt to finalize the execution, which should fail.
                         if let Ok(..) = process.finalize_execution(state, store, execution) {
@@ -578,7 +592,7 @@ finalize transfer_public:
             Transaction::Execute(_, execution, fee) => ConfirmedTransaction::RejectedExecute(
                 index,
                 Transaction::from_fee(fee.clone().unwrap()).unwrap(),
-                crate::Rejected(execution.clone()),
+                crate::Reject::new_execution(execution.clone()),
             ),
             _ => panic!("only reject execution transactions"),
         }
@@ -871,7 +885,7 @@ function ped_hash:
             if let Transaction::Execute(_, execution, fee) = transaction {
                 let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
                 let expected_confirmed_transaction =
-                    ConfirmedTransaction::RejectedExecute(0, fee_transaction, crate::Rejected(execution));
+                    ConfirmedTransaction::RejectedExecute(0, fee_transaction, crate::Reject::new_execution(execution));
 
                 let confirmed_transaction = confirmed_transactions.iter().next().unwrap();
                 assert_eq!(confirmed_transaction, &expected_confirmed_transaction);

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -592,7 +592,7 @@ finalize transfer_public:
             Transaction::Execute(_, execution, fee) => ConfirmedTransaction::RejectedExecute(
                 index,
                 Transaction::from_fee(fee.clone().unwrap()).unwrap(),
-                crate::Rejected::new_execution(execution.clone()),
+                Rejected::new_execution(execution.clone()),
             ),
             _ => panic!("only reject execution transactions"),
         }
@@ -884,11 +884,8 @@ function ped_hash:
             assert!(transaction.is_execute());
             if let Transaction::Execute(_, execution, fee) = transaction {
                 let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
-                let expected_confirmed_transaction = ConfirmedTransaction::RejectedExecute(
-                    0,
-                    fee_transaction,
-                    crate::Rejected::new_execution(execution),
-                );
+                let expected_confirmed_transaction =
+                    ConfirmedTransaction::RejectedExecute(0, fee_transaction, Rejected::new_execution(execution));
 
                 let confirmed_transaction = confirmed_transactions.iter().next().unwrap();
                 assert_eq!(confirmed_transaction, &expected_confirmed_transaction);


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR introduces a formalized enum `Rejected` for rejected deployments and executions.

This change addresses #1735, by modifying `check_next_block` to properly check `vm.speculate`. 

We now properly reproduce the original unconfirmed transaction from the confirmed transactions, so we don't run into the  `Cannot speculate on a fee transaction` errors in `check_next_block` like before.

_Note: This change is safe to include in `testnet3`, because no rejected executions or deployments have been included on-chain yet._
## Test Plan

Tests have been added to check that the new `check_next_block` logic correctly checks that transactions are rejected properly.

