### PR TITLE
Speed up PoseidonGrainLFSR::new

### DIFF
--- a/fields/src/traits/poseidon_grain_lfsr.rs
+++ b/fields/src/traits/poseidon_grain_lfsr.rs
@@ -77,11 +77,8 @@ impl PoseidonGrainLFSR {
             }
         }
 
-        #[allow(clippy::needless_range_loop)]
         // b50, ..., b79 are set to 1
-        for i in 50..=79 {
-            state[i] = true;
-        }
+        state[50..=79].copy_from_slice(&[true; 30]);
 
         // Initialize.
         let mut res = Self { field_size_in_bits, state, head: 0 };


### PR DESCRIPTION
Instead of updating 30 bits individually, update them all at once with `copy_from_slice`; this appeases `clippy` and should make the operation a lot times faster (>15x when I benchmarked it locally), at least in unoptimized builds.