### PR TITLE
Use SmolStr in FromBytesVisitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,6 +2470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "snarkvm"
 version = "0.14.6"
 dependencies = [
@@ -3355,6 +3364,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "smol_str",
  "snarkvm-utilities-derives",
  "thiserror",
 ]

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -62,6 +62,9 @@ default-features = false
 version = "1.0"
 features = [ "preserve_order" ]
 
+[dependencies.smol_str]
+version = "0.2"
+
 [dependencies.thiserror]
 version = "1.0"
 

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -25,6 +25,7 @@ use serde::{
     Deserializer,
     Serializer,
 };
+use smol_str::SmolStr;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 /// Takes as input a sequence of structs, and converts them to a series of little-endian bytes.
@@ -160,12 +161,12 @@ impl<'de, T: FromBytes> FromBytesDeserializer<T> {
     }
 }
 
-pub struct FromBytesVisitor<'a>(&'a mut Vec<u8>, String, Option<usize>);
+pub struct FromBytesVisitor<'a>(&'a mut Vec<u8>, SmolStr, Option<usize>);
 
 impl<'a> FromBytesVisitor<'a> {
     /// Initializes a new `FromBytesVisitor` with the given `buffer` and `name`.
     pub fn new(buffer: &'a mut Vec<u8>, name: &str) -> Self {
-        Self(buffer, name.to_string(), None)
+        Self(buffer, SmolStr::new(name), None)
     }
 }
 


### PR DESCRIPTION
This is a drive-by from snarkOS performance tests, which revealed a relatively large number of tiny allocations; this PR reduces it by ~30%.

`SmolStr` is similar to `SmallVec`; it can hold up to 23B without allocating, making it a good pick for the short-lived `FromBytesVisitor` object whose `name` is typically short.