### PR TITLE
[Feature] Enables the use of `ArrayType` in `synthesizer`.

### DIFF
--- a/circuit/program/src/data/record/find.rs
+++ b/circuit/program/src/data/record/find.rs
@@ -26,7 +26,7 @@ impl<A: Aleo> Record<A, Plaintext<A>> {
         if let Some((first, rest)) = path.split_first() {
             let first = match first {
                 Access::Member(identifier) => identifier,
-                Access::Index(_) => bail!("Attempted to index into a record"),
+                Access::Index(_) => bail!("Attempted to access a record with '{first}'"),
             };
             // Retrieve the top-level entry.
             match self.data.get(first) {

--- a/console/program/src/data/record/find.rs
+++ b/console/program/src/data/record/find.rs
@@ -26,7 +26,7 @@ impl<N: Network> Record<N, Plaintext<N>> {
         if let Some((first, rest)) = path.split_first() {
             let first = match first {
                 Access::Member(identifier) => *identifier,
-                Access::Index(_) => bail!("Attempted to index into a record"),
+                Access::Index(_) => bail!("Attempted to access a record with '{first}'"),
             };
             // Retrieve the top-level entry.
             match self.data.get(&first) {

--- a/console/program/src/data_types/array_type/mod.rs
+++ b/console/program/src/data_types/array_type/mod.rs
@@ -32,6 +32,7 @@ pub struct ArrayType<N: Network> {
 impl<N: Network> ArrayType<N> {
     /// Constructs a new array type.
     pub fn new(element_type: ElementType<N>, length: U32<N>) -> Result<Self> {
+        // TODO: Should empty arrays be allowed?
         ensure!(*length != 0, "The array must have at least one element");
         ensure!(
             *length as usize <= N::MAX_ARRAY_ENTRIES,
@@ -49,6 +50,12 @@ impl<N: Network> ArrayType<N> {
     /// Returns the length of the array.
     pub fn length(&self) -> &U32<N> {
         &self.length
+    }
+
+    /// Indexes an array type, returning the element type if the index is within bounds.
+    pub fn index(&self, index: &U32<N>) -> Result<&ElementType<N>> {
+        ensure!(index < &self.length, "Index out of bounds");
+        Ok(&self.element_type)
     }
 }
 

--- a/console/program/src/data_types/array_type/mod.rs
+++ b/console/program/src/data_types/array_type/mod.rs
@@ -111,6 +111,9 @@ mod tests {
         let type_ = ArrayType::<CurrentNetwork>::from_str("[field; 4294967296]");
         assert!(type_.is_err());
 
+        let type_ = ArrayType::<CurrentNetwork>::from_str("[field]");
+        assert!(type_.is_err());
+
         let type_ = ArrayType::<CurrentNetwork>::from_str("[foo; -1]");
         assert!(type_.is_err());
 

--- a/console/program/src/data_types/plaintext_type/bytes.rs
+++ b/console/program/src/data_types/plaintext_type/bytes.rs
@@ -21,7 +21,8 @@ impl<N: Network> FromBytes for PlaintextType<N> {
         match variant {
             0 => Ok(Self::Literal(LiteralType::read_le(&mut reader)?)),
             1 => Ok(Self::Struct(Identifier::read_le(&mut reader)?)),
-            2.. => Err(error(format!("Failed to deserialize annotation variant {variant}"))),
+            2 => Ok(Self::Array(ArrayType::read_le(&mut reader)?)),
+            3.. => Err(error(format!("Failed to deserialize annotation variant {variant}"))),
         }
     }
 }
@@ -37,6 +38,10 @@ impl<N: Network> ToBytes for PlaintextType<N> {
             Self::Struct(identifier) => {
                 u8::write_le(&1u8, &mut writer)?;
                 identifier.write_le(&mut writer)
+            }
+            Self::Array(array_type) => {
+                u8::write_le(&2u8, &mut writer)?;
+                array_type.write_le(&mut writer)
             }
         }
     }

--- a/console/program/src/data_types/plaintext_type/mod.rs
+++ b/console/program/src/data_types/plaintext_type/mod.rs
@@ -16,10 +16,10 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{ElementType, Identifier, LiteralType};
+use crate::{ArrayType, ElementType, Identifier, LiteralType};
 use snarkvm_console_network::prelude::*;
 
-/// A `ValueType` defines the type parameter for an entry in an `Struct`.
+/// A `PlaintextType` defines the type parameter for an entry in an `Record` or standalone value.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PlaintextType<N: Network> {
     /// A literal type contains its type name.
@@ -28,6 +28,9 @@ pub enum PlaintextType<N: Network> {
     /// An struct type contains its identifier.
     /// The format of the type is `<identifier>`.
     Struct(Identifier<N>),
+    /// An array type contains its element type and length.
+    /// The format of the type is `[<element_type>; <length>]`.
+    Array(ArrayType<N>),
 }
 
 impl<N: Network> From<LiteralType> for PlaintextType<N> {
@@ -41,6 +44,13 @@ impl<N: Network> From<Identifier<N>> for PlaintextType<N> {
     /// Initializes a plaintext type from a struct type.
     fn from(struct_: Identifier<N>) -> Self {
         PlaintextType::Struct(struct_)
+    }
+}
+
+impl<N: Network> From<ArrayType<N>> for PlaintextType<N> {
+    /// Initializes a plaintext type from an array type.
+    fn from(array: ArrayType<N>) -> Self {
+        PlaintextType::Array(array)
     }
 }
 

--- a/console/program/src/data_types/plaintext_type/parse.rs
+++ b/console/program/src/data_types/plaintext_type/parse.rs
@@ -22,6 +22,7 @@ impl<N: Network> Parser for PlaintextType<N> {
         alt((
             map(LiteralType::parse, |type_| Self::Literal(type_)),
             map(Identifier::parse, |identifier| Self::Struct(identifier)),
+            map(ArrayType::parse, |array| Self::Array(array)),
         ))(string)
     }
 }
@@ -58,6 +59,8 @@ impl<N: Network> Display for PlaintextType<N> {
             Self::Literal(literal) => Display::fmt(literal, f),
             // Prints the struct, i.e. signature
             Self::Struct(struct_) => Display::fmt(struct_, f),
+            // Prints the array, i.e. [field; 2]
+            Self::Array(array) => Display::fmt(array, f),
         }
     }
 }
@@ -78,6 +81,10 @@ mod tests {
         assert_eq!(
             PlaintextType::parse("signature"),
             Ok(("", PlaintextType::<CurrentNetwork>::Struct(Identifier::from_str("signature")?)))
+        );
+        assert_eq!(
+            PlaintextType::parse("[field; 2]"),
+            Ok(("", PlaintextType::<CurrentNetwork>::Array(ArrayType::from_str("[field; 2]")?)))
         );
         Ok(())
     }
@@ -150,6 +157,10 @@ mod tests {
         assert_eq!(
             PlaintextType::<CurrentNetwork>::Struct(Identifier::from_str("signature")?).to_string(),
             "signature"
+        );
+        assert_eq!(
+            PlaintextType::<CurrentNetwork>::Array(ArrayType::from_str("[field; 2]")?).to_string(),
+            "[field; 2]"
         );
         Ok(())
     }

--- a/console/program/src/data_types/plaintext_type/serialize.rs
+++ b/console/program/src/data_types/plaintext_type/serialize.rs
@@ -67,6 +67,9 @@ mod tests {
         "passport",
         "object",
         "array",
+        // Array
+        "[address; 1]",
+        "[foo, 3]",
     ];
 
     fn check_serde_json<

--- a/synthesizer/process/src/stack/finalize_types/matches.rs
+++ b/synthesizer/process/src/stack/finalize_types/matches.rs
@@ -101,7 +101,7 @@ impl<N: Network> FinalizeTypes<N> {
         array_type: &ArrayType<N>,
     ) -> Result<()> {
         // Ensure that there is at least one operand.
-        if !operands.is_empty() {
+        if operands.is_empty() {
             bail!("Array must have at least 1 operand")
         }
         // Ensure the number of elements does not exceed the maximum.

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -122,7 +122,7 @@ impl<N: Network> FinalizeTypes<N> {
                 PlaintextType::Struct(struct_name) => {
                     let path_name = match path_name {
                         Access::Member(path_name) => path_name,
-                        Access::Index(_) => bail!("Attempted to index a struct"),
+                        Access::Index(_) => bail!("Attempted to access a struct with '{path_name}'"),
                     };
                     // Retrieve the member type from the struct.
                     match stack.program().get_struct(struct_name)?.members().get(path_name) {
@@ -130,6 +130,15 @@ impl<N: Network> FinalizeTypes<N> {
                         Some(plaintext_type) => *plaintext_type,
                         None => bail!("'{path_name}' does not exist in struct '{struct_name}'"),
                     }
+                }
+                // Access the index on the path to output the register type.
+                PlaintextType::Array(array_type) => {
+                    let path_index = match path_name {
+                        Access::Index(path_index) => path_index,
+                        Access::Member(_) => bail!("Attempted to an array with '{path_name}'"),
+                    };
+                    // Retrieve the element type from the array.
+                    PlaintextType::from(*array_type.index(path_index)?)
                 }
             }
         }

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -165,6 +165,18 @@ impl<N: Network> Stack<N> {
 
                 Plaintext::Struct(members, Default::default())
             }
+            // Sample an array.
+            PlaintextType::Array(array_type) => {
+                // Get the length of the array.
+                let length = **array_type.length();
+                // Sample each element of the array.
+                let elements = (0..length)
+                    .map(|_| {
+                        self.sample_plaintext_internal(&PlaintextType::from(*array_type.element_type()), depth + 1, rng)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Plaintext::List(elements, Default::default())
+            }
         };
         // Return the plaintext.
         Ok(plaintext)

--- a/synthesizer/process/src/stack/register_types/matches.rs
+++ b/synthesizer/process/src/stack/register_types/matches.rs
@@ -106,7 +106,7 @@ impl<N: Network> RegisterTypes<N> {
         array_type: &ArrayType<N>,
     ) -> Result<()> {
         // Ensure that there is at least one operand.
-        if !operands.is_empty() {
+        if operands.is_empty() {
             bail!("Array must have at least 1 operand")
         }
         // Ensure the number of elements does not exceed the maximum.

--- a/synthesizer/program/src/logic/instruction/operation/cast.rs
+++ b/synthesizer/program/src/logic/instruction/operation/cast.rs
@@ -400,7 +400,7 @@ impl<N: Network> Cast<N> {
             }
             CastType::RegisterType(RegisterType::Plaintext(PlaintextType::Array(array_type))) => {
                 // Ensure the operands length is at least the minimum.
-                if inputs.len() == 0 {
+                if inputs.is_empty() {
                     bail!("Casting to an array requires at least 1 operand")
                 }
 
@@ -647,7 +647,7 @@ impl<N: Network> Cast<N> {
             CastType::RegisterType(RegisterType::Plaintext(PlaintextType::Array(array_type))) => {
                 // Retrieve the element type and ensure it is defined in the program.
                 if let ElementType::Struct(struct_name) = array_type.element_type() {
-                    stack.program().get_struct(&struct_name)?;
+                    stack.program().get_struct(struct_name)?;
                 }
 
                 // Ensure that the number of input types is equal to the length of the array.
@@ -807,7 +807,7 @@ impl<N: Network> Cast<N> {
         inputs: Vec<Value<N>>,
     ) -> Result<()> {
         // Ensure that there is at least one operand.
-        if inputs.len() == 0 {
+        if inputs.is_empty() {
             bail!("Casting to an array requires at least 1 operand")
         }
 

--- a/synthesizer/program/src/logic/instruction/operation/literals.rs
+++ b/synthesizer/program/src/logic/instruction/operation/literals.rs
@@ -174,11 +174,10 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
             .copied()
             .map(|input_type| match input_type {
                 RegisterType::Plaintext(PlaintextType::Literal(literal_type)) => Ok(literal_type),
-                RegisterType::Plaintext(PlaintextType::Struct(..)) => {
-                    bail!("Expected literal type, found '{input_type}'")
-                }
-                RegisterType::Record(..) => bail!("Expected literal type, found '{input_type}'"),
-                RegisterType::ExternalRecord(..) => bail!("Expected literal type, found '{input_type}'"),
+                RegisterType::Plaintext(PlaintextType::Struct(..))
+                | RegisterType::Plaintext(PlaintextType::Array(..))
+                | RegisterType::Record(..)
+                | RegisterType::ExternalRecord(..) => bail!("Expected literal type, found '{input_type}'"),
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/synthesizer/tests/expectations/process/execute/linalg.out
+++ b/synthesizer/tests/expectations/process/execute/linalg.out
@@ -1,0 +1,2 @@
+- - 0field
+- - 9field

--- a/synthesizer/tests/expectations/process/execute/linalg.out
+++ b/synthesizer/tests/expectations/process/execute/linalg.out
@@ -1,2 +1,26 @@
 - - 0field
 - - 9field
+- - |-
+    [
+      1field,
+      2field,
+      0field,
+      0field,
+      1field,
+      1field,
+      0field,
+      1field,
+      1field
+    ]
+- - |-
+    [
+      15field,
+      18field,
+      21field,
+      42field,
+      54field,
+      66field,
+      69field,
+      90field,
+      111field
+    ]

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/linalg.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/linalg.out
@@ -1,22 +1,44 @@
 - execute:
     linalg.aleo/frobenius_inner_product:
       outputs:
-      - '{"type":"private","id":"7806078897425429982566693726823612490374760421890961243904218025642476974206field","value":"ciphertext1qgqwfsfaa4tkuw5ea36thp2kvmx9qfnsg08hw7qmnedkzux364hwcp90955m02y8dk0jgkgzr2c5hflqjdvxgvah42e3l7ewuvvq680vpg67hn33"}'
+      - '{"type":"private","id":"2735150779168922044218569729301511207824064961886015444113693850965656772526field","value":"ciphertext1qgqvwtn0ze6uppeulelewg4s80f906dt7lfhh0j63cwg9av6chld2z9ny5jj59kvyqxwxqlf6twqtkatj5qm9gptpvq6m6qk4xlf0t8lqqjwvkjm"}'
       finalize: []
     credits.aleo/fee:
       outputs:
-      - '{"type":"record","id":"979891262903599480596068885687275772210264710658083098833727036852934142600field","checksum":"3083175099825638798757684588978047307516015307129764973816913143532803103367field","value":"record1qyqsqt88gtd4f9wrly00fpgxy7n8v2qdfmu6wt9tzppc0fvma35rs6qjqyxx66trwfhkxun9v35hguerqqpqzq8qg0y35fmnj5ls6v7p3muc4re4pyr47ekqcfcxzwrd2207de09z9t2uzt46vluapjy093xsd65fgalkf7henhjnx3cl7h52080zcesycyrtct"}'
+      - '{"type":"record","id":"5626491913185527731591297168032824281941450574754860016128592742344556084678field","checksum":"1964482817489510747629877909825716574263390516340151790292699952103900348573field","value":"record1qyqsphxk6900rlu40cth5c08ewkzk42yu6u7jucu6zkplqwgqueux7grqyxx66trwfhkxun9v35hguerqqpqzqyytu858tnqc89juqf7ykkm9t05cxva9h28gj3vc7590m9qaqtpzx7a59kurejezfttwlqf0y935rc3mssmn88k40j2wned5s36j28qwzen5t9"}'
       finalize: []
   speculate: the execution was accepted
   add_next_block: succeeded.
 - execute:
     linalg.aleo/frobenius_inner_product:
       outputs:
-      - '{"type":"private","id":"3580100037086521953006304637805207312172135160876365699393571843442104240121field","value":"ciphertext1qgqv7f4pyyzahyp9w3nt7cjs23dz786u5pg2fcn22py92h5tktx3vp263v90c4ayhxeeja5uctf5h2s6az3v4zkqt28k8edtda90xhuvpcy3ejl3"}'
+      - '{"type":"private","id":"202231592990154528885023987396837867664860213608345216257695685191059763182field","value":"ciphertext1qgqpejralvvrg93f3dk7flnx7c6w265g5gxs3njf0t4udma9942tkq3nn6vrl5ncsnc9wp7kxldgr6jgphwdfu30qkxym9r3wgjuvyaqpsznsm0q"}'
       finalize: []
     credits.aleo/fee:
       outputs:
-      - '{"type":"record","id":"4772323396752114238678458095748484933554817744837727964945265462135276754532field","checksum":"3069270940717194385953061931395050147050443575754014344538556303847701325035field","value":"record1qyqsqgtr6uwg8nj6e4phl2226erwlarmhv8rlek5fa5gk65cju6whhc2qyxx66trwfhkxun9v35hguerqqpqzqp8fq6txtujqzavd79ru84krwjxl0285w2uafr7v4zscyx93sqqpj02rwq4lrv7t7cl8s7hnvn6rllyk7jzrwu74zammzyk7fpwu7hpql3cnll"}'
+      - '{"type":"record","id":"8122093733941099360022425300235463719585735867802969687092843854070254767575field","checksum":"6414805689035441836700203005298983192123590708667514085669465152796977711741field","value":"record1qyqsq2u75vwsjp5z73sfuvkvay45dzhwh0k9d3ftc845rnmredpzdhcdqyxx66trwfhkxun9v35hguerqqpqzqq765dwztljd5lrncvuye8kyc70x33s4lny8eznqp89u6fp9xg6p22lxe40ht6gxgu4ssxml9wkv7zqne0g4wv4dx2satwcyej3kavscluldha"}'
+      finalize: []
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- execute:
+    linalg.aleo/matrix_multiply:
+      outputs:
+      - '{"type":"private","id":"5879989330784446737676223120558941284130148452508168508039299159310867286289field","value":"ciphertext1pvqg45phelh7lhw9clqvjlma0r545k3v9me9qay9p3kqjdat47stsyqpj7sygchjy0rfchzkww56fehw3m9ytkhrdxhj4xcxych0cr5mpmfpjc0k338qjhr4dk8dma6khkl0mp38gxx5q5s6ltpk7p92gqzs4s9y85pyskk8tv4g8umsccv9p2296v6qgxx2403a64yc05f5wecyya9g72k4alu2urxjna9ytgn8axe6knzpweas4ghjqcgms7x3qgyd3qxdhqq2ra44jm2ntd2v7dw95xpx7ffx4sn34tnsdndt6nlx6zpjudhas85enp4nl43sl2tfkxfswclm8cm4vr9pxmy4x0s7amzxppxgswqntasr7t7nkdn7gar8qwnhs950j3vc900mvms3zn74z9psld9pxtyrsqe2mynfrh7zne0grv024jc8caa6tq2fpfzhngx35cqy9z5x5e9m4rrtfuyv479vl0337j6hcmasn8t8zwpl5hhhlpgs7v9vjtfjzw2epc83ndjd0dh9de6f9c7tlxhxvvzdkgaqvhjmyarg2qs4q566m"}'
+      finalize: []
+    credits.aleo/fee:
+      outputs:
+      - '{"type":"record","id":"6645704167183331747577139695361056538890021687008967746856933233479692091382field","checksum":"5911228915383716048312186066365308781973792970863338015398871195688962690600field","value":"record1qyqsqzxlqz6m7u62pk4g7xqzmp4grpuqq8gr9fk8yht7xcpjur6yevqsqyxx66trwfhkxun9v35hguerqqpqzqpl6zqxxz2s7cds6gswcjpz74xxtskg3np6ks3gyr0jg00rj0upqyfpcsg8er8sllqhmzzwylwug8l5qrpvwn90aj2w0nr0j3ev8p7s5j5j5ju"}'
+      finalize: []
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- execute:
+    linalg.aleo/matrix_multiply:
+      outputs:
+      - '{"type":"private","id":"1835738414645382802590919275364483464924215306102951902006262503270750694649field","value":"ciphertext1pvqxpz5nckhnjuv44xe5j70meeq78mrea7hl55fq07hqu67k3sl8qqr0ge5kpwc4u90s0cad6hrc7scxv0shzw6868zpp07fru0t00lgz9ur7u0g4dqg46csf693e202zmm8tek6l55pc98hrd3usktnjj4q70safx2t6nq9q4vw3swf0tankww9ut46jr3gtuyxxvqm6anewlqtsq4rcfem7rfwwsvmwn8eta839dk3099dmnc99fudunjrsztcavx6ayksfnxzypa6tthtwpn90nfzk9eseh0ah08h79yga49d8p2l7ztgtgxgrkwa2m45tyl4nuhfetm3k82x7cflzqvse7y3eu9wdrjkzzc04mqmw064quunl68vhugspezaazlxpyfvyhyjlce0eq2z4ewppgc69h77gvh5w43t7rd9jwz7unajw5pv5d0tv6uptu8je7rggaczmrrd5a7cfn0jcfau2fqsjpmyp2tvcs6ymmpy2s0dcdt5mnd3gqq5ewhklh4e64x76km8fgjavyrxzgpxrf8d7nzyvcjsm30tr9yn5zcxy078g"}'
+      finalize: []
+    credits.aleo/fee:
+      outputs:
+      - '{"type":"record","id":"3969684653508248996982974500175046981524448560439425229042793965693172107866field","checksum":"2758401230614205868258289621514078511558042629111853170943940337594346596265field","value":"record1qyqspl6ltvzwz6pdvq74jcsf730j30vum3mfz3q6ezrhqlqjemgm8nq9qyxx66trwfhkxun9v35hguerqqpqzq9vstalpdtcagkg2z96kzyt7tfvhdxfse9el7ft7tly6mjggreuzyruty4rug8m29m3aq6y0ywnxs0f9wqu0u0l4m884q4jz68kddxpz5t0zuc"}'
       finalize: []
   speculate: the execution was accepted
   add_next_block: succeeded.

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/linalg.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/linalg.out
@@ -1,0 +1,22 @@
+- execute:
+    linalg.aleo/frobenius_inner_product:
+      outputs:
+      - '{"type":"private","id":"7806078897425429982566693726823612490374760421890961243904218025642476974206field","value":"ciphertext1qgqwfsfaa4tkuw5ea36thp2kvmx9qfnsg08hw7qmnedkzux364hwcp90955m02y8dk0jgkgzr2c5hflqjdvxgvah42e3l7ewuvvq680vpg67hn33"}'
+      finalize: []
+    credits.aleo/fee:
+      outputs:
+      - '{"type":"record","id":"979891262903599480596068885687275772210264710658083098833727036852934142600field","checksum":"3083175099825638798757684588978047307516015307129764973816913143532803103367field","value":"record1qyqsqt88gtd4f9wrly00fpgxy7n8v2qdfmu6wt9tzppc0fvma35rs6qjqyxx66trwfhkxun9v35hguerqqpqzq8qg0y35fmnj5ls6v7p3muc4re4pyr47ekqcfcxzwrd2207de09z9t2uzt46vluapjy093xsd65fgalkf7henhjnx3cl7h52080zcesycyrtct"}'
+      finalize: []
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- execute:
+    linalg.aleo/frobenius_inner_product:
+      outputs:
+      - '{"type":"private","id":"3580100037086521953006304637805207312172135160876365699393571843442104240121field","value":"ciphertext1qgqv7f4pyyzahyp9w3nt7cjs23dz786u5pg2fcn22py92h5tktx3vp263v90c4ayhxeeja5uctf5h2s6az3v4zkqt28k8edtda90xhuvpcy3ejl3"}'
+      finalize: []
+    credits.aleo/fee:
+      outputs:
+      - '{"type":"record","id":"4772323396752114238678458095748484933554817744837727964945265462135276754532field","checksum":"3069270940717194385953061931395050147050443575754014344538556303847701325035field","value":"record1qyqsqgtr6uwg8nj6e4phl2226erwlarmhv8rlek5fa5gk65cju6whhc2qyxx66trwfhkxun9v35hguerqqpqzqp8fq6txtujqzavd79ru84krwjxl0285w2uafr7v4zscyx93sqqpj02rwq4lrv7t7cl8s7hnvn6rllyk7jzrwu74zammzyk7fpwu7hpql3cnll"}'
+      finalize: []
+  speculate: the execution was accepted
+  add_next_block: succeeded.

--- a/synthesizer/tests/tests/program/linalg.aleo
+++ b/synthesizer/tests/tests/program/linalg.aleo
@@ -11,6 +11,16 @@ cases:
         "[1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]",
         "[1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]"
     ]
+  - function: matrix_multiply
+    inputs: [
+        "[1field, 1field, 0field, 1field, 0field, 1field, 1field, 0field, 1field]",
+        "[0field, 1field, 0field, 1field, 1field, 0field, 0field, 0field, 1field]"
+    ]
+  - function: matrix_multiply
+    inputs: [
+        "[0field, 1field, 2field, 3field, 4field, 5field, 6field, 7field, 8field]",
+        "[0field, 1field, 2field, 3field, 4field, 5field, 6field, 7field, 8field]"
+    ]
 */
 
 program linalg.aleo;
@@ -36,6 +46,57 @@ function frobenius_inner_product:
     add r16 r9 into r17;
     add r17 r10 into r18;
     output r18 as field.private;
+
+function matrix_multiply:
+    input r0 as [field; 9].private;
+    input r1 as [field; 9].private;
+    mul r0[0] r1[0] into r2;
+    mul r0[1] r1[3] into r3;
+    mul r0[2] r1[6] into r4;
+    add r2 r3 into r5;
+    add r5 r4 into r6;
+    mul r0[0] r1[1] into r7;
+    mul r0[1] r1[4] into r8;
+    mul r0[2] r1[7] into r9;
+    add r7 r8 into r10;
+    add r10 r9 into r11;
+    mul r0[0] r1[2] into r12;
+    mul r0[1] r1[5] into r13;
+    mul r0[2] r1[8] into r14;
+    add r12 r13 into r15;
+    add r15 r14 into r16;
+    mul r0[3] r1[0] into r17;
+    mul r0[4] r1[3] into r18;
+    mul r0[5] r1[6] into r19;
+    add r17 r18 into r20;
+    add r20 r19 into r21;
+    mul r0[3] r1[1] into r22;
+    mul r0[4] r1[4] into r23;
+    mul r0[5] r1[7] into r24;
+    add r22 r23 into r25;
+    add r25 r24 into r26;
+    mul r0[3] r1[2] into r27;
+    mul r0[4] r1[5] into r28;
+    mul r0[5] r1[8] into r29;
+    add r27 r28 into r30;
+    add r30 r29 into r31;
+    mul r0[6] r1[0] into r32;
+    mul r0[7] r1[3] into r33;
+    mul r0[8] r1[6] into r34;
+    add r32 r33 into r35;
+    add r35 r34 into r36;
+    mul r0[6] r1[1] into r37;
+    mul r0[7] r1[4] into r38;
+    mul r0[8] r1[7] into r39;
+    add r37 r38 into r40;
+    add r40 r39 into r41;
+    mul r0[6] r1[2] into r42;
+    mul r0[7] r1[5] into r43;
+    mul r0[8] r1[8] into r44;
+    add r42 r43 into r45;
+    add r45 r44 into r46;
+    cast r6 r11 r16 r21 r26 r31 r36 r41 r46 into r47 as [field; 9];
+    output r47 as [field; 9].private;
 
 
 

--- a/synthesizer/tests/tests/program/linalg.aleo
+++ b/synthesizer/tests/tests/program/linalg.aleo
@@ -3,13 +3,13 @@ randomness: 2937849
 cases:
   - function: frobenius_inner_product
     inputs: [
-        [0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field],
-        [1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]
+        "[0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field]",
+        "[1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]"
     ]
   - function: frobenius_inner_product
     inputs: [
-        [1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field],
-        [1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]
+        "[1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]",
+        "[1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field, 1field]"
     ]
 */
 


### PR DESCRIPTION
This PR adds `ArrayType` to `PlaintextType`, allowing it to be used in `synthesizer` and consequently in programs.
This PR also extends the `cast` operation to arrays.

Depends on #1778. 
