### PR TITLE
Add self.parent opcode & thus unlock composable programs

### DIFF
--- a/circuit/program/src/request/mod.rs
+++ b/circuit/program/src/request/mod.rs
@@ -118,6 +118,8 @@ impl<A: Aleo> ToFields for InputID<A> {
 pub struct Request<A: Aleo> {
     /// The request caller.
     caller: Address<A>,
+    /// The request parent, i.e. the caller/program directly invoking this request.
+    parent: Address<A>,
     /// The network ID.
     network_id: U16<A>,
     /// The program ID.
@@ -211,6 +213,7 @@ impl<A: Aleo> Inject for Request<A> {
 
         Self {
             caller: Address::new(mode, *request.caller()),
+            parent: Address::new(mode, *request.parent()),
             network_id: U16::new(Mode::Constant, *request.network_id()),
             program_id: ProgramID::new(Mode::Constant, *request.program_id()),
             function_name: Identifier::new(Mode::Constant, *request.function_name()),
@@ -229,6 +232,11 @@ impl<A: Aleo> Request<A> {
     /// Returns the request caller.
     pub const fn caller(&self) -> &Address<A> {
         &self.caller
+    }
+
+    /// Returns the request parent.
+    pub const fn parent(&self) -> &Address<A> {
+        &self.parent
     }
 
     /// Returns the network ID.
@@ -306,6 +314,7 @@ impl<A: Aleo> Eject for Request<A> {
     fn eject_value(&self) -> Self::Primitive {
         Self::Primitive::from((
             self.caller.eject_value(),
+            self.parent.eject_value(),
             self.network_id.eject_value(),
             self.program_id.eject_value(),
             self.function_name.eject_value(),

--- a/circuit/program/src/request/verify.rs
+++ b/circuit/program/src/request/verify.rs
@@ -352,7 +352,7 @@ mod tests {
 
             // Compute the signed request.
             let request =
-                console::Request::sign(&private_key, program_id, function_name, inputs.iter(), &input_types, rng)?;
+                console::Request::sign(&private_key, address, program_id, function_name, inputs.iter(), &input_types, rng)?;
             assert!(request.verify(&input_types));
 
             // Inject the request into a circuit.

--- a/console/program/src/request/bytes.rs
+++ b/console/program/src/request/bytes.rs
@@ -26,6 +26,8 @@ impl<N: Network> FromBytes for Request<N> {
 
         // Read the caller.
         let caller = FromBytes::read_le(&mut reader)?;
+        // Read the parent.
+        let parent = FromBytes::read_le(&mut reader)?;
         // Read the network ID.
         let network_id = FromBytes::read_le(&mut reader)?;
         // Read the program ID.
@@ -53,6 +55,7 @@ impl<N: Network> FromBytes for Request<N> {
 
         Ok(Self::from((
             caller,
+            parent,
             network_id,
             program_id,
             function_name,
@@ -75,6 +78,8 @@ impl<N: Network> ToBytes for Request<N> {
 
         // Write the caller.
         self.caller.write_le(&mut writer)?;
+        // Write the parent.
+        self.parent.write_le(&mut writer)?;
         // Write the network ID.
         self.network_id.write_le(&mut writer)?;
         // Write the program ID.

--- a/console/program/src/request/serialize.rs
+++ b/console/program/src/request/serialize.rs
@@ -23,6 +23,7 @@ impl<N: Network> Serialize for Request<N> {
             true => {
                 let mut transition = serializer.serialize_struct("Request", 9)?;
                 transition.serialize_field("caller", &self.caller)?;
+                transition.serialize_field("parent", &self.parent)?;
                 transition.serialize_field("network", &self.network_id)?;
                 transition.serialize_field("program", &self.program_id)?;
                 transition.serialize_field("function", &self.function_name)?;
@@ -51,6 +52,8 @@ impl<'de, N: Network> Deserialize<'de> for Request<N> {
                 Ok(Self::from((
                     // Retrieve the caller.
                     DeserializeExt::take_from_value::<D>(&mut request, "caller")?,
+                    // Retrieve the parent.
+                    DeserializeExt::take_from_value::<D>(&mut request, "parent")?,
                     // Retrieve the network ID.
                     DeserializeExt::take_from_value::<D>(&mut request, "network")?,
                     // Retrieve the program ID.

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -20,6 +20,7 @@ impl<N: Network> Request<N> {
     ///     response := r - challenge * sk_sig
     pub fn sign<R: Rng + CryptoRng>(
         private_key: &PrivateKey<N>,
+        parent_address: Address<N>,
         program_id: ProgramID<N>,
         function_name: Identifier<N>,
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
@@ -215,6 +216,7 @@ impl<N: Network> Request<N> {
 
         Ok(Self {
             caller,
+            parent: parent_address,
             network_id: U16::new(N::ID),
             program_id,
             function_name,

--- a/console/program/src/request/verify.rs
+++ b/console/program/src/request/verify.rs
@@ -264,7 +264,7 @@ mod tests {
 
             // Compute the signed request.
             let request =
-                Request::sign(&private_key, program_id, function_name, inputs.into_iter(), &input_types, rng).unwrap();
+                Request::sign(&private_key, address, program_id, function_name, inputs.into_iter(), &input_types, rng).unwrap();
             assert!(request.verify(&input_types));
         }
     }

--- a/synthesizer/process/src/authorize.rs
+++ b/synthesizer/process/src/authorize.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use console::types::Address;
+
 impl<N: Network> Process<N> {
     /// Authorizes a call to the program function for the given inputs.
     #[inline]
@@ -61,7 +63,8 @@ impl<N: Network> Process<N> {
         lap!(timer, "Construct the inputs");
 
         // Compute the request.
-        let request = Request::sign(private_key, program_id, function_name, inputs.iter(), &input_types, rng)?;
+        let parent_address = Address::try_from(private_key)?;
+        let request = Request::sign(private_key, parent_address, program_id, function_name, inputs.iter(), &input_types, rng)?;
         finish!(timer, "Compute the request");
 
         // Return the authorization.
@@ -93,7 +96,8 @@ impl<N: Network> Process<N> {
         lap!(timer, "Construct the inputs");
 
         // Compute the request.
-        let request = Request::sign(private_key, program_id, function_name, inputs.iter(), &input_types, rng)?;
+        let parent_address = Address::try_from(private_key)?;
+        let request = Request::sign(private_key, parent_address, program_id, function_name, inputs.iter(), &input_types, rng)?;
         finish!(timer, "Compute the request");
 
         // Return the authorization.

--- a/synthesizer/process/src/stack/authorize.rs
+++ b/synthesizer/process/src/stack/authorize.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use console::types::Address;
+
 impl<N: Network> Stack<N> {
     /// Authorizes a call to the program function for the given inputs.
     #[inline]
@@ -33,7 +35,8 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Retrieve the input types");
 
         // Compute the request.
-        let request = Request::sign(private_key, *self.program.id(), function_name, inputs, &input_types, rng)?;
+        let parent_address = Address::try_from(private_key)?;
+        let request = Request::sign(private_key, parent_address, *self.program.id(), function_name, inputs, &input_types, rng)?;
         lap!(timer, "Compute the request");
         // Initialize the authorization.
         let authorization = Authorization::from(request.clone());

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -89,6 +89,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 &inputs,
                 registers.call_stack(),
                 registers.caller()?,
+                registers.parent()?,
                 registers.tvk()?,
             )?
         }
@@ -170,6 +171,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 &inputs,
                 registers.call_stack(),
                 registers.caller_circuit()?,
+                registers.parent_circuit()?,
                 registers.tvk_circuit()?,
             )?
         }
@@ -195,6 +197,9 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 // Initialize an RNG.
                 let rng = &mut rand::thread_rng();
 
+                // Set the parent address to the current calling stack's program
+                let parent_address = stack.program_id().to_address()?;
+
                 match registers.call_stack() {
                     // If the circuit is in authorize or synthesize mode, then add any external calls to the stack.
                     CallStack::Authorize(_, private_key, authorization)
@@ -202,6 +207,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         // Compute the request.
                         let request = Request::sign(
                             &private_key,
+                            parent_address,
                             *substack.program_id(),
                             *function.name(),
                             inputs.iter(),
@@ -227,6 +233,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         // Compute the request.
                         let request = Request::sign(
                             &private_key,
+                            parent_address,
                             *substack.program_id(),
                             *function.name(),
                             inputs.iter(),

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -100,6 +100,7 @@ impl<N: Network> Stack<N> {
             // Compute the request, with a burner private key.
             let request = Request::sign(
                 &burner_private_key,
+                burner_address,
                 *program_id,
                 *function.name(),
                 inputs.into_iter(),

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -26,6 +26,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         inputs: &[Value<N>],
         call_stack: CallStack<N>,
         caller: Address<N>,
+        parent: Address<N>,
         tvk: Field<N>,
     ) -> Result<Vec<Value<N>>> {
         let timer = timer!("Stack::evaluate_closure");
@@ -39,6 +40,8 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         let mut registers = Registers::<N, A>::new(call_stack, self.get_register_types(closure.name())?.clone());
         // Set the transition caller.
         registers.set_caller(caller);
+        // Set the transition parent.
+        registers.set_parent(parent);
         // Set the transition view key.
         registers.set_tvk(tvk);
         lap!(timer, "Initialize the registers");
@@ -75,6 +78,8 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                     }
                     // If the operand is the caller, retrieve the caller from the registers.
                     Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),
+                    // If the operand is the parent, retrieve the parent from the registers.
+                    Operand::Parent => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.parent()?)))),
                     // If the operand is the block height, throw an error.
                     Operand::BlockHeight => bail!("Cannot retrieve the block height from a closure scope."),
                 }
@@ -121,6 +126,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         let function = self.get_function(request.function_name())?;
         let inputs = request.inputs();
         let caller = *request.caller();
+        let parent = *request.parent();
         let tvk = *request.tvk();
 
         // Ensure the number of inputs matches.
@@ -139,6 +145,8 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         let mut registers = Registers::<N, A>::new(call_stack, self.get_register_types(function.name())?.clone());
         // Set the transition caller.
         registers.set_caller(caller);
+        // Set the transition parent.
+        registers.set_parent(parent);
         // Set the transition view key.
         registers.set_tvk(tvk);
         lap!(timer, "Initialize the registers");
@@ -190,6 +198,8 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                     }
                     // If the operand is the caller, retrieve the caller from the registers.
                     Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),
+                    // If the operand is the parent, retrieve the parent from the registers.
+                    Operand::Parent => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.parent()?)))),
                     // If the operand is the block height, throw an error.
                     Operand::BlockHeight => bail!("Cannot retrieve the block height from a function scope."),
                 }

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -26,6 +26,7 @@ impl<N: Network> StackExecute<N> for Stack<N> {
         inputs: &[circuit::Value<A>],
         call_stack: CallStack<N>,
         caller: circuit::Address<A>,
+        parent: circuit::Address<A>,
         tvk: circuit::Field<A>,
     ) -> Result<Vec<circuit::Value<A>>> {
         let timer = timer!("Stack::execute_closure");
@@ -46,6 +47,8 @@ impl<N: Network> StackExecute<N> for Stack<N> {
         let mut registers = Registers::new(call_stack, self.get_register_types(closure.name())?.clone());
         // Set the transition caller, as a circuit.
         registers.set_caller_circuit(caller);
+        // Set the transition parent, as a circuit.
+        registers.set_parent_circuit(parent);
         // Set the transition view key, as a circuit.
         registers.set_tvk_circuit(tvk);
         lap!(timer, "Initialize the registers");
@@ -103,6 +106,9 @@ impl<N: Network> StackExecute<N> for Stack<N> {
                     // If the operand is the caller, retrieve the caller from the registers.
                     Operand::Caller => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
                         circuit::Literal::Address(registers.caller_circuit()?),
+                    ))),
+                    Operand::Parent => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
+                        circuit::Literal::Address(registers.parent_circuit()?),
                     ))),
                     // If the operand is the block height, throw an error.
                     Operand::BlockHeight => {
@@ -186,6 +192,11 @@ impl<N: Network> StackExecute<N> for Stack<N> {
         registers.set_caller(*console_request.caller());
         // Set the transition caller, as a circuit.
         registers.set_caller_circuit(request.caller().clone());
+        
+        // Set the transition parent.
+        registers.set_parent(*console_request.parent());
+        // Set the transition parent, as a circuit.
+        registers.set_parent_circuit(request.parent().clone());
 
         // Set the transition view key.
         registers.set_tvk(*console_request.tvk());
@@ -278,6 +289,9 @@ impl<N: Network> StackExecute<N> for Stack<N> {
                     // If the operand is the caller, retrieve the caller from the registers.
                     Operand::Caller => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
                         circuit::Literal::Address(registers.caller_circuit()?),
+                    ))),
+                    Operand::Parent => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
+                        circuit::Literal::Address(registers.parent_circuit()?),
                     ))),
                     // If the operand is the block height, throw an error.
                     Operand::BlockHeight => {

--- a/synthesizer/process/src/stack/finalize_registers/load.rs
+++ b/synthesizer/process/src/stack/finalize_registers/load.rs
@@ -34,6 +34,8 @@ impl<N: Network> RegistersLoad<N> for FinalizeRegisters<N> {
             }
             // If the operand is the caller, throw an error.
             Operand::Caller => bail!("Forbidden operation: Cannot use 'self.caller' in 'finalize'"),
+            // If the operand is the parent, throw an error.
+            Operand::Parent => bail!("Forbidden operation: Cannot use 'self.parent' in 'finalize'"),
             // If the operand is the block height, load the block height.
             Operand::BlockHeight => {
                 return Ok(Value::Plaintext(Plaintext::from(Literal::U32(U32::new(self.state.block_height())))));

--- a/synthesizer/process/src/stack/finalize_types/matches.rs
+++ b/synthesizer/process/src/stack/finalize_types/matches.rs
@@ -77,6 +77,10 @@ impl<N: Network> FinalizeTypes<N> {
                 Operand::Caller => bail!(
                     "Struct member '{struct_name}.{member_name}' cannot be cast from a caller in a finalize scope."
                 ),
+                // If the operand is a parent, throw an error.
+                Operand::Parent => bail!(
+                    "Struct member '{struct_name}.{member_name}' cannot be cast from a parent in a finalize scope."
+                ),
                 // Ensure the block height type (u32) matches the member type.
                 Operand::BlockHeight => {
                     // Retrieve the block height type.

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -77,6 +77,7 @@ impl<N: Network> FinalizeTypes<N> {
             Operand::Register(register) => self.get_type(stack, register)?,
             Operand::ProgramID(_) => PlaintextType::Literal(LiteralType::Address),
             Operand::Caller => bail!("'self.caller' is not a valid operand in a finalize context."),
+            Operand::Parent => bail!("'self.parent' is not a valid operand in a finalize context."),
             Operand::BlockHeight => PlaintextType::Literal(LiteralType::U32),
         })
     }

--- a/synthesizer/process/src/stack/helpers/synthesize.rs
+++ b/synthesizer/process/src/stack/helpers/synthesize.rs
@@ -52,7 +52,7 @@ impl<N: Network> Stack<N> {
 
         // Compute the request, with a burner private key.
         let request =
-            Request::sign(&burner_private_key, *program_id, *function_name, inputs.into_iter(), &input_types, rng)?;
+            Request::sign(&burner_private_key, burner_address, *program_id, *function_name, inputs.into_iter(), &input_types, rng)?;
         // Initialize the authorization.
         let authorization = Authorization::from(request.clone());
         // Initialize the call stack.

--- a/synthesizer/process/src/stack/register_types/matches.rs
+++ b/synthesizer/process/src/stack/register_types/matches.rs
@@ -90,6 +90,16 @@ impl<N: Network> RegisterTypes<N> {
                         "Struct member '{struct_name}.{member_name}' expects {member_type}, but found '{caller_type}' in the operand '{operand}'.",
                     )
                 }
+                // Ensure the parent type (address) matches the member type.
+                Operand::Parent => {
+                    // Retrieve the parent type.
+                    let parent_type = PlaintextType::Literal(LiteralType::Address);
+                    // Ensure the parent type matches the member type.
+                    ensure!(
+                        &parent_type == member_type,
+                        "Struct member '{struct_name}.{member_name}' expects {member_type}, but found '{parent_type}' in the operand '{operand}'.",
+                    )
+                }
                 // If the operand is a block height type, throw an error.
                 Operand::BlockHeight => bail!(
                     "Struct member '{struct_name}.{member_name}' cannot be from a block height in a non-finalize scope"
@@ -153,6 +163,7 @@ impl<N: Network> RegisterTypes<N> {
                 bail!("Forbidden operation: Cannot cast a program ID ('{program_id}') as a record owner")
             }
             Operand::Caller => {}
+            Operand::Parent => {}
             Operand::BlockHeight => {
                 bail!("Forbidden operation: Cannot cast a block height as a record owner")
             }
@@ -209,6 +220,16 @@ impl<N: Network> RegisterTypes<N> {
                             ensure!(
                                 caller_type == plaintext_type,
                                 "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found '{caller_type}' in the operand '{operand}'.",
+                            )
+                        }
+                        // Ensure the parent type (address) matches the entry type.
+                        Operand::Parent => {
+                            // Retrieve the parent type.
+                            let parent_type = &PlaintextType::Literal(LiteralType::Address);
+                            // Ensure the parent type matches the entry type.
+                            ensure!(
+                                parent_type == plaintext_type,
+                                "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found '{parent_type}' in the operand '{operand}'.",
                             )
                         }
                         // Fail if the operand is a block height.

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -93,6 +93,7 @@ impl<N: Network> RegisterTypes<N> {
             Operand::Register(register) => self.get_type(stack, register)?,
             Operand::ProgramID(_) => RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address)),
             Operand::Caller => RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address)),
+            Operand::Parent => RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address)),
             Operand::BlockHeight => bail!("'block.height' is not a valid operand in a non-finalize context."),
         })
     }

--- a/synthesizer/process/src/stack/registers/caller.rs
+++ b/synthesizer/process/src/stack/registers/caller.rs
@@ -27,6 +27,18 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCaller<N> for Registers
         self.caller = Some(caller);
     }
 
+    /// Returns the transition parent.
+    #[inline]
+    fn parent(&self) -> Result<Address<N>> {
+        self.parent.ok_or_else(|| anyhow!("Parent address (console) is not set in the registers."))
+    }
+
+    /// Sets the transition parent.
+    #[inline]
+    fn set_parent(&mut self, parent: Address<N>) {
+        self.parent = Some(parent);
+    }
+
     /// Returns the transition view key.
     #[inline]
     fn tvk(&self) -> Result<Field<N>> {
@@ -51,6 +63,18 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCallerCircuit<N, A> for
     #[inline]
     fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>) {
         self.caller_circuit = Some(caller_circuit);
+    }
+
+    /// Returns the transition parent, as a circuit.
+    #[inline]
+    fn parent_circuit(&self) -> Result<circuit::Address<A>> {
+        self.parent_circuit.clone().ok_or_else(|| anyhow!("Parent address (circuit) is not set in the registers."))
+    }
+
+    /// Sets the transition parent, as a circuit.
+    #[inline]
+    fn set_parent_circuit(&mut self, parent_circuit: circuit::Address<A>) {
+        self.parent_circuit = Some(parent_circuit);
     }
 
     /// Returns the transition view key, as a circuit.

--- a/synthesizer/process/src/stack/registers/load.rs
+++ b/synthesizer/process/src/stack/registers/load.rs
@@ -34,6 +34,8 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoad<N> for Registers<N
             }
             // If the operand is the caller, load the value of the caller.
             Operand::Caller => return Ok(Value::Plaintext(Plaintext::from(Literal::Address(self.caller()?)))),
+            // If the operand is the parent, load the value of the parent.
+            Operand::Parent => return Ok(Value::Plaintext(Plaintext::from(Literal::Address(self.parent()?)))),
             // If the operand is the block height, throw an error.
             Operand::BlockHeight => bail!("Cannot load the block height in a non-finalize context"),
         };
@@ -107,6 +109,12 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoadCircuit<N, A> for R
             Operand::Caller => {
                 return Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
                     self.caller_circuit()?,
+                ))));
+            }
+            // If the operand is the parent, load the value of the parent.
+            Operand::Parent => {
+                return Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
+                    self.parent_circuit()?,
                 ))));
             }
             // If the operand is the block height, throw an error.

--- a/synthesizer/process/src/stack/registers/mod.rs
+++ b/synthesizer/process/src/stack/registers/mod.rs
@@ -51,6 +51,10 @@ pub struct Registers<N: Network, A: circuit::Aleo<Network = N>> {
     caller: Option<Address<N>>,
     /// The transition caller, as a circuit.
     caller_circuit: Option<circuit::Address<A>>,
+    /// The transition parent.
+    parent: Option<Address<N>>,
+    /// The transition parent, as a circuit.
+    parent_circuit: Option<circuit::Address<A>>,
     /// The transition view key.
     tvk: Option<Field<N>>,
     /// The transition view key, as a circuit.
@@ -68,6 +72,8 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
             circuit_registers: IndexMap::new(),
             caller: None,
             caller_circuit: None,
+            parent: None,
+            parent_circuit: None,
             tvk: None,
             tvk_circuit: None,
         }

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -15,7 +15,7 @@
 use crate::Process;
 use circuit::network::AleoV0;
 use console::{
-    account::{Address, PrivateKey},
+    account::{Address, PrivateKey, Address},
     network::{prelude::*, Testnet3},
     program::{Identifier, Literal, Plaintext, ProgramID, Value},
     types::U64,
@@ -1494,8 +1494,9 @@ mod sanity_checks {
         // Retrieve the input types.
         let input_types = program.get_function(&function_name).unwrap().input_types();
         // Compute the request.
+        let parent_address = Address::try_from(&private_key).unwrap();
         let request =
-            Request::sign(private_key, *program.id(), function_name, inputs.iter(), &input_types, rng).unwrap();
+            Request::sign(private_key, parent_address, *program.id(), function_name, inputs.iter(), &input_types, rng).unwrap();
         // Initialize the assignments.
         let assignments = Assignments::<N>::default();
         // Initialize the call stack.

--- a/synthesizer/process/src/traits/mod.rs
+++ b/synthesizer/process/src/traits/mod.rs
@@ -32,6 +32,7 @@ pub trait StackEvaluate<N: Network>: Clone {
         inputs: &[Value<N>],
         call_stack: CallStack<N>,
         caller: Address<N>,
+        parent: Address<N>,
         tvk: Field<N>,
     ) -> Result<Vec<Value<N>>>;
 
@@ -53,6 +54,7 @@ pub trait StackExecute<N: Network> {
         inputs: &[circuit::Value<A>],
         call_stack: CallStack<N>,
         caller: circuit::Address<A>,
+        parent: circuit::Address<A>,
         tvk: circuit::Field<A>,
     ) -> Result<Vec<circuit::Value<A>>>;
 

--- a/synthesizer/program/src/logic/instruction/operand/bytes.rs
+++ b/synthesizer/program/src/logic/instruction/operand/bytes.rs
@@ -21,7 +21,8 @@ impl<N: Network> FromBytes for Operand<N> {
             1 => Ok(Self::Register(Register::read_le(&mut reader)?)),
             2 => Ok(Self::ProgramID(ProgramID::read_le(&mut reader)?)),
             3 => Ok(Self::Caller),
-            4 => Ok(Self::BlockHeight),
+            4 => Ok(Self::Parent),
+            5 => Ok(Self::BlockHeight),
             variant => Err(error(format!("Failed to deserialize operand variant {variant}"))),
         }
     }
@@ -43,7 +44,8 @@ impl<N: Network> ToBytes for Operand<N> {
                 program_id.write_le(&mut writer)
             }
             Self::Caller => 3u8.write_le(&mut writer),
-            Self::BlockHeight => 4u8.write_le(&mut writer),
+            Self::Parent => 4u8.write_le(&mut writer),
+            Self::BlockHeight => 5u8.write_le(&mut writer),
         }
     }
 }

--- a/synthesizer/program/src/logic/instruction/operand/mod.rs
+++ b/synthesizer/program/src/logic/instruction/operand/mod.rs
@@ -34,6 +34,9 @@ pub enum Operand<N: Network> {
     /// The operand is the caller address.
     /// Note: This variant is only accessible in the `function` scope.
     Caller,
+    /// The operand is the parent address.
+    /// Note: This variant is only accessible in the `function` scope.
+    Parent,
     /// The operand is the block height.
     /// Note: This variant is only accessible in the `finalize` scope.
     BlockHeight,

--- a/synthesizer/program/src/logic/instruction/operand/parse.rs
+++ b/synthesizer/program/src/logic/instruction/operand/parse.rs
@@ -24,6 +24,7 @@ impl<N: Network> Parser for Operand<N> {
             // This ensures correctness in the case where a special operand is a prefix of, or could be parsed as, a literal, register, or program ID.
             map(tag("group::GEN"), |_| Self::Literal(Literal::Group(Group::generator()))),
             map(tag("self.caller"), |_| Self::Caller),
+            map(tag("self.parent"), |_| Self::Parent),
             map(tag("block.height"), |_| Self::BlockHeight),
             map(Literal::parse, |literal| Self::Literal(literal)),
             map(Register::parse, |register| Self::Register(register)),
@@ -69,6 +70,8 @@ impl<N: Network> Display for Operand<N> {
             Self::ProgramID(program_id) => Display::fmt(program_id, f),
             // Prints the identifier for the caller, i.e. self.caller
             Self::Caller => write!(f, "self.caller"),
+            // Prints the identifier for the parent, i.e. self.parent
+            Self::Parent => write!(f, "self.parent"),
             // Prints the identifier for the block height, i.e. block.height
             Self::BlockHeight => write!(f, "block.height"),
         }
@@ -98,6 +101,9 @@ mod tests {
 
         let operand = Operand::<CurrentNetwork>::parse("self.caller").unwrap().1;
         assert_eq!(Operand::Caller, operand);
+
+        let operand = Operand::<CurrentNetwork>::parse("self.parent").unwrap().1;
+        assert_eq!(Operand::Parent, operand);
 
         let operand = Operand::<CurrentNetwork>::parse("block.height").unwrap().1;
         assert_eq!(Operand::BlockHeight, operand);

--- a/synthesizer/program/src/resources/credits.aleo
+++ b/synthesizer/program/src/resources/credits.aleo
@@ -668,6 +668,38 @@ finalize set_validator_state:
 
 /**********************************************************************************************************************/
 
+// The `transfer_program` function sends the specified amount
+// from the program's `account` to the receiver's `account`.
+function transfer_program:
+    // Input the receiver.
+    input r0 as address.public;
+    // Input the amount.
+    input r1 as u64.public;
+    // Transfer the credits publicly.
+    finalize self.parent r0 r1;
+
+finalize transfer_program:
+    // Input the sender.
+    input r0 as address.public;
+    // Input the receiver.
+    input r1 as address.public;
+    // Input the amount.
+    input r2 as u64.public;
+    // Decrements `account[r0]` by `r2`.
+    // If `account[r0]` does not exist, 0u64 is used.
+    // If `account[r0] - r2` underflows, `transfer_program` is reverted.
+    get.or_use account[r0] 0u64 into r3;
+    sub r3 r2 into r4;
+    set r4 into account[r0];
+    // Increments `account[r1]` by `r2`.
+    // If `account[r1]` does not exist, 0u64 is used.
+    // If `account[r1] + r2` overflows, `transfer_programc` is reverted.
+    get.or_use account[r1] 0u64 into r5;
+    add r5 r2 into r6;
+    set r6 into account[r1];
+
+/**********************************************************************************************************************/
+
 // The `transfer_public` function sends the specified amount
 // from the sender's `account` to the receiver's `account`.
 function transfer_public:

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -94,6 +94,12 @@ pub trait RegistersCaller<N: Network> {
     /// Sets the transition caller.
     fn set_caller(&mut self, caller: Address<N>);
 
+    /// Returns the transition parent.
+    fn parent(&self) -> Result<Address<N>>;
+
+    /// Sets the transition parent.
+    fn set_parent(&mut self, parent: Address<N>);
+
     /// Returns the transition view key.
     fn tvk(&self) -> Result<Field<N>>;
 
@@ -107,6 +113,12 @@ pub trait RegistersCallerCircuit<N: Network, A: circuit::Aleo<Network = N>> {
 
     /// Sets the transition caller, as a circuit.
     fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>);
+
+    /// Returns the transition parent, as a circuit.
+    fn parent_circuit(&self) -> Result<circuit::Address<A>>;
+
+    /// Sets the transition parent, as a circuit.
+    fn set_parent_circuit(&mut self, parent_circuit: circuit::Address<A>);
 
     /// Returns the transition view key, as a circuit.
     fn tvk_circuit(&self) -> Result<circuit::Field<A>>;


### PR DESCRIPTION
This is an updated version of: https://github.com/AleoHQ/snarkVM/pull/1178

## Motivation

Building the https://github.com/AleoHQ/ARCs/discussions/11 self.parent functionality will unlock a wide variety of applications to be built on top of Aleo, including anything that relates to DeFi and NFTs. As an application builder in the Aleo ecosystem, I want to be able to use self.parent functionality, so I can build robust smart contracts involving token swaps, escrow contracts, and NFTs. In particular, when programs are able to know which contract is calling them, access controls can be expanded beyond just users. This allows callee programs with public state in mappings to assign state to program addresses, and only allow calls by that program address to modify that state. The Aleo-equivalent of ERC-20 can leverage this feature to be a fully functional implementation of the ERC-20 contract.


## Potential Security Considerations

### Reentrancy attacks
This shouldn't really be possible given that the `call` opcode needs to match against a `locator` ie `some_program.aleo/some_function`. Since `self.parent` and `self.caller` compile to an address and not a locator, it shouldn't be possible for a program to use: `call self.parent/some_function ...args` any more than it's possible to use `call self.caller/some_function ..args`

If this is still a concern, we can further restrict the usage of `self.parent` to only be used as an argument to a finalize statement. Note, it cannot be used within a finalize block, only as an argument from the transition to the finalize block. Restricting as such would still serve every significant use case I can imagine.

### Deriving the private key that leads to the address
If someone can recover the private key that derives a public key that matches the program, this would be a majority vulnerability. Someone could easily clear the balance held by a program.

This shouldn't be any easier than guessing a private key from a public key.
The program address is calculated as `HashToGroup(program_id)` and a normal address is calculated as `address := pk_sig + pr_sig + pk_prf`

### Programs owning records
This could lead to programs that create records with an owner of `self.parent` which would effectively make them unusable forever. I don't think this is a big consideration as it's already possible to randomly generate a public key and then transfer a record to it. This may perhaps just make it more likely someone does this. I wouldn't consider it a large consideration but leo should perhaps be updated to throw warnings if someone tries to set the owner of a record to `self.parent`

## Related PRs

* https://github.com/AleoHQ/snarkVM/pull/1178
* https://github.com/AleoHQ/welcome/pull/139
* https://github.com/AleoHQ/ARCs/discussions/11
