### PR TITLE
[Refactor] Remove identifier from `MapKey` and `MapValue`.

### DIFF
--- a/ledger/block/src/transaction/deployment/mod.rs
+++ b/ledger/block/src/transaction/deployment/mod.rs
@@ -151,8 +151,8 @@ pub mod test_helpers {
 program testing.aleo;
 
 mapping store:
-    key item as u32.public;
-    value object as u32.public;
+    key as u32.public;
+    value as u32.public;
 
 function compute:
     input r0 as u32.private;

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -133,8 +133,8 @@ pub fn sample_deployment(rng: &mut TestRng) -> Deployment<CurrentNetwork> {
 program testing.aleo;
 
 mapping store:
-    key item as u32.public;
-    value object as u32.public;
+    key as u32.public;
+    value as u32.public;
 
 function compute:
     input r0 as u32.private;

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -319,8 +319,8 @@ struct message:
     amount as u128;
 
 mapping account:
-    key owner as address.public;
-    value amount as u64.public;
+    key as address.public;
+    value as u64.public;
 
 record token:
     owner as address.private;

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -1193,8 +1193,8 @@ fn test_process_execute_and_finalize_get_add_set() {
 program testing.aleo;
 
 mapping account:
-    key owner as address.public;
-    value amount as u64.public;
+    key as address.public;
+    value as u64.public;
 
 function compute:
     input r0 as address.public;
@@ -1304,8 +1304,8 @@ fn test_process_execute_and_finalize_increment_decrement_via_get_set() {
 program testing.aleo;
 
 mapping account:
-    key owner as address.public;
-    value amount as u64.public;
+    key as address.public;
+    value as u64.public;
 
 function compute:
     input r0 as address.public;
@@ -1419,9 +1419,9 @@ program token.aleo;
 // and `amount` as the value.
 mapping account:
     // The token owner.
-    key owner as address.public;
+    key as address.public;
     // The token amount.
-    value amount as u64.public;
+    value as u64.public;
 
 // The function `mint_public` issues the specified token amount
 // for the token receiver publicly on the network.
@@ -1549,9 +1549,9 @@ program token.aleo;
 // and `amount` as the value.
 mapping account:
     // The token owner.
-    key owner as address.public;
+    key as address.public;
     // The token amount.
-    value amount as u64.public;
+    value as u64.public;
 
 // The function `mint_public` issues the specified token amount
 // for the token receiver publicly on the network.
@@ -1697,8 +1697,8 @@ fn test_process_execute_and_finalize_get_set() {
 program testing.aleo;
 
 mapping account:
-    key owner as address.public;
-    value amount as u64.public;
+    key as address.public;
+    value as u64.public;
 
 function compute:
     input r0 as address.public;
@@ -2122,8 +2122,8 @@ struct entry:
     data as u8;
 
 mapping entries:
-    key owner as address.public;
-    value entry as entry.public;
+    key as address.public;
+    value as entry.public;
 
 function compute:
     input r0 as u8.public;

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -662,8 +662,8 @@ mod tests {
         let mapping = Mapping::<CurrentNetwork>::from_str(
             r"
 mapping message:
-    key first as field.public;
-    value second as field.public;",
+    key as field.public;
+    value as field.public;",
         )?;
 
         // Initialize a new program.

--- a/synthesizer/program/src/mapping/bytes.rs
+++ b/synthesizer/program/src/mapping/bytes.rs
@@ -53,8 +53,8 @@ mod tests {
     fn test_mapping_bytes() -> Result<()> {
         let mapping_string = r"
 mapping main:
-    key a as field.public;
-    value b as field.public;";
+    key as field.public;
+    value as field.public;";
 
         let expected = Mapping::<CurrentNetwork>::from_str(mapping_string)?;
         let expected_bytes = expected.to_bytes_le()?;

--- a/synthesizer/program/src/mapping/key/bytes.rs
+++ b/synthesizer/program/src/mapping/key/bytes.rs
@@ -17,20 +17,16 @@ use super::*;
 impl<N: Network> FromBytes for MapKey<N> {
     /// Reads the key statement from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        // Read the key name.
-        let name = FromBytes::read_le(&mut reader)?;
         // Read the key type.
         let plaintext_type = FromBytes::read_le(&mut reader)?;
         // Return the key.
-        Ok(Self { name, plaintext_type })
+        Ok(Self { plaintext_type })
     }
 }
 
 impl<N: Network> ToBytes for MapKey<N> {
     /// Writes the key statement to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        // Write the key name.
-        self.name.write_le(&mut writer)?;
         // Write the key type.
         self.plaintext_type.write_le(&mut writer)
     }

--- a/synthesizer/program/src/mapping/key/mod.rs
+++ b/synthesizer/program/src/mapping/key/mod.rs
@@ -18,7 +18,7 @@ mod parse;
 use console::{network::prelude::*, program::PlaintextType};
 
 /// A key statement is of the form `key as {plaintext_type}.public`.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct MapKey<N: Network> {
     /// The key plaintext type.
     plaintext_type: PlaintextType<N>,

--- a/synthesizer/program/src/mapping/key/mod.rs
+++ b/synthesizer/program/src/mapping/key/mod.rs
@@ -15,27 +15,16 @@
 mod bytes;
 mod parse;
 
-use console::{
-    network::prelude::*,
-    program::{Identifier, PlaintextType},
-};
+use console::{network::prelude::*, program::PlaintextType};
 
-/// A key statement is of the form `key {name} as {plaintext_type}.public`.
+/// A key statement is of the form `key as {plaintext_type}.public`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MapKey<N: Network> {
-    /// The key name.
-    name: Identifier<N>,
     /// The key plaintext type.
     plaintext_type: PlaintextType<N>,
 }
 
 impl<N: Network> MapKey<N> {
-    /// Returns the key name.
-    #[inline]
-    pub const fn name(&self) -> &Identifier<N> {
-        &self.name
-    }
-
     /// Returns the key plaintext type.
     #[inline]
     pub const fn plaintext_type(&self) -> &PlaintextType<N> {

--- a/synthesizer/program/src/mapping/key/parse.rs
+++ b/synthesizer/program/src/mapping/key/parse.rs
@@ -15,17 +15,13 @@
 use super::*;
 
 impl<N: Network> Parser for MapKey<N> {
-    /// Parses a string into a key statement of the form `key {name} as {plaintext_type}.public;`.
+    /// Parses a string into a key statement of the form `key as {plaintext_type}.public;`.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the keyword from the string.
         let (string, _) = tag(Self::type_name())(string)?;
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the name from the string.
-        let (string, name) = Identifier::parse(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "as" from the string.
@@ -39,7 +35,7 @@ impl<N: Network> Parser for MapKey<N> {
         // Parse the semicolon from the string.
         let (string, _) = tag(";")(string)?;
         // Return the key statement.
-        Ok((string, Self { name, plaintext_type }))
+        Ok((string, Self { plaintext_type }))
     }
 }
 
@@ -71,13 +67,7 @@ impl<N: Network> Debug for MapKey<N> {
 impl<N: Network> Display for MapKey<N> {
     /// Prints the key statement as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{type_} {name} as {plaintext_type}.public;",
-            type_ = Self::type_name(),
-            name = self.name,
-            plaintext_type = self.plaintext_type
-        )
+        write!(f, "{type_} {plaintext_type}.public;", type_ = Self::type_name(), plaintext_type = self.plaintext_type)
     }
 }
 
@@ -91,8 +81,7 @@ mod tests {
     #[test]
     fn test_key_parse() -> Result<()> {
         // Literal
-        let key = MapKey::<CurrentNetwork>::parse("key hello as field.public;").unwrap().1;
-        assert_eq!(key.name(), &Identifier::<CurrentNetwork>::from_str("hello")?);
+        let key = MapKey::<CurrentNetwork>::parse("key as field.public;").unwrap().1;
         assert_eq!(key.plaintext_type(), &PlaintextType::<CurrentNetwork>::from_str("field")?);
 
         Ok(())
@@ -101,8 +90,8 @@ mod tests {
     #[test]
     fn test_key_display() -> Result<()> {
         // Literal
-        let key = MapKey::<CurrentNetwork>::from_str("key hello as field.public;")?;
-        assert_eq!("key hello as field.public;", key.to_string());
+        let key = MapKey::<CurrentNetwork>::from_str("key as field.public;")?;
+        assert_eq!("key as field.public;", key.to_string());
 
         Ok(())
     }

--- a/synthesizer/program/src/mapping/key/parse.rs
+++ b/synthesizer/program/src/mapping/key/parse.rs
@@ -67,7 +67,12 @@ impl<N: Network> Debug for MapKey<N> {
 impl<N: Network> Display for MapKey<N> {
     /// Prints the key statement as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{type_} {plaintext_type}.public;", type_ = Self::type_name(), plaintext_type = self.plaintext_type)
+        write!(
+            f,
+            "{type_} as {plaintext_type}.public;",
+            type_ = Self::type_name(),
+            plaintext_type = self.plaintext_type
+        )
     }
 }
 

--- a/synthesizer/program/src/mapping/parse.rs
+++ b/synthesizer/program/src/mapping/parse.rs
@@ -87,23 +87,21 @@ mod tests {
         let mapping = Mapping::<CurrentNetwork>::parse(
             r"
 mapping foo:
-    key a as field.public;
-    value b as field.public;",
+    key as field.public;
+    value as field.public;",
         )
         .unwrap()
         .1;
         assert_eq!("foo", mapping.name().to_string());
-        assert_eq!("a", mapping.key.name().to_string());
         assert_eq!("field", mapping.key.plaintext_type().to_string());
-        assert_eq!("b", mapping.value.name().to_string());
         assert_eq!("field", mapping.value.plaintext_type().to_string());
     }
 
     #[test]
     fn test_mapping_display() {
         let expected = r"mapping foo:
-    key a as field.public;
-    value b as field.public;";
+    key as field.public;
+    value as field.public;";
         let mapping = Mapping::<CurrentNetwork>::parse(expected).unwrap().1;
         assert_eq!(expected, format!("{mapping}"),);
     }

--- a/synthesizer/program/src/mapping/value/bytes.rs
+++ b/synthesizer/program/src/mapping/value/bytes.rs
@@ -17,19 +17,15 @@ use super::*;
 impl<N: Network> FromBytes for MapValue<N> {
     /// Reads the value statement from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        // Read the value name.
-        let name = FromBytes::read_le(&mut reader)?;
         // Read the value type.
         let plaintext_type = FromBytes::read_le(&mut reader)?;
-        Ok(Self { name, plaintext_type })
+        Ok(Self { plaintext_type })
     }
 }
 
 impl<N: Network> ToBytes for MapValue<N> {
     /// Writes the value statement to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        // Write the value name.
-        self.name.write_le(&mut writer)?;
         // Write the value type.
         self.plaintext_type.write_le(&mut writer)
     }

--- a/synthesizer/program/src/mapping/value/mod.rs
+++ b/synthesizer/program/src/mapping/value/mod.rs
@@ -18,7 +18,7 @@ mod parse;
 use console::{network::prelude::*, program::PlaintextType};
 
 /// An value statement is of the form `value as {plaintext_type}.public;`.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct MapValue<N: Network> {
     /// The value plaintext type.
     plaintext_type: PlaintextType<N>,

--- a/synthesizer/program/src/mapping/value/mod.rs
+++ b/synthesizer/program/src/mapping/value/mod.rs
@@ -15,27 +15,16 @@
 mod bytes;
 mod parse;
 
-use console::{
-    network::prelude::*,
-    program::{Identifier, PlaintextType},
-};
+use console::{network::prelude::*, program::PlaintextType};
 
-/// An value statement is of the form `value {name} as {plaintext_type}.public;`.
+/// An value statement is of the form `value as {plaintext_type}.public;`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MapValue<N: Network> {
-    /// The value name.
-    name: Identifier<N>,
     /// The value plaintext type.
     plaintext_type: PlaintextType<N>,
 }
 
 impl<N: Network> MapValue<N> {
-    /// Returns the value name.
-    #[inline]
-    pub const fn name(&self) -> &Identifier<N> {
-        &self.name
-    }
-
     /// Returns the value plaintext type.
     #[inline]
     pub const fn plaintext_type(&self) -> &PlaintextType<N> {

--- a/synthesizer/program/src/mapping/value/parse.rs
+++ b/synthesizer/program/src/mapping/value/parse.rs
@@ -15,17 +15,13 @@
 use super::*;
 
 impl<N: Network> Parser for MapValue<N> {
-    /// Parses a string into the value statement of the form `value {name} as {plaintext_type}.public;`.
+    /// Parses a string into a value statement of the form `value as {plaintext_type}.public;`.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the keyword from the string.
         let (string, _) = tag(Self::type_name())(string)?;
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
-        // Parse the name from the string.
-        let (string, name) = Identifier::parse(string)?;
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the "as" from the string.
@@ -39,7 +35,7 @@ impl<N: Network> Parser for MapValue<N> {
         // Parse the semicolon from the string.
         let (string, _) = tag(";")(string)?;
         // Return the value statement.
-        Ok((string, Self { name, plaintext_type }))
+        Ok((string, Self { plaintext_type }))
     }
 }
 
@@ -73,9 +69,8 @@ impl<N: Network> Display for MapValue<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "{type_} {name} as {plaintext_type}.public;",
+            "{type_} as {plaintext_type}.public;",
             type_ = Self::type_name(),
-            name = self.name,
             plaintext_type = self.plaintext_type
         )
     }
@@ -91,8 +86,7 @@ mod tests {
     #[test]
     fn test_value_parse() -> Result<()> {
         // Literal
-        let value = MapValue::<CurrentNetwork>::parse("value abcd as field.public;").unwrap().1;
-        assert_eq!(value.name(), &Identifier::<CurrentNetwork>::from_str("abcd")?);
+        let value = MapValue::<CurrentNetwork>::parse("value as field.public;").unwrap().1;
         assert_eq!(value.plaintext_type(), &PlaintextType::<CurrentNetwork>::from_str("field")?);
 
         Ok(())
@@ -101,7 +95,7 @@ mod tests {
     #[test]
     fn test_value_display() {
         // Literal
-        let value = MapValue::<CurrentNetwork>::parse("value abc as field.public;").unwrap().1;
-        assert_eq!(format!("{value}"), "value abc as field.public;");
+        let value = MapValue::<CurrentNetwork>::parse("value as field.public;").unwrap().1;
+        assert_eq!(format!("{value}"), "value as field.public;");
     }
 }

--- a/synthesizer/program/src/resources/credits.aleo
+++ b/synthesizer/program/src/resources/credits.aleo
@@ -20,9 +20,9 @@ program credits.aleo;
 /// The `committee` mapping contains the active validator set and their corresponding stake.
 mapping committee:
     // The key represents the address of the validator.
-    key validator as address.public;
+    key as address.public;
     // The value represents the committee state of the validator.
-    value committee_state as committee_state.public;
+    value as committee_state.public;
 
 // The `committee_state` struct tracks the total stake of the validator, and whether they are open to stakers.
 struct committee_state:
@@ -36,9 +36,9 @@ struct committee_state:
 // The `bonded` mapping represents the amount of microcredits that are currently bonded.
 mapping bonded:
     // The key represents the address of the staker, which includes the validators and their delegators.
-    key staker as address.public;
+    key as address.public;
     // The value represents the bond state.
-    value bond_state as bond_state.public;
+    value as bond_state.public;
 
 // The `bond_state` struct tracks the amount of microcredits that are currently bonded to the specified validator.
 struct bond_state:
@@ -52,9 +52,9 @@ struct bond_state:
 // The `unbonding` mapping contains a set of stakers with their unbonding microcredits and unlock height.
 mapping unbonding:
     // The key represents the address of the staker, which includes the validators and their delegators.
-    key staker as address.public;
+    key as address.public;
     // The value represents the unbond state.
-    value unbond_state as unbond_state.public;
+    value as unbond_state.public;
 
 // The `unbond_state` struct tracks the microcredits that are currently unbonding, along with the unlock height.
 struct unbond_state:
@@ -68,9 +68,9 @@ struct unbond_state:
 // The `account` mapping is used to store credits publicly.
 mapping account:
     // The key represents the address of the owner.
-    key owner as address.public;
+    key as address.public;
     // The value represents the amount of public microcredits that belong to the specified owner.
-    value microcredits as u64.public;
+    value as u64.public;
 
 /**********************************************************************************************************************/
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -630,9 +630,9 @@ program {program_name};
 
 mapping account:
     // The token owner.
-    key owner as address.public;
+    key as address.public;
     // The token amount.
-    value amount as u64.public;
+    value as u64.public;
 
 function mint_public:
     input r0 as address.public;
@@ -1092,8 +1092,8 @@ finalize transfer_public:
 program {program_id};
 
 mapping hashes:
-    key preimage as u128.public;
-    value val as field.public;
+    key as u128.public;
+    value as field.public;
 
 function ped_hash:
     input r0 as u128.public;
@@ -1182,8 +1182,8 @@ function ped_hash:
 program testing.aleo;
 
 mapping entries:
-    key owner as address.public;
-    value data as u8.public;
+    key as address.public;
+    value as u8.public;
 
 function compute:
     input r0 as u8.public;

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -360,8 +360,8 @@ struct message:
     amount as u128;
 
 mapping account:
-    key owner as address.public;
-    value amount as u64.public;
+    key as address.public;
+    value as u64.public;
 
 record token:
     owner as address.private;
@@ -680,8 +680,8 @@ function compute:
         let first_program = r"
 program test_program_1.aleo;
 mapping map_0:
-    key left as field.public;
-    value right as field.public;
+    key as field.public;
+    value as field.public;
 function init:
     finalize;
 finalize init:
@@ -694,8 +694,8 @@ finalize getter:
         let second_program = r"
 program test_program_2.aleo;
 mapping map_0:
-    key left as field.public;
-    value right as field.public;
+    key as field.public;
+    value as field.public;
 function init:
     finalize;
 finalize init:

--- a/synthesizer/tests/tests/parser/program/finalize_entry.aleo
+++ b/synthesizer/tests/tests/parser/program/finalize_entry.aleo
@@ -6,8 +6,8 @@ struct entry:
     data as u8;
 
 mapping entries:
-    key owner as address.public;
-    value entry as entry.public;
+    key as address.public;
+    value as entry.public;
 
 function compute:
     input r0 as u8.public;

--- a/synthesizer/tests/tests/vm/execute_and_finalize/mapping_operations.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/mapping_operations.aleo
@@ -14,8 +14,8 @@ cases:
 program mapping_operations.aleo;
 
 mapping data:
-    key left as u8.public;
-    value right as u8.public;
+    key as u8.public;
+    value as u8.public;
 
 function insert_contains_remove:
     input r0 as u8.public;


### PR DESCRIPTION
This PR removes identifiers from `MapKey` and `MapValue` as they are not necessary.
Users can now declare mappings in the following way:
```aleo
mapping balances:
    key as address.public;
    value as u64.public;
```
