### PR TITLE
Preallocate some BHP hash inputs

### DIFF
--- a/console/collections/src/merkle_tree/helpers/leaf_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/leaf_hash.rs
@@ -42,8 +42,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash for 
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `false` bit.
-        let mut input = vec![false];
+        input.push(false);
         input.extend(leaf);
         // Hash the input.
         Hash::hash(self, &input)

--- a/console/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/path_hash.rs
@@ -45,8 +45,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> PathHash for 
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Result<Self::Hash> {
+        let mut input = Vec::with_capacity(1 + <Self::Hash as SizeInBits>::size_in_bits() * 2);
         // Prepend the nodes with a `true` bit.
-        let mut input = vec![true];
+        input.push(true);
         left.write_bits_le(&mut input);
         right.write_bits_le(&mut input);
         // Hash the input.


### PR DESCRIPTION
Another tiny PR with a small reduction in allocations; found via profiling.