### PR TITLE
Fix benchmark CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,16 +67,16 @@ jobs:
           cargo bench --bench curves -- --output-format bencher | tee -a ../output.txt
           cd ..
 
-      - name: Benchmark synthesizer
+      - name: Benchmark ledger
         run: |
-          cd synthesizer
+          cd ledger
           cargo bench --bench block -- --output-format bencher | tee -a ../output.txt
           cargo bench --bench transaction -- --output-format bencher | tee -a ../output.txt
           cd ..
 
-      - name: Benchmark synthesizer/coinbase
+      - name: Benchmark ledger/coinbase
         run: |
-          cd synthesizer/coinbase
+          cd ledger/coinbase
           cargo bench --bench coinbase_puzzle --features "setup" -- --output-format bencher | tee -a ../../output.txt
           cd ../..
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the Benchmarks CI to match the new refactor of `synthesizer` types that now live in `ledger`.