### PR TITLE
[Test] Check implementation of `Display` on `Entry`.

### DIFF
--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -286,4 +286,23 @@ mod tests {
         assert_eq!(expected, candidate.to_string());
         assert_eq!("", remainder);
     }
+
+    #[test]
+    fn test_nested_structs3() {
+        let expected = r"{
+  c: {
+    a: 0u8,
+    b: 1u8
+  },
+  d: {
+    a: 0u8,
+    b: 1u8
+  }
+}";
+
+        let (remainder, candidate) = Plaintext::<CurrentNetwork>::parse(expected).unwrap();
+        println!("\nExpected: {expected}\n\nFound: {candidate}\n");
+        assert_eq!(expected, candidate.to_string());
+        assert_eq!("", remainder);
+    }
 }

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -244,16 +244,16 @@ mod tests {
     privately_minted: {
       positive: 0u64.private,
       negative: 0u64.private
+    },
+    royalty_fees: 500u16.private,
+    publicizable: true.private,
+    updatable: true.private,
+    metadata_uri: {
+      part0: 140152554740597502496525853903429913932u128.private,
+      part1: 134617583084312214720973570367896241221u128.private,
+      part2: 104133346941662617879306115050903128141u128.private,
+      part3: 153398181356134783820482129834790617088u128.private
     }
-  },
-  royalty_fees: 500u16.private,
-  publicizable: true.private,
-  updatable: true.private,
-  metadata_uri: {
-    part0: 140152554740597502496525853903429913932u128.private,
-    part1: 134617583084312214720973570367896241221u128.private,
-    part2: 104133346941662617879306115050903128141u128.private,
-    part3: 153398181356134783820482129834790617088u128.private
   },
   _nonce: 4657518007057346011967333542044959903015797864849889452602278140358226817257group.public
 }";

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -234,6 +234,34 @@ mod tests {
         println!("\nExpected: {expected}\n\nFound: {candidate}\n");
         assert_eq!(expected, candidate.to_string());
         assert_eq!("", remainder);
+
+        let expected = r"{
+  owner: aleo1wamjqlka7d0gazlxdys6n8e8zeee3ymedwvw8elvh7529kwd45rq0plgax.private,
+  id: {
+    collection_number: 25371715469272213720224343178070736482u128.private
+  },
+  data: {
+    privately_minted: {
+      positive: 0u64.private,
+      negative: 0u64.private
+    }
+  },
+  royalty_fees: 500u16.private,
+  publicizable: true.private,
+  updatable: true.private,
+  metadata_uri: {
+    part0: 140152554740597502496525853903429913932u128.private,
+    part1: 134617583084312214720973570367896241221u128.private,
+    part2: 104133346941662617879306115050903128141u128.private,
+    part3: 153398181356134783820482129834790617088u128.private
+  },
+  _nonce: 4657518007057346011967333542044959903015797864849889452602278140358226817257group.public
+}";
+        let (remainder, candidate) = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::parse(expected)?;
+        println!("\nExpected: {expected}\n\nFound: {candidate}\n");
+        assert_eq!(expected, candidate.to_string());
+        assert_eq!("", remainder);
+
         Ok(())
     }
 

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -236,26 +236,24 @@ mod tests {
         assert_eq!("", remainder);
 
         let expected = r"{
-  owner: aleo1wamjqlka7d0gazlxdys6n8e8zeee3ymedwvw8elvh7529kwd45rq0plgax.private,
-  id: {
-    collection_number: 25371715469272213720224343178070736482u128.private
+  owner: aleo1lhcpfumagern97esytsgdva2ytme043zydlzyprhejsd0gw5vypqqz0zkw.private,
+  foo: {
+    bar: 0u128.private
   },
-  data: {
-    privately_minted: {
-      positive: 0u64.private,
-      negative: 0u64.private
+  baz: {
+    quine: {
+      flop: 0u64.private
     },
-    royalty_fees: 500u16.private,
-    publicizable: true.private,
-    updatable: true.private,
-    metadata_uri: {
-      part0: 140152554740597502496525853903429913932u128.private,
-      part1: 134617583084312214720973570367896241221u128.private,
-      part2: 104133346941662617879306115050903128141u128.private,
-      part3: 153398181356134783820482129834790617088u128.private
+    slice: 0u16.private,
+    flag: true.private,
+    square: {
+      first: 0u128.private,
+      second: 1u128.private,
+      third: 2u128.private,
+      fourth: 3u128.private
     }
   },
-  _nonce: 4657518007057346011967333542044959903015797864849889452602278140358226817257group.public
+  _nonce: 0group.public
 }";
         let (remainder, candidate) = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::parse(expected)?;
         println!("\nExpected: {expected}\n\nFound: {candidate}\n");

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -262,6 +262,35 @@ mod tests {
         assert_eq!(expected, candidate.to_string());
         assert_eq!("", remainder);
 
+        let expected = r"{
+  owner: aleo18ttcegpydcs95yw4je0u400j3u7r26yqr9h8evqps3qa9slrvyrsqjwt9l.private,
+  c: {
+    c: {
+      a: 0u8.private,
+      b: 1u8.private
+    },
+    d: {
+      a: 0u8.private,
+      b: 1u8.private
+    }
+  },
+  d: {
+    c: {
+      a: 0u8.private,
+      b: 1u8.private
+    },
+    d: {
+      a: 0u8.private,
+      b: 1u8.private
+    }
+  },
+  _nonce: 8102307625287186026775464343238779600702564007094834161216556016558567413871group.public
+}";
+        let (remainder, candidate) = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::parse(expected)?;
+        println!("\nExpected: {expected}\n\nFound: {candidate}\n");
+        assert_eq!(expected, candidate.to_string());
+        assert_eq!("", remainder);
+
         Ok(())
     }
 


### PR DESCRIPTION
This PR adds tests checking that the implementation of `Display` on `Entry` is correct.
Note that it includes the test case from #1743.
