### PR TITLE
Defer loading `credits.aleo` proving keys and inclusion proving keys until time of use.

### DIFF
--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -158,14 +158,6 @@ impl<N: Network> Process<N> {
         }
         lap!(timer, "Load circuit keys");
 
-        // Initialize the inclusion proving key.
-        let _ = N::inclusion_proving_key();
-        lap!(timer, "Load inclusion proving key");
-
-        // Initialize the inclusion verifying key.
-        let _ = N::inclusion_verifying_key();
-        lap!(timer, "Load inclusion verifying key");
-
         // Add the stack to the process.
         process.add_stack(stack);
 

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -149,13 +149,8 @@ impl<N: Network> Process<N> {
         let stack = Stack::new(&process, &program)?;
         lap!(timer, "Initialize stack");
 
-        // Synthesize the 'credits.aleo' circuit keys.
+        // Synthesize the 'credits.aleo' verifying keys.
         for function_name in program.functions().keys() {
-            // Load the proving key.
-            let proving_key = N::get_credits_proving_key(function_name.to_string())?;
-            stack.insert_proving_key(function_name, ProvingKey::new(proving_key.clone()))?;
-            lap!(timer, "Load proving key for {function_name}");
-
             // Load the verifying key.
             let verifying_key = N::get_credits_verifying_key(function_name.to_string())?;
             stack.insert_verifying_key(function_name, VerifyingKey::new(verifying_key.clone()))?;

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -313,6 +313,8 @@ impl<N: Network> Stack<N> {
     /// Returns the proving key for the given function name.
     #[inline]
     pub fn get_proving_key(&self, function_name: &Identifier<N>) -> Result<ProvingKey<N>> {
+        // If the program is 'credits.aleo', try to load the proving key, if it does not exist.
+        self.try_insert_credits_function_proving_key(function_name)?;
         // Return the proving key, if it exists.
         match self.proving_keys.read().get(function_name) {
             Some(proving_key) => Ok(proving_key.clone()),
@@ -368,6 +370,22 @@ impl<N: Network> Stack<N> {
     #[inline]
     pub fn remove_verifying_key(&self, function_name: &Identifier<N>) {
         self.verifying_keys.write().remove(function_name);
+    }
+}
+
+impl<N: Network> Stack<N> {
+    /// Inserts the proving key if the program ID is 'credits.aleo'.
+    fn try_insert_credits_function_proving_key(&self, function_name: &Identifier<N>) -> Result<()> {
+        // If the program is 'credits.aleo' and it does not exist yet, load the proving key directly.
+        if self.program_id() == &ProgramID::from_str("credits.aleo")?
+            && !self.proving_keys.read().contains_key(function_name)
+        {
+            // Load the 'credits.aleo' function proving key.
+            let proving_key = N::get_credits_proving_key(function_name.to_string())?;
+            // Insert the 'credits.aleo' function proving key.
+            self.insert_proving_key(function_name, ProvingKey::new(proving_key.clone()))?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR defers loading `credits.aleo` proving keys and inclusion proving keys until time of use.
