### PR TITLE
Renames `Struct` to `StructType`

### DIFF
--- a/console/program/src/data_types/mod.rs
+++ b/console/program/src/data_types/mod.rs
@@ -24,8 +24,8 @@ pub use record_type::{EntryType, RecordType};
 mod register_type;
 pub use register_type::RegisterType;
 
-mod struct_;
-pub use struct_::Struct;
+mod struct_type;
+pub use struct_type::StructType;
 
 mod value_type;
 pub use value_type::ValueType;

--- a/console/program/src/data_types/struct_type/bytes.rs
+++ b/console/program/src/data_types/struct_type/bytes.rs
@@ -14,10 +14,10 @@
 
 use super::*;
 
-impl<N: Network> FromBytes for Struct<N> {
-    /// Reads a struct from a buffer.
+impl<N: Network> FromBytes for StructType<N> {
+    /// Reads a struct type from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        // Read the name of the struct.
+        // Read the name of the struct type.
         let name = Identifier::read_le(&mut reader)?;
 
         // Read the number of members.
@@ -25,7 +25,7 @@ impl<N: Network> FromBytes for Struct<N> {
         // Ensure the number of members is within the maximum limit.
         if num_members as usize > N::MAX_STRUCT_ENTRIES {
             return Err(error(format!(
-                "Struct exceeds size: expected <= {}, found {num_members}",
+                "StructType exceeds size: expected <= {}, found {num_members}",
                 N::MAX_STRUCT_ENTRIES
             )));
         }
@@ -46,8 +46,8 @@ impl<N: Network> FromBytes for Struct<N> {
     }
 }
 
-impl<N: Network> ToBytes for Struct<N> {
-    /// Writes the struct to a buffer.
+impl<N: Network> ToBytes for StructType<N> {
+    /// Writes the struct type to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Ensure the number of members is within the maximum limit.
         if self.members.len() > N::MAX_STRUCT_ENTRIES {
@@ -80,8 +80,8 @@ mod tests {
     #[test]
     fn test_bytes() -> Result<()> {
         let expected =
-            Struct::<CurrentNetwork>::from_str("struct message:\n    first as field;\n    second as field;")?;
-        let candidate = Struct::from_bytes_le(&expected.to_bytes_le().unwrap()).unwrap();
+            StructType::<CurrentNetwork>::from_str("struct message:\n    first as field;\n    second as field;")?;
+        let candidate = StructType::from_bytes_le(&expected.to_bytes_le().unwrap()).unwrap();
         assert_eq!(expected, candidate);
         Ok(())
     }

--- a/console/program/src/data_types/struct_type/mod.rs
+++ b/console/program/src/data_types/struct_type/mod.rs
@@ -22,28 +22,28 @@ use snarkvm_console_network::prelude::*;
 use indexmap::IndexMap;
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct Struct<N: Network> {
+pub struct StructType<N: Network> {
     /// The name of the struct.
     name: Identifier<N>,
     /// The name and type for the members of the struct.
     members: IndexMap<Identifier<N>, PlaintextType<N>>,
 }
 
-impl<N: Network> Struct<N> {
-    /// Returns the name of the struct.
+impl<N: Network> StructType<N> {
+    /// Returns the name of the struct type.
     #[inline]
     pub const fn name(&self) -> &Identifier<N> {
         &self.name
     }
 
-    /// Returns the members of the struct.
+    /// Returns the members of the struct type.
     #[inline]
     pub const fn members(&self) -> &IndexMap<Identifier<N>, PlaintextType<N>> {
         &self.members
     }
 }
 
-impl<N: Network> TypeName for Struct<N> {
+impl<N: Network> TypeName for StructType<N> {
     /// Returns the type name.
     fn type_name() -> &'static str {
         "struct"

--- a/console/program/src/data_types/struct_type/serialize.rs
+++ b/console/program/src/data_types/struct_type/serialize.rs
@@ -14,8 +14,8 @@
 
 use super::*;
 
-impl<N: Network> Serialize for Struct<N> {
-    /// Serializes the struct into string or bytes.
+impl<N: Network> Serialize for StructType<N> {
+    /// Serializes the struct type into string or bytes.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => serializer.collect_str(self),
@@ -24,12 +24,12 @@ impl<N: Network> Serialize for Struct<N> {
     }
 }
 
-impl<'de, N: Network> Deserialize<'de> for Struct<N> {
-    /// Deserializes the struct from a string or bytes.
+impl<'de, N: Network> Deserialize<'de> for StructType<N> {
+    /// Deserializes the struct type from a string or bytes.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "struct"),
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "struct type"),
         }
     }
 }
@@ -77,14 +77,14 @@ mod tests {
     #[test]
     fn test_serde_json() {
         for case in TEST_CASES.iter() {
-            check_serde_json(Struct::<CurrentNetwork>::from_str(case).unwrap());
+            check_serde_json(StructType::<CurrentNetwork>::from_str(case).unwrap());
         }
     }
 
     #[test]
     fn test_bincode() {
         for case in TEST_CASES.iter() {
-            check_bincode(Struct::<CurrentNetwork>::from_str(case).unwrap());
+            check_bincode(StructType::<CurrentNetwork>::from_str(case).unwrap());
         }
     }
 }

--- a/synthesizer/process/src/stack/finalize_types/matches.rs
+++ b/synthesizer/process/src/stack/finalize_types/matches.rs
@@ -20,7 +20,7 @@ impl<N: Network> FinalizeTypes<N> {
         &self,
         stack: &(impl StackMatches<N> + StackProgram<N>),
         operands: &[Operand<N>],
-        struct_: &Struct<N>,
+        struct_: &StructType<N>,
     ) -> Result<()> {
         // Retrieve the struct name.
         let struct_name = struct_.name();

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -17,7 +17,7 @@ mod matches;
 
 use console::{
     network::prelude::*,
-    program::{Identifier, LiteralType, PlaintextType, Register, RegisterType, Struct},
+    program::{Identifier, LiteralType, PlaintextType, Register, RegisterType, StructType},
 };
 use synthesizer_program::{
     Command,

--- a/synthesizer/process/src/stack/register_types/matches.rs
+++ b/synthesizer/process/src/stack/register_types/matches.rs
@@ -20,7 +20,7 @@ impl<N: Network> RegisterTypes<N> {
         &self,
         stack: &(impl StackMatches<N> + StackProgram<N>),
         operands: &[Operand<N>],
-        struct_: &Struct<N>,
+        struct_: &StructType<N>,
     ) -> Result<()> {
         // Retrieve the struct name.
         let struct_name = struct_.name();

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -25,7 +25,7 @@ use console::{
         RecordType,
         Register,
         RegisterType,
-        Struct,
+        StructType,
         ValueType,
     },
 };

--- a/synthesizer/program/src/bytes.rs
+++ b/synthesizer/program/src/bytes.rs
@@ -48,7 +48,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Fro
                 // Read the mapping.
                 0 => program.add_mapping(Mapping::read_le(&mut reader)?).map_err(|e| error(e.to_string()))?,
                 // Read the struct.
-                1 => program.add_struct(Struct::read_le(&mut reader)?).map_err(|e| error(e.to_string()))?,
+                1 => program.add_struct(StructType::read_le(&mut reader)?).map_err(|e| error(e.to_string()))?,
                 // Read the record.
                 2 => program.add_record(RecordType::read_le(&mut reader)?).map_err(|e| error(e.to_string()))?,
                 // Read the closure.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -84,7 +84,7 @@ use console::{
         TypeName,
         Write,
     },
-    program::{EntryType, Identifier, PlaintextType, ProgramID, RecordType, Struct},
+    program::{EntryType, Identifier, PlaintextType, ProgramID, RecordType, StructType},
 };
 
 use indexmap::IndexMap;
@@ -114,7 +114,7 @@ pub struct ProgramCore<N: Network, Instruction: InstructionTrait<N>, Command: Co
     /// A map of the declared mappings for the program.
     mappings: IndexMap<Identifier<N>, Mapping<N>>,
     /// A map of the declared structs for the program.
-    structs: IndexMap<Identifier<N>, Struct<N>>,
+    structs: IndexMap<Identifier<N>, StructType<N>>,
     /// A map of the declared record types for the program.
     records: IndexMap<Identifier<N>, RecordType<N>>,
     /// A map of the declared closures for the program.
@@ -164,7 +164,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
     }
 
     /// Returns the structs in the program.
-    pub const fn structs(&self) -> &IndexMap<Identifier<N>, Struct<N>> {
+    pub const fn structs(&self) -> &IndexMap<Identifier<N>, StructType<N>> {
         &self.structs
     }
 
@@ -224,7 +224,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
     }
 
     /// Returns the struct with the given name.
-    pub fn get_struct(&self, name: &Identifier<N>) -> Result<Struct<N>> {
+    pub fn get_struct(&self, name: &Identifier<N>) -> Result<StructType<N>> {
         // Attempt to retrieve the struct.
         let struct_ = self.structs.get(name).cloned().ok_or_else(|| anyhow!("Struct '{name}' is not defined."))?;
         // Ensure the struct name matches.
@@ -350,7 +350,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
     /// This method will halt if the struct name is a reserved opcode or keyword.
     /// This method will halt if any structs in the struct's members are not already defined.
     #[inline]
-    fn add_struct(&mut self, struct_: Struct<N>) -> Result<()> {
+    fn add_struct(&mut self, struct_: StructType<N>) -> Result<()> {
         // Retrieve the struct name.
         let struct_name = *struct_.name();
 
@@ -668,7 +668,7 @@ mapping message:
     #[test]
     fn test_program_struct() -> Result<()> {
         // Create a new struct.
-        let struct_ = Struct::<CurrentNetwork>::from_str(
+        let struct_ = StructType::<CurrentNetwork>::from_str(
             r"
 struct message:
     first as field;

--- a/synthesizer/program/src/parse.rs
+++ b/synthesizer/program/src/parse.rs
@@ -23,7 +23,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Par
         // A helper to parse a program.
         enum P<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> {
             M(Mapping<N>),
-            I(Struct<N>),
+            I(StructType<N>),
             R(RecordType<N>),
             C(ClosureCore<N, Instruction>),
             F(FunctionCore<N, Instruction, Command>),
@@ -47,7 +47,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Par
         // Parse the struct or function from the string.
         let (string, components) = many1(alt((
             map(Mapping::parse, |mapping| P::<N, Instruction, Command>::M(mapping)),
-            map(Struct::parse, |struct_| P::<N, Instruction, Command>::I(struct_)),
+            map(StructType::parse, |struct_| P::<N, Instruction, Command>::I(struct_)),
             map(RecordType::parse, |record| P::<N, Instruction, Command>::R(record)),
             map(ClosureCore::parse, |closure| P::<N, Instruction, Command>::C(closure)),
             map(FunctionCore::parse, |function| P::<N, Instruction, Command>::F(function)),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Renames `Struct` to `StructType`.

This is to align with the naming convention of all the other data type instantiations.
