### PR TITLE
Wrap DataMap in an Arc internally

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -138,13 +138,13 @@ impl Database for RocksDB {
         context.extend_from_slice(&(map_id.into()).to_le_bytes());
 
         // Return the DataMap.
-        Ok(DataMap {
+        Ok(DataMap(Arc::new(InnerDataMap {
             database,
             context,
             batch_in_progress: Default::default(),
             atomic_batch: Default::default(),
             checkpoints: Default::default(),
-        })
+        })))
     }
 }
 
@@ -204,13 +204,13 @@ impl RocksDB {
         context.extend_from_slice(&(map_id.into()).to_le_bytes());
 
         // Return the DataMap.
-        Ok(DataMap {
+        Ok(DataMap(Arc::new(InnerDataMap {
             database,
             context,
             batch_in_progress: Default::default(),
             atomic_batch: Default::default(),
             checkpoints: Default::default(),
-        })
+        })))
     }
 }
 


### PR DESCRIPTION
Clones of `DataMap`s are popping up as sources of many tiny allocations in heap profiles; using an inner `Arc` avoids the deep clones of the `context`, and also reduces the number of atomic operations involved when cloning the map (not just due to the removal of the existing `Arc`s, but also due to omitting the shallow clones otherwise involved when cloning the `database` member).