### PR TITLE
Enable short circuiting in additional is_equal console impls

### DIFF
--- a/console/program/src/data/ciphertext/equal.rs
+++ b/console/program/src/data/ciphertext/equal.rs
@@ -32,25 +32,17 @@ impl<N: Network> Equal<Self> for Ciphertext<N> {
         if self.0.len() != other.0.len() {
             return Boolean::new(false);
         }
+
         // Check each field element for equality.
-        let mut equal = Boolean::new(true);
-        for (a, b) in self.0.iter().zip_eq(other.0.iter()) {
-            equal &= a.is_equal(b);
+        if self.0.iter().zip_eq(other.0.iter()).all(|(a, b)| *a.is_equal(b)) {
+            Boolean::new(true)
+        } else {
+            Boolean::new(false)
         }
-        equal
     }
 
     /// Returns `true` if `self` and `other` are *not* equal.
     fn is_not_equal(&self, other: &Self) -> Self::Output {
-        // Check if the ciphertexts have different numbers of field elements.
-        if self.0.len() != other.0.len() {
-            return Boolean::new(true);
-        }
-        // Recursively check each member for inequality.
-        let mut not_equal = Boolean::new(false);
-        for (a, b) in self.0.iter().zip_eq(other.0.iter()) {
-            not_equal |= a.is_not_equal(b);
-        }
-        not_equal
+        !self.is_equal(other)
     }
 }


### PR DESCRIPTION
In addition, it corrects the docs for the `Record` impls, where it was stated that `nonce` was not being checked, while it is.