### PR TITLE
[Feature] Array Concatenation.

### DIFF
--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -95,6 +95,8 @@ pub enum Instruction<N: Network> {
     CommitPED64(CommitPED64<N>),
     /// Performs a Pedersen commitment on up to a 128-bit input.
     CommitPED128(CommitPED128<N>),
+    /// Concatenates `first` and `second`, storing the outcome in `destination`.
+    Concat(Concat<N>),
     /// Divides `first` by `second`, storing the outcome in `destination`.
     Div(Div<N>),
     /// Divides `first` by `second`, wrapping around at the boundary of the type, and storing the outcome in `destination`.
@@ -243,6 +245,7 @@ macro_rules! instruction {
             CommitBHP1024,
             CommitPED64,
             CommitPED128,
+            Concat,
             Div,
             DivWrapped,
             Double,
@@ -463,7 +466,7 @@ mod tests {
     fn test_opcodes() {
         // Sanity check the number of instructions is unchanged.
         assert_eq!(
-            66,
+            67,
             Instruction::<CurrentNetwork>::OPCODES.len(),
             "Update me if the number of instructions changes."
         );

--- a/synthesizer/program/src/logic/instruction/opcode/mod.rs
+++ b/synthesizer/program/src/logic/instruction/opcode/mod.rs
@@ -27,6 +27,8 @@ pub enum Opcode {
     Command(&'static str),
     /// The opcode is for a commit operation (i.e. `commit.psd4`).
     Commit(&'static str),
+    /// The opcode is for a concat operation (i.e. `concat`).
+    Concat,
     /// The opcode is for a finalize operation (i.e. `finalize`).
     Finalize(&'static str),
     /// The opcode is for a hash operation (i.e. `hash.psd4`).
@@ -50,6 +52,7 @@ impl Deref for Opcode {
             Opcode::Cast => &"cast",
             Opcode::Command(opcode) => opcode,
             Opcode::Commit(opcode) => opcode,
+            Opcode::Concat => &"concat",
             Opcode::Finalize(opcode) => opcode,
             Opcode::Hash(opcode) => opcode,
             Opcode::Is(opcode) => opcode,
@@ -75,6 +78,7 @@ impl Display for Opcode {
             Self::Cast => write!(f, "{}", self.deref()),
             Self::Command(opcode) => write!(f, "{opcode}"),
             Self::Commit(opcode) => write!(f, "{opcode}"),
+            Self::Concat => write!(f, "{}", self.deref()),
             Self::Finalize(opcode) => write!(f, "{opcode}"),
             Self::Hash(opcode) => write!(f, "{opcode}"),
             Self::Is(opcode) => write!(f, "{opcode}"),

--- a/synthesizer/program/src/logic/instruction/operation/concat.rs
+++ b/synthesizer/program/src/logic/instruction/operation/concat.rs
@@ -1,0 +1,351 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    traits::{RegistersLoad, RegistersLoadCircuit, RegistersStore, RegistersStoreCircuit, StackMatches, StackProgram},
+    Opcode,
+    Operand,
+};
+use circuit::Eject;
+use console::{
+    network::prelude::*,
+    program::{ArrayType, Plaintext, PlaintextType, Register, RegisterType, Value},
+};
+
+/// Concatenates `first` and `second`, storing the outcome in `destination`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Concat<N: Network> {
+    /// The operands.
+    operands: Vec<Operand<N>>,
+    /// The destination register.
+    destination: Register<N>,
+    /// The target type.
+    target_type: ArrayType<N>,
+}
+
+impl<N: Network> Concat<N> {
+    /// Initializes a new `concat` instruction.
+    #[inline]
+    pub fn new(operands: Vec<Operand<N>>, destination: Register<N>, target_type: ArrayType<N>) -> Result<Self> {
+        // Sanity check the number of operands.
+        ensure!(operands.len() == 2, "Instruction '{}' must have two operands", Self::opcode());
+        // Return the instruction.
+        Ok(Self { operands, destination, target_type })
+    }
+
+    /// Returns the opcode.
+    #[inline]
+    pub const fn opcode() -> Opcode {
+        Opcode::Concat
+    }
+
+    /// Returns the operands in the operation.
+    #[inline]
+    pub fn operands(&self) -> &[Operand<N>] {
+        // Sanity check that there are exactly three operands.
+        debug_assert!(self.operands.len() == 2, "Instruction '{}' must have two operands", Self::opcode());
+        // Return the operands.
+        &self.operands
+    }
+
+    /// Returns the destination register.
+    #[inline]
+    pub fn destinations(&self) -> Vec<Register<N>> {
+        vec![self.destination.clone()]
+    }
+
+    /// Returns the target type.
+    #[inline]
+    pub fn target_type(&self) -> &ArrayType<N> {
+        &self.target_type
+    }
+}
+
+impl<N: Network> Concat<N> {
+    /// Evaluates the instruction.
+    #[inline]
+    pub fn evaluate(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
+        // Ensure the number of operands is correct.
+        if self.operands.len() != 2 {
+            bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
+        }
+
+        // Retrieve the inputs, ensuring that they are arrays.
+        let mut first = match registers.load(stack, &self.operands[0])? {
+            Value::Plaintext(Plaintext::Array(first, _)) => first,
+            _ => bail!("Expected the first operand to be an array."),
+        };
+        let mut second = match registers.load(stack, &self.operands[1])? {
+            Value::Plaintext(Plaintext::Array(second, _)) => second,
+            _ => bail!("Expected the second operand to be an array."),
+        };
+
+        // Ensure that the sum of the lengths of the arrays match the target type.
+        ensure!(
+            first.len() + second.len() == **self.target_type.length() as usize,
+            "Expected the sum of the lengths of the arrays to match the target type."
+        );
+
+        // Ensure that the elements of the arrays match the target element type.
+        for element in first.iter() {
+            stack.matches_plaintext(element, self.target_type.next_element_type())?;
+        }
+        for element in second.iter() {
+            stack.matches_plaintext(element, self.target_type.next_element_type())?;
+        }
+
+        // Concatenate the arrays.
+        first.append(&mut second);
+        let output = Value::Plaintext(Plaintext::Array(first, Default::default()));
+
+        // Store the output.
+        registers.store(stack, &self.destination, output)
+    }
+
+    /// Executes the instruction.
+    #[inline]
+    pub fn execute<A: circuit::Aleo<Network = N>>(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        registers: &mut (impl RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
+    ) -> Result<()> {
+        // Ensure the number of operands is correct.
+        if self.operands.len() != 2 {
+            bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
+        }
+
+        // Retrieve the inputs, ensuring that they are arrays.
+        let mut first = match registers.load_circuit(stack, &self.operands[0])? {
+            circuit::Value::Plaintext(circuit::Plaintext::Array(first, _)) => first,
+            _ => bail!("Expected the first operand to be an array."),
+        };
+        let mut second = match registers.load_circuit(stack, &self.operands[1])? {
+            circuit::Value::Plaintext(circuit::Plaintext::Array(second, _)) => second,
+            _ => bail!("Expected the second operand to be an array."),
+        };
+
+        // Ensure that the sum of the lengths of the arrays match the target type.
+        ensure!(
+            first.len() + second.len() == **self.target_type.length() as usize,
+            "Expected the sum of the lengths of the arrays to match the target type."
+        );
+
+        // Ensure that the elements of the arrays match the target element type.
+        for element in first.iter() {
+            stack.matches_plaintext(&element.eject_value(), self.target_type.next_element_type())?;
+        }
+        for element in second.iter() {
+            stack.matches_plaintext(&element.eject_value(), self.target_type.next_element_type())?;
+        }
+
+        // Concatenate the arrays.
+        first.append(&mut second);
+        let output = circuit::Value::Plaintext(circuit::Plaintext::Array(first, Default::default()));
+
+        // Store the output.
+        registers.store_circuit(stack, &self.destination, output)
+    }
+
+    /// Finalizes the instruction.
+    #[inline]
+    pub fn finalize(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
+        self.evaluate(stack, registers)
+    }
+
+    /// Returns the output type from the given program and input types.
+    #[inline]
+    pub fn output_types(
+        &self,
+        _stack: &impl StackProgram<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
+        // Ensure the number of input types is correct.
+        if input_types.len() != 2 {
+            bail!("Instruction '{}' expects 2 inputs, found {} inputs", Self::opcode(), input_types.len())
+        }
+
+        // Ensure the first operand is an array.
+        let first_type = match &input_types[0] {
+            RegisterType::Plaintext(PlaintextType::Array(first_type)) => first_type,
+            _ => bail!(
+                "Instruction '{}' expects the first input to be an 'array'. Found input of type '{}'",
+                Self::opcode(),
+                input_types[0]
+            ),
+        };
+
+        // Ensure the second operand is an array.
+        let second_type = match &input_types[1] {
+            RegisterType::Plaintext(PlaintextType::Array(second_type)) => second_type,
+            _ => bail!(
+                "Instruction '{}' expects the second input to be an 'array'. Found input of type '{}'",
+                Self::opcode(),
+                input_types[1]
+            ),
+        };
+
+        // Check that the sum of the lengths of the arrays match the target type.
+        if **first_type.length() + **second_type.length() != **self.target_type.length() {
+            bail!("Expected the sum of the lengths of the arrays to match the target type.")
+        }
+
+        // Check that the element types of the arrays match the target element type.
+        if first_type.next_element_type() != self.target_type.next_element_type() {
+            bail!("Expected the element types of the first array to match the target element type.")
+        }
+        if second_type.next_element_type() != self.target_type.next_element_type() {
+            bail!("Expected the element types of the second array to match the target element type.")
+        }
+
+        Ok(vec![RegisterType::Plaintext(PlaintextType::Array(self.target_type.clone()))])
+    }
+}
+
+impl<N: Network> Parser for Concat<N> {
+    /// Parses a string into an operation.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the opcode from the string.
+        let (string, _) = tag(*Self::opcode())(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the first operand from the string.
+        let (string, first) = Operand::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the second operand from the string.
+        let (string, second) = Operand::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "into" from the string.
+        let (string, _) = tag("into")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the destination register from the string.
+        let (string, destination) = Register::parse(string)?;
+        // Parse the "as" from the string.
+        let (string, _) = tag("as")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the target type from the string.
+        let (string, target_type) = ArrayType::parse(string)?;
+
+        Ok((string, Self { operands: vec![first, second], destination, target_type }))
+    }
+}
+
+impl<N: Network> FromStr for Concat<N> {
+    type Err = Error;
+
+    /// Parses a string into an operation.
+    #[inline]
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for Concat<N> {
+    /// Prints the operation as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for Concat<N> {
+    /// Prints the operation to a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Ensure the number of operands is 2.
+        if self.operands.len() != 2 {
+            return Err(fmt::Error);
+        }
+        // Print the operation.
+        write!(f, "{} ", Self::opcode())?;
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))?;
+        write!(f, "into {} as {}", self.destination, self.target_type)
+    }
+}
+
+impl<N: Network> FromBytes for Concat<N> {
+    /// Reads the operation from a buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Initialize the vector for the operands.
+        let mut operands = Vec::with_capacity(3);
+        // Read the operands.
+        for _ in 0..2 {
+            operands.push(Operand::read_le(&mut reader)?);
+        }
+        // Read the destination register.
+        let destination = Register::read_le(&mut reader)?;
+        // Read the target type.
+        let target_type = ArrayType::read_le(&mut reader)?;
+
+        // Return the operation.
+        Ok(Self { operands, destination, target_type })
+    }
+}
+
+impl<N: Network> ToBytes for Concat<N> {
+    /// Writes the operation to a buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Ensure the number of operands is 2.
+        if self.operands.len() != 2 {
+            return Err(error(format!("The number of operands must be 2, found {}", self.operands.len())));
+        }
+        // Write the operands.
+        self.operands.iter().try_for_each(|operand| operand.write_le(&mut writer))?;
+        // Write the destination register.
+        self.destination.write_le(&mut writer)?;
+        // Write the target type.
+        self.target_type.write_le(&mut writer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_parse() {
+        let (string, concat) = Concat::<CurrentNetwork>::parse("concat r0 r1 into r2 as [boolean; 2u32]").unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+        assert_eq!(concat.operands.len(), 2, "The number of operands is incorrect");
+        assert_eq!(concat.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+        assert_eq!(concat.operands[1], Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(concat.destination, Register::Locator(2), "The destination register is incorrect");
+        assert_eq!(
+            concat.target_type,
+            ArrayType::new(PlaintextType::Literal(LiteralType::Boolean), vec![console::program::U32::new(2)]),
+            "The target type is incorrect"
+        );
+    }
+}

--- a/synthesizer/program/src/logic/instruction/operation/concat.rs
+++ b/synthesizer/program/src/logic/instruction/operation/concat.rs
@@ -242,6 +242,8 @@ impl<N: Network> Parser for Concat<N> {
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the destination register from the string.
         let (string, destination) = Register::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "as" from the string.
         let (string, _) = tag("as")(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/operation/concat.rs
+++ b/synthesizer/program/src/logic/instruction/operation/concat.rs
@@ -344,7 +344,10 @@ mod tests {
         assert_eq!(concat.destination, Register::Locator(2), "The destination register is incorrect");
         assert_eq!(
             concat.target_type,
-            ArrayType::new(PlaintextType::Literal(LiteralType::Boolean), vec![console::program::U32::new(2)]),
+            ArrayType::new(PlaintextType::Literal(console::program::LiteralType::Boolean), vec![
+                console::program::U32::new(2)
+            ])
+            .unwrap(),
             "The target type is incorrect"
         );
     }

--- a/synthesizer/program/src/logic/instruction/operation/mod.rs
+++ b/synthesizer/program/src/logic/instruction/operation/mod.rs
@@ -24,6 +24,9 @@ pub use cast::*;
 mod commit;
 pub use commit::*;
 
+mod concat;
+pub use concat::*;
+
 mod finalize;
 pub use finalize::*;
 

--- a/synthesizer/src/vm/helpers/cost.rs
+++ b/synthesizer/src/vm/helpers/cost.rs
@@ -116,6 +116,7 @@ pub fn cost_in_microcredits<N: Network>(finalize: &Finalize<N>) -> Result<u64> {
         Command::Instruction(Instruction::CommitBHP1024(_)) => Ok(200_000),
         Command::Instruction(Instruction::CommitPED64(_)) => Ok(100_000),
         Command::Instruction(Instruction::CommitPED128(_)) => Ok(100_000),
+        Command::Instruction(Instruction::Concat(_)) => Ok(2_000),
         Command::Instruction(Instruction::Div(_)) => Ok(10_000),
         Command::Instruction(Instruction::DivWrapped(_)) => Ok(2_000),
         Command::Instruction(Instruction::Double(_)) => Ok(2_000),

--- a/synthesizer/tests/expectations/process/execute/arrays.out
+++ b/synthesizer/tests/expectations/process/execute/arrays.out
@@ -1,24 +1,6 @@
 - - |-
     [
       [
-        true,
-        false,
-        true,
-        false
-      ]
-    ]
-  - |-
-    [
-      [
-        false,
-        true,
-        false,
-        true
-      ]
-    ]
-  - |-
-    [
-      [
         false,
         false,
         false,
@@ -44,3 +26,29 @@
         ]
       ]
     }
+- - |-
+    [
+      [
+        true,
+        true,
+        true,
+        true
+      ],
+      [
+        false,
+        false,
+        false,
+        false
+      ]
+    ]
+  - |-
+    [
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/arrays_in_finalize.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/arrays_in_finalize.out
@@ -1,10 +1,8 @@
 - execute:
-    arrays_in_finalize.aleo/test_arrays:
+    arrays_in_finalize.aleo/test_array_cast:
       outputs:
-      - '{"type":"public","id":"7478840637674867348334152936830348927618689666735497694442760373406118031677field","value":"[\n  [\n    true,\n    false,\n    true,\n    false\n  ]\n]"}'
-      - '{"type":"public","id":"5497626638973564164115408441431072571251727387638555124557359358862572601150field","value":"[\n  [\n    false,\n    true,\n    false,\n    true\n  ]\n]"}'
-      - '{"type":"public","id":"6826141182633851685078476561830773249264254215146313720362967764421378578986field","value":"[\n  [\n    false,\n    false,\n    false,\n    false\n  ]\n]"}'
-      - '{"type":"private","id":"8090041184628455649123912475425661970245522643231603870408821235652148265153field","value":"ciphertext1qvq9rlleav6excsnqaep0h3cztdzpergd8pdrhnrhapvr49kfrws6zwarcw9rxh9q3g0v8e5dutwyw34qslkjeqx6jzexjt2qrthnnazqerfvaxj939casntsm62yke9djhnked6nv4mufg8rmh27macnejpzdgpy4a"}'
+      - '{"type":"public","id":"618009125056813724019938266607788336058924648638837614752261920890593269253field","value":"[\n  [\n    false,\n    false,\n    false,\n    false\n  ]\n]"}'
+      - '{"type":"private","id":"4895717349716591412552990208391508358948637013082938110574901730383478316360field","value":"ciphertext1qvqpae0w40vf22ysxg83vghyhggcqfemj3hz6pxyct3xm9qtmhjvjqqy5axagn4ynrd55632yrrlemjse25yzxyac9rmnhh97prp293nq09fnt0fpny2t878jt4h4cveescncyj602y0lastu7ux3gdlr5mqvza0clh"}'
       finalize:
       - |-
         [
@@ -26,7 +24,35 @@
         ]
     credits.aleo/fee_private:
       outputs:
-      - '{"type":"record","id":"1851602959723702773465320694036686070079159723381074216772112503607625694111field","checksum":"4064206344687993996447328386354781883592711575645253061397494836228763520050field","value":"record1qyqsp8vzct4ed5hge87puykkd4yem36s30w2x9hntmxlg43zar9ymeqzqyxx66trwfhkxun9v35hguerqqpqzqz4fgl4y44nzzlrvs38xfpzew83cru4c57xx6qpph932h5h8kd8zff5ypw2lqqkg8nw53f4uvt5urv5kl3txkaewvwqq52zxc62ly6qs6sgc3h"}'
+      - '{"type":"record","id":"12195331829681529393535173981913011208337217771301192461142640534534318436field","checksum":"6181590621439946386292069442208135426409672777888603362185479492519791781085field","value":"record1qyqsq9cvd8qu7p0ztl96drjuf8ya442x3y7usf5qzzq5cu6e3xyvfrgzqyxx66trwfhkxun9v35hguerqqpqzqq5ltda0rh9xkpmd4xq34dqk4jygguq3fye4t7m9swz4q2phen2qwq9avzng3znhg9syn52v8j806fhlujcf605tu98y09t4fz2833sv725zsv"}'
+      finalize: []
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- execute:
+    arrays_in_finalize.aleo/test_array_concat:
+      outputs: []
+      finalize:
+      - |-
+        [
+          [
+            true,
+            true,
+            true,
+            true
+          ]
+        ]
+      - |-
+        [
+          [
+            false,
+            false,
+            false,
+            false
+          ]
+        ]
+    credits.aleo/fee_private:
+      outputs:
+      - '{"type":"record","id":"3507557030367042943751639406815591924237900659848129228262864458778661242705field","checksum":"6251448169019973173797326353192407245999790704443631155041224386707896984854field","value":"record1qyqsqujwanp5cf9yvx8qaym3v6wyvj4aevk2ae3azyfr767pwjqdqlgrqyxx66trwfhkxun9v35hguerqqpqzqrpa7e9sh4panjvkua2g730vd68awfanad0au875ujrpmu5en45qz60000qeqc9pz644qufry206fm4a0jj9g6qjed4xhjphwzlg3dsslphyg5"}'
       finalize: []
   speculate: the execution was accepted
   add_next_block: succeeded.

--- a/synthesizer/tests/tests/process/execute/arrays.aleo
+++ b/synthesizer/tests/tests/process/execute/arrays.aleo
@@ -1,10 +1,15 @@
 /*
 randomness: 2937849
 cases:
-  - function: test_arrays
+  - function: test_array_cast
     inputs:
     - "[[true, false, true, false]]"
     - "[[false, true, false, true]]"
+  - function: test_array_concat
+    inputs:
+    - "[[true, true, true, true]]"
+    - "[[false, false, false, false]]"
+
 
 */
 
@@ -14,7 +19,7 @@ struct tree:
     left as [[boolean; 4u32]; 1u32];
     right as [[boolean; 4u32]; 1u32];
 
-function test_arrays:
+function test_array_cast:
     input r0 as [[boolean; 4u32]; 1u32].private;
     input r1 as [[boolean; 4u32]; 1u32].private;
     cast r0 r1 into r2 as tree;
@@ -24,9 +29,16 @@ function test_arrays:
     and r2.left[0u32][3u32] r2.right[0u32][3u32] into r6;
     cast r3 r4 r5 r6 into r7 as [boolean; 4u32];
     cast r7 into r8 as [[boolean; 4u32]; 1u32];
-    output r0 as [[boolean; 4u32]; 1u32].private;
-    output r1 as [[boolean; 4u32]; 1u32].private;
     output r8 as [[boolean; 4u32]; 1u32].private;
     output r2 as tree.private;
+
+function test_array_concat:
+    input r0 as [[boolean; 4u32]; 1u32].private;
+    input r1 as [[boolean; 4u32]; 1u32].private;
+    concat r0 r1 into r2 as [[boolean; 4u32]; 2u32];
+    concat r0[0u32] r1[0u32] into r3 as [boolean; 8u32];
+    output r2 as [[boolean; 4u32]; 2u32].private;
+    output r3 as [boolean; 8u32].private;
+
 
 

--- a/synthesizer/tests/tests/vm/execute_and_finalize/arrays_in_finalize.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/arrays_in_finalize.aleo
@@ -1,10 +1,14 @@
 /*
 randomness: 2937849
 cases:
-  - function: test_arrays
+  - function: test_array_cast
     inputs:
     - "[[true, false, true, false]]"
     - "[[false, true, false, true]]"
+  - function: test_array_concat
+    inputs:
+    - "[[true, true, true, true]]"
+    - "[[false, false, false, false]]"
 
 */
 
@@ -14,7 +18,7 @@ struct tree:
     left as [[boolean; 4u32]; 1u32];
     right as [[boolean; 4u32]; 1u32];
 
-function test_arrays:
+function test_array_cast:
     input r0 as [[boolean; 4u32]; 1u32].public;
     input r1 as [[boolean; 4u32]; 1u32].public;
     cast r0 r1 into r2 as tree;
@@ -24,13 +28,11 @@ function test_arrays:
     and r2.left[0u32][3u32] r2.right[0u32][3u32] into r6;
     cast r3 r4 r5 r6 into r7 as [boolean; 4u32];
     cast r7 into r8 as [[boolean; 4u32]; 1u32];
-    output r0 as [[boolean; 4u32]; 1u32].public;
-    output r1 as [[boolean; 4u32]; 1u32].public;
     output r8 as [[boolean; 4u32]; 1u32].public;
     output r2 as tree.private;
     finalize r0 r1;
 
-finalize test_arrays:
+finalize test_array_cast:
     input r0 as [[boolean; 4u32]; 1u32].public;
     input r1 as [[boolean; 4u32]; 1u32].public;
     and r0[0u32][0u32] r1[0u32][0u32] into r2;
@@ -43,6 +45,27 @@ finalize test_arrays:
     assert.eq r7[0u32][1u32] false;
     assert.eq r7[0u32][2u32] false;
     assert.eq r7[0u32][3u32] false;
+
+function test_array_concat:
+    input r0 as [[boolean; 4u32]; 1u32].public;
+    input r1 as [[boolean; 4u32]; 1u32].public;
+    finalize r0 r1;
+
+finalize test_array_concat:
+    input r0 as [[boolean; 4u32]; 1u32].public;
+    input r1 as [[boolean; 4u32]; 1u32].public;
+    concat r0 r1 into r2 as [[boolean; 4u32]; 2u32];
+    concat r0[0u32] r1[0u32] into r3 as [boolean; 8u32];
+    assert.eq r2[0u32][0u32] r3[0u32];
+    assert.eq r2[0u32][1u32] r3[1u32];
+    assert.eq r2[0u32][2u32] r3[2u32];
+    assert.eq r2[0u32][3u32] r3[3u32];
+    assert.eq r2[1u32][0u32] r3[4u32];
+    assert.eq r2[1u32][1u32] r3[5u32];
+    assert.eq r2[1u32][2u32] r3[6u32];
+    assert.eq r2[1u32][3u32] r3[7u32];
+
+
 
 
 


### PR DESCRIPTION
This PR supports concatenating two arrays via the `concat` instruction.
```
concat r0 r1 into r2 as [boolean; 8u32];
```
Note that users must specify the target type.


An alternate design choice was considered:
```
concat r0 r1 into r2;
```
However, the first solution was favored as it makes the types explicit.
