### PR TITLE
Reduce duplication of universal provers

### DIFF
--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -85,8 +85,6 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, MM: SNARKMode> VarunaSNARK
         }
         let degree_info = degree_info.unwrap();
 
-        // TODO: Add check that c is in the correct mode.
-        // Ensure the universal SRS supports the circuit size.
         universal_srs
             .download_powers_for(0..degree_info.max_degree)
             .map_err(|e| anyhow!("Failed to download powers for degree {}: {e}", degree_info.max_degree))?;

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -76,10 +76,9 @@ impl<N: Network> ProvingKey<N> {
         let mut degree_info: Option<DegreeInfo> = None;
         for (pk, _) in assignments {
             let degree_info_i = pk.circuit.index_info.degree_info::<N::Field, varuna::VarunaHidingMode>();
-            degree_info = if let Some(degree_info) = degree_info {
-                Some(degree_info.union(&degree_info_i))
-            } else {
-                Some(degree_info_i)
+            degree_info = match degree_info {
+                Some(degree_info) => Some(degree_info.union(&degree_info_i)),
+                None => Some(degree_info_i),
             };
         }
         let universal_prover = N::varuna_universal_prover(degree_info.unwrap());


### PR DESCRIPTION
## Motivation

When creating circuit keys for a batch of N circuits, we are currently creating the universal prover N times. This PR reduces it to only once.

Side note: the way synthesizer works, making one proving key at a time, when proving N transitions we still end up creating a universal_prover N+1 times (N times during key generation and once before proving). I benchmarked it and the cost is too low to justify a big refactor now, but will clean this up in the future.

## Test Plan

I removed comments in 92f4ea67e because I believe we already take `MM` into account when calling `AHPForR1CS::<_, MM>::index`, and if the SRS is not big enough, we will gently fail when we `download_powers_for`.