### PR TITLE
Add profiler for deployment verification of a large program

### DIFF
--- a/synthesizer/process/src/resources/large_functions.aleo
+++ b/synthesizer/process/src/resources/large_functions.aleo
@@ -1,0 +1,242 @@
+import credits.aleo;
+
+program large_functions.aleo;
+
+function join_3:
+    input r0 as credits.aleo/credits.record;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    assert.eq r0.owner r1.owner;
+    assert.eq r1.owner r2.owner;
+    call credits.aleo/join r0 r1 into r3;
+    call credits.aleo/join r3 r2 into r4;
+    output r4 as credits.aleo/credits.record;
+
+function join_5:
+    input r0 as credits.aleo/credits.record;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    assert.eq r0.owner r1.owner;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    call credits.aleo/join r0 r1 into r5;
+    call credits.aleo/join r2 r3 into r6;
+    call credits.aleo/join r5 r6 into r7;
+    call credits.aleo/join r7 r4 into r8;
+    output r8 as credits.aleo/credits.record;
+
+function join6:
+    input r0 as credits.aleo/credits.record;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    input r5 as credits.aleo/credits.record;
+    assert.eq r0.owner r1.owner;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    assert.eq r4.owner r5.owner;
+    call credits.aleo/join r0 r1 into r6;
+    call credits.aleo/join r2 r3 into r7;
+    call credits.aleo/join r4 r5 into r8;
+    call credits.aleo/join r6 r7 into r9;
+    call credits.aleo/join r9 r8 into r10;
+    output r10 as credits.aleo/credits.record;
+
+function join7:
+    input r0 as credits.aleo/credits.record;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    input r5 as credits.aleo/credits.record;
+    input r6 as credits.aleo/credits.record;
+    assert.eq r0.owner r1.owner;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    assert.eq r4.owner r5.owner;
+    assert.eq r5.owner r6.owner;
+    call credits.aleo/join r0 r1 into r7;
+    call credits.aleo/join r2 r3 into r8;
+    call credits.aleo/join r4 r5 into r9;
+    call credits.aleo/join r7 r8 into r10;
+    call credits.aleo/join r10 r9 into r11;
+    call credits.aleo/join r11 r6 into r12;
+    output r12 as credits.aleo/credits.record;
+
+function join8:
+    input r0 as credits.aleo/credits.record;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    input r5 as credits.aleo/credits.record;
+    input r6 as credits.aleo/credits.record;
+    input r7 as credits.aleo/credits.record;
+    assert.eq r0.owner r1.owner;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    assert.eq r4.owner r5.owner;
+    assert.eq r5.owner r6.owner;
+    assert.eq r6.owner r7.owner;
+    call credits.aleo/join r0 r1 into r8;
+    call credits.aleo/join r2 r3 into r9;
+    call credits.aleo/join r4 r5 into r10;
+    call credits.aleo/join r6 r7 into r11;
+    call credits.aleo/join r8 r9 into r12;
+    call credits.aleo/join r11 r10 into r13;
+    call credits.aleo/join r12 r13 into r14;
+    output r14 as credits.aleo/credits.record;
+
+function join9:
+    input r0 as credits.aleo/credits.record;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    input r5 as credits.aleo/credits.record;
+    input r6 as credits.aleo/credits.record;
+    input r7 as credits.aleo/credits.record;
+    input r8 as credits.aleo/credits.record;
+    assert.eq r0.owner r1.owner;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    assert.eq r4.owner r5.owner;
+    assert.eq r5.owner r6.owner;
+    assert.eq r6.owner r7.owner;
+    assert.eq r7.owner r8.owner;
+    call credits.aleo/join r0 r1 into r9;
+    call credits.aleo/join r2 r3 into r10;
+    call credits.aleo/join r4 r5 into r11;
+    call credits.aleo/join r6 r7 into r12;
+    call credits.aleo/join r9 r10 into r13;
+    call credits.aleo/join r12 r11 into r14;
+    call credits.aleo/join r13 r14 into r15;
+    call credits.aleo/join r15 r8 into r16;
+    output r16 as credits.aleo/credits.record;
+
+function join10:
+    input r0 as credits.aleo/credits.record;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    input r5 as credits.aleo/credits.record;
+    input r6 as credits.aleo/credits.record;
+    input r7 as credits.aleo/credits.record;
+    input r8 as credits.aleo/credits.record;
+    input r9 as credits.aleo/credits.record;
+    assert.eq r0.owner r1.owner;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    assert.eq r4.owner r5.owner;
+    assert.eq r5.owner r6.owner;
+    assert.eq r6.owner r7.owner;
+    assert.eq r7.owner r8.owner;
+    assert.eq r8.owner r9.owner;
+    call credits.aleo/join r0 r1 into r10;
+    call credits.aleo/join r2 r3 into r11;
+    call credits.aleo/join r4 r5 into r12;
+    call credits.aleo/join r6 r7 into r13;
+    call credits.aleo/join r8 r9 into r14;
+    call credits.aleo/join r10 r11 into r15;
+    call credits.aleo/join r13 r12 into r16;
+    call credits.aleo/join r15 r16 into r17;
+    call credits.aleo/join r17 r14 into r18;
+    output r18 as credits.aleo/credits.record;
+
+function transfer_3:
+    input r0 as address.private;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    call credits.aleo/transfer_private r1 r0 r1.microcredits into r4 r5;
+    call credits.aleo/transfer_private r2 r0 r2.microcredits into r6 r7;
+    call credits.aleo/transfer_private r3 r0 r3.microcredits into r8 r9;
+    output r4 as credits.aleo/credits.record;
+    output r5 as credits.aleo/credits.record;
+    output r6 as credits.aleo/credits.record;
+    output r7 as credits.aleo/credits.record;
+    output r8 as credits.aleo/credits.record;
+    output r9 as credits.aleo/credits.record;
+
+function transfer_5:
+    input r0 as address.private;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    input r5 as credits.aleo/credits.record;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    assert.eq r4.owner r5.owner;
+    call credits.aleo/transfer_private r1 r0 r1.microcredits into r6 r7;
+    call credits.aleo/transfer_private r2 r0 r2.microcredits into r8 r9;
+    call credits.aleo/transfer_private r3 r0 r3.microcredits into r10 r11;
+    call credits.aleo/transfer_private r4 r0 r4.microcredits into r12 r13;
+    call credits.aleo/transfer_private r5 r0 r5.microcredits into r14 r15;
+    output r6 as credits.aleo/credits.record;
+    output r7 as credits.aleo/credits.record;
+    output r8 as credits.aleo/credits.record;
+    output r9 as credits.aleo/credits.record;
+    output r10 as credits.aleo/credits.record;
+    output r11 as credits.aleo/credits.record;
+    output r12 as credits.aleo/credits.record;
+    output r13 as credits.aleo/credits.record;
+    output r14 as credits.aleo/credits.record;
+    output r15 as credits.aleo/credits.record;
+
+function split_3:
+    input r0 as u64.private;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    call credits.aleo/split r1 r0 into r4 r5;
+    call credits.aleo/split r2 r0 into r6 r7;
+    call credits.aleo/split r3 r0 into r8 r9;
+    output r4 as credits.aleo/credits.record;
+    output r5 as credits.aleo/credits.record;
+    output r6 as credits.aleo/credits.record;
+    output r7 as credits.aleo/credits.record;
+    output r8 as credits.aleo/credits.record;
+    output r9 as credits.aleo/credits.record;
+
+function split_5:
+    input r0 as u64.private;
+    input r1 as credits.aleo/credits.record;
+    input r2 as credits.aleo/credits.record;
+    input r3 as credits.aleo/credits.record;
+    input r4 as credits.aleo/credits.record;
+    input r5 as credits.aleo/credits.record;
+    assert.eq r1.owner r2.owner;
+    assert.eq r2.owner r3.owner;
+    assert.eq r3.owner r4.owner;
+    assert.eq r4.owner r5.owner;
+    call credits.aleo/split r1 r0 into r6 r7;
+    call credits.aleo/split r2 r0 into r8 r9;
+    call credits.aleo/split r3 r0 into r10 r11;
+    call credits.aleo/split r4 r0 into r12 r13;
+    call credits.aleo/split r5 r0 into r14 r15;
+    output r6 as credits.aleo/credits.record;
+    output r7 as credits.aleo/credits.record;
+    output r8 as credits.aleo/credits.record;
+    output r9 as credits.aleo/credits.record;
+    output r10 as credits.aleo/credits.record;
+    output r11 as credits.aleo/credits.record;
+    output r12 as credits.aleo/credits.record;
+    output r13 as credits.aleo/credits.record;
+    output r14 as credits.aleo/credits.record;
+    output r15 as credits.aleo/credits.record;

--- a/synthesizer/process/src/verify_deployment.rs
+++ b/synthesizer/process/src/verify_deployment.rs
@@ -40,3 +40,31 @@ impl<N: Network> Process<N> {
         verification
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type CurrentAleo = circuit::network::AleoV0;
+
+    /// Use `cargo test profiler --features timer` to run this test.
+    #[ignore]
+    #[test]
+    fn test_profiler() -> Result<()> {
+        let rng = &mut TestRng::default();
+
+        // Initialize the process.
+        let process = Process::load()?;
+
+        // Fetch the large program to deploy.
+        let large_program = Program::from_str(include_str!("./resources/large_functions.aleo"))?;
+
+        // Create a deployment for the program.
+        let deployment = process.deploy::<CurrentAleo, _>(&large_program, rng)?;
+
+        // Verify the deployment.
+        assert!(process.verify_deployment::<CurrentAleo, _>(&deployment, rng).is_ok());
+
+        bail!("\n\nRemember to #[ignore] this test!\n\n")
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a profiler for `verify_deployment` for a large program defined in `synthesizer/process/src/resources/large_functions.aleo`. These functions perform many `calls` to `credits.aleo` functions, which greatly increase the `verify_deployment` time.