### PR TITLE
Avoid some more vec allocations

### DIFF
--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -401,6 +401,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
                     .unwrap(); // therefore, the lowest `bits_per_non_top_limb` bits is what we want.
             limbs.push(F::from_bigint(cur_mod_r).unwrap());
             cur.divn(params.bits_per_limb as u32);
+            // Clear the vector after every iteration so its allocation can be reused.
             cur_bits.clear();
         }
 

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -338,15 +338,18 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
 
         let params = get_params(TargetField::size_in_bits(), F::size_in_bits(), ty);
 
+        // Prepare a reusable vector to be used in overhead calculation.
+        let mut num_bits = Vec::new();
+
         let mut i = 0;
         let src_len = src_limbs.len();
         while i < src_len {
             let first = &src_limbs[i];
             let second = if i + 1 < src_len { Some(&src_limbs[i + 1]) } else { None };
 
-            let first_max_bits_per_limb = params.bits_per_limb + crate::overhead!(first.1 + F::one());
+            let first_max_bits_per_limb = params.bits_per_limb + crate::overhead!(first.1 + F::one(), &mut num_bits);
             let second_max_bits_per_limb = if let Some(second) = second {
-                params.bits_per_limb + crate::overhead!(second.1 + F::one())
+                params.bits_per_limb + crate::overhead!(second.1 + F::one(), &mut num_bits)
             } else {
                 0
             };

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -129,7 +129,7 @@ impl<F: PrimeField, const RATE: usize> AlgebraicSponge<F, RATE> for PoseidonSpon
             mode: DuplexSpongeMode::Absorbing { next_absorb_index: 0 },
             adjustment_factor_lookup_table: {
                 let capacity = F::size_in_bits() - 1;
-                let mut table = Vec::<F>::new();
+                let mut table = Vec::<F>::with_capacity(capacity);
 
                 let mut cur = F::one();
                 for _ in 0..capacity {

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -139,7 +139,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
         circuit_commitments: impl Iterator<Item = &'a [crate::polycommit::sonic_pc::Commitment<E>]>,
     ) -> FS {
         let mut sponge = FS::new_with_parameters(fs_parameters);
-        sponge.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME].unwrap());
+        sponge.absorb_bytes(Self::PROTOCOL_NAME);
         for (batch_size, inputs) in inputs_and_batch_sizes.values() {
             sponge.absorb_bytes(&(u64::try_from(*batch_size).unwrap()).to_le_bytes());
             for input in inputs.iter() {

--- a/algorithms/src/traits/algebraic_sponge.rs
+++ b/algorithms/src/traits/algebraic_sponge.rs
@@ -100,10 +100,11 @@ pub(crate) mod nonnative_params {
     /// A macro for computing ceil(log2(x))+1 for a field element x
     #[macro_export]
     macro_rules! overhead {
-        ($x:expr) => {{
+        ($x:expr, $num_bits:expr) => {{
             use snarkvm_utilities::ToBits;
             let num = $x;
-            let num_bits = num.to_bigint().to_bits_be();
+            let num_bits = $num_bits;
+            num.to_bigint().write_bits_be(num_bits);
             let mut skipped_bits = 0;
             for b in num_bits.iter() {
                 if *b == false {
@@ -120,7 +121,12 @@ pub(crate) mod nonnative_params {
                 }
             }
 
-            if is_power_of_2 { num_bits.len() - skipped_bits } else { num_bits.len() - skipped_bits + 1 }
+            let result = if is_power_of_2 { num_bits.len() - skipped_bits } else { num_bits.len() - skipped_bits + 1 };
+
+            // Clear the reusable vector for bits.
+            num_bits.clear();
+
+            result
         }};
     }
 

--- a/algorithms/src/traits/algebraic_sponge.rs
+++ b/algorithms/src/traits/algebraic_sponge.rs
@@ -97,7 +97,9 @@ pub enum DuplexSpongeMode {
 }
 
 pub(crate) mod nonnative_params {
-    /// A macro for computing ceil(log2(x))+1 for a field element x
+    /// A macro for computing ceil(log2(x))+1 for a field element x. The num_bits
+    /// param is expected to be a vector to which the BE bits can be written; it is
+    /// not created here, as reusing it allows us to avoid a lot of allocations.
     #[macro_export]
     macro_rules! overhead {
         ($x:expr, $num_bits:expr) => {{

--- a/algorithms/src/traits/algebraic_sponge.rs
+++ b/algorithms/src/traits/algebraic_sponge.rs
@@ -45,9 +45,9 @@ pub trait AlgebraicSponge<F: PrimeField, const RATE: usize>: Clone + Debug {
     /// Takes in bytes.
     fn absorb_bytes(&mut self, elements: &[u8]) {
         let capacity = F::size_in_bits() - 1;
-        let mut bits = Vec::<bool>::new();
+        let mut bits = Vec::<bool>::with_capacity(elements.len() * 8);
         for elem in elements {
-            bits.append(&mut vec![
+            bits.extend_from_slice(&[
                 elem & 128 != 0,
                 elem & 64 != 0,
                 elem & 32 != 0,

--- a/utilities/src/biginteger/bigint_256.rs
+++ b/utilities/src/biginteger/bigint_256.rs
@@ -256,9 +256,16 @@ impl FromBits for BigInteger256 {
     #[doc = " Returns a `BigInteger` by parsing a slice of bits in big-endian format"]
     #[doc = " and transforms it into a slice of little-endian u64 elements."]
     fn from_bits_be(bits: &[bool]) -> Result<Self> {
-        let mut bits_reversed = bits.to_vec();
-        bits_reversed.reverse();
-        Self::from_bits_le(&bits_reversed)
+        let mut res = Self::default();
+        for (i, bits64) in bits.rchunks(64).enumerate() {
+            let mut acc: u64 = 0;
+            for bit in bits64.iter() {
+                acc <<= 1;
+                acc += *bit as u64;
+            }
+            res.0[i] = acc;
+        }
+        Ok(res)
     }
 }
 

--- a/utilities/src/biginteger/bigint_384.rs
+++ b/utilities/src/biginteger/bigint_384.rs
@@ -261,9 +261,16 @@ impl FromBits for BigInteger384 {
     #[doc = " Returns a `BigInteger` by parsing a slice of bits in big-endian format"]
     #[doc = " and transforms it into a slice of little-endian u64 elements."]
     fn from_bits_be(bits: &[bool]) -> Result<Self> {
-        let mut bits_reversed = bits.to_vec();
-        bits_reversed.reverse();
-        Self::from_bits_le(&bits_reversed)
+        let mut res = Self::default();
+        for (i, bits64) in bits.rchunks(64).enumerate() {
+            let mut acc: u64 = 0;
+            for bit in bits64.iter() {
+                acc <<= 1;
+                acc += *bit as u64;
+            }
+            res.0[i] = acc;
+        }
+        Ok(res)
     }
 }
 impl ToBytes for BigInteger384 {


### PR DESCRIPTION
The first commit is quite trival, as it removes one redundant allocation and adds a full preallocation.

The other commit implements `from_bits_be` for `BigInteger256` and `BigInteger384` without relying on the `from_bits_le` impl, by doing basically the same thing, but in reverse (`chunks + iter + rev` > `rchunks + iter`).

Both were found via heap profiling, with especially the second one having a sizable impact.