### PR TITLE
Refactor proof state

### DIFF
--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -165,8 +165,8 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
             prover_third_message.sum(batch_combiners, eta_b, eta_c) * state.max_variable_domain.size_inv;
 
         let verifier::FourthMessage { delta_a, delta_b, delta_c } = state.fourth_round_message.as_ref().unwrap();
-        let beta = state.third_round_message.unwrap().beta;
-        let gamma = state.gamma.unwrap();
+        let beta = state.third_round_message.as_ref().unwrap().beta;
+        let gamma = state.fifth_round_message.as_ref().unwrap().gamma;
 
         let mut linear_combinations = BTreeMap::new();
         let mut selectors = BTreeMap::new();

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -130,7 +130,7 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
         evals: &E,
         prover_third_message: &prover::ThirdMessage<F>,
         prover_fourth_message: &prover::FourthMessage<F>,
-        state: &verifier::State<F, MM>,
+        state: verifier::State<F, MM>,
     ) -> Result<BTreeMap<String, LinearCombination<F>>, AHPError> {
         assert!(!public_inputs.is_empty());
         let max_constraint_domain = state.max_constraint_domain;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fifth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fifth.rs
@@ -18,6 +18,7 @@ use crate::{
     fft::DensePolynomial,
     polycommit::sonic_pc::{LabeledPolynomial, PolynomialInfo, PolynomialLabel},
     snark::varuna::{ahp::AHPError, prover, AHPForR1CS, SNARKMode},
+    AlgebraicSponge,
 };
 
 use itertools::Itertools;
@@ -64,5 +65,13 @@ impl<'a, F: PrimeField, MM: SNARKMode> prover::State<'a, F, MM> {
         let oracles = prover::FifthOracles { h_2 };
         assert!(oracles.matches_info(&AHPForR1CS::<F, MM>::fifth_round_polynomial_info()));
         Ok(oracles)
+    }
+
+    pub fn verifier_fifth_round<Fq: PrimeField, R: AlgebraicSponge<Fq, 2>>(
+        &mut self,
+        fs_rng: &mut R,
+    ) -> Result<(), AHPError> {
+        self.verifier_state.as_mut().unwrap().fifth_round(fs_rng)?;
+        Ok(())
     }
 }

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
@@ -23,13 +23,7 @@ use crate::{
         SparsePolynomial,
     },
     polycommit::sonic_pc::{LabeledPolynomial, PolynomialInfo, PolynomialLabel},
-    snark::varuna::{
-        ahp::{AHPError, AHPForR1CS},
-        prover,
-        witness_label,
-        CircuitId,
-        SNARKMode,
-    },
+    snark::varuna::{ahp::AHPError, prover, witness_label, AHPForR1CS, CircuitId, SNARKMode},
 };
 use itertools::Itertools;
 use rand_core::RngCore;
@@ -60,17 +54,15 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
         }
         polynomials.into_iter().map(|info| (info.label().into(), info)).collect()
     }
+}
 
-    /// Output the first round message and the next state.
-    pub fn prover_first_round<'a, R: RngCore>(
-        mut state: prover::State<'a, F, MM>,
-        rng: &mut R,
-    ) -> Result<prover::State<'a, F, MM>, AHPError> {
+impl<'a, F: PrimeField, MM: SNARKMode> prover::State<'a, F, MM> {
+    pub fn first_round<R: RngCore>(&mut self, rng: &mut R) -> Result<(), AHPError> {
         let round_time = start_timer!(|| "AHP::Prover::FirstRound");
-        let fft_precomp = state.fft_precomputation;
-        let ifft_precomp = state.ifft_precomputation;
-        let mut job_pool = snarkvm_utilities::ExecutionPool::with_capacity(state.total_instances);
-        for (circuit, circuit_state) in state.circuit_specific_states.iter_mut() {
+        let fft_precomp = self.fft_precomputation;
+        let ifft_precomp = self.ifft_precomputation;
+        let mut job_pool = snarkvm_utilities::ExecutionPool::with_capacity(self.total_instances);
+        for (circuit, circuit_state) in self.circuit_specific_states.iter_mut() {
             let batch_size = circuit_state.batch_size;
 
             let private_variables = core::mem::take(&mut circuit_state.private_variables);
@@ -90,21 +82,21 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
         }
         let mut batches =
             job_pool.execute_all().into_iter().map(|w_poly| prover::WitnessPoly(w_poly)).collect::<Vec<_>>();
-        assert_eq!(batches.len(), state.total_instances);
+        assert_eq!(batches.len(), self.total_instances);
 
         let mut circuit_specific_batches = BTreeMap::new();
-        for (circuit, state) in state.circuit_specific_states.iter_mut() {
+        for (circuit, state) in self.circuit_specific_states.iter_mut() {
             let batches = batches.drain(0..state.batch_size).collect_vec();
             circuit_specific_batches.insert(circuit.id, batches);
             end_timer!(round_time);
         }
-        let mask_poly = MM::ZK.then(|| Self::calculate_mask_poly(state.max_variable_domain, rng));
+        let mask_poly = MM::ZK.then(|| Self::calculate_mask_poly(self.max_variable_domain, rng));
         let oracles = prover::FirstOracles { batches: circuit_specific_batches, mask_poly };
-        assert!(oracles.matches_info(&Self::first_round_polynomial_info(
-            state.circuit_specific_states.iter().map(|(c, s)| (&c.id, &s.batch_size))
+        assert!(oracles.matches_info(&AHPForR1CS::<F, MM>::first_round_polynomial_info(
+            self.circuit_specific_states.iter().map(|(c, s)| (&c.id, &s.batch_size))
         )));
-        state.first_round_oracles = Some(oracles);
-        Ok(state)
+        self.first_round_oracles = Some(oracles);
+        Ok(())
     }
 
     fn calculate_mask_poly<R: RngCore>(variable_domain: EvaluationDomain<F>, rng: &mut R) -> LabeledPolynomial<F> {
@@ -132,7 +124,7 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
         LabeledPolynomial::new("mask_poly".to_string(), mask_poly, None, None)
     }
 
-    fn calculate_w<'a>(
+    fn calculate_w(
         label: String,
         private_variables: Vec<F>,
         x_poly: DensePolynomial<F>,

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
@@ -29,6 +29,7 @@ use crate::{
         AHPForR1CS,
         SNARKMode,
     },
+    AlgebraicSponge,
 };
 use snarkvm_fields::{batch_inversion_and_mul, PrimeField};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, ExecutionPool};
@@ -241,5 +242,13 @@ impl<'a, F: PrimeField, MM: SNARKMode> prover::State<'a, F, MM> {
         assert!(lhs.degree() <= non_zero_domain.size() - 2);
         assert!(g.degree() <= non_zero_domain.size() - 2);
         Ok((f.coeffs[0], lhs, g, a_poly, b_poly))
+    }
+
+    pub fn verifier_fourth_round<Fq: PrimeField, R: AlgebraicSponge<Fq, 2>>(
+        &mut self,
+        fs_rng: &mut R,
+    ) -> Result<(), AHPError> {
+        self.verifier_state.as_mut().unwrap().fourth_round(fs_rng)?;
+        Ok(())
     }
 }

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -13,11 +13,6 @@
 // limitations under the License.
 
 use crate::{
-    fft::{
-        domain::{FFTPrecomputation, IFFTPrecomputation},
-        DensePolynomial,
-        EvaluationDomain,
-    },
     r1cs::ConstraintSynthesizer,
     snark::varuna::{
         ahp::{indexer::Circuit, AHPError, AHPForR1CS},
@@ -33,9 +28,11 @@ use rand::Rng;
 use rand_core::CryptoRng;
 use std::collections::BTreeMap;
 
+use crate::fft::domain::{FFTPrecomputation, IFFTPrecomputation};
+use snarkvm_utilities::cfg_iter;
+
 #[cfg(not(feature = "std"))]
 use snarkvm_utilities::println;
-use snarkvm_utilities::{cfg_iter, cfg_iter_mut};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -170,61 +167,6 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
         let state = prover::State::initialize(indices_and_assignments, fft_precomp, ifft_precomp)?;
 
         Ok(state)
-    }
-
-    /// Throughout the protocol, we are tasked with computing a zerocheck or sumcheck
-    /// of multiple polynomials over different domains.
-    /// These can be combined into a single check by taking a random linear combination
-    /// of the polynomials and multiplying them by an appropriate selector polynomial.
-    /// This function applies the random combiner and selector in an optimized way
-    fn apply_randomized_selector(
-        poly: &mut DensePolynomial<F>,
-        combiner: F,
-        target_domain: &EvaluationDomain<F>,
-        src_domain: &EvaluationDomain<F>,
-        remainder_witness: bool,
-    ) -> Result<(DensePolynomial<F>, Option<DensePolynomial<F>>)> {
-        // Let H = target_domain;
-        // Let H_i = src_domain;
-        // Let v_H := H.vanishing_polynomial();
-        // Let v_H_i := H_i.vanishing_polynomial();
-        // Let s_i := H.selector_polynomial(H_i) = (v_H / v_H_i) * (H_i.size() / H.size());
-        // Let c_i := circuit combiner
-        // Let poly_i := circuit specific polynomial which is being checked
-
-        // Instead of just multiplying each poly_i by `s_i*c_i`, we reorder the check to cancel out division by v_H
-        // This removes a mul and div by v_H operation over each circuit's (target_domain - src_domain)
-        // We have two scenario's: either we return a remainder witness or there is none.
-        if !remainder_witness {
-            // Substituting in s_i, we get that poly_i * s_i / v_H = poly_i / v_H * (H_i.size() / H.size());
-            let selector_time = start_timer!(|| "Compute selector without remainder witness");
-            let (mut h_i, remainder) = poly
-                .divide_by_vanishing_poly(*src_domain)
-                .ok_or(anyhow::anyhow!("could not divide by vanishing poly"))?;
-            assert!(remainder.is_zero());
-            let multiplier = combiner * src_domain.size_as_field_element * target_domain.size_inv;
-            cfg_iter_mut!(h_i.coeffs).for_each(|c| *c *= multiplier);
-            end_timer!(selector_time);
-            Ok((h_i, None))
-        } else {
-            // Substituting in s_i, we get that:
-            // \sum_i{poly_i}/v_H = \sum{h_i*v_H + x_g_i}
-            // \sum_i{c_i*s_i*(poly_i/v_H - x_g_i)} = \sum{h_i*v_H}
-            // \sum_i{c_i*(H_i.size()/H.size())*(poly_i/v_H_i - x_g_i*v_H/v_H_i)} = \sum{h_i*v_H}
-            // \sum_i{c_i*(H_i.size()/H.size())*(poly_i/v_H_i} = \sum{h_i*v_H} + \sum{c_i*x_g_i*(v_H/v_H_i)*(H_i.size()/H.size())}
-            // (\sum_i{c_i*s_i*poly_i})/v_H = \sum{h_i*v_H} + \sum{c_i*s_i*x_g_i}
-            // (\sum_i{c_i*s_i*poly_i})/v_H = h_1*v_H + x_g_1
-            // That's what we're computing here.
-            let selector_time = start_timer!(|| "Compute selector with remainder witness");
-            let multiplier = combiner * src_domain.size_as_field_element * target_domain.size_inv;
-            cfg_iter_mut!(poly.coeffs).for_each(|c| *c *= multiplier);
-            let (h_i, mut xg_i) = poly.divide_by_vanishing_poly(*src_domain).unwrap();
-            xg_i = xg_i.mul_by_vanishing_poly(*target_domain);
-            let (xg_i, remainder) = xg_i.divide_by_vanishing_poly(*src_domain).unwrap();
-            assert!(remainder.is_zero());
-            end_timer!(selector_time);
-            Ok((h_i, Some(xg_i)))
-        }
     }
 }
 

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
@@ -23,7 +23,8 @@ use crate::{
         Evaluations as EvaluationsOnDomain,
     },
     polycommit::sonic_pc::{LabeledPolynomial, PolynomialInfo, PolynomialLabel},
-    snark::varuna::{ahp::verifier, prover, witness_label, AHPForR1CS, SNARKMode},
+    snark::varuna::{ahp::verifier, prover, witness_label, AHPError, AHPForR1CS, SNARKMode},
+    AlgebraicSponge,
 };
 use anyhow::{anyhow, Result};
 use snarkvm_fields::PrimeField;
@@ -160,5 +161,13 @@ impl<'a, F: PrimeField, MM: SNARKMode> prover::State<'a, F, MM> {
         end_timer!(poly_time);
 
         poly
+    }
+
+    pub fn verifier_second_round<Fq: PrimeField, R: AlgebraicSponge<Fq, 2>>(
+        &mut self,
+        fs_rng: &mut R,
+    ) -> Result<(), AHPError> {
+        self.verifier_state.as_mut().unwrap().second_round(fs_rng)?;
+        Ok(())
     }
 }

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -30,6 +30,7 @@ use crate::{
         Matrix,
         SNARKMode,
     },
+    AlgebraicSponge,
 };
 
 use itertools::Itertools;
@@ -322,5 +323,13 @@ impl<'a, F: PrimeField, MM: SNARKMode> prover::State<'a, F, MM> {
         end_timer!(sumcheck_time);
 
         Ok(LinevalInstance { h_1_i, xg_1_i, sum })
+    }
+
+    pub fn verifier_third_round<Fq: PrimeField, R: AlgebraicSponge<Fq, 2>>(
+        &mut self,
+        fs_rng: &mut R,
+    ) -> Result<(), AHPError> {
+        self.verifier_state.as_mut().unwrap().third_round(fs_rng)?;
+        Ok(())
     }
 }

--- a/algorithms/src/snark/varuna/ahp/prover/state.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/state.rs
@@ -23,7 +23,13 @@ use crate::{
     },
     polycommit::sonic_pc::LabeledPolynomial,
     r1cs::{SynthesisError, SynthesisResult},
-    snark::varuna::{verifier, AHPError, AHPForR1CS, Circuit, SNARKMode},
+    snark::varuna::{
+        verifier::{self, QuerySet},
+        AHPError,
+        AHPForR1CS,
+        Circuit,
+        SNARKMode,
+    },
 };
 use anyhow::{anyhow, Result};
 #[cfg(not(feature = "serial"))]
@@ -97,7 +103,7 @@ pub struct State<'a, F: PrimeField, MM: SNARKMode> {
     /// Precomputed inverse roots for calculating inverse FFTs
     pub(in crate::snark) ifft_precomputation: &'a IFFTPrecomputation<F>,
     /// The verifier state along all rounds of the AHP
-    pub(in crate::snark) verifier_state: Option<verifier::State<F, MM>>,
+    pub(super) verifier_state: Option<verifier::State<F, MM>>,
 }
 
 /// The public inputs for a single instance.
@@ -235,6 +241,16 @@ impl<'a, F: PrimeField, MM: SNARKMode> State<'a, F, MM> {
     /// Get the zk_bound for the AHP
     pub fn zk_bound() -> Option<usize> {
         AHPForR1CS::<F, MM>::zk_bound()
+    }
+
+    /// Output the query set
+    pub fn query_set(&self) -> QuerySet<F> {
+        QuerySet::new(self.verifier_state.as_ref().unwrap())
+    }
+
+    /// Output the verifier state
+    pub fn verifier_state(&mut self) -> verifier::State<F, MM> {
+        self.verifier_state.take().unwrap()
     }
 
     /// Throughout the protocol, we are tasked with computing a zerocheck or sumcheck

--- a/algorithms/src/snark/varuna/ahp/verifier/messages.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/messages.rs
@@ -70,6 +70,12 @@ impl<F: PrimeField> FourthMessage<F> {
     }
 }
 
+/// Fifth message of the verifier.
+#[derive(Clone, Debug)]
+pub struct FifthMessage<F> {
+    pub gamma: F,
+}
+
 /// Query set of the verifier.
 #[derive(Clone, Debug)]
 pub struct QuerySet<F: PrimeField> {
@@ -89,8 +95,8 @@ pub struct QuerySet<F: PrimeField> {
 impl<F: PrimeField> QuerySet<F> {
     pub fn new<MM: SNARKMode>(state: &super::State<F, MM>) -> Self {
         let alpha = state.second_round_message.as_ref().unwrap().alpha;
-        let beta = state.third_round_message.unwrap().beta;
-        let gamma = state.gamma.unwrap();
+        let beta = state.third_round_message.as_ref().unwrap().beta;
+        let gamma = state.fifth_round_message.as_ref().unwrap().gamma;
         // The rowcheck_zerocheck, lineval_sumcheck and matrix_sumcheck are linear combinations ("virtual oracles") of other oracles
         // The rowcheck_zerocheck evaluates whether our polynomial constraints (e.g. R1CS) hold
         // The lineval_sumcheck evaluates whether those constraints hold on an evaluation of assignments multiplied by constraint matrices

--- a/algorithms/src/snark/varuna/ahp/verifier/state.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/state.rs
@@ -17,7 +17,7 @@ use core::marker::PhantomData;
 use crate::{
     fft::EvaluationDomain,
     snark::varuna::{
-        ahp::verifier::{FirstMessage, FourthMessage, SecondMessage, ThirdMessage},
+        ahp::verifier::{FifthMessage, FirstMessage, FourthMessage, SecondMessage, ThirdMessage},
         CircuitId,
         SNARKMode,
     },
@@ -58,7 +58,7 @@ pub struct State<F: PrimeField, MM: SNARKMode> {
     pub(crate) third_round_message: Option<ThirdMessage<F>>,
     /// The verifier message in the fourth round of the AHP
     pub(crate) fourth_round_message: Option<FourthMessage<F>>,
-    /// The verifier's random challenge in the last round of the AHP
-    pub(crate) gamma: Option<F>,
+    /// The verifier message in the fifth round of the AHP
+    pub(crate) fifth_round_message: Option<FifthMessage<F>>,
     pub(crate) mode: PhantomData<MM>,
 }

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -544,13 +544,13 @@ where
         }
 
         // Compute the AHP verifier's query set.
-        let query_set = prover_state.verifier_state.as_ref().unwrap().query_set();
+        let query_set = prover_state.query_set();
         let lc_s = AHPForR1CS::<_, MM>::construct_linear_combinations(
             &public_inputs,
             &polynomials,
             &prover_third_message,
             &prover_fourth_message,
-            prover_state.verifier_state.take().unwrap(),
+            prover_state.verifier_state(),
         )?;
 
         let eval_time = start_timer!(|| "Evaluating linear combinations over query set");


### PR DESCRIPTION
## Motivation

The round functions mutate prover/verifier state and keep passing it as they go along, see as a starting point
algorithms/src/snark/varuna/varuna.rs

This PR cleans that up by making round functions members of prover/verifier `State`. We also make verifier State a member of prover State.

## Test Plan

This is just a refactor which should not impact any values or tests.
