### PR TITLE
Check circuit id and info in verify_vk

### DIFF
--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -43,7 +43,7 @@ use snarkvm_utilities::println;
 use super::Matrix;
 
 impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
-    /// Generate the index for this constraint system.
+    /// Generate the index polynomials for this constraint system.
     pub fn index<C: ConstraintSynthesizer<F>>(c: &C) -> Result<Circuit<F, MM>> {
         let IndexerState {
             constraint_domain,
@@ -62,8 +62,8 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
             c_evals,
 
             index_info,
+            id,
         } = Self::index_helper(c).map_err(|e| anyhow!("{e:?}"))?;
-        let id = Circuit::<F, MM>::hash(&index_info, &a, &b, &c).unwrap();
         let joint_arithmetization_time = start_timer!(|| format!("Arithmetizing A,B,C {id}"));
 
         let [a_arith, b_arith, c_arith]: [_; 3] = [("a", a_evals), ("b", b_evals), ("c", c_evals)]
@@ -128,7 +128,9 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
         })
     }
 
-    fn index_helper<C: ConstraintSynthesizer<F>>(c: &C) -> Result<IndexerState<F>, AHPError> {
+    /// Generate the indexed circuit evaluations for this constraint system.
+    /// Used by both the Prover and Verifier
+    pub(crate) fn index_helper<C: ConstraintSynthesizer<F>>(c: &C) -> Result<IndexerState<F>, AHPError> {
         let index_time = start_timer!(|| "AHP::Index");
 
         let constraint_time = start_timer!(|| "Generating constraints");
@@ -212,6 +214,8 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
                 .try_into()
                 .unwrap();
 
+        let id = Circuit::<F, MM>::hash(&index_info, &a, &b, &c).unwrap();
+
         let result = Ok(IndexerState {
             constraint_domain,
             variable_domain,
@@ -229,17 +233,17 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
             c_evals,
 
             index_info,
+            id,
         });
         end_timer!(index_time);
         result
     }
 
-    pub fn evaluate_index_polynomials<C: ConstraintSynthesizer<F>>(
-        c: &C,
+    pub(crate) fn evaluate_index_polynomials(
+        state: IndexerState<F>,
         id: &CircuitId,
         point: F,
     ) -> Result<impl Iterator<Item = F>, AHPError> {
-        let state = Self::index_helper(c)?;
         let mut evals = [
             (state.a_evals, state.non_zero_a_domain),
             (state.b_evals, state.non_zero_b_domain),
@@ -257,7 +261,7 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
     }
 }
 
-struct IndexerState<F: PrimeField> {
+pub(crate) struct IndexerState<F: PrimeField> {
     constraint_domain: EvaluationDomain<F>,
     variable_domain: EvaluationDomain<F>,
 
@@ -273,5 +277,6 @@ struct IndexerState<F: PrimeField> {
     non_zero_c_domain: EvaluationDomain<F>,
     c_evals: MatrixEvals<F>,
 
-    index_info: CircuitInfo,
+    pub(crate) index_info: CircuitInfo,
+    pub(crate) id: CircuitId,
 }

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -224,8 +224,7 @@ where
         Ok(circuit_keys.pop().unwrap())
     }
 
-    /// Prove that the verifying key indeed includes a part of the reference string,
-    /// as well as the indexed circuit (i.e. the circuit as a set of linear-sized polynomials).
+    /// Prove that the verifying key commitments commit to the indexed circuit's polynomials
     fn prove_vk(
         universal_prover: &Self::UniversalProver,
         fs_parameters: &Self::FSParameters,
@@ -273,8 +272,8 @@ where
         Ok(Self::Certificate::new(certificate))
     }
 
-    /// Verify that the verifying key indeed includes a part of the reference string,
-    /// as well as the indexed circuit (i.e. the circuit as a set of linear-sized polynomials).
+    /// Verify that the verifying key commitments commit to the indexed circuit's polynomials
+    /// Verify that the verifying key's circuit_info is correct
     fn verify_vk<C: ConstraintSynthesizer<Self::ScalarField>>(
         universal_verifier: &Self::UniversalVerifier,
         fs_parameters: &Self::FSParameters,
@@ -282,36 +281,45 @@ where
         verifying_key: &Self::VerifyingKey,
         certificate: &Self::Certificate,
     ) -> Result<bool, SNARKError> {
+        // Ensure the VerifyingKey encodes the expected circuit.
         let circuit_id = &verifying_key.id;
-        let info = AHPForR1CS::<E::Fr, MM>::index_polynomial_info(std::iter::once(circuit_id));
+        let state = AHPForR1CS::<E::Fr, MM>::index_helper(circuit)?;
+        if state.index_info != verifying_key.circuit_info {
+            return Err(SNARKError::CircuitNotFound);
+        }
+        if state.id != *circuit_id {
+            return Err(SNARKError::CircuitNotFound);
+        }
+
         // Initialize sponge.
         let mut sponge = Self::init_sponge_for_certificate(fs_parameters, &verifying_key.circuit_commitments);
+
         // Compute challenges for linear combination, and the point to evaluate the polynomials at.
         // The linear combination requires `num_polynomials - 1` coefficients
         // (since the first coeff is 1), and so we squeeze out `num_polynomials` points.
         let mut challenges = sponge.squeeze_nonnative_field_elements(verifying_key.circuit_commitments.len());
         let point = challenges.pop().unwrap();
-
-        let evaluations_at_point = AHPForR1CS::<E::Fr, MM>::evaluate_index_polynomials(circuit, circuit_id, point)?;
         let one = E::Fr::one();
         let linear_combination_challenges = core::iter::once(&one).chain(challenges.iter());
 
         // We will construct a linear combination and provide a proof of evaluation of the lc at `point`.
+        let poly_info = AHPForR1CS::<E::Fr, MM>::index_polynomial_info(std::iter::once(circuit_id));
+        let evaluations_at_point = AHPForR1CS::<E::Fr, MM>::evaluate_index_polynomials(state, circuit_id, point)?;
         let mut lc = crate::polycommit::sonic_pc::LinearCombination::empty("circuit_check");
         let mut evaluation = E::Fr::zero();
-        for ((label, &c), eval) in info.keys().zip_eq(linear_combination_challenges).zip_eq(evaluations_at_point) {
+        for ((label, &c), eval) in poly_info.keys().zip_eq(linear_combination_challenges).zip_eq(evaluations_at_point) {
             lc.add(c, label.as_str());
             evaluation += c * eval;
         }
 
-        let query_set = QuerySet::from_iter([("circuit_check".into(), ("challenge".into(), point))]);
         let commitments = verifying_key
             .iter()
             .cloned()
-            .zip_eq(info.values())
+            .zip_eq(poly_info.values())
             .map(|(c, info)| LabeledCommitment::new_with_info(info, c))
             .collect::<Vec<_>>();
         let evaluations = Evaluations::from_iter([(("circuit_check".into(), point), evaluation)]);
+        let query_set = QuerySet::from_iter([("circuit_check".into(), ("challenge".into(), point))]);
 
         SonicKZG10::<E, FS>::check_combinations(
             universal_verifier,


### PR DESCRIPTION
## Motivation

Previously, we were only checking in `verify_vk(...)` whether the index commitments were correct. However, the `verify_batch` function also uses the verifying_key for its `circuit_id` and `circuit_info`. Potentially this could be exploited by letting a user verify a proof for circuit A when the user thinks they are verifying it for circuit B. We resolve the issue by actually checking in `verify_vk(...)` whether the right circuit id and info are in the VerifyingKey.

## Test Plan

I could add another negative test which calls verify_vk with a wrong `circuit_{id,info}` but it seems superfluous.