### PR TITLE
[Fix] Remove `Send` requirement from async_trait

### DIFF
--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -59,7 +59,7 @@ impl<N: Network, B: BlockStorage<N>> From<&str> for Query<N, B> {
     }
 }
 
-#[cfg_attr(feature = "async", async_trait)]
+#[cfg_attr(feature = "async", async_trait(?Send))]
 impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     /// Returns the current state root.
     fn current_state_root(&self) -> Result<N::StateRoot> {

--- a/ledger/query/src/traits.rs
+++ b/ledger/query/src/traits.rs
@@ -14,7 +14,7 @@
 
 use console::{network::Network, prelude::Result, program::StatePath, types::Field};
 
-#[cfg_attr(feature = "async", async_trait)]
+#[cfg_attr(feature = "async", async_trait(?Send))]
 pub trait QueryTrait<N: Network> {
     /// Returns the current state root.
     fn current_state_root(&self) -> Result<N::StateRoot>;


### PR DESCRIPTION
## Motivation

The implementation of `async_trait` for the Query trait introduces a send bound on the futures which is incompatible with wasm-bindgen. This PR removes the explicit send requirement on the async trait allowing wasm to properly compile.
