### PR TITLE
[zksecurity 06] Explicitly check consistency of proof component lengths

### DIFF
--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -251,19 +251,44 @@ impl<E: PairingEngine> Proof<E> {
         pc_proof: sonic_pc::BatchLCProof<E>,
     ) -> Result<Self, SNARKError> {
         let batch_sizes: Vec<usize> = batch_sizes.into_values().collect();
-        let total_instances = batch_sizes.iter().sum::<usize>();
-        if commitments.witness_commitments.len() != total_instances {
-            return Err(SNARKError::BatchSizeMismatch);
-        }
         Ok(Self { batch_sizes, commitments, evaluations, third_msg, fourth_msg, pc_proof })
     }
 
-    pub fn batch_sizes(&self) -> Result<&[usize], SNARKError> {
+    pub fn batch_sizes(&self) -> &[usize] {
+        &self.batch_sizes
+    }
+
+    /// Check that the number of messages is consistent with our batch size
+    pub fn check_batch_sizes(&self) -> Result<(), SNARKError> {
         let total_instances = self.batch_sizes.iter().sum::<usize>();
         if self.commitments.witness_commitments.len() != total_instances {
             return Err(SNARKError::BatchSizeMismatch);
         }
-        Ok(&self.batch_sizes)
+        let g_comms =
+            [&self.commitments.g_a_commitments, &self.commitments.g_b_commitments, &self.commitments.g_c_commitments];
+        for comms in g_comms {
+            if comms.len() != self.batch_sizes.len() {
+                return Err(SNARKError::BatchSizeMismatch);
+            }
+        }
+        let g_evals = [&self.evaluations.g_a_evals, &self.evaluations.g_b_evals, &self.evaluations.g_c_evals];
+        for evals in g_evals {
+            if evals.len() != self.batch_sizes.len() {
+                return Err(SNARKError::BatchSizeMismatch);
+            }
+        }
+        if self.third_msg.sums.len() != self.batch_sizes.len() {
+            return Err(SNARKError::BatchSizeMismatch);
+        }
+        for (msg, &batch_size) in self.third_msg.sums.iter().zip(self.batch_sizes.iter()) {
+            if msg.len() != batch_size {
+                return Err(SNARKError::BatchSizeMismatch);
+            }
+        }
+        if self.fourth_msg.sums.len() != self.batch_sizes.len() {
+            return Err(SNARKError::BatchSizeMismatch);
+        }
+        Ok(())
     }
 }
 

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -618,6 +618,7 @@ where
             prover_fourth_message,
             pc_proof,
         )?;
+        proof.check_batch_sizes()?;
         assert_eq!(proof.pc_proof.is_hiding(), SM::ZK);
 
         end_timer!(prover_time);
@@ -637,7 +638,8 @@ where
             return Err(SNARKError::EmptyBatch);
         }
 
-        let batch_sizes_vec = proof.batch_sizes()?;
+        proof.check_batch_sizes()?;
+        let batch_sizes_vec = proof.batch_sizes();
         let mut batch_sizes = BTreeMap::new();
         for (i, (vk, public_inputs_i)) in keys_to_inputs.iter().enumerate() {
             batch_sizes.insert(vk.id, batch_sizes_vec[i]);


### PR DESCRIPTION
## Motivation

Zksecurity informational finding as defense in depth to prevent amiguous encoding in Fiat-Shamir transcript.

> Recommendation. We recommend adding explicit length checks to all the vectors in the `Proof` (as is currently done
for the public input) to avoid accidentally introducing vulnerabilities in the future if the serialization code changes,
since the serialization/deserialization code might erroneously be considered security non-critical