### PR TITLE
Update varuna test

### DIFF
--- a/algorithms/src/snark/varuna/ahp/verifier/verifier.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/verifier.rs
@@ -152,7 +152,7 @@ impl<TargetField: PrimeField, MM: SNARKMode> AHPForR1CS<TargetField, MM> {
     ) -> Result<(ThirdMessage<TargetField>, State<TargetField, MM>), AHPError> {
         let elems = fs_rng.squeeze_nonnative_field_elements(1);
         let beta = elems[0];
-        assert!(!state.max_constraint_domain.evaluate_vanishing_polynomial(beta).is_zero());
+        assert!(!state.max_variable_domain.evaluate_vanishing_polynomial(beta).is_zero());
 
         let message = ThirdMessage { beta };
         state.third_round_message = Some(message);
@@ -192,6 +192,7 @@ impl<TargetField: PrimeField, MM: SNARKMode> AHPForR1CS<TargetField, MM> {
     ) -> Result<State<TargetField, MM>, AHPError> {
         let elems = fs_rng.squeeze_nonnative_field_elements(1);
         let gamma = elems[0];
+        assert!(!state.max_non_zero_domain.evaluate_vanishing_polynomial(gamma).is_zero());
 
         state.gamma = Some(gamma);
         Ok(state)

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -328,7 +328,7 @@ where
     #[allow(clippy::only_used_in_recursion)]
     /// This is the main entrypoint for creating proofs.
     /// You can find a specification of the prover algorithm in:
-    /// https://github.com/AleoHQ/protocol-docs/tree/main/marlin
+    /// https://github.com/AleoHQ/protocol-docs/tree/main/snark/varuna
     fn prove_batch<C: ConstraintSynthesizer<E::Fr>, R: Rng + CryptoRng>(
         universal_prover: &Self::UniversalProver,
         fs_parameters: &Self::FSParameters,


### PR DESCRIPTION
Time for a smaller PR. I noticed we were inconsistent in checking whether our challenges were sampled correctly. It is easy to see that in `verifier.rs` we were doing a proper check that evaluation challenge `alpha` was not in `constraint_domain` evaluation domain. This PR fixes that `beta` and `gamma` are not in the `variable_domain` and `non_zero_domain` respectively.
