### PR TITLE
[Fix] Fixes `verify_execution` on functions that call closures.

### DIFF
--- a/synthesizer/src/process/tests.rs
+++ b/synthesizer/src/process/tests.rs
@@ -1464,7 +1464,7 @@ finalize mint_public:
     // Prepare the trace.
     trace.prepare(block_store).unwrap();
     // Prove the execution.
-    let execution = trace.prove_execution::<CurrentAleo, _>("testing", rng).unwrap();
+    let execution = trace.prove_execution::<CurrentAleo, _>("token", rng).unwrap();
 
     // Verify the execution.
     process.verify_execution(&execution).unwrap();
@@ -1613,7 +1613,7 @@ function mint:
     // Prepare the trace.
     trace.prepare(block_store).unwrap();
     // Prove the execution.
-    let execution = trace.prove_execution::<CurrentAleo, _>("testing", rng).unwrap();
+    let execution = trace.prove_execution::<CurrentAleo, _>("token", rng).unwrap();
 
     // Verify the execution.
     process.verify_execution(&execution).unwrap();
@@ -1855,7 +1855,7 @@ function a:
     // Prepare the trace.
     trace.prepare(block_store).unwrap();
     // Prove the execution.
-    let execution = trace.prove_execution::<CurrentAleo, _>("testing", rng).unwrap();
+    let execution = trace.prove_execution::<CurrentAleo, _>("two", rng).unwrap();
 
     // Verify the execution.
     process.verify_execution(&execution).unwrap();
@@ -2042,7 +2042,7 @@ fn test_complex_execution_order() {
     // Prepare the trace.
     trace.prepare(block_store).unwrap();
     // Prove the execution.
-    let execution = trace.prove_execution::<CurrentAleo, _>("testing", rng).unwrap();
+    let execution = trace.prove_execution::<CurrentAleo, _>("four", rng).unwrap();
 
     // Verify the execution.
     process.verify_execution(&execution).unwrap();
@@ -2227,6 +2227,105 @@ fn test_sanity_check_transfer_and_fee() {
         assert_eq!(41265, assignment.num_constraints());
         assert_eq!((64422, 92898, 62357), assignment.num_nonzeros());
     }
+}
+
+#[test]
+fn test_process_execute_and_verify_call_to_closure() {
+    // Initialize a new program.
+    let (string, program) = Program::<CurrentNetwork>::parse(
+        r"
+program testing.aleo;
+
+// (a + (a + b)) + (a + b) == (3a + 2b)
+closure execute:
+    input r0 as field;
+    input r1 as field;
+    add r0 r1 into r2;
+    add r0 r2 into r3;
+    add r2 r3 into r4;
+    output r4 as field;
+    output r3 as field;
+    output r2 as field;
+
+closure check_not_equal:
+    input r0 as field;
+    input r1 as field;
+    assert.neq r0 r1;
+
+function compute:
+    input r0 as field.private;
+    input r1 as field.public;
+    call check_not_equal r0 r1;
+    call execute r0 r1 into r2 r3 r4;
+    output r2 as field.private;
+    output r3 as field.private;
+    output r4 as field.private;",
+    )
+    .unwrap();
+    assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+    // Declare the function name.
+    let function_name = Identifier::from_str("compute").unwrap();
+
+    // Initialize the RNG.
+    let rng = &mut TestRng::default();
+
+    // Construct the process.
+    let process = super::test_helpers::sample_process(&program);
+    // Check that the circuit key can be synthesized.
+    process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
+
+    // Reset the process.
+    let process = super::test_helpers::sample_process(&program);
+
+    // Initialize a new caller account.
+    let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+
+    // Declare the input value.
+    let r0 = Value::<CurrentNetwork>::from_str("3field").unwrap();
+    let r1 = Value::<CurrentNetwork>::from_str("5field").unwrap();
+
+    // Authorize the function call.
+    let authorization = process
+        .authorize::<CurrentAleo, _>(&caller_private_key, program.id(), function_name, [r0, r1].iter(), rng)
+        .unwrap();
+    assert_eq!(authorization.len(), 1);
+
+    let r2 = Value::from_str("19field").unwrap();
+    let r3 = Value::from_str("11field").unwrap();
+    let r4 = Value::from_str("8field").unwrap();
+
+    // Check again to make sure we didn't modify the authorization before calling `evaluate`.
+    assert_eq!(authorization.len(), 1);
+
+    // Compute the output value.
+    let response = process.evaluate::<CurrentAleo>(authorization.replicate()).unwrap();
+    let candidate = response.outputs();
+    assert_eq!(3, candidate.len());
+    assert_eq!(r2, candidate[0]);
+    assert_eq!(r3, candidate[1]);
+    assert_eq!(r4, candidate[2]);
+
+    // Check again to make sure we didn't modify the authorization after calling `evaluate`.
+    assert_eq!(authorization.len(), 1);
+
+    // Execute the request.
+    let (response, mut trace) = process.execute::<CurrentAleo>(authorization).unwrap();
+    let candidate = response.outputs();
+    assert_eq!(3, candidate.len());
+    assert_eq!(r2, candidate[0]);
+    assert_eq!(r3, candidate[1]);
+    assert_eq!(r4, candidate[2]);
+
+    // Initialize a new block store.
+    let block_store = BlockStore::<_, BlockMemory<_>>::open(None).unwrap();
+    // Prepare the trace.
+    trace.prepare(block_store).unwrap();
+    // Prove the execution.
+    let execution = trace.prove_execution::<CurrentAleo, _>("testing", rng).unwrap();
+
+    // Verify the execution.
+    process.verify_execution(&execution).unwrap();
 }
 
 fn get_assignment(

--- a/synthesizer/src/process/verify_execution.rs
+++ b/synthesizer/src/process/verify_execution.rs
@@ -324,20 +324,19 @@ impl<N: Network> Process<N> {
                 // Retrieve the function from the stack.
                 let function = stack.get_function(&top.fname)?;
                 // Collect the children of the current transition.
-                let children = function
-                    .instructions()
-                    .iter()
-                    .filter_map(|instruction| match instruction {
-                        Instruction::Call(call) => {
-                            let (pid, fname) = match call.operator() {
-                                crate::CallOperator::Locator(locator) => (locator.program_id(), locator.resource()),
-                                crate::CallOperator::Resource(fname) => (&top.pid, fname),
-                            };
-                            Some(TransitionMetadata::new(&mut counter, *pid, *fname, None))
+                let mut children = Vec::new();
+                for instruction in function.instructions() {
+                    if let Instruction::Call(call) = instruction {
+                        let (pid, fname) = match call.operator() {
+                            crate::CallOperator::Locator(locator) => (locator.program_id(), locator.resource()),
+                            crate::CallOperator::Resource(fname) => (&top.pid, fname),
+                        };
+                        // Add the child to the traversal stack, only if it is a call to a transition.
+                        if self.get_stack(pid)?.get_function(fname).is_ok() {
+                            children.push(TransitionMetadata::new(&mut counter, *pid, *fname, None));
                         }
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>();
+                    }
+                }
 
                 // Add the children UIDs to the metadata.
                 // Note this unwrap is safe, for the same reason as above.


### PR DESCRIPTION
This PR, fixes `verify_execution` on functions that call closures.
Prior to this PR, the call graph, used to verify transitions, would include calls to closures. 
This resulted in call graphs that were inconsistent with the transitions in an `Execution`.
The errors produced were of the form:
```
Invalid traversal - traversal stack is not empty',
```
This PR fixes the issue by excluding calls to closures from the call graph.
