### PR TITLE
Speed up OutputStorage::get

### DIFF
--- a/ledger/store/src/transition/output.rs
+++ b/ledger/store/src/transition/output.rs
@@ -284,7 +284,7 @@ pub trait OutputStorage<N: Network>: Clone + Send + Sync {
             if let Some(record) = self.record_map().get_confirmed(&output_id)? {
                 return Ok(into_output!(Output::Record(output_id, record)));
             }
-            if let Some(_) = self.external_record_map().get_confirmed(&output_id)? {
+            if self.external_record_map().get_confirmed(&output_id)?.is_some() {
                 return Ok(Output::ExternalRecord(output_id));
             }
             if let Some(future) = self.future_map().get_confirmed(&output_id)? {


### PR DESCRIPTION
This PR is opened against `feat/futures-2`.

While this logic doesn't allow us to ensure that there aren't multiple outputs, it should be much faster on average.