### PR TITLE
Handle fee amounts

### DIFF
--- a/ledger/src/check_transaction_basic.rs
+++ b/ledger/src/check_transaction_basic.rs
@@ -17,33 +17,10 @@ use super::*;
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Checks the given transaction is well-formed and unique.
     pub fn check_transaction_basic(&self, transaction: &Transaction<N>, rejected_id: Option<Field<N>>) -> Result<()> {
-        let transaction_id = transaction.id();
-
         /* Fee */
 
-        // If the transaction contains only 1 transition, and the transition is a split, then the fee can be skipped.
-        let is_fee_required = match transaction.execution() {
-            Some(execution) => !(execution.len() == 1 && transaction.contains_split()),
-            None => true,
-        };
-
-        if is_fee_required {
-            // Retrieve the transaction fee.
-            let fee_amount = *transaction.fee_amount()?;
-            // Retrieve the minimum cost of the transaction.
-            let (cost, _) = match transaction {
-                // Compute the deployment cost.
-                Transaction::Deploy(_, _, deployment, _) => synthesizer::deployment_cost(deployment)?,
-                // Compute the execution cost.
-                Transaction::Execute(_, execution, _) => synthesizer::execution_cost(self.vm(), execution)?,
-                // TODO (howardwu): Plug in the Rejected struct, to compute the cost.
-                Transaction::Fee(_, _) => (0, (0, 0)),
-            };
-            // Ensure the transaction has a sufficient fee.
-            if cost > fee_amount {
-                bail!("Transaction '{transaction_id}' has an insufficient fee - expected at least {cost} microcredits")
-            }
-        }
+        // Ensure the transaction fee amount is sufficient.
+        self.vm().check_fee_amount(transaction)?;
 
         /* Transaction */
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -204,7 +204,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             }
 
             // Ensure all transactions were processed.
-            if confirmed.len() != num_transactions {
+            if confirmed.len() + aborted.len() != num_transactions {
                 // Note: This will abort the entire atomic batch.
                 return Err("Not all transactions were processed in 'VM::atomic_speculate'".to_string());
             }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR aborts transactions in `atomic_speculate` if the transaction does not have sufficient fee to pay for the transaction.

NOTE: This model will change slightly with the introduction of a gas-like model of pay for execution. It will likely be cleaner to do that approach first.

TODO:
- [ ] For private fees, we need to consume this record (despite the insufficient amount)
- [ ] For public fees, we need to consume this amount from the public balance (despite the insufficient amount). This will be done in a subsequent Ratify operation.
    - In addition, we must check if the spender of the fee even has the amount to spend.