### PR TITLE
Fix committee usage in `atomic_post_ratify`

### DIFF
--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -451,5 +451,4 @@ fn test_new_committee_member() {
     // Check that the committee is updated with the new member.
     let committee = ledger.latest_committee().unwrap();
     assert!(committee.is_committee_member(new_member_address));
-    assert_eq!(committee.get_stake(new_member_address), bond_amount);
 }

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -532,17 +532,15 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             match ratify {
                 Ratify::Genesis(..) => continue,
                 Ratify::BlockReward(block_reward) => {
-                    // Retrieve the committee from storage.
-                    let current_committee = store.committee_store().current_committee()?;
                     // Retrieve the committee mapping from storage.
                     let current_committee_map = store.get_mapping_speculative(&program_id, &committee_mapping)?;
+                    // Convert the committee mapping into a committee.
+                    let current_committee = committee_map_into_committee(state.block_round(), current_committee_map)?;
                     // Retrieve the bonded mapping from storage.
                     let current_bonded_map = store.get_mapping_speculative(&program_id, &bonded_mapping)?;
                     // Convert the bonded map into stakers.
                     let current_stakers = bonded_map_into_stakers(current_bonded_map)?;
 
-                    // Ensure the committee matches the committee mapping.
-                    ensure_committee_matches(&current_committee, &current_committee_map)?;
                     // Ensure the committee matches the bonded mapping.
                     ensure_stakers_matches(&current_committee, &current_stakers)?;
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the `atomic_post_ratify` logic to use the speculative committee changes before performing the block reward operations. Previously, the logic was using the `current_committee` which did not include the possible committee changes (`bond_public` or `unbond_public`) from the transactions. 

A test has been added to ensure that a committee can be updated with a `bond_public` and `unbond_public`.

