### PR TITLE
Adds support for SocketAddr in ToBytes/FromBytes

### DIFF
--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -25,6 +25,7 @@ use serde::{
     Deserializer,
     Serializer,
 };
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 /// Takes as input a sequence of structs, and converts them to a series of little-endian bytes.
 /// All traits that implement `ToBytes` can be automatically converted to bytes in this manner.
@@ -289,6 +290,41 @@ impl FromBytes for bool {
     }
 }
 
+impl ToBytes for SocketAddr {
+    #[inline]
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the IP address.
+        match self.ip() {
+            IpAddr::V4(ipv4) => {
+                0u8.write_le(&mut writer)?;
+                u32::from(ipv4).write_le(&mut writer)?;
+            }
+            IpAddr::V6(ipv6) => {
+                1u8.write_le(&mut writer)?;
+                u128::from(ipv6).write_le(&mut writer)?;
+            }
+        }
+        // Write the port.
+        self.port().write_le(&mut writer)?;
+        Ok(())
+    }
+}
+
+impl FromBytes for SocketAddr {
+    #[inline]
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the IP address.
+        let ip = match u8::read_le(&mut reader)? {
+            0 => IpAddr::V4(Ipv4Addr::from(u32::read_le(&mut reader)?)),
+            1 => IpAddr::V6(Ipv6Addr::from(u128::read_le(&mut reader)?)),
+            _ => return Err(error("Invalid IP address")),
+        };
+        // Read the port.
+        let port = u16::read_le(&mut reader)?;
+        Ok(SocketAddr::new(ip, port))
+    }
+}
+
 macro_rules! impl_bytes_for_integer {
     ($int:ty) => {
         impl ToBytes for $int {
@@ -500,6 +536,35 @@ mod test {
             let recovered_bytes = bytes_from_bits_le(&bits);
 
             assert_eq!(given_bytes.to_vec(), recovered_bytes);
+        }
+    }
+
+    #[test]
+    fn test_socketaddr_bytes() {
+        fn random_ipv4_address(rng: &mut TestRng) -> Ipv4Addr {
+            Ipv4Addr::new(rng.gen(), rng.gen(), rng.gen(), rng.gen())
+        }
+
+        fn random_ipv6_address(rng: &mut TestRng) -> Ipv6Addr {
+            Ipv6Addr::new(rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen())
+        }
+
+        fn random_port(rng: &mut TestRng) -> u16 {
+            rng.gen_range(1025..=65535) // excluding well-known ports
+        }
+
+        let rng = &mut TestRng::default();
+
+        for _ in 0..1_000_000 {
+            let ipv4 = SocketAddr::new(IpAddr::V4(random_ipv4_address(rng)), random_port(rng));
+            let bytes = ipv4.to_bytes_le().unwrap();
+            let ipv4_2 = SocketAddr::read_le(&bytes[..]).unwrap();
+            assert_eq!(ipv4, ipv4_2);
+
+            let ipv6 = SocketAddr::new(IpAddr::V6(random_ipv6_address(rng)), random_port(rng));
+            let bytes = ipv6.to_bytes_le().unwrap();
+            let ipv6_2 = SocketAddr::read_le(&bytes[..]).unwrap();
+            assert_eq!(ipv6, ipv6_2);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Adds support for SocketAddr in ToBytes/FromBytes

## Test Plan

A unit test to check random IP v4 and v6 addresses is included.