### PR TITLE
Use an array in IsInstruction, AssertInstruction, CommitInstruction and SignVerify

### DIFF
--- a/synthesizer/program/tests/instruction/assert.rs
+++ b/synthesizer/program/tests/instruction/assert.rs
@@ -37,7 +37,7 @@ fn sample_stack(
     type_b: LiteralType,
     mode_a: circuit::Mode,
     mode_b: circuit::Mode,
-) -> Result<(Stack<CurrentNetwork>, Vec<Operand<CurrentNetwork>>)> {
+) -> Result<(Stack<CurrentNetwork>, [Operand<CurrentNetwork>; 2])> {
     // Initialize the opcode.
     let opcode = opcode.to_string();
 
@@ -68,7 +68,7 @@ fn sample_stack(
     // Initialize the operands.
     let operand_a = Operand::Register(r0);
     let operand_b = Operand::Register(r1);
-    let operands = vec![operand_a, operand_b];
+    let operands = [operand_a, operand_b];
 
     // Initialize the stack.
     let stack = Stack::new(&Process::load()?, &program)?;
@@ -77,7 +77,7 @@ fn sample_stack(
 }
 
 fn check_assert<const VARIANT: u8>(
-    operation: impl FnOnce(Vec<Operand<CurrentNetwork>>) -> AssertInstruction<CurrentNetwork, VARIANT>,
+    operation: impl FnOnce([Operand<CurrentNetwork>; 2]) -> AssertInstruction<CurrentNetwork, VARIANT>,
     opcode: Opcode,
     literal_a: &Literal<CurrentNetwork>,
     literal_b: &Literal<CurrentNetwork>,

--- a/synthesizer/program/tests/instruction/commit.rs
+++ b/synthesizer/program/tests/instruction/commit.rs
@@ -57,7 +57,7 @@ fn sample_stack(
     mode_a: circuit::Mode,
     mode_b: circuit::Mode,
     destination_type: LiteralType,
-) -> Result<(Stack<CurrentNetwork>, Vec<Operand<CurrentNetwork>>, Register<CurrentNetwork>)> {
+) -> Result<(Stack<CurrentNetwork>, [Operand<CurrentNetwork>; 2], Register<CurrentNetwork>)> {
     // Initialize the opcode.
     let opcode = opcode.to_string();
 
@@ -89,7 +89,7 @@ fn sample_stack(
     // Initialize the operands.
     let operand_a = Operand::Register(r0);
     let operand_b = Operand::Register(r1);
-    let operands = vec![operand_a, operand_b];
+    let operands = [operand_a, operand_b];
 
     // Initialize the stack.
     let stack = Stack::new(&Process::load()?, &program)?;
@@ -99,7 +99,7 @@ fn sample_stack(
 
 fn check_commit<const VARIANT: u8>(
     operation: impl FnOnce(
-        Vec<Operand<CurrentNetwork>>,
+        [Operand<CurrentNetwork>; 2],
         Register<CurrentNetwork>,
         LiteralType,
     ) -> CommitInstruction<CurrentNetwork, VARIANT>,

--- a/synthesizer/program/tests/instruction/is.rs
+++ b/synthesizer/program/tests/instruction/is.rs
@@ -47,7 +47,7 @@ fn sample_stack(
     type_b: LiteralType,
     mode_a: circuit::Mode,
     mode_b: circuit::Mode,
-) -> Result<(Stack<CurrentNetwork>, Vec<Operand<CurrentNetwork>>, Register<CurrentNetwork>)> {
+) -> Result<(Stack<CurrentNetwork>, [Operand<CurrentNetwork>; 2], Register<CurrentNetwork>)> {
     // Initialize the opcode.
     let opcode = opcode.to_string();
 
@@ -79,7 +79,7 @@ fn sample_stack(
     // Initialize the operands.
     let operand_a = Operand::Register(r0);
     let operand_b = Operand::Register(r1);
-    let operands = vec![operand_a, operand_b];
+    let operands = [operand_a, operand_b];
 
     // Initialize the stack.
     let stack = Stack::new(&Process::load()?, &program)?;
@@ -88,7 +88,7 @@ fn sample_stack(
 }
 
 fn check_is<const VARIANT: u8>(
-    operation: impl FnOnce(Vec<Operand<CurrentNetwork>>, Register<CurrentNetwork>) -> IsInstruction<CurrentNetwork, VARIANT>,
+    operation: impl FnOnce([Operand<CurrentNetwork>; 2], Register<CurrentNetwork>) -> IsInstruction<CurrentNetwork, VARIANT>,
     opcode: Opcode,
     literal_a: &Literal<CurrentNetwork>,
     literal_b: &Literal<CurrentNetwork>,


### PR DESCRIPTION
Since we only ever use and expect 2 operands in `IsInstruction`, it's both faster and safer to use a fixed-sized array, which is not only faster to clone, but also makes the length checks redundant (as they are enforced at compilation time).