### PR TITLE
Remove extra closing brace for structs in records

### DIFF
--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -193,7 +193,7 @@ impl<N: Network> Entry<N, Plaintext<N>> {
                                 // Print the last member without a comma.
                                 true => write!(f, "\n{:indent$}}}", "", indent = depth * INDENT),
                                 // Print the member with a comma.
-                                false => write!(f, "\n{:indent$}}},", "", indent = depth * INDENT),
+                                false => write!(f, ","),
                             }
                         }
                     }

--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -190,9 +190,9 @@ impl<N: Network> Entry<N, Plaintext<N>> {
                             }
                             // Print the closing brace.
                             match i == struct_.len() - 1 {
-                                // Print the last member without a comma.
+                                // If this inner struct is the last member of the outer struct, print the closing brace of the outer struct.
                                 true => write!(f, "\n{:indent$}}}", "", indent = depth * INDENT),
-                                // Print the member with a comma.
+                                // Otherwise, print a comma after the inner struct, because the outer struct has more members after this one.
                                 false => write!(f, ","),
                             }
                         }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Remove the extra closing brace on every struct. Fixes #1743.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

There should be a test case for this as the output is frequently used by end users.
<sup>but i still didn't write one</sup>

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM and https://github.com/AleoHQ/protocol-docs,
    and link to your PR here.
-->

/
