### PR TITLE
[Refactor] Rename caller to signer, then parent to caller.

### DIFF
--- a/circuit/program/src/request/mod.rs
+++ b/circuit/program/src/request/mod.rs
@@ -116,10 +116,10 @@ impl<A: Aleo> ToFields for InputID<A> {
 }
 
 pub struct Request<A: Aleo> {
+    /// The request signer.
+    signer: Address<A>,
     /// The request caller.
     caller: Address<A>,
-    /// The request parent.
-    parent: Address<A>,
     /// The `is_root` flag.
     is_root: Boolean<A>,
     /// The network ID.
@@ -214,8 +214,8 @@ impl<A: Aleo> Inject for Request<A> {
         };
 
         Self {
+            signer: Address::new(mode, *request.signer()),
             caller: Address::new(mode, *request.caller()),
-            parent: Address::new(mode, *request.parent()),
             is_root: Boolean::new(mode, **request.is_root()),
             network_id: U16::new(Mode::Constant, *request.network_id()),
             program_id: ProgramID::new(Mode::Constant, *request.program_id()),
@@ -232,14 +232,14 @@ impl<A: Aleo> Inject for Request<A> {
 }
 
 impl<A: Aleo> Request<A> {
+    /// Returns the request signer.
+    pub const fn signer(&self) -> &Address<A> {
+        &self.signer
+    }
+
     /// Returns the request caller.
     pub const fn caller(&self) -> &Address<A> {
         &self.caller
-    }
-
-    /// Returns the request parent.
-    pub const fn parent(&self) -> &Address<A> {
-        &self.parent
     }
 
     /// Returns the `is_root` flag.
@@ -304,8 +304,8 @@ impl<A: Aleo> Eject for Request<A> {
 
     /// Ejects the mode of the request.
     fn eject_mode(&self) -> Mode {
-        Mode::combine(self.caller.eject_mode(), [
-            self.parent.eject_mode(),
+        Mode::combine(self.signer.eject_mode(), [
+            self.caller.eject_mode(),
             self.is_root.eject_mode(),
             self.network_id.eject_mode(),
             self.program_id.eject_mode(),
@@ -323,8 +323,8 @@ impl<A: Aleo> Eject for Request<A> {
     /// Ejects the request as a primitive.
     fn eject_value(&self) -> Self::Primitive {
         Self::Primitive::from((
+            self.signer.eject_value(),
             self.caller.eject_value(),
-            self.parent.eject_value(),
             console::Boolean::new(self.is_root.eject_value()),
             self.network_id.eject_value(),
             self.program_id.eject_value(),

--- a/circuit/program/src/response/from_outputs.rs
+++ b/circuit/program/src/response/from_outputs.rs
@@ -15,7 +15,7 @@
 use super::*;
 
 impl<A: Aleo> Response<A> {
-    /// Initializes a response, given the number of inputs, caller, tvk, tcm, outputs, output types, and output registers.
+    /// Initializes a response, given the number of inputs, tvk, tcm, outputs, output types, and output registers.
     pub fn from_outputs(
         network_id: &U16<A>,
         program_id: &ProgramID<A>,

--- a/circuit/program/src/response/process_outputs_from_callback.rs
+++ b/circuit/program/src/response/process_outputs_from_callback.rs
@@ -15,7 +15,7 @@
 use super::*;
 
 impl<A: Aleo> Response<A> {
-    /// Returns the injected circuit outputs, given the number of inputs, caller, tvk, tcm, outputs, and output types.
+    /// Returns the injected circuit outputs, given the number of inputs, tvk, tcm, outputs, and output types.
     pub fn process_outputs_from_callback(
         network_id: &U16<A>,
         program_id: &ProgramID<A>,

--- a/console/program/src/request/bytes.rs
+++ b/console/program/src/request/bytes.rs
@@ -24,10 +24,10 @@ impl<N: Network> FromBytes for Request<N> {
             return Err(error("Invalid request version"));
         }
 
+        // Read the signer.
+        let signer = FromBytes::read_le(&mut reader)?;
         // Read the caller.
         let caller = FromBytes::read_le(&mut reader)?;
-        // Read the parent.
-        let parent = FromBytes::read_le(&mut reader)?;
         // Read the `is_root` flag.
         let is_root = FromBytes::read_le(&mut reader)?;
         // Read the network ID.
@@ -56,8 +56,8 @@ impl<N: Network> FromBytes for Request<N> {
         let tcm = FromBytes::read_le(&mut reader)?;
 
         Ok(Self::from((
+            signer,
             caller,
-            parent,
             is_root,
             network_id,
             program_id,
@@ -79,10 +79,10 @@ impl<N: Network> ToBytes for Request<N> {
         // Write the version.
         0u8.write_le(&mut writer)?;
 
+        // Write the signer.
+        self.signer.write_le(&mut writer)?;
         // Write the caller.
         self.caller.write_le(&mut writer)?;
-        // Write the parent.
-        self.parent.write_le(&mut writer)?;
         // Write the `is_root` flag.
         self.is_root.write_le(&mut writer)?;
         // Write the network ID.

--- a/console/program/src/request/mod.rs
+++ b/console/program/src/request/mod.rs
@@ -28,10 +28,10 @@ use snarkvm_console_types::prelude::*;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Request<N: Network> {
+    /// The request signer.
+    signer: Address<N>,
     /// The request caller.
     caller: Address<N>,
-    /// The request parent.
-    parent: Address<N>,
     /// The `is_root` flag.
     is_root: Boolean<N>,
     /// The network ID.
@@ -76,8 +76,8 @@ impl<N: Network>
     /// Note: See `Request::sign` to create the request. This method is used to eject from a circuit.
     fn from(
         (
+            signer,
             caller,
-            parent,
             is_root,
             network_id,
             program_id,
@@ -110,8 +110,8 @@ impl<N: Network>
             N::halt(format!("Invalid network ID. Expected {}, found {}", N::ID, *network_id))
         } else {
             Self {
+                signer,
                 caller,
-                parent,
                 is_root,
                 network_id,
                 program_id,
@@ -129,14 +129,14 @@ impl<N: Network>
 }
 
 impl<N: Network> Request<N> {
+    /// Returns the request signer.
+    pub const fn signer(&self) -> &Address<N> {
+        &self.signer
+    }
+
     /// Returns the request caller.
     pub const fn caller(&self) -> &Address<N> {
         &self.caller
-    }
-
-    /// Returns the request parent.
-    pub const fn parent(&self) -> &Address<N> {
-        &self.parent
     }
 
     /// Returns the `is_root` flag.
@@ -219,8 +219,8 @@ mod test_helpers {
     pub(super) fn sample_requests(rng: &mut TestRng) -> Vec<Request<CurrentNetwork>> {
         (0..ITERATIONS)
             .map(|i| {
-                // Sample a random address for the parent.
-                let parent = Address::<CurrentNetwork>::rand(rng);
+                // Sample a random address for the caller.
+                let caller = Address::<CurrentNetwork>::rand(rng);
 
                 // Sample a random boolean for the `is_root` flag.
                 let is_root = Boolean::rand(rng);
@@ -256,7 +256,7 @@ mod test_helpers {
 
                 // Compute the signed request.
                 let request =
-                    Request::sign(&private_key, parent, is_root, program_id, function_name, inputs.into_iter(), &input_types, rng).unwrap();
+                    Request::sign(&private_key, caller, is_root, program_id, function_name, inputs.into_iter(), &input_types, rng).unwrap();
                 assert!(request.verify(&input_types));
                 request
             })

--- a/console/program/src/request/serialize.rs
+++ b/console/program/src/request/serialize.rs
@@ -22,8 +22,8 @@ impl<N: Network> Serialize for Request<N> {
         match serializer.is_human_readable() {
             true => {
                 let mut transition = serializer.serialize_struct("Request", 13)?;
+                transition.serialize_field("signer", &self.signer)?;
                 transition.serialize_field("caller", &self.caller)?;
-                transition.serialize_field("parent", &self.parent)?;
                 transition.serialize_field("is_root", &self.is_root)?;
                 transition.serialize_field("network", &self.network_id)?;
                 transition.serialize_field("program", &self.program_id)?;
@@ -51,10 +51,10 @@ impl<'de, N: Network> Deserialize<'de> for Request<N> {
                 let mut request = serde_json::Value::deserialize(deserializer)?;
                 // Recover the request.
                 Ok(Self::from((
+                    // Retrieve the signer.
+                    DeserializeExt::take_from_value::<D>(&mut request, "signer")?,
                     // Retrieve the caller.
                     DeserializeExt::take_from_value::<D>(&mut request, "caller")?,
-                    // Retrieve the parent.
-                    DeserializeExt::take_from_value::<D>(&mut request, "parent")?,
                     // Retrieve the `is_root` flag.
                     DeserializeExt::take_from_value::<D>(&mut request, "is_root")?,
                     // Retrieve the network ID.

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -15,12 +15,12 @@
 use super::*;
 
 impl<N: Network> Request<N> {
-    /// Returns the request for a given private key, parent, is_root, program ID, function name, inputs, input types, and RNG, where:
-    ///     challenge := HashToScalar(r * G, pk_sig, pr_sig, caller, \[tvk, tcm, parent, is_root, function ID, input IDs\])
+    /// Returns the request for a given private key, caller, is_root, program ID, function name, inputs, input types, and RNG, where:
+    ///     challenge := HashToScalar(r * G, pk_sig, pr_sig, signer, \[tvk, tcm, caller, is_root, function ID, input IDs\])
     ///     response := r - challenge * sk_sig
     pub fn sign<R: Rng + CryptoRng>(
         private_key: &PrivateKey<N>,
-        parent: Address<N>,
+        caller: Address<N>,
         is_root: Boolean<N>,
         program_id: ProgramID<N>,
         function_name: Identifier<N>,
@@ -59,10 +59,10 @@ impl<N: Network> Request<N> {
         // Compute `g_r` as `r * G`. Note: This is the transition public key `tpk`.
         let g_r = N::g_scalar_multiply(&r);
 
-        // Derive the caller from the compute key.
-        let caller = Address::try_from(compute_key)?;
-        // Compute the transition view key `tvk` as `r * caller`.
-        let tvk = (*caller * r).to_x_coordinate();
+        // Derive the signer from the compute key.
+        let signer = Address::try_from(compute_key)?;
+        // Compute the transition view key `tvk` as `r * signer`.
+        let tvk = (*signer * r).to_x_coordinate();
         // Compute the transition commitment `tcm` as `Hash(tvk)`.
         let tcm = N::hash_psd2(&[tvk])?;
 
@@ -74,10 +74,10 @@ impl<N: Network> Request<N> {
         // Map `is_root` to a field element.
         let is_root_field = Field::ternary(&is_root, &Field::one(), &Field::zero());
 
-        // Construct the hash input as `(r * G, pk_sig, pr_sig, caller, [tvk, tcm, parent, is_root, function ID, input IDs])`.
+        // Construct the hash input as `(r * G, pk_sig, pr_sig, signer, [tvk, tcm, caller, is_root, function ID, input IDs])`.
         let mut message = Vec::with_capacity(9 + 2 * inputs.len());
-        message.extend([g_r, pk_sig, pr_sig, *caller].map(|point| point.to_x_coordinate()));
-        message.extend([tvk, tcm, parent.to_field()?, is_root_field, function_id]);
+        message.extend([g_r, pk_sig, pr_sig, *signer].map(|point| point.to_x_coordinate()));
+        message.extend([tvk, tcm, caller.to_field()?, is_root_field, function_id]);
 
         // Initialize a vector to store the prepared inputs.
         let mut prepared_inputs = Vec::with_capacity(inputs.len());
@@ -167,8 +167,8 @@ impl<N: Network> Request<N> {
                         Value::Plaintext(..) => bail!("Expected a record input, found a plaintext input"),
                         Value::Future(..) => bail!("Expected a record input, found a future input"),
                     };
-                    // Ensure the record belongs to the caller.
-                    ensure!(**record.owner() == caller, "Input record for '{program_id}' must belong to the signer");
+                    // Ensure the record belongs to the signer.
+                    ensure!(**record.owner() == signer, "Input record for '{program_id}' must belong to the signer");
 
                     // Compute the record commitment.
                     let commitment = record.to_commitment(&program_id, record_name)?;
@@ -217,14 +217,14 @@ impl<N: Network> Request<N> {
             }
         }
 
-        // Compute `challenge` as `HashToScalar(r * G, pk_sig, pr_sig, caller, [tvk, tcm, function ID, input IDs])`.
+        // Compute `challenge` as `HashToScalar(r * G, pk_sig, pr_sig, signer, [tvk, tcm, function ID, input IDs])`.
         let challenge = N::hash_to_scalar_psd8(&message)?;
         // Compute `response` as `r - challenge * sk_sig`.
         let response = r - challenge * sk_sig;
 
         Ok(Self {
+            signer,
             caller,
-            parent,
             is_root,
             network_id: U16::new(N::ID),
             program_id,

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -78,7 +78,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                     }
                     // If the operand is the signer, retrieve the signer from the registers.
                     Operand::Signer => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.signer()?)))),
-                    // If the operand is the caller, retrieve the parent from the registers.
+                    // If the operand is the caller, retrieve the caller from the registers.
                     Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),
                     // If the operand is the block height, throw an error.
                     Operand::BlockHeight => bail!("Cannot retrieve the block height from a closure scope."),

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -76,7 +76,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                     Operand::ProgramID(program_id) => {
                         Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))))
                     }
-                    // If the operand is the signer, retrieve the caller from the registers.
+                    // If the operand is the signer, retrieve the signer from the registers.
                     Operand::Signer => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.signer()?)))),
                     // If the operand is the caller, retrieve the parent from the registers.
                     Operand::Caller => Ok(Value::Plaintext(Plaintext::from(Literal::Address(registers.caller()?)))),

--- a/synthesizer/process/src/stack/finalize_registers/load.rs
+++ b/synthesizer/process/src/stack/finalize_registers/load.rs
@@ -33,10 +33,10 @@ impl<N: Network> RegistersLoad<N> for FinalizeRegisters<N> {
             Operand::ProgramID(program_id) => {
                 return Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))));
             }
+            // If the operand is the signer, throw an error.
+            Operand::Signer => bail!("Forbidden operation: Cannot use 'self.signer' in 'finalize'"),
             // If the operand is the caller, throw an error.
             Operand::Caller => bail!("Forbidden operation: Cannot use 'self.caller' in 'finalize'"),
-            // If the operand is the parent, throw an error.
-            Operand::Parent => bail!("Forbidden operation: Cannot use 'self.parent' in 'finalize'"),
             // If the operand is the block height, load the block height.
             Operand::BlockHeight => {
                 return Ok(Value::Plaintext(Plaintext::from(Literal::U32(U32::new(self.state.block_height())))));

--- a/synthesizer/process/src/stack/finalize_types/matches.rs
+++ b/synthesizer/process/src/stack/finalize_types/matches.rs
@@ -78,13 +78,13 @@ impl<N: Network> FinalizeTypes<N> {
                         "Struct member '{struct_name}.{member_name}' expects {member_type}, but found '{program_ref_type}' in the operand '{operand}'.",
                     )
                 }
+                // If the operand is a signer, throw an error.
+                Operand::Signer => bail!(
+                    "Struct member '{struct_name}.{member_name}' cannot be cast from a signer in a finalize scope."
+                ),
                 // If the operand is a caller, throw an error.
                 Operand::Caller => bail!(
                     "Struct member '{struct_name}.{member_name}' cannot be cast from a caller in a finalize scope."
-                ),
-                // If the operand is a parent, throw an error.
-                Operand::Parent => bail!(
-                    "Struct member '{struct_name}.{member_name}' cannot be cast from a parent in a finalize scope."
                 ),
                 // Ensure the block height type (u32) matches the member type.
                 Operand::BlockHeight => {
@@ -162,10 +162,10 @@ impl<N: Network> FinalizeTypes<N> {
                         array_type.next_element_type()
                     )
                 }
+                // If the operand is a signer, throw an error.
+                Operand::Signer => bail!("Array element cannot be cast from a signer in a finalize scope."),
                 // If the operand is a caller, throw an error.
                 Operand::Caller => bail!("Array element cannot be cast from a caller in a finalize scope."),
-                // If the operand is a parent, throw an error.
-                Operand::Parent => bail!("Array element cannot be cast from a parent in a finalize scope."),
                 // Ensure the block height type (u32) matches the member type.
                 Operand::BlockHeight => {
                     // Retrieve the block height type.

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -76,8 +76,8 @@ impl<N: Network> FinalizeTypes<N> {
             Operand::Literal(literal) => FinalizeType::Plaintext(PlaintextType::from(literal.to_type())),
             Operand::Register(register) => self.get_type(stack, register)?,
             Operand::ProgramID(_) => FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::Address)),
+            Operand::Signer => bail!("'self.signer' is not a valid operand in a finalize context."),
             Operand::Caller => bail!("'self.caller' is not a valid operand in a finalize context."),
-            Operand::Parent => bail!("'self.parent' is not a valid operand in a finalize context."),
             Operand::BlockHeight => FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::U32)),
         })
     }

--- a/synthesizer/process/src/stack/register_types/matches.rs
+++ b/synthesizer/process/src/stack/register_types/matches.rs
@@ -74,8 +74,8 @@ impl<N: Network> RegisterTypes<N> {
                         }
                     }
                 }
-                // Ensure the program ID, caller, and parent types (address) match the member type.
-                Operand::ProgramID(..) | Operand::Caller | Operand::Parent => {
+                // Ensure the program ID, signer, and caller types (address) match the member type.
+                Operand::ProgramID(..) | Operand::Signer | Operand::Caller => {
                     // Retrieve the operand type.
                     let operand_type = PlaintextType::Literal(LiteralType::Address);
                     // Ensure the operand type matches the member type.
@@ -149,8 +149,8 @@ impl<N: Network> RegisterTypes<N> {
                         }
                     }
                 }
-                // Ensure the program ID type, caller type, and parent types (address) match the element type.
-                Operand::ProgramID(..) | Operand::Caller | Operand::Parent => {
+                // Ensure the program ID type, signer type, and caller types (address) match the element type.
+                Operand::ProgramID(..) | Operand::Signer | Operand::Caller => {
                     // Retrieve the operand type.
                     let operand_type = PlaintextType::Literal(LiteralType::Address);
                     // Ensure the operand type matches the element type.
@@ -220,7 +220,7 @@ impl<N: Network> RegisterTypes<N> {
                 // They must hold all necessary state in storage instead.
                 bail!("Forbidden operation: Cannot cast a program ID ('{program_id}') as a record owner")
             }
-            Operand::Caller | Operand::Parent => {
+            Operand::Signer | Operand::Caller => {
                 // No-op.
             }
             Operand::BlockHeight => {
@@ -265,8 +265,8 @@ impl<N: Network> RegisterTypes<N> {
                                 }
                             }
                         }
-                        // Ensure the program ID, caller, and parent types (address) match the entry type.
-                        Operand::ProgramID(..) | Operand::Caller | Operand::Parent => {
+                        // Ensure the program ID, signer, and caller types (address) match the entry type.
+                        Operand::ProgramID(..) | Operand::Signer | Operand::Caller => {
                             // Retrieve the operand type.
                             let operand_type = &PlaintextType::Literal(LiteralType::Address);
                             // Ensure the operand type matches the entry type.

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -93,7 +93,7 @@ impl<N: Network> RegisterTypes<N> {
         Ok(match operand {
             Operand::Literal(literal) => RegisterType::Plaintext(PlaintextType::from(literal.to_type())),
             Operand::Register(register) => self.get_type(stack, register)?,
-            Operand::ProgramID(_) | Operand::Caller | Operand::Parent => {
+            Operand::ProgramID(_) | Operand::Signer | Operand::Caller => {
                 RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Address))
             }
             Operand::BlockHeight => bail!("'block.height' is not a valid operand in a non-finalize context."),

--- a/synthesizer/process/src/stack/registers/caller.rs
+++ b/synthesizer/process/src/stack/registers/caller.rs
@@ -14,29 +14,29 @@
 
 use super::*;
 
-impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCaller<N> for Registers<N, A> {
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersSigner<N> for Registers<N, A> {
+    /// Returns the transition signer.
+    #[inline]
+    fn signer(&self) -> Result<Address<N>> {
+        self.signer.ok_or_else(|| anyhow!("Signer address (console) is not set in the registers."))
+    }
+
+    /// Sets the transition signer.
+    #[inline]
+    fn set_signer(&mut self, signer: Address<N>) {
+        self.signer = Some(signer);
+    }
+
     /// Returns the transition caller.
     #[inline]
     fn caller(&self) -> Result<Address<N>> {
-        self.caller.ok_or_else(|| anyhow!("Caller address (console) is not set in the registers."))
+        self.caller.ok_or_else(|| anyhow!("Parent address (console) is not set in the registers."))
     }
 
     /// Sets the transition caller.
     #[inline]
     fn set_caller(&mut self, caller: Address<N>) {
         self.caller = Some(caller);
-    }
-
-    /// Returns the transition parent.
-    #[inline]
-    fn parent(&self) -> Result<Address<N>> {
-        self.parent.ok_or_else(|| anyhow!("Parent address (console) is not set in the registers."))
-    }
-
-    /// Sets the transition parent.
-    #[inline]
-    fn set_parent(&mut self, parent: Address<N>) {
-        self.parent = Some(parent);
     }
 
     /// Returns the transition view key.
@@ -52,29 +52,29 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCaller<N> for Registers
     }
 }
 
-impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCallerCircuit<N, A> for Registers<N, A> {
+impl<N: Network, A: circuit::Aleo<Network = N>> RegistersSignerCircuit<N, A> for Registers<N, A> {
+    /// Returns the transition signer, as a circuit.
+    #[inline]
+    fn signer_circuit(&self) -> Result<circuit::Address<A>> {
+        self.signer_circuit.clone().ok_or_else(|| anyhow!("Caller address (circuit) is not set in the registers."))
+    }
+
+    /// Sets the transition signer, as a circuit.
+    #[inline]
+    fn set_signer_circuit(&mut self, signer_circuit: circuit::Address<A>) {
+        self.signer_circuit = Some(signer_circuit);
+    }
+
     /// Returns the transition caller, as a circuit.
     #[inline]
     fn caller_circuit(&self) -> Result<circuit::Address<A>> {
-        self.caller_circuit.clone().ok_or_else(|| anyhow!("Caller address (circuit) is not set in the registers."))
+        self.caller_circuit.clone().ok_or_else(|| anyhow!("Parent address (circuit) is not set in the registers."))
     }
 
     /// Sets the transition caller, as a circuit.
     #[inline]
     fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>) {
         self.caller_circuit = Some(caller_circuit);
-    }
-
-    /// Returns the transition parent, as a circuit.
-    #[inline]
-    fn parent_circuit(&self) -> Result<circuit::Address<A>> {
-        self.parent_circuit.clone().ok_or_else(|| anyhow!("Parent address (circuit) is not set in the registers."))
-    }
-
-    /// Sets the transition parent, as a circuit.
-    #[inline]
-    fn set_parent_circuit(&mut self, parent_circuit: circuit::Address<A>) {
-        self.parent_circuit = Some(parent_circuit);
     }
 
     /// Returns the transition view key, as a circuit.

--- a/synthesizer/process/src/stack/registers/load.rs
+++ b/synthesizer/process/src/stack/registers/load.rs
@@ -32,10 +32,10 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoad<N> for Registers<N
             Operand::ProgramID(program_id) => {
                 return Ok(Value::Plaintext(Plaintext::from(Literal::Address(program_id.to_address()?))));
             }
+            // If the operand is the signer, load the value of the signer.
+            Operand::Signer => return Ok(Value::Plaintext(Plaintext::from(Literal::Address(self.signer()?)))),
             // If the operand is the caller, load the value of the caller.
             Operand::Caller => return Ok(Value::Plaintext(Plaintext::from(Literal::Address(self.caller()?)))),
-            // If the operand is the parent, load the value of the parent.
-            Operand::Parent => return Ok(Value::Plaintext(Plaintext::from(Literal::Address(self.parent()?)))),
             // If the operand is the block height, throw an error.
             Operand::BlockHeight => bail!("Cannot load the block height in a non-finalize context"),
         };
@@ -107,16 +107,16 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersLoadCircuit<N, A> for R
                     Literal::Address(program_id.to_address()?),
                 ))));
             }
+            // If the operand is the signer, load the value of the signer.
+            Operand::Signer => {
+                return Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
+                    self.signer_circuit()?,
+                ))));
+            }
             // If the operand is the caller, load the value of the caller.
             Operand::Caller => {
                 return Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
                     self.caller_circuit()?,
-                ))));
-            }
-            // If the operand is the parent, load the value of the parent.
-            Operand::Parent => {
-                return Ok(circuit::Value::Plaintext(circuit::Plaintext::from(circuit::Literal::Address(
-                    self.parent_circuit()?,
                 ))));
             }
             // If the operand is the block height, throw an error.

--- a/synthesizer/process/src/stack/registers/mod.rs
+++ b/synthesizer/process/src/stack/registers/mod.rs
@@ -25,10 +25,10 @@ use console::{
 };
 use synthesizer_program::{
     Operand,
-    RegistersCaller,
-    RegistersCallerCircuit,
     RegistersLoad,
     RegistersLoadCircuit,
+    RegistersSigner,
+    RegistersSignerCircuit,
     RegistersStore,
     RegistersStoreCircuit,
     StackMatches,
@@ -47,14 +47,14 @@ pub struct Registers<N: Network, A: circuit::Aleo<Network = N>> {
     console_registers: IndexMap<u64, Value<N>>,
     /// The mapping of assigned circuit registers to their values.
     circuit_registers: IndexMap<u64, circuit::Value<A>>,
+    /// The transition signer.
+    signer: Option<Address<N>>,
+    /// The transition signer, as a circuit.
+    signer_circuit: Option<circuit::Address<A>>,
     /// The transition caller.
     caller: Option<Address<N>>,
     /// The transition caller, as a circuit.
     caller_circuit: Option<circuit::Address<A>>,
-    /// The transition parent.
-    parent: Option<Address<N>>,
-    /// The transition parent, as a circuit.
-    parent_circuit: Option<circuit::Address<A>>,
     /// The transition view key.
     tvk: Option<Field<N>>,
     /// The transition view key, as a circuit.
@@ -70,10 +70,10 @@ impl<N: Network, A: circuit::Aleo<Network = N>> Registers<N, A> {
             register_types,
             console_registers: IndexMap::new(),
             circuit_registers: IndexMap::new(),
+            signer: None,
+            signer_circuit: None,
             caller: None,
             caller_circuit: None,
-            parent: None,
-            parent_circuit: None,
             tvk: None,
             tvk_circuit: None,
         }

--- a/synthesizer/process/src/traits/mod.rs
+++ b/synthesizer/process/src/traits/mod.rs
@@ -31,8 +31,8 @@ pub trait StackEvaluate<N: Network>: Clone {
         closure: &Closure<N>,
         inputs: &[Value<N>],
         call_stack: CallStack<N>,
+        signer: Address<N>,
         caller: Address<N>,
-        parent: Address<N>,
         tvk: Field<N>,
     ) -> Result<Vec<Value<N>>>;
 
@@ -53,8 +53,8 @@ pub trait StackExecute<N: Network> {
         closure: &Closure<N>,
         inputs: &[circuit::Value<A>],
         call_stack: CallStack<N>,
+        signer: circuit::Address<A>,
         caller: circuit::Address<A>,
-        parent: circuit::Address<A>,
         tvk: circuit::Field<A>,
     ) -> Result<Vec<circuit::Value<A>>>;
 

--- a/synthesizer/process/src/verify_fee.rs
+++ b/synthesizer/process/src/verify_fee.rs
@@ -116,15 +116,15 @@ impl<N: Network> Process<N> {
         // Compute the x- and y-coordinate of `tpk`.
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
-        // Compute the x- and y-coordinate of `parent`.
-        let (parent_x, parent_y) = fee.program_id().to_address()?.to_xy_coordinates();
+        // Compute the x- and y-coordinate of `caller`.
+        let (caller_x, caller_y) = fee.program_id().to_address()?.to_xy_coordinates();
 
         // Construct the public inputs to verify the proof.
         let mut inputs = vec![N::Field::one(), *tpk_x, *tpk_y, **fee.tcm()];
         // Extend the inputs with the input IDs.
         inputs.extend(fee.inputs().iter().flat_map(|input| input.verifier_inputs()));
-        // Extend the verifier inputs with the 'self.parent' public inputs.
-        inputs.extend([*Field::<N>::one(), *parent_x, *parent_y]);
+        // Extend the verifier inputs with the 'self.caller' public inputs.
+        inputs.extend([*Field::<N>::one(), *caller_x, *caller_y]);
         // Extend the inputs with the output IDs.
         inputs.extend(fee.outputs().iter().flat_map(|output| output.verifier_inputs()));
         lap!(timer, "Construct the verifier inputs");
@@ -186,15 +186,15 @@ impl<N: Network> Process<N> {
         // Compute the x- and y-coordinate of `tpk`.
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
-        // Compute the x- and y-coordinate of `parent`.
-        let (parent_x, parent_y) = fee.program_id().to_address()?.to_xy_coordinates();
+        // Compute the x- and y-coordinate of `caller`.
+        let (caller_x, caller_y) = fee.program_id().to_address()?.to_xy_coordinates();
 
         // Construct the public inputs to verify the proof.
         let mut inputs = vec![N::Field::one(), *tpk_x, *tpk_y, **fee.tcm()];
         // Extend the inputs with the input IDs.
         inputs.extend(fee.inputs().iter().flat_map(|input| input.verifier_inputs()));
-        // Extend the verifier inputs with the 'self.parent' public inputs.
-        inputs.extend([*Field::<N>::one(), *parent_x, *parent_y]);
+        // Extend the verifier inputs with the 'self.caller' public inputs.
+        inputs.extend([*Field::<N>::one(), *caller_x, *caller_y]);
         // Extend the inputs with the output IDs.
         inputs.extend(fee.outputs().iter().flat_map(|output| output.verifier_inputs()));
         lap!(timer, "Construct the verifier inputs");

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -599,6 +599,8 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         "mapping",
         "key",
         "value",
+        "async",
+        "finalize",
         // Reserved (catch all)
         "global",
         "block",
@@ -622,8 +624,6 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         "impl",
         "type",
         "future",
-        "async",
-        "finalize",
     ];
 
     /// Returns `true` if the given name does not already exist in the program.

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -26,10 +26,10 @@ mod parse;
 
 use crate::traits::{
     InstructionTrait,
-    RegistersCaller,
-    RegistersCallerCircuit,
     RegistersLoad,
     RegistersLoadCircuit,
+    RegistersSigner,
+    RegistersSignerCircuit,
     RegistersStore,
     RegistersStoreCircuit,
     StackMatches,
@@ -408,7 +408,7 @@ impl<N: Network> Instruction<N> {
     pub fn evaluate(
         &self,
         stack: &(impl StackMatches<N> + StackProgram<N>),
-        registers: &mut (impl RegistersCaller<N> + RegistersLoad<N> + RegistersStore<N>),
+        registers: &mut (impl RegistersSigner<N> + RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         instruction!(self, |instruction| instruction.evaluate(stack, registers))
     }
@@ -418,7 +418,7 @@ impl<N: Network> Instruction<N> {
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &(impl StackMatches<N> + StackProgram<N>),
-        registers: &mut (impl RegistersCallerCircuit<N, A> + RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
+        registers: &mut (impl RegistersSignerCircuit<N, A> + RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         instruction!(self, |instruction| instruction.execute::<A>(stack, registers))
     }

--- a/synthesizer/program/src/logic/instruction/operand/bytes.rs
+++ b/synthesizer/program/src/logic/instruction/operand/bytes.rs
@@ -20,8 +20,8 @@ impl<N: Network> FromBytes for Operand<N> {
             0 => Ok(Self::Literal(Literal::read_le(&mut reader)?)),
             1 => Ok(Self::Register(Register::read_le(&mut reader)?)),
             2 => Ok(Self::ProgramID(ProgramID::read_le(&mut reader)?)),
-            3 => Ok(Self::Caller),
-            4 => Ok(Self::Parent),
+            3 => Ok(Self::Signer),
+            4 => Ok(Self::Caller),
             5 => Ok(Self::BlockHeight),
             variant => Err(error(format!("Failed to deserialize operand variant {variant}"))),
         }
@@ -43,8 +43,8 @@ impl<N: Network> ToBytes for Operand<N> {
                 2u8.write_le(&mut writer)?;
                 program_id.write_le(&mut writer)
             }
-            Self::Caller => 3u8.write_le(&mut writer),
-            Self::Parent => 4u8.write_le(&mut writer),
+            Self::Signer => 3u8.write_le(&mut writer),
+            Self::Caller => 4u8.write_le(&mut writer),
             Self::BlockHeight => 5u8.write_le(&mut writer),
         }
     }

--- a/synthesizer/program/src/logic/instruction/operand/mod.rs
+++ b/synthesizer/program/src/logic/instruction/operand/mod.rs
@@ -31,12 +31,12 @@ pub enum Operand<N: Network> {
     Register(Register<N>),
     /// The operand is the program ID.
     ProgramID(ProgramID<N>),
+    /// The operand is the signer address.
+    /// Note: This variant is only accessible in the `function` scope.
+    Signer,
     /// The operand is the caller address.
     /// Note: This variant is only accessible in the `function` scope.
     Caller,
-    /// The operand is the parent address.
-    /// Note: This variant is only accessible in the `function` scope.
-    Parent,
     /// The operand is the block height.
     /// Note: This variant is only accessible in the `finalize` scope.
     BlockHeight,

--- a/synthesizer/program/src/logic/instruction/operand/parse.rs
+++ b/synthesizer/program/src/logic/instruction/operand/parse.rs
@@ -23,8 +23,8 @@ impl<N: Network> Parser for Operand<N> {
             // Parse special operands before literals, registers, and program IDs.
             // This ensures correctness in the case where a special operand is a prefix of, or could be parsed as, a literal, register, or program ID.
             map(tag("group::GEN"), |_| Self::Literal(Literal::Group(Group::generator()))),
+            map(tag("self.signer"), |_| Self::Signer),
             map(tag("self.caller"), |_| Self::Caller),
-            map(tag("self.parent"), |_| Self::Parent),
             map(tag("block.height"), |_| Self::BlockHeight),
             map(Literal::parse, |literal| Self::Literal(literal)),
             map(Register::parse, |register| Self::Register(register)),
@@ -68,10 +68,10 @@ impl<N: Network> Display for Operand<N> {
             Self::Register(register) => Display::fmt(register, f),
             // Prints the program ID, i.e. howard.aleo
             Self::ProgramID(program_id) => Display::fmt(program_id, f),
+            // Prints the identifier for the signer, i.e. self.signer
+            Self::Signer => write!(f, "self.signer"),
             // Prints the identifier for the caller, i.e. self.caller
             Self::Caller => write!(f, "self.caller"),
-            // Prints the identifier for the parent, i.e. self.parent
-            Self::Parent => write!(f, "self.parent"),
             // Prints the identifier for the block height, i.e. block.height
             Self::BlockHeight => write!(f, "block.height"),
         }
@@ -99,11 +99,11 @@ mod tests {
         let operand = Operand::<CurrentNetwork>::parse("howard.aleo").unwrap().1;
         assert_eq!(Operand::ProgramID(ProgramID::from_str("howard.aleo")?), operand);
 
+        let operand = Operand::<CurrentNetwork>::parse("self.signer").unwrap().1;
+        assert_eq!(Operand::Signer, operand);
+
         let operand = Operand::<CurrentNetwork>::parse("self.caller").unwrap().1;
         assert_eq!(Operand::Caller, operand);
-
-        let operand = Operand::<CurrentNetwork>::parse("self.parent").unwrap().1;
-        assert_eq!(Operand::Parent, operand);
 
         let operand = Operand::<CurrentNetwork>::parse("block.height").unwrap().1;
         assert_eq!(Operand::BlockHeight, operand);
@@ -133,11 +133,11 @@ mod tests {
         let operand = Operand::<CurrentNetwork>::parse("howard.aleo").unwrap().1;
         assert_eq!(format!("{operand}"), "howard.aleo");
 
+        let operand = Operand::<CurrentNetwork>::parse("self.signer").unwrap().1;
+        assert_eq!(format!("{operand}"), "self.signer");
+
         let operand = Operand::<CurrentNetwork>::parse("self.caller").unwrap().1;
         assert_eq!(format!("{operand}"), "self.caller");
-
-        let operand = Operand::<CurrentNetwork>::parse("self.parent").unwrap().1;
-        assert_eq!(format!("{operand}"), "self.parent");
 
         let operand = Operand::<CurrentNetwork>::parse("group::GEN").unwrap().1;
         assert_eq!(

--- a/synthesizer/program/src/logic/instruction/operation/cast.rs
+++ b/synthesizer/program/src/logic/instruction/operation/cast.rs
@@ -14,10 +14,10 @@
 
 use crate::{
     traits::{
-        RegistersCaller,
-        RegistersCallerCircuit,
         RegistersLoad,
         RegistersLoadCircuit,
+        RegistersSigner,
+        RegistersSignerCircuit,
         RegistersStore,
         RegistersStoreCircuit,
         StackMatches,
@@ -204,7 +204,7 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
     pub fn evaluate(
         &self,
         stack: &(impl StackMatches<N> + StackProgram<N>),
-        registers: &mut (impl RegistersCaller<N> + RegistersLoad<N> + RegistersStore<N>),
+        registers: &mut (impl RegistersSigner<N> + RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
         // TODO (howardwu & d0cd): Re-enable after stabilizing.
         if VARIANT == CastVariant::CastLossy as u8 {
@@ -331,7 +331,7 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
         stack: &(impl StackMatches<N> + StackProgram<N>),
-        registers: &mut (impl RegistersCallerCircuit<N, A> + RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
+        registers: &mut (impl RegistersSignerCircuit<N, A> + RegistersLoadCircuit<N, A> + RegistersStoreCircuit<N, A>),
     ) -> Result<()> {
         // TODO (howardwu & d0cd): Re-enable after stabilizing.
         if VARIANT == CastVariant::CastLossy as u8 {

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -94,18 +94,18 @@ pub trait FinalizeRegistersState<N: Network> {
     fn function_name(&self) -> &Identifier<N>;
 }
 
-pub trait RegistersCaller<N: Network> {
+pub trait RegistersSigner<N: Network> {
+    /// Returns the transition signer.
+    fn signer(&self) -> Result<Address<N>>;
+
+    /// Sets the transition signer.
+    fn set_signer(&mut self, signer: Address<N>);
+
     /// Returns the transition caller.
     fn caller(&self) -> Result<Address<N>>;
 
     /// Sets the transition caller.
     fn set_caller(&mut self, caller: Address<N>);
-
-    /// Returns the transition parent.
-    fn parent(&self) -> Result<Address<N>>;
-
-    /// Sets the transition parent.
-    fn set_parent(&mut self, parent: Address<N>);
 
     /// Returns the transition view key.
     fn tvk(&self) -> Result<Field<N>>;
@@ -114,18 +114,18 @@ pub trait RegistersCaller<N: Network> {
     fn set_tvk(&mut self, tvk: Field<N>);
 }
 
-pub trait RegistersCallerCircuit<N: Network, A: circuit::Aleo<Network = N>> {
+pub trait RegistersSignerCircuit<N: Network, A: circuit::Aleo<Network = N>> {
+    /// Returns the transition signer, as a circuit.
+    fn signer_circuit(&self) -> Result<circuit::Address<A>>;
+
+    /// Sets the transition signer, as a circuit.
+    fn set_signer_circuit(&mut self, signer_circuit: circuit::Address<A>);
+
     /// Returns the transition caller, as a circuit.
     fn caller_circuit(&self) -> Result<circuit::Address<A>>;
 
     /// Sets the transition caller, as a circuit.
     fn set_caller_circuit(&mut self, caller_circuit: circuit::Address<A>);
-
-    /// Returns the transition parent, as a circuit.
-    fn parent_circuit(&self) -> Result<circuit::Address<A>>;
-
-    /// Sets the transition parent, as a circuit.
-    fn set_parent_circuit(&mut self, parent_circuit: circuit::Address<A>);
 
     /// Returns the transition view key, as a circuit.
     fn tvk_circuit(&self) -> Result<circuit::Field<A>>;

--- a/synthesizer/tests/tests/vm/execute_and_finalize/child_and_parent.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/child_and_parent.aleo
@@ -12,8 +12,8 @@ cases:
 program child.aleo;
 
 function foo:
-    output self.parent as address.public;
     output self.caller as address.public;
+    output self.signer as address.public;
 
 /////////////////////////////////////////////////
 
@@ -25,6 +25,6 @@ function foo:
     call child.aleo/foo into r0 r1;
     output r0 as address.public;
     output r1 as address.public;
-    output self.parent as address.public;
     output self.caller as address.public;
+    output self.signer as address.public;
 

--- a/synthesizer/tests/tests/vm/execute_and_finalize/program_callable.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/program_callable.aleo
@@ -12,9 +12,9 @@ cases:
 program child.aleo;
 
 function foo:
-    assert.neq self.parent self.caller;
-    output self.parent as address.public;
+    assert.neq self.caller self.signer;
     output self.caller as address.public;
+    output self.signer as address.public;
 
 /////////////////////////////////////////////////
 
@@ -26,6 +26,6 @@ function foo:
     call child.aleo/foo into r0 r1;
     output r0 as address.public;
     output r1 as address.public;
-    output self.parent as address.public;
     output self.caller as address.public;
+    output self.signer as address.public;
 

--- a/synthesizer/tests/tests/vm/execute_and_finalize/user_callable.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/user_callable.aleo
@@ -12,9 +12,9 @@ cases:
 program child.aleo;
 
 function foo:
-    assert.eq self.parent self.caller;
-    output self.parent as address.public;
+    assert.eq self.caller self.signer;
     output self.caller as address.public;
+    output self.signer as address.public;
 
 /////////////////////////////////////////////////
 
@@ -26,6 +26,6 @@ function foo:
     call child.aleo/foo into r0 r1;
     output r0 as address.public;
     output r1 as address.public;
-    output self.parent as address.public;
     output self.caller as address.public;
+    output self.signer as address.public;
 


### PR DESCRIPTION
This PR renames `caller` to `signer` and then `parent` to `caller` in `Request` and `Operand`.
Note that `self.signer` is the user that signed the original request, while `self.caller` is the address (user or program) that invoked the current request.
Note that existing programs that use `self.caller` are backed into the composability offered by `self.caller`.
If this is not the intended behavior, those programs would need to be adjusted to use `self.signer`.
