### PR TITLE
Parallelize `Deployment` verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
+ "rayon",
  "snarkvm-circuit",
  "snarkvm-console",
  "snarkvm-ledger-block",

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -102,6 +102,9 @@ version = "0.12"
 [dependencies.rand]
 version = "0.8"
 
+[dependencies.rayon]
+version = "1"
+
 [dev-dependencies.ledger-query]
 package = "snarkvm-ledger-query"
 path = "../../ledger/query"

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = [ "indexmap/rayon" ]
+default = [ "indexmap/rayon", "rayon" ]
 aleo-cli = [ ]
 async = [ "ledger-query/async" ]
 serial = [
@@ -104,6 +104,7 @@ version = "0.8"
 
 [dependencies.rayon]
 version = "1"
+optional = true
 
 [dev-dependencies.ledger-query]
 package = "snarkvm-ledger-query"

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -112,12 +112,13 @@ impl<N: Network> Stack<N> {
             // Initialize the call stack.
             let call_stack = CallStack::CheckDeployment(vec![request], burner_private_key, assignments.clone());
 
-            call_stacks.push((call_stack, assignments, function.name()));
+            // Append the function name, callstack, and assignments.
+            call_stacks.push((function.name(), call_stack, assignments));
         }
 
         // Verify the certificates.
         cfg_iter!(call_stacks).zip_eq(deployment.verifying_keys()).try_for_each(
-            |((call_stack, assignments, function_name), (_, (verifying_key, certificate)))| {
+            |((function_name, call_stack, assignments), (_, (verifying_key, certificate)))| {
                 // Synthesize the circuit.
                 let _response = self.execute_function::<A>(call_stack.clone()).unwrap();
                 lap!(timer, "Synthesize the circuit");

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -69,6 +69,9 @@ use indexmap::IndexMap;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
+
 pub type Assignments<N> = Arc<RwLock<Vec<circuit::Assignment<<N as Environment>::Field>>>>;
 
 #[derive(Clone)]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR speeds up `Deployment` verification (in `Stack::verify_deployment`) by synthesizing the function circuits and verifying their corresponding certificates in in parallel. 

This optimization is much more noticeable when verifying deployments of programs with many large functions, as each function needs to go through the same disjoint verification process. 

