### PR TITLE
[TOB] Adds check for possible panics in FromBytes impls

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -151,6 +151,9 @@ pub trait Network:
     /// The maximum number of outputs per transition.
     const MAX_OUTPUTS: usize = 16;
 
+    /// The maximum number of nodes that can be in a committee.
+    const MAX_COMMITTEE_SIZE: u16 = 200;
+
     /// The state root type.
     type StateRoot: Bech32ID<Field<Self>>;
     /// The block hash type.

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -40,6 +40,13 @@ impl<N: Network> FromBytes for Block<N> {
 
         // Read the ratifications.
         let num_ratifications = u32::read_le(&mut reader)?;
+        if num_ratifications > u32::try_from(Self::MAX_RATIFICATIONS).map_err(|e| error(e.to_string()))? {
+            return Err(error(format!(
+                "Block cannot exceed {} ratifications, found {}",
+                Self::MAX_RATIFICATIONS,
+                num_ratifications
+            )));
+        }
         let mut ratifications = Vec::with_capacity(num_ratifications as usize);
         for _ in 0..num_ratifications {
             ratifications.push(FromBytes::read_le(&mut reader)?);

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -426,6 +426,9 @@ impl<N: Network> Block<N> {
     }
 }
 impl<N: Network> Block<N> {
+    /// The maximum number of ratifications allowed in a block.
+    pub const MAX_RATIFICATIONS: usize = usize::pow(2, RATIFICATIONS_DEPTH as u32);
+
     /// Computes the transactions root for the block.
     fn compute_transactions_root(&self) -> Result<Field<N>> {
         match self.transactions.to_transactions_root() {
@@ -444,6 +447,13 @@ impl<N: Network> Block<N> {
 
     /// Computes the ratifications root for the block.
     fn compute_ratifications_root(&self) -> Result<Field<N>> {
+        ensure!(
+            self.ratifications.len() <= Self::MAX_RATIFICATIONS,
+            "Block cannot exceed {} ratifications, found {}",
+            Self::MAX_RATIFICATIONS,
+            self.ratifications.len()
+        );
+
         let leaves =
             self.ratifications.iter().map(|r| Ok(r.to_bytes_le()?.to_bits_le())).collect::<Result<Vec<_>, Error>>()?;
 

--- a/ledger/committee/src/bytes.rs
+++ b/ledger/committee/src/bytes.rs
@@ -28,6 +28,13 @@ impl<N: Network> FromBytes for Committee<N> {
         let starting_round = u64::read_le(&mut reader)?;
         // Read the number of members.
         let num_members = u32::read_le(&mut reader)?;
+        if num_members > u32::try_from(N::MAX_COMMITTEE_SIZE).map_err(|e| error(e.to_string()))? {
+            return Err(error(format!(
+                "Committee cannot exceed {} members, found {}",
+                N::MAX_COMMITTEE_SIZE,
+                num_members
+            )));
+        }
         // Read the members.
         let mut members = IndexMap::with_capacity(num_members as usize);
         for _ in 0..num_members {

--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -30,6 +30,10 @@ impl<N: Network> FromBytes for BatchCertificate<N> {
         let batch_header = BatchHeader::read_le(&mut reader)?;
         // Read the number of signatures.
         let num_signatures = u32::read_le(&mut reader)?;
+        // Ensure the number of signatures is within bounds.
+        if num_signatures > i32::MAX as u32 {
+            return Err(error("Number of signatures exceeds maximum"));
+        }
         // Read the signatures.
         let mut signatures = IndexMap::with_capacity(num_signatures as usize);
         for _ in 0..num_signatures {

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -34,16 +34,24 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         let timestamp = i64::read_le(&mut reader)?;
 
         // Read the number of transmission IDs.
-        let num_transmissions = u32::read_le(&mut reader)?;
+        let num_transmission_ids = u32::read_le(&mut reader)?;
+        // Ensure the number of transmission ids is within bounds.
+        if num_transmission_ids > i32::MAX as u32 {
+            return Err(error("Number of transmission ids exceeds maximum"));
+        }
         // Read the transmission IDs.
-        let mut transmission_ids = IndexSet::new();
-        for _ in 0..num_transmissions {
+        let mut transmission_ids = IndexSet::with_capacity(num_transmission_ids as usize);
+        for _ in 0..num_transmission_ids {
             // Insert the transmission ID.
             transmission_ids.insert(TransmissionID::read_le(&mut reader)?);
         }
 
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u32::read_le(&mut reader)?;
+        // Ensure the number of previous certificate ids is within bounds.
+        if num_previous_certificate_ids > i32::MAX as u32 {
+            return Err(error("Number of previous certificate ids exceeds maximum"));
+        }
         // Read the previous certificate IDs.
         let mut previous_certificate_ids = IndexSet::with_capacity(num_previous_certificate_ids as usize);
         for _ in 0..num_previous_certificate_ids {

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -33,6 +33,10 @@ impl<N: Network> FromBytes for Subdag<N> {
             let round = u64::read_le(&mut reader)?;
             // Read the number of certificates.
             let num_certificates = u32::read_le(&mut reader)?;
+            // Ensure the number of certificates is within bounds.
+            if num_certificates > i32::MAX as u32 {
+                return Err(error("Number of certificates exceeds maximum"));
+            }
             // Read the certificates.
             let mut certificates = IndexSet::with_capacity(num_certificates as usize);
             for _ in 0..num_certificates {

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -143,6 +143,11 @@ impl<'de, T: FromBytes> FromBytesDeserializer<T> {
             false => (size_b, size_a),
         };
 
+        // Ensure size_b is within bounds.
+        if size_b > i32::MAX as usize {
+            return Err(D::Error::custom("size_b exceeds maximum"));
+        }
+
         // Reserve a new `Vec` with the larger size capacity.
         let mut buffer = Vec::with_capacity(size_b);
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds guards for possible denial of service vectors in `FromBytes` implementations. 

Example: 

```
let num_ratifications = u32::read_le(&mut reader)?;
let mut ratifications = Vec::with_capacity(num_ratifications as usize);
```
This will cause a panic in 32-bit architectures if `num_ratifications` exceeds `i32::MAX`.

Some checks have explicit guards, other checks simply 

TODO: 

- [ ] Add more defined checks instead of `i32::MAX`
- [ ] Add checks in `sonic_pc/data_structures`

Finding: TOB-ALEO-1

Tracking PR: [Coming Soon]