### PR TITLE
[Aleo ins parser] Fix in struct/array parsing.

### DIFF
--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -41,18 +41,20 @@ impl<N: Network> Parser for Plaintext<N> {
             // Parse the "{" from the string.
             let (string, _) = tag("{")(string)?;
             // Parse the members.
-            let (string, members) =
-                map_res(separated_list1(pair(Sanitizer::parse_whitespaces,tag(",")), parse_pair), |members: Vec<_>| {
-                // Ensure the members has no duplicate names.
-                if has_duplicates(members.iter().map(|(name, ..)| name)) {
-                    return Err(error("Duplicate member in struct"));
-                }
-                // Ensure the number of structs is within the maximum limit.
-                match members.len() <= N::MAX_STRUCT_ENTRIES {
-                    true => Ok(members),
-                    false => Err(error(format!("Found a plaintext that exceeds size ({})", members.len()))),
-                }
-            })(string)?;
+            let (string, members) = map_res(
+                separated_list1(pair(Sanitizer::parse_whitespaces, tag(",")), parse_pair),
+                |members: Vec<_>| {
+                    // Ensure the members has no duplicate names.
+                    if has_duplicates(members.iter().map(|(name, ..)| name)) {
+                        return Err(error("Duplicate member in struct"));
+                    }
+                    // Ensure the number of structs is within the maximum limit.
+                    match members.len() <= N::MAX_STRUCT_ENTRIES {
+                        true => Ok(members),
+                        false => Err(error(format!("Found a plaintext that exceeds size ({})", members.len()))),
+                    }
+                },
+            )(string)?;
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the '}' from the string.
@@ -68,7 +70,8 @@ impl<N: Network> Parser for Plaintext<N> {
             // Parse the "[" from the string.
             let (string, _) = tag("[")(string)?;
             // Parse the members.
-            let (string, members) = separated_list1(pair(Sanitizer::parse_whitespaces,tag(",")), Plaintext::parse)(string)?;
+            let (string, members) =
+                separated_list1(pair(Sanitizer::parse_whitespaces, tag(",")), Plaintext::parse)(string)?;
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the ']' from the string.

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -41,7 +41,8 @@ impl<N: Network> Parser for Plaintext<N> {
             // Parse the "{" from the string.
             let (string, _) = tag("{")(string)?;
             // Parse the members.
-            let (string, members) = map_res(separated_list1(tag(","), parse_pair), |members: Vec<_>| {
+            let (string, members) =
+                map_res(separated_list1(pair(Sanitizer::parse_whitespaces,tag(",")), parse_pair), |members: Vec<_>| {
                 // Ensure the members has no duplicate names.
                 if has_duplicates(members.iter().map(|(name, ..)| name)) {
                     return Err(error("Duplicate member in struct"));
@@ -67,7 +68,7 @@ impl<N: Network> Parser for Plaintext<N> {
             // Parse the "[" from the string.
             let (string, _) = tag("[")(string)?;
             // Parse the members.
-            let (string, members) = separated_list1(tag(","), Plaintext::parse)(string)?;
+            let (string, members) = separated_list1(pair(Sanitizer::parse_whitespaces,tag(",")), Plaintext::parse)(string)?;
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the ']' from the string.

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -30,6 +30,8 @@ impl<N: Network> Parser for Plaintext<N> {
             let (string, _) = tag(":")(string)?;
             // Parse the plaintext from the string.
             let (string, plaintext) = Plaintext::parse(string)?;
+            // Parse the whitespace from the string.
+            let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Return the identifier and plaintext.
             Ok((string, (identifier, plaintext)))
         }
@@ -41,20 +43,17 @@ impl<N: Network> Parser for Plaintext<N> {
             // Parse the "{" from the string.
             let (string, _) = tag("{")(string)?;
             // Parse the members.
-            let (string, members) = map_res(
-                separated_list1(pair(Sanitizer::parse_whitespaces, tag(",")), parse_pair),
-                |members: Vec<_>| {
-                    // Ensure the members has no duplicate names.
-                    if has_duplicates(members.iter().map(|(name, ..)| name)) {
-                        return Err(error("Duplicate member in struct"));
-                    }
-                    // Ensure the number of structs is within the maximum limit.
-                    match members.len() <= N::MAX_STRUCT_ENTRIES {
-                        true => Ok(members),
-                        false => Err(error(format!("Found a plaintext that exceeds size ({})", members.len()))),
-                    }
-                },
-            )(string)?;
+            let (string, members) = map_res(separated_list1(tag(","), parse_pair), |members: Vec<_>| {
+                // Ensure the members has no duplicate names.
+                if has_duplicates(members.iter().map(|(name, ..)| name)) {
+                    return Err(error("Duplicate member in struct"));
+                }
+                // Ensure the number of structs is within the maximum limit.
+                match members.len() <= N::MAX_STRUCT_ENTRIES {
+                    true => Ok(members),
+                    false => Err(error(format!("Found a plaintext that exceeds size ({})", members.len()))),
+                }
+            })(string)?;
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the '}' from the string.
@@ -70,8 +69,7 @@ impl<N: Network> Parser for Plaintext<N> {
             // Parse the "[" from the string.
             let (string, _) = tag("[")(string)?;
             // Parse the members.
-            let (string, members) =
-                separated_list1(pair(Sanitizer::parse_whitespaces, tag(",")), Plaintext::parse)(string)?;
+            let (string, members) = separated_list1(tag(","), Plaintext::parse)(string)?;
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the ']' from the string.

--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -47,6 +47,8 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
                 // Parse an array.
                 parse_array,
             ))(string)?;
+            // Parse the whitespace from the string.
+            let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Return the identifier, plaintext, and visibility.
             Ok((string, (identifier, plaintext, mode)))
         }

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -33,6 +33,8 @@ impl<N: Network> Parser for Record<N, Plaintext<N>> {
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the entry from the string.
             let (string, entry) = Entry::parse(string)?;
+            // Parse the whitespace from the string.
+            let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Return the identifier and entry.
             Ok((string, (identifier, entry)))
         }


### PR DESCRIPTION
This is fairly minor, but the current parser disallows whitespace between a component of a struct or an array and the comma that separates it from the next component. For instance, this is currently disallowed:
```
{x: 0u8 , y: 1u8}
```
because of the space between `0u8` and `,`. Regardless of whether it is good or bad style to put a space there, other parts of the Aleo instruction syntax allow whitespace just before separators like commas or colons. Thus, this PR allows that.
