### PR TITLE
Add `unconfirmed_id` helper method for `ConfirmedTransaction`s

### DIFF
--- a/ledger/block/src/transactions/confirmed/mod.rs
+++ b/ledger/block/src/transactions/confirmed/mod.rs
@@ -115,7 +115,9 @@ impl<N: Network> ConfirmedTransaction<N> {
         }
     }
 
-    /// Returns the transaction id of the transaction before it was confirmed.
+    /// Returns the unconfirmed transaction ID, which is defined as the transaction ID prior to confirmation.
+    /// When a transaction is rejected, its fee transition is used to construct the confirmed transaction ID,
+    /// changing the original transaction ID.
     pub fn unconfirmed_id(&self) -> Result<N::TransactionID> {
         match self {
             Self::AcceptedDeploy(_, transaction, _) => Ok(transaction.id()),
@@ -321,19 +323,19 @@ mod test {
     fn test_unconfirmed_transaction_ids() {
         let rng = &mut TestRng::default();
 
-        // Ensure that the unconfirmed transaction id of an accepted deployment is equivalent to its id.
+        // Ensure that the unconfirmed transaction ID of an accepted deployment is equivalent to its confirmed transaction ID.
         let accepted_deploy = test_helpers::sample_accepted_deploy(Uniform::rand(rng), rng);
         assert_eq!(accepted_deploy.unconfirmed_id().unwrap(), accepted_deploy.id());
 
-        // Ensure that the unconfirmed transaction id of an accepted execute is equivalent to its id.
+        // Ensure that the unconfirmed transaction ID of an accepted execute is equivalent to its confirmed transaction ID.
         let accepted_execution = test_helpers::sample_accepted_execute(Uniform::rand(rng), rng);
         assert_eq!(accepted_execution.unconfirmed_id().unwrap(), accepted_execution.id());
 
-        // Ensure that the unconfirmed transaction id of a rejected deployment is not equivalent to its id.
+        // Ensure that the unconfirmed transaction ID of a rejected deployment is not equivalent to its confirmed transaction ID.
         let rejected_deploy = test_helpers::sample_rejected_deploy(Uniform::rand(rng), rng);
         assert_ne!(rejected_deploy.unconfirmed_id().unwrap(), rejected_deploy.id());
 
-        // Ensure that the unconfirmed transaction id of a rejected execute is not equivalent to its id.
+        // Ensure that the unconfirmed transaction ID of a rejected execute is not equivalent to its confirmed transaction ID.
         let rejected_execution = test_helpers::sample_rejected_execute(Uniform::rand(rng), rng);
         assert_ne!(rejected_execution.unconfirmed_id().unwrap(), rejected_execution.id());
     }

--- a/ledger/block/src/transactions/confirmed/mod.rs
+++ b/ledger/block/src/transactions/confirmed/mod.rs
@@ -114,20 +114,6 @@ impl<N: Network> ConfirmedTransaction<N> {
             false => bail!("Transaction '{}' is not a fee transaction", transaction.id()),
         }
     }
-
-    /// Returns the unconfirmed transaction ID, which is defined as the transaction ID prior to confirmation.
-    /// When a transaction is rejected, its fee transition is used to construct the confirmed transaction ID,
-    /// changing the original transaction ID.
-    pub fn unconfirmed_id(&self) -> Result<N::TransactionID> {
-        match self {
-            Self::AcceptedDeploy(_, transaction, _) => Ok(transaction.id()),
-            Self::AcceptedExecute(_, transaction, _) => Ok(transaction.id()),
-            Self::RejectedDeploy(_, fee_transaction, rejected)
-            | Self::RejectedExecute(_, fee_transaction, rejected) => {
-                Ok(rejected.to_unconfirmed_id(&fee_transaction.fee_transition())?.into())
-            }
-        }
-    }
 }
 
 impl<N: Network> ConfirmedTransaction<N> {
@@ -200,6 +186,20 @@ impl<N: Network> ConfirmedTransaction<N> {
             Self::AcceptedDeploy(_, _, finalize) => Some(finalize),
             Self::AcceptedExecute(_, _, finalize) => Some(finalize),
             Self::RejectedDeploy(..) | Self::RejectedExecute(..) => None,
+        }
+    }
+
+    /// Returns the unconfirmed transaction ID, which is defined as the transaction ID prior to confirmation.
+    /// When a transaction is rejected, its fee transition is used to construct the confirmed transaction ID,
+    /// changing the original transaction ID.
+    pub fn unconfirmed_id(&self) -> Result<N::TransactionID> {
+        match self {
+            Self::AcceptedDeploy(_, transaction, _) => Ok(transaction.id()),
+            Self::AcceptedExecute(_, transaction, _) => Ok(transaction.id()),
+            Self::RejectedDeploy(_, fee_transaction, rejected)
+            | Self::RejectedExecute(_, fee_transaction, rejected) => {
+                Ok(rejected.to_unconfirmed_id(&fee_transaction.fee_transition())?.into())
+            }
         }
     }
 }

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -80,7 +80,9 @@ impl<N: Network> Rejected<N> {
         }
     }
 
-    /// Returns the transaction id of the transaction before it was rejected.
+    /// Returns the unconfirmed transaction ID, which is defined as the transaction ID prior to confirmation.
+    /// When a transaction is rejected, its fee transition is used to construct the confirmed transaction ID,
+    /// changing the original transaction ID.
     pub fn to_unconfirmed_id(&self, fee: &Option<Fee<N>>) -> Result<Field<N>> {
         match self {
             Self::Deployment(_, deployment) => Ok(*Transaction::deployment_tree(deployment, fee.as_ref())?.root()),

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -18,7 +18,7 @@ mod string;
 
 use super::*;
 
-use crate::{Deployment, Execution};
+use crate::{Deployment, Execution, Fee};
 
 /// A wrapper around the rejected deployment or execution.
 #[derive(Clone, PartialEq, Eq)]
@@ -77,6 +77,14 @@ impl<N: Network> Rejected<N> {
         match self {
             Self::Deployment(_, deployment) => deployment.to_deployment_id(),
             Self::Execution(execution) => execution.to_execution_id(),
+        }
+    }
+
+    /// Returns the transaction id of the transaction before it was rejected.
+    pub fn to_unconfirmed_id(&self, fee: &Option<Fee<N>>) -> Result<Field<N>> {
+        match self {
+            Self::Deployment(_, deployment) => Ok(*Transaction::deployment_tree(deployment, fee.as_ref())?.root()),
+            Self::Execution(execution) => Ok(*Transaction::execution_tree(execution, fee)?.root()),
         }
     }
 }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -247,6 +247,7 @@ finalize failed_assert:
             rng,
         )
         .unwrap();
+    let failed_assert_transaction_id = failed_assert_transaction.id();
 
     // Construct the next block containing the new transaction.
     let next_block = ledger
@@ -264,6 +265,9 @@ finalize failed_assert:
 
         assert_eq!(confirmed_transaction, &expected_confirmed_transaction);
     }
+
+    // Check that the unconfirmed transaction id of the rejected execution is correct.
+    assert_eq!(confirmed_transaction.unconfirmed_id().unwrap(), failed_assert_transaction_id);
 
     // Check that the next block is valid.
     ledger.check_next_block(&next_block).unwrap();

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -266,7 +266,7 @@ finalize failed_assert:
         assert_eq!(confirmed_transaction, &expected_confirmed_transaction);
     }
 
-    // Check that the unconfirmed transaction id of the rejected execution is correct.
+    // Check that the unconfirmed transaction ID of the rejected execution is correct.
     assert_eq!(confirmed_transaction.unconfirmed_id().unwrap(), failed_assert_transaction_id);
 
     // Check that the next block is valid.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -559,6 +559,7 @@ finalize transfer_public:
 
         // Fetch a deployment transaction.
         let deployment_transaction = crate::vm::test_helpers::sample_deployment_transaction(rng);
+        let deployment_transaction_id = deployment_transaction.id();
 
         // Construct the program name.
         let program_id = ProgramID::from_str("testing.aleo").unwrap();
@@ -587,6 +588,9 @@ finalize transfer_public:
             vm.atomic_speculate(sample_finalize_state(1), [deployment_transaction].iter()).unwrap();
         assert_eq!(candidate_transactions.len(), 1);
         assert!(matches!(candidate_transactions[0], ConfirmedTransaction::RejectedDeploy(..)));
+
+        // Check that the unconfirmed transaction id of the rejected deployment is correct.
+        assert_eq!(candidate_transactions[0].unconfirmed_id().unwrap(), deployment_transaction_id);
     }
 
     #[test]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a helper method to derive the `ConfirmedTransaction`'s original `unconfirmed_id` before it was confirmed. 

In the case of an accepted deploy or execute, the id remains the same. 
In the case of a rejected deploy or execute, we regenerate the original transaction id by rebuilding the deployment or execution trees.

Note: We may want to consider adding a DataMap that stores the reference of the original transaction ids to the confirmed transaction ids. This will be helpful for users to find their rejected transactions on chain.