### PR TITLE
[Aleo ins parser] Minor code and doc fixes.

### DIFF
--- a/console/program/src/data/future/parse.rs
+++ b/console/program/src/data/future/parse.rs
@@ -28,7 +28,7 @@ impl<N: Network> Parser for Future<N> {
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the members.
             let (string, arguments) = separated_list0(
-                pair(pair(Sanitizer::parse, tag(",")), Sanitizer::parse),
+                pair(pair(Sanitizer::parse_whitespaces, tag(",")), Sanitizer::parse),
                 alt((map(Future::parse, Argument::Future), map(Plaintext::parse, Argument::Plaintext))),
             )(string)?;
             // Parse the whitespace and comments from the string.
@@ -103,7 +103,7 @@ impl<N: Network> Parser for Future<N> {
 impl<N: Network> FromStr for Future<N> {
     type Err = Error;
 
-    /// Returns a plaintext from a string literal.
+    /// Returns a future from a string literal.
     fn from_str(string: &str) -> Result<Self> {
         match Self::parse(string) {
             Ok((remainder, object)) => {
@@ -118,21 +118,21 @@ impl<N: Network> FromStr for Future<N> {
 }
 
 impl<N: Network> Debug for Future<N> {
-    /// Prints the plaintext as a string.
+    /// Prints the future as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
 impl<N: Network> Display for Future<N> {
-    /// Prints the plaintext as a string.
+    /// Prints the future as a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         self.fmt_internal(f, 0)
     }
 }
 
 impl<N: Network> Future<N> {
-    /// Prints the plaintext with the given indentation depth.
+    /// Prints the future with the given indentation depth.
     fn fmt_internal(&self, f: &mut Formatter, depth: usize) -> fmt::Result {
         /// The number of spaces to indent.
         const INDENT: usize = 2;


### PR DESCRIPTION
This is for futures.

Update some doc comments.

The code fix is for parsing whitespace just before commas of future arguments. The current code allows comments and new lines there, which I don't think we want (not wrong per se, but anomalous, inconsistent with other parts of the syntax). So the fix restricts that to just whitespace (no comments) without new lines. We still allow comments and new lines after the comma, consistently with other parts of the syntax.
