### PR TITLE
Ensure Mul of LinearCombination doesnt create zero entries in the R1CS

### DIFF
--- a/algorithms/src/snark/marlin/ahp/errors.rs
+++ b/algorithms/src/snark/marlin/ahp/errors.rs
@@ -15,6 +15,8 @@
 /// Describes the failure modes of the AHP scheme.
 #[derive(Debug)]
 pub enum AHPError {
+    /// Anyhow error
+    Anyhow(anyhow::Error),
     /// The batch size is zero.
     BatchSizeIsZero,
     /// An error occurred during constraint generation.
@@ -34,5 +36,11 @@ pub enum AHPError {
 impl From<crate::r1cs::errors::SynthesisError> for AHPError {
     fn from(other: crate::r1cs::errors::SynthesisError) -> Self {
         AHPError::ConstraintSystemError(other)
+    }
+}
+
+impl From<anyhow::Error> for AHPError {
+    fn from(other: anyhow::Error) -> Self {
+        AHPError::Anyhow(other)
     }
 }

--- a/algorithms/src/snark/marlin/ahp/indexer/constraint_system.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/constraint_system.rs
@@ -43,17 +43,17 @@ impl<F: Field> ConstraintSystem<F> {
     }
 
     #[inline]
-    pub(crate) fn a_matrix(&self) -> Vec<Vec<(F, usize)>> {
+    pub(crate) fn a_matrix(&self) -> Result<Vec<Vec<(F, usize)>>, anyhow::Error> {
         to_matrix_helper(&self.a, self.num_public_variables)
     }
 
     #[inline]
-    pub(crate) fn b_matrix(&self) -> Vec<Vec<(F, usize)>> {
+    pub(crate) fn b_matrix(&self) -> Result<Vec<Vec<(F, usize)>>, anyhow::Error> {
         to_matrix_helper(&self.b, self.num_public_variables)
     }
 
     #[inline]
-    pub(crate) fn c_matrix(&self) -> Vec<Vec<(F, usize)>> {
+    pub(crate) fn c_matrix(&self) -> Result<Vec<Vec<(F, usize)>>, anyhow::Error> {
         to_matrix_helper(&self.c, self.num_public_variables)
     }
 

--- a/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/indexer.rs
@@ -137,9 +137,9 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         crate::snark::marlin::ahp::matrices::pad_input_for_indexer_and_prover(&mut ics);
         ics.make_matrices_square();
 
-        let a = ics.a_matrix();
-        let b = ics.b_matrix();
-        let c = ics.c_matrix();
+        let a = ics.a_matrix()?;
+        let b = ics.b_matrix()?;
+        let c = ics.c_matrix()?;
 
         // balance_matrices(&mut a, &mut b);
         end_timer!(padding_time);

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -424,6 +424,8 @@ impl<F: PrimeField> Mul<&F> for LinearCombination<F> {
         let mut output = self;
         output.constant *= coefficient;
         output.terms.iter_mut().for_each(|(_, current_coefficient)| *current_coefficient *= coefficient);
+        // If the coefficient of terms are now zero, remove the entries.
+        output.terms = output.terms.into_iter().filter(|(_, v)| *v != F::zero()).collect();
         output.value *= coefficient;
         output
     }


### PR DESCRIPTION
## Motivation

This PR ensures only non-zero valued entries end up in our sparse R1CS matrices. 

Goals I kept in mind:
- semantic correctness: sparse R1CS matrices should not contain non-zero entries
- proper abstraction: functionality such as filtering out zero entries should happen at the same level of abstraction
- performance during normal workloads

Background: recall that these matrices are of the form `[(variable_index, value), ...]`. So if we have a single variable `1` and a single constraint `1*1=1`, we have matrices: `[(1,1)]*[(1,1)]=[(1,1)]`. Any value of `0` doesn't make sense.

The zero entries are caused by the way we track of variables and constraints. E.g. when multiplying a `Field<E>` of zero by another `Field<E>` with actual terms, we keep those zeroed terms around. This led to 1542 entries in the R1CS matrix of the form: `Public(0, 1) * 0` when running `credits.sh`. 

We already have logic for filtering out zero entries in `impl {From, Add} for LinearCombination<F>`, this PR adds it for `Mul`.

## Test Plan

The performance impact on running a large script (credits.sh) is insignificant on my machine.