### PR TITLE
[Feature] Support `Access::Index` variant.

### DIFF
--- a/circuit/program/src/data/access/mod.rs
+++ b/circuit/program/src/data/access/mod.rs
@@ -14,7 +14,7 @@
 
 use crate::Identifier;
 use snarkvm_circuit_network::Aleo;
-use snarkvm_circuit_types::{environment::prelude::*, Eject, Inject, Mode, Parser, ParserResult};
+use snarkvm_circuit_types::{environment::prelude::*, Eject, Inject, Mode, Parser, ParserResult, U32};
 
 use std::{
     fmt,
@@ -25,7 +25,8 @@ use std::{
 /// A register `Access`.
 #[derive(Clone)]
 pub enum Access<A: Aleo> {
-    // TODO (d0cd): Add the index variant.
+    /// The access is an index.
+    Index(U32<A>),
     /// The access is a member.
     Member(Identifier<A>),
 }
@@ -37,6 +38,7 @@ impl<A: Aleo> Inject for Access<A> {
     /// Initializes a new access circuit from a primitive.
     fn new(mode: Mode, plaintext: Self::Primitive) -> Self {
         match plaintext {
+            Self::Primitive::Index(index) => Self::Index(U32::new(mode, index)),
             Self::Primitive::Member(identifier) => Self::Member(Identifier::new(mode, identifier)),
         }
     }
@@ -49,6 +51,7 @@ impl<A: Aleo> Eject for Access<A> {
     /// Ejects the mode of the access.
     fn eject_mode(&self) -> Mode {
         match self {
+            Self::Index(index) => index.eject_mode(),
             Self::Member(member) => member.eject_mode(),
         }
     }
@@ -56,6 +59,7 @@ impl<A: Aleo> Eject for Access<A> {
     /// Ejects the access.
     fn eject_value(&self) -> Self::Primitive {
         match self {
+            Self::Index(index) => console::Access::Index(index.eject_value()),
             Self::Member(identifier) => console::Access::Member(identifier.eject_value()),
         }
     }

--- a/circuit/program/src/data/plaintext/equal.rs
+++ b/circuit/program/src/data/plaintext/equal.rs
@@ -37,7 +37,7 @@ impl<A: Aleo> Equal<Self> for Plaintext<A> {
                     // Recursively check each element for equality.
                     let mut equal = Boolean::constant(true);
                     for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
-                        equal = equal & plaintext_a.is_equal(plaintext_b);
+                        equal &= plaintext_a.is_equal(plaintext_b);
                     }
                     equal
                 }
@@ -67,7 +67,7 @@ impl<A: Aleo> Equal<Self> for Plaintext<A> {
                     // Recursively check each element for inequality.
                     let mut not_equal = Boolean::constant(false);
                     for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
-                        not_equal = not_equal | plaintext_a.is_not_equal(plaintext_b);
+                        not_equal |= plaintext_a.is_not_equal(plaintext_b);
                     }
                     not_equal
                 }

--- a/circuit/program/src/data/plaintext/equal.rs
+++ b/circuit/program/src/data/plaintext/equal.rs
@@ -32,7 +32,18 @@ impl<A: Aleo> Equal<Self> for Plaintext<A> {
                 }
                 false => Boolean::constant(false),
             },
-            (Self::Literal(..), _) | (Self::Struct(..), _) => Boolean::constant(false),
+            (Self::List(a, _), Self::List(b, _)) => match a.len() == b.len() {
+                true => {
+                    // Recursively check each element for equality.
+                    let mut equal = Boolean::constant(true);
+                    for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
+                        equal = equal & plaintext_a.is_equal(plaintext_b);
+                    }
+                    equal
+                }
+                false => Boolean::constant(false),
+            },
+            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::List(..), _) => Boolean::constant(false),
         }
     }
 
@@ -51,7 +62,18 @@ impl<A: Aleo> Equal<Self> for Plaintext<A> {
                 }
                 false => Boolean::constant(true),
             },
-            (Self::Literal(..), _) | (Self::Struct(..), _) => Boolean::constant(true),
+            (Self::List(a, _), Self::List(b, _)) => match a.len() == b.len() {
+                true => {
+                    // Recursively check each element for inequality.
+                    let mut not_equal = Boolean::constant(false);
+                    for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
+                        not_equal = not_equal | plaintext_a.is_not_equal(plaintext_b);
+                    }
+                    not_equal
+                }
+                false => Boolean::constant(true),
+            },
+            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::List(..), _) => Boolean::constant(true),
         }
     }
 }

--- a/circuit/program/src/data/plaintext/find.rs
+++ b/circuit/program/src/data/plaintext/find.rs
@@ -48,6 +48,20 @@ impl<A: Aleo> Plaintext<A> {
                                     None => bail!("Failed to locate access '{access}'"),
                                 }
                             }
+                            (Self::List(list, ..), Access::Index(index)) => {
+                                let index = match index.eject_mode() {
+                                    Mode::Constant => index.eject_value(),
+                                    _ => bail!("'{index}' must be a constant"),
+                                };
+                                match list.get(*index as usize) {
+                                    // Halts if the element is not a struct or list.
+                                    Some(Self::Literal(..)) => bail!("'{index}' must be a struct or list"),
+                                    // Retrieve the element and update `plaintext` for the next iteration.
+                                    Some(element) => plaintext = element,
+                                    // Halts if the element does not exist.
+                                    None => bail!("Failed to locate access '{access}'"),
+                                }
+                            }
                             _ => bail!("Invalid access `{access}`"),
                         }
                     }
@@ -60,6 +74,18 @@ impl<A: Aleo> Plaintext<A> {
                                     Some(member) => output = Some(member.clone()),
                                     // Halts if the member does not exist.
                                     None => bail!("Failed to locate member '{identifier}'"),
+                                }
+                            }
+                            (Self::List(list, ..), Access::Index(index)) => {
+                                let index = match index.eject_mode() {
+                                    Mode::Constant => index.eject_value(),
+                                    _ => bail!("'{index}' must be a constant"),
+                                };
+                                match list.get(*index as usize) {
+                                    // Retrieve the element and update `plaintext` for the next iteration.
+                                    Some(element) => output = Some(element.clone()),
+                                    // Halts if the element does not exist.
+                                    None => bail!("Failed to locate element '{index}'"),
                                 }
                             }
                             _ => bail!("Invalid access `{access}``"),

--- a/circuit/program/src/data/plaintext/from_bits.rs
+++ b/circuit/program/src/data/plaintext/from_bits.rs
@@ -72,6 +72,30 @@ impl<A: Aleo> FromBits for Plaintext<A> {
                 Err(_) => A::halt("Failed to store the plaintext bits in the cache."),
             }
         }
+        // List
+        else if variant == [true, false] {
+            let num_elements = U32::from_bits_le(&bits_le[counter..counter + 32]).eject_value();
+            counter += 32;
+
+            let mut elements = Vec::with_capacity(*num_elements as usize);
+            for _ in 0..*num_elements {
+                let element_size = U16::from_bits_le(&bits_le[counter..counter + 16]).eject_value();
+                counter += 16;
+
+                let value = Plaintext::from_bits_le(&bits_le[counter..counter + *element_size as usize]);
+                counter += *element_size as usize;
+
+                elements.push(value);
+            }
+
+            // Store the plaintext bits in the cache.
+            let cache = OnceCell::new();
+            match cache.set(bits_le.to_vec()) {
+                // Return the list.
+                Ok(_) => Self::List(elements, cache),
+                Err(_) => A::halt("Failed to store the plaintext bits in the cache."),
+            }
+        }
         // Unknown variant.
         else {
             A::halt("Unknown plaintext variant.")
@@ -130,6 +154,30 @@ impl<A: Aleo> FromBits for Plaintext<A> {
             match cache.set(bits_be.to_vec()) {
                 // Return the member.
                 Ok(_) => Self::Struct(members, cache),
+                Err(_) => A::halt("Failed to store the plaintext bits in the cache."),
+            }
+        }
+        // List
+        else if variant == [true, false] {
+            let num_elements = U32::from_bits_be(&bits_be[counter..counter + 32]).eject_value();
+            counter += 32;
+
+            let mut elements = Vec::with_capacity(*num_elements as usize);
+            for _ in 0..*num_elements {
+                let element_size = U16::from_bits_be(&bits_be[counter..counter + 16]).eject_value();
+                counter += 16;
+
+                let value = Plaintext::from_bits_be(&bits_be[counter..counter + *element_size as usize]);
+                counter += *element_size as usize;
+
+                elements.push(value);
+            }
+
+            // Store the plaintext bits in the cache.
+            let cache = OnceCell::new();
+            match cache.set(bits_be.to_vec()) {
+                // Return the member.
+                Ok(_) => Self::List(elements, cache),
                 Err(_) => A::halt("Failed to store the plaintext bits in the cache."),
             }
         }

--- a/circuit/program/src/data/plaintext/mod.rs
+++ b/circuit/program/src/data/plaintext/mod.rs
@@ -27,7 +27,7 @@ mod to_fields;
 
 use crate::{Access, Ciphertext, Identifier, Literal, Visibility};
 use snarkvm_circuit_network::Aleo;
-use snarkvm_circuit_types::{environment::prelude::*, Address, Boolean, Field, Scalar, U16, U8};
+use snarkvm_circuit_types::{environment::prelude::*, Address, Boolean, Field, Scalar, U16, U32, U8};
 
 #[derive(Clone)]
 pub enum Plaintext<A: Aleo> {
@@ -35,6 +35,8 @@ pub enum Plaintext<A: Aleo> {
     Literal(Literal<A>, OnceCell<Vec<Boolean<A>>>),
     /// A plaintext struct.
     Struct(IndexMap<Identifier<A>, Plaintext<A>>, OnceCell<Vec<Boolean<A>>>),
+    /// A plaintext list.
+    List(Vec<Plaintext<A>>, OnceCell<Vec<Boolean<A>>>),
 }
 
 #[cfg(console)]
@@ -46,6 +48,7 @@ impl<A: Aleo> Inject for Plaintext<A> {
         match plaintext {
             Self::Primitive::Literal(literal, _) => Self::Literal(Literal::new(mode, literal), Default::default()),
             Self::Primitive::Struct(struct_, _) => Self::Struct(Inject::new(mode, struct_), Default::default()),
+            Self::Primitive::List(list, _) => Self::List(Inject::new(mode, list), Default::default()),
         }
     }
 }
@@ -63,6 +66,7 @@ impl<A: Aleo> Eject for Plaintext<A> {
                 .map(|(identifier, value)| (identifier, value).eject_mode())
                 .collect::<Vec<_>>()
                 .eject_mode(),
+            Self::List(list, _) => list.iter().map(|value| value.eject_mode()).collect::<Vec<_>>().eject_mode(),
         }
     }
 
@@ -72,6 +76,9 @@ impl<A: Aleo> Eject for Plaintext<A> {
             Self::Literal(literal, _) => console::Plaintext::Literal(literal.eject_value(), Default::default()),
             Self::Struct(struct_, _) => {
                 console::Plaintext::Struct(struct_.iter().map(|pair| pair.eject_value()).collect(), Default::default())
+            }
+            Self::List(list, _) => {
+                console::Plaintext::List(list.iter().map(|value| value.eject_value()).collect(), Default::default())
             }
         }
     }

--- a/circuit/program/src/data/plaintext/to_bits.rs
+++ b/circuit/program/src/data/plaintext/to_bits.rs
@@ -43,6 +43,18 @@ impl<A: Aleo> ToBits for Plaintext<A> {
                     bits_le
                 })
                 .clone(),
+            Self::List(members, bits_le) => bits_le
+                .get_or_init(|| {
+                    let mut bits_le = vec![Boolean::constant(true), Boolean::constant(false)]; // Variant bit.
+                    bits_le.extend(U32::constant(console::U32::new(members.len() as u32)).to_bits_le());
+                    for value in members {
+                        let value_bits = value.to_bits_le();
+                        bits_le.extend(U16::constant(console::U16::new(value_bits.len() as u16)).to_bits_le());
+                        bits_le.extend(value_bits);
+                    }
+                    bits_le
+                })
+                .clone(),
         }
     }
 
@@ -66,6 +78,18 @@ impl<A: Aleo> ToBits for Plaintext<A> {
                         let value_bits = value.to_bits_be();
                         bits_be.extend(identifier.size_in_bits().to_bits_be());
                         bits_be.extend(identifier.to_bits_be());
+                        bits_be.extend(U16::constant(console::U16::new(value_bits.len() as u16)).to_bits_be());
+                        bits_be.extend(value_bits);
+                    }
+                    bits_be
+                })
+                .clone(),
+            Self::List(members, bits_be) => bits_be
+                .get_or_init(|| {
+                    let mut bits_be = vec![Boolean::constant(true), Boolean::constant(false)]; // Variant bit.
+                    bits_be.extend(U32::constant(console::U32::new(members.len() as u32)).to_bits_be());
+                    for value in members {
+                        let value_bits = value.to_bits_be();
                         bits_be.extend(U16::constant(console::U16::new(value_bits.len() as u16)).to_bits_be());
                         bits_be.extend(value_bits);
                     }

--- a/circuit/program/src/data/record/find.rs
+++ b/circuit/program/src/data/record/find.rs
@@ -24,7 +24,10 @@ impl<A: Aleo> Record<A, Plaintext<A>> {
 
         // Ensure the path is not empty.
         if let Some((first, rest)) = path.split_first() {
-            let Access::Member(first) = first;
+            let first = match first {
+                Access::Member(identifier) => identifier,
+                Access::Index(_) => bail!("Attempted to index into a record"),
+            };
             // Retrieve the top-level entry.
             match self.data.get(first) {
                 Some(entry) => match rest.is_empty() {

--- a/console/program/src/data/access/mod.rs
+++ b/console/program/src/data/access/mod.rs
@@ -16,14 +16,15 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::Identifier;
+use crate::{Identifier, U32};
 
 use snarkvm_console_network::prelude::*;
 
 /// A register `Access`.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Access<N: Network> {
-    // TODO (d0cd): Introduce the `Index` variant.
+    /// The access is an index.
+    Index(U32<N>),
     /// The access is a member.
     Member(Identifier<N>),
 }

--- a/console/program/src/data/access/parse.rs
+++ b/console/program/src/data/access/parse.rs
@@ -19,8 +19,18 @@ impl<N: Network> Parser for Access<N> {
     where
         Self: Sized,
     {
+        // A helper function to parse an index access.
+        fn parse_index(string: &str) -> ParserResult<u32> {
+            // Parse the opening bracket '['.
+            let (string, _) = tag("[")(string)?;
+            // Parse the digits from the string.
+            let (string, primitive) = recognize(many1(terminated(one_of("0123456789"), many0(char('_')))))(string)?;
+            // Parse the closing bracket ']' and return the value as a U32.
+            map_res(tag("]"), |_| primitive.replace('_', "").parse())(string)
+        }
+
         alt((
-            map(pair(tag("["), pair(U32::parse, tag("]"))), |(_, (index, _))| Self::Index(index)),
+            map(parse_index, |index| Self::Index(U32::new(index))),
             map(pair(tag("."), Identifier::parse), |(_, identifier)| Self::Member(identifier)),
         ))(string)
     }
@@ -56,7 +66,7 @@ impl<N: Network> Display for Access<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             // Prints the access index, i.e. `[0]`
-            Self::Index(index) => write!(f, "[{}]", index),
+            Self::Index(index) => write!(f, "[{}]", **index),
             // Prints the access member, i.e. `.foo`
             Self::Member(identifier) => write!(f, ".{}", identifier),
         }

--- a/console/program/src/data/access/serialize.rs
+++ b/console/program/src/data/access/serialize.rs
@@ -74,6 +74,7 @@ mod tests {
     #[test]
     fn test_serde_json() {
         for i in 0..1000 {
+            check_serde_json(Access::<CurrentNetwork>::from_str(&format!("[{i}]")).unwrap());
             check_serde_json(Access::<CurrentNetwork>::from_str(&format!(".owner_{i}")).unwrap());
         }
     }
@@ -81,6 +82,7 @@ mod tests {
     #[test]
     fn test_bincode() {
         for i in 0..1000 {
+            check_bincode(Access::<CurrentNetwork>::from_str(&format!("[{i}]")).unwrap());
             check_bincode(Access::<CurrentNetwork>::from_str(&format!(".owner_{i}")).unwrap());
         }
     }

--- a/console/program/src/data/plaintext/equal.rs
+++ b/console/program/src/data/plaintext/equal.rs
@@ -41,7 +41,18 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                 }
                 false => Boolean::new(false),
             },
-            (Self::Literal(..), _) | (Self::Struct(..), _) => Boolean::new(false),
+            (Self::Vector(a, _), Self::Vector(b, _)) => match a.len() == b.len() {
+                true => {
+                    // Recursively check each element for equality.
+                    let mut equal = Boolean::new(true);
+                    for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
+                        equal = equal & plaintext_a.is_equal(plaintext_b);
+                    }
+                    equal
+                }
+                false => Boolean::new(false),
+            },
+            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::Vector(..), _) => Boolean::new(false),
         }
     }
 
@@ -60,7 +71,18 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                 }
                 false => Boolean::new(true),
             },
-            (Self::Literal(..), _) | (Self::Struct(..), _) => Boolean::new(true),
+            (Self::Vector(a, _), Self::Vector(b, _)) => match a.len() == b.len() {
+                true => {
+                    // Recursively check each element for equality.
+                    let mut not_equal = Boolean::new(false);
+                    for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
+                        not_equal = not_equal | plaintext_a.is_not_equal(plaintext_b);
+                    }
+                    not_equal
+                }
+                false => Boolean::new(true),
+            },
+            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::Vector(..), _) => Boolean::new(true),
         }
     }
 }

--- a/console/program/src/data/plaintext/equal.rs
+++ b/console/program/src/data/plaintext/equal.rs
@@ -46,7 +46,7 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                     // Recursively check each element for equality.
                     let mut equal = Boolean::new(true);
                     for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
-                        equal = equal & plaintext_a.is_equal(plaintext_b);
+                        equal &= plaintext_a.is_equal(plaintext_b);
                     }
                     equal
                 }
@@ -76,7 +76,7 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                     // Recursively check each element for equality.
                     let mut not_equal = Boolean::new(false);
                     for (plaintext_a, plaintext_b) in a.iter().zip_eq(b.iter()) {
-                        not_equal = not_equal | plaintext_a.is_not_equal(plaintext_b);
+                        not_equal |= plaintext_a.is_not_equal(plaintext_b);
                     }
                     not_equal
                 }

--- a/console/program/src/data/plaintext/equal.rs
+++ b/console/program/src/data/plaintext/equal.rs
@@ -41,7 +41,7 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                 }
                 false => Boolean::new(false),
             },
-            (Self::Vector(a, _), Self::Vector(b, _)) => match a.len() == b.len() {
+            (Self::List(a, _), Self::List(b, _)) => match a.len() == b.len() {
                 true => {
                     // Recursively check each element for equality.
                     let mut equal = Boolean::new(true);
@@ -52,7 +52,7 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                 }
                 false => Boolean::new(false),
             },
-            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::Vector(..), _) => Boolean::new(false),
+            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::List(..), _) => Boolean::new(false),
         }
     }
 
@@ -71,7 +71,7 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                 }
                 false => Boolean::new(true),
             },
-            (Self::Vector(a, _), Self::Vector(b, _)) => match a.len() == b.len() {
+            (Self::List(a, _), Self::List(b, _)) => match a.len() == b.len() {
                 true => {
                     // Recursively check each element for equality.
                     let mut not_equal = Boolean::new(false);
@@ -82,7 +82,7 @@ impl<N: Network> Equal<Self> for Plaintext<N> {
                 }
                 false => Boolean::new(true),
             },
-            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::Vector(..), _) => Boolean::new(true),
+            (Self::Literal(..), _) | (Self::Struct(..), _) | (Self::List(..), _) => Boolean::new(true),
         }
     }
 }

--- a/console/program/src/data/plaintext/find.rs
+++ b/console/program/src/data/plaintext/find.rs
@@ -24,7 +24,7 @@ impl<N: Network> Plaintext<N> {
             // Halts if the value is not a struct.
             Self::Literal(..) => bail!("'{self}' is not a struct"),
             // Retrieve the value of the member (from the value).
-            Self::Struct(..) | Self::Vector(..) => {
+            Self::Struct(..) | Self::List(..) => {
                 // Initialize the plaintext starting from the top-level.
                 let mut plaintext = self;
 
@@ -33,13 +33,13 @@ impl<N: Network> Plaintext<N> {
 
                 // Iterate through the path to retrieve the value.
                 for (i, access) in path.iter().enumerate() {
-                    // If this is not the last item in the path, ensure the value is either a struct or vector.
+                    // If this is not the last item in the path, ensure the value is either a struct or list.
                     if i != path.len() - 1 {
                         match (plaintext, access) {
                             (Self::Struct(members, ..), Access::Member(identifier)) => {
                                 match members.get(identifier) {
-                                    // Halts if the member is not a struct or array.
-                                    Some(Self::Literal(..)) => bail!("'{identifier}' must be a struct or array"),
+                                    // Halts if the member is not a struct or list.
+                                    Some(Self::Literal(..)) => bail!("'{identifier}' must be a struct or list"),
                                     // Retrieve the member and update `plaintext` for the next iteration.
                                     Some(member) => plaintext = member,
                                     // Halts if the member does not exist.

--- a/console/program/src/data/plaintext/find.rs
+++ b/console/program/src/data/plaintext/find.rs
@@ -46,6 +46,16 @@ impl<N: Network> Plaintext<N> {
                                     None => bail!("Failed to locate member '{identifier}' in '{self}'"),
                                 }
                             }
+                            (Self::List(list, ..), Access::Index(index)) => {
+                                match list.get(**index as usize) {
+                                    // Halts if the element is not a struct or list.
+                                    Some(Self::Literal(..)) => bail!("'{index}' must be a struct or list"),
+                                    // Retrieve the element and update `plaintext` for the next iteration.
+                                    Some(member) => plaintext = member,
+                                    // Halts if the index is out of bounds.
+                                    None => bail!("Index '{index}' for '{self}' is out of bounds"),
+                                }
+                            }
                             _ => bail!("Invalid access `{access}` for `{plaintext}`"),
                         }
                     }
@@ -58,6 +68,14 @@ impl<N: Network> Plaintext<N> {
                                     Some(member) => output = Some(member.clone()),
                                     // Halts if the member does not exist.
                                     None => bail!("Failed to locate member '{identifier}' in '{self}'"),
+                                }
+                            }
+                            (Self::List(list, ..), Access::Index(index)) => {
+                                match list.get(**index as usize) {
+                                    // Retrieve the element and update `plaintext` for the next iteration.
+                                    Some(member) => output = Some(member.clone()),
+                                    // Halts if the index is out of bounds.
+                                    None => bail!("Index '{index}' for '{self}' is out of bounds"),
                                 }
                             }
                             _ => bail!("Invalid access `{access}` for `{plaintext}`"),

--- a/console/program/src/data/plaintext/from_bits.rs
+++ b/console/program/src/data/plaintext/from_bits.rs
@@ -72,6 +72,30 @@ impl<N: Network> FromBits for Plaintext<N> {
                 Err(_) => bail!("Failed to store the plaintext bits in the cache."),
             }
         }
+        // Vector
+        else if variant == [true, false] {
+            let num_elements = u32::from_bits_le(&bits_le[counter..counter + 32])?;
+            counter += 32;
+
+            let mut elements = Vec::with_capacity(num_elements as usize);
+            for _ in 0..num_elements {
+                let element_size = u16::from_bits_le(&bits_le[counter..counter + 16])?;
+                counter += 16;
+
+                let element = Plaintext::from_bits_le(&bits_le[counter..counter + element_size as usize])?;
+                counter += element_size as usize;
+
+                elements.push(element);
+            }
+
+            // Store the plaintext bits in the cache.
+            let cache = OnceCell::new();
+            match cache.set(bits_le.to_vec()) {
+                // Return the vector.
+                Ok(_) => Ok(Self::Vector(elements, cache)),
+                Err(_) => bail!("Failed to store the plaintext bits in the cache."),
+            }
+        }
         // Unknown variant.
         else {
             bail!("Unknown plaintext variant.");
@@ -132,6 +156,30 @@ impl<N: Network> FromBits for Plaintext<N> {
             match cache.set(bits_be.to_vec()) {
                 // Return the struct.
                 Ok(_) => Ok(Self::Struct(members, cache)),
+                Err(_) => bail!("Failed to store the plaintext bits in the cache."),
+            }
+        }
+        // Vector
+        else if variant == [true, false] {
+            let num_elements = u32::from_bits_be(&bits_be[counter..counter + 32])?;
+            counter += 32;
+
+            let mut elements = Vec::with_capacity(num_elements as usize);
+            for _ in 0..num_elements {
+                let element_size = u16::from_bits_be(&bits_be[counter..counter + 16])?;
+                counter += 16;
+
+                let element = Plaintext::from_bits_be(&bits_be[counter..counter + element_size as usize])?;
+                counter += element_size as usize;
+
+                elements.push(element);
+            }
+
+            // Store the plaintext bits in the cache.
+            let cache = OnceCell::new();
+            match cache.set(bits_be.to_vec()) {
+                // Return the vector.
+                Ok(_) => Ok(Self::Vector(elements, cache)),
                 Err(_) => bail!("Failed to store the plaintext bits in the cache."),
             }
         }

--- a/console/program/src/data/plaintext/from_bits.rs
+++ b/console/program/src/data/plaintext/from_bits.rs
@@ -72,7 +72,7 @@ impl<N: Network> FromBits for Plaintext<N> {
                 Err(_) => bail!("Failed to store the plaintext bits in the cache."),
             }
         }
-        // Vector
+        // List
         else if variant == [true, false] {
             let num_elements = u32::from_bits_le(&bits_le[counter..counter + 32])?;
             counter += 32;
@@ -91,8 +91,8 @@ impl<N: Network> FromBits for Plaintext<N> {
             // Store the plaintext bits in the cache.
             let cache = OnceCell::new();
             match cache.set(bits_le.to_vec()) {
-                // Return the vector.
-                Ok(_) => Ok(Self::Vector(elements, cache)),
+                // Return the list.
+                Ok(_) => Ok(Self::List(elements, cache)),
                 Err(_) => bail!("Failed to store the plaintext bits in the cache."),
             }
         }
@@ -159,7 +159,7 @@ impl<N: Network> FromBits for Plaintext<N> {
                 Err(_) => bail!("Failed to store the plaintext bits in the cache."),
             }
         }
-        // Vector
+        // List
         else if variant == [true, false] {
             let num_elements = u32::from_bits_be(&bits_be[counter..counter + 32])?;
             counter += 32;
@@ -178,8 +178,8 @@ impl<N: Network> FromBits for Plaintext<N> {
             // Store the plaintext bits in the cache.
             let cache = OnceCell::new();
             match cache.set(bits_be.to_vec()) {
-                // Return the vector.
-                Ok(_) => Ok(Self::Vector(elements, cache)),
+                // Return the list.
+                Ok(_) => Ok(Self::List(elements, cache)),
                 Err(_) => bail!("Failed to store the plaintext bits in the cache."),
             }
         }

--- a/console/program/src/data/plaintext/mod.rs
+++ b/console/program/src/data/plaintext/mod.rs
@@ -38,6 +38,8 @@ pub enum Plaintext<N: Network> {
     Literal(Literal<N>, OnceCell<Vec<bool>>),
     /// A struct.
     Struct(IndexMap<Identifier<N>, Plaintext<N>>, OnceCell<Vec<bool>>),
+    /// A vector.
+    Vector(Vec<Plaintext<N>>, OnceCell<Vec<bool>>),
 }
 
 impl<N: Network> From<Literal<N>> for Plaintext<N> {
@@ -48,7 +50,7 @@ impl<N: Network> From<Literal<N>> for Plaintext<N> {
 }
 
 impl<N: Network> From<&Literal<N>> for Plaintext<N> {
-    /// Returns a new `Plaintext` from a `Literal`.
+    /// Returns a new `Plaintext` from a `&Literal`.
     fn from(literal: &Literal<N>) -> Self {
         Self::Literal(literal.clone(), OnceCell::new())
     }
@@ -151,6 +153,33 @@ mod tests {
             OnceCell::new(),
         );
         assert_eq!(value.to_bits_le(), Plaintext::<CurrentNetwork>::from_bits_le(&value.to_bits_le())?.to_bits_le());
+
+        // Test a vector of literals.
+        let value = Plaintext::<CurrentNetwork>::Vector(
+            vec![
+                Plaintext::<CurrentNetwork>::from_str("0field")?,
+                Plaintext::<CurrentNetwork>::from_str("1field")?,
+                Plaintext::<CurrentNetwork>::from_str("2field")?,
+                Plaintext::<CurrentNetwork>::from_str("3field")?,
+                Plaintext::<CurrentNetwork>::from_str("4field")?,
+            ],
+            OnceCell::new(),
+        );
+        assert_eq!(value.to_bits_le(), Plaintext::<CurrentNetwork>::from_bits_le(&value.to_bits_le())?.to_bits_le());
+
+        // Test a vector of structs.
+        let value = Plaintext::<CurrentNetwork>::Vector(
+            vec![
+                Plaintext::<CurrentNetwork>::from_str("{ x: 0field, y: 1field }")?,
+                Plaintext::<CurrentNetwork>::from_str("{ x: 2field, y: 3field }")?,
+                Plaintext::<CurrentNetwork>::from_str("{ x: 4field, y: 5field }")?,
+                Plaintext::<CurrentNetwork>::from_str("{ x: 6field, y: 7field }")?,
+                Plaintext::<CurrentNetwork>::from_str("{ x: 8field, y: 9field }")?,
+            ],
+            OnceCell::new(),
+        );
+        assert_eq!(value.to_bits_le(), Plaintext::<CurrentNetwork>::from_bits_le(&value.to_bits_le())?.to_bits_le());
+
         Ok(())
     }
 }

--- a/console/program/src/data/plaintext/mod.rs
+++ b/console/program/src/data/plaintext/mod.rs
@@ -38,8 +38,8 @@ pub enum Plaintext<N: Network> {
     Literal(Literal<N>, OnceCell<Vec<bool>>),
     /// A struct.
     Struct(IndexMap<Identifier<N>, Plaintext<N>>, OnceCell<Vec<bool>>),
-    /// A vector.
-    Vector(Vec<Plaintext<N>>, OnceCell<Vec<bool>>),
+    /// A list.
+    List(Vec<Plaintext<N>>, OnceCell<Vec<bool>>),
 }
 
 impl<N: Network> From<Literal<N>> for Plaintext<N> {
@@ -154,8 +154,8 @@ mod tests {
         );
         assert_eq!(value.to_bits_le(), Plaintext::<CurrentNetwork>::from_bits_le(&value.to_bits_le())?.to_bits_le());
 
-        // Test a vector of literals.
-        let value = Plaintext::<CurrentNetwork>::Vector(
+        // Test a list of literals.
+        let value = Plaintext::<CurrentNetwork>::List(
             vec![
                 Plaintext::<CurrentNetwork>::from_str("0field")?,
                 Plaintext::<CurrentNetwork>::from_str("1field")?,
@@ -167,8 +167,8 @@ mod tests {
         );
         assert_eq!(value.to_bits_le(), Plaintext::<CurrentNetwork>::from_bits_le(&value.to_bits_le())?.to_bits_le());
 
-        // Test a vector of structs.
-        let value = Plaintext::<CurrentNetwork>::Vector(
+        // Test a list of structs.
+        let value = Plaintext::<CurrentNetwork>::List(
             vec![
                 Plaintext::<CurrentNetwork>::from_str("{ x: 0field, y: 1field }")?,
                 Plaintext::<CurrentNetwork>::from_str("{ x: 2field, y: 3field }")?,

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -165,8 +165,8 @@ impl<N: Network> Plaintext<N> {
             }
             // Prints the list, i.e. [ 10u64, 198u64 ]
             Self::List(list, ..) => {
-                // Print the opening brace.
-                write!(f, "{{")?;
+                // Print the opening bracket.
+                write!(f, "[")?;
                 // Print the members.
                 list.iter().enumerate().try_for_each(|(i, plaintext)| {
                     match plaintext {
@@ -181,6 +181,8 @@ impl<N: Network> Plaintext<N> {
                             false => write!(f, "\n{:indent$}{literal},", "", indent = (depth + 1) * INDENT),
                         },
                         Self::Struct(..) | Self::List(..) => {
+                            // Print a newline.
+                            write!(f, "\n{:indent$}", "", indent = (depth + 1) * INDENT)?;
                             // Print the member.
                             plaintext.fmt_internal(f, depth + 1)?;
                             // Print the closing brace.
@@ -330,6 +332,60 @@ mod tests {
   }
 }";
 
+        let (remainder, candidate) = Plaintext::<CurrentNetwork>::parse(expected).unwrap();
+        println!("\nExpected: {expected}\n\nFound: {candidate}\n");
+        assert_eq!(expected, candidate.to_string());
+        assert_eq!("", remainder);
+    }
+
+    #[test]
+    fn test_struct_with_lists() {
+        let expected = r"{
+  foo: [
+    1u8,
+    2u8,
+    3u8
+  ],
+  bar: [
+    4u8,
+    5u8,
+    6u8
+  ]
+}";
+        let (remainder, candidate) = Plaintext::<CurrentNetwork>::parse(expected).unwrap();
+        println!("\nExpected: {expected}\n\nFound: {candidate}\n");
+        assert_eq!(expected, candidate.to_string());
+        assert_eq!("", remainder);
+    }
+
+    #[test]
+    fn test_list() {
+        // Test a list of literals.
+        let expected = r"[
+  1u8,
+  2u8,
+  3u8
+]";
+        let (remainder, candidate) = Plaintext::<CurrentNetwork>::parse(expected).unwrap();
+        println!("\nExpected: {expected}\n\nFound: {candidate}\n");
+        assert_eq!(expected, candidate.to_string());
+        assert_eq!("", remainder);
+
+        // Test a list of structs.
+        let expected = r"[
+  {
+    foo: 1u8,
+    bar: 2u8
+  },
+  {
+    foo: 3u8,
+    bar: 4u8
+  },
+  {
+    foo: 5u8,
+    bar: 6u8
+  }
+]";
         let (remainder, candidate) = Plaintext::<CurrentNetwork>::parse(expected).unwrap();
         println!("\nExpected: {expected}\n\nFound: {candidate}\n");
         assert_eq!(expected, candidate.to_string());

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -60,8 +60,8 @@ impl<N: Network> Parser for Plaintext<N> {
             Ok((string, Plaintext::Struct(IndexMap::from_iter(members.into_iter()), Default::default())))
         }
 
-        /// Parses a plaintext as a vector: `[plaintext_0, ..., plaintext_n]`.
-        fn parse_vector<N: Network>(string: &str) -> ParserResult<Plaintext<N>> {
+        /// Parses a plaintext as a list: `[plaintext_0, ..., plaintext_n]`.
+        fn parse_list<N: Network>(string: &str) -> ParserResult<Plaintext<N>> {
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the "[" from the string.
@@ -73,7 +73,7 @@ impl<N: Network> Parser for Plaintext<N> {
             // Parse the ']' from the string.
             let (string, _) = tag("]")(string)?;
             // Output the plaintext.
-            Ok((string, Plaintext::Vector(members, Default::default())))
+            Ok((string, Plaintext::List(members, Default::default())))
         }
 
         // Parse the whitespace from the string.
@@ -84,8 +84,8 @@ impl<N: Network> Parser for Plaintext<N> {
             map(Literal::parse, |literal| Self::Literal(literal, Default::default())),
             // Parse a plaintext struct.
             parse_struct,
-            // Parse a plaintext vector.
-            parse_vector,
+            // Parse a plaintext list.
+            parse_list,
         ))(string)
     }
 }
@@ -147,7 +147,7 @@ impl<N: Network> Plaintext<N> {
                             // Print the member with a comma.
                             false => write!(f, "\n{:indent$}{name}: {literal},", "", indent = (depth + 1) * INDENT),
                         },
-                        Self::Struct(..) | Self::Vector(..) => {
+                        Self::Struct(..) | Self::List(..) => {
                             // Print the member name.
                             write!(f, "\n{:indent$}{name}: ", "", indent = (depth + 1) * INDENT)?;
                             // Print the member.
@@ -163,14 +163,14 @@ impl<N: Network> Plaintext<N> {
                     }
                 })
             }
-            // Prints the vector, i.e. [ 10u64, 198u64 ]
-            Self::Vector(vector, ..) => {
+            // Prints the list, i.e. [ 10u64, 198u64 ]
+            Self::List(list, ..) => {
                 // Print the opening brace.
                 write!(f, "{{")?;
                 // Print the members.
-                vector.iter().enumerate().try_for_each(|(i, plaintext)| {
+                list.iter().enumerate().try_for_each(|(i, plaintext)| {
                     match plaintext {
-                        Self::Literal(literal, ..) => match i == vector.len() - 1 {
+                        Self::Literal(literal, ..) => match i == list.len() - 1 {
                             true => {
                                 // Print the last member without a comma.
                                 write!(f, "\n{:indent$}{literal}", "", indent = (depth + 1) * INDENT)?;
@@ -180,11 +180,11 @@ impl<N: Network> Plaintext<N> {
                             // Print the member with a comma.
                             false => write!(f, "\n{:indent$}{literal},", "", indent = (depth + 1) * INDENT),
                         },
-                        Self::Struct(..) | Self::Vector(..) => {
+                        Self::Struct(..) | Self::List(..) => {
                             // Print the member.
                             plaintext.fmt_internal(f, depth + 1)?;
                             // Print the closing brace.
-                            match i == vector.len() - 1 {
+                            match i == list.len() - 1 {
                                 // Print the last member without a comma.
                                 true => write!(f, "\n{:indent$}]", "", indent = depth * INDENT),
                                 // Print the member with a comma.

--- a/console/program/src/data/plaintext/serialize.rs
+++ b/console/program/src/data/plaintext/serialize.rs
@@ -45,41 +45,53 @@ mod tests {
 
     #[test]
     fn test_serde_json() -> Result<()> {
-        for _ in 0..ITERATIONS {
-            // Sample a new plaintext.
-            let expected = Plaintext::<CurrentNetwork>::from_str(
-                "{ owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah, token_amount: 100u64 }",
-            )?;
+        fn run_test(expected: Plaintext<CurrentNetwork>) {
+            for _ in 0..ITERATIONS {
+                // Serialize
+                let expected_string = &expected.to_string();
+                let candidate_string = serde_json::to_string(&expected).unwrap();
+                assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
 
-            // Serialize
-            let expected_string = &expected.to_string();
-            let candidate_string = serde_json::to_string(&expected)?;
-            assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string)?.as_str().unwrap());
-
-            // Deserialize
-            assert_eq!(expected, Plaintext::from_str(expected_string)?);
-            assert_eq!(expected, serde_json::from_str(&candidate_string)?);
+                // Deserialize
+                assert_eq!(expected, Plaintext::from_str(expected_string).unwrap());
+                assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+            }
         }
+
+        // Test struct.
+        run_test(Plaintext::<CurrentNetwork>::from_str(
+            "{ owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah, token_amount: 100u64 }",
+        )?);
+
+        // Test vector.
+        run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field, ]")?);
+
         Ok(())
     }
 
     #[test]
     fn test_bincode() -> Result<()> {
-        for _ in 0..ITERATIONS {
-            // Sample a new plaintext.
-            let expected = Plaintext::<CurrentNetwork>::from_str(
-                "{ owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah, token_amount: 100u64 }",
-            )?;
+        fn run_test(expected: Plaintext<CurrentNetwork>) {
+            for _ in 0..ITERATIONS {
+                // Serialize
+                let expected_bytes = expected.to_bytes_le().unwrap();
+                let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+                assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
 
-            // Serialize
-            let expected_bytes = expected.to_bytes_le()?;
-            let expected_bytes_with_size_encoding = bincode::serialize(&expected)?;
-            assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
-
-            // Deserialize
-            assert_eq!(expected, Plaintext::read_le(&expected_bytes[..])?);
-            assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..])?);
+                // Deserialize
+                assert_eq!(expected, Plaintext::read_le(&expected_bytes[..]).unwrap());
+                assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+            }
         }
+
+        // Test struct.
+        run_test(Plaintext::<CurrentNetwork>::from_str(
+            "{ owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah, token_amount: 100u64 }",
+        )?);
+
+        // Test vector.
+        run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field, ]")?);
+
         Ok(())
     }
 }

--- a/console/program/src/data/plaintext/serialize.rs
+++ b/console/program/src/data/plaintext/serialize.rs
@@ -63,7 +63,7 @@ mod tests {
             "{ owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah, token_amount: 100u64 }",
         )?);
 
-        // Test vector.
+        // Test list.
         run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field, ]")?);
 
         Ok(())
@@ -89,7 +89,7 @@ mod tests {
             "{ owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah, token_amount: 100u64 }",
         )?);
 
-        // Test vector.
+        // Test list.
         run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field, ]")?);
 
         Ok(())

--- a/console/program/src/data/plaintext/serialize.rs
+++ b/console/program/src/data/plaintext/serialize.rs
@@ -64,7 +64,7 @@ mod tests {
         )?);
 
         // Test list.
-        run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field, ]")?);
+        run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field ]")?);
 
         Ok(())
     }
@@ -90,7 +90,7 @@ mod tests {
         )?);
 
         // Test list.
-        run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field, ]")?);
+        run_test(Plaintext::<CurrentNetwork>::from_str("[ 0field, 1field, 2field, 3field, 4field ]")?);
 
         Ok(())
     }

--- a/console/program/src/data/plaintext/to_bits.rs
+++ b/console/program/src/data/plaintext/to_bits.rs
@@ -49,15 +49,15 @@ impl<N: Network> ToBits for Plaintext<N> {
                     bits_le
                 })
                 .clone(),
-            Self::Vector(vector, bits_le) => bits_le
+            Self::List(list, bits_le) => bits_le
                 .get_or_init(|| {
                     let mut bits_le = vec![true, false]; // Variant bits.
                     bits_le.extend(
-                        u32::try_from(vector.len())
-                            .or_halt_with::<N>("Plaintext vector length exceeds u32::MAX")
+                        u32::try_from(list.len())
+                            .or_halt_with::<N>("Plaintext list length exceeds u32::MAX")
                             .to_bits_le(),
                     );
-                    for element in vector {
+                    for element in list {
                         let element_bits = element.to_bits_le();
                         bits_le.extend(
                             u16::try_from(element_bits.len())
@@ -106,15 +106,15 @@ impl<N: Network> ToBits for Plaintext<N> {
                     bits_be
                 })
                 .clone(),
-            Self::Vector(vector, bits_be) => bits_be
+            Self::List(list, bits_be) => bits_be
                 .get_or_init(|| {
                     let mut bits_be = vec![true, false]; // Variant bits.
                     bits_be.extend(
-                        u32::try_from(vector.len())
-                            .or_halt_with::<N>("Plaintext vector length exceeds u32::MAX")
+                        u32::try_from(list.len())
+                            .or_halt_with::<N>("Plaintext list length exceeds u32::MAX")
                             .to_bits_be(),
                     );
-                    for element in vector {
+                    for element in list {
                         let element_bits = element.to_bits_be();
                         bits_be.extend(
                             u16::try_from(element_bits.len())

--- a/console/program/src/data/plaintext/to_bits.rs
+++ b/console/program/src/data/plaintext/to_bits.rs
@@ -49,6 +49,26 @@ impl<N: Network> ToBits for Plaintext<N> {
                     bits_le
                 })
                 .clone(),
+            Self::Vector(vector, bits_le) => bits_le
+                .get_or_init(|| {
+                    let mut bits_le = vec![true, false]; // Variant bits.
+                    bits_le.extend(
+                        u32::try_from(vector.len())
+                            .or_halt_with::<N>("Plaintext vector length exceeds u32::MAX")
+                            .to_bits_le(),
+                    );
+                    for element in vector {
+                        let element_bits = element.to_bits_le();
+                        bits_le.extend(
+                            u16::try_from(element_bits.len())
+                                .or_halt_with::<N>("Plaintext element exceeds u16::MAX bits")
+                                .to_bits_le(),
+                        );
+                        bits_le.extend(element_bits);
+                    }
+                    bits_le
+                })
+                .clone(),
         }
     }
 
@@ -82,6 +102,26 @@ impl<N: Network> ToBits for Plaintext<N> {
                                 .to_bits_be(),
                         );
                         bits_be.extend(value_bits);
+                    }
+                    bits_be
+                })
+                .clone(),
+            Self::Vector(vector, bits_be) => bits_be
+                .get_or_init(|| {
+                    let mut bits_be = vec![true, false]; // Variant bits.
+                    bits_be.extend(
+                        u32::try_from(vector.len())
+                            .or_halt_with::<N>("Plaintext vector length exceeds u32::MAX")
+                            .to_bits_be(),
+                    );
+                    for element in vector {
+                        let element_bits = element.to_bits_be();
+                        bits_be.extend(
+                            u16::try_from(element_bits.len())
+                                .or_halt_with::<N>("Plaintext element exceeds u16::MAX bits")
+                                .to_bits_be(),
+                        );
+                        bits_be.extend(element_bits);
                     }
                     bits_be
                 })

--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -124,7 +124,7 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             // Parse the ']' from the string.
             let (string, _) = tag("]")(string)?;
             // Output the plaintext and visibility.
-            Ok((string, (Plaintext::Vector(members, Default::default()), mode)))
+            Ok((string, (Plaintext::List(members, Default::default()), mode)))
         }
 
         // Parse the whitespace from the string.
@@ -213,7 +213,7 @@ impl<N: Network> Entry<N, Plaintext<N>> {
                             // Print the member with a comma.
                             false => write!(f, "\n{:indent$}{name}: {literal}.{visibility},", "", indent = (depth + 1) * INDENT),
                         },
-                        Plaintext::Struct(..) | Plaintext::Vector(..) => {
+                        Plaintext::Struct(..) | Plaintext::List(..) => {
                             // Print the member name.
                             write!(f, "\n{:indent$}{name}: ", "", indent = (depth + 1) * INDENT)?;
                             // Print the member.
@@ -234,7 +234,7 @@ impl<N: Network> Entry<N, Plaintext<N>> {
                 })
             }
             // Prints the vector, i.e. [ 10u64.public, 198u64.private ]
-            Plaintext::Vector(vector, ..) => {
+            Plaintext::List(vector, ..) => {
                 // Print the opening bracket.
                 write!(f, "[")?;
                 // Print the members.
@@ -251,7 +251,7 @@ impl<N: Network> Entry<N, Plaintext<N>> {
                             // Print the member with a comma.
                             false => write!(f, "\n{:indent$}{literal}.{visibility},", "", indent = (depth + 1) * INDENT),
                         },
-                        Plaintext::Struct(..) | Plaintext::Vector(..) => {
+                        Plaintext::Struct(..) | Plaintext::List(..) => {
                             // Print the member.
                             match self {
                                 Self::Constant(..) => Self::Constant(plaintext.clone()).fmt_internal(f, depth + 1)?,

--- a/console/program/src/data/record/find.rs
+++ b/console/program/src/data/record/find.rs
@@ -24,9 +24,12 @@ impl<N: Network> Record<N, Plaintext<N>> {
 
         // Ensure the path is not empty.
         if let Some((first, rest)) = path.split_first() {
-            let Access::Member(first) = first;
+            let first = match first {
+                Access::Member(identifier) => *identifier,
+                Access::Index(_) => bail!("Attempted to index into a record"),
+            };
             // Retrieve the top-level entry.
-            match self.data.get(first) {
+            match self.data.get(&first) {
                 Some(entry) => match rest.is_empty() {
                     // If the remaining path is empty, return the top-level entry.
                     true => Ok(entry.clone()),

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -159,9 +159,9 @@ impl<N: Network> Record<N, Plaintext<N>> {
                 Entry::Constant(Plaintext::Struct(..))
                 | Entry::Public(Plaintext::Struct(..))
                 | Entry::Private(Plaintext::Struct(..))
-                | Entry::Constant(Plaintext::Vector(..))
-                | Entry::Public(Plaintext::Vector(..))
-                | Entry::Private(Plaintext::Vector(..)) => entry.fmt_internal(f, depth + 1)?,
+                | Entry::Constant(Plaintext::List(..))
+                | Entry::Public(Plaintext::List(..))
+                | Entry::Private(Plaintext::List(..)) => entry.fmt_internal(f, depth + 1)?,
             }
             // Print the comma.
             write!(f, ",")?;

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -241,6 +241,25 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_with_list_entry() -> Result<()> {
+        let expected = r"{
+  owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.public,
+  foo: 5u8.public,
+  bar: [
+    6u8.private,
+    7u8.private,
+    8u8.private
+  ],
+  _nonce: 0group.public
+}";
+        let (remainder, candidate) = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::parse(expected)?;
+        println!("\nExpected: {expected}\n\nFound: {candidate}\n");
+        assert_eq!(expected, candidate.to_string());
+        assert_eq!("", remainder);
+        Ok(())
+    }
+
+    #[test]
     fn test_parse_fails() -> Result<()> {
         // Missing owner.
         let expected = "{ foo: 5u8.private, _nonce: 0group.public }";

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -155,10 +155,13 @@ impl<N: Network> Record<N, Plaintext<N>> {
                 Entry::Constant(Plaintext::Literal(..))
                 | Entry::Public(Plaintext::Literal(..))
                 | Entry::Private(Plaintext::Literal(..)) => write!(f, "{entry}")?,
-                // If the entry is a struct, print the entry with indentation.
+                // If the entry is a struct or a vector, print the entry with indentation.
                 Entry::Constant(Plaintext::Struct(..))
                 | Entry::Public(Plaintext::Struct(..))
-                | Entry::Private(Plaintext::Struct(..)) => entry.fmt_internal(f, depth + 1)?,
+                | Entry::Private(Plaintext::Struct(..))
+                | Entry::Constant(Plaintext::Vector(..))
+                | Entry::Public(Plaintext::Vector(..))
+                | Entry::Private(Plaintext::Vector(..)) => entry.fmt_internal(f, depth + 1)?,
             }
             // Print the comma.
             write!(f, ",")?;

--- a/console/program/src/data/register/mod.rs
+++ b/console/program/src/data/register/mod.rs
@@ -56,7 +56,9 @@ impl<N: Network> PartialOrd for Register<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Identifier;
+
+    use crate::{Identifier, U32};
+
     use snarkvm_console_network::Testnet3;
 
     type CurrentNetwork = Testnet3;
@@ -77,7 +79,7 @@ mod tests {
             Register::<CurrentNetwork>::Locator(1).partial_cmp(&Register::<CurrentNetwork>::Locator(0))
         );
 
-        // Register::Member
+        // Register::Access with Access::Member
         assert_eq!(
             Some(Ordering::Equal),
             Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)]).partial_cmp(
@@ -96,6 +98,71 @@ mod tests {
                 &Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)])
             )
         );
+
+        // Register::Access with Access::Index
+        assert_eq!(
+            Some(Ordering::Equal),
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]).partial_cmp(&Register::<
+                CurrentNetwork,
+            >::Access(
+                0,
+                vec![Access::Index(U32::new(0))]
+            ))
+        );
+        assert_eq!(
+            Some(Ordering::Less),
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]).partial_cmp(&Register::<
+                CurrentNetwork,
+            >::Access(
+                1,
+                vec![Access::Index(U32::new(0))]
+            ))
+        );
+        assert_eq!(
+            Some(Ordering::Greater),
+            Register::<CurrentNetwork>::Access(1, vec![Access::Index(U32::new(0))]).partial_cmp(&Register::<
+                CurrentNetwork,
+            >::Access(
+                0,
+                vec![Access::Index(U32::new(0))]
+            ))
+        );
+
+        // Register::Access with a combination of Access::Member and Access::Index
+        assert_eq!(
+            Some(Ordering::Equal),
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+            .partial_cmp(&Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]))
+        );
+        assert_eq!(
+            Some(Ordering::Less),
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+            .partial_cmp(&Register::<CurrentNetwork>::Access(1, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]))
+        );
+        assert_eq!(
+            Some(Ordering::Greater),
+            Register::<CurrentNetwork>::Access(1, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+            .partial_cmp(&Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]))
+        );
+
         Ok(())
     }
 
@@ -108,7 +175,7 @@ mod tests {
         assert_ne!(Register::<CurrentNetwork>::Locator(0), Register::<CurrentNetwork>::Locator(3));
         assert_ne!(Register::<CurrentNetwork>::Locator(0), Register::<CurrentNetwork>::Locator(4));
 
-        // Register::Member
+        // Register::Access with Access::Member
         assert_eq!(
             Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)]),
             Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)])
@@ -129,6 +196,81 @@ mod tests {
             Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)]),
             Register::<CurrentNetwork>::Access(4, vec![Access::Member(Identifier::from_str("owner")?)])
         );
+
+        // Register::Access with Access::Index
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]),
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]),
+            Register::<CurrentNetwork>::Access(1, vec![Access::Index(U32::new(0))])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]),
+            Register::<CurrentNetwork>::Access(2, vec![Access::Index(U32::new(0))])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]),
+            Register::<CurrentNetwork>::Access(3, vec![Access::Index(U32::new(0))])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]),
+            Register::<CurrentNetwork>::Access(4, vec![Access::Index(U32::new(0))])
+        );
+
+        // Register::Access with a combination of Access::Member and Access::Index
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]),
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]),
+            Register::<CurrentNetwork>::Access(1, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]),
+            Register::<CurrentNetwork>::Access(2, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]),
+            Register::<CurrentNetwork>::Access(3, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+        );
+        assert_ne!(
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ]),
+            Register::<CurrentNetwork>::Access(4, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+        );
+
         Ok(())
     }
 }

--- a/console/program/src/data/register/parse.rs
+++ b/console/program/src/data/register/parse.rs
@@ -87,7 +87,9 @@ impl<N: Network> Display for Register<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Identifier;
+
+    use crate::{Identifier, U32};
+
     use snarkvm_console_network::Testnet3;
 
     type CurrentNetwork = Testnet3;
@@ -101,7 +103,7 @@ mod tests {
         assert_eq!("r3", Register::<CurrentNetwork>::Locator(3).to_string());
         assert_eq!("r4", Register::<CurrentNetwork>::Locator(4).to_string());
 
-        // Register::Member
+        // Register::Access with Access::Member
         assert_eq!(
             "r0.owner",
             Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)]).to_string()
@@ -122,6 +124,97 @@ mod tests {
             "r4.owner",
             Register::<CurrentNetwork>::Access(4, vec![Access::Member(Identifier::from_str("owner")?)]).to_string()
         );
+
+        // Register::Access with Access::Index
+        assert_eq!("r0[0]", Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]).to_string());
+        assert_eq!(
+            "r1[0][1]",
+            Register::<CurrentNetwork>::Access(1, vec![Access::Index(U32::new(0)), Access::Index(U32::new(1))])
+                .to_string()
+        );
+        assert_eq!(
+            "r2[0][1][2]",
+            Register::<CurrentNetwork>::Access(2, vec![
+                Access::Index(U32::new(0)),
+                Access::Index(U32::new(1)),
+                Access::Index(U32::new(2))
+            ])
+            .to_string()
+        );
+        assert_eq!(
+            "r3[0][1][2][3]",
+            Register::<CurrentNetwork>::Access(3, vec![
+                Access::Index(U32::new(0)),
+                Access::Index(U32::new(1)),
+                Access::Index(U32::new(2)),
+                Access::Index(U32::new(3))
+            ])
+            .to_string()
+        );
+        assert_eq!(
+            "r4[0][1][2][3][4]",
+            Register::<CurrentNetwork>::Access(4, vec![
+                Access::Index(U32::new(0)),
+                Access::Index(U32::new(1)),
+                Access::Index(U32::new(2)),
+                Access::Index(U32::new(3)),
+                Access::Index(U32::new(4))
+            ])
+            .to_string()
+        );
+
+        // Register::Access with Access::Member and Access::Index
+        assert_eq!(
+            "r0.owner[0]",
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+            .to_string()
+        );
+        assert_eq!(
+            "r1.owner[0].owner",
+            Register::<CurrentNetwork>::Access(1, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?)
+            ])
+            .to_string()
+        );
+        assert_eq!(
+            "r2.owner[0].owner[1]",
+            Register::<CurrentNetwork>::Access(2, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(1))
+            ])
+            .to_string()
+        );
+        assert_eq!(
+            "r3.owner[0].owner[1].owner",
+            Register::<CurrentNetwork>::Access(3, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(1)),
+                Access::Member(Identifier::from_str("owner")?)
+            ])
+            .to_string()
+        );
+        assert_eq!(
+            "r4.owner[0].owner[1].owner[2]",
+            Register::<CurrentNetwork>::Access(4, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(1)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(2))
+            ])
+            .to_string()
+        );
+
         Ok(())
     }
 
@@ -134,7 +227,7 @@ mod tests {
         assert_eq!(Register::<CurrentNetwork>::Locator(3).to_string(), "r3".to_string());
         assert_eq!(Register::<CurrentNetwork>::Locator(4).to_string(), "r4".to_string());
 
-        // Register::Member
+        // Register::Access with Access::Member
         assert_eq!(
             Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)]).to_string(),
             "r0.owner".to_string()
@@ -155,6 +248,100 @@ mod tests {
             Register::<CurrentNetwork>::Access(4, vec![Access::Member(Identifier::from_str("owner")?)]).to_string(),
             "r4.owner".to_string()
         );
+
+        // Register::Access with Access::Index
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))]).to_string(),
+            "r0[0]".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(1, vec![Access::Index(U32::new(0)), Access::Index(U32::new(1))])
+                .to_string(),
+            "r1[0][1]".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(2, vec![
+                Access::Index(U32::new(0)),
+                Access::Index(U32::new(1)),
+                Access::Index(U32::new(2))
+            ])
+            .to_string(),
+            "r2[0][1][2]".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(3, vec![
+                Access::Index(U32::new(0)),
+                Access::Index(U32::new(1)),
+                Access::Index(U32::new(2)),
+                Access::Index(U32::new(3))
+            ])
+            .to_string(),
+            "r3[0][1][2][3]".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(4, vec![
+                Access::Index(U32::new(0)),
+                Access::Index(U32::new(1)),
+                Access::Index(U32::new(2)),
+                Access::Index(U32::new(3)),
+                Access::Index(U32::new(4))
+            ])
+            .to_string(),
+            "r4[0][1][2][3][4]".to_string()
+        );
+
+        // Register::Access with Access::Member and Access::Index
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(0, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0))
+            ])
+            .to_string(),
+            "r0.owner[0]".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(1, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?)
+            ])
+            .to_string(),
+            "r1.owner[0].owner".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(2, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(1))
+            ])
+            .to_string(),
+            "r2.owner[0].owner[1]".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(3, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(1)),
+                Access::Member(Identifier::from_str("owner")?)
+            ])
+            .to_string(),
+            "r3.owner[0].owner[1].owner".to_string()
+        );
+        assert_eq!(
+            Register::<CurrentNetwork>::Access(4, vec![
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(0)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(1)),
+                Access::Member(Identifier::from_str("owner")?),
+                Access::Index(U32::new(2))
+            ])
+            .to_string(),
+            "r4.owner[0].owner[1].owner[2]".to_string()
+        );
+
         Ok(())
     }
 
@@ -167,7 +354,7 @@ mod tests {
         assert_eq!(("", Register::<CurrentNetwork>::Locator(3)), Register::parse("r3").unwrap());
         assert_eq!(("", Register::<CurrentNetwork>::Locator(4)), Register::parse("r4").unwrap());
 
-        // Register::Member
+        // Register::Access with Access::Member
         assert_eq!(
             ("", Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?)])),
             Register::parse("r0.owner").unwrap()
@@ -189,19 +376,113 @@ mod tests {
             Register::parse("r4.owner").unwrap()
         );
 
-        // Register::Member with multiple identifiers
         for i in 1..=CurrentNetwork::MAX_DATA_DEPTH {
-            let mut string = "r0.".to_string();
+            let mut string = "r0".to_string();
             for _ in 0..i {
-                string.push_str("owner.");
+                string.push_str(".owner");
             }
-            string.pop(); // Remove last '.'
 
             assert_eq!(
                 ("", Register::<CurrentNetwork>::Access(0, vec![Access::Member(Identifier::from_str("owner")?); i])),
                 Register::<CurrentNetwork>::parse(&string).unwrap()
             );
         }
+
+        // Register::Access with Access::Index
+        assert_eq!(
+            ("", Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0))])),
+            Register::parse("r0[0]").unwrap()
+        );
+        assert_eq!(
+            ("", Register::<CurrentNetwork>::Access(1, vec![Access::Index(U32::new(0))])),
+            Register::parse("r1[0]").unwrap()
+        );
+        assert_eq!(
+            ("", Register::<CurrentNetwork>::Access(2, vec![Access::Index(U32::new(0))])),
+            Register::parse("r2[0]").unwrap()
+        );
+        assert_eq!(
+            ("", Register::<CurrentNetwork>::Access(3, vec![Access::Index(U32::new(0))])),
+            Register::parse("r3[0]").unwrap()
+        );
+        assert_eq!(
+            ("", Register::<CurrentNetwork>::Access(4, vec![Access::Index(U32::new(0))])),
+            Register::parse("r4[0]").unwrap()
+        );
+
+        for i in 1..=CurrentNetwork::MAX_DATA_DEPTH {
+            let mut string = "r0".to_string();
+            for _ in 0..i {
+                string.push_str("[0]");
+            }
+
+            assert_eq!(
+                ("", Register::<CurrentNetwork>::Access(0, vec![Access::Index(U32::new(0)); i])),
+                Register::<CurrentNetwork>::parse(&string).unwrap()
+            );
+        }
+
+        // Register::Access with Access::Member and Access::Index
+        assert_eq!(
+            (
+                "",
+                Register::<CurrentNetwork>::Access(0, vec![
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0))
+                ])
+            ),
+            Register::parse("r0.owner[0]").unwrap()
+        );
+        assert_eq!(
+            (
+                "",
+                Register::<CurrentNetwork>::Access(1, vec![
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0)),
+                    Access::Member(Identifier::from_str("owner")?)
+                ])
+            ),
+            Register::parse("r1.owner[0].owner").unwrap()
+        );
+        assert_eq!(
+            (
+                "",
+                Register::<CurrentNetwork>::Access(2, vec![
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0)),
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0))
+                ])
+            ),
+            Register::parse("r2.owner[0].owner[0]").unwrap()
+        );
+        assert_eq!(
+            (
+                "",
+                Register::<CurrentNetwork>::Access(3, vec![
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0)),
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0)),
+                    Access::Member(Identifier::from_str("owner")?)
+                ])
+            ),
+            Register::parse("r3.owner[0].owner[0].owner").unwrap()
+        );
+        assert_eq!(
+            (
+                "",
+                Register::<CurrentNetwork>::Access(4, vec![
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0)),
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0)),
+                    Access::Member(Identifier::from_str("owner")?),
+                    Access::Index(U32::new(0))
+                ])
+            ),
+            Register::parse("r4.owner[0].owner[0].owner[0]").unwrap()
+        );
 
         Ok(())
     }
@@ -211,13 +492,36 @@ mod tests {
         assert!(Register::<CurrentNetwork>::parse("").is_err());
         assert!(Register::<CurrentNetwork>::parse("r").is_err());
 
-        // Register::Member with multiple identifiers that exceed the maximum depth.
+        // Register::Access with multiple identifiers that exceed the maximum depth.
         for i in CurrentNetwork::MAX_DATA_DEPTH + 1..CurrentNetwork::MAX_DATA_DEPTH * 2 {
-            let mut string = "r0.".to_string();
+            let mut string = "r0".to_string();
             for _ in 0..i {
-                string.push_str("owner.");
+                string.push_str(".owner");
             }
-            string.pop(); // Remove last '.'
+
+            assert!(Register::<CurrentNetwork>::parse(&string).is_err());
+        }
+
+        // Register::Access with multiple indices that exceed the maximum depth.
+        for i in CurrentNetwork::MAX_DATA_DEPTH + 1..CurrentNetwork::MAX_DATA_DEPTH * 2 {
+            let mut string = "r0".to_string();
+            for _ in 0..i {
+                string.push_str("[0]");
+            }
+
+            assert!(Register::<CurrentNetwork>::parse(&string).is_err());
+        }
+
+        // Register::Access with multiple indices and members that exceed the maximum depth.
+        for i in CurrentNetwork::MAX_DATA_DEPTH + 1..CurrentNetwork::MAX_DATA_DEPTH * 2 {
+            let mut string = "r0".to_string();
+            for n in 0..i {
+                if n % 2 == 0 {
+                    string.push_str("[0]");
+                } else {
+                    string.push_str(".owner");
+                }
+            }
 
             assert!(Register::<CurrentNetwork>::parse(&string).is_err());
         }

--- a/console/program/src/data_types/array_type/mod.rs
+++ b/console/program/src/data_types/array_type/mod.rs
@@ -16,56 +16,39 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{Identifier, LiteralType, PlaintextType, U32};
+use crate::{ElementType, U32};
 use snarkvm_console_network::prelude::*;
 
 use core::fmt::{Debug, Display};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub enum ArrayType<N: Network> {
-    /// An array of literals.
-    Literal(LiteralType, U32<N>),
-    /// An array of structs.
-    Struct(Identifier<N>, U32<N>),
+pub struct ArrayType<N: Network> {
+    /// The type of the elements in the array.
+    element_type: ElementType<N>,
+    /// The length of the array.
+    length: U32<N>,
 }
 
 impl<N: Network> ArrayType<N> {
-    /// Constructs a new type defining an array of literals.
-    pub fn new_literal_array(literal_type: LiteralType, length: U32<N>) -> Result<Self> {
+    /// Constructs a new array type.
+    pub fn new(element_type: ElementType<N>, length: U32<N>) -> Result<Self> {
         ensure!(*length != 0, "The array must have at least one element");
         ensure!(
             *length as usize <= N::MAX_ARRAY_ENTRIES,
             "The array must have at most {} elements",
             N::MAX_ARRAY_ENTRIES
         );
-        Ok(Self::Literal(literal_type, length))
-    }
-
-    /// Constructs a new type defining an array of structs.
-    pub fn new_struct_array(struct_: Identifier<N>, length: U32<N>) -> Result<Self> {
-        ensure!(*length != 0, "The array must have at least one element");
-        ensure!(
-            *length as usize <= N::MAX_ARRAY_ENTRIES,
-            "The array must have at most {} elements",
-            N::MAX_ARRAY_ENTRIES
-        );
-        Ok(Self::Struct(struct_, length))
+        Ok(Self { element_type, length })
     }
 
     /// Returns the element type.
-    pub fn element_type(&self) -> PlaintextType<N> {
-        match &self {
-            ArrayType::Literal(literal_type, ..) => PlaintextType::Literal(*literal_type),
-            ArrayType::Struct(identifier, ..) => PlaintextType::Struct(*identifier),
-        }
+    pub fn element_type(&self) -> &ElementType<N> {
+        &self.element_type
     }
 
     /// Returns the length of the array.
     pub fn length(&self) -> &U32<N> {
-        match &self {
-            ArrayType::Literal(_, length) => length,
-            ArrayType::Struct(_, length) => length,
-        }
+        &self.length
     }
 }
 
@@ -74,6 +57,7 @@ mod tests {
     use super::*;
     use snarkvm_console_network::Testnet3;
 
+    use crate::{Identifier, LiteralType};
     use core::str::FromStr;
 
     type CurrentNetwork = Testnet3;
@@ -82,32 +66,38 @@ mod tests {
     fn test_array_type() -> Result<()> {
         // Test literal array types.
         let type_ = ArrayType::<CurrentNetwork>::from_str("[field; 4]")?;
-        assert_eq!(type_, ArrayType::<CurrentNetwork>::Literal(LiteralType::Field, U32::new(4)));
+        assert_eq!(type_, ArrayType::<CurrentNetwork>::new(ElementType::from(LiteralType::Field), U32::new(4))?);
         assert_eq!(
             type_.to_bytes_le()?,
             ArrayType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
         );
-        assert_eq!(type_.element_type(), PlaintextType::Literal(LiteralType::Field));
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Field));
         assert_eq!(type_.length(), &U32::new(4));
 
         // Test struct array types.
         let type_ = ArrayType::<CurrentNetwork>::from_str("[foo; 1]")?;
-        assert_eq!(type_, ArrayType::<CurrentNetwork>::Struct(Identifier::from_str("foo")?, U32::new(1)));
+        assert_eq!(
+            type_,
+            ArrayType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?), U32::new(1))?
+        );
         assert_eq!(
             type_.to_bytes_le()?,
             ArrayType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
         );
-        assert_eq!(type_.element_type(), PlaintextType::Struct(Identifier::from_str("foo")?));
+        assert_eq!(type_.element_type(), &ElementType::from(Identifier::from_str("foo")?));
         assert_eq!(type_.length(), &U32::new(1));
 
         // Test array type with maximum length.
         let type_ = ArrayType::<CurrentNetwork>::from_str("[scalar; 4294967295]")?;
-        assert_eq!(type_, ArrayType::<CurrentNetwork>::Literal(LiteralType::Scalar, U32::new(4294967295)));
+        assert_eq!(
+            type_,
+            ArrayType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar), U32::new(4294967295))?
+        );
         assert_eq!(
             type_.to_bytes_le()?,
             ArrayType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
         );
-        assert_eq!(type_.element_type(), PlaintextType::Literal(LiteralType::Scalar));
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Scalar));
         assert_eq!(type_.length(), &U32::new(4294967295));
 
         Ok(())

--- a/console/program/src/data_types/array_type/mod.rs
+++ b/console/program/src/data_types/array_type/mod.rs
@@ -21,7 +21,7 @@ use snarkvm_console_network::prelude::*;
 
 use core::fmt::{Debug, Display};
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ArrayType<N: Network> {
     /// The type of the elements in the array.
     element_type: ElementType<N>,

--- a/console/program/src/data_types/array_type/parse.rs
+++ b/console/program/src/data_types/array_type/parse.rs
@@ -23,33 +23,27 @@ impl<N: Network> Parser for ArrayType<N> {
         // Parse the whitespaces from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
 
-        // A helper function to parse the semicolon, length, and closing bracket.
-        fn parse_length(string: &str) -> ParserResult<u32> {
-            // Parse the whitespaces from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Parse the semicolon.
-            let (string, _) = tag(";")(string)?;
-            // Parse the whitespaces from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Parse the length from the string.
-            let (string, length) =
-                map_res(recognize(many1(one_of("0123456789"))), |digits: &str| digits.parse::<u32>())(string)?;
-            // Parse the whitespaces from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Parse the closing bracket.
-            let (string, _) = tag("]")(string)?;
-            Ok((string, length))
-        }
+        // Parse the element type.
+        let (string, element_type) = ElementType::parse(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
 
-        // Parse the element type, followed by the length.
-        alt((
-            map_res(pair(LiteralType::parse, parse_length), |(element_type, length)| {
-                ArrayType::new_literal_array(element_type, U32::new(length))
-            }),
-            map_res(pair(Identifier::parse, parse_length), |(element_type, length)| {
-                ArrayType::new_struct_array(element_type, U32::new(length))
-            }),
-        ))(string)
+        // Parse the semicolon.
+        let (string, _) = tag(";")(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the length from the string.
+        let (string, length) =
+            map_res(recognize(many1(one_of("0123456789"))), |digits: &str| digits.parse::<u32>())(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the closing bracket.
+        let (string, _) = tag("]")(string)?;
+
+        // Return the array type.
+        map_res(take(0usize), move |_| Self::new(element_type, U32::new(length)))(string)
     }
 }
 
@@ -80,9 +74,6 @@ impl<N: Network> Debug for ArrayType<N> {
 impl<N: Network> Display for ArrayType<N> {
     /// Prints the array type as a string.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Literal(literal_type, length) => write!(f, "[{}; {}]", literal_type, **length),
-            Self::Struct(identifier, length) => write!(f, "[{}; {}]", identifier, **length),
-        }
+        write!(f, "[{}; {}]", self.element_type, *self.length)
     }
 }

--- a/console/program/src/data_types/element_type/bytes.rs
+++ b/console/program/src/data_types/element_type/bytes.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for ElementType<N> {
+    /// Reads an element type from a buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let variant = u8::read_le(&mut reader)?;
+        match variant {
+            0 => Ok(Self::Literal(LiteralType::read_le(&mut reader)?)),
+            1 => Ok(Self::Struct(Identifier::read_le(&mut reader)?)),
+            2.. => Err(error(format!("Failed to deserialize annotation variant {variant}"))),
+        }
+    }
+}
+
+impl<N: Network> ToBytes for ElementType<N> {
+    /// Writes an element type to a buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        match self {
+            Self::Literal(literal_type) => {
+                u8::write_le(&0u8, &mut writer)?;
+                literal_type.write_le(&mut writer)
+            }
+            Self::Struct(identifier) => {
+                u8::write_le(&1u8, &mut writer)?;
+                identifier.write_le(&mut writer)
+            }
+        }
+    }
+}

--- a/console/program/src/data_types/element_type/mod.rs
+++ b/console/program/src/data_types/element_type/mod.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod parse;
+mod serialize;
+
+use crate::{Identifier, LiteralType};
+use snarkvm_console_network::prelude::*;
+
+/// An `ElementType` defines the type parameter for an element in an `Array` or `Vector`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ElementType<N: Network> {
+    /// A literal element type.
+    Literal(LiteralType),
+    /// A struct element type.
+    Struct(Identifier<N>),
+}
+
+impl<N: Network> From<LiteralType> for ElementType<N> {
+    /// Initializes an element type from a literal type.
+    fn from(literal: LiteralType) -> Self {
+        ElementType::Literal(literal)
+    }
+}
+
+impl<N: Network> From<Identifier<N>> for ElementType<N> {
+    /// Initializes an element type from a struct type.
+    fn from(struct_: Identifier<N>) -> Self {
+        ElementType::Struct(struct_)
+    }
+}

--- a/console/program/src/data_types/element_type/parse.rs
+++ b/console/program/src/data_types/element_type/parse.rs
@@ -1,0 +1,150 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Parser for ElementType<N> {
+    /// Parses a string into an element type.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse to determine the element type (order matters).
+        alt((
+            map(LiteralType::parse, |type_| Self::Literal(type_)),
+            map(Identifier::parse, |identifier| Self::Struct(identifier)),
+        ))(string)
+    }
+}
+
+impl<N: Network> FromStr for ElementType<N> {
+    type Err = Error;
+
+    /// Returns an element type from a string literal.
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for ElementType<N> {
+    /// Prints the element type as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for ElementType<N> {
+    /// Prints the element type as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            // Prints the literal, i.e. field
+            Self::Literal(literal) => Display::fmt(literal, f),
+            // Prints the struct, i.e. signature
+            Self::Struct(struct_) => Display::fmt(struct_, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_parse() -> Result<()> {
+        assert_eq!(ElementType::parse("field"), Ok(("", ElementType::<CurrentNetwork>::Literal(LiteralType::Field))));
+        assert_eq!(
+            ElementType::parse("signature"),
+            Ok(("", ElementType::<CurrentNetwork>::Struct(Identifier::from_str("signature")?)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_fails() -> Result<()> {
+        // Literal type must not contain visibility.
+        assert_eq!(
+            Ok((".constant", ElementType::<CurrentNetwork>::from_str("field")?)),
+            ElementType::<CurrentNetwork>::parse("field.constant")
+        );
+        assert_eq!(
+            Ok((".public", ElementType::<CurrentNetwork>::from_str("field")?)),
+            ElementType::<CurrentNetwork>::parse("field.public")
+        );
+        assert_eq!(
+            Ok((".private", ElementType::<CurrentNetwork>::from_str("field")?)),
+            ElementType::<CurrentNetwork>::parse("field.private")
+        );
+
+        // Struct type must not contain visibility.
+        assert_eq!(
+            Ok((".constant", Identifier::<CurrentNetwork>::from_str("signature")?)),
+            Identifier::<CurrentNetwork>::parse("signature.constant")
+        );
+        assert_eq!(
+            Ok((".public", Identifier::<CurrentNetwork>::from_str("signature")?)),
+            Identifier::<CurrentNetwork>::parse("signature.public")
+        );
+        assert_eq!(
+            Ok((".private", Identifier::<CurrentNetwork>::from_str("signature")?)),
+            Identifier::<CurrentNetwork>::parse("signature.private")
+        );
+
+        // Must be non-empty.
+        assert!(ElementType::<CurrentNetwork>::parse("").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("{}").is_err());
+
+        // Invalid characters.
+        assert!(ElementType::<CurrentNetwork>::parse("_").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("__").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("___").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("-").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("--").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("---").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("*").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("**").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("***").is_err());
+
+        // Must not start with a number.
+        assert!(ElementType::<CurrentNetwork>::parse("1").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("2").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("3").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("1foo").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("12").is_err());
+        assert!(ElementType::<CurrentNetwork>::parse("111").is_err());
+
+        // Must fit within the data capacity of a base field element.
+        let struct_ = ElementType::<CurrentNetwork>::parse(
+            "foo_bar_baz_qux_quux_quuz_corge_grault_garply_waldo_fred_plugh_xyzzy",
+        );
+        assert!(struct_.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_display() -> Result<()> {
+        assert_eq!(ElementType::<CurrentNetwork>::Literal(LiteralType::Field).to_string(), "field");
+        assert_eq!(ElementType::<CurrentNetwork>::Struct(Identifier::from_str("signature")?).to_string(), "signature");
+        Ok(())
+    }
+}

--- a/console/program/src/data_types/element_type/serialize.rs
+++ b/console/program/src/data_types/element_type/serialize.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Serialize for ElementType<N> {
+    /// Serializes the element type into string or bytes.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => serializer.collect_str(self),
+            false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
+        }
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for ElementType<N> {
+    /// Deserializes the element type from a string or bytes.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "element type"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
+
+    /// Add test cases here to be checked for serialization.
+    const TEST_CASES: &[&str] = &[
+        // Literal
+        "address",
+        "boolean",
+        "field",
+        "group",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+        "i128",
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "u128",
+        "scalar",
+        "string",
+        // Struct
+        "signature",
+        "message",
+        "item",
+        "passport",
+        "object",
+        "array",
+    ];
+
+    fn check_serde_json<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_string = &expected.to_string();
+        let candidate_string = serde_json::to_string(&expected).unwrap();
+        assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
+
+        // Deserialize
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
+        assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+    }
+
+    fn check_bincode<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_bytes = expected.to_bytes_le().unwrap();
+        let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(expected, T::read_le(&expected_bytes[..]).unwrap());
+        assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json() {
+        for case in TEST_CASES.iter() {
+            check_serde_json(ElementType::<CurrentNetwork>::from_str(case).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        for case in TEST_CASES.iter() {
+            check_bincode(ElementType::<CurrentNetwork>::from_str(case).unwrap());
+        }
+    }
+}

--- a/console/program/src/data_types/mod.rs
+++ b/console/program/src/data_types/mod.rs
@@ -15,6 +15,9 @@
 mod array_type;
 pub use array_type::ArrayType;
 
+mod element_type;
+pub use element_type::ElementType;
+
 mod literal_type;
 pub use literal_type::LiteralType;
 

--- a/console/program/src/data_types/plaintext_type/mod.rs
+++ b/console/program/src/data_types/plaintext_type/mod.rs
@@ -16,7 +16,7 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{Identifier, LiteralType};
+use crate::{ElementType, Identifier, LiteralType};
 use snarkvm_console_network::prelude::*;
 
 /// A `ValueType` defines the type parameter for an entry in an `Struct`.
@@ -41,5 +41,15 @@ impl<N: Network> From<Identifier<N>> for PlaintextType<N> {
     /// Initializes a plaintext type from a struct type.
     fn from(struct_: Identifier<N>) -> Self {
         PlaintextType::Struct(struct_)
+    }
+}
+
+impl<N: Network> From<ElementType<N>> for PlaintextType<N> {
+    /// Initializes a plaintext type from an element type.
+    fn from(element: ElementType<N>) -> Self {
+        match element {
+            ElementType::Literal(literal) => PlaintextType::Literal(literal),
+            ElementType::Struct(struct_) => PlaintextType::Struct(struct_),
+        }
     }
 }

--- a/console/program/src/data_types/vector_type/bytes.rs
+++ b/console/program/src/data_types/vector_type/bytes.rs
@@ -12,29 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod array_type;
-pub use array_type::ArrayType;
+use super::*;
 
-mod element_type;
-pub use element_type::ElementType;
+impl<N: Network> FromBytes for VectorType<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the element type.
+        let element_type = ElementType::read_le(&mut reader)?;
+        // Return the vector type.
+        Ok(Self::new(element_type))
+    }
+}
 
-mod literal_type;
-pub use literal_type::LiteralType;
-
-mod plaintext_type;
-pub use plaintext_type::PlaintextType;
-
-mod record_type;
-pub use record_type::{EntryType, RecordType};
-
-mod register_type;
-pub use register_type::RegisterType;
-
-mod struct_;
-pub use struct_::Struct;
-
-mod value_type;
-pub use value_type::ValueType;
-
-mod vector_type;
-pub use vector_type::VectorType;
+impl<N: Network> ToBytes for VectorType<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the element type.
+        self.element_type.write_le(&mut writer)
+    }
+}

--- a/console/program/src/data_types/vector_type/mod.rs
+++ b/console/program/src/data_types/vector_type/mod.rs
@@ -1,0 +1,106 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod parse;
+mod serialize;
+
+use crate::{ElementType};
+use snarkvm_console_network::prelude::*;
+
+use core::fmt::{Debug, Display};
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct VectorType<N: Network> {
+    /// The type of the elements in the vector.
+    element_type: ElementType<N>,
+}
+
+impl<N: Network> VectorType<N> {
+    /// Constructs a new vector type.
+    pub fn new(element_type: ElementType<N>) -> Self {
+        Self { element_type }
+    }
+
+    /// Returns the element type.
+    pub fn element_type(&self) -> &ElementType<N> {
+        &self.element_type
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    use crate::{Identifier, LiteralType};
+    use core::str::FromStr;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_vector_type() -> Result<()> {
+        // Test literal vector types.
+        let type_ = VectorType::<CurrentNetwork>::from_str("[field]")?;
+        assert_eq!(type_, VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Field)));
+        assert_eq!(
+            type_.to_bytes_le()?,
+            VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
+        );
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Field));
+
+        // Test struct vector types.
+        let type_ = VectorType::<CurrentNetwork>::from_str("[foo]")?;
+        assert_eq!(
+            type_,
+            VectorType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?))
+        );
+        assert_eq!(
+            type_.to_bytes_le()?,
+            VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
+        );
+        assert_eq!(type_.element_type(), &ElementType::from(Identifier::from_str("foo")?));
+
+        // Test vector type with maximum length.
+        let type_ = VectorType::<CurrentNetwork>::from_str("[scalar]")?;
+        assert_eq!(
+            type_,
+            VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar))
+        );
+        assert_eq!(
+            type_.to_bytes_le()?,
+            VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
+        );
+        assert_eq!(type_.element_type(), &ElementType::from(LiteralType::Scalar));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_vector_type_fails() -> Result<()> {
+        let type_ = VectorType::<CurrentNetwork>::from_str("[[field]]");
+        assert!(type_.is_err());
+
+        let type_ = VectorType::<CurrentNetwork>::from_str("[[foo]]");
+        assert!(type_.is_err());
+
+        let type_ = VectorType::<CurrentNetwork>::from_str("[field; 3]");
+        assert!(type_.is_err());
+
+        let type_ = VectorType::<CurrentNetwork>::from_str("[foo; -1]");
+        assert!(type_.is_err());
+
+        Ok(())
+    }
+}

--- a/console/program/src/data_types/vector_type/mod.rs
+++ b/console/program/src/data_types/vector_type/mod.rs
@@ -16,7 +16,7 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{ElementType};
+use crate::ElementType;
 use snarkvm_console_network::prelude::*;
 
 use core::fmt::{Debug, Display};
@@ -62,10 +62,7 @@ mod tests {
 
         // Test struct vector types.
         let type_ = VectorType::<CurrentNetwork>::from_str("[foo]")?;
-        assert_eq!(
-            type_,
-            VectorType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?))
-        );
+        assert_eq!(type_, VectorType::<CurrentNetwork>::new(ElementType::from(Identifier::from_str("foo")?)));
         assert_eq!(
             type_.to_bytes_le()?,
             VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?
@@ -74,10 +71,7 @@ mod tests {
 
         // Test vector type with maximum length.
         let type_ = VectorType::<CurrentNetwork>::from_str("[scalar]")?;
-        assert_eq!(
-            type_,
-            VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar))
-        );
+        assert_eq!(type_, VectorType::<CurrentNetwork>::new(ElementType::from(LiteralType::Scalar)));
         assert_eq!(
             type_.to_bytes_le()?,
             VectorType::<CurrentNetwork>::from_bytes_le(&type_.to_bytes_le()?)?.to_bytes_le()?

--- a/console/program/src/data_types/vector_type/parse.rs
+++ b/console/program/src/data_types/vector_type/parse.rs
@@ -1,0 +1,68 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Parser for VectorType<N> {
+    /// Parses a string into a literal type.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the opening bracket.
+        let (string, _) = tag("[")(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the element type.
+        let (string, element_type) = ElementType::parse(string)?;
+        // Parse the whitespaces from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the closing bracket.
+        let (string, _) = tag("]")(string)?;
+
+        // Return the vector type.
+        Ok((string, Self::new(element_type)))
+    }
+}
+
+impl<N: Network> FromStr for VectorType<N> {
+    type Err = Error;
+
+    /// Returns an vector type from a string literal.
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for VectorType<N> {
+    /// Prints the vector type as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for VectorType<N> {
+    /// Prints the vector type as a string.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}]", self.element_type)
+    }
+}

--- a/console/program/src/data_types/vector_type/serialize.rs
+++ b/console/program/src/data_types/vector_type/serialize.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Serialize for VectorType<N> {
+    /// Serializes the vector type into string or bytes.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => serializer.collect_str(self),
+            false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
+        }
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for VectorType<N> {
+    /// Deserializes the vector type from a string or bytes.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "vector type"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    /// Add test cases here to be checked for serialization.
+    const TEST_CASES: &[&str] = &["[u8]", "[foo]"];
+
+    fn check_serde_json<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_string = &expected.to_string();
+        let candidate_string = serde_json::to_string(&expected).unwrap();
+        assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
+
+        // Deserialize
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
+        assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+    }
+
+    fn check_bincode<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_bytes = expected.to_bytes_le().unwrap();
+        let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(expected, T::read_le(&expected_bytes[..]).unwrap());
+        assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json() {
+        for case in TEST_CASES.iter() {
+            check_serde_json(VectorType::<Testnet3>::from_str(case).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        for case in TEST_CASES.iter() {
+            check_bincode(VectorType::<Testnet3>::from_str(case).unwrap());
+        }
+    }
+}

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -354,11 +354,12 @@ impl<N: Network> StackExecute<N> for Stack<N> {
                 for operand in command.operands() {
                     // Retrieve the finalize input.
                     let value = registers.load_circuit(self, operand)?;
-                    // Ensure the value is a literal or a struct.
+                    // Ensure the value is a literal, struct, or list.
                     // See `RegisterTypes::initialize_function_types()` for the same set of checks.
                     match value {
-                        circuit::Value::Plaintext(circuit::Plaintext::Literal(..)) => (),
-                        circuit::Value::Plaintext(circuit::Plaintext::Struct(..)) => (),
+                        circuit::Value::Plaintext(circuit::Plaintext::Literal(..))
+                        | circuit::Value::Plaintext(circuit::Plaintext::Struct(..))
+                        | circuit::Value::Plaintext(circuit::Plaintext::List(..)) => (),
                         circuit::Value::Record(..) => {
                             bail!(
                                 "'{}/{}' attempts to pass a 'record' into 'finalize'",

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -120,7 +120,10 @@ impl<N: Network> FinalizeTypes<N> {
                 PlaintextType::Literal(..) => bail!("'{register}' references a literal."),
                 // Access the member on the path to output the register type.
                 PlaintextType::Struct(struct_name) => {
-                    let Access::Member(path_name) = path_name;
+                    let path_name = match path_name {
+                        Access::Member(path_name) => path_name,
+                        Access::Index(_) => bail!("Attempted to index a struct"),
+                    };
                     // Retrieve the member type from the struct.
                     match stack.program().get_struct(struct_name)?.members().get(path_name) {
                         // Update the member type.

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -193,6 +193,8 @@ impl<N: Network> Stack<N> {
                 }
                 // If `plaintext` is a struct, this is a mismatch.
                 Plaintext::Struct(..) => bail!("'{plaintext_type}' is invalid: expected literal, found struct"),
+                // If `plaintext` is a list, this is a mismatch.
+                Plaintext::List(..) => bail!("'{plaintext_type}' is invalid: expected literal, found list"),
             },
             PlaintextType::Struct(struct_name) => {
                 // Ensure the struct name is valid.
@@ -212,6 +214,7 @@ impl<N: Network> Stack<N> {
                 // Retrieve the struct members.
                 let members = match plaintext {
                     Plaintext::Literal(..) => bail!("'{struct_name}' is invalid: expected struct, found literal"),
+                    Plaintext::List(..) => bail!("'{struct_name}' is invalid: expected struct, found list"),
                     Plaintext::Struct(members, ..) => members,
                 };
 

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -136,7 +136,10 @@ impl<N: Network> RegisterTypes<N> {
                 RegisterType::Plaintext(PlaintextType::Literal(..)) => bail!("'{register}' references a literal."),
                 // Traverse the path to output the register type.
                 RegisterType::Plaintext(PlaintextType::Struct(struct_name)) => {
-                    let Access::Member(path_name) = path_name;
+                    let path_name = match path_name {
+                        Access::Member(path_name) => path_name,
+                        Access::Index(_) => bail!("Attempted to index a struct"),
+                    };
                     // Retrieve the member type from the struct.
                     match stack.program().get_struct(struct_name)?.members().get(path_name) {
                         // Update the member type.
@@ -152,7 +155,10 @@ impl<N: Network> RegisterTypes<N> {
                         // If the member is the owner, then output the address type.
                         RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address))
                     } else {
-                        let Access::Member(path_name) = path_name;
+                        let path_name = match path_name {
+                            Access::Member(path_name) => path_name,
+                            Access::Index(_) => bail!("Attempted to index into a record"),
+                        };
                         // Retrieve the entry type from the record.
                         match stack.program().get_record(record_name)?.entries().get(path_name) {
                             // Update the entry type.
@@ -173,7 +179,10 @@ impl<N: Network> RegisterTypes<N> {
                         // If the member is the owner, then output the address type.
                         RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address))
                     } else {
-                        let Access::Member(path_name) = path_name;
+                        let path_name = match path_name {
+                            Access::Member(path_name) => path_name,
+                            Access::Index(_) => bail!("Attempted to index into an external record"),
+                        };
                         // Retrieve the entry type from the external record.
                         match stack.get_external_record(locator)?.entries().get(path_name) {
                             // Update the entry type.

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -137,8 +137,9 @@ pub trait RegistersLoad<N: Network> {
     ) -> Result<Literal<N>> {
         match self.load(stack, operand)? {
             Value::Plaintext(Plaintext::Literal(literal, ..)) => Ok(literal),
-            Value::Plaintext(Plaintext::Struct(..)) => bail!("Operand must be a literal"),
-            Value::Record(..) => bail!("Operand must be a literal"),
+            Value::Plaintext(Plaintext::Struct(..)) | Value::Plaintext(Plaintext::List(..)) | Value::Record(..) => {
+                bail!("Operand must be a literal")
+            }
         }
     }
 
@@ -187,8 +188,9 @@ pub trait RegistersLoadCircuit<N: Network, A: circuit::Aleo<Network = N>> {
     ) -> Result<circuit::Literal<A>> {
         match self.load_circuit(stack, operand)? {
             circuit::Value::Plaintext(circuit::Plaintext::Literal(literal, ..)) => Ok(literal),
-            circuit::Value::Plaintext(circuit::Plaintext::Struct(..)) => bail!("Operand must be a literal"),
-            circuit::Value::Record(..) => bail!("Operand must be a literal"),
+            circuit::Value::Plaintext(circuit::Plaintext::Struct(..))
+            | circuit::Value::Plaintext(circuit::Plaintext::List(..))
+            | circuit::Value::Record(..) => bail!("Operand must be a literal"),
         }
     }
 

--- a/synthesizer/tests/tests/program/linalg.aleo
+++ b/synthesizer/tests/tests/program/linalg.aleo
@@ -1,0 +1,44 @@
+/*
+randomness: 2937849
+cases:
+  - function: frobenius_inner_product
+    inputs: [
+        [0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field],
+        [1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]
+    ]
+  - function: frobenius_inner_product
+    inputs: [
+        [1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field],
+        [1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]
+    ]
+*/
+
+program linalg.aleo;
+
+function frobenius_inner_product:
+    input r0 as [field; 9].private;
+    input r1 as [field; 9].private;
+    mul r0[0] r1[0] into r2;
+    mul r0[1] r1[1] into r3;
+    mul r0[2] r1[2] into r4;
+    mul r0[3] r1[3] into r5;
+    mul r0[4] r1[4] into r6;
+    mul r0[5] r1[5] into r7;
+    mul r0[6] r1[6] into r8;
+    mul r0[7] r1[7] into r9;
+    mul r0[8] r1[8] into r10;
+    add r2 r3 into r11;
+    add r11 r4 into r12;
+    add r12 r5 into r13;
+    add r13 r6 into r14;
+    add r14 r7 into r15;
+    add r15 r8 into r16;
+    add r16 r9 into r17;
+    add r17 r10 into r18;
+    output r18 as field.private;
+
+
+
+
+
+


### PR DESCRIPTION
This PR supports the `Access::Index` variant, allowing users to index into `Plaintext::List` with constant indices.

Depends on #1777.
