### PR TITLE
Fully atomic rocksDB writes

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -178,6 +178,9 @@ pub enum ProgramMap {
 #[repr(u16)]
 pub enum TestMap {
     Test = DataID::Test as u16,
+    Test2 = DataID::Test2 as u16,
+    Test3 = DataID::Test3 as u16,
+    Test4 = DataID::Test4 as u16,
 }
 
 /// The RocksDB map prefix.
@@ -252,4 +255,10 @@ enum DataID {
     // Testing
     #[cfg(test)]
     Test,
+    #[cfg(test)]
+    Test2,
+    #[cfg(test)]
+    Test3,
+    #[cfg(test)]
+    Test4,
 }

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -1275,6 +1275,12 @@ mod tests {
 
                 // Make sure the checkpoint index is 1.
                 assert_eq!(map.checkpoints.lock().last(), Some(&1));
+                // Ensure that the atomic batch is empty.
+                assert!(self.atomic_batch.lock().is_empty());
+                // Ensure that the database atomic batch size is 1.
+                assert_eq!(self.database.atomic_batch.lock().len(), 1);
+                // Ensure that the database atomic depth is 1.
+                assert_eq!(self.database.atomic_depth.load(Ordering::SeqCst), 1);
 
                 // Simulates an instruction that fails.
                 let result: Result<()> = atomic_batch_scope!(map, {

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -206,6 +206,8 @@ impl<
             let batch = mem::take(&mut *self.database.atomic_batch.lock());
             // Execute all the operations atomically.
             self.database.rocksdb.write(batch)?;
+            // Ensure that the database atomic batch is empty.
+            assert!(self.database.atomic_batch.lock().is_empty());
         }
 
         Ok(())

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -135,6 +135,14 @@ impl<
 
         // Remove all operations after the checkpoint.
         atomic_batch.truncate(checkpoint);
+
+        // Subtract the database-wide atomic batch index.
+        let idx = self.database.atomic_batch_index.fetch_sub(1, Ordering::SeqCst);
+        // If the rewind cascades to all the other maps via `?`, this operation can
+        // overflow once (wrapping around to `usize::MAX`).
+        if idx == usize::MAX {
+            self.database.atomic_batch_index.store(0, Ordering::SeqCst);
+        }
     }
 
     ///
@@ -364,12 +372,177 @@ mod tests {
         helpers::rocksdb::{internal::tests::temp_dir, MapID, TestMap},
         FinalizeMode,
     };
-    use console::{account::Address, network::Testnet3, prelude::*};
+    use anyhow::anyhow;
+    use console::{
+        account::{Address, FromStr},
+        network::Testnet3,
+    };
 
     use serial_test::serial;
     use tracing_test::traced_test;
 
     type CurrentNetwork = Testnet3;
+
+    // Below are a few objects that mimic the way our DataMaps are organized,
+    // in order to provide a more accurate test setup for some scenarios.
+
+    fn open_map_testing_from_db<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned, T: Into<u16>>(
+        database: RocksDB,
+        map_id: T,
+    ) -> DataMap<K, V> {
+        // Combine contexts to create a new scope.
+        let mut context = database.network_id.to_le_bytes().to_vec();
+        context.extend_from_slice(&(map_id.into()).to_le_bytes());
+
+        // Return the DataMap.
+        DataMap {
+            database,
+            context,
+            atomic_batch: Default::default(),
+            batch_in_progress: Default::default(),
+            checkpoint: Default::default(),
+        }
+    }
+
+    struct TestStorage {
+        own_map: DataMap<usize, String>,
+        extra_maps: TestStorage2,
+    }
+
+    impl TestStorage {
+        fn open() -> Self {
+            // Initialize a database.
+            let database = RocksDB::open_testing(temp_dir(), None).expect("Failed to open a test database");
+
+            Self {
+                own_map: open_map_testing_from_db(database.clone(), MapID::Test(TestMap::Test)),
+                extra_maps: TestStorage2::open(database),
+            }
+        }
+
+        fn start_atomic(&self) {
+            self.own_map.start_atomic();
+            self.extra_maps.start_atomic();
+        }
+
+        fn is_atomic_in_progress(&self) -> bool {
+            self.own_map.is_atomic_in_progress() || self.extra_maps.is_atomic_in_progress()
+        }
+
+        fn atomic_checkpoint(&self) {
+            self.own_map.atomic_checkpoint();
+            self.extra_maps.atomic_checkpoint();
+        }
+
+        fn clear_latest_checkpoint(&self) {
+            self.own_map.clear_latest_checkpoint();
+            self.extra_maps.clear_latest_checkpoint();
+        }
+
+        fn atomic_rewind(&self) {
+            self.own_map.atomic_rewind();
+            self.extra_maps.atomic_rewind();
+        }
+
+        fn finish_atomic(&self) -> Result<()> {
+            self.own_map.finish_atomic()?;
+            self.extra_maps.finish_atomic()
+        }
+
+        // While the methods above mimic the typical snarkVM ones, this method is purely for testing.
+        fn is_atomic_in_progress_everywhere(&self) -> bool {
+            self.own_map.is_atomic_in_progress()
+                && self.extra_maps.own_map1.is_atomic_in_progress()
+                && self.extra_maps.own_map1.is_atomic_in_progress()
+                && self.extra_maps.extra_maps.own_map.is_atomic_in_progress()
+        }
+    }
+
+    struct TestStorage2 {
+        own_map1: DataMap<usize, String>,
+        own_map2: DataMap<usize, String>,
+        extra_maps: TestStorage3,
+    }
+
+    impl TestStorage2 {
+        fn open(database: RocksDB) -> Self {
+            Self {
+                own_map1: open_map_testing_from_db(database.clone(), MapID::Test(TestMap::Test2)),
+                own_map2: open_map_testing_from_db(database.clone(), MapID::Test(TestMap::Test3)),
+                extra_maps: TestStorage3::open(database),
+            }
+        }
+
+        fn start_atomic(&self) {
+            self.own_map1.start_atomic();
+            self.own_map2.start_atomic();
+            self.extra_maps.start_atomic();
+        }
+
+        fn is_atomic_in_progress(&self) -> bool {
+            self.own_map1.is_atomic_in_progress()
+                || self.own_map2.is_atomic_in_progress()
+                || self.extra_maps.is_atomic_in_progress()
+        }
+
+        fn atomic_checkpoint(&self) {
+            self.own_map1.atomic_checkpoint();
+            self.own_map2.atomic_checkpoint();
+            self.extra_maps.atomic_checkpoint();
+        }
+
+        fn clear_latest_checkpoint(&self) {
+            self.own_map1.clear_latest_checkpoint();
+            self.own_map2.clear_latest_checkpoint();
+            self.extra_maps.clear_latest_checkpoint();
+        }
+
+        fn atomic_rewind(&self) {
+            self.own_map1.atomic_rewind();
+            self.own_map2.atomic_rewind();
+            self.extra_maps.atomic_rewind();
+        }
+
+        fn finish_atomic(&self) -> Result<()> {
+            self.own_map1.finish_atomic()?;
+            self.own_map2.finish_atomic()?;
+            self.extra_maps.finish_atomic()
+        }
+    }
+
+    struct TestStorage3 {
+        own_map: DataMap<usize, String>,
+    }
+
+    impl TestStorage3 {
+        fn open(database: RocksDB) -> Self {
+            Self { own_map: open_map_testing_from_db(database, MapID::Test(TestMap::Test4)) }
+        }
+
+        fn start_atomic(&self) {
+            self.own_map.start_atomic();
+        }
+
+        fn is_atomic_in_progress(&self) -> bool {
+            self.own_map.is_atomic_in_progress()
+        }
+
+        fn atomic_checkpoint(&self) {
+            self.own_map.atomic_checkpoint();
+        }
+
+        fn clear_latest_checkpoint(&self) {
+            self.own_map.clear_latest_checkpoint();
+        }
+
+        fn atomic_rewind(&self) {
+            self.own_map.atomic_rewind();
+        }
+
+        fn finish_atomic(&self) -> Result<()> {
+            self.own_map.finish_atomic()
+        }
+    }
 
     #[test]
     #[serial]
@@ -1134,5 +1307,191 @@ mod tests {
         assert_eq!(*map.iter_confirmed().next().unwrap().1, "1");
 
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    #[traced_test]
+    fn test_nested_atomic_write_batch_success() -> Result<()> {
+        // Initialize a multi-layer test storage.
+        let test_storage = TestStorage::open();
+
+        // Sanity check.
+        assert!(test_storage.own_map.iter_confirmed().next().is_none());
+        assert!(test_storage.extra_maps.own_map1.iter_confirmed().next().is_none());
+        assert!(test_storage.extra_maps.own_map2.iter_confirmed().next().is_none());
+        assert!(test_storage.extra_maps.extra_maps.own_map.iter_confirmed().next().is_none());
+
+        // Note: all the checks going through .database can be performed on any one
+        // of the objects, as all of them share the same instance of the database.
+
+        // Ensure the batch depth is 0, meaning the atomic operation has not started yet.
+        assert_eq!(0, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+        assert!(!test_storage.is_atomic_in_progress_everywhere());
+
+        // Start an atomic write batch.
+        crate::atomic_batch_scope!(test_storage, {
+            // Ensure the batch depth is 4, as all of the underlying maps have called start_atomic.
+            assert_eq!(4, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+            assert!(test_storage.is_atomic_in_progress_everywhere());
+
+            // Write an item into the first map.
+            test_storage.own_map.insert(0, 0.to_string()).unwrap();
+
+            // Start another atomic write batch.
+            crate::atomic_batch_scope!(test_storage.extra_maps.own_map1, {
+                // Ensure the batch depth is still 4, as only the first, outermost call triggers this increase.
+                assert_eq!(4, test_storage.extra_maps.own_map1.database.atomic_batch_index.load(Ordering::SeqCst));
+                assert!(test_storage.is_atomic_in_progress_everywhere());
+
+                // Write an item into the second map.
+                test_storage.extra_maps.own_map1.insert(1, 1.to_string()).unwrap();
+
+                // Write an item into the third map.
+                test_storage.extra_maps.own_map2.insert(2, 2.to_string()).unwrap();
+
+                // Start another atomic write batch.
+                crate::atomic_batch_scope!(test_storage.extra_maps.extra_maps.own_map, {
+                    // Ensure the batch depth is still 4.
+                    assert_eq!(
+                        4,
+                        test_storage.extra_maps.extra_maps.own_map.database.atomic_batch_index.load(Ordering::SeqCst)
+                    );
+                    assert!(test_storage.extra_maps.extra_maps.own_map.is_atomic_in_progress());
+
+                    // Write an item into the fourth map.
+                    test_storage.extra_maps.extra_maps.own_map.insert(3, 3.to_string()).unwrap();
+
+                    Ok(())
+                })?;
+
+                // Ensure the batch depth is still 4, as only the last, outermost call triggers the decrease.
+                assert_eq!(4, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+                assert!(test_storage.is_atomic_in_progress_everywhere());
+
+                Ok(())
+            })?;
+
+            // Ensure the batch depth is still 4.
+            assert_eq!(4, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+            assert!(test_storage.is_atomic_in_progress_everywhere());
+
+            Ok(())
+        })?;
+
+        // Ensure the batch depth is 0 now, meaning the atomic operation has concluded.
+        assert_eq!(0, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+        assert!(!test_storage.is_atomic_in_progress_everywhere());
+
+        // Ensure that all the items are present.
+        assert_eq!(test_storage.own_map.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.extra_maps.own_map1.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.extra_maps.own_map2.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.extra_maps.extra_maps.own_map.iter_confirmed().count(), 1);
+
+        // The atomic_write_batch macro uses ?, so the test returns a Result for simplicity.
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    #[traced_test]
+    fn test_nested_atomic_write_batch_failure() {
+        // We'll want to execute the atomic write batch in its own function, in order to be able to
+        // inspect the aftermatch after an error, as opposed to returning from the whole test.
+        fn execute_atomic_write_batch(test_storage: &TestStorage) -> Result<()> {
+            // Start an atomic write batch.
+            crate::atomic_batch_scope!(test_storage, {
+                // Ensure the batch depth is 4, as all of the underlying maps have called start_atomic.
+                assert_eq!(4, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+                assert!(test_storage.is_atomic_in_progress_everywhere());
+
+                // Write an item into the first map.
+                test_storage.own_map.insert(0, 0.to_string()).unwrap();
+
+                // Start another atomic write batch.
+                crate::atomic_batch_scope!(test_storage.extra_maps.own_map1, {
+                    // Ensure the batch depth is still 4, as only the first, outermost call triggers this increase.
+                    assert_eq!(4, test_storage.extra_maps.own_map1.database.atomic_batch_index.load(Ordering::SeqCst));
+                    assert!(test_storage.is_atomic_in_progress_everywhere());
+
+                    // Write an item into the second map.
+                    test_storage.extra_maps.own_map1.insert(1, 1.to_string()).unwrap();
+
+                    // Perform an atomic checkpoint.
+                    test_storage.extra_maps.own_map1.atomic_checkpoint();
+
+                    // Write an item into the third map.
+                    test_storage.extra_maps.own_map2.insert(2, 2.to_string()).unwrap();
+
+                    // Start another atomic write batch.
+                    crate::atomic_batch_scope!(test_storage.extra_maps.extra_maps.own_map, {
+                        // Ensure the batch depth is still 4.
+                        assert_eq!(
+                            4,
+                            test_storage
+                                .extra_maps
+                                .extra_maps
+                                .own_map
+                                .database
+                                .atomic_batch_index
+                                .load(Ordering::SeqCst)
+                        );
+                        assert!(test_storage.is_atomic_in_progress_everywhere());
+
+                        // Write an item into the fourth map.
+                        test_storage.extra_maps.extra_maps.own_map.insert(3, 3.to_string()).unwrap();
+
+                        // Rewind the atomic batch via a simulated error.
+                        bail!("An error that will trigger a cascade rewind.");
+                    })?;
+
+                    // Ensure the batch depth is still 4, as only the last, outermost call triggers the decrease.
+                    assert_eq!(4, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+                    assert!(test_storage.is_atomic_in_progress_everywhere());
+
+                    Ok(())
+                })?;
+
+                // Ensure the batch depth is still 4.
+                assert_eq!(4, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+                assert!(test_storage.is_atomic_in_progress_everywhere());
+
+                Ok(())
+            })?;
+
+            Ok(())
+        }
+
+        // Initialize a multi-layer test storage.
+        let test_storage = TestStorage::open();
+
+        // Sanity check.
+        assert!(test_storage.own_map.iter_confirmed().next().is_none());
+        assert!(test_storage.extra_maps.own_map1.iter_confirmed().next().is_none());
+        assert!(test_storage.extra_maps.own_map2.iter_confirmed().next().is_none());
+        assert!(test_storage.extra_maps.extra_maps.own_map.iter_confirmed().next().is_none());
+
+        // Note: all the checks going through .database can be performed on any one
+        // of the objects, as all of them share the same instance of the database.
+
+        // Ensure the batch depth is 0.
+        assert_eq!(0, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+        assert!(!test_storage.is_atomic_in_progress_everywhere());
+
+        // Perform the atomic operations defined in the free function at the beginning of the test.
+        assert!(execute_atomic_write_batch(&test_storage).is_err());
+
+        // Ensure the batch depth is 0 now.
+        assert_eq!(0, test_storage.own_map.database.atomic_batch_index.load(Ordering::SeqCst));
+        assert!(!test_storage.is_atomic_in_progress_everywhere());
+
+        // Ensure that all the items up until the checkpoint are present.
+        assert_eq!(test_storage.own_map.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.extra_maps.own_map1.iter_confirmed().count(), 1);
+
+        // Ensure that all the items after the checkpoint are not present.
+        assert_eq!(test_storage.extra_maps.own_map2.iter_confirmed().count(), 0);
+        assert_eq!(test_storage.extra_maps.extra_maps.own_map.iter_confirmed().count(), 0);
     }
 }

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -1279,10 +1279,10 @@ mod tests {
 
                 // Make sure the checkpoint index is 1.
                 assert_eq!(map.checkpoints.lock().last(), Some(&1));
-                // Ensure that the atomic batch is empty.
-                assert!(map.atomic_batch.lock().is_empty());
-                // Ensure that the database atomic batch size is 1.
-                assert_eq!(map.database.atomic_batch.lock().len(), 1);
+                // Ensure that the atomic batch length is 2.
+                assert_eq!(map.atomic_batch.lock().len(), 2);
+                // Ensure that the database atomic batch is empty.
+                assert!(map.database.atomic_batch.lock().is_empty());
                 // Ensure that the database atomic depth is 1.
                 assert_eq!(map.database.atomic_depth.load(Ordering::SeqCst), 1);
 
@@ -1309,7 +1309,14 @@ mod tests {
             assert_eq!(map.iter_pending().count(), 1);
             // Make sure the pending operations still has the initial insertion.
             assert_eq!(map.get_pending(&0), Some(Some("1".to_string())));
+            // Make sure the checkpoint index is None.
             assert_eq!(map.checkpoints.lock().last(), None);
+            // Ensure that the atomic batch length is 1.
+            assert_eq!(map.atomic_batch.lock().len(), 1);
+            // Ensure that the database atomic batch is empty.
+            assert!(map.database.atomic_batch.lock().is_empty());
+            // Ensure that the database atomic depth is 1.
+            assert_eq!(map.database.atomic_depth.load(Ordering::SeqCst), 1);
 
             Ok(())
         });
@@ -1321,6 +1328,12 @@ mod tests {
         assert!(map.iter_pending().next().is_none());
         // Make sure the checkpoint index is None.
         assert_eq!(map.checkpoints.lock().last(), None);
+        // Ensure that the atomic batch is empty.
+        assert!(map.atomic_batch.lock().is_empty());
+        // Ensure that the database atomic batch is empty.
+        assert!(map.database.atomic_batch.lock().is_empty());
+        // Ensure that the database atomic depth is 0.
+        assert_eq!(map.database.atomic_depth.load(Ordering::SeqCst), 0);
 
         // Ensure that the map value is correct.
         assert_eq!(*map.iter_confirmed().next().unwrap().1, "1");


### PR DESCRIPTION
While we're already using rocksDB's atomic write batches, they are currently only atomic within a single `DataMap`. In order to have fully atomic writes, we need to adjust the current logic to keep track of the queued operations across all the maps and perform a write only once per atomic write batch.

Unlike with the typed `DataMap`s, this forces us to keep track of the untyped/serialized operations within the shared storage object, and to update it in tandem with operations on all the maps. This is made more complicated by the checkpointing logic, but it can be achieved by keeping track of the atomic scope depth (i.e. the checkpoint index) and using a "stack of stacks" instead of a single stack (like in the `DataMap`). This way we are able to keep track of the checkpoints across all the `DataMap`s, and gain improved tracking of nested storage operations.

In order to better reflect the complexity of our typical storage operations, 2 new tests containing nested `DataMap`s are also added.

As a drive-by, the `checkpoint` field in `DataMap` is renamed to `checkpoints` in order to better reflect that it contains a number of them as opposed to a single one at a time. Also, some of the occurrences of replacing a vector with a new empty one are replaced with a call to `Vec::clear` in order to preserve the earlier allocation(s).