### PR TITLE
[Feature] Introduce `VectorType`.

### DIFF
--- a/console/program/src/data_types/array_type/mod.rs
+++ b/console/program/src/data_types/array_type/mod.rs
@@ -16,56 +16,39 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{Identifier, LiteralType, PlaintextType, U32};
+use crate::{ElementType, U32};
 use snarkvm_console_network::prelude::*;
 
 use core::fmt::{Debug, Display};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub enum ArrayType<N: Network> {
-    /// An array of literals.
-    Literal(LiteralType, U32<N>),
-    /// An array of structs.
-    Struct(Identifier<N>, U32<N>),
+pub struct ArrayType<N: Network> {
+    /// The type of the elements in the array.
+    element_type: ElementType<N>,
+    /// The length of the array.
+    length: U32<N>,
 }
 
 impl<N: Network> ArrayType<N> {
-    /// Constructs a new type defining an array of literals.
-    pub fn new_literal_array(literal_type: LiteralType, length: U32<N>) -> Result<Self> {
+    /// Constructs a new array type.
+    pub fn new(element_type: ElementType<N>, length: U32<N>) -> Result<Self> {
         ensure!(*length != 0, "The array must have at least one element");
         ensure!(
             *length as usize <= N::MAX_ARRAY_ENTRIES,
             "The array must have at most {} elements",
             N::MAX_ARRAY_ENTRIES
         );
-        Ok(Self::Literal(literal_type, length))
-    }
-
-    /// Constructs a new type defining an array of structs.
-    pub fn new_struct_array(struct_: Identifier<N>, length: U32<N>) -> Result<Self> {
-        ensure!(*length != 0, "The array must have at least one element");
-        ensure!(
-            *length as usize <= N::MAX_ARRAY_ENTRIES,
-            "The array must have at most {} elements",
-            N::MAX_ARRAY_ENTRIES
-        );
-        Ok(Self::Struct(struct_, length))
+        Ok(Self { element_type, length })
     }
 
     /// Returns the element type.
-    pub fn element_type(&self) -> PlaintextType<N> {
-        match &self {
-            ArrayType::Literal(literal_type, ..) => PlaintextType::Literal(*literal_type),
-            ArrayType::Struct(identifier, ..) => PlaintextType::Struct(*identifier),
-        }
+    pub fn element_type(&self) -> &ElementType<N> {
+        &self.element_type
     }
 
     /// Returns the length of the array.
     pub fn length(&self) -> &U32<N> {
-        match &self {
-            ArrayType::Literal(_, length) => length,
-            ArrayType::Struct(_, length) => length,
-        }
+        &self.length
     }
 }
 
@@ -74,6 +57,7 @@ mod tests {
     use super::*;
     use snarkvm_console_network::Testnet3;
 
+    use crate::{Identifier, LiteralType};
     use core::str::FromStr;
 
     type CurrentNetwork = Testnet3;
@@ -82,32 +66,38 @@ mod tests {
     fn test_array_type() -> Result<()> {
         // Test literal array types.
         let type_ = ArrayType::<CurrentNetwork>::from_str("[field; 4]")?;
-        assert_eq!(type_, ArrayType::<CurrentNetwork>::Literal(LiteralType::Field, U32::new(4)));
+        assert_eq!(type_, ArrayType::<CurrentNetwork>::new(ElementType::from(LiteralType::Field), U32::new(4))?);
         assert_eq!(
             type_.to_bytes_le()?,
             ArrayType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
         );
-        assert_eq!(type_.element_type(), PlaintextType::Literal(LiteralType::Field));
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Field));
         assert_eq!(type_.length(), &U32::new(4));
 
         // Test struct array types.
         let type_ = ArrayType::<CurrentNetwork>::from_str("[foo; 1]")?;
-        assert_eq!(type_, ArrayType::<CurrentNetwork>::Struct(Identifier::from_str("foo")?, U32::new(1)));
+        assert_eq!(
+            type_,
+            ArrayType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?), U32::new(1))?
+        );
         assert_eq!(
             type_.to_bytes_le()?,
             ArrayType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
         );
-        assert_eq!(type_.element_type(), PlaintextType::Struct(Identifier::from_str("foo")?));
+        assert_eq!(type_.element_type(), &ElementType::from(Identifier::from_str("foo")?));
         assert_eq!(type_.length(), &U32::new(1));
 
         // Test array type with maximum length.
         let type_ = ArrayType::<CurrentNetwork>::from_str("[scalar; 4294967295]")?;
-        assert_eq!(type_, ArrayType::<CurrentNetwork>::Literal(LiteralType::Scalar, U32::new(4294967295)));
+        assert_eq!(
+            type_,
+            ArrayType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar), U32::new(4294967295))?
+        );
         assert_eq!(
             type_.to_bytes_le()?,
             ArrayType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
         );
-        assert_eq!(type_.element_type(), PlaintextType::Literal(LiteralType::Scalar));
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Scalar));
         assert_eq!(type_.length(), &U32::new(4294967295));
 
         Ok(())

--- a/console/program/src/data_types/array_type/mod.rs
+++ b/console/program/src/data_types/array_type/mod.rs
@@ -21,7 +21,7 @@ use snarkvm_console_network::prelude::*;
 
 use core::fmt::{Debug, Display};
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ArrayType<N: Network> {
     /// The type of the elements in the array.
     element_type: ElementType<N>,

--- a/console/program/src/data_types/array_type/parse.rs
+++ b/console/program/src/data_types/array_type/parse.rs
@@ -23,33 +23,27 @@ impl<N: Network> Parser for ArrayType<N> {
         // Parse the whitespaces from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
 
-        // A helper function to parse the semicolon, length, and closing bracket.
-        fn parse_length(string: &str) -> ParserResult<u32> {
-            // Parse the whitespaces from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Parse the semicolon.
-            let (string, _) = tag(";")(string)?;
-            // Parse the whitespaces from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Parse the length from the string.
-            let (string, length) =
-                map_res(recognize(many1(one_of("0123456789"))), |digits: &str| digits.parse::<u32>())(string)?;
-            // Parse the whitespaces from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Parse the closing bracket.
-            let (string, _) = tag("]")(string)?;
-            Ok((string, length))
-        }
+        // Parse the element type.
+        let (string, element_type) = ElementType::parse(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
 
-        // Parse the element type, followed by the length.
-        alt((
-            map_res(pair(LiteralType::parse, parse_length), |(element_type, length)| {
-                ArrayType::new_literal_array(element_type, U32::new(length))
-            }),
-            map_res(pair(Identifier::parse, parse_length), |(element_type, length)| {
-                ArrayType::new_struct_array(element_type, U32::new(length))
-            }),
-        ))(string)
+        // Parse the semicolon.
+        let (string, _) = tag(";")(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the length from the string.
+        let (string, length) =
+            map_res(recognize(many1(one_of("0123456789"))), |digits: &str| digits.parse::<u32>())(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the closing bracket.
+        let (string, _) = tag("]")(string)?;
+
+        // Return the array type.
+        map_res(take(0usize), move |_| Self::new(element_type, U32::new(length)))(string)
     }
 }
 
@@ -80,9 +74,6 @@ impl<N: Network> Debug for ArrayType<N> {
 impl<N: Network> Display for ArrayType<N> {
     /// Prints the array type as a string.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Literal(literal_type, length) => write!(f, "[{}; {}]", literal_type, **length),
-            Self::Struct(identifier, length) => write!(f, "[{}; {}]", identifier, **length),
-        }
+        write!(f, "[{}; {}]", self.element_type, *self.length)
     }
 }

--- a/console/program/src/data_types/element_type/bytes.rs
+++ b/console/program/src/data_types/element_type/bytes.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for ElementType<N> {
+    /// Reads an element type from a buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let variant = u8::read_le(&mut reader)?;
+        match variant {
+            0 => Ok(Self::Literal(LiteralType::read_le(&mut reader)?)),
+            1 => Ok(Self::Struct(Identifier::read_le(&mut reader)?)),
+            2.. => Err(error(format!("Failed to deserialize annotation variant {variant}"))),
+        }
+    }
+}
+
+impl<N: Network> ToBytes for ElementType<N> {
+    /// Writes an element type to a buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        match self {
+            Self::Literal(literal_type) => {
+                u8::write_le(&0u8, &mut writer)?;
+                literal_type.write_le(&mut writer)
+            }
+            Self::Struct(identifier) => {
+                u8::write_le(&1u8, &mut writer)?;
+                identifier.write_le(&mut writer)
+            }
+        }
+    }
+}

--- a/console/program/src/data_types/element_type/mod.rs
+++ b/console/program/src/data_types/element_type/mod.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod parse;
+mod serialize;
+
+use crate::{Identifier, LiteralType};
+use snarkvm_console_network::prelude::*;
+
+/// An `ElementType` defines the type parameter for an element in an `Array` or `Vector`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ElementType<N: Network> {
+    /// A literal element type.
+    Literal(LiteralType),
+    /// A struct element type.
+    Struct(Identifier<N>),
+}
+
+impl<N: Network> From<LiteralType> for ElementType<N> {
+    /// Initializes an element type from a literal type.
+    fn from(literal: LiteralType) -> Self {
+        ElementType::Literal(literal)
+    }
+}
+
+impl<N: Network> From<Identifier<N>> for ElementType<N> {
+    /// Initializes an element type from a struct type.
+    fn from(struct_: Identifier<N>) -> Self {
+        ElementType::Struct(struct_)
+    }
+}

--- a/console/program/src/data_types/element_type/parse.rs
+++ b/console/program/src/data_types/element_type/parse.rs
@@ -1,0 +1,150 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Parser for ElementType<N> {
+    /// Parses a string into an element type.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse to determine the element type (order matters).
+        alt((
+            map(LiteralType::parse, |type_| Self::Literal(type_)),
+            map(Identifier::parse, |identifier| Self::Struct(identifier)),
+        ))(string)
+    }
+}
+
+impl<N: Network> FromStr for ElementType<N> {
+    type Err = Error;
+
+    /// Returns an element type from a string literal.
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for ElementType<N> {
+    /// Prints the element type as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for ElementType<N> {
+    /// Prints the element type as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            // Prints the literal, i.e. field
+            Self::Literal(literal) => Display::fmt(literal, f),
+            // Prints the struct, i.e. signature
+            Self::Struct(struct_) => Display::fmt(struct_, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_parse() -> Result<()> {
+        assert_eq!(ElementType::parse("field"), Ok(("", ElementType::<CurrentNetwork>::Literal(LiteralType::Field))));
+        assert_eq!(
+            ElementType::parse("signature"),
+            Ok(("", ElementType::<CurrentNetwork>::Struct(Identifier::from_str("signature")?)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_fails() -> Result<()> {
+        // Literal type must not contain visibility.
+        assert_eq!(
+            Ok((".constant", ElementType::<CurrentNetwork>::from_str("field")?)),
+            ElementType::<CurrentNetwork>::parse("field.constant")
+        );
+        assert_eq!(
+            Ok((".public", ElementType::<CurrentNetwork>::from_str("field")?)),
+            ElementType::<CurrentNetwork>::parse("field.public")
+        );
+        assert_eq!(
+            Ok((".private", ElementType::<CurrentNetwork>::from_str("field")?)),
+            ElementType::<CurrentNetwork>::parse("field.private")
+        );
+
+        // Struct type must not contain visibility.
+        assert_eq!(
+            Ok((".constant", Identifier::<CurrentNetwork>::from_str("signature")?)),
+            Identifier::<CurrentNetwork>::parse("signature.constant")
+        );
+        assert_eq!(
+            Ok((".public", Identifier::<CurrentNetwork>::from_str("signature")?)),
+            Identifier::<CurrentNetwork>::parse("signature.public")
+        );
+        assert_eq!(
+            Ok((".private", Identifier::<CurrentNetwork>::from_str("signature")?)),
+            Identifier::<CurrentNetwork>::parse("signature.private")
+        );
+
+        // Must be non-empty.
+        assert!(ElementType::<CurrentNetwork>::parse("").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("{}").is_err());
+
+        // Invalid characters.
+        assert!(ElementType::<CurrentNetwork>::parse("_").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("__").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("___").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("-").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("--").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("---").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("*").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("**").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("***").is_err());
+
+        // Must not start with a number.
+        assert!(ElementType::<CurrentNetwork>::parse("1").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("2").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("3").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("1foo").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("12").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("111").is_err());
+
+        // Must fit within the data capacity of a base field element.
+        let struct_ = ElementType::<CurrentNetwork>::parse(
+            "foo_bar_baz_qux_quux_quuz_corge_grault_garply_waldo_fred_plugh_xyzzy",
+        );
+        assert!(struct_.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_display() -> Result<()> {
+        assert_eq!(ElementType::<CurrentNetwork>::Literal(LiteralType::Field).to_string(), "field");
+        assert_eq!(ElementType::<CurrentNetwork>::Struct(Identifier::from_str("signature")?).to_string(), "signature");
+        Ok(())
+    }
+}

--- a/console/program/src/data_types/element_type/serialize.rs
+++ b/console/program/src/data_types/element_type/serialize.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Serialize for ElementType<N> {
+    /// Serializes the element type into string or bytes.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => serializer.collect_str(self),
+            false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
+        }
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for ElementType<N> {
+    /// Deserializes the element type from a string or bytes.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "element type"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
+
+    /// Add test cases here to be checked for serialization.
+    const TEST_CASES: &[&str] = &[
+        // Literal
+        "address",
+        "boolean",
+        "field",
+        "group",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+        "i128",
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "u128",
+        "scalar",
+        "string",
+        // Struct
+        "signature",
+        "message",
+        "item",
+        "passport",
+        "object",
+        "array",
+    ];
+
+    fn check_serde_json<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_string = &expected.to_string();
+        let candidate_string = serde_json::to_string(&expected).unwrap();
+        assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
+
+        // Deserialize
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
+        assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+    }
+
+    fn check_bincode<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_bytes = expected.to_bytes_le().unwrap();
+        let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(expected, T::read_le(&expected_bytes[..]).unwrap());
+        assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json() {
+        for case in TEST_CASES.iter() {
+            check_serde_json(ElementType::<CurrentNetwork>::from_str(case).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        for case in TEST_CASES.iter() {
+            check_bincode(ElementType::<CurrentNetwork>::from_str(case).unwrap());
+        }
+    }
+}

--- a/console/program/src/data_types/mod.rs
+++ b/console/program/src/data_types/mod.rs
@@ -15,6 +15,9 @@
 mod array_type;
 pub use array_type::ArrayType;
 
+mod element_type;
+pub use element_type::ElementType;
+
 mod literal_type;
 pub use literal_type::LiteralType;
 

--- a/console/program/src/data_types/plaintext_type/mod.rs
+++ b/console/program/src/data_types/plaintext_type/mod.rs
@@ -16,7 +16,7 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{Identifier, LiteralType};
+use crate::{ElementType, Identifier, LiteralType};
 use snarkvm_console_network::prelude::*;
 
 /// A `ValueType` defines the type parameter for an entry in an `Struct`.
@@ -41,5 +41,15 @@ impl<N: Network> From<Identifier<N>> for PlaintextType<N> {
     /// Initializes a plaintext type from a struct type.
     fn from(struct_: Identifier<N>) -> Self {
         PlaintextType::Struct(struct_)
+    }
+}
+
+impl<N: Network> From<ElementType<N>> for PlaintextType<N> {
+    /// Initializes a plaintext type from an element type.
+    fn from(element: ElementType<N>) -> Self {
+        match element {
+            ElementType::Literal(literal) => PlaintextType::Literal(literal),
+            ElementType::Struct(struct_) => PlaintextType::Struct(struct_),
+        }
     }
 }

--- a/console/program/src/data_types/vector_type/bytes.rs
+++ b/console/program/src/data_types/vector_type/bytes.rs
@@ -12,29 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod array_type;
-pub use array_type::ArrayType;
+use super::*;
 
-mod element_type;
-pub use element_type::ElementType;
+impl<N: Network> FromBytes for VectorType<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the element type.
+        let element_type = ElementType::read_le(&mut reader)?;
+        // Return the vector type.
+        Ok(Self::new(element_type))
+    }
+}
 
-mod literal_type;
-pub use literal_type::LiteralType;
-
-mod plaintext_type;
-pub use plaintext_type::PlaintextType;
-
-mod record_type;
-pub use record_type::{EntryType, RecordType};
-
-mod register_type;
-pub use register_type::RegisterType;
-
-mod struct_;
-pub use struct_::Struct;
-
-mod value_type;
-pub use value_type::ValueType;
-
-mod vector_type;
-pub use vector_type::VectorType;
+impl<N: Network> ToBytes for VectorType<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the element type.
+        self.element_type.write_le(&mut writer)
+    }
+}

--- a/console/program/src/data_types/vector_type/mod.rs
+++ b/console/program/src/data_types/vector_type/mod.rs
@@ -1,0 +1,106 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod parse;
+mod serialize;
+
+use crate::{ElementType};
+use snarkvm_console_network::prelude::*;
+
+use core::fmt::{Debug, Display};
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct VectorType<N: Network> {
+    /// The type of the elements in the vector.
+    element_type: ElementType<N>,
+}
+
+impl<N: Network> VectorType<N> {
+    /// Constructs a new vector type.
+    pub fn new(element_type: ElementType<N>) -> Self {
+        Self { element_type }
+    }
+
+    /// Returns the element type.
+    pub fn element_type(&self) -> &ElementType<N> {
+        &self.element_type
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    use crate::{Identifier, LiteralType};
+    use core::str::FromStr;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_vector_type() -> Result<()> {
+        // Test literal vector types.
+        let type_ = VectorType::<CurrentNetwork>::from_str("[field]")?;
+        assert_eq!(type_, VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Field)));
+        assert_eq!(
+            type_.to_bytes_le()?,
+            VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
+        );
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Field));
+
+        // Test struct vector types.
+        let type_ = VectorType::<CurrentNetwork>::from_str("[foo]")?;
+        assert_eq!(
+            type_,
+            VectorType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?))
+        );
+        assert_eq!(
+            type_.to_bytes_le()?,
+            VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
+        );
+        assert_eq!(type_.element_type(), &ElementType::from(Identifier::from_str("foo")?));
+
+        // Test vector type with maximum length.
+        let type_ = VectorType::<CurrentNetwork>::from_str("[scalar]")?;
+        assert_eq!(
+            type_,
+            VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar))
+        );
+        assert_eq!(
+            type_.to_bytes_le()?,
+            VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
+        );
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Scalar));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_vector_type_fails() -> Result<()> {
+        let type_ = VectorType::<CurrentNetwork>::from_str("[[field]]");
+        assert!(type_.is_err());
+
+        let type_ = VectorType::<CurrentNetwork>::from_str("[[foo]]");
+        assert!(type_.is_err());
+
+        let type_ = VectorType::<CurrentNetwork>::from_str("[field; 3]");
+        assert!(type_.is_err());
+
+        let type_ = VectorType::<CurrentNetwork>::from_str("[foo; -1]");
+        assert!(type_.is_err());
+
+        Ok(())
+    }
+}

--- a/console/program/src/data_types/vector_type/mod.rs
+++ b/console/program/src/data_types/vector_type/mod.rs
@@ -16,7 +16,7 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{ElementType};
+use crate::ElementType;
 use snarkvm_console_network::prelude::*;
 
 use core::fmt::{Debug, Display};
@@ -62,10 +62,7 @@ mod tests {
 
         // Test struct vector types.
         let type_ = VectorType::<CurrentNetwork>::from_str("[foo]")?;
-        assert_eq!(
-            type_,
-            VectorType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?))
-        );
+        assert_eq!(type_, VectorType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?)));
         assert_eq!(
             type_.to_bytes_le()?,
             VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
@@ -74,10 +71,7 @@ mod tests {
 
         // Test vector type with maximum length.
         let type_ = VectorType::<CurrentNetwork>::from_str("[scalar]")?;
-        assert_eq!(
-            type_,
-            VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar))
-        );
+        assert_eq!(type_, VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar)));
         assert_eq!(
             type_.to_bytes_le()?,
             VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?

--- a/console/program/src/data_types/vector_type/parse.rs
+++ b/console/program/src/data_types/vector_type/parse.rs
@@ -1,0 +1,68 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Parser for VectorType<N> {
+    /// Parses a string into a literal type.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the opening bracket.
+        let (string, _) = tag("[")(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the element type.
+        let (string, element_type) = ElementType::parse(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the closing bracket.
+        let (string, _) = tag("]")(string)?;
+
+        // Return the vector type.
+        Ok((string, Self::new(element_type)))
+    }
+}
+
+impl<N: Network> FromStr for VectorType<N> {
+    type Err = Error;
+
+    /// Returns an vector type from a string literal.
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for VectorType<N> {
+    /// Prints the vector type as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for VectorType<N> {
+    /// Prints the vector type as a string.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}]", self.element_type)
+    }
+}

--- a/console/program/src/data_types/vector_type/serialize.rs
+++ b/console/program/src/data_types/vector_type/serialize.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Serialize for VectorType<N> {
+    /// Serializes the vector type into string or bytes.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => serializer.collect_str(self),
+            false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
+        }
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for VectorType<N> {
+    /// Deserializes the vector type from a string or bytes.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "vector type"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    /// Add test cases here to be checked for serialization.
+    const TEST_CASES: &[&str] = &["[u8]", "[foo]"];
+
+    fn check_serde_json<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_string = &expected.to_string();
+        let candidate_string = serde_json::to_string(&expected).unwrap();
+        assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
+
+        // Deserialize
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
+        assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+    }
+
+    fn check_bincode<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_bytes = expected.to_bytes_le().unwrap();
+        let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(expected, T::read_le(&expected_bytes[..]).unwrap());
+        assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json() {
+        for case in TEST_CASES.iter() {
+            check_serde_json(VectorType::<Testnet3>::from_str(case).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        for case in TEST_CASES.iter() {
+            check_bincode(VectorType::<Testnet3>::from_str(case).unwrap());
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the `VectorType` to `console::data_types`.
This allows users to define single-dimensional vectors, e.g [u8].
Vectors are only allowed to be used in `finalize` contexts.
Note that this PR does not integrate `VectorType` into the rest of the codebase, just introduces it as an isolated module.

Depends on #1728.
