### PR TITLE
[zksecurity 02] Fiat shamir vk

### DIFF
--- a/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{fft::EvaluationDomain, polycommit::sonic_pc, snark::varuna::ahp::indexer::*};
+use crate::{polycommit::sonic_pc, snark::varuna::ahp::indexer::*};
 use snarkvm_curves::PairingEngine;
-use snarkvm_fields::{ConstraintFieldError, ToConstraintField};
 use snarkvm_utilities::{
     error,
     io::{self, Read, Write},
@@ -57,32 +56,6 @@ impl<E: PairingEngine> CircuitVerifyingKey<E> {
     /// Iterate over the commitments to indexed polynomials in `self`.
     pub fn iter(&self) -> impl Iterator<Item = &sonic_pc::Commitment<E>> {
         self.circuit_commitments.iter()
-    }
-}
-
-impl<E: PairingEngine> ToConstraintField<E::Fq> for CircuitVerifyingKey<E> {
-    fn to_field_elements(&self) -> Result<Vec<E::Fq>, ConstraintFieldError> {
-        let constraint_domain_size =
-            EvaluationDomain::<E::Fr>::compute_size_of_domain(self.circuit_info.num_constraints).unwrap() as u128;
-        let non_zero_a_domain_size =
-            EvaluationDomain::<E::Fr>::compute_size_of_domain(self.circuit_info.num_non_zero_a).unwrap() as u128;
-        let non_zero_b_domain_size =
-            EvaluationDomain::<E::Fr>::compute_size_of_domain(self.circuit_info.num_non_zero_b).unwrap() as u128;
-        let non_zero_c_domain_size =
-            EvaluationDomain::<E::Fr>::compute_size_of_domain(self.circuit_info.num_non_zero_c).unwrap() as u128;
-
-        let mut res = Vec::new();
-        res.append(&mut E::Fq::from(constraint_domain_size).to_field_elements()?);
-        res.append(&mut E::Fq::from(non_zero_a_domain_size).to_field_elements()?);
-        res.append(&mut E::Fq::from(non_zero_b_domain_size).to_field_elements()?);
-        res.append(&mut E::Fq::from(non_zero_c_domain_size).to_field_elements()?);
-        for comm in self.circuit_commitments.iter() {
-            res.append(&mut comm.to_field_elements()?);
-        }
-
-        // Intentionally ignore the appending of the PC verifier key.
-
-        Ok(res)
     }
 }
 

--- a/algorithms/src/traits/snark.rs
+++ b/algorithms/src/traits/snark.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::{errors::SNARKError, r1cs::ConstraintSynthesizer, AlgebraicSponge};
-use snarkvm_fields::{PrimeField, ToConstraintField};
+use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{CanonicalDeserialize, CanonicalSerialize, FromBytes, ToBytes};
 
 use anyhow::Result;
@@ -49,7 +49,7 @@ pub trait SNARK {
     type UniversalVerifier;
 
     type VerifierInput: ?Sized;
-    type VerifyingKey: Clone + Send + Sync + ToBytes + FromBytes + ToConstraintField<Self::BaseField> + Ord;
+    type VerifyingKey: Clone + Send + Sync + ToBytes + FromBytes + Ord;
 
     type FiatShamirRng: AlgebraicSponge<Self::BaseField, 2, Parameters = Self::FSParameters>;
     type FSParameters;


### PR DESCRIPTION
## Motivation

Our original code enabled a malicious party to:
- Generate a valid certificate for the verification key of a maliciously generated circuit.
- Subsequently change the circuit to be an innocuous-looking circuit without invalidating the certificate.As long as the "matrix polynomials" col, row, col_row, col_row_val of the new circuit evaluate to the same as the malicious circuit at the single "point",

The certificate of the malicious circuit will be accepted as belonging the innocuous circuit.

## Test Plan

Not adding the highly specific attack vector and its many variations in a test. If there is a new vulnerability coming up, it will probably be because we forget to FS something different.