### PR TITLE
Improve the performance of R1CS

### DIFF
--- a/circuit/environment/src/helpers/counter.rs
+++ b/circuit/environment/src/helpers/counter.rs
@@ -15,15 +15,17 @@
 use crate::*;
 use snarkvm_fields::PrimeField;
 
+use std::rc::Rc;
+
 #[derive(Debug, Default)]
 pub(crate) struct Counter<F: PrimeField> {
     scope: Scope,
-    constraints: Vec<Constraint<F>>,
+    constraints: Vec<Rc<Constraint<F>>>,
     constants: u64,
     public: u64,
     private: u64,
     nonzeros: (u64, u64, u64),
-    parents: Vec<(Scope, Vec<Constraint<F>>, u64, u64, u64, (u64, u64, u64))>,
+    parents: Vec<(Scope, Vec<Rc<Constraint<F>>>, u64, u64, u64, (u64, u64, u64))>,
 }
 
 impl<F: PrimeField> Counter<F> {
@@ -91,7 +93,7 @@ impl<F: PrimeField> Counter<F> {
     }
 
     /// Increments the number of constraints by 1.
-    pub(crate) fn add_constraint(&mut self, constraint: Constraint<F>) {
+    pub(crate) fn add_constraint(&mut self, constraint: Rc<Constraint<F>>) {
         let (a_nonzeros, b_nonzeros, c_nonzeros) = constraint.num_nonzeros();
         self.nonzeros.0 += a_nonzeros;
         self.nonzeros.1 += b_nonzeros;

--- a/circuit/environment/src/helpers/counter.rs
+++ b/circuit/environment/src/helpers/counter.rs
@@ -15,7 +15,7 @@
 use crate::*;
 use snarkvm_fields::PrimeField;
 
-use std::rc::Rc;
+use std::{mem, rc::Rc};
 
 #[derive(Debug, Default)]
 pub(crate) struct Counter<F: PrimeField> {
@@ -44,7 +44,7 @@ impl<F: PrimeField> Counter<F> {
                 // Save the current scope members.
                 self.parents.push((
                     self.scope.clone(),
-                    self.constraints.clone(),
+                    mem::take(&mut self.constraints),
                     self.constants,
                     self.public,
                     self.private,
@@ -53,7 +53,6 @@ impl<F: PrimeField> Counter<F> {
 
                 // Initialize the new scope members.
                 self.scope = scope;
-                self.constraints = Default::default();
                 self.constants = 0;
                 self.public = 0;
                 self.private = 0;

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -27,7 +27,7 @@ pub struct R1CS<F: PrimeField> {
     constants: Vec<Variable<F>>,
     public: Vec<Variable<F>>,
     private: Vec<Variable<F>>,
-    constraints: Vec<Constraint<F>>,
+    constraints: Vec<Rc<Constraint<F>>>,
     counter: Counter<F>,
     nonzeros: (u64, u64, u64),
 }
@@ -86,7 +86,8 @@ impl<F: PrimeField> R1CS<F> {
         self.nonzeros.1 += b_nonzeros;
         self.nonzeros.2 += c_nonzeros;
 
-        self.constraints.push(constraint.clone());
+        let constraint = Rc::new(constraint);
+        self.constraints.push(Rc::clone(&constraint));
         self.counter.add_constraint(constraint);
     }
 
@@ -166,7 +167,7 @@ impl<F: PrimeField> R1CS<F> {
     }
 
     /// Returns the constraints in the constraint system.
-    pub fn to_constraints(&self) -> &Vec<Constraint<F>> {
+    pub fn to_constraints(&self) -> &Vec<Rc<Constraint<F>>> {
         &self.constraints
     }
 }


### PR DESCRIPTION
I found this while working on improving the performance of Keccak introduced in https://github.com/AleoHQ/snarkVM/pull/1911; with this change and a benchmark I was using locally (similar to `check_hash`), the difference in performance is as follows:

runtime: -34%
allocations: -19%
max RAM: -60%