### PR TITLE
Avoid single element allocations, explicitly preallocate some vecs

### DIFF
--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -101,7 +101,7 @@ impl<F: Field> DensePolynomial<F> {
         } else if point.is_zero() {
             return self.coeffs[0];
         }
-        let mut powers_of_point = Vec::new();
+        let mut powers_of_point = Vec::with_capacity(1 + self.degree());
         powers_of_point.push(F::one());
         let mut cur = point;
         for _ in 0..self.degree() {

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -101,7 +101,8 @@ impl<F: Field> DensePolynomial<F> {
         } else if point.is_zero() {
             return self.coeffs[0];
         }
-        let mut powers_of_point = vec![F::one()];
+        let mut powers_of_point = Vec::new();
+        powers_of_point.push(F::one());
         let mut cur = point;
         for _ in 0..self.degree() {
             powers_of_point.push(cur);

--- a/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
@@ -37,7 +37,8 @@ impl<F: Field> ConstraintSystem<F> {
     /// Formats the public input according to the requirements of the constraint
     /// system
     pub(crate) fn format_public_input(public_input: &[F]) -> Vec<F> {
-        let mut input = vec![F::one()];
+        let mut input = Vec::new();
+        input.push(F::one());
         input.extend_from_slice(public_input);
         input
     }

--- a/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
@@ -37,7 +37,7 @@ impl<F: Field> ConstraintSystem<F> {
     /// Formats the public input according to the requirements of the constraint
     /// system
     pub(crate) fn format_public_input(public_input: &[F]) -> Vec<F> {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + public_input.len());
         input.push(F::one());
         input.extend_from_slice(public_input);
         input

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -201,7 +201,8 @@ impl<F: PrimeField> Evaluations<F> {
     }
 
     pub fn to_field_elements(&self) -> Vec<F> {
-        let mut result = vec![self.g_1_eval];
+        let mut result = Vec::new();
+        result.push(self.g_1_eval);
         result.extend_from_slice(&self.g_a_evals);
         result.extend_from_slice(&self.g_b_evals);
         result.extend_from_slice(&self.g_c_evals);

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -201,7 +201,7 @@ impl<F: PrimeField> Evaluations<F> {
     }
 
     pub fn to_field_elements(&self) -> Vec<F> {
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(1 + self.g_a_evals.len() + self.g_b_evals.len() + self.g_c_evals.len());
         result.push(self.g_1_eval);
         result.extend_from_slice(&self.g_a_evals);
         result.extend_from_slice(&self.g_b_evals);

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -676,7 +676,8 @@ where
                     .iter()
                     .map(|input| {
                         let input = input.borrow().to_field_elements().unwrap();
-                        let mut new_input = vec![E::Fr::one()];
+                        let mut new_input = Vec::new();
+                        new_input.push(E::Fr::one());
                         new_input.extend_from_slice(&input);
                         new_input.resize(input.len().max(input_domain.size()), E::Fr::zero());
                         if cfg!(debug_assertions) {

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -676,7 +676,7 @@ where
                     .iter()
                     .map(|input| {
                         let input = input.borrow().to_field_elements().unwrap();
-                        let mut new_input = Vec::new();
+                        let mut new_input = Vec::with_capacity(input.len().max(input_domain.size()));
                         new_input.push(E::Fr::one());
                         new_input.extend_from_slice(&input);
                         new_input.resize(input.len().max(input_domain.size()), E::Fr::zero());

--- a/circuit/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
+++ b/circuit/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
@@ -30,7 +30,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash for 
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `false` bit.
         input.push(Boolean::constant(false));
         input.extend_from_slice(leaf);
@@ -45,7 +45,7 @@ impl<E: Environment, const RATE: usize> LeafHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `0field` element.
         input.push(Self::Hash::zero());
         input.extend_from_slice(leaf);
@@ -60,7 +60,7 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> LeafHash for Keccak<E
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `false` bit.
         input.push(Boolean::constant(false));
         input.extend_from_slice(leaf);

--- a/circuit/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
+++ b/circuit/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
@@ -30,8 +30,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash for 
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the leaf with a `false` bit.
-        let mut input = vec![Boolean::constant(false)];
+        input.push(Boolean::constant(false));
         input.extend_from_slice(leaf);
         // Hash the input.
         Hash::hash(self, &input)
@@ -44,8 +45,9 @@ impl<E: Environment, const RATE: usize> LeafHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the leaf with a `0field` element.
-        let mut input = vec![Self::Hash::zero()];
+        input.push(Self::Hash::zero());
         input.extend_from_slice(leaf);
         // Hash the input.
         Hash::hash(self, &input)
@@ -58,8 +60,9 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> LeafHash for Keccak<E
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the leaf with a `false` bit.
-        let mut input = vec![Boolean::constant(false)];
+        input.push(Boolean::constant(false));
         input.extend_from_slice(leaf);
         // Hash the input.
         let output = Hash::hash(self, &input);

--- a/circuit/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/circuit/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -58,7 +58,7 @@ impl<E: Environment, const RATE: usize> PathHash<E> for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Self::Hash {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + children.len());
         // Prepend the nodes with a `1field` byte.
         input.push(Self::Hash::one());
         for child in children {

--- a/circuit/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/circuit/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -41,8 +41,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> PathHash<E> f
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the nodes with a `true` bit.
-        let mut input = vec![Boolean::constant(true)];
+        input.push(Boolean::constant(true));
         for child in children {
             child.write_bits_le(&mut input);
         }
@@ -57,8 +58,9 @@ impl<E: Environment, const RATE: usize> PathHash<E> for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the nodes with a `1field` byte.
-        let mut input = vec![Self::Hash::one()];
+        input.push(Self::Hash::one());
         for child in children {
             input.push(child.clone());
         }
@@ -73,8 +75,9 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> PathHash<E> for Kecca
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the nodes with a `true` bit.
-        let mut input = vec![Boolean::constant(true)];
+        input.push(Boolean::constant(true));
         for child in children {
             child.write_bits_le(&mut input);
         }

--- a/circuit/collections/src/merkle_tree/helpers/leaf_hash.rs
+++ b/circuit/collections/src/merkle_tree/helpers/leaf_hash.rs
@@ -30,8 +30,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash<E> f
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the leaf with a `false` bit.
-        let mut input = vec![Boolean::constant(false)];
+        input.push(Boolean::constant(false));
         input.extend_from_slice(leaf);
         // Hash the input.
         Hash::hash(self, &input)
@@ -44,8 +45,9 @@ impl<E: Environment, const RATE: usize> LeafHash<E> for Poseidon<E, RATE> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the leaf with a `0field` element.
-        let mut input = vec![Self::Hash::zero()];
+        input.push(Self::Hash::zero());
         input.extend_from_slice(leaf);
         // Hash the input.
         Hash::hash(self, &input)

--- a/circuit/collections/src/merkle_tree/helpers/leaf_hash.rs
+++ b/circuit/collections/src/merkle_tree/helpers/leaf_hash.rs
@@ -30,7 +30,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash<E> f
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `false` bit.
         input.push(Boolean::constant(false));
         input.extend_from_slice(leaf);
@@ -45,7 +45,7 @@ impl<E: Environment, const RATE: usize> LeafHash<E> for Poseidon<E, RATE> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Self::Hash {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `0field` element.
         input.push(Self::Hash::zero());
         input.extend_from_slice(leaf);

--- a/circuit/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/circuit/collections/src/merkle_tree/helpers/path_hash.rs
@@ -33,8 +33,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> PathHash<E> f
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the nodes with a `true` bit.
-        let mut input = vec![Boolean::constant(true)];
+        input.push(Boolean::constant(true));
         left.write_bits_le(&mut input);
         right.write_bits_le(&mut input);
         // Hash the input.
@@ -47,8 +48,9 @@ impl<E: Environment, const RATE: usize> PathHash<E> for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
+        let mut input = Vec::new();
         // Prepend the nodes with a `1field` byte.
-        let mut input = vec![Self::Hash::one()];
+        input.push(Self::Hash::one());
         input.push(left.clone());
         input.push(right.clone());
         // Hash the input.

--- a/circuit/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/circuit/collections/src/merkle_tree/helpers/path_hash.rs
@@ -48,7 +48,7 @@ impl<E: Environment, const RATE: usize> PathHash<E> for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(3);
         // Prepend the nodes with a `1field` byte.
         input.push(Self::Hash::one());
         input.push(left.clone());

--- a/circuit/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/circuit/collections/src/merkle_tree/helpers/path_hash.rs
@@ -48,13 +48,10 @@ impl<E: Environment, const RATE: usize> PathHash<E> for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
-        let mut input = Vec::with_capacity(3);
         // Prepend the nodes with a `1field` byte.
-        input.push(Self::Hash::one());
-        input.push(left.clone());
-        input.push(right.clone());
+        let input = &[Self::Hash::one(), left.clone(), right.clone()];
         // Hash the input.
-        Hash::hash(self, &input)
+        Hash::hash(self, input)
     }
 }
 

--- a/circuit/program/src/request/verify.rs
+++ b/circuit/program/src/request/verify.rs
@@ -144,7 +144,8 @@ impl<A: Aleo> Request<A> {
                         // Prepare the index as a constant field element.
                         let input_index = Field::constant(console::Field::from_u16(index as u16));
                         // Construct the preimage as `(function ID || input || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(input.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(input_index);
@@ -167,7 +168,8 @@ impl<A: Aleo> Request<A> {
                         // Prepare the index as a constant field element.
                         let input_index = Field::constant(console::Field::from_u16(index as u16));
                         // Construct the preimage as `(function ID || input || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(input.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(input_index);
@@ -276,7 +278,8 @@ impl<A: Aleo> Request<A> {
                         // Prepare the index as a constant field element.
                         let input_index = Field::constant(console::Field::from_u16(index as u16));
                         // Construct the preimage as `(function ID || input || tvk || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(record.to_fields());
                         preimage.push(tvk.clone());
                         preimage.push(input_index);

--- a/circuit/program/src/response/from_outputs.rs
+++ b/circuit/program/src/response/from_outputs.rs
@@ -44,7 +44,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(output_index);
@@ -63,7 +64,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(output_index);
@@ -130,7 +132,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tvk || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tvk.clone());
                         preimage.push(output_index);
@@ -148,7 +151,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(output_index);

--- a/circuit/program/src/response/process_outputs_from_callback.rs
+++ b/circuit/program/src/response/process_outputs_from_callback.rs
@@ -46,7 +46,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(output_index);
@@ -70,7 +71,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(output_index);
@@ -134,7 +136,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tvk || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tvk.clone());
                         preimage.push(output_index);
@@ -157,7 +160,8 @@ impl<A: Aleo> Response<A> {
                         // Prepare the index as a constant field element.
                         let output_index = Field::constant(console::Field::from_u16((num_inputs + index) as u16));
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id.clone()];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id.clone());
                         preimage.extend(output.to_fields());
                         preimage.push(tcm.clone());
                         preimage.push(output_index);

--- a/console/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
@@ -43,8 +43,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash for 
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
+        let mut input = Vec::new();
         // Prepend the leaf with a `false` bit.
-        let mut input = vec![false];
+        input.push(false);
         input.extend(leaf);
         // Hash the input.
         Hash::hash(self, &input)
@@ -57,8 +58,9 @@ impl<E: Environment, const RATE: usize> LeafHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
+        let mut input = Vec::new();
         // Prepend the leaf with a `0field` element.
-        let mut input = vec![Self::Hash::zero()];
+        input.push(Self::Hash::zero());
         input.extend(leaf);
         // Hash the input.
         Hash::hash(self, &input)
@@ -71,8 +73,9 @@ impl<const TYPE: u8, const VARIANT: usize> LeafHash for Keccak<TYPE, VARIANT> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
+        let mut input = Vec::new();
         // Prepend the leaf with a `false` bit.
-        let mut input = vec![false];
+        input.push(false);
         input.extend(leaf);
         // Hash the input.
         let output = Hash::hash(self, &input)?;

--- a/console/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
@@ -43,7 +43,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> LeafHash for 
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `false` bit.
         input.push(false);
         input.extend(leaf);
@@ -58,7 +58,7 @@ impl<E: Environment, const RATE: usize> LeafHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `0field` element.
         input.push(Self::Hash::zero());
         input.extend(leaf);
@@ -73,7 +73,7 @@ impl<const TYPE: u8, const VARIANT: usize> LeafHash for Keccak<TYPE, VARIANT> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `false` bit.
         input.push(false);
         input.extend(leaf);

--- a/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -47,8 +47,9 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> PathHash for 
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Result<Self::Hash> {
+        let mut input = Vec::new();
         // Prepend the nodes with a `true` bit.
-        let mut input = vec![true];
+        input.push(true);
         for child in children {
             child.write_bits_le(&mut input);
         }
@@ -62,8 +63,9 @@ impl<E: Environment, const RATE: usize> PathHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Result<Self::Hash> {
+        let mut input = Vec::new();
         // Prepend the nodes with a `1field` byte.
-        let mut input = vec![Self::Hash::one()];
+        input.push(Self::Hash::one());
         for child in children {
             input.push(*child);
         }
@@ -77,8 +79,9 @@ impl<const TYPE: u8, const VARIANT: usize> PathHash for Keccak<TYPE, VARIANT> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Result<Self::Hash> {
+        let mut input = Vec::new();
         // Prepend the nodes with a `true` bit.
-        let mut input = vec![true];
+        input.push(true);
         for child in children {
             input.extend_from_slice(child.as_slice());
         }

--- a/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -63,7 +63,7 @@ impl<E: Environment, const RATE: usize> PathHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, children: &[Self::Hash]) -> Result<Self::Hash> {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(1 + children.len());
         // Prepend the nodes with a `1field` byte.
         input.push(Self::Hash::one());
         for child in children {

--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -119,7 +119,8 @@ impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: 
         for _ in 0..padding_depth {
             // Update the root hash, by hashing the current root hash with the empty hashes.
 
-            let mut input = vec![root_hash];
+            let mut input = Vec::new();
+            input.push(root_hash);
             // Resize the vector to ARITY length, filling with empty_hash if necessary.
             input.resize(ARITY as usize, empty_hash);
 

--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -119,7 +119,7 @@ impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: 
         for _ in 0..padding_depth {
             // Update the root hash, by hashing the current root hash with the empty hashes.
 
-            let mut input = Vec::new();
+            let mut input = Vec::with_capacity(ARITY as usize);
             input.push(root_hash);
             // Resize the vector to ARITY length, filling with empty_hash if necessary.
             input.resize(ARITY as usize, empty_hash);

--- a/console/collections/src/merkle_tree/helpers/leaf_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/leaf_hash.rs
@@ -57,8 +57,9 @@ impl<E: Environment, const RATE: usize> LeafHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given leaf node.
     fn hash_leaf(&self, leaf: &Self::Leaf) -> Result<Self::Hash> {
+        let mut input = Vec::with_capacity(1 + leaf.len());
         // Prepend the leaf with a `0field` element.
-        let mut input = vec![Self::Hash::zero(); 1];
+        input.push(Self::Hash::zero());
         input.extend(leaf);
         // Hash the input.
         Hash::hash(self, &input)

--- a/console/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/path_hash.rs
@@ -60,8 +60,9 @@ impl<E: Environment, const RATE: usize> PathHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Result<Self::Hash> {
+        let mut input = Vec::new();
         // Prepend the nodes with a `1field` byte.
-        let mut input = vec![Self::Hash::one()];
+        input.push(Self::Hash::one());
         input.push(*left);
         input.push(*right);
         // Hash the input.

--- a/console/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/path_hash.rs
@@ -60,12 +60,9 @@ impl<E: Environment, const RATE: usize> PathHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Result<Self::Hash> {
-        let mut input = Vec::with_capacity(3);
         // Prepend the nodes with a `1field` byte.
-        input.push(Self::Hash::one());
-        input.push(*left);
-        input.push(*right);
+        let input = &[Self::Hash::one(), *left, *right];
         // Hash the input.
-        Hash::hash(self, &input)
+        Hash::hash(self, input)
     }
 }

--- a/console/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/path_hash.rs
@@ -60,7 +60,7 @@ impl<E: Environment, const RATE: usize> PathHash for Poseidon<E, RATE> {
 
     /// Returns the hash of the given child nodes.
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Result<Self::Hash> {
-        let mut input = Vec::new();
+        let mut input = Vec::with_capacity(3);
         // Prepend the nodes with a `1field` byte.
         input.push(Self::Hash::one());
         input.push(*left);

--- a/console/collections/src/merkle_tree/mod.rs
+++ b/console/collections/src/merkle_tree/mod.rs
@@ -333,7 +333,8 @@ impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>
         lap!(timer, "Hashed {} new leaves", leaf_hashes.len());
 
         // Store the updated hashes by level.
-        let mut updated_hashes = vec![leaf_hashes];
+        let mut updated_hashes = Vec::new();
+        updated_hashes.push(leaf_hashes);
 
         // A helper function to compute the path hashes for a given level.
         type Update<PH> = (usize, (<PH as PathHash>::Hash, <PH as PathHash>::Hash));

--- a/console/program/src/data_types/array_type/bytes.rs
+++ b/console/program/src/data_types/array_type/bytes.rs
@@ -50,7 +50,8 @@ impl<N: Network> ToBytes for ArrayType<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Initialize the components to serialize.
         let mut element_type = *self.element_type.clone();
-        let mut lengths = vec![*self.length()];
+        let mut lengths = Vec::new();
+        lengths.push(*self.length());
 
         // Collect the each dimension of the array.
         // Note that the lengths are in the order of the outermost dimension to the innermost dimension.

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -97,7 +97,8 @@ impl<N: Network> Request<N> {
                     // Construct the (console) input index as a field element.
                     let index = Field::from_u16(u16::try_from(index).or_halt_with::<N>("Input index exceeds u16"));
                     // Construct the preimage as `(function ID || input || tcm || index)`.
-                    let mut preimage = vec![function_id];
+                    let mut preimage = Vec::new();
+                    preimage.push(function_id);
                     preimage.extend(input.to_fields()?);
                     preimage.push(tcm);
                     preimage.push(index);
@@ -117,7 +118,8 @@ impl<N: Network> Request<N> {
                     // Construct the (console) input index as a field element.
                     let index = Field::from_u16(u16::try_from(index).or_halt_with::<N>("Input index exceeds u16"));
                     // Construct the preimage as `(function ID || input || tcm || index)`.
-                    let mut preimage = vec![function_id];
+                    let mut preimage = Vec::new();
+                    preimage.push(function_id);
                     preimage.extend(input.to_fields()?);
                     preimage.push(tcm);
                     preimage.push(index);
@@ -195,7 +197,8 @@ impl<N: Network> Request<N> {
                     // Construct the (console) input index as a field element.
                     let index = Field::from_u16(u16::try_from(index).or_halt_with::<N>("Input index exceeds u16"));
                     // Construct the preimage as `(function ID || input || tvk || index)`.
-                    let mut preimage = vec![function_id];
+                    let mut preimage = Vec::new();
+                    preimage.push(function_id);
                     preimage.extend(input.to_fields()?);
                     preimage.push(tvk);
                     preimage.push(index);

--- a/console/program/src/request/verify.rs
+++ b/console/program/src/request/verify.rs
@@ -88,7 +88,8 @@ impl<N: Network> Request<N> {
                         // Construct the (console) input index as a field element.
                         let index = Field::from_u16(u16::try_from(index).or_halt_with::<N>("Input index exceeds u16"));
                         // Construct the preimage as `(function ID || input || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(input.to_fields()?);
                         preimage.push(self.tcm);
                         preimage.push(index);
@@ -108,7 +109,8 @@ impl<N: Network> Request<N> {
                         // Construct the (console) input index as a field element.
                         let index = Field::from_u16(u16::try_from(index).or_halt_with::<N>("Input index exceeds u16"));
                         // Construct the preimage as `(function ID || input || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(input.to_fields()?);
                         preimage.push(self.tcm);
                         preimage.push(index);
@@ -194,7 +196,8 @@ impl<N: Network> Request<N> {
                         // Construct the (console) input index as a field element.
                         let index = Field::from_u16(u16::try_from(index).or_halt_with::<N>("Input index exceeds u16"));
                         // Construct the preimage as `(function ID || input || tvk || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(input.to_fields()?);
                         preimage.push(self.tvk);
                         preimage.push(index);

--- a/console/program/src/response/mod.rs
+++ b/console/program/src/response/mod.rs
@@ -82,7 +82,8 @@ impl<N: Network> Response<N> {
                             u16::try_from(num_inputs + index).or_halt_with::<N>("Output index exceeds u16"),
                         );
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(output.to_fields()?);
                         preimage.push(*tcm);
                         preimage.push(index);
@@ -102,7 +103,8 @@ impl<N: Network> Response<N> {
                             u16::try_from(num_inputs + index).or_halt_with::<N>("Output index exceeds u16"),
                         );
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(output.to_fields()?);
                         preimage.push(*tcm);
                         preimage.push(index);
@@ -176,7 +178,8 @@ impl<N: Network> Response<N> {
                             u16::try_from(num_inputs + index).or_halt_with::<N>("Output index exceeds u16"),
                         );
                         // Construct the preimage as `(function ID || output || tvk || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(output.to_fields()?);
                         preimage.push(*tvk);
                         preimage.push(index);
@@ -196,7 +199,8 @@ impl<N: Network> Response<N> {
                             u16::try_from(num_inputs + index).or_halt_with::<N>("Output index exceeds u16"),
                         );
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(output.to_fields()?);
                         preimage.push(*tcm);
                         preimage.push(index);

--- a/ledger/block/src/transition/input/mod.rs
+++ b/ledger/block/src/transition/input/mod.rs
@@ -115,7 +115,8 @@ impl<N: Network> Input<N> {
                         // Construct the (console) input index as a field element.
                         let index = Field::from_u16(index as u16);
                         // Construct the preimage as `(function ID || input || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(fields);
                         preimage.push(*tcm);
                         preimage.push(index);
@@ -134,7 +135,8 @@ impl<N: Network> Input<N> {
                         // Construct the (console) input index as a field element.
                         let index = Field::from_u16(index as u16);
                         // Construct the preimage as `(function ID || input || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(fields);
                         preimage.push(*tcm);
                         preimage.push(index);

--- a/ledger/block/src/transition/mod.rs
+++ b/ledger/block/src/transition/mod.rs
@@ -225,7 +225,8 @@ impl<N: Network> Transition<N> {
                         // Construct the (console) output index as a field element.
                         let index = Field::from_u16(u16::try_from(num_inputs + index)?);
                         // Construct the preimage as `(function ID || output || tvk || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(record.to_fields()?);
                         preimage.push(*request.tvk());
                         preimage.push(index);

--- a/ledger/block/src/transition/output/mod.rs
+++ b/ledger/block/src/transition/output/mod.rs
@@ -164,7 +164,8 @@ impl<N: Network> Output<N> {
                         // Construct the (console) output index as a field element.
                         let index = Field::from_u16(index as u16);
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(fields);
                         preimage.push(*tcm);
                         preimage.push(index);
@@ -183,7 +184,8 @@ impl<N: Network> Output<N> {
                         // Construct the (console) output index as a field element.
                         let index = Field::from_u16(index as u16);
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(fields);
                         preimage.push(*tcm);
                         preimage.push(index);
@@ -216,7 +218,8 @@ impl<N: Network> Output<N> {
                         // Construct the (future) output index as a field element.
                         let index = Field::from_u16(index as u16);
                         // Construct the preimage as `(function ID || output || tcm || index)`.
-                        let mut preimage = vec![function_id];
+                        let mut preimage = Vec::new();
+                        preimage.push(function_id);
                         preimage.extend(fields);
                         preimage.push(*tcm);
                         preimage.push(index);


### PR DESCRIPTION
This PR consists of 2 commits: the first one avoids single-element vector allocations, and the other fully preallocates for the expected length of some those vectors.