### PR TITLE
Remove unused allows and derivations in algorithms and utilities

### DIFF
--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -44,8 +44,7 @@ pub enum Polynomial<'a, F: Field> {
 }
 
 impl<'a, F: Field> CanonicalSerialize for Polynomial<'a, F> {
-    #[allow(unused_mut, unused_variables)]
-    fn serialize_with_mode<W: Write>(&self, mut writer: W, compress: Compress) -> Result<(), SerializationError> {
+    fn serialize_with_mode<W: Write>(&self, writer: W, compress: Compress) -> Result<(), SerializationError> {
         match self {
             Sparse(p) => {
                 let p: DensePolynomial<F> = p.clone().into_owned().into();
@@ -55,7 +54,6 @@ impl<'a, F: Field> CanonicalSerialize for Polynomial<'a, F> {
         }
     }
 
-    #[allow(unused_mut, unused_variables)]
     fn serialized_size(&self, mode: Compress) -> usize {
         match self {
             Sparse(p) => {
@@ -74,7 +72,6 @@ impl<'a, F: Field> Valid for Polynomial<'a, F> {
 }
 
 impl<'a, F: Field> CanonicalDeserialize for Polynomial<'a, F> {
-    #[allow(unused_mut, unused_variables)]
     fn deserialize_with_mode<R: Read>(
         reader: R,
         compress: Compress,

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -209,7 +209,6 @@ impl<E: PairingEngine> KZG10<E> {
     /// The witness polynomial w(x) the quotient of the division (p(x) - p(z)) / (x - z)
     /// Observe that this quotient does not change with z because
     /// p(z) is the remainder term. We can therefore omit p(z) when computing the quotient.
-    #[allow(clippy::type_complexity)]
     pub fn compute_witness_polynomial(
         polynomial: &DensePolynomial<E::Fr>,
         point: E::Fr,

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -171,7 +171,6 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
     ///
     /// If for some `i`, `polynomials[i].degree_bound().is_some()`, then that
     /// polynomial will have the corresponding degree bound enforced.
-    #[allow(clippy::type_complexity)]
     #[allow(clippy::format_push_string)]
     pub fn commit<'b>(
         universal_prover: &UniversalProver<E>,
@@ -211,7 +210,6 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                     hiding_bound,
                 ));
 
-                #[allow(clippy::or_fun_call)]
                 let (comm, rand) = p
                     .sum()
                     .map(move |p| {
@@ -634,7 +632,6 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         end_timer!(acc_time);
     }
 
-    #[allow(clippy::type_complexity)]
     fn check_elems(
         vk: &UniversalVerifier<E>,
         combined_comms: BTreeMap<Option<usize>, E::G1Projective>,

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
@@ -19,8 +19,7 @@ use snarkvm_utilities::{serialize::*, ToBytes};
 /// Information about the circuit, including the field of definition, the number of
 /// variables, the number of constraints, and the maximum number of non-zero
 /// entries in any of the constraint matrices.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct CircuitInfo {
     /// The number of public inputs after padding.
     pub num_public_inputs: usize,

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
@@ -57,7 +57,6 @@ impl<F: PrimeField, MM: SNARKMode> AHPForR1CS<F, MM> {
     }
 
     /// Output the first round message and the next state.
-    #[allow(clippy::type_complexity)]
     pub fn prover_first_round<'a, R: RngCore>(
         mut state: prover::State<'a, F, MM>,
         rng: &mut R,

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -334,7 +334,6 @@ where
         .map_err(Into::into)
     }
 
-    #[allow(clippy::only_used_in_recursion)]
     /// This is the main entrypoint for creating proofs.
     /// You can find a specification of the prover algorithm in:
     /// https://github.com/AleoHQ/protocol-docs/tree/main/snark/varuna

--- a/utilities/derives/src/canonical_deserialize.rs
+++ b/utilities/derives/src/canonical_deserialize.rs
@@ -80,12 +80,11 @@ fn impl_valid(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl #impl_generics snarkvm_utilities::Valid for #name #ty_generics #where_clause {
-            #[allow(unused_mut, unused_variables)]
+            #[allow(unused_variables)]
             fn check(&self) -> Result<(), snarkvm_utilities::serialize::SerializationError> {
                 #(#check_body)*
                 Ok(())
             }
-            #[allow(unused_mut, unused_variables)]
             fn batch_check<'a>(batch: impl Iterator<Item = &'a Self> + Send) -> Result<(), snarkvm_utilities::serialize::SerializationError>
                 where
             Self: 'a
@@ -159,7 +158,6 @@ pub(super) fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream 
 
     let mut gen = quote! {
         impl #impl_generics CanonicalDeserialize for #name #ty_generics #where_clause {
-            #[allow(unused_mut,unused_variables)]
             fn deserialize_with_mode<R: snarkvm_utilities::io::Read>(
                 mut reader: R,
                 compress: snarkvm_utilities::serialize::Compress,

--- a/utilities/derives/src/canonical_serialize.rs
+++ b/utilities/derives/src/canonical_serialize.rs
@@ -94,12 +94,10 @@ pub(super) fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl #impl_generics snarkvm_utilities::CanonicalSerialize for #name #ty_generics #where_clause {
-            #[allow(unused_mut, unused_variables)]
             fn serialize_with_mode<W: snarkvm_utilities::io::Write>(&self, mut writer: W, compress: snarkvm_utilities::serialize::Compress) -> Result<(), snarkvm_utilities::serialize::SerializationError> {
                 #(#serialize_body)*
                 Ok(())
             }
-            #[allow(unused_mut, unused_variables)]
             fn serialized_size(&self, compress: snarkvm_utilities::serialize::Compress) -> usize {
                 let mut size = 0;
                 #(#serialized_size_body)*


### PR DESCRIPTION
## Motivation

Removing these allows and derives seemed harmless to me.

## Test Plan

The only issue I can imagine is that we fail building or clippy on some combination of feature flags - but that combination should really be added into a CI then. ljedrz and iamalwaysuncomfortable should be able to reason about features used in snarkOS and SDK respectively.