### PR TITLE
Prevent addition overflow

### DIFF
--- a/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
@@ -155,7 +155,6 @@ impl<F: PrimeField, MM: SNARKMode> Circuit<F, MM> {
 }
 
 impl<F: PrimeField, MM: SNARKMode> CanonicalSerialize for Circuit<F, MM> {
-    #[allow(unused_mut, unused_variables)]
     fn serialize_with_mode<W: Write>(&self, mut writer: W, compress: Compress) -> Result<(), SerializationError> {
         self.index_info.serialize_with_mode(&mut writer, compress)?;
         self.a.serialize_with_mode(&mut writer, compress)?;
@@ -167,10 +166,9 @@ impl<F: PrimeField, MM: SNARKMode> CanonicalSerialize for Circuit<F, MM> {
         Ok(())
     }
 
-    #[allow(unused_mut, unused_variables)]
     fn serialized_size(&self, mode: Compress) -> usize {
-        0usize
-            .saturating_add(self.index_info.serialized_size(mode))
+        self.index_info
+            .serialized_size(mode)
             .saturating_add(self.a.serialized_size(mode))
             .saturating_add(self.b.serialized_size(mode))
             .saturating_add(self.c.serialized_size(mode))
@@ -185,10 +183,7 @@ impl<F: PrimeField, MM: SNARKMode> snarkvm_utilities::Valid for Circuit<F, MM> {
         Ok(())
     }
 
-    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self> + Send) -> Result<(), SerializationError>
-    where
-        Self: 'a,
-    {
+    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self> + Send) -> Result<(), SerializationError> {
         Ok(())
     }
 }

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
@@ -169,15 +169,14 @@ impl<F: PrimeField, MM: SNARKMode> CanonicalSerialize for Circuit<F, MM> {
 
     #[allow(unused_mut, unused_variables)]
     fn serialized_size(&self, mode: Compress) -> usize {
-        let mut size = 0;
-        size += self.index_info.serialized_size(mode);
-        size += self.a.serialized_size(mode);
-        size += self.b.serialized_size(mode);
-        size += self.c.serialized_size(mode);
-        size += self.a_arith.serialized_size(mode);
-        size += self.b_arith.serialized_size(mode);
-        size += self.c_arith.serialized_size(mode);
-        size
+        0usize
+            .saturating_add(self.index_info.serialized_size(mode))
+            .saturating_add(self.a.serialized_size(mode))
+            .saturating_add(self.b.serialized_size(mode))
+            .saturating_add(self.c.serialized_size(mode))
+            .saturating_add(self.a_arith.serialized_size(mode))
+            .saturating_add(self.b_arith.serialized_size(mode))
+            .saturating_add(self.c_arith.serialized_size(mode))
     }
 }
 

--- a/algorithms/src/snark/varuna/ahp/prover/state.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/state.rs
@@ -104,7 +104,7 @@ impl<'a, F: PrimeField, MM: SNARKMode> State<'a, F, MM> {
         let mut max_non_zero_domain: Option<EvaluationDomain<F>> = None;
         let mut max_num_constraints = 0;
         let mut max_num_variables = 0;
-        let mut total_instances = 0;
+        let mut total_instances = 0usize;
         let circuit_specific_states = indices_and_assignments
             .into_iter()
             .map(|(circuit, variable_assignments)| {
@@ -124,7 +124,8 @@ impl<'a, F: PrimeField, MM: SNARKMode> State<'a, F, MM> {
                 let first_padded_public_inputs = &variable_assignments[0].0;
                 let input_domain = EvaluationDomain::new(first_padded_public_inputs.len()).unwrap();
                 let batch_size = variable_assignments.len();
-                total_instances += batch_size;
+                total_instances =
+                    total_instances.checked_add(batch_size).ok_or_else(|| anyhow::anyhow!("Batch size too large"))?;
                 let mut z_as = Vec::with_capacity(batch_size);
                 let mut z_bs = Vec::with_capacity(batch_size);
                 let mut z_cs = Vec::with_capacity(batch_size);

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -71,17 +71,15 @@ impl<E: PairingEngine> Commitments<E> {
     }
 
     fn serialized_size(&self, compress: Compress) -> usize {
-        let mut size = 0;
-        size += serialized_vec_size_without_len(&self.witness_commitments, compress);
-        size += CanonicalSerialize::serialized_size(&self.mask_poly, compress);
-        size += CanonicalSerialize::serialized_size(&self.h_0, compress);
-        size += CanonicalSerialize::serialized_size(&self.g_1, compress);
-        size += CanonicalSerialize::serialized_size(&self.h_1, compress);
-        size += serialized_vec_size_without_len(&self.g_a_commitments, compress);
-        size += serialized_vec_size_without_len(&self.g_b_commitments, compress);
-        size += serialized_vec_size_without_len(&self.g_c_commitments, compress);
-        size += CanonicalSerialize::serialized_size(&self.h_2, compress);
-        size
+        serialized_vec_size_without_len(&self.witness_commitments, compress)
+            .saturating_add(CanonicalSerialize::serialized_size(&self.mask_poly, compress))
+            .saturating_add(CanonicalSerialize::serialized_size(&self.h_0, compress))
+            .saturating_add(CanonicalSerialize::serialized_size(&self.g_1, compress))
+            .saturating_add(CanonicalSerialize::serialized_size(&self.h_1, compress))
+            .saturating_add(serialized_vec_size_without_len(&self.g_a_commitments, compress))
+            .saturating_add(serialized_vec_size_without_len(&self.g_b_commitments, compress))
+            .saturating_add(serialized_vec_size_without_len(&self.g_c_commitments, compress))
+            .saturating_add(CanonicalSerialize::serialized_size(&self.h_2, compress))
     }
 
     fn deserialize_with_mode<R: snarkvm_utilities::Read>(
@@ -140,12 +138,10 @@ impl<F: PrimeField> Evaluations<F> {
     }
 
     fn serialized_size(&self, compress: Compress) -> usize {
-        let mut size = 0;
-        size += CanonicalSerialize::serialized_size(&self.g_1_eval, compress);
-        size += serialized_vec_size_without_len(&self.g_a_evals, compress);
-        size += serialized_vec_size_without_len(&self.g_b_evals, compress);
-        size += serialized_vec_size_without_len(&self.g_c_evals, compress);
-        size
+        CanonicalSerialize::serialized_size(&self.g_1_eval, compress)
+            .saturating_add(serialized_vec_size_without_len(&self.g_a_evals, compress))
+            .saturating_add(serialized_vec_size_without_len(&self.g_b_evals, compress))
+            .saturating_add(serialized_vec_size_without_len(&self.g_c_evals, compress))
     }
 
     fn deserialize_with_mode<R: snarkvm_utilities::Read>(

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -358,7 +358,7 @@ where
         let mut batch_sizes = BTreeMap::new();
         let mut circuit_infos = BTreeMap::new();
         let mut inputs_and_batch_sizes = BTreeMap::new();
-        let mut total_instances = 0;
+        let mut total_instances = 0usize;
         let mut public_inputs = BTreeMap::new(); // inputs need to live longer than the rest of prover_state
         let num_unique_circuits = keys_to_constraints.len();
         let mut circuit_ids = Vec::with_capacity(num_unique_circuits);
@@ -371,8 +371,9 @@ where
             batch_sizes.insert(circuit_id, batch_size);
             circuit_infos.insert(circuit_id, &pk.circuit_verifying_key.circuit_info);
             inputs_and_batch_sizes.insert(circuit_id, (batch_size, padded_public_input));
-            total_instances += batch_size;
             public_inputs.insert(circuit_id, public_input);
+            total_instances = total_instances.saturating_add(batch_size);
+
             circuit_ids.push(circuit_id);
         }
         assert_eq!(prover_state.total_instances, total_instances);


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

We should avoid panics, this PR adds checking if additions are allowed in snarkVM. I could not find problematic subtraction cases.

For this, we should agree on the attack surface. I can imagine the following attack vectors:

- an attacker lets different nodes misinterpret a serialized object, which can happen if our flags are serialized last. Fortunately I haven't seen this anywhere.
- an attacker's frontend lets an honest user serialize a giant object so their local node panics, I don't think this is a huge issue
- an attacker lets an honest node deserialize a giant object so it panics. This might kill the network so we should prevent this. Nodes already seem to have a [maximum message size](https://github.com/AleoHQ/snarkOS/blob/1ec292b8d3d71013f43084f663e4e7b926e8c170/node/messages/src/helpers/codec.rs#L26), but as defense in depth I use saturating_add in serialized_size. Using checked_add there is tricky as it will change the serialized_size trait function signature all over the codebase, including in macros and for types which we know have a fixed size.
    

## Test Plan

The existing tests should cover it.

## Related PRs

Succeeding: https://github.com/AleoHQ/snarkVM/pull/1584
Compared to that PR, here we *only* care about fixing addition overflow and we are rebased on testnet3