### PR TITLE
Add `Keccak` and `Sha3` support to K-ary Merkle trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,7 +2567,6 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
- "tiny-keccak",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2567,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2757,6 +2764,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -3525,6 +3533,15 @@ name = "time-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinytemplate"

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -21,6 +21,9 @@ path = "../../fields"
 version = "=0.14.6"
 default-features = false
 
+[dev-dependencies.anyhow]
+version = "1.0.73"
+
 [dev-dependencies.snarkvm-curves]
 path = "../../curves"
 default-features = false
@@ -29,8 +32,9 @@ default-features = false
 path = "../../utilities"
 default-features = false
 
-[dev-dependencies.anyhow]
-version = "1.0.73"
+[dev-dependencies.tiny-keccak]
+version = "2"
+features = [ "keccak", "sha3" ]
 
 [features]
 default = [ "enable_console" ]

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -32,10 +32,6 @@ default-features = false
 path = "../../utilities"
 default-features = false
 
-[dev-dependencies.tiny-keccak]
-version = "2"
-features = [ "keccak", "sha3" ]
-
 [features]
 default = [ "enable_console" ]
 enable_console = [ "console" ]

--- a/circuit/algorithms/src/keccak/hash.rs
+++ b/circuit/algorithms/src/keccak/hash.rs
@@ -154,12 +154,17 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIA
         rotl: &[usize],
     ) -> Vec<Boolean<E>> {
         debug_assert_eq!(input.len(), WIDTH, "The input vector must have {WIDTH} bits");
+        debug_assert_eq!(
+            round_constants.len(),
+            NUM_ROUNDS,
+            "The round constants vector must have {NUM_ROUNDS} elements"
+        );
 
         // Partition the input into 64-bit chunks.
-        let mut a = input.chunks(64).map(|e| U64::from_bits_le(e)).collect::<Vec<_>>();
+        let mut a = input.chunks(64).map(U64::from_bits_le).collect::<Vec<_>>();
         // Permute the input.
-        for i in 0..NUM_ROUNDS {
-            a = Self::round(a, &round_constants[i], rotl);
+        for round_constant in round_constants.iter().take(NUM_ROUNDS) {
+            a = Self::round(a, round_constant, rotl);
         }
         // Return the permuted input.
         a.into_iter().flat_map(|e| e.to_bits_le()).collect()

--- a/circuit/algorithms/src/keccak/hash.rs
+++ b/circuit/algorithms/src/keccak/hash.rs
@@ -280,7 +280,7 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIA
 #[cfg(all(test, console))]
 mod tests {
     use super::*;
-    use console::Rng;
+    use console::{Console, Rng};
     use snarkvm_circuit_types::environment::Circuit;
 
     const ITERATIONS: usize = 3;
@@ -323,7 +323,7 @@ mod tests {
     ) {
         use console::Hash as H;
 
-        let native = console::Keccak256::default();
+        let native = console::Keccak256::<Console>::new();
         let keccak = Keccak256::<Circuit>::new();
 
         for i in 0..ITERATIONS {
@@ -414,41 +414,41 @@ mod tests {
 
     #[test]
     fn test_keccak_224_equivalence() {
-        check_equivalence!(console::Keccak224::default(), Keccak224::<Circuit>::new());
+        check_equivalence!(console::Keccak224::<Console>::new(), Keccak224::<Circuit>::new());
     }
 
     #[test]
     fn test_keccak_256_equivalence() {
-        check_equivalence!(console::Keccak256::default(), Keccak256::<Circuit>::new());
+        check_equivalence!(console::Keccak256::<Console>::new(), Keccak256::<Circuit>::new());
     }
 
     #[test]
     fn test_keccak_384_equivalence() {
-        check_equivalence!(console::Keccak384::default(), Keccak384::<Circuit>::new());
+        check_equivalence!(console::Keccak384::<Console>::new(), Keccak384::<Circuit>::new());
     }
 
     #[test]
     fn test_keccak_512_equivalence() {
-        check_equivalence!(console::Keccak512::default(), Keccak512::<Circuit>::new());
+        check_equivalence!(console::Keccak512::<Console>::new(), Keccak512::<Circuit>::new());
     }
 
     #[test]
     fn test_sha3_224_equivalence() {
-        check_equivalence!(console::Sha3_224::default(), Sha3_224::<Circuit>::new());
+        check_equivalence!(console::Sha3_224::<Console>::new(), Sha3_224::<Circuit>::new());
     }
 
     #[test]
     fn test_sha3_256_equivalence() {
-        check_equivalence!(console::Sha3_256::default(), Sha3_256::<Circuit>::new());
+        check_equivalence!(console::Sha3_256::<Console>::new(), Sha3_256::<Circuit>::new());
     }
 
     #[test]
     fn test_sha3_384_equivalence() {
-        check_equivalence!(console::Sha3_384::default(), Sha3_384::<Circuit>::new());
+        check_equivalence!(console::Sha3_384::<Console>::new(), Sha3_384::<Circuit>::new());
     }
 
     #[test]
     fn test_sha3_512_equivalence() {
-        check_equivalence!(console::Sha3_512::default(), Sha3_512::<Circuit>::new());
+        check_equivalence!(console::Sha3_512::<Console>::new(), Sha3_512::<Circuit>::new());
     }
 }

--- a/circuit/algorithms/src/keccak/hash.rs
+++ b/circuit/algorithms/src/keccak/hash.rs
@@ -12,80 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, console))]
-use snarkvm_circuit_types::environment::assert_scope;
-#[cfg(test)]
-use snarkvm_utilities::{TestRng, Uniform};
-
-use crate::Hash;
-use snarkvm_circuit_types::{environment::prelude::*, Boolean, U64};
-
-/// The Keccak-224 hash function.
-pub type Keccak224<E> = Keccak<E, { KeccakType::Keccak as u8 }, 224>;
-/// The Keccak-256 hash function.
-pub type Keccak256<E> = Keccak<E, { KeccakType::Keccak as u8 }, 256>;
-/// The Keccak-384 hash function.
-pub type Keccak384<E> = Keccak<E, { KeccakType::Keccak as u8 }, 384>;
-/// The Keccak-512 hash function.
-pub type Keccak512<E> = Keccak<E, { KeccakType::Keccak as u8 }, 512>;
-
-/// The SHA3-224 hash function.
-pub type Sha3_224<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 224>;
-/// The SHA3-256 hash function.
-pub type Sha3_256<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 256>;
-/// The SHA3-384 hash function.
-pub type Sha3_384<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 384>;
-/// The SHA3-512 hash function.
-pub type Sha3_512<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 512>;
-
-/// A helper to specify the hash type.
-enum KeccakType {
-    Keccak,
-    Sha3,
-}
-
-/// The rows and columns are 5-bit lanes.
-const MODULO: usize = 5;
-/// The permutation type `l`.
-const L: usize = 6;
-/// The number of rounds in a full-round operation.
-const NUM_ROUNDS: usize = 12 + 2 * L;
-
-/// The sponge construction `Sponge[f, pad, r]` is a function that takes a variable-length input
-/// and produces a fixed-length output (the hash value).
-///
-/// The permutation `f` is a function that takes a fixed-length input and produces a fixed-length output,
-/// defined as `f = Keccak-f[b]`, where `b := 25 * 2^l` is the width of the permutation,
-/// and `l` is the log width of the permutation.
-/// For our case, `l = 6`, thus `b = 1600`.
-///
-/// The padding rule `pad` is a function that takes a variable-length input and produces a fixed-length output.
-/// In Keccak, `pad` is a multi-rate padding, defined as `pad(M) = M || 0x01 || 0x00…0x00 || 0x80`,
-/// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
-/// In SHA-3, `pad` is a SHAKE, defined as `pad(M) = M || 0x06 || 0x00…0x00 || 0x80`,
-/// where `M` is the input data, and `0x06 || 0x00…0x00 || 0x80` is the padding.
-///
-/// The bitrate `r` is the number of bits that are absorbed into the sponge state in each iteration
-/// of the absorbing phase.
-///
-/// In addition, the capacity is defined as `c := b - r`.
-pub struct Keccak<E: Environment, const TYPE: u8, const VARIANT: usize> {
-    /// The round constants `RC[t] ∈ GF(2)` are defined as the
-    /// output of a linear feedback shift register (LFSR).
-    round_constants: Vec<U64<E>>,
-    /// Precomputations for the ρ step.
-    rotl: Vec<usize>,
-}
-
-impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIANT> {
-    /// Initializes a new Keccak hash function.
-    pub fn new() -> Self {
-        Self {
-            round_constants: Self::ROUND_CONSTANTS.into_iter().map(|e| U64::constant(console::U64::new(e))).collect(),
-            rotl: Self::rotl_offsets::<NUM_ROUNDS>(),
-        }
-    }
-}
+use super::*;
 
 impl<E: Environment, const TYPE: u8, const VARIANT: usize> Hash for Keccak<E, TYPE, VARIANT> {
     type Input = Boolean<E>;
@@ -94,9 +21,6 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> Hash for Keccak<E, TY
     /// Returns the Keccak hash of the given input as bits.
     #[inline]
     fn hash(&self, input: &[Self::Input]) -> Self::Output {
-        /// The permutation width `b`.
-        const PERMUTATION_WIDTH: usize = 1600;
-
         // The bitrate `r`.
         let bitrate = (200 - (VARIANT / 4)) * 8;
         debug_assert!(bitrate < PERMUTATION_WIDTH, "The bitrate must be less than the permutation width");
@@ -156,66 +80,6 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> Hash for Keccak<E, TY
 }
 
 impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIANT> {
-    /// The values `ROUND_CONSTANTS[t] ∈ GF(2)` are defined as the
-    /// output of a binary linear feedback shift register (LFSR):
-    /// ```text
-    /// ROUND_CONSTANTS[t] = (x^t) mod (x^8 + x^6 + x^5 + x^4 + 1) mod x in GF(2)[x]
-    /// ```
-    /// where `t ∈ {0, 1, …, NUM_ROUNDS}`.
-    const ROUND_CONSTANTS: [u64; NUM_ROUNDS] = [
-        0x0000000000000001,
-        0x0000000000008082,
-        0x800000000000808A,
-        0x8000000080008000,
-        0x000000000000808B,
-        0x0000000080000001,
-        0x8000000080008081,
-        0x8000000000008009,
-        0x000000000000008A,
-        0x0000000000000088,
-        0x0000000080008009,
-        0x000000008000000A,
-        0x000000008000808B,
-        0x800000000000008B,
-        0x8000000000008089,
-        0x8000000000008003,
-        0x8000000000008002,
-        0x8000000000000080,
-        0x000000000000800A,
-        0x800000008000000A,
-        0x8000000080008081,
-        0x8000000000008080,
-        0x0000000080000001,
-        0x8000000080008008,
-    ];
-
-    /// Returns the ROTL offsets for the ρ step.
-    ///
-    /// The offsets are defined as follows:
-    /// ```text
-    /// for t = 0 to NUM_ROUNDS do
-    ///   offset[t] = (t + 1)(t + 2)/2
-    /// end for
-    /// ```
-    ///
-    /// This method transposes the offsets to match the access pattern (i.e. for y, then for x).
-    fn rotl_offsets<const NUM_ROUNDS: usize>() -> Vec<usize> {
-        let mut rotl = vec![0; MODULO * MODULO];
-        let mut x: usize = 1;
-        let mut y: usize = 0;
-
-        for t in 0..NUM_ROUNDS {
-            let rotr = ((t + 1) * (t + 2) / 2) % 64;
-            rotl[x + (y * MODULO)] = (64 - rotr) % 64;
-
-            // Update x and y.
-            let x_old = x;
-            x = y;
-            y = (2 * x_old + 3 * y) % MODULO;
-        }
-        rotl
-    }
-
     /// In Keccak, `pad` is a multi-rate padding, defined as `pad(M) = M || 0x01 || 0x00…0x00 || 0x80`,
     /// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
     /// The padding extends the input data to a multiple of the bitrate `r`, defined as `r = b - c`,

--- a/circuit/algorithms/src/keccak/mod.rs
+++ b/circuit/algorithms/src/keccak/mod.rs
@@ -1,0 +1,154 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod hash;
+
+#[cfg(all(test, console))]
+use snarkvm_circuit_types::environment::assert_scope;
+#[cfg(test)]
+use snarkvm_utilities::{TestRng, Uniform};
+
+use crate::Hash;
+use snarkvm_circuit_types::{environment::prelude::*, Boolean, U64};
+
+/// The Keccak-224 hash function.
+pub type Keccak224<E> = Keccak<E, { KeccakType::Keccak as u8 }, 224>;
+/// The Keccak-256 hash function.
+pub type Keccak256<E> = Keccak<E, { KeccakType::Keccak as u8 }, 256>;
+/// The Keccak-384 hash function.
+pub type Keccak384<E> = Keccak<E, { KeccakType::Keccak as u8 }, 384>;
+/// The Keccak-512 hash function.
+pub type Keccak512<E> = Keccak<E, { KeccakType::Keccak as u8 }, 512>;
+
+/// The SHA3-224 hash function.
+pub type Sha3_224<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 224>;
+/// The SHA3-256 hash function.
+pub type Sha3_256<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 256>;
+/// The SHA3-384 hash function.
+pub type Sha3_384<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 384>;
+/// The SHA3-512 hash function.
+pub type Sha3_512<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 512>;
+
+/// A helper to specify the hash type.
+enum KeccakType {
+    Keccak,
+    Sha3,
+}
+
+/// The rows and columns are 5-bit lanes.
+const MODULO: usize = 5;
+/// The permutation type `l`.
+const L: usize = 6;
+/// The number of rounds in a full-round operation.
+const NUM_ROUNDS: usize = 12 + 2 * L;
+/// The permutation width `b`.
+const PERMUTATION_WIDTH: usize = 1600;
+
+/// The sponge construction `Sponge[f, pad, r]` is a function that takes a variable-length input
+/// and produces a fixed-length output (the hash value).
+///
+/// The permutation `f` is a function that takes a fixed-length input and produces a fixed-length output,
+/// defined as `f = Keccak-f[b]`, where `b := 25 * 2^l` is the width of the permutation,
+/// and `l` is the log width of the permutation.
+/// For our case, `l = 6`, thus `b = 1600`.
+///
+/// The padding rule `pad` is a function that takes a variable-length input and produces a fixed-length output.
+/// In Keccak, `pad` is a multi-rate padding, defined as `pad(M) = M || 0x01 || 0x00…0x00 || 0x80`,
+/// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
+/// In SHA-3, `pad` is a SHAKE, defined as `pad(M) = M || 0x06 || 0x00…0x00 || 0x80`,
+/// where `M` is the input data, and `0x06 || 0x00…0x00 || 0x80` is the padding.
+///
+/// The bitrate `r` is the number of bits that are absorbed into the sponge state in each iteration
+/// of the absorbing phase.
+///
+/// In addition, the capacity is defined as `c := b - r`.
+pub struct Keccak<E: Environment, const TYPE: u8, const VARIANT: usize> {
+    /// The round constants `RC[t] ∈ GF(2)` are defined as the
+    /// output of a linear feedback shift register (LFSR).
+    round_constants: Vec<U64<E>>,
+    /// Precomputations for the ρ step.
+    rotl: Vec<usize>,
+}
+
+impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIANT> {
+    /// Initializes a new Keccak hash function.
+    pub fn new() -> Self {
+        Self {
+            round_constants: Self::ROUND_CONSTANTS.into_iter().map(|e| U64::constant(console::U64::new(e))).collect(),
+            rotl: Self::rotl_offsets::<NUM_ROUNDS>(),
+        }
+    }
+}
+
+impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIANT> {
+    /// The values `ROUND_CONSTANTS[t] ∈ GF(2)` are defined as the
+    /// output of a binary linear feedback shift register (LFSR):
+    /// ```text
+    /// ROUND_CONSTANTS[t] = (x^t) mod (x^8 + x^6 + x^5 + x^4 + 1) mod x in GF(2)[x]
+    /// ```
+    /// where `t ∈ {0, 1, …, NUM_ROUNDS}`.
+    const ROUND_CONSTANTS: [u64; NUM_ROUNDS] = [
+        0x0000000000000001,
+        0x0000000000008082,
+        0x800000000000808A,
+        0x8000000080008000,
+        0x000000000000808B,
+        0x0000000080000001,
+        0x8000000080008081,
+        0x8000000000008009,
+        0x000000000000008A,
+        0x0000000000000088,
+        0x0000000080008009,
+        0x000000008000000A,
+        0x000000008000808B,
+        0x800000000000008B,
+        0x8000000000008089,
+        0x8000000000008003,
+        0x8000000000008002,
+        0x8000000000000080,
+        0x000000000000800A,
+        0x800000008000000A,
+        0x8000000080008081,
+        0x8000000000008080,
+        0x0000000080000001,
+        0x8000000080008008,
+    ];
+
+    /// Returns the ROTL offsets for the ρ step.
+    ///
+    /// The offsets are defined as follows:
+    /// ```text
+    /// for t = 0 to NUM_ROUNDS do
+    ///   offset[t] = (t + 1)(t + 2)/2
+    /// end for
+    /// ```
+    ///
+    /// This method transposes the offsets to match the access pattern (i.e. for y, then for x).
+    fn rotl_offsets<const NUM_ROUNDS: usize>() -> Vec<usize> {
+        let mut rotl = vec![0; MODULO * MODULO];
+        let mut x: usize = 1;
+        let mut y: usize = 0;
+
+        for t in 0..NUM_ROUNDS {
+            let rotr = ((t + 1) * (t + 2) / 2) % 64;
+            rotl[x + (y * MODULO)] = (64 - rotr) % 64;
+
+            // Update x and y.
+            let x_old = x;
+            x = y;
+            y = (2 * x_old + 3 * y) % MODULO;
+        }
+        rotl
+    }
+}

--- a/circuit/algorithms/src/keccak/mod.rs
+++ b/circuit/algorithms/src/keccak/mod.rs
@@ -73,6 +73,7 @@ const PERMUTATION_WIDTH: usize = 1600;
 /// of the absorbing phase.
 ///
 /// In addition, the capacity is defined as `c := b - r`.
+#[derive(Clone, Debug, Default)]
 pub struct Keccak<E: Environment, const TYPE: u8, const VARIANT: usize> {
     /// The round constants `RC[t] ∈ GF(2)` are defined as the
     /// output of a linear feedback shift register (LFSR).

--- a/circuit/algorithms/src/keccak256/mod.rs
+++ b/circuit/algorithms/src/keccak256/mod.rs
@@ -1,0 +1,474 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, console))]
+use snarkvm_circuit_types::environment::assert_scope;
+#[cfg(test)]
+use snarkvm_utilities::{TestRng, Uniform};
+
+use crate::Hash;
+use snarkvm_circuit_types::{environment::prelude::*, Boolean, U64};
+
+/// The rows and columns are 5 bits.
+const MODULO: usize = 5;
+
+/// The permutation type `l`.
+const L: usize = 6;
+/// The number of rounds in a full-round operation.
+const NUM_ROUNDS: usize = 12 + 2 * L;
+
+/// The sponge construction `Sponge[f, pad, r]` is a function that takes a variable-length input
+/// and produces a fixed-length output (the hash value).
+///
+/// The permutation `f` is a function that takes a fixed-length input and produces a fixed-length output,
+/// defined as `f = Keccak-f[b]`, where `b := 25 * 2^l` is the width of the permutation,
+/// and `l` is the log width of the permutation.
+/// For our case, `l = 6`, thus `b = 1600`.
+///
+/// The padding rule `pad` is a function that takes a variable-length input and produces a fixed-length output.
+/// In Keccak, `pad` is a multi-rate padding, defined as `pad(M) = M || 0x01 || 0x00…0x00 || 0x80`,
+/// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
+/// In SHA-3, `pad` is a SHAKE or cSHAKE (for XOF) padding, defined as `pad(M) = M || 0x01 || 0x00…0x00`,
+/// where `M` is the input data, and `0x01 || 0x00…0x00` is the padding.
+///
+/// The bitrate `r` is the number of bits that are absorbed into the sponge state in each iteration
+/// of the absorbing phase.
+/// For our case, `r = 1088`.
+///
+/// In addition, the capacity is defined as `c := b - r`. For our case, `c = 512`, as `b = 1600` and `r = 1088`.
+pub struct Keccak<E: Environment> {
+    /// The round constants `RC[t] ∈ GF(2)` are defined as the
+    /// output of a linear feedback shift register (LFSR).
+    round_constants: Vec<U64<E>>,
+    /// Precomputations for the ρ step.
+    rotl: Vec<usize>,
+}
+
+impl<E: Environment> Keccak<E> {
+    /// Initializes a new Keccak hash function.
+    pub fn new() -> Self {
+        Self {
+            round_constants: Self::ROUND_CONSTANTS.into_iter().map(|e| U64::constant(console::U64::new(e))).collect(),
+            rotl: Self::rotl_offsets::<NUM_ROUNDS>(),
+        }
+    }
+}
+
+impl<E: Environment> Hash for Keccak<E> {
+    type Input = Boolean<E>;
+    type Output = Vec<Boolean<E>>;
+
+    /// Returns the Keccak-256 hash of the given input as bits.
+    #[inline]
+    fn hash(&self, input: &[Self::Input]) -> Self::Output {
+        /// The capacity `c`.
+        const CAPACITY: usize = 512;
+        /// The permutation width `b`.
+        const PERMUTATION_WIDTH: usize = 1600;
+        /// The bitrate `r`.
+        const BITRATE: usize = PERMUTATION_WIDTH - CAPACITY;
+        /// The output length `l`.
+        const OUTPUT_LENGTH: usize = 256;
+
+        debug_assert!(BITRATE < PERMUTATION_WIDTH, "The bitrate must be less than the permutation width");
+
+        // The padded blocks `P`.
+        let padded_blocks = Self::pad_keccak::<PERMUTATION_WIDTH>(input, CAPACITY, BITRATE);
+
+        // The root state `s` is defined as `0^b`.
+        let mut s = vec![Boolean::constant(false); PERMUTATION_WIDTH];
+
+        /* The first part of the sponge construction (the absorbing phase):
+         *
+         * for i = 0 to |P|_r − 1 do
+         *   s = s ⊕ (P_i || 0^c) # Note: |P_i| + c == b, since |P_i| == r
+         *   s = f(s)
+         * end for
+         */
+        for block in padded_blocks {
+            // s = s ⊕ (P_i || 0^c)
+            for (j, bit) in block.into_iter().enumerate() {
+                s[j] = &s[j] ^ &bit;
+            }
+            // s = f(s)
+            s = Self::permutation_f::<PERMUTATION_WIDTH, NUM_ROUNDS>(s, &self.round_constants, &self.rotl);
+        }
+
+        /* The second part of the sponge construction (the squeezing phase):
+         *
+         * Z = s[0..r-1]
+         * while |Z|_r < l do
+         *   s = f(s)
+         *   Z = Z || s[0..r-1]
+         * end while
+         * return Z[0..l-1]
+         */
+        // Z = s[0..r-1]
+        let mut z = s[..BITRATE].to_vec();
+        // while |Z|_r < l do
+        while z.len() < OUTPUT_LENGTH {
+            // s = f(s)
+            s = Self::permutation_f::<PERMUTATION_WIDTH, NUM_ROUNDS>(s, &self.round_constants, &self.rotl);
+            // Z = Z || s[0..r-1]
+            z.extend(s.iter().take(BITRATE).cloned());
+        }
+        // return Z[0..l-1]
+        z.into_iter().take(OUTPUT_LENGTH).collect()
+    }
+}
+
+impl<E: Environment> Keccak<E> {
+    /// The values `ROUND_CONSTANTS[t] ∈ GF(2)` are defined as the
+    /// output of a binary linear feedback shift register (LFSR):
+    /// ```text
+    /// ROUND_CONSTANTS[t] = (x^t) mod (x^8 + x^6 + x^5 + x^4 + 1) mod x in GF(2)[x]
+    /// ```
+    /// where `t ∈ {0, 1, …, NUM_ROUNDS}`.
+    const ROUND_CONSTANTS: [u64; NUM_ROUNDS] = [
+        0x0000000000000001,
+        0x0000000000008082,
+        0x800000000000808A,
+        0x8000000080008000,
+        0x000000000000808B,
+        0x0000000080000001,
+        0x8000000080008081,
+        0x8000000000008009,
+        0x000000000000008A,
+        0x0000000000000088,
+        0x0000000080008009,
+        0x000000008000000A,
+        0x000000008000808B,
+        0x800000000000008B,
+        0x8000000000008089,
+        0x8000000000008003,
+        0x8000000000008002,
+        0x8000000000000080,
+        0x000000000000800A,
+        0x800000008000000A,
+        0x8000000080008081,
+        0x8000000000008080,
+        0x0000000080000001,
+        0x8000000080008008,
+    ];
+
+    /// Returns the ROTL offsets for the ρ step.
+    ///
+    /// The offsets are defined as follows:
+    /// ```text
+    /// for t = 0 to NUM_ROUNDS do
+    ///   offset[t] = (t + 1)(t + 2)/2
+    /// end for
+    /// ```
+    ///
+    /// This method transposes the offsets to match the access pattern (i.e. for y, then for x).
+    fn rotl_offsets<const NUM_ROUNDS: usize>() -> Vec<usize> {
+        let mut rotl = vec![0; MODULO * MODULO];
+        let mut x: usize = 1;
+        let mut y: usize = 0;
+
+        for t in 0..NUM_ROUNDS {
+            let rotr = ((t + 1) * (t + 2) / 2) % 64;
+            rotl[x + (y * MODULO)] = (64 - rotr) % 64;
+
+            // Update x and y.
+            let x_old = x;
+            x = y;
+            y = (2 * x_old + 3 * y) % MODULO;
+        }
+        rotl
+    }
+
+    /// In Keccak, `pad` is a multi-rate padding, defined as `pad(M) = M || 0x01 || 0x00…0x00 || 0x80`,
+    /// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
+    /// The padding extends the input data to a multiple of the bitrate `r`, defined as `r = b - c`,
+    /// where `b` is the width of the permutation, and `c` is the capacity.
+    fn pad_keccak<const WIDTH: usize>(input: &[Boolean<E>], capacity: usize, bitrate: usize) -> Vec<Vec<Boolean<E>>> {
+        debug_assert_eq!(bitrate, WIDTH - capacity, "The bitrate must be less than the permutation width");
+        // Initialize a vector to store the padded blocks.
+        let mut result = Vec::with_capacity(input.len() / capacity);
+        // Iterate over the input in `capacity` chunks.
+        for block in input.chunks(capacity) {
+            // Construct the padded block.
+            let mut m = block.to_vec();
+            m.push(Boolean::constant(true));
+            m.resize(WIDTH, Boolean::constant(false));
+            m[bitrate - 1] = Boolean::constant(true);
+            // Append the padded block to the result.
+            result.push(m);
+        }
+        // Return the result.
+        result
+    }
+
+    /// The permutation `f` is a function that takes a fixed-length input and produces a fixed-length output,
+    /// defined as `f = Keccak-f[b]`, where `b := 25 * 2^l` is the width of the permutation,
+    /// and `l` is the log width of the permutation.
+    ///
+    /// The round function `R` is applied `12 + 2l` times, where `l` is the log width of the permutation.
+    fn permutation_f<const WIDTH: usize, const NUM_ROUNDS: usize>(
+        input: Vec<Boolean<E>>,
+        round_constants: &[U64<E>],
+        rotl: &[usize],
+    ) -> Vec<Boolean<E>> {
+        debug_assert_eq!(input.len(), WIDTH, "The input vector must have {WIDTH} bits");
+
+        // Partition the input into 64-bit chunks.
+        let mut a = input.chunks(64).map(|e| U64::from_bits_le(e)).collect::<Vec<_>>();
+        // Permute the input.
+        for i in 0..NUM_ROUNDS {
+            a = Self::round(a, &round_constants[i], rotl);
+        }
+        // Return the permuted input.
+        a.into_iter().flat_map(|e| e.to_bits_le()).collect()
+    }
+
+    /// The round function `R` is defined as follows:
+    /// ```text
+    /// R = ι ◦ χ ◦ π ◦ ρ ◦ θ
+    /// ```
+    /// where `◦` denotes function composition.
+    fn round(a: Vec<U64<E>>, round_constant: &U64<E>, rotl: &[usize]) -> Vec<U64<E>> {
+        debug_assert_eq!(a.len(), MODULO * MODULO, "The input vector 'a' must have {} elements", MODULO * MODULO);
+
+        const WEIGHT: usize = MODULO - 1;
+
+        /* The first part of Algorithm 3, θ:
+         *
+         * for x = 0 to 4 do
+         *   C[x] = a[x, 0]
+         *   for y = 1 to 4 do
+         *     C[x] = C[x] ⊕ a[x, y]
+         *   end for
+         * end for
+         */
+        let mut c = Vec::with_capacity(WEIGHT);
+        for x in 0..MODULO {
+            c.push(&a[x + 0] ^ &a[x + MODULO] ^ &a[x + (2 * MODULO)] ^ &a[x + (3 * MODULO)] ^ &a[x + (4 * MODULO)]);
+        }
+
+        /* The second part of Algorithm 3, θ:
+         *
+         * for x = 0 to 4 do
+         *   D[x] = C[x−1] ⊕ ROT(C[x+1],1)
+         *   for y = 0 to 4 do
+         *     A[x, y] = a[x, y] ⊕ D[x]
+         *   end for
+         * end for
+         */
+        let mut d = Vec::with_capacity(WEIGHT);
+        for x in 0..MODULO {
+            d.push(&c[(x + 4) % MODULO] ^ Self::rotate_left(&c[(x + 1) % MODULO], 63));
+        }
+        let mut a_1 = Vec::with_capacity(WEIGHT * WEIGHT);
+        for y in 0..MODULO {
+            for x in 0..MODULO {
+                a_1.push(&a[x + (y * MODULO)] ^ &d[x]);
+            }
+        }
+
+        /* Algorithm 4, π:
+         *
+         * for x = 0 to 4 do
+         *   for y = 0 to 4 do
+         *     (X, Y) = (y, (2*x + 3*y) mod 5)
+         *     A[X, Y] = a[x, y]
+         *   end for
+         * end for
+         *
+         * Algorithm 5, ρ:
+         *
+         * A[0, 0] = a[0, 0]
+         * (x, y) = (1, 0)
+         * for t = 0 to 23 do
+         *   A[x, y] = ROT(a[x, y], (t + 1)(t + 2)/2)
+         *   (x, y) = (y, (2*x + 3*y) mod 5)
+         * end for
+         */
+        let mut a_2 = a_1.clone();
+        for y in 0..MODULO {
+            for x in 0..MODULO {
+                // This step combines the π and ρ steps into one.
+                a_2[y + ((((2 * x) + (3 * y)) % MODULO) * MODULO)] =
+                    Self::rotate_left(&a_1[x + (y * MODULO)], rotl[x + (y * MODULO)]);
+            }
+        }
+
+        /* Algorithm 2, χ:
+         *
+         * for y = 0 to 4 do
+         *   for x = 0 to 4 do
+         *     A[x, y] = a[x, y] ⊕ ((¬a[x+1, y]) ∧ a[x+2, y])
+         *   end for
+         * end for
+         */
+        let mut a_3 = Vec::with_capacity(WEIGHT * WEIGHT);
+        for y in 0..MODULO {
+            for x in 0..MODULO {
+                let a = &a_2[x + (y * MODULO)];
+                let b = &a_2[((x + 1) % MODULO) + (y * MODULO)];
+                let c = &a_2[((x + 2) % MODULO) + (y * MODULO)];
+                a_3.push(a ^ ((!b) & c));
+            }
+        }
+
+        /* ι:
+         *
+         * A[0, 0] = A[0, 0] ⊕ RC
+         */
+        a_3[0] = &a_3[0] ^ round_constant;
+        a_3
+    }
+
+    /// Performs a rotate left operation on the given `u64` value.
+    fn rotate_left(value: &U64<E>, n: usize) -> U64<E> {
+        // Perform the rotation.
+        let bits_le = value.to_bits_le();
+        let bits_le = bits_le.iter().skip(n).chain(bits_le.iter()).take(64).cloned().collect::<Vec<_>>();
+        // Return the rotated value.
+        U64::from_bits_le(&bits_le)
+    }
+}
+
+#[cfg(all(test, console))]
+mod tests {
+    use super::*;
+    use snarkvm_circuit_types::environment::Circuit;
+    use snarkvm_utilities::{bits_from_bytes_le, bytes_from_bits_le};
+
+    use tiny_keccak::{Hasher, Keccak as TinyKeccak};
+
+    const ITERATIONS: usize = 10;
+
+    /// Computes the Keccak-256 hash of the given preimage as bytes.
+    fn keccak256_native(preimage: &[u8]) -> [u8; 32] {
+        let mut keccak = TinyKeccak::v256();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 32];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
+    fn check_hash(
+        mode: Mode,
+        num_inputs: usize,
+        num_constants: u64,
+        num_public: u64,
+        num_private: u64,
+        num_constraints: u64,
+        rng: &mut TestRng,
+    ) {
+        use console::Hash as H;
+
+        // let native = console::Poseidon::<<Circuit as Environment>::Network, RATE>::setup(DOMAIN)?;
+        let keccak = Keccak::<Circuit>::new();
+
+        for i in 0..ITERATIONS {
+            // Prepare the preimage.
+            let native_input = (0..num_inputs).map(|_| Uniform::rand(rng)).collect::<Vec<bool>>();
+            let input = native_input.iter().map(|v| Boolean::<Circuit>::new(mode, *v)).collect::<Vec<_>>();
+
+            // Compute the native hash.
+            // let expected = native.hash(&native_input).expect("Failed to hash native input");
+            let expected = keccak256_native(&bytes_from_bits_le(&native_input));
+            let expected = bits_from_bytes_le(&expected).collect::<Vec<_>>();
+
+            // Compute the circuit hash.
+            Circuit::scope(format!("Keccak {mode} {i}"), || {
+                let candidate = keccak.hash(&input);
+                assert_eq!(expected, candidate.eject_value());
+                let case = format!("(mode = {mode}, num_inputs = {num_inputs})");
+                assert_scope!(case, num_constants, num_public, num_private, num_constraints);
+            });
+            Circuit::reset();
+        }
+    }
+
+    // #[test]
+    // fn test_hash_constant() -> Result<()> {
+    //     let mut rng = TestRng::default();
+    //
+    //     for num_inputs in 0..=RATE {
+    //         check_hash(Mode::Constant, num_inputs, 1, 0, 0, 0, &mut rng)?;
+    //     }
+    //     Ok(())
+    // }
+
+    // #[test]
+    // fn test_hash_public() -> Result<()> {
+    //     let mut rng = TestRng::default();
+    //
+    //     check_hash(Mode::Public, 0, 1, 0, 0, 0, &mut rng)?;
+    //     check_hash(Mode::Public, 1, 1, 0, 335, 335, &mut rng)?;
+    //     check_hash(Mode::Public, 2, 1, 0, 340, 340, &mut rng)?;
+    //     check_hash(Mode::Public, 3, 1, 0, 345, 345, &mut rng)?;
+    //     check_hash(Mode::Public, 4, 1, 0, 350, 350, &mut rng)?;
+    //     check_hash(Mode::Public, 5, 1, 0, 705, 705, &mut rng)?;
+    //     check_hash(Mode::Public, 6, 1, 0, 705, 705, &mut rng)?;
+    //     check_hash(Mode::Public, 7, 1, 0, 705, 705, &mut rng)?;
+    //     check_hash(Mode::Public, 8, 1, 0, 705, 705, &mut rng)?;
+    //     check_hash(Mode::Public, 9, 1, 0, 1060, 1060, &mut rng)?;
+    //     check_hash(Mode::Public, 10, 1, 0, 1060, 1060, &mut rng)
+    // }
+
+    #[test]
+    fn test_hash_private() {
+        let mut rng = TestRng::default();
+
+        // check_hash(Mode::Private, 32, 0, 0, 145394, 145394, &mut rng);
+        // check_hash(Mode::Private, 64, 0, 0, 146650, 146650, &mut rng);
+        check_hash(Mode::Private, 512, 0, 0, 151424, 151424, &mut rng);
+        // check_hash(Mode::Private, 1024, 0, 0, 151424, 151424, &mut rng);
+        // check_hash(Mode::Private, 0, 1, 0, 0, 0, &mut rng);
+        // check_hash(Mode::Private, 2, 1, 0, 340, 340, &mut rng)?;
+        // check_hash(Mode::Private, 3, 1, 0, 345, 345, &mut rng)?;
+        // check_hash(Mode::Private, 4, 1, 0, 350, 350, &mut rng)?;
+        // check_hash(Mode::Private, 5, 1, 0, 705, 705, &mut rng)?;
+        // check_hash(Mode::Private, 6, 1, 0, 705, 705, &mut rng)?;
+        // check_hash(Mode::Private, 7, 1, 0, 705, 705, &mut rng)?;
+        // check_hash(Mode::Private, 8, 1, 0, 705, 705, &mut rng)?;
+        // check_hash(Mode::Private, 9, 1, 0, 1060, 1060, &mut rng)?;
+        // check_hash(Mode::Private, 10, 1, 0, 1060, 1060, &mut rng)
+    }
+
+    #[test]
+    fn test_keccak256_simple() {
+        let input = [
+            91, 7, 224, 119, 168, 31, 252, 107, 71, 67, 95, 101, 168, 114, 123, 204, 84, 43, 198, 252, 15, 37, 165, 98,
+            16, 239, 177, 167, 75, 136, 165, 174, 94, 93, 131, 178, 76, 70, 67, 50, 228, 244, 192, 226, 95, 102, 35,
+            138, 63, 100, 209, 199, 71, 209, 21, 102, 164, 189, 160, 179, 187, 246, 232, 176,
+        ];
+        let output = [
+            107, 59, 106, 234, 176, 69, 94, 6, 174, 161, 74, 60, 246, 41, 201, 195, 133, 117, 2, 65, 58, 246, 33, 201,
+            230, 106, 98, 171, 43, 238, 105, 82,
+        ];
+        assert_eq!(output, keccak256_native(&input));
+
+        let input_circuit =
+            input.to_bits_le().iter().map(|b| Boolean::<Circuit>::new(Mode::Public, *b)).collect::<Vec<_>>();
+
+        let keccak = Keccak::<Circuit>::new();
+
+        let output_circuit = keccak.hash(&input_circuit);
+
+        let output_bits_le = output.to_bits_le();
+
+        println!("{:?}", output_bits_le);
+        println!("{:?}", output_circuit);
+
+        for (i, bit) in output_circuit.iter().enumerate() {
+            assert_eq!(output_bits_le[i], bit.eject_value());
+        }
+    }
+}

--- a/circuit/algorithms/src/keccak256/mod.rs
+++ b/circuit/algorithms/src/keccak256/mod.rs
@@ -20,9 +20,32 @@ use snarkvm_utilities::{TestRng, Uniform};
 use crate::Hash;
 use snarkvm_circuit_types::{environment::prelude::*, Boolean, U64};
 
-/// The rows and columns are 5 bits.
-const MODULO: usize = 5;
+/// The Keccak-224 hash function.
+pub type Keccak224<E> = Keccak<E, { KeccakType::Keccak as u8 }, 224>;
+/// The Keccak-256 hash function.
+pub type Keccak256<E> = Keccak<E, { KeccakType::Keccak as u8 }, 256>;
+/// The Keccak-384 hash function.
+pub type Keccak384<E> = Keccak<E, { KeccakType::Keccak as u8 }, 384>;
+/// The Keccak-512 hash function.
+pub type Keccak512<E> = Keccak<E, { KeccakType::Keccak as u8 }, 512>;
 
+/// The SHA3-224 hash function.
+pub type Sha3_224<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 224>;
+/// The SHA3-256 hash function.
+pub type Sha3_256<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 256>;
+/// The SHA3-384 hash function.
+pub type Sha3_384<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 384>;
+/// The SHA3-512 hash function.
+pub type Sha3_512<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 512>;
+
+/// A helper to specify the hash type.
+enum KeccakType {
+    Keccak,
+    Sha3,
+}
+
+/// The rows and columns are 5-bit lanes.
+const MODULO: usize = 5;
 /// The permutation type `l`.
 const L: usize = 6;
 /// The number of rounds in a full-round operation.
@@ -39,15 +62,14 @@ const NUM_ROUNDS: usize = 12 + 2 * L;
 /// The padding rule `pad` is a function that takes a variable-length input and produces a fixed-length output.
 /// In Keccak, `pad` is a multi-rate padding, defined as `pad(M) = M || 0x01 || 0x00…0x00 || 0x80`,
 /// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
-/// In SHA-3, `pad` is a SHAKE or cSHAKE (for XOF) padding, defined as `pad(M) = M || 0x01 || 0x00…0x00`,
-/// where `M` is the input data, and `0x01 || 0x00…0x00` is the padding.
+/// In SHA-3, `pad` is a SHAKE, defined as `pad(M) = M || 0x06 || 0x00…0x00 || 0x80`,
+/// where `M` is the input data, and `0x06 || 0x00…0x00 || 0x80` is the padding.
 ///
 /// The bitrate `r` is the number of bits that are absorbed into the sponge state in each iteration
 /// of the absorbing phase.
-/// For our case, `r = 1088`.
 ///
-/// In addition, the capacity is defined as `c := b - r`. For our case, `c = 512`, as `b = 1600` and `r = 1088`.
-pub struct Keccak<E: Environment> {
+/// In addition, the capacity is defined as `c := b - r`.
+pub struct Keccak<E: Environment, const TYPE: u8, const VARIANT: usize> {
     /// The round constants `RC[t] ∈ GF(2)` are defined as the
     /// output of a linear feedback shift register (LFSR).
     round_constants: Vec<U64<E>>,
@@ -55,7 +77,7 @@ pub struct Keccak<E: Environment> {
     rotl: Vec<usize>,
 }
 
-impl<E: Environment> Keccak<E> {
+impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIANT> {
     /// Initializes a new Keccak hash function.
     pub fn new() -> Self {
         Self {
@@ -65,34 +87,34 @@ impl<E: Environment> Keccak<E> {
     }
 }
 
-impl<E: Environment> Hash for Keccak<E> {
+impl<E: Environment, const TYPE: u8, const VARIANT: usize> Hash for Keccak<E, TYPE, VARIANT> {
     type Input = Boolean<E>;
     type Output = Vec<Boolean<E>>;
 
-    /// Returns the Keccak-256 hash of the given input as bits.
+    /// Returns the Keccak hash of the given input as bits.
     #[inline]
     fn hash(&self, input: &[Self::Input]) -> Self::Output {
-        /// The capacity `c`.
-        const CAPACITY: usize = 512;
         /// The permutation width `b`.
         const PERMUTATION_WIDTH: usize = 1600;
-        /// The bitrate `r`.
-        const BITRATE: usize = PERMUTATION_WIDTH - CAPACITY;
-        /// The output length `l`.
-        const OUTPUT_LENGTH: usize = 256;
 
-        debug_assert!(BITRATE < PERMUTATION_WIDTH, "The bitrate must be less than the permutation width");
+        // The bitrate `r`.
+        let bitrate = (200 - (VARIANT / 4)) * 8;
+        debug_assert!(bitrate < PERMUTATION_WIDTH, "The bitrate must be less than the permutation width");
 
         // Ensure the input is not empty.
         if input.is_empty() {
             E::halt("The input to the hash function must not be empty")
         }
 
-        // The padded blocks `P`.
-        let padded_blocks = Self::pad_keccak::<PERMUTATION_WIDTH>(input, CAPACITY, BITRATE);
-
         // The root state `s` is defined as `0^b`.
         let mut s = vec![Boolean::constant(false); PERMUTATION_WIDTH];
+
+        // The padded blocks `P`.
+        let padded_blocks = match TYPE {
+            0 => Self::pad_keccak(input, bitrate),
+            1 => Self::pad_sha3(input, bitrate),
+            2.. => unreachable!("Invalid Keccak type"),
+        };
 
         /* The first part of the sponge construction (the absorbing phase):
          *
@@ -120,20 +142,20 @@ impl<E: Environment> Hash for Keccak<E> {
          * return Z[0..l-1]
          */
         // Z = s[0..r-1]
-        let mut z = s[..BITRATE].to_vec();
+        let mut z = s[..bitrate].to_vec();
         // while |Z|_r < l do
-        while z.len() < OUTPUT_LENGTH {
+        while z.len() < VARIANT {
             // s = f(s)
             s = Self::permutation_f::<PERMUTATION_WIDTH, NUM_ROUNDS>(s, &self.round_constants, &self.rotl);
             // Z = Z || s[0..r-1]
-            z.extend(s.iter().take(BITRATE).cloned());
+            z.extend(s.iter().take(bitrate).cloned());
         }
         // return Z[0..l-1]
-        z.into_iter().take(OUTPUT_LENGTH).collect()
+        z.into_iter().take(VARIANT).collect()
     }
 }
 
-impl<E: Environment> Keccak<E> {
+impl<E: Environment, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIANT> {
     /// The values `ROUND_CONSTANTS[t] ∈ GF(2)` are defined as the
     /// output of a binary linear feedback shift register (LFSR):
     /// ```text
@@ -198,26 +220,62 @@ impl<E: Environment> Keccak<E> {
     /// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
     /// The padding extends the input data to a multiple of the bitrate `r`, defined as `r = b - c`,
     /// where `b` is the width of the permutation, and `c` is the capacity.
-    fn pad_keccak<const WIDTH: usize>(input: &[Boolean<E>], capacity: usize, bitrate: usize) -> Vec<Vec<Boolean<E>>> {
-        debug_assert_eq!(bitrate, WIDTH - capacity, "The bitrate must be less than the permutation width");
+    fn pad_keccak(input: &[Boolean<E>], bitrate: usize) -> Vec<Vec<Boolean<E>>> {
+        debug_assert!(bitrate > 0, "The bitrate must be positive");
 
         // Resize the input to a multiple of 8.
-        let mut input = input.to_vec();
-        input.resize((input.len() + 7) / 8 * 8, Boolean::constant(false));
+        let mut padded_input = input.to_vec();
+        padded_input.resize((input.len() + 7) / 8 * 8, Boolean::constant(false));
 
-        // Initialize a vector to store the padded blocks.
-        let mut result = Vec::with_capacity(input.len() / capacity);
-        // Iterate over the input in `capacity` chunks.
-        for block in input.chunks(capacity) {
-            // Construct the padded block.
-            let mut m = block.to_vec();
-            m.push(Boolean::constant(true));
-            m.resize(WIDTH, Boolean::constant(false));
-            m[bitrate - 1] = Boolean::constant(true);
-            // Append the padded block to the result.
-            result.push(m);
+        // Step 1: Append the bit "1" to the message.
+        padded_input.push(Boolean::constant(true));
+
+        // Step 2: Append "0" bits until the length of the message is congruent to r-1 mod r.
+        while (padded_input.len() % bitrate) != (bitrate - 1) {
+            padded_input.push(Boolean::constant(false));
         }
-        // Return the result.
+
+        // Step 3: Append the bit "1" to the message.
+        padded_input.push(Boolean::constant(true));
+
+        // Construct the padded blocks.
+        let mut result = Vec::new();
+        for block in padded_input.chunks(bitrate) {
+            result.push(block.to_vec());
+        }
+        result
+    }
+
+    /// In SHA-3, `pad` is a SHAKE, defined as `pad(M) = M || 0x06 || 0x00…0x00 || 0x80`,
+    /// where `M` is the input data, and `0x06 || 0x00…0x00 || 0x80` is the padding.
+    /// The padding extends the input data to a multiple of the bitrate `r`, defined as `r = b - c`,
+    /// where `b` is the width of the permutation, and `c` is the capacity.
+    fn pad_sha3(input: &[Boolean<E>], bitrate: usize) -> Vec<Vec<Boolean<E>>> {
+        debug_assert!(bitrate > 1, "The bitrate must be greater than 1");
+
+        // Resize the input to a multiple of 8.
+        let mut padded_input = input.to_vec();
+        padded_input.resize((input.len() + 7) / 8 * 8, Boolean::constant(false));
+
+        // Step 1: Append the "0x06" byte to the message.
+        padded_input.push(Boolean::constant(false));
+        padded_input.push(Boolean::constant(true));
+        padded_input.push(Boolean::constant(true));
+        padded_input.push(Boolean::constant(false));
+
+        // Step 2: Append "0" bits until the length of the message is congruent to r-1 mod r.
+        while (padded_input.len() % bitrate) != (bitrate - 1) {
+            padded_input.push(Boolean::constant(false));
+        }
+
+        // Step 3: Append the bit "1" to the message.
+        padded_input.push(Boolean::constant(true));
+
+        // Construct the padded blocks.
+        let mut result = Vec::new();
+        for block in padded_input.chunks(bitrate) {
+            result.push(block.to_vec());
+        }
         result
     }
 
@@ -356,18 +414,114 @@ mod tests {
     use snarkvm_circuit_types::environment::Circuit;
     use snarkvm_utilities::{bits_from_bytes_le, bytes_from_bits_le};
 
-    use tiny_keccak::{Hasher, Keccak as TinyKeccak};
+    use tiny_keccak::{Hasher, Keccak as TinyKeccak, Sha3 as TinySha3};
 
     const ITERATIONS: usize = 3;
 
+    /// Computes the Keccak-224 hash of the given preimage as bytes.
+    fn keccak_224_native(preimage: &[u8]) -> [u8; 28] {
+        let mut keccak = TinyKeccak::v224();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 28];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
     /// Computes the Keccak-256 hash of the given preimage as bytes.
-    fn keccak256_native(preimage: &[u8]) -> [u8; 32] {
+    fn keccak_256_native(preimage: &[u8]) -> [u8; 32] {
         let mut keccak = TinyKeccak::v256();
         keccak.update(preimage);
 
         let mut hash = [0u8; 32];
         keccak.finalize(&mut hash);
         hash
+    }
+
+    /// Computes the Keccak-384 hash of the given preimage as bytes.
+    fn keccak_384_native(preimage: &[u8]) -> [u8; 48] {
+        let mut keccak = TinyKeccak::v384();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 48];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
+    /// Computes the Keccak-512 hash of the given preimage as bytes.
+    fn keccak_512_native(preimage: &[u8]) -> [u8; 64] {
+        let mut keccak = TinyKeccak::v512();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 64];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
+    /// Computes the SHA3-224 hash of the given preimage as bytes.
+    fn sha3_224_native(preimage: &[u8]) -> [u8; 28] {
+        let mut keccak = TinySha3::v224();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 28];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
+    /// Computes the SHA3-256 hash of the given preimage as bytes.
+    fn sha3_256_native(preimage: &[u8]) -> [u8; 32] {
+        let mut keccak = TinySha3::v256();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 32];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
+    /// Computes the SHA3-384 hash of the given preimage as bytes.
+    fn sha3_384_native(preimage: &[u8]) -> [u8; 48] {
+        let mut keccak = TinySha3::v384();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 48];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
+    /// Computes the SHA3-512 hash of the given preimage as bytes.
+    fn sha3_512_native(preimage: &[u8]) -> [u8; 64] {
+        let mut keccak = TinySha3::v512();
+        keccak.update(preimage);
+
+        let mut hash = [0u8; 64];
+        keccak.finalize(&mut hash);
+        hash
+    }
+
+    macro_rules! check_equivalence {
+        ($circuit:expr, $native:expr) => {
+            let rng = &mut TestRng::default();
+
+            let mut input_sizes = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 32, 64, 128, 256, 512, 1024];
+            input_sizes.extend((0..5).map(|_| u8::rand(rng) as usize));
+
+            for num_inputs in input_sizes {
+                println!("Checking equivalence for {num_inputs} inputs");
+
+                // Prepare the preimage.
+                let native_input = (0..num_inputs).map(|_| Uniform::rand(rng)).collect::<Vec<bool>>();
+                let input = native_input.iter().map(|v| Boolean::<Circuit>::new(Mode::Private, *v)).collect::<Vec<_>>();
+
+                // Compute the native hash.
+                let expected = $native(&bytes_from_bits_le(&native_input));
+                let expected = bits_from_bytes_le(&expected).collect::<Vec<_>>();
+
+                // Compute the circuit hash.
+                let candidate = $circuit.hash(&input);
+                assert_eq!(expected, candidate.eject_value());
+                Circuit::reset();
+            }
+        };
     }
 
     fn check_hash(
@@ -382,7 +536,7 @@ mod tests {
         use console::Hash as H;
 
         // let native = console::Poseidon::<<Circuit as Environment>::Network, RATE>::setup(DOMAIN)?;
-        let keccak = Keccak::<Circuit>::new();
+        let keccak = Keccak256::<Circuit>::new();
 
         for i in 0..ITERATIONS {
             // Prepare the preimage.
@@ -391,7 +545,7 @@ mod tests {
 
             // Compute the native hash.
             // let expected = native.hash(&native_input).expect("Failed to hash native input");
-            let expected = keccak256_native(&bytes_from_bits_le(&native_input));
+            let expected = keccak_256_native(&bytes_from_bits_le(&native_input));
             let expected = bits_from_bytes_le(&expected).collect::<Vec<_>>();
 
             // Compute the circuit hash.
@@ -406,7 +560,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_constant() {
+    fn test_keccak_256_hash_constant() {
         let mut rng = TestRng::default();
 
         check_hash(Mode::Constant, 1, 0, 0, 0, 0, &mut rng);
@@ -422,11 +576,16 @@ mod tests {
         check_hash(Mode::Constant, 64, 0, 0, 0, 0, &mut rng);
         check_hash(Mode::Constant, 128, 0, 0, 0, 0, &mut rng);
         check_hash(Mode::Constant, 256, 0, 0, 0, 0, &mut rng);
+        check_hash(Mode::Constant, 511, 0, 0, 0, 0, &mut rng);
         check_hash(Mode::Constant, 512, 0, 0, 0, 0, &mut rng);
+        check_hash(Mode::Constant, 513, 0, 0, 0, 0, &mut rng);
+        check_hash(Mode::Constant, 1023, 0, 0, 0, 0, &mut rng);
+        check_hash(Mode::Constant, 1024, 0, 0, 0, 0, &mut rng);
+        check_hash(Mode::Constant, 1025, 0, 0, 0, 0, &mut rng);
     }
 
     #[test]
-    fn test_hash_public() {
+    fn test_keccak_256_hash_public() {
         let mut rng = TestRng::default();
 
         check_hash(Mode::Public, 1, 0, 0, 138157, 138157, &mut rng);
@@ -443,10 +602,11 @@ mod tests {
         check_hash(Mode::Public, 128, 0, 0, 149248, 149248, &mut rng);
         check_hash(Mode::Public, 256, 0, 0, 150848, 150848, &mut rng);
         check_hash(Mode::Public, 512, 0, 0, 151424, 151424, &mut rng);
+        check_hash(Mode::Public, 1024, 0, 0, 152448, 152448, &mut rng);
     }
 
     #[test]
-    fn test_hash_private() {
+    fn test_keccak_256_hash_private() {
         let mut rng = TestRng::default();
 
         check_hash(Mode::Private, 1, 0, 0, 138157, 138157, &mut rng);
@@ -463,10 +623,51 @@ mod tests {
         check_hash(Mode::Private, 128, 0, 0, 149248, 149248, &mut rng);
         check_hash(Mode::Private, 256, 0, 0, 150848, 150848, &mut rng);
         check_hash(Mode::Private, 512, 0, 0, 151424, 151424, &mut rng);
+        check_hash(Mode::Private, 1024, 0, 0, 152448, 152448, &mut rng);
     }
 
     #[test]
-    fn test_keccak256_simple() {
+    fn test_keccak_224_equivalence() {
+        check_equivalence!(Keccak224::<Circuit>::new(), keccak_224_native);
+    }
+
+    #[test]
+    fn test_keccak_256_equivalence() {
+        check_equivalence!(Keccak256::<Circuit>::new(), keccak_256_native);
+    }
+
+    #[test]
+    fn test_keccak_384_equivalence() {
+        check_equivalence!(Keccak384::<Circuit>::new(), keccak_384_native);
+    }
+
+    #[test]
+    fn test_keccak_512_equivalence() {
+        check_equivalence!(Keccak512::<Circuit>::new(), keccak_512_native);
+    }
+
+    #[test]
+    fn test_sha3_224_equivalence() {
+        check_equivalence!(Sha3_224::<Circuit>::new(), sha3_224_native);
+    }
+
+    #[test]
+    fn test_sha3_256_equivalence() {
+        check_equivalence!(Sha3_256::<Circuit>::new(), sha3_256_native);
+    }
+
+    #[test]
+    fn test_sha3_384_equivalence() {
+        check_equivalence!(Sha3_384::<Circuit>::new(), sha3_384_native);
+    }
+
+    #[test]
+    fn test_sha3_512_equivalence() {
+        check_equivalence!(Sha3_512::<Circuit>::new(), sha3_512_native);
+    }
+
+    #[test]
+    fn test_keccak_256_simple() {
         let input = [
             91, 7, 224, 119, 168, 31, 252, 107, 71, 67, 95, 101, 168, 114, 123, 204, 84, 43, 198, 252, 15, 37, 165, 98,
             16, 239, 177, 167, 75, 136, 165, 174, 94, 93, 131, 178, 76, 70, 67, 50, 228, 244, 192, 226, 95, 102, 35,
@@ -476,12 +677,12 @@ mod tests {
             107, 59, 106, 234, 176, 69, 94, 6, 174, 161, 74, 60, 246, 41, 201, 195, 133, 117, 2, 65, 58, 246, 33, 201,
             230, 106, 98, 171, 43, 238, 105, 82,
         ];
-        assert_eq!(output, keccak256_native(&input));
+        assert_eq!(output, keccak_256_native(&input));
 
         let input_circuit =
             input.to_bits_le().iter().map(|b| Boolean::<Circuit>::new(Mode::Public, *b)).collect::<Vec<_>>();
 
-        let keccak = Keccak::<Circuit>::new();
+        let keccak = Keccak256::<Circuit>::new();
 
         let output_circuit = keccak.hash(&input_circuit);
 

--- a/circuit/algorithms/src/lib.rs
+++ b/circuit/algorithms/src/lib.rs
@@ -21,6 +21,9 @@ pub use bhp::*;
 pub mod elligator2;
 pub use elligator2::Elligator2;
 
+pub mod keccak256;
+pub use keccak256::*;
+
 pub mod pedersen;
 pub use pedersen::*;
 

--- a/circuit/algorithms/src/lib.rs
+++ b/circuit/algorithms/src/lib.rs
@@ -21,8 +21,8 @@ pub use bhp::*;
 pub mod elligator2;
 pub use elligator2::Elligator2;
 
-pub mod keccak256;
-pub use keccak256::*;
+pub mod keccak;
+pub use keccak::*;
 
 pub mod pedersen;
 pub use pedersen::*;

--- a/circuit/algorithms/src/traits.rs
+++ b/circuit/algorithms/src/traits.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkvm_circuit_types::environment::{Eject, GroupTrait, Inject, ScalarTrait, Ternary, ToBits};
+use snarkvm_circuit_types::environment::{Eject, GroupTrait, Inject, ScalarTrait, ToBits};
 
 /// A trait for a commitment scheme.
 pub trait Commit {

--- a/circuit/algorithms/src/traits.rs
+++ b/circuit/algorithms/src/traits.rs
@@ -37,7 +37,7 @@ pub trait CommitUncompressed {
 /// A trait for a hash function.
 pub trait Hash {
     type Input: Inject + Eject + Clone;
-    type Output: Inject + Eject + Ternary<Output = Self::Output> + ToBits + Clone;
+    type Output: Inject + Eject + ToBits + Clone;
 
     /// Returns the hash of the given input.
     fn hash(&self, input: &[Self::Input]) -> Self::Output;

--- a/circuit/types/field/src/lib.rs
+++ b/circuit/types/field/src/lib.rs
@@ -52,6 +52,13 @@ pub struct Field<E: Environment> {
 
 impl<E: Environment> FieldTrait for Field<E> {}
 
+impl<E: Environment> Default for Field<E> {
+    /// Returns the default field element.
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
 #[cfg(console)]
 impl<E: Environment> Inject for Field<E> {
     type Primitive = console::Field<E::Network>;

--- a/console/algorithms/Cargo.toml
+++ b/console/algorithms/Cargo.toml
@@ -39,6 +39,10 @@ version = "1.11"
 default-features = false
 features = [ "const_generics", "const_new" ]
 
+[dependencies.tiny-keccak]
+version = "2"
+features = [ "keccak", "sha3" ]
+
 [dev-dependencies.snarkvm-curves]
 path = "../../curves"
 default-features = false

--- a/console/algorithms/src/keccak/hash.rs
+++ b/console/algorithms/src/keccak/hash.rs
@@ -1,0 +1,189 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use snarkvm_utilities::{bits_from_bytes_le, bytes_from_bits_le};
+
+impl<const TYPE: u8, const VARIANT: usize> Hash for Keccak<TYPE, VARIANT> {
+    type Input = bool;
+    type Output = Vec<bool>;
+
+    /// Returns the Keccak hash of the given input as bits.
+    #[inline]
+    fn hash(&self, input: &[Self::Input]) -> Result<Self::Output> {
+        let result = match (TYPE, VARIANT) {
+            (0, 224) => bits_from_bytes_le(&keccak_224_native(&bytes_from_bits_le(input))).collect(),
+            (0, 256) => bits_from_bytes_le(&keccak_256_native(&bytes_from_bits_le(input))).collect(),
+            (0, 384) => bits_from_bytes_le(&keccak_384_native(&bytes_from_bits_le(input))).collect(),
+            (0, 512) => bits_from_bytes_le(&keccak_512_native(&bytes_from_bits_le(input))).collect(),
+            (1, 224) => bits_from_bytes_le(&sha3_224_native(&bytes_from_bits_le(input))).collect(),
+            (1, 256) => bits_from_bytes_le(&sha3_256_native(&bytes_from_bits_le(input))).collect(),
+            (1, 384) => bits_from_bytes_le(&sha3_384_native(&bytes_from_bits_le(input))).collect(),
+            (1, 512) => bits_from_bytes_le(&sha3_512_native(&bytes_from_bits_le(input))).collect(),
+            _ => unreachable!("Invalid Keccak type and variant"),
+        };
+        Ok(result)
+    }
+}
+
+/// Computes the Keccak-224 hash of the given preimage as bytes.
+fn keccak_224_native(preimage: &[u8]) -> [u8; 28] {
+    let mut keccak = TinyKeccak::v224();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 28];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+/// Computes the Keccak-256 hash of the given preimage as bytes.
+fn keccak_256_native(preimage: &[u8]) -> [u8; 32] {
+    let mut keccak = TinyKeccak::v256();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 32];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+/// Computes the Keccak-384 hash of the given preimage as bytes.
+fn keccak_384_native(preimage: &[u8]) -> [u8; 48] {
+    let mut keccak = TinyKeccak::v384();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 48];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+/// Computes the Keccak-512 hash of the given preimage as bytes.
+fn keccak_512_native(preimage: &[u8]) -> [u8; 64] {
+    let mut keccak = TinyKeccak::v512();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 64];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+/// Computes the SHA3-224 hash of the given preimage as bytes.
+fn sha3_224_native(preimage: &[u8]) -> [u8; 28] {
+    let mut keccak = TinySha3::v224();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 28];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+/// Computes the SHA3-256 hash of the given preimage as bytes.
+fn sha3_256_native(preimage: &[u8]) -> [u8; 32] {
+    let mut keccak = TinySha3::v256();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 32];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+/// Computes the SHA3-384 hash of the given preimage as bytes.
+fn sha3_384_native(preimage: &[u8]) -> [u8; 48] {
+    let mut keccak = TinySha3::v384();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 48];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+/// Computes the SHA3-512 hash of the given preimage as bytes.
+fn sha3_512_native(preimage: &[u8]) -> [u8; 64] {
+    let mut keccak = TinySha3::v512();
+    keccak.update(preimage);
+
+    let mut hash = [0u8; 64];
+    keccak.finalize(&mut hash);
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Rng;
+    use snarkvm_utilities::{bits_from_bytes_le, bytes_from_bits_le};
+
+    macro_rules! check_equivalence {
+        ($console:expr, $native:expr) => {
+            let rng = &mut TestRng::default();
+
+            let mut input_sizes = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 32, 64, 128, 256, 512, 1024];
+            input_sizes.extend((0..100).map(|_| rng.gen_range(1..1024)));
+
+            for num_inputs in input_sizes {
+                println!("Checking equivalence for {num_inputs} inputs");
+
+                // Prepare the preimage.
+                let input = (0..num_inputs).map(|_| Uniform::rand(rng)).collect::<Vec<bool>>();
+
+                // Compute the native hash.
+                let expected = $native(&bytes_from_bits_le(&input));
+                let expected = bits_from_bytes_le(&expected).collect::<Vec<_>>();
+
+                // Compute the console hash.
+                let candidate = $console.hash(&input).unwrap();
+                assert_eq!(expected, candidate);
+            }
+        };
+    }
+
+    #[test]
+    fn test_keccak_224_equivalence() {
+        check_equivalence!(Keccak224::default(), keccak_224_native);
+    }
+
+    #[test]
+    fn test_keccak_256_equivalence() {
+        check_equivalence!(Keccak256::default(), keccak_256_native);
+    }
+
+    #[test]
+    fn test_keccak_384_equivalence() {
+        check_equivalence!(Keccak384::default(), keccak_384_native);
+    }
+
+    #[test]
+    fn test_keccak_512_equivalence() {
+        check_equivalence!(Keccak512::default(), keccak_512_native);
+    }
+
+    #[test]
+    fn test_sha3_224_equivalence() {
+        check_equivalence!(Sha3_224::default(), sha3_224_native);
+    }
+
+    #[test]
+    fn test_sha3_256_equivalence() {
+        check_equivalence!(Sha3_256::default(), sha3_256_native);
+    }
+
+    #[test]
+    fn test_sha3_384_equivalence() {
+        check_equivalence!(Sha3_384::default(), sha3_384_native);
+    }
+
+    #[test]
+    fn test_sha3_512_equivalence() {
+        check_equivalence!(Sha3_512::default(), sha3_512_native);
+    }
+}

--- a/console/algorithms/src/keccak/hash.rs
+++ b/console/algorithms/src/keccak/hash.rs
@@ -15,7 +15,7 @@
 use super::*;
 use snarkvm_utilities::{bits_from_bytes_le, bytes_from_bits_le};
 
-impl<const TYPE: u8, const VARIANT: usize> Hash for Keccak<TYPE, VARIANT> {
+impl<E, const TYPE: u8, const VARIANT: usize> Hash for Keccak<E, TYPE, VARIANT> {
     type Input = bool;
     type Output = Vec<bool>;
 
@@ -149,41 +149,41 @@ mod tests {
 
     #[test]
     fn test_keccak_224_equivalence() {
-        check_equivalence!(Keccak224::default(), keccak_224_native);
+        check_equivalence!(Keccak224::<Console>::new(), keccak_224_native);
     }
 
     #[test]
     fn test_keccak_256_equivalence() {
-        check_equivalence!(Keccak256::default(), keccak_256_native);
+        check_equivalence!(Keccak256::<Console>::new(), keccak_256_native);
     }
 
     #[test]
     fn test_keccak_384_equivalence() {
-        check_equivalence!(Keccak384::default(), keccak_384_native);
+        check_equivalence!(Keccak384::<Console>::new(), keccak_384_native);
     }
 
     #[test]
     fn test_keccak_512_equivalence() {
-        check_equivalence!(Keccak512::default(), keccak_512_native);
+        check_equivalence!(Keccak512::<Console>::new(), keccak_512_native);
     }
 
     #[test]
     fn test_sha3_224_equivalence() {
-        check_equivalence!(Sha3_224::default(), sha3_224_native);
+        check_equivalence!(Sha3_224::<Console>::new(), sha3_224_native);
     }
 
     #[test]
     fn test_sha3_256_equivalence() {
-        check_equivalence!(Sha3_256::default(), sha3_256_native);
+        check_equivalence!(Sha3_256::<Console>::new(), sha3_256_native);
     }
 
     #[test]
     fn test_sha3_384_equivalence() {
-        check_equivalence!(Sha3_384::default(), sha3_384_native);
+        check_equivalence!(Sha3_384::<Console>::new(), sha3_384_native);
     }
 
     #[test]
     fn test_sha3_512_equivalence() {
-        check_equivalence!(Sha3_512::default(), sha3_512_native);
+        check_equivalence!(Sha3_512::<Console>::new(), sha3_512_native);
     }
 }

--- a/console/algorithms/src/keccak/mod.rs
+++ b/console/algorithms/src/keccak/mod.rs
@@ -22,23 +22,25 @@ use snarkvm_console_types::environment::prelude::*;
 
 use tiny_keccak::{Hasher, Keccak as TinyKeccak, Sha3 as TinySha3};
 
+use std::marker::PhantomData;
+
 /// The Keccak-224 hash function.
-pub type Keccak224 = Keccak<{ KeccakType::Keccak as u8 }, 224>;
+pub type Keccak224<E> = Keccak<E, { KeccakType::Keccak as u8 }, 224>;
 /// The Keccak-256 hash function.
-pub type Keccak256 = Keccak<{ KeccakType::Keccak as u8 }, 256>;
+pub type Keccak256<E> = Keccak<E, { KeccakType::Keccak as u8 }, 256>;
 /// The Keccak-384 hash function.
-pub type Keccak384 = Keccak<{ KeccakType::Keccak as u8 }, 384>;
+pub type Keccak384<E> = Keccak<E, { KeccakType::Keccak as u8 }, 384>;
 /// The Keccak-512 hash function.
-pub type Keccak512 = Keccak<{ KeccakType::Keccak as u8 }, 512>;
+pub type Keccak512<E> = Keccak<E, { KeccakType::Keccak as u8 }, 512>;
 
 /// The SHA3-224 hash function.
-pub type Sha3_224 = Keccak<{ KeccakType::Sha3 as u8 }, 224>;
+pub type Sha3_224<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 224>;
 /// The SHA3-256 hash function.
-pub type Sha3_256 = Keccak<{ KeccakType::Sha3 as u8 }, 256>;
+pub type Sha3_256<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 256>;
 /// The SHA3-384 hash function.
-pub type Sha3_384 = Keccak<{ KeccakType::Sha3 as u8 }, 384>;
+pub type Sha3_384<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 384>;
 /// The SHA3-512 hash function.
-pub type Sha3_512 = Keccak<{ KeccakType::Sha3 as u8 }, 512>;
+pub type Sha3_512<E> = Keccak<E, { KeccakType::Sha3 as u8 }, 512>;
 
 /// A helper to specify the hash type.
 enum KeccakType {
@@ -65,4 +67,12 @@ enum KeccakType {
 ///
 /// In addition, the capacity is defined as `c := b - r`.
 #[derive(Copy, Clone, Debug, Default)]
-pub struct Keccak<const TYPE: u8, const VARIANT: usize>;
+pub struct Keccak<E, const TYPE: u8, const VARIANT: usize> {
+    _engine: PhantomData<E>,
+}
+
+impl<E, const TYPE: u8, const VARIANT: usize> Keccak<E, TYPE, VARIANT> {
+    pub fn new() -> Self {
+        Self { _engine: PhantomData }
+    }
+}

--- a/console/algorithms/src/keccak/mod.rs
+++ b/console/algorithms/src/keccak/mod.rs
@@ -1,0 +1,68 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod hash;
+
+#[cfg(test)]
+use snarkvm_utilities::Uniform;
+
+use crate::Hash;
+use snarkvm_console_types::environment::prelude::*;
+
+use tiny_keccak::{Hasher, Keccak as TinyKeccak, Sha3 as TinySha3};
+
+/// The Keccak-224 hash function.
+pub type Keccak224 = Keccak<{ KeccakType::Keccak as u8 }, 224>;
+/// The Keccak-256 hash function.
+pub type Keccak256 = Keccak<{ KeccakType::Keccak as u8 }, 256>;
+/// The Keccak-384 hash function.
+pub type Keccak384 = Keccak<{ KeccakType::Keccak as u8 }, 384>;
+/// The Keccak-512 hash function.
+pub type Keccak512 = Keccak<{ KeccakType::Keccak as u8 }, 512>;
+
+/// The SHA3-224 hash function.
+pub type Sha3_224 = Keccak<{ KeccakType::Sha3 as u8 }, 224>;
+/// The SHA3-256 hash function.
+pub type Sha3_256 = Keccak<{ KeccakType::Sha3 as u8 }, 256>;
+/// The SHA3-384 hash function.
+pub type Sha3_384 = Keccak<{ KeccakType::Sha3 as u8 }, 384>;
+/// The SHA3-512 hash function.
+pub type Sha3_512 = Keccak<{ KeccakType::Sha3 as u8 }, 512>;
+
+/// A helper to specify the hash type.
+enum KeccakType {
+    Keccak,
+    Sha3,
+}
+
+/// The sponge construction `Sponge[f, pad, r]` is a function that takes a variable-length input
+/// and produces a fixed-length output (the hash value).
+///
+/// The permutation `f` is a function that takes a fixed-length input and produces a fixed-length output,
+/// defined as `f = Keccak-f[b]`, where `b := 25 * 2^l` is the width of the permutation,
+/// and `l` is the log width of the permutation.
+/// For our case, `l = 6`, thus `b = 1600`.
+///
+/// The padding rule `pad` is a function that takes a variable-length input and produces a fixed-length output.
+/// In Keccak, `pad` is a multi-rate padding, defined as `pad(M) = M || 0x01 || 0x00…0x00 || 0x80`,
+/// where `M` is the input data, and `0x01 || 0x00…0x00 || 0x80` is the padding.
+/// In SHA-3, `pad` is a SHAKE, defined as `pad(M) = M || 0x06 || 0x00…0x00 || 0x80`,
+/// where `M` is the input data, and `0x06 || 0x00…0x00 || 0x80` is the padding.
+///
+/// The bitrate `r` is the number of bits that are absorbed into the sponge state in each iteration
+/// of the absorbing phase.
+///
+/// In addition, the capacity is defined as `c := b - r`.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Keccak<const TYPE: u8, const VARIANT: usize>;

--- a/console/algorithms/src/lib.rs
+++ b/console/algorithms/src/lib.rs
@@ -28,6 +28,9 @@ pub use blake2xs::Blake2Xs;
 mod elligator2;
 pub use elligator2::Elligator2;
 
+mod keccak;
+pub use keccak::*;
+
 mod pedersen;
 pub use pedersen::{Pedersen, Pedersen128, Pedersen64};
 

--- a/console/collections/src/k_ary_merkle_tree/helpers/leaf_hash.rs
+++ b/console/collections/src/k_ary_merkle_tree/helpers/leaf_hash.rs
@@ -64,8 +64,8 @@ impl<E: Environment, const RATE: usize> LeafHash for Poseidon<E, RATE> {
     }
 }
 
-impl<const TYPE: u8, const VARIANT: usize> LeafHash for Keccak<TYPE, VARIANT> {
-    type Hash = Field<Console>;
+impl<E: Environment, const TYPE: u8, const VARIANT: usize> LeafHash for Keccak<E, TYPE, VARIANT> {
+    type Hash = Field<E>;
     type Leaf = Vec<bool>;
 
     /// Returns the hash of the given leaf node.

--- a/console/collections/src/k_ary_merkle_tree/helpers/mod.rs
+++ b/console/collections/src/k_ary_merkle_tree/helpers/mod.rs
@@ -17,3 +17,49 @@ pub use leaf_hash::*;
 
 mod path_hash;
 pub use path_hash::*;
+
+use snarkvm_console_types::prelude::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BooleanHash<const VARIANT: usize>(pub [bool; VARIANT]);
+
+impl<const VARIANT: usize> BooleanHash<VARIANT> {
+    /// Initializes a new "empty" boolean hash.
+    pub const fn new() -> Self {
+        Self([false; VARIANT])
+    }
+}
+
+impl<const VARIANT: usize> Default for BooleanHash<VARIANT> {
+    /// Initializes a new "empty" boolean hash.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const VARIANT: usize> FromBytes for BooleanHash<VARIANT> {
+    /// Reads `self` from `reader` in little-endian order.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the bits.
+        let bits = (0..VARIANT).map(|_| bool::read_le(&mut reader)).collect::<Result<Vec<bool>, _>>()?;
+        // Convert the Vec into a fixed-size array.
+        let mut array = [false; VARIANT];
+        array.copy_from_slice(&bits);
+        Ok(Self(array))
+    }
+}
+
+impl<const VARIANT: usize> ToBytes for BooleanHash<VARIANT> {
+    /// Writes `self` to `writer` in little-endian order.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.0.as_slice().write_le(&mut writer)
+    }
+}
+
+impl<const VARIANT: usize> Deref for BooleanHash<VARIANT> {
+    type Target = [bool; VARIANT];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/console/collections/src/k_ary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/k_ary_merkle_tree/helpers/path_hash.rs
@@ -71,8 +71,8 @@ impl<E: Environment, const RATE: usize> PathHash for Poseidon<E, RATE> {
     }
 }
 
-impl<const TYPE: u8, const VARIANT: usize> PathHash for Keccak<TYPE, VARIANT> {
-    type Hash = Field<Console>;
+impl<E: Environment, const TYPE: u8, const VARIANT: usize> PathHash for Keccak<E, TYPE, VARIANT> {
+    type Hash = Field<E>;
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Result<Self::Hash> {

--- a/console/collections/src/k_ary_merkle_tree/mod.rs
+++ b/console/collections/src/k_ary_merkle_tree/mod.rs
@@ -26,13 +26,7 @@ use snarkvm_console_types::prelude::*;
 use aleo_std::prelude::*;
 
 #[derive(Clone)]
-pub struct KAryMerkleTree<
-    E: Environment,
-    LH: LeafHash<Hash = PH::Hash>,
-    PH: PathHash<Hash = Field<E>>,
-    const DEPTH: u8,
-    const ARITY: u8,
-> {
+pub struct KAryMerkleTree<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: u8> {
     /// The leaf hasher for the Merkle tree.
     leaf_hasher: LH,
     /// The path hasher for the Merkle tree.
@@ -42,7 +36,7 @@ pub struct KAryMerkleTree<
     /// The internal hashes, from root to hashed leaves, of the full Merkle tree.
     tree: Vec<PH::Hash>,
     /// The canonical empty hash.
-    empty_hash: Field<E>,
+    empty_hash: PH::Hash,
     /// The number of hashed leaves in the tree.
     number_of_leaves: usize,
 }
@@ -61,8 +55,8 @@ fn checked_next_power_of_n(base: usize, n: usize) -> Option<usize> {
     Some(value)
 }
 
-impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>>, const DEPTH: u8, const ARITY: u8>
-    KAryMerkleTree<E, LH, PH, DEPTH, ARITY>
+impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: u8>
+    KAryMerkleTree<LH, PH, DEPTH, ARITY>
 {
     #[inline]
     /// Initializes a new Merkle tree with the given leaves.
@@ -238,7 +232,7 @@ impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>
 
     #[inline]
     /// Returns the Merkle path for the given leaf index and leaf.
-    pub fn prove(&self, leaf_index: usize, leaf: &LH::Leaf) -> Result<KAryMerklePath<E, DEPTH, ARITY>> {
+    pub fn prove(&self, leaf_index: usize, leaf: &LH::Leaf) -> Result<KAryMerklePath<PH, DEPTH, ARITY>> {
         // Ensure the leaf index is valid.
         ensure!(leaf_index < self.number_of_leaves, "The given Merkle leaf index is out of bounds");
 
@@ -284,11 +278,11 @@ impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>
         path.resize(DEPTH as usize, empty_hashes);
 
         // Return the Merkle path.
-        KAryMerklePath::try_from((U64::new(leaf_index as u64), path))
+        KAryMerklePath::try_from((leaf_index as u64, path))
     }
 
     /// Returns `true` if the given Merkle path is valid for the given root and leaf.
-    pub fn verify(&self, path: &KAryMerklePath<E, DEPTH, ARITY>, root: &PH::Hash, leaf: &LH::Leaf) -> bool {
+    pub fn verify(&self, path: &KAryMerklePath<PH, DEPTH, ARITY>, root: &PH::Hash, leaf: &LH::Leaf) -> bool {
         path.verify(&self.leaf_hasher, &self.path_hasher, root, leaf)
     }
 

--- a/console/collections/src/k_ary_merkle_tree/path/mod.rs
+++ b/console/collections/src/k_ary_merkle_tree/path/mod.rs
@@ -15,20 +15,16 @@
 use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct KAryMerklePath<E: Environment, const DEPTH: u8, const ARITY: u8> {
+pub struct KAryMerklePath<PH: PathHash, const DEPTH: u8, const ARITY: u8> {
     /// The leaf index for the path.
-    leaf_index: U64<E>,
+    leaf_index: u64,
     /// The `siblings` contains a list of sibling hashes from the leaf to the root.
-    siblings: Vec<Vec<Field<E>>>,
+    siblings: Vec<Vec<PH::Hash>>,
 }
 
-impl<E: Environment, const DEPTH: u8, const ARITY: u8> TryFrom<(U64<E>, Vec<Vec<Field<E>>>)>
-    for KAryMerklePath<E, DEPTH, ARITY>
-{
-    type Error = Error;
-
+impl<PH: PathHash, const DEPTH: u8, const ARITY: u8> KAryMerklePath<PH, DEPTH, ARITY> {
     /// Returns a new instance of a Merkle path.
-    fn try_from((leaf_index, siblings): (U64<E>, Vec<Vec<Field<E>>>)) -> Result<Self> {
+    pub fn try_from((leaf_index, siblings): (u64, Vec<Vec<PH::Hash>>)) -> Result<Self> {
         // Ensure the Merkle tree depth is greater than 0.
         ensure!(DEPTH > 0, "Merkle tree depth must be greater than 0");
         // Ensure the Merkle tree depth is less than or equal to 64.
@@ -36,7 +32,7 @@ impl<E: Environment, const DEPTH: u8, const ARITY: u8> TryFrom<(U64<E>, Vec<Vec<
         // Ensure the Merkle tree arity is greater than 1.
         ensure!(ARITY > 1, "Merkle tree arity must be greater than 1");
         // Ensure the leaf index is within the tree depth.
-        ensure!((*leaf_index as u128) < (ARITY as u128).pow(DEPTH as u32), "Found an out of bounds Merkle leaf index");
+        ensure!((leaf_index as u128) < (ARITY as u128).pow(DEPTH as u32), "Found an out of bounds Merkle leaf index");
         // Ensure the Merkle path is the correct length.
         ensure!(siblings.len() == DEPTH as usize, "Found an incorrect Merkle path length");
         for sibling in &siblings {
@@ -47,19 +43,19 @@ impl<E: Environment, const DEPTH: u8, const ARITY: u8> TryFrom<(U64<E>, Vec<Vec<
     }
 }
 
-impl<E: Environment, const DEPTH: u8, const ARITY: u8> KAryMerklePath<E, DEPTH, ARITY> {
+impl<PH: PathHash, const DEPTH: u8, const ARITY: u8> KAryMerklePath<PH, DEPTH, ARITY> {
     /// Returns the leaf index for the path.
-    pub fn leaf_index(&self) -> U64<E> {
+    pub fn leaf_index(&self) -> u64 {
         self.leaf_index
     }
 
     /// Returns the siblings for the path.
-    pub fn siblings(&self) -> &[Vec<Field<E>>] {
+    pub fn siblings(&self) -> &[Vec<PH::Hash>] {
         &self.siblings
     }
 
     /// Returns `true` if the Merkle path is valid for the given root and leaf.
-    pub fn verify<LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>>>(
+    pub fn verify<LH: LeafHash<Hash = PH::Hash>>(
         &self,
         leaf_hasher: &LH,
         path_hasher: &PH,
@@ -67,7 +63,7 @@ impl<E: Environment, const DEPTH: u8, const ARITY: u8> KAryMerklePath<E, DEPTH, 
         leaf: &LH::Leaf,
     ) -> bool {
         // Ensure the leaf index is within the tree depth.
-        if (*self.leaf_index as u128) >= (ARITY as u128).checked_pow(DEPTH as u32).unwrap_or(u128::MAX) {
+        if (self.leaf_index as u128) >= (ARITY as u128).checked_pow(DEPTH as u32).unwrap_or(u128::MAX) {
             eprintln!("Found an out of bounds Merkle leaf index");
             return false;
         }
@@ -89,7 +85,7 @@ impl<E: Environment, const DEPTH: u8, const ARITY: u8> KAryMerklePath<E, DEPTH, 
         // Compute the ordering of the current hash and sibling hashes on each level.
         // The indicator index determines which sibling the current hash is.
         let indicator_indexes: Vec<usize> = match (0..DEPTH)
-            .map(|i| usize::try_from(*self.leaf_index as u128 / (ARITY as u128).pow(i as u32) % ARITY as u128))
+            .map(|i| usize::try_from(self.leaf_index as u128 / (ARITY as u128).pow(i as u32) % ARITY as u128))
             .collect::<Result<Vec<_>, _>>()
         {
             Ok(indexes) => indexes,
@@ -122,7 +118,7 @@ impl<E: Environment, const DEPTH: u8, const ARITY: u8> KAryMerklePath<E, DEPTH, 
     }
 }
 
-impl<E: Environment, const DEPTH: u8, const ARITY: u8> FromBytes for KAryMerklePath<E, DEPTH, ARITY> {
+impl<PH: PathHash, const DEPTH: u8, const ARITY: u8> FromBytes for KAryMerklePath<PH, DEPTH, ARITY> {
     /// Reads in a Merkle path from a buffer.
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
@@ -130,14 +126,14 @@ impl<E: Environment, const DEPTH: u8, const ARITY: u8> FromBytes for KAryMerkleP
         let leaf_index = u64::read_le(&mut reader)?;
         // Read the Merkle path siblings.
         let siblings = (0..DEPTH)
-            .map(|_| (0..ARITY).map(|_| Ok(Field::new(FromBytes::read_le(&mut reader)?))).collect::<IoResult<Vec<_>>>())
+            .map(|_| (0..ARITY).map(|_| Ok(FromBytes::read_le(&mut reader)?)).collect::<IoResult<Vec<_>>>())
             .collect::<IoResult<Vec<_>>>()?;
         // Return the Merkle path.
-        Self::try_from((U64::new(leaf_index), siblings)).map_err(|err| error(err.to_string()))
+        Self::try_from((leaf_index, siblings)).map_err(error)
     }
 }
 
-impl<E: Environment, const DEPTH: u8, const ARITY: u8> ToBytes for KAryMerklePath<E, DEPTH, ARITY> {
+impl<PH: PathHash, const DEPTH: u8, const ARITY: u8> ToBytes for KAryMerklePath<PH, DEPTH, ARITY> {
     /// Writes the Merkle path to a buffer.
     #[inline]
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
@@ -150,16 +146,14 @@ impl<E: Environment, const DEPTH: u8, const ARITY: u8> ToBytes for KAryMerklePat
     }
 }
 
-impl<E: Environment, const DEPTH: u8, const ARITY: u8> Serialize for KAryMerklePath<E, DEPTH, ARITY> {
+impl<PH: PathHash, const DEPTH: u8, const ARITY: u8> Serialize for KAryMerklePath<PH, DEPTH, ARITY> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        ToBytesSerializer::serialize(self, serializer)
+        ToBytesSerializer::serialize_with_size_encoding(self, serializer)
     }
 }
 
-impl<'de, E: Environment, const DEPTH: u8, const ARITY: u8> Deserialize<'de> for KAryMerklePath<E, DEPTH, ARITY> {
+impl<'de, PH: PathHash, const DEPTH: u8, const ARITY: u8> Deserialize<'de> for KAryMerklePath<PH, DEPTH, ARITY> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        // Compute the size for: u64 + (Field::SIZE_IN_BYTES * DEPTH * (ARITY - 1)).
-        let size = 8 + DEPTH as usize * (ARITY.saturating_sub(1) as usize) * (Field::<E>::size_in_bits() + 7) / 8;
-        FromBytesDeserializer::<Self>::deserialize(deserializer, "Merkle path", size)
+        FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "K-ary Merkle path")
     }
 }

--- a/console/collections/src/k_ary_merkle_tree/tests/mod.rs
+++ b/console/collections/src/k_ary_merkle_tree/tests/mod.rs
@@ -359,11 +359,11 @@ fn test_k_ary_merkle_tree_poseidon() -> Result<()> {
 #[test]
 fn test_k_ary_merkle_tree_keccak() -> Result<()> {
     fn run_test<const DEPTH: u8, const ARITY: u8>(rng: &mut TestRng) -> Result<()> {
-        type LH = Keccak256;
-        type PH = Keccak256;
+        type LH = Keccak256<CurrentEnvironment>;
+        type PH = Keccak256<CurrentEnvironment>;
 
-        let leaf_hasher = Keccak256::default();
-        let path_hasher = Keccak256::default();
+        let leaf_hasher = LH::new();
+        let path_hasher = PH::new();
 
         for i in 0..ITERATIONS {
             println!("Running test for depth {DEPTH} arity {ARITY} and iteration {i}");
@@ -403,11 +403,11 @@ fn test_k_ary_merkle_tree_keccak() -> Result<()> {
 #[test]
 fn test_k_ary_merkle_tree_sha3() -> Result<()> {
     fn run_test<const DEPTH: u8, const ARITY: u8>(rng: &mut TestRng) -> Result<()> {
-        type LH = Sha3_256;
-        type PH = Sha3_256;
+        type LH = Sha3_256<CurrentEnvironment>;
+        type PH = Sha3_256<CurrentEnvironment>;
 
-        let leaf_hasher = Sha3_256::default();
-        let path_hasher = Sha3_256::default();
+        let leaf_hasher = LH::new();
+        let path_hasher = PH::new();
 
         for i in 0..ITERATIONS {
             println!("Running test for depth {DEPTH} arity {ARITY} and iteration {i}");
@@ -482,11 +482,11 @@ fn test_merkle_tree_depth_2_arity_3_poseidon() -> Result<()> {
 
 #[test]
 fn test_merkle_tree_depth_2_arity_3_keccak() -> Result<()> {
-    type LH = Keccak256;
-    type PH = Keccak256;
+    type LH = Keccak256<CurrentEnvironment>;
+    type PH = Keccak256<CurrentEnvironment>;
 
-    let leaf_hasher = Keccak256::default();
-    let path_hasher = Keccak256::default();
+    let leaf_hasher = LH::new();
+    let path_hasher = PH::new();
 
     let mut rng = TestRng::default();
 
@@ -500,11 +500,11 @@ fn test_merkle_tree_depth_2_arity_3_keccak() -> Result<()> {
 
 #[test]
 fn test_merkle_tree_depth_2_arity_3_sha3() -> Result<()> {
-    type LH = Sha3_256;
-    type PH = Sha3_256;
+    type LH = Sha3_256<CurrentEnvironment>;
+    type PH = Sha3_256<CurrentEnvironment>;
 
-    let leaf_hasher = Sha3_256::default();
-    let path_hasher = Sha3_256::default();
+    let leaf_hasher = LH::new();
+    let path_hasher = PH::new();
 
     let mut rng = TestRng::default();
 
@@ -556,11 +556,11 @@ fn test_merkle_tree_depth_3_arity_3_poseidon() -> Result<()> {
 
 #[test]
 fn test_merkle_tree_depth_3_arity_3_keccak() -> Result<()> {
-    type LH = Keccak256;
-    type PH = Keccak256;
+    type LH = Keccak256<CurrentEnvironment>;
+    type PH = Keccak256<CurrentEnvironment>;
 
-    let leaf_hasher = Keccak256::default();
-    let path_hasher = Keccak256::default();
+    let leaf_hasher = LH::new();
+    let path_hasher = PH::new();
 
     let mut rng = TestRng::default();
 
@@ -575,11 +575,11 @@ fn test_merkle_tree_depth_3_arity_3_keccak() -> Result<()> {
 
 #[test]
 fn test_merkle_tree_depth_3_arity_3_sha3() -> Result<()> {
-    type LH = Sha3_256;
-    type PH = Sha3_256;
+    type LH = Sha3_256<CurrentEnvironment>;
+    type PH = Sha3_256<CurrentEnvironment>;
 
-    let leaf_hasher = Sha3_256::default();
-    let path_hasher = Sha3_256::default();
+    let leaf_hasher = LH::new();
+    let path_hasher = PH::new();
 
     let mut rng = TestRng::default();
 

--- a/console/collections/src/k_ary_merkle_tree/tests/mod.rs
+++ b/console/collections/src/k_ary_merkle_tree/tests/mod.rs
@@ -30,22 +30,14 @@ use run_tests;
 /// Runs the following test:
 /// 1. Construct the Merkle tree for the leaves.
 /// 2. Check that the Merkle proof for every leaf is valid.
-fn check_k_ary_merkle_tree<
-    E: Environment,
-    LH: LeafHash<Hash = PH::Hash>,
-    PH: PathHash<Hash = Field<E>>,
-    const DEPTH: u8,
-    const ARITY: u8,
->(
+fn check_k_ary_merkle_tree<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: u8>(
     leaf_hasher: &LH,
     path_hasher: &PH,
     leaves: &[LH::Leaf],
 ) -> Result<()> {
     // Construct the Merkle tree for the given leaves.
-    let merkle_tree = KAryMerkleTree::<E, LH, PH, DEPTH, ARITY>::new(leaf_hasher, path_hasher, leaves)?;
+    let merkle_tree = KAryMerkleTree::<LH, PH, DEPTH, ARITY>::new(leaf_hasher, path_hasher, leaves)?;
     assert_eq!(leaves.len(), merkle_tree.number_of_leaves);
-
-    let mut rng = TestRng::default();
 
     // Check each leaf in the Merkle tree.
     if !leaves.is_empty() {
@@ -56,9 +48,7 @@ fn check_k_ary_merkle_tree<
             // Verify the Merkle proof succeeds.
             assert!(proof.verify(leaf_hasher, path_hasher, merkle_tree.root(), leaf));
             // Verify the Merkle proof **fails** on an invalid root.
-            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::zero(), leaf));
-            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::one(), leaf));
-            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(&mut rng), leaf));
+            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::default(), leaf));
         }
     }
     Ok(())
@@ -67,7 +57,7 @@ fn check_k_ary_merkle_tree<
 /// Runs the following test:
 /// 1. Construct a depth-2 arity-3 Merkle tree with 9 leaves.
 /// 2. Checks that every node hash and the Merkle root is correct.
-fn check_merkle_tree_depth_2_arity_3<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>>>(
+fn check_merkle_tree_depth_2_arity_3<LH: LeafHash<Hash = PH::Hash>, PH: PathHash>(
     leaf_hasher: &LH,
     path_hasher: &PH,
     leaves: &[LH::Leaf],
@@ -75,7 +65,7 @@ fn check_merkle_tree_depth_2_arity_3<E: Environment, LH: LeafHash<Hash = PH::Has
     assert_eq!(9, leaves.len(), "Depth-2 test requires 9 leaves");
 
     // Construct the Merkle tree for the given leaves.
-    let merkle_tree = KAryMerkleTree::<E, LH, PH, 2, 3>::new(leaf_hasher, path_hasher, leaves)?;
+    let merkle_tree = KAryMerkleTree::<LH, PH, 2, 3>::new(leaf_hasher, path_hasher, leaves)?;
     assert_eq!(13, merkle_tree.tree.len());
     assert_eq!(9, merkle_tree.number_of_leaves);
 
@@ -117,11 +107,7 @@ fn check_merkle_tree_depth_2_arity_3<E: Environment, LH: LeafHash<Hash = PH::Has
 /// Runs the following test:
 /// 1. Construct a depth-3 Merkle tree with 10 leaves (leaving 17 leaves empty).
 /// 2. Checks that every node hash and the Merkle root is correct.
-fn check_merkle_tree_depth_3_arity_3_padded<
-    E: Environment,
-    LH: LeafHash<Hash = PH::Hash>,
-    PH: PathHash<Hash = Field<E>>,
->(
+fn check_merkle_tree_depth_3_arity_3_padded<LH: LeafHash<Hash = PH::Hash>, PH: PathHash>(
     leaf_hasher: &LH,
     path_hasher: &PH,
     leaves: &[LH::Leaf],
@@ -133,7 +119,7 @@ fn check_merkle_tree_depth_3_arity_3_padded<
     const ARITY: u8 = 3;
 
     // Construct the Merkle tree for the given leaves.
-    let merkle_tree = KAryMerkleTree::<E, LH, PH, 3, ARITY>::new(leaf_hasher, path_hasher, leaves)?;
+    let merkle_tree = KAryMerkleTree::<LH, PH, 3, ARITY>::new(leaf_hasher, path_hasher, leaves)?;
     assert_eq!(13, merkle_tree.tree.len());
     assert_eq!(9, merkle_tree.number_of_leaves);
 
@@ -183,7 +169,7 @@ fn check_merkle_tree_depth_3_arity_3_padded<
     let leaves = [leaves, additional_leaves].concat();
 
     // Construct the Merkle tree for the given leaves.
-    let merkle_tree = KAryMerkleTree::<E, LH, PH, 3, ARITY>::new(leaf_hasher, path_hasher, &leaves)?;
+    let merkle_tree = KAryMerkleTree::<LH, PH, 3, ARITY>::new(leaf_hasher, path_hasher, &leaves)?;
     assert_eq!(40, merkle_tree.tree.len());
     assert_eq!(10, merkle_tree.number_of_leaves);
 
@@ -288,7 +274,7 @@ fn test_k_ary_merkle_tree_bhp() -> Result<()> {
             let num_leaves = core::cmp::min((ARITY as u128).checked_pow(DEPTH as u32).unwrap_or(i), i);
 
             // Check the Merkle tree.
-            check_k_ary_merkle_tree::<CurrentEnvironment, LH, PH, DEPTH, ARITY>(
+            check_k_ary_merkle_tree::<LH, PH, DEPTH, ARITY>(
                 &leaf_hasher,
                 &path_hasher,
                 &(0..num_leaves)
@@ -330,7 +316,7 @@ fn test_k_ary_merkle_tree_poseidon() -> Result<()> {
             // Determine the number of leaves.
             let num_leaves = core::cmp::min((ARITY as u128).pow(DEPTH as u32), i);
             // Check the Merkle tree.
-            check_k_ary_merkle_tree::<CurrentEnvironment, LH, PH, DEPTH, ARITY>(
+            check_k_ary_merkle_tree::<LH, PH, DEPTH, ARITY>(
                 &leaf_hasher,
                 &path_hasher,
                 &(0..num_leaves).map(|_| vec![Uniform::rand(rng)]).collect::<Vec<_>>(),
@@ -371,7 +357,7 @@ fn test_k_ary_merkle_tree_keccak() -> Result<()> {
             let num_leaves = core::cmp::min((ARITY as u128).checked_pow(DEPTH as u32).unwrap_or(i), i);
 
             // Check the Merkle tree.
-            check_k_ary_merkle_tree::<CurrentEnvironment, LH, PH, DEPTH, ARITY>(
+            check_k_ary_merkle_tree::<LH, PH, DEPTH, ARITY>(
                 &leaf_hasher,
                 &path_hasher,
                 &(0..num_leaves)
@@ -415,7 +401,7 @@ fn test_k_ary_merkle_tree_sha3() -> Result<()> {
             let num_leaves = core::cmp::min((ARITY as u128).checked_pow(DEPTH as u32).unwrap_or(i), i);
 
             // Check the Merkle tree.
-            check_k_ary_merkle_tree::<CurrentEnvironment, LH, PH, DEPTH, ARITY>(
+            check_k_ary_merkle_tree::<LH, PH, DEPTH, ARITY>(
                 &leaf_hasher,
                 &path_hasher,
                 &(0..num_leaves)
@@ -455,7 +441,7 @@ fn test_merkle_tree_depth_2_arity_3_bhp() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-2 arity-3 Merkle tree.
-    check_merkle_tree_depth_2_arity_3::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_2_arity_3::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| Field::<CurrentEnvironment>::rand(&mut rng).to_bits_le()).collect::<Vec<Vec<bool>>>(),
@@ -473,7 +459,7 @@ fn test_merkle_tree_depth_2_arity_3_poseidon() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-2 arity-3 Merkle tree.
-    check_merkle_tree_depth_2_arity_3::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_2_arity_3::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| vec![Uniform::rand(&mut rng)]).collect::<Vec<_>>(),
@@ -491,7 +477,7 @@ fn test_merkle_tree_depth_2_arity_3_keccak() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-2 arity-3 Merkle tree.
-    check_merkle_tree_depth_2_arity_3::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_2_arity_3::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| Field::<CurrentEnvironment>::rand(&mut rng).to_bits_le()).collect::<Vec<Vec<bool>>>(),
@@ -509,7 +495,7 @@ fn test_merkle_tree_depth_2_arity_3_sha3() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-2 arity-3 Merkle tree.
-    check_merkle_tree_depth_2_arity_3::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_2_arity_3::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| Field::<CurrentEnvironment>::rand(&mut rng).to_bits_le()).collect::<Vec<Vec<bool>>>(),
@@ -527,7 +513,7 @@ fn test_merkle_tree_depth_3_arity_3_padded_bhp() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-2 arity-3 Merkle tree.
-    check_merkle_tree_depth_3_arity_3_padded::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_3_arity_3_padded::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| Field::<CurrentEnvironment>::rand(&mut rng).to_bits_le()).collect::<Vec<Vec<bool>>>(),
@@ -546,7 +532,7 @@ fn test_merkle_tree_depth_3_arity_3_poseidon() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-3 arity-3 Merkle tree.
-    check_merkle_tree_depth_3_arity_3_padded::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_3_arity_3_padded::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| vec![Uniform::rand(&mut rng)]).collect::<Vec<_>>(),
@@ -565,7 +551,7 @@ fn test_merkle_tree_depth_3_arity_3_keccak() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-3 arity-3 Merkle tree.
-    check_merkle_tree_depth_3_arity_3_padded::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_3_arity_3_padded::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| vec![Uniform::rand(&mut rng)]).collect::<Vec<_>>(),
@@ -584,7 +570,7 @@ fn test_merkle_tree_depth_3_arity_3_sha3() -> Result<()> {
     let mut rng = TestRng::default();
 
     // Check the depth-3 arity-3 Merkle tree.
-    check_merkle_tree_depth_3_arity_3_padded::<CurrentEnvironment, LH, PH>(
+    check_merkle_tree_depth_3_arity_3_padded::<LH, PH>(
         &leaf_hasher,
         &path_hasher,
         &(0..9).map(|_| vec![Uniform::rand(&mut rng)]).collect::<Vec<_>>(),

--- a/console/collections/src/lib.rs
+++ b/console/collections/src/lib.rs
@@ -17,6 +17,7 @@
 #![warn(clippy::cast_possible_truncation)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 
+pub use snarkvm_console_algorithms as algorithms;
 pub use snarkvm_console_types::prelude::*;
 
 pub mod k_ary_merkle_tree;

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -40,10 +40,7 @@ use snarkvm_algorithms::{
     AlgebraicSponge,
 };
 use snarkvm_console_algorithms::{Poseidon2, Poseidon4, BHP1024, BHP512};
-use snarkvm_console_collections::{
-    k_ary_merkle_tree::{KAryMerklePath, KAryMerkleTree},
-    merkle_tree::{MerklePath, MerkleTree},
-};
+use snarkvm_console_collections::merkle_tree::{MerklePath, MerkleTree};
 use snarkvm_console_types::{Field, Group, Scalar};
 use snarkvm_curves::PairingEngine;
 
@@ -55,13 +52,6 @@ use std::sync::Arc;
 pub type BHPMerkleTree<N, const DEPTH: u8> = MerkleTree<N, BHP1024<N>, BHP512<N>, DEPTH>;
 /// A helper type for the Poseidon Merkle tree.
 pub type PoseidonMerkleTree<N, const DEPTH: u8> = MerkleTree<N, Poseidon4<N>, Poseidon2<N>, DEPTH>;
-
-/// A helper type for the k-ary BHP Merkle tree.
-pub type KAryBHPMerkleTree<N, const DEPTH: u8, const ARITY: u8> =
-    KAryMerkleTree<N, BHP1024<N>, BHP512<N>, DEPTH, ARITY>;
-/// A helper type for the k-ary Poseidon Merkle tree.
-pub type KAryPoseidonMerkleTree<N, const DEPTH: u8, const ARITY: u8> =
-    KAryMerkleTree<N, Poseidon4<N>, Poseidon2<N>, DEPTH, ARITY>;
 
 /// Helper types for the Varuna parameters.
 type Fq<N> = <<N as Environment>::PairingCurve as PairingEngine>::Fq;
@@ -328,16 +318,6 @@ pub trait Network:
     /// Returns a Merkle tree with a Poseidon leaf hasher with input rate of 4 and a Poseidon path hasher with input rate of 2.
     fn merkle_tree_psd<const DEPTH: u8>(leaves: &[Vec<Field<Self>>]) -> Result<PoseidonMerkleTree<Self, DEPTH>>;
 
-    /// Returns a k-ary Merkle tree with a BHP leaf hasher of 1024-bits and a BHP path hasher of 512-bits.
-    fn k_ary_merkle_tree_bhp<const DEPTH: u8, const ARITY: u8>(
-        leaves: &[Vec<bool>],
-    ) -> Result<KAryBHPMerkleTree<Self, DEPTH, ARITY>>;
-
-    /// Returns a k-ary Merkle tree with a Poseidon leaf hasher with input rate of 4 and a Poseidon path hasher with input rate of 2.
-    fn k_ary_merkle_tree_psd<const DEPTH: u8, const ARITY: u8>(
-        leaves: &[Vec<Field<Self>>],
-    ) -> Result<KAryPoseidonMerkleTree<Self, DEPTH, ARITY>>;
-
     /// Returns `true` if the given Merkle path is valid for the given root and leaf.
     #[allow(clippy::ptr_arg)]
     fn verify_merkle_path_bhp<const DEPTH: u8>(
@@ -350,22 +330,6 @@ pub trait Network:
     #[allow(clippy::ptr_arg)]
     fn verify_merkle_path_psd<const DEPTH: u8>(
         path: &MerklePath<Self, DEPTH>,
-        root: &Field<Self>,
-        leaf: &Vec<Field<Self>>,
-    ) -> bool;
-
-    /// Returns `true` if the given k-ary Merkle path is valid for the given root and leaf.
-    #[allow(clippy::ptr_arg)]
-    fn verify_k_ary_merkle_path_bhp<const DEPTH: u8, const ARITY: u8>(
-        path: &KAryMerklePath<Self, DEPTH, ARITY>,
-        root: &Field<Self>,
-        leaf: &Vec<bool>,
-    ) -> bool;
-
-    /// Returns `true` if the given k-ary Merkle path is valid for the given root and leaf.
-    #[allow(clippy::ptr_arg)]
-    fn verify_k_ary_merkle_path_psd<const DEPTH: u8, const ARITY: u8>(
-        path: &KAryMerklePath<Self, DEPTH, ARITY>,
         root: &Field<Self>,
         leaf: &Vec<Field<Self>>,
     ) -> bool;

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -424,20 +424,6 @@ impl Network for Testnet3 {
         MerkleTree::new(&*POSEIDON_4, &*POSEIDON_2, leaves)
     }
 
-    /// Returns a k-ary Merkle tree with a BHP leaf hasher of 1024-bits and a BHP path hasher of 512-bits.
-    fn k_ary_merkle_tree_bhp<const DEPTH: u8, const ARITY: u8>(
-        leaves: &[Vec<bool>],
-    ) -> Result<KAryBHPMerkleTree<Self, DEPTH, ARITY>> {
-        KAryMerkleTree::new(&*BHP_1024, &*BHP_512, leaves)
-    }
-
-    /// Returns a k-ary Merkle tree with a Poseidon leaf hasher with input rate of 4 and a Poseidon path hasher with input rate of 2.
-    fn k_ary_merkle_tree_psd<const DEPTH: u8, const ARITY: u8>(
-        leaves: &[Vec<Field<Self>>],
-    ) -> Result<KAryPoseidonMerkleTree<Self, DEPTH, ARITY>> {
-        KAryMerkleTree::new(&*POSEIDON_4, &*POSEIDON_2, leaves)
-    }
-
     /// Returns `true` if the given Merkle path is valid for the given root and leaf.
     fn verify_merkle_path_bhp<const DEPTH: u8>(
         path: &MerklePath<Self, DEPTH>,
@@ -450,26 +436,6 @@ impl Network for Testnet3 {
     /// Returns `true` if the given Merkle path is valid for the given root and leaf.
     fn verify_merkle_path_psd<const DEPTH: u8>(
         path: &MerklePath<Self, DEPTH>,
-        root: &Field<Self>,
-        leaf: &Vec<Field<Self>>,
-    ) -> bool {
-        path.verify(&*POSEIDON_4, &*POSEIDON_2, root, leaf)
-    }
-
-    /// Returns `true` if the given k-ary Merkle path is valid for the given root and leaf.
-    #[allow(clippy::ptr_arg)]
-    fn verify_k_ary_merkle_path_bhp<const DEPTH: u8, const ARITY: u8>(
-        path: &KAryMerklePath<Self, DEPTH, ARITY>,
-        root: &Field<Self>,
-        leaf: &Vec<bool>,
-    ) -> bool {
-        path.verify(&*BHP_1024, &*BHP_512, root, leaf)
-    }
-
-    /// Returns `true` if the given k-ary Merkle path is valid for the given root and leaf.
-    #[allow(clippy::ptr_arg)]
-    fn verify_k_ary_merkle_path_psd<const DEPTH: u8, const ARITY: u8>(
-        path: &KAryMerklePath<Self, DEPTH, ARITY>,
         root: &Field<Self>,
         leaf: &Vec<Field<Self>>,
     ) -> bool {

--- a/console/types/field/src/lib.rs
+++ b/console/types/field/src/lib.rs
@@ -89,6 +89,13 @@ impl<E: Environment> Field<E> {
     }
 }
 
+impl<E: Environment> Default for Field<E> {
+    /// Returns the default field element.
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
 impl<E: Environment> TypeName for Field<E> {
     /// Returns the type name as a string.
     #[inline]

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -113,6 +113,14 @@ pub enum Instruction<N: Network> {
     HashBHP768(HashBHP768<N>),
     /// Performs a BHP hash on inputs of 1024-bit chunks.
     HashBHP1024(HashBHP1024<N>),
+    /// Performs a Keccak hash, outputting 224 bits.
+    HashKeccak224(HashKeccak224<N>),
+    /// Performs a Keccak hash, outputting 256 bits.
+    HashKeccak256(HashKeccak256<N>),
+    /// Performs a Keccak hash, outputting 384 bits.
+    HashKeccak384(HashKeccak384<N>),
+    /// Performs a Keccak hash, outputting 512 bits.
+    HashKeccak512(HashKeccak512<N>),
     /// Performs a Pedersen hash on up to a 64-bit input.
     HashPED64(HashPED64<N>),
     /// Performs a Pedersen hash on up to a 128-bit input.
@@ -123,6 +131,14 @@ pub enum Instruction<N: Network> {
     HashPSD4(HashPSD4<N>),
     /// Performs a Poseidon hash with an input rate of 8.
     HashPSD8(HashPSD8<N>),
+    /// Performs a SHA3 hash, outputting 224 bits.
+    HashSha3_224(HashSha3_224<N>),
+    /// Performs a SHA3 hash, outputting 256 bits.
+    HashSha3_256(HashSha3_256<N>),
+    /// Performs a SHA3 hash, outputting 384 bits.
+    HashSha3_384(HashSha3_384<N>),
+    /// Performs a SHA3 hash, outputting 512 bits.
+    HashSha3_512(HashSha3_512<N>),
     /// Performs a Poseidon hash with an input rate of 2.
     HashManyPSD2(HashManyPSD2<N>),
     /// Performs a Poseidon hash with an input rate of 4.
@@ -238,11 +254,19 @@ macro_rules! instruction {
             HashBHP512,
             HashBHP768,
             HashBHP1024,
+            HashKeccak224,
+            HashKeccak256,
+            HashKeccak384,
+            HashKeccak512,
             HashPED64,
             HashPED128,
             HashPSD2,
             HashPSD4,
             HashPSD8,
+            HashSha3_224,
+            HashSha3_256,
+            HashSha3_384,
+            HashSha3_512,
             HashManyPSD2,
             HashManyPSD4,
             HashManyPSD8,
@@ -442,7 +466,7 @@ mod tests {
     fn test_opcodes() {
         // Sanity check the number of instructions is unchanged.
         assert_eq!(
-            59,
+            67,
             Instruction::<CurrentNetwork>::OPCODES.len(),
             "Update me if the number of instructions changes."
         );

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -31,6 +31,15 @@ pub type HashBHP768<N> = HashInstruction<N, { Hasher::HashBHP768 as u8 }>;
 /// BHP1024 is a collision-resistant hash function that processes inputs in 1024-bit chunks.
 pub type HashBHP1024<N> = HashInstruction<N, { Hasher::HashBHP1024 as u8 }>;
 
+/// Keccak224 is a cryptographic hash function that outputs a 224-bit digest.
+pub type HashKeccak224<N> = HashInstruction<N, { Hasher::HashKeccak224 as u8 }>;
+/// Keccak256 is a cryptographic hash function that outputs a 256-bit digest.
+pub type HashKeccak256<N> = HashInstruction<N, { Hasher::HashKeccak256 as u8 }>;
+/// Keccak384 is a cryptographic hash function that outputs a 384-bit digest.
+pub type HashKeccak384<N> = HashInstruction<N, { Hasher::HashKeccak384 as u8 }>;
+/// Keccak512 is a cryptographic hash function that outputs a 512-bit digest.
+pub type HashKeccak512<N> = HashInstruction<N, { Hasher::HashKeccak512 as u8 }>;
+
 /// Pedersen64 is a collision-resistant hash function that processes inputs in 64-bit chunks.
 pub type HashPED64<N> = HashInstruction<N, { Hasher::HashPED64 as u8 }>;
 /// Pedersen128 is a collision-resistant hash function that processes inputs in 128-bit chunks.
@@ -42,6 +51,15 @@ pub type HashPSD2<N> = HashInstruction<N, { Hasher::HashPSD2 as u8 }>;
 pub type HashPSD4<N> = HashInstruction<N, { Hasher::HashPSD4 as u8 }>;
 /// Poseidon8 is a cryptographic hash function that processes inputs in 8-field chunks.
 pub type HashPSD8<N> = HashInstruction<N, { Hasher::HashPSD8 as u8 }>;
+
+/// SHA3-224 is a cryptographic hash function that outputs a 224-bit digest.
+pub type HashSha3_224<N> = HashInstruction<N, { Hasher::HashSha3_224 as u8 }>;
+/// SHA3-256 is a cryptographic hash function that outputs a 256-bit digest.
+pub type HashSha3_256<N> = HashInstruction<N, { Hasher::HashSha3_256 as u8 }>;
+/// SHA3-384 is a cryptographic hash function that outputs a 384-bit digest.
+pub type HashSha3_384<N> = HashInstruction<N, { Hasher::HashSha3_384 as u8 }>;
+/// SHA3-512 is a cryptographic hash function that outputs a 512-bit digest.
+pub type HashSha3_512<N> = HashInstruction<N, { Hasher::HashSha3_512 as u8 }>;
 
 /// Poseidon2 is a cryptographic hash function that processes inputs in 2-field chunks.
 pub type HashManyPSD2<N> = HashInstruction<N, { Hasher::HashManyPSD2 as u8 }>;
@@ -55,11 +73,19 @@ enum Hasher {
     HashBHP512,
     HashBHP768,
     HashBHP1024,
+    HashKeccak224,
+    HashKeccak256,
+    HashKeccak384,
+    HashKeccak512,
     HashPED64,
     HashPED128,
     HashPSD2,
     HashPSD4,
     HashPSD8,
+    HashSha3_224,
+    HashSha3_256,
+    HashSha3_384,
+    HashSha3_512,
     HashManyPSD2,
     HashManyPSD4,
     HashManyPSD8,
@@ -68,7 +94,7 @@ enum Hasher {
 /// Returns the expected number of operands given the variant.
 const fn expected_num_operands(variant: u8) -> usize {
     match variant {
-        9..=11 => 2,
+        17..=19 => 2,
         _ => 1,
     }
 }
@@ -121,15 +147,23 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
             1 => Opcode::Hash("hash.bhp512"),
             2 => Opcode::Hash("hash.bhp768"),
             3 => Opcode::Hash("hash.bhp1024"),
-            4 => Opcode::Hash("hash.ped64"),
-            5 => Opcode::Hash("hash.ped128"),
-            6 => Opcode::Hash("hash.psd2"),
-            7 => Opcode::Hash("hash.psd4"),
-            8 => Opcode::Hash("hash.psd8"),
-            9 => Opcode::Hash("hash_many.psd2"),
-            10 => Opcode::Hash("hash_many.psd4"),
-            11 => Opcode::Hash("hash_many.psd8"),
-            12.. => panic!("Invalid 'hash' instruction opcode"),
+            4 => Opcode::Hash("hash.keccak224"),
+            5 => Opcode::Hash("hash.keccak256"),
+            6 => Opcode::Hash("hash.keccak384"),
+            7 => Opcode::Hash("hash.keccak512"),
+            8 => Opcode::Hash("hash.ped64"),
+            9 => Opcode::Hash("hash.ped128"),
+            10 => Opcode::Hash("hash.psd2"),
+            11 => Opcode::Hash("hash.psd4"),
+            12 => Opcode::Hash("hash.psd8"),
+            13 => Opcode::Hash("hash.sha3_224"),
+            14 => Opcode::Hash("hash.sha3_256"),
+            15 => Opcode::Hash("hash.sha3_384"),
+            16 => Opcode::Hash("hash.sha3_512"),
+            17 => Opcode::Hash("hash_many.psd2"),
+            18 => Opcode::Hash("hash_many.psd4"),
+            19 => Opcode::Hash("hash_many.psd8"),
+            20.. => panic!("Invalid 'hash' instruction opcode"),
         }
     }
 
@@ -180,24 +214,32 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
             (1, _) => Literal::Group(N::hash_to_group_bhp512(&input.to_bits_le())?),
             (2, _) => Literal::Group(N::hash_to_group_bhp768(&input.to_bits_le())?),
             (3, _) => Literal::Group(N::hash_to_group_bhp1024(&input.to_bits_le())?),
-            (4, _) => Literal::Group(N::hash_to_group_ped64(&input.to_bits_le())?),
-            (5, _) => Literal::Group(N::hash_to_group_ped128(&input.to_bits_le())?),
-            (6, LiteralType::Address) | (6, LiteralType::Group) => {
+            (4, _) => bail!("'hash.keccak224' is not yet implemented"),
+            (5, _) => bail!("'hash.keccak256' is not yet implemented"),
+            (6, _) => bail!("'hash.keccak384' is not yet implemented"),
+            (7, _) => bail!("'hash.keccak512' is not yet implemented"),
+            (8, _) => Literal::Group(N::hash_to_group_ped64(&input.to_bits_le())?),
+            (9, _) => Literal::Group(N::hash_to_group_ped128(&input.to_bits_le())?),
+            (10, LiteralType::Address) | (10, LiteralType::Group) => {
                 Literal::Group(N::hash_to_group_psd2(&input.to_fields()?)?)
             }
-            (6, _) => Literal::Field(N::hash_psd2(&input.to_fields()?)?),
-            (7, LiteralType::Address) | (7, LiteralType::Group) => {
+            (10, _) => Literal::Field(N::hash_psd2(&input.to_fields()?)?),
+            (11, LiteralType::Address) | (11, LiteralType::Group) => {
                 Literal::Group(N::hash_to_group_psd4(&input.to_fields()?)?)
             }
-            (7, _) => Literal::Field(N::hash_psd4(&input.to_fields()?)?),
-            (8, LiteralType::Address) | (8, LiteralType::Group) => {
+            (11, _) => Literal::Field(N::hash_psd4(&input.to_fields()?)?),
+            (12, LiteralType::Address) | (12, LiteralType::Group) => {
                 Literal::Group(N::hash_to_group_psd8(&input.to_fields()?)?)
             }
-            (8, _) => Literal::Field(N::hash_psd8(&input.to_fields()?)?),
-            (9, _) => bail!("'hash_many' is not yet implemented"),
-            (10, _) => bail!("'hash_many' is not yet implemented"),
-            (11, _) => bail!("'hash_many' is not yet implemented"),
-            (12.., _) => bail!("Invalid 'hash' variant: {VARIANT}"),
+            (12, _) => Literal::Field(N::hash_psd8(&input.to_fields()?)?),
+            (13, _) => bail!("'hash.sha3_224' is not yet implemented"),
+            (14, _) => bail!("'hash.sha3_256' is not yet implemented"),
+            (15, _) => bail!("'hash.sha3_384' is not yet implemented"),
+            (16, _) => bail!("'hash.sha3_512' is not yet implemented"),
+            (17, _) => bail!("'hash_many.psd2' is not yet implemented"),
+            (18, _) => bail!("'hash_many.psd4' is not yet implemented"),
+            (19, _) => bail!("'hash_many.psd8' is not yet implemented"),
+            (20.., _) => bail!("Invalid 'hash' variant: {VARIANT}"),
         };
         // Cast the output to the destination type.
         let output = output.downcast_lossy(self.destination_type)?;
@@ -227,24 +269,32 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
             (1, _) => circuit::Literal::Group(A::hash_to_group_bhp512(&input.to_bits_le())),
             (2, _) => circuit::Literal::Group(A::hash_to_group_bhp768(&input.to_bits_le())),
             (3, _) => circuit::Literal::Group(A::hash_to_group_bhp1024(&input.to_bits_le())),
-            (4, _) => circuit::Literal::Group(A::hash_to_group_ped64(&input.to_bits_le())),
-            (5, _) => circuit::Literal::Group(A::hash_to_group_ped128(&input.to_bits_le())),
-            (6, LiteralType::Address) | (6, LiteralType::Group) => {
+            (4, _) => bail!("'hash.keccak224' is not yet implemented"),
+            (5, _) => bail!("'hash.keccak256' is not yet implemented"),
+            (6, _) => bail!("'hash.keccak384' is not yet implemented"),
+            (7, _) => bail!("'hash.keccak512' is not yet implemented"),
+            (8, _) => circuit::Literal::Group(A::hash_to_group_ped64(&input.to_bits_le())),
+            (9, _) => circuit::Literal::Group(A::hash_to_group_ped128(&input.to_bits_le())),
+            (10, LiteralType::Address) | (10, LiteralType::Group) => {
                 circuit::Literal::Group(A::hash_to_group_psd2(&input.to_fields()))
             }
-            (6, _) => circuit::Literal::Field(A::hash_psd2(&input.to_fields())),
-            (7, LiteralType::Address) | (7, LiteralType::Group) => {
+            (10, _) => circuit::Literal::Field(A::hash_psd2(&input.to_fields())),
+            (11, LiteralType::Address) | (11, LiteralType::Group) => {
                 circuit::Literal::Group(A::hash_to_group_psd4(&input.to_fields()))
             }
-            (7, _) => circuit::Literal::Field(A::hash_psd4(&input.to_fields())),
-            (8, LiteralType::Address) | (8, LiteralType::Group) => {
+            (11, _) => circuit::Literal::Field(A::hash_psd4(&input.to_fields())),
+            (12, LiteralType::Address) | (12, LiteralType::Group) => {
                 circuit::Literal::Group(A::hash_to_group_psd8(&input.to_fields()))
             }
-            (8, _) => circuit::Literal::Field(A::hash_psd8(&input.to_fields())),
-            (9, _) => bail!("'hash_many' is not yet implemented"),
-            (10, _) => bail!("'hash_many' is not yet implemented"),
-            (11, _) => bail!("'hash_many' is not yet implemented"),
-            (12.., _) => bail!("Invalid 'hash' variant: {VARIANT}"),
+            (12, _) => circuit::Literal::Field(A::hash_psd8(&input.to_fields())),
+            (13, _) => bail!("'hash.sha3_224' is not yet implemented"),
+            (14, _) => bail!("'hash.sha3_256' is not yet implemented"),
+            (15, _) => bail!("'hash.sha3_384' is not yet implemented"),
+            (16, _) => bail!("'hash.sha3_512' is not yet implemented"),
+            (17, _) => bail!("'hash_many.psd2' is not yet implemented"),
+            (18, _) => bail!("'hash_many.psd4' is not yet implemented"),
+            (19, _) => bail!("'hash_many.psd8' is not yet implemented"),
+            (20.., _) => bail!("Invalid 'hash' variant: {VARIANT}"),
         };
         let output = output.downcast_lossy(self.destination_type)?;
         // Convert the output to a stack value.
@@ -280,9 +330,12 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
         // TODO (howardwu): If the operation is Pedersen, check that it is within the number of bits.
 
         match VARIANT {
-            0..=8 => Ok(vec![RegisterType::Plaintext(PlaintextType::Literal(self.destination_type))]),
-            9..=11 => bail!("'hash_many' is not yet implemented"),
-            12.. => bail!("Invalid 'hash' variant: {VARIANT}"),
+            0..=3 => Ok(vec![RegisterType::Plaintext(PlaintextType::Literal(self.destination_type))]),
+            4..=7 => bail!("'hash.keccak*' is not yet implemented"),
+            8..=12 => Ok(vec![RegisterType::Plaintext(PlaintextType::Literal(self.destination_type))]),
+            13..=16 => bail!("'hash.sha3*' is not yet implemented"),
+            17..=19 => bail!("'hash_many' is not yet implemented"),
+            20.. => bail!("Invalid 'hash' variant: {VARIANT}"),
         }
     }
 }

--- a/synthesizer/src/vm/helpers/cost.rs
+++ b/synthesizer/src/vm/helpers/cost.rs
@@ -122,6 +122,18 @@ pub fn cost_in_microcredits<N: Network>(finalize: &Finalize<N>) -> Result<u64> {
         Command::Instruction(Instruction::HashBHP512(_)) => Ok(100_000),
         Command::Instruction(Instruction::HashBHP768(_)) => Ok(100_000),
         Command::Instruction(Instruction::HashBHP1024(_)) => Ok(100_000),
+        Command::Instruction(Instruction::HashKeccak224(_)) => {
+            bail!("`hash.keccak224` is not supported in finalize yet.")
+        }
+        Command::Instruction(Instruction::HashKeccak256(_)) => {
+            bail!("`hash.keccak256` is not supported in finalize yet.")
+        }
+        Command::Instruction(Instruction::HashKeccak384(_)) => {
+            bail!("`hash.keccak384` is not supported in finalize yet.")
+        }
+        Command::Instruction(Instruction::HashKeccak512(_)) => {
+            bail!("`hash.keccak512` is not supported in finalize yet.")
+        }
         Command::Instruction(Instruction::HashPED64(_)) => Ok(20_000),
         Command::Instruction(Instruction::HashPED128(_)) => Ok(30_000),
         Command::Instruction(Instruction::HashPSD2(hash)) => match hash.destination_type() {
@@ -136,6 +148,18 @@ pub fn cost_in_microcredits<N: Network>(finalize: &Finalize<N>) -> Result<u64> {
             LiteralType::Address | LiteralType::Group => Ok(800_000),
             _ => Ok(200_000),
         },
+        Command::Instruction(Instruction::HashSha3_224(_)) => {
+            bail!("`hash.sha3_224` is not supported in finalize yet.")
+        }
+        Command::Instruction(Instruction::HashSha3_256(_)) => {
+            bail!("`hash.sha3_256` is not supported in finalize yet.")
+        }
+        Command::Instruction(Instruction::HashSha3_384(_)) => {
+            bail!("`hash.sha3_384` is not supported in finalize yet.")
+        }
+        Command::Instruction(Instruction::HashSha3_512(_)) => {
+            bail!("`hash.sha3_512` is not supported in finalize yet.")
+        }
         Command::Instruction(Instruction::HashManyPSD2(_)) => {
             bail!("`hash_many.psd2` is not supported in finalize.")
         }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds `Keccak` and `Sha3` support to K-ary merkle tree by implementing the `PathHash` and `LeafHash` traits.


### Note: 
The leaf and path hashers convert the outputs to Fields rather than `Keccak`'s native `Vec<bool>` type. This adds many additional constraints, and should be updated by updating the PathHash trait and MerkleTree construction to use generic hash types.
 - A generic was added to the `Keccak` type to support the above
