### PR TITLE
Generate timestamps outside `Batch::new` and `BatchHeader::new`

### DIFF
--- a/ledger/narwhal/src/batch/mod.rs
+++ b/ledger/narwhal/src/batch/mod.rs
@@ -48,9 +48,9 @@ impl<N: Network> Batch<N> {
     pub fn new<R: Rng + CryptoRng>(
         private_key: &PrivateKey<N>,
         round: u64,
+        timestamp: i64,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         previous_certificates: IndexSet<BatchCertificate<N>>,
-        timestamp: i64,
         rng: &mut R,
     ) -> Result<Self> {
         match round {
@@ -206,7 +206,7 @@ pub mod test_helpers {
             // Checkpoint the timestamp for the batch.
             let timestamp = OffsetDateTime::now_utc().unix_timestamp();
             // Append the batch.
-            sample.push(Batch::new(&private_key, rng.gen(), transmissions, certificates, timestamp, rng).unwrap());
+            sample.push(Batch::new(&private_key, rng.gen(), timestamp, transmissions, certificates, rng).unwrap());
         }
         // Return the sample vector.
         sample

--- a/ledger/narwhal/src/batch/mod.rs
+++ b/ledger/narwhal/src/batch/mod.rs
@@ -24,7 +24,6 @@ use console::{
 };
 
 use indexmap::{IndexMap, IndexSet};
-use time::OffsetDateTime;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Batch<N: Network> {
@@ -183,6 +182,7 @@ impl<N: Network> Batch<N> {
 pub mod test_helpers {
     use super::*;
     use console::{account::PrivateKey, network::Testnet3, prelude::TestRng};
+    use time::OffsetDateTime;
 
     type CurrentNetwork = Testnet3;
 

--- a/ledger/narwhal/src/batch/mod.rs
+++ b/ledger/narwhal/src/batch/mod.rs
@@ -51,6 +51,7 @@ impl<N: Network> Batch<N> {
         round: u64,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         previous_certificates: IndexSet<BatchCertificate<N>>,
+        timestamp: i64,
         rng: &mut R,
     ) -> Result<Self> {
         match round {
@@ -63,8 +64,6 @@ impl<N: Network> Batch<N> {
         ensure!(!transmissions.is_empty(), "Batch must contain at least one transmission");
         // Construct the author.
         let author = Address::try_from(private_key)?;
-        // Checkpoint the timestamp for the batch.
-        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
         // Construct the transmission IDs.
         let transmission_ids = transmissions.keys().copied().collect();
         // Compute the previous certificate IDs.
@@ -204,8 +203,10 @@ pub mod test_helpers {
             assert!(!transmissions.is_empty());
             // Sample certificates.
             let certificates = crate::batch_certificate::test_helpers::sample_batch_certificates(rng);
+            // Checkpoint the timestamp for the batch.
+            let timestamp = OffsetDateTime::now_utc().unix_timestamp();
             // Append the batch.
-            sample.push(Batch::new(&private_key, rng.gen(), transmissions, certificates, rng).unwrap());
+            sample.push(Batch::new(&private_key, rng.gen(), transmissions, certificates, timestamp, rng).unwrap());
         }
         // Return the sample vector.
         sample

--- a/ledger/narwhal/src/batch_header/mod.rs
+++ b/ledger/narwhal/src/batch_header/mod.rs
@@ -51,6 +51,7 @@ impl<N: Network> BatchHeader<N> {
         round: u64,
         transmission_ids: IndexSet<TransmissionID<N>>,
         previous_certificate_ids: IndexSet<Field<N>>,
+        timestamp: i64,
         rng: &mut R,
     ) -> Result<Self> {
         match round {
@@ -61,8 +62,6 @@ impl<N: Network> BatchHeader<N> {
         }
         // Retrieve the address.
         let author = Address::try_from(private_key)?;
-        // Checkpoint the timestamp for the batch.
-        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
         // Compute the batch ID.
         let batch_id = Self::compute_batch_id(author, round, timestamp, &transmission_ids, &previous_certificate_ids)?;
         // Sign the preimage.
@@ -167,8 +166,10 @@ pub mod test_helpers {
             crate::transmission_id::test_helpers::sample_transmission_ids(rng).into_iter().collect::<IndexSet<_>>();
         // Sample certificate IDs.
         let certificate_ids = (0..10).map(|_| Field::<CurrentNetwork>::rand(rng)).collect::<IndexSet<_>>();
+        // Checkpoint the timestamp for the batch.
+        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
         // Return the batch header.
-        BatchHeader::new(&private_key, rng.gen(), transmission_ids, certificate_ids, rng).unwrap()
+        BatchHeader::new(&private_key, rng.gen(), transmission_ids, certificate_ids, timestamp, rng).unwrap()
     }
 
     /// Returns a list of sample batch headers, sampled at random.

--- a/ledger/narwhal/src/batch_header/mod.rs
+++ b/ledger/narwhal/src/batch_header/mod.rs
@@ -47,9 +47,9 @@ impl<N: Network> BatchHeader<N> {
     pub fn new<R: Rng + CryptoRng>(
         private_key: &PrivateKey<N>,
         round: u64,
+        timestamp: i64,
         transmission_ids: IndexSet<TransmissionID<N>>,
         previous_certificate_ids: IndexSet<Field<N>>,
-        timestamp: i64,
         rng: &mut R,
     ) -> Result<Self> {
         match round {
@@ -168,7 +168,7 @@ pub mod test_helpers {
         // Checkpoint the timestamp for the batch.
         let timestamp = OffsetDateTime::now_utc().unix_timestamp();
         // Return the batch header.
-        BatchHeader::new(&private_key, rng.gen(), transmission_ids, certificate_ids, timestamp, rng).unwrap()
+        BatchHeader::new(&private_key, rng.gen(), timestamp, transmission_ids, certificate_ids, rng).unwrap()
     }
 
     /// Returns a list of sample batch headers, sampled at random.

--- a/ledger/narwhal/src/batch_header/mod.rs
+++ b/ledger/narwhal/src/batch_header/mod.rs
@@ -22,9 +22,7 @@ use console::{
     prelude::*,
     types::Field,
 };
-
 use indexmap::IndexSet;
-use time::OffsetDateTime;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BatchHeader<N: Network> {
@@ -154,6 +152,7 @@ impl<N: Network> BatchHeader<N> {
 pub mod test_helpers {
     use super::*;
     use console::{account::PrivateKey, network::Testnet3, prelude::TestRng};
+    use time::OffsetDateTime;
 
     type CurrentNetwork = Testnet3;
 


### PR DESCRIPTION
This PR moves the timestamp generation from `Batch::new` and `BatchHeader::new` to call sites . 

Rationale is to give test code a full control to timestamps so that related logic can be tested thoroughly; and make the `Batch` and `BatchHeader` creation fns more deterministic.