### PR TITLE
[Proposal] Update `finalize_root` derivation

### DIFF
--- a/console/program/src/state_path/configuration/mod.rs
+++ b/console/program/src/state_path/configuration/mod.rs
@@ -19,8 +19,6 @@ use snarkvm_console_network::BHPMerkleTree;
 pub const BLOCKS_DEPTH: u8 = 32;
 /// The depth of the Merkle tree for the block header.
 pub const HEADER_DEPTH: u8 = 3;
-/// The depth of the Merkle tree for finalize operations in a block.
-pub const FINALIZE_OPERATIONS_DEPTH: u8 = 20;
 /// The depth of the Merkle tree for the ratifications in a block.
 pub const RATIFICATIONS_DEPTH: u8 = 20;
 /// The depth of the Merkle tree for transactions in a block.

--- a/ledger/block/src/header/genesis.rs
+++ b/ledger/block/src/header/genesis.rs
@@ -16,11 +16,10 @@ use super::*;
 
 impl<N: Network> Header<N> {
     /// Initializes the genesis block header.
-    pub fn genesis(transactions: &Transactions<N>) -> Result<Self> {
+    pub fn genesis(transactions: &Transactions<N>, finalize_root: Field<N>) -> Result<Self> {
         // Prepare a genesis block header.
         let previous_state_root = Into::<N::StateRoot>::into(Field::zero());
         let transactions_root = transactions.to_transactions_root()?;
-        let finalize_root = transactions.to_finalize_root()?;
         let ratifications_root = *N::merkle_tree_bhp::<RATIFICATIONS_DEPTH>(&[])?.root();
         let coinbase_accumulator_point = Field::zero();
         let metadata = Metadata::genesis()?;

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -563,8 +563,11 @@ pub mod test_helpers {
         // Prepare the transactions.
         let transactions = Transactions::from_iter([confirmed].into_iter());
 
+        // TODO (raychu86): Sample the finalize_root properly.
+        let finalize_root = CurrentNetwork::hash_bhp1024(&[]).unwrap();
+
         // Prepare the block header.
-        let header = Header::genesis(&transactions).unwrap();
+        let header = Header::genesis(&transactions, finalize_root).unwrap();
         // Prepare the previous block hash.
         let previous_hash = <CurrentNetwork as Network>::BlockHash::default();
 

--- a/ledger/block/src/transactions/merkle.rs
+++ b/ledger/block/src/transactions/merkle.rs
@@ -15,18 +15,6 @@
 use super::*;
 
 impl<N: Network> Transactions<N> {
-    /// Returns the finalize root of the transactions.
-    pub fn to_finalize_root(&self) -> Result<Field<N>> {
-        // Prepare the leaves.
-        let leaves = self.finalize_operations().map(|op| op.to_bits_le());
-        // Compute the finalize tree.
-        let tree = N::merkle_tree_bhp::<FINALIZE_OPERATIONS_DEPTH>(&leaves.collect::<Vec<_>>())?;
-        // Return the finalize root.
-        Ok(*tree.root())
-    }
-}
-
-impl<N: Network> Transactions<N> {
     /// Returns the transactions root, by computing the root for a Merkle tree of the transaction IDs.
     pub fn to_transactions_root(&self) -> Result<Field<N>> {
         Ok(*self.to_tree()?.root())

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -26,15 +26,7 @@ mod string;
 use crate::{Transaction, Transition};
 use console::{
     network::prelude::*,
-    program::{
-        Ciphertext,
-        ProgramOwner,
-        Record,
-        TransactionsPath,
-        TransactionsTree,
-        FINALIZE_OPERATIONS_DEPTH,
-        TRANSACTIONS_DEPTH,
-    },
+    program::{Ciphertext, ProgramOwner, Record, TransactionsPath, TransactionsTree, TRANSACTIONS_DEPTH},
     types::{Field, Group, U64},
 };
 use synthesizer_program::FinalizeOperation;

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -29,6 +29,7 @@ impl<N: Network> Block<N> {
         current_puzzle: &CoinbasePuzzle<N>,
         current_epoch_challenge: &EpochChallenge<N>,
         current_timestamp: i64,
+        expected_finalize_root: Field<N>,
     ) -> Result<()> {
         // Ensure the block hash is correct.
         self.verify_hash(previous_block.height(), previous_block.hash())?;
@@ -59,8 +60,6 @@ impl<N: Network> Block<N> {
         let expected_previous_state_root = current_state_root;
         // Compute the expected transactions root.
         let expected_transactions_root = self.compute_transactions_root()?;
-        // Compute the expected finalize root.
-        let expected_finalize_root = self.compute_finalize_root()?;
         // Compute the expected ratifications root.
         let expected_ratifications_root = self.compute_ratifications_root()?;
         // Compute the expected solutions root.
@@ -431,14 +430,6 @@ impl<N: Network> Block<N> {
         match self.transactions.to_transactions_root() {
             Ok(transactions_root) => Ok(transactions_root),
             Err(error) => bail!("Failed to compute the transactions root for block {} - {error}", self.height()),
-        }
-    }
-
-    /// Computes the finalize root for the block.
-    fn compute_finalize_root(&self) -> Result<Field<N>> {
-        match self.transactions.to_finalize_root() {
-            Ok(finalize_root) => Ok(finalize_root),
-            Err(error) => bail!("Failed to compute the finalize root for block {} - {error}", self.height()),
         }
     }
 

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -200,7 +200,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             previous_block.hash(),
         )?;
         // Select the transactions from the memory pool.
-        let (transactions, _aborted) =
+        let (transactions, _aborted, finalize_root) =
             self.vm.speculate(state, &ratifications, solutions.as_ref(), candidate_transactions.iter())?;
 
         // Construct the metadata.
@@ -221,7 +221,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let header = Header::from(
             latest_state_root,
             transactions.to_transactions_root()?,
-            transactions.to_finalize_root()?,
+            finalize_root,
             ratifications_root,
             coinbase_accumulator_point,
             metadata,

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -392,8 +392,11 @@ fn sample_genesis_block_and_components_raw(
     // Prepare the transactions.
     let transactions = Transactions::from_iter([confirmed].into_iter());
 
+    // TODO (raychu86): Sample the finalize_root properly.
+    let finalize_root = CurrentNetwork::hash_bhp1024(&[]).unwrap();
+
     // Prepare the block header.
-    let header = Header::genesis(&transactions).unwrap();
+    let header = Header::genesis(&transactions, finalize_root).unwrap();
     // Prepare the previous block hash.
     let previous_hash = <CurrentNetwork as Network>::BlockHash::default();
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -18,7 +18,7 @@ use ledger_coinbase::CoinbaseSolution;
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Speculates on the given list of transactions in the VM,
-    /// returning the confirmed and aborted transactions.
+    /// returning the confirmed transactions, aborted transactions, and the finalize digest.
     #[inline]
     pub fn speculate<'a>(
         &self,
@@ -26,20 +26,25 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         ratifications: &[Ratify<N>],
         solutions: Option<&CoinbaseSolution<N>>,
         transactions: impl ExactSizeIterator<Item = &'a Transaction<N>>,
-    ) -> Result<(Transactions<N>, Vec<Transaction<N>>)> {
+    ) -> Result<(Transactions<N>, Vec<Transaction<N>>, Field<N>)> {
         let timer = timer!("VM::speculate");
 
         // Performs a **dry-run** over the list of ratifications, solutions, and transactions.
-        let (confirmed_transactions, aborted_transactions) =
+        let (confirmed_transactions, aborted_transactions, write_batch) =
             self.atomic_speculate(state, ratifications, solutions, transactions)?;
+
+        // TODO (raychu86): Optimize this. We can use any hash function.
+        // Compute the finalize digest.
+        let input = write_batch.iter().flat_map(|b| b.to_bits_le()).collect::<Vec<_>>();
+        let finalize_digest = N::hash_bhp1024(&input)?;
 
         finish!(timer, "Finished dry-run of the transactions");
 
         // Return the transactions.
-        Ok((confirmed_transactions.into_iter().collect(), aborted_transactions))
+        Ok((confirmed_transactions.into_iter().collect(), aborted_transactions, finalize_digest))
     }
 
-    /// Finalizes the given transactions into the VM.
+    /// Finalizes the given transactions into the VM, returning the finalize digest.
     #[inline]
     pub fn finalize(
         &self,
@@ -47,27 +52,33 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         ratifications: &[Ratify<N>],
         solutions: Option<&CoinbaseSolution<N>>,
         transactions: &Transactions<N>,
-    ) -> Result<()> {
+    ) -> Result<Field<N>> {
         let timer = timer!("VM::finalize");
 
         // Performs a **real-run** of finalize over the list of ratifications, solutions, and transactions.
-        self.atomic_finalize(state, ratifications, solutions, transactions)?;
+        let write_batch = self.atomic_finalize(state, ratifications, solutions, transactions)?;
+
+        // TODO (raychu86): Optimize this. We can use any hash function.
+        // Compute the finalize digest.
+        let input = write_batch.iter().flat_map(|b| b.to_bits_le()).collect::<Vec<_>>();
+        let finalize_digest = N::hash_bhp1024(&input)?;
 
         finish!(timer, "Finished real-run of finalize");
-        Ok(())
+        Ok(finalize_digest)
     }
 }
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Performs atomic speculation over a list of transactions,
-    /// and returns the confirmed and aborted transactions.
+    /// and returns the confirmed transactions, aborted transactions,
+    /// and the finalize store write batch.
     fn atomic_speculate<'a>(
         &self,
         state: FinalizeGlobalState,
         ratifications: &[Ratify<N>],
         solutions: Option<&CoinbaseSolution<N>>,
         transactions: impl ExactSizeIterator<Item = &'a Transaction<N>>,
-    ) -> Result<(Vec<ConfirmedTransaction<N>>, Vec<Transaction<N>>)> {
+    ) -> Result<(Vec<ConfirmedTransaction<N>>, Vec<Transaction<N>>, Vec<u8>)> {
         let timer = timer!("VM::atomic_speculate");
 
         // Retrieve the number of transactions.
@@ -218,12 +229,21 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             finish!(timer);
 
-            // On return, 'atomic_finalize!' will abort the batch, and return the confirmed & aborted transactions.
-            Ok((confirmed, aborted))
+            // Get the write batch of the finalize store.
+            let write_batch = match store.get_write_batch() {
+                Ok(write_batch) => write_batch,
+                Err(e) => {
+                    // Note: This will abort the entire atomic batch.
+                    return Err(format!("Failed to get the write batch - {e}"));
+                }
+            };
+
+            // On return, 'atomic_finalize!' will abort the batch, and return the confirmed transactions, aborted transactions and write batch.
+            Ok((confirmed, aborted, write_batch))
         })
     }
 
-    /// Performs atomic finalization over a list of transactions.
+    /// Performs atomic finalization over a list of transactions. Returns the write batch.
     #[inline]
     fn atomic_finalize(
         &self,
@@ -231,7 +251,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         ratifications: &[Ratify<N>],
         solutions: Option<&CoinbaseSolution<N>>,
         transactions: &Transactions<N>,
-    ) -> Result<()> {
+    ) -> Result<Vec<u8>> {
         let timer = timer!("VM::atomic_finalize");
 
         // Perform the finalize operation on the preset finalize mode.
@@ -433,9 +453,18 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 stacks.into_iter().for_each(|stack| process.add_stack(stack))
             }
 
+            // Get the write batch of the finalize store.
+            let write_batch = match store.get_write_batch() {
+                Ok(write_batch) => write_batch,
+                Err(e) => {
+                    // Note: This will abort the entire atomic batch.
+                    return Err(format!("Failed to get the write batch - {e}"));
+                }
+            };
+
             finish!(timer); // <- Note: This timer does **not** include the time to write batch to DB.
 
-            Ok(())
+            Ok(write_batch)
         })
     }
 
@@ -696,7 +725,8 @@ finalize transfer_public:
         rng: &mut R,
     ) -> Result<Block<CurrentNetwork>> {
         // Construct the new block header.
-        let (transactions, _) = vm.speculate(sample_finalize_state(1), &[], None, transactions.iter())?;
+        let (transactions, _, finalize_root) =
+            vm.speculate(sample_finalize_state(1), &[], None, transactions.iter())?;
         // Construct the metadata associated with the block.
         let metadata = Metadata::new(
             CurrentNetwork::ID,
@@ -714,7 +744,7 @@ finalize transfer_public:
         let header = Header::from(
             vm.block_store().current_state_root(),
             transactions.to_transactions_root().unwrap(),
-            transactions.to_finalize_root().unwrap(),
+            finalize_root,
             crate::vm::test_helpers::sample_ratifications_root(),
             Field::zero(),
             metadata,
@@ -862,7 +892,7 @@ finalize transfer_public:
         let program_id = ProgramID::from_str("testing.aleo").unwrap();
 
         // Prepare the confirmed transactions.
-        let (confirmed_transactions, _) =
+        let (confirmed_transactions, _, _) =
             vm.speculate(sample_finalize_state(1), &[], None, [deployment_transaction.clone()].iter()).unwrap();
 
         // Ensure the VM does not contain this program.
@@ -881,7 +911,7 @@ finalize transfer_public:
         assert!(vm.contains_program(&program_id));
 
         // Ensure the dry run of the redeployment will cause a reject transaction to be created.
-        let (candidate_transactions, _) =
+        let (candidate_transactions, _, _) =
             vm.atomic_speculate(sample_finalize_state(1), &[], None, [deployment_transaction].iter()).unwrap();
         assert_eq!(candidate_transactions.len(), 1);
         assert!(matches!(candidate_transactions[0], ConfirmedTransaction::RejectedDeploy(..)));
@@ -982,7 +1012,7 @@ finalize transfer_public:
         // Transfer_20 -> Balance = 20 - 20 = 0
         {
             let transactions = [mint_10.clone(), transfer_10.clone(), transfer_20.clone()];
-            let (confirmed_transactions, _) =
+            let (confirmed_transactions, _, _) =
                 vm.atomic_speculate(sample_finalize_state(1), &[], None, transactions.iter()).unwrap();
 
             // Assert that all the transactions are accepted.
@@ -1001,7 +1031,7 @@ finalize transfer_public:
         // Transfer_30 -> Balance = 30 - 30 = 0
         {
             let transactions = [transfer_20.clone(), mint_10.clone(), mint_20.clone(), transfer_30.clone()];
-            let (confirmed_transactions, _) =
+            let (confirmed_transactions, _, _) =
                 vm.atomic_speculate(sample_finalize_state(1), &[], None, transactions.iter()).unwrap();
 
             // Assert that all the transactions are accepted.
@@ -1020,7 +1050,7 @@ finalize transfer_public:
         // Transfer_10 -> Balance = 0 - 10 = -10 (should be rejected)
         {
             let transactions = [transfer_20.clone(), transfer_10.clone()];
-            let (confirmed_transactions, _) =
+            let (confirmed_transactions, _, _) =
                 vm.atomic_speculate(sample_finalize_state(1), &[], None, transactions.iter()).unwrap();
 
             // Assert that the accepted and rejected transactions are correct.
@@ -1040,7 +1070,7 @@ finalize transfer_public:
         // Transfer_10 -> Balance = 10 - 10 = 0
         {
             let transactions = [mint_20.clone(), transfer_30.clone(), transfer_20.clone(), transfer_10.clone()];
-            let (confirmed_transactions, _) =
+            let (confirmed_transactions, _, _) =
                 vm.atomic_speculate(sample_finalize_state(1), &[], None, transactions.iter()).unwrap();
 
             // Assert that the accepted and rejected transactions are correct.
@@ -1134,7 +1164,7 @@ function ped_hash:
                 create_execution(&vm, caller_private_key, program_id, "ped_hash", inputs, &mut unspent_records, rng);
 
             // Speculatively execute the transaction. Ensure that this call does not panic and returns a rejected transaction.
-            let (confirmed_transactions, _) =
+            let (confirmed_transactions, _, _) =
                 vm.speculate(sample_finalize_state(1), &[], None, [transaction.clone()].iter()).unwrap();
 
             // Ensure that the transaction is rejected.

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -432,7 +432,7 @@ mod tests {
         let deployment_transaction = vm.deploy(&caller_private_key, &program, Some(credits), 10, None, rng).unwrap();
 
         // Construct the new block header.
-        let (transactions, _) =
+        let (transactions, _, finalize_root) =
             vm.speculate(sample_finalize_state(1), &[], None, [deployment_transaction].iter()).unwrap();
 
         // Construct the metadata associated with the block.
@@ -453,7 +453,7 @@ mod tests {
         let deployment_header = Header::from(
             vm.block_store().current_state_root(),
             transactions.to_transactions_root().unwrap(),
-            transactions.to_finalize_root().unwrap(),
+            finalize_root,
             crate::vm::test_helpers::sample_ratifications_root(),
             Field::zero(),
             deployment_metadata,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR explores a new method of deriving the finalize root. Instead of using `FinalizeOperations` to create a tree and find the root, we use the `FinalizeStore` `atomic_write_batch` instead. We simply hash it to construct the new `finalize_root` (which can be renamed as it is no longer a root).

The finalize root is now derived when `VM::speculate` or `VM::finalize` is called, instead of being derived from the `FinalizeOperation` state in `Transactions`, which means we can safely remove `FinalizeOperations` entirely if desired.


Note: The `FinalizeOperations` have not been removed in this proposal, but will be removed if we decide to go down this route.


TODO: Resample genesis block
