### PR TITLE
Introduce ToBits::to_bits_le_into and use it in Vec/[T]

### DIFF
--- a/fields/src/macros.rs
+++ b/fields/src/macros.rs
@@ -108,14 +108,12 @@ macro_rules! sqrt_impl {
                 l_s.resize(l_s.len() + k_1 as usize, l_minus_one);
                 l_s.resize(l_s.len() + k_2 as usize, l);
 
-                let mut x_s: Vec<$Self> = Vec::with_capacity(k as usize);
                 let mut l_sum = 0;
-                l_s.iter().take((k as usize) - 1).for_each(|l| {
+                let x_s = l_s.iter().take((k as usize) - 1).map(|l| {
                     l_sum += l;
-                    let x = x.pow(BigInteger::from(2u64.pow((n - 1 - l_sum) as u32)));
-                    x_s.push(x);
+                    x.pow(BigInteger::from(2u64.pow((n - 1 - l_sum) as u32)))
                 });
-                x_s.push(x);
+                let x_s = x_s.chain(Some(x));
 
                 let find = |delta: $Self| -> u64 {
                     let mut mu = delta;
@@ -167,12 +165,12 @@ macro_rules! sqrt_impl {
                 let mut q_s = Vec::<Vec<bool>>::with_capacity(k as usize);
                 let two_to_n_minus_l = 2u64.pow((n - l) as u32);
                 let two_to_n_minus_l_minus_one = 2u64.pow((n - l_minus_one) as u32);
-                x_s.iter().enumerate().for_each(|(i, x)| {
+                x_s.enumerate().for_each(|(i, x)| {
                     // Calculate g^t.
                     // This algorithm deviates from the standard description in the paper, and is
                     // explained in detail in page 6, in section 2.1.
                     let gamma = calc_gamma(i, &q_s, false);
-                    let alpha = *x * gamma;
+                    let alpha = x * gamma;
                     q_s.push(
                         (eval(alpha) / if i < k_1 as usize { two_to_n_minus_l_minus_one } else { two_to_n_minus_l })
                             .to_bits_le(),


### PR DESCRIPTION
This PR targets the `feat/narwhal` branch, but it's quite likely it would result in a performance improvement in other use cases as well; it introduces a `ToBits::to_bits_le_into` method that allows us to avoid a lot of allocations when calling `Vec::to_bits` on large collections.

In a 1-minute run of `test_state_coherence` in `snarkOS/narwhal`, this PR reduces the number of allocations from ~4.2M to ~2M, and temporary allocations from ~2.2M to ~0.7M, as measured with `heaptrack`.

I've investigated the option of calling `to_bits_le` directly in `BatchHeader::compute_batch_id`, but that would require plenty of additional implementations of `ToBits`, and it wouldn't have the potential to reduce other allocations in snarkVM, so I decided against that.

I'm filing this as a draft until all the tests have run - it's possible that I might need to introduce another impl of `ToBits::to_bits_le_into`, which should be trivial.

before:
![image](https://github.com/AleoHQ/snarkVM/assets/3750347/0d859416-23a6-4007-b373-2e4a803be261)
![image](https://github.com/AleoHQ/snarkVM/assets/3750347/468246e0-8feb-4ce4-aeb8-9b42905e9af0)
![image](https://github.com/AleoHQ/snarkVM/assets/3750347/985bc6d5-def1-4a6d-95b0-31477ef958f8)

after:
![image](https://github.com/AleoHQ/snarkVM/assets/3750347/d0f1e88d-abb3-4ec0-9b4c-dfc06d333652)
![image](https://github.com/AleoHQ/snarkVM/assets/3750347/78425289-f768-473e-aff1-97c8af6f298f)
![image](https://github.com/AleoHQ/snarkVM/assets/3750347/a72a46e4-0cf2-4b50-8523-25de3233475b)
