### PR TITLE
[Optimization] Checked Multiplication

### DIFF
--- a/circuit/types/integers/src/mul_checked.rs
+++ b/circuit/types/integers/src/mul_checked.rs
@@ -126,7 +126,7 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
     fn mul_and_check(this: &Integer<E, I>, that: &Integer<E, I>) -> Integer<E, I> {
         // Case 1 - 2 integers fit in 1 field element (u8, u16, u32, u64, i8, i16, i32, i64).
         if 2 * I::BITS < (E::BaseField::size_in_bits() - 1) as u64 {
-            // Instead of multiplying the bits of `self` and `other` directly, witness the integer product directly.
+            // Instead of multiplying the bits of `self` and `other`, witness the integer product.
             let product: Integer<E, I> = witness!(|this, that| this.mul_wrapped(&that));
 
             // Check that the computed product is equal to witnessed product, in the base field.

--- a/circuit/types/integers/src/mul_checked.rs
+++ b/circuit/types/integers/src/mul_checked.rs
@@ -131,9 +131,7 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
 
             // Check that the computed product is equal to witnessed product, in the base field.
             // Note: The multiplication is safe as the field twice as large as the maximum integer type supported.
-            let computed_product = this.to_field() * that.to_field();
-            let witnessed_product = product.to_field();
-            E::assert_eq(&computed_product, &witnessed_product);
+            E::enforce(|| (this.to_field(), that.to_field(), product.to_field()));
 
             product
         }
@@ -196,9 +194,9 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
         b_m_bits.push(Boolean::constant(true));
 
         let b_m = Field::from_bits_le(&b_m_bits);
-        let z_0_concat_z_1 = &z_0 + (&z_1 * &b_m);
+        let z_0_plus_scaled_z_1 = &z_0 + (&z_1 * &b_m);
 
-        let bits_le = z_0_concat_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
+        let bits_le = z_0_plus_scaled_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
 
         // Split the integer bits into product bits and the upper bits of z1.
         let (bits_le, carry) = bits_le.split_at(I::BITS as usize);
@@ -221,13 +219,13 @@ impl<E: Environment, I: IntegerType> Metrics<dyn MulChecked<Integer<E, I>, Outpu
                     (Mode::Constant, _) | (_, Mode::Constant) => {
                         Count::is(4 * I::BITS, 0, (6 * I::BITS) + 4, (6 * I::BITS) + 9)
                     }
-                    (_, _) => Count::is(3 * I::BITS, 0, (8 * I::BITS) + 7, (8 * I::BITS) + 13),
+                    (_, _) => Count::is(3 * I::BITS, 0, (8 * I::BITS) + 6, (8 * I::BITS) + 12),
                 },
                 // Unsigned case
                 false => match (case.0, case.1) {
                     (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
                     (Mode::Constant, _) | (_, Mode::Constant) => Count::is(0, 0, I::BITS, I::BITS + 1),
-                    (_, _) => Count::is(0, 0, I::BITS + 1, I::BITS + 2),
+                    (_, _) => Count::is(0, 0, I::BITS, I::BITS + 1),
                 },
             }
         }

--- a/circuit/types/integers/src/mul_checked.rs
+++ b/circuit/types/integers/src/mul_checked.rs
@@ -90,15 +90,9 @@ impl<E: Environment, I: IntegerType> MulChecked<Self> for Integer<E, I> {
                 None => E::halt("Integer overflow on multiplication of two constants"),
             }
         } else if I::is_signed() {
-            // Multiply the absolute value of `self` and `other` in the base field.
+            // Compute the product of `abs(self)` and `abs(other)`, checking for overflow
             // Note that it is safe to use abs_wrapped since we want Integer::MIN to be interpreted as an unsigned number.
-            let (product, carry) = Self::mul_with_carry(&self.abs_wrapped(), &other.abs_wrapped());
-
-            // We need to check that the abs(a) * abs(b) did not exceed the unsigned maximum.
-            // We do this by checking that none of the carry bits are set.
-            for bit in carry.iter() {
-                E::assert_eq(bit, E::zero());
-            }
+            let product = Self::mul_and_check(&self.abs_wrapped(), &other.abs_wrapped());
 
             // If the product should be positive, then it cannot exceed the signed maximum.
             let operands_same_sign = &self.msb().is_equal(other.msb());
@@ -119,94 +113,100 @@ impl<E: Environment, I: IntegerType> MulChecked<Self> for Integer<E, I> {
             // Return the product of `self` and `other` with the appropriate sign.
             Self::ternary(operands_same_sign, &product, &Self::zero().sub_wrapped(&product))
         } else {
-            // Compute the product of `self` and `other`.
-            let (product, carry) = Self::mul_with_carry(self, other);
+            // Compute the product of `self` and `other`, checking for overflow.
+            Self::mul_and_check(self, other)
+        }
+    }
+}
 
-            // For unsigned multiplication, check that none of the carry bits are set.
+impl<E: Environment, I: IntegerType> Integer<E, I> {
+    /// Multiply the integer bits of `this` and `that`, checking for overflow.
+    /// This function assumes that `this` and `that` are non-negative.
+    #[inline]
+    fn mul_and_check(this: &Integer<E, I>, that: &Integer<E, I>) -> Integer<E, I> {
+        // Case 1 - 2 integers fit in 1 field element (u8, u16, u32, u64, i8, i16, i32, i64).
+        if 2 * I::BITS < (E::BaseField::size_in_bits() - 1) as u64 {
+            // Instead of multiplying the bits of `self` and `other` directly, witness the integer product directly.
+            let product: Integer<E, I> = witness!(|this, that| this.mul_wrapped(&that));
+
+            // Check that the computed product is equal to witnessed product, in the base field.
+            // Note: The multiplication is safe as the field twice as large as the maximum integer type supported.
+            let computed_product = this.to_field() * that.to_field();
+            let witnessed_product = product.to_field();
+            E::assert_eq(&computed_product, &witnessed_product);
+
+            product
+        }
+        // Case 2 - 1.5 integers fit in 1 field element (u128, i128).
+        else if (I::BITS + I::BITS / 2) < (E::BaseField::size_in_bits() - 1) as u64 {
+            // Use Babbage multiplication to compute the product of `self` and `other`.
+            let (product, carry) = Self::babbage_multiply(this, that);
+
+            // Check that the carry bits are all zero.
             for bit in carry.iter() {
                 E::assert_eq(bit, E::zero());
             }
 
             // Return the product of `self` and `other`.
             product
+        } else {
+            E::halt(format!("Multiplication of integers of size {} is not supported", I::BITS))
         }
     }
 }
 
 impl<E: Environment, I: IntegerType> Integer<E, I> {
-    /// Multiply the integer bits of `this` and `that` in the base field,
-    /// returning the carry bits in a separate vector.
-    /// The returned carry bits are not quite the ones whose value is the carry:
-    /// instead, they are the concatenation of the carry bits from two sub-multiplications
-    /// (see the comments in the code for details);
-    /// this is adequate for the current uses of this function,
-    /// where the callers just use the returned carry bits to check that they are all zero.
+    /// Multiply the integer bits of `this` and `that`, returning flag bits indicating whether the product overflowed.
+    /// If any of the flag bits are set, then an overflow occurred.
+    /// This function assumes that 1.5 * I::BITS fits in 1 field element.
     #[inline]
-    pub(super) fn mul_with_carry(this: &Integer<E, I>, that: &Integer<E, I>) -> (Integer<E, I>, Vec<Boolean<E>>) {
-        // Case 1 - 2 integers fit in 1 field element (u8, u16, u32, u64, i8, i16, i32, i64).
-        if 2 * I::BITS < (E::BaseField::size_in_bits() - 1) as u64 {
-            // Instead of multiplying the bits of `self` and `other` directly, the integers are
-            // converted into field elements, multiplied, and the result is converted back to an integer.
-            // Note: This is safe as the field is larger than the maximum integer type supported.
-            let product = (this.to_field() * that.to_field()).to_lower_bits_le(2 * I::BITS as usize);
+    pub(super) fn babbage_multiply(this: &Integer<E, I>, that: &Integer<E, I>) -> (Integer<E, I>, Vec<Boolean<E>>) {
+        // Perform multiplication by decomposing it into operations on its upper and lower bits.
+        // See this page for reference: https://en.wikipedia.org/wiki/Karatsuba_algorithm.
+        // We follow the naming convention given in the `Basic Step` section of the cited page.
+        // Note that currently here we perform Babbage multiplication, not Karatsuba multiplication.
+        let x_1 = Field::from_bits_le(&this.bits_le[(I::BITS as usize / 2)..]);
+        let x_0 = Field::from_bits_le(&this.bits_le[..(I::BITS as usize / 2)]);
+        let y_1 = Field::from_bits_le(&that.bits_le[(I::BITS as usize / 2)..]);
+        let y_0 = Field::from_bits_le(&that.bits_le[..(I::BITS as usize / 2)]);
 
-            // Split the integer bits into product bits and carry bits.
-            let (bits_le, carry) = product.split_at(I::BITS as usize);
+        let z_0 = &x_0 * &y_0;
+        let z_1 = (&x_1 * &y_0) + (&x_0 * &y_1);
 
-            // Return the product of `self` and `other`, along with the carry bits.
-            (Integer::from_bits_le(bits_le), carry.to_vec())
-        }
-        // Case 2 - 1.5 integers fit in 1 field element (u128, i128).
-        else if (I::BITS + I::BITS / 2) < (E::BaseField::size_in_bits() - 1) as u64 {
-            // Perform multiplication by decomposing it into operations on its upper and lower bits.
-            // See this page for reference: https://en.wikipedia.org/wiki/Karatsuba_algorithm.
-            // We follow the naming convention given in the `Basic Step` section of the cited page.
-            // Note that currently here we perform Babbage multiplication, not Karatsuba multiplication.
-            let x_1 = Field::from_bits_le(&this.bits_le[(I::BITS as usize / 2)..]);
-            let x_0 = Field::from_bits_le(&this.bits_le[..(I::BITS as usize / 2)]);
-            let y_1 = Field::from_bits_le(&that.bits_le[(I::BITS as usize / 2)..]);
-            let y_0 = Field::from_bits_le(&that.bits_le[..(I::BITS as usize / 2)]);
+        let mut b_m_bits = vec![Boolean::constant(false); I::BITS as usize / 2];
+        b_m_bits.push(Boolean::constant(true));
 
-            let z_0 = &x_0 * &y_0;
-            let z_1 = (&x_1 * &y_0) + (&x_0 * &y_1);
+        let b_m = Field::from_bits_le(&b_m_bits);
+        let z_0_plus_z_1 = &z_0 + (&z_1 * &b_m);
 
-            let mut b_m_bits = vec![Boolean::constant(false); I::BITS as usize / 2];
-            b_m_bits.push(Boolean::constant(true));
+        let mut bits_le = z_0_plus_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
 
-            let b_m = Field::from_bits_le(&b_m_bits);
-            let z_0_plus_z_1 = &z_0 + (&z_1 * &b_m);
+        // Note that the bits of z2 are appended after the bits of z0_plus_z1.
+        // This means that the bits in bits_le[I::BITS..] are not quite the bits of the carry value of the product,
+        // which should be calculated by adding the bits of z2, suitably shifted, to the bits of z0_plus_z1.
+        // Here is a picture of the bits involved, placed according to the power-of-two weights, in little endian order:
+        //   x0: <--I::BITS/2-->
+        //   x1:                <--I::BITS/2-->
+        //   y0: <--I::BITS/2-->
+        //   y1:                <--I::BITS/2-->
+        //   z0: <-----------I::BITS---------->
+        //   z1:                <-----------I::BITS+1--------->
+        //   z2:                               <-----------I::BITS---------->
+        //                                     |   overlap    |
+        // Note the overlap between the high (carry) bits of z1 and the (all carry) bits of z2;
+        // the bits for the total carry value should be calculated by adding at the overlap,
+        // but instead those bits are concatenated, as if they did not overlap, and returned by this function.
+        // This is actually adequate (and saves constraints),
+        // because currently the only purpose of the carry bits returned by this function
+        // is for the callers to check that they are all zero.
+        let z_2 = &x_1 * &y_1;
+        bits_le.append(&mut z_2.to_lower_bits_le(I::BITS as usize));
 
-            let mut bits_le = z_0_plus_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
+        // Split the integer bits into product bits and carry bits.
+        let (bits_le, carry) = bits_le.split_at(I::BITS as usize);
 
-            // Note that the bits of z2 are appended after the bits of z0_plus_z1.
-            // This means that the bits in bits_le[I::BITS..] are not quite the bits of the carry value of the product,
-            // which should be calculated by adding the bits of z2, suitably shifted, to the bits of z0_plus_z1.
-            // Here is a picture of the bits involved, placed according to the power-of-two weights, in little endian order:
-            //   x0: <--I::BITS/2-->
-            //   x1:                <--I::BITS/2-->
-            //   y0: <--I::BITS/2-->
-            //   y1:                <--I::BITS/2-->
-            //   z0: <-----------I::BITS---------->
-            //   z1:                <-----------I::BITS+1--------->
-            //   z2:                               <-----------I::BITS---------->
-            //                                     |   overlap    |
-            // Note the overlap between the high (carry) bits of z1 and the (all carry) bits of z2;
-            // the bits for the total carry value should be calculated by adding at the overlap,
-            // but instead those bits are concatenated, as if they did not overlap, and returned by this function.
-            // This is actually adequate (and saves constraints),
-            // because currently the only purpose of the carry bits returned by this function
-            // is for the callers to check that they are all zero.
-            let z_2 = &x_1 * &y_1;
-            bits_le.append(&mut z_2.to_lower_bits_le(I::BITS as usize));
-
-            // Split the integer bits into product bits and carry bits.
-            let (bits_le, carry) = bits_le.split_at(I::BITS as usize);
-
-            // Return the product of `self` and `other`, along with the carry bits.
-            (Integer::from_bits_le(bits_le), carry.to_vec())
-        } else {
-            E::halt(format!("Multiplication of integers of size {} is not supported", I::BITS))
-        }
+        // Return the product of `self` and `other`, along with the carry bits.
+        (Integer::from_bits_le(bits_le), carry.to_vec())
     }
 }
 
@@ -221,15 +221,15 @@ impl<E: Environment, I: IntegerType> Metrics<dyn MulChecked<Integer<E, I>, Outpu
                 true => match (case.0, case.1) {
                     (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
                     (Mode::Constant, _) | (_, Mode::Constant) => {
-                        Count::is(4 * I::BITS, 0, (7 * I::BITS) + 4, (8 * I::BITS) + 9)
+                        Count::is(4 * I::BITS, 0, (6 * I::BITS) + 4, (6 * I::BITS) + 9)
                     }
-                    (_, _) => Count::is(3 * I::BITS, 0, (9 * I::BITS) + 7, (10 * I::BITS) + 13),
+                    (_, _) => Count::is(3 * I::BITS, 0, (8 * I::BITS) + 7, (8 * I::BITS) + 13),
                 },
                 // Unsigned case
                 false => match (case.0, case.1) {
                     (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
-                    (Mode::Constant, _) | (_, Mode::Constant) => Count::is(0, 0, 2 * I::BITS, (3 * I::BITS) + 1),
-                    (_, _) => Count::is(0, 0, 2 * I::BITS + 1, (3 * I::BITS) + 2),
+                    (Mode::Constant, _) | (_, Mode::Constant) => Count::is(0, 0, I::BITS, I::BITS + 1),
+                    (_, _) => Count::is(0, 0, I::BITS + 1, I::BITS + 2),
                 },
             }
         }

--- a/circuit/types/integers/src/mul_wrapped.rs
+++ b/circuit/types/integers/src/mul_wrapped.rs
@@ -44,9 +44,9 @@ impl<E: Environment, I: IntegerType> MulWrapped<Self> for Integer<E, I> {
             b_m_bits.push(Boolean::constant(true));
 
             let b_m = Field::from_bits_le(&b_m_bits);
-            let z_0_concat_z_1 = &z_0 + (&z_1 * &b_m);
+            let z_0_plus_scaled_z_1 = &z_0 + (&z_1 * &b_m);
 
-            let mut bits_le = z_0_concat_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
+            let mut bits_le = z_0_plus_scaled_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
 
             // Remove any carry bits.
             bits_le.truncate(I::BITS as usize);

--- a/circuit/types/integers/src/mul_wrapped.rs
+++ b/circuit/types/integers/src/mul_wrapped.rs
@@ -44,9 +44,9 @@ impl<E: Environment, I: IntegerType> MulWrapped<Self> for Integer<E, I> {
             b_m_bits.push(Boolean::constant(true));
 
             let b_m = Field::from_bits_le(&b_m_bits);
-            let z_0_plus_z_1 = &z_0 + (&z_1 * &b_m);
+            let z_0_concat_z_1 = &z_0 + (&z_1 * &b_m);
 
-            let mut bits_le = z_0_plus_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
+            let mut bits_le = z_0_concat_z_1.to_lower_bits_le(I::BITS as usize + I::BITS as usize / 2 + 1);
 
             // Remove any carry bits.
             bits_le.truncate(I::BITS as usize);

--- a/circuit/types/integers/src/pow_checked.rs
+++ b/circuit/types/integers/src/pow_checked.rs
@@ -106,7 +106,7 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
     fn mul_with_flags(this: &Integer<E, I>, that: &Integer<E, I>) -> (Integer<E, I>, Boolean<E>) {
         // Case 1 - 2 integers fit in 1 field element (u8, u16, u32, u64, i8, i16, i32, i64).
         if 2 * I::BITS < (E::BaseField::size_in_bits() - 1) as u64 {
-            // Instead of multiplying the bits of `self` and `other` directly, witness the integer product directly.
+            // Instead of multiplying the bits of `self` and `other`, witness the integer product.
             let product: Integer<E, I> = witness!(|this, that| this.mul_wrapped(&that));
 
             // Check that the computed product is not equal to witnessed product, in the base field.

--- a/circuit/types/integers/src/pow_checked.rs
+++ b/circuit/types/integers/src/pow_checked.rs
@@ -83,7 +83,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> PowChecked<Integer<E, M>> for
                     // Return the product of `self` and `other` with the appropriate sign.
                     Self::ternary(operands_same_sign, &product, &(!&product).add_wrapped(&Self::one()))
                 } else {
-                    let (product, overlow) = Self::mul_with_flags(&result, self);
+                    let (product, overflow) = Self::mul_with_flags(&result, self);
 
                     // For unsigned multiplication, check that the overflow flag is not set.
                     E::assert_eq(overlow & bit, E::zero());

--- a/circuit/types/integers/src/pow_checked.rs
+++ b/circuit/types/integers/src/pow_checked.rs
@@ -61,10 +61,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> PowChecked<Integer<E, M>> for
                 let result_times_self = if I::is_signed() {
                     // Multiply the absolute value of `self` and `other` in the base field.
                     // Note that it is safe to use abs_wrapped since we want Integer::MIN to be interpreted as an unsigned number.
-                    let (product, carry) = Self::mul_with_carry(&(&result).abs_wrapped(), &self.abs_wrapped());
-
-                    // We need to check that the abs(a) * abs(b) did not exceed the unsigned maximum.
-                    let carry_bits_nonzero = carry.iter().fold(Boolean::constant(false), |a, b| a | b);
+                    let (product, overflow) = Self::mul_with_flags(&(&result).abs_wrapped(), &self.abs_wrapped());
 
                     // If the product should be positive, then it cannot exceed the signed maximum.
                     let operands_same_sign = &result.msb().is_equal(self.msb());
@@ -80,17 +77,16 @@ impl<E: Environment, I: IntegerType, M: Magnitude> PowChecked<Integer<E, M>> for
                         !operands_same_sign & !negative_product_lt_or_eq_signed_min
                     };
 
-                    let overflow = carry_bits_nonzero | positive_product_overflows | negative_product_underflows;
+                    let overflow = overflow | positive_product_overflows | negative_product_underflows;
                     E::assert_eq(overflow & bit, E::zero());
 
                     // Return the product of `self` and `other` with the appropriate sign.
                     Self::ternary(operands_same_sign, &product, &(!&product).add_wrapped(&Self::one()))
                 } else {
-                    let (product, carry) = Self::mul_with_carry(&result, self);
+                    let (product, overlow) = Self::mul_with_flags(&result, self);
 
-                    // For unsigned multiplication, check that the none of the carry bits are set.
-                    let overflow = carry.iter().fold(Boolean::constant(false), |a, b| a | b);
-                    E::assert_eq(overflow & bit, E::zero());
+                    // For unsigned multiplication, check that the overflow flag is not set.
+                    E::assert_eq(overlow & bit, E::zero());
 
                     // Return the product of `self` and `other`.
                     product
@@ -99,6 +95,43 @@ impl<E: Environment, I: IntegerType, M: Magnitude> PowChecked<Integer<E, M>> for
                 result = Self::ternary(bit, &result_times_self, &result);
             }
             result
+        }
+    }
+}
+
+impl<E: Environment, I: IntegerType> Integer<E, I> {
+    /// Multiply the integer bits of `this` and `that`, returning a flag indicating whether the product overflowed.
+    /// This method assumes that the `this` and `that` are both positive.
+    #[inline]
+    fn mul_with_flags(this: &Integer<E, I>, that: &Integer<E, I>) -> (Integer<E, I>, Boolean<E>) {
+        // Case 1 - 2 integers fit in 1 field element (u8, u16, u32, u64, i8, i16, i32, i64).
+        if 2 * I::BITS < (E::BaseField::size_in_bits() - 1) as u64 {
+            // Instead of multiplying the bits of `self` and `other` directly, witness the integer product directly.
+            let product: Integer<E, I> = witness!(|this, that| this.mul_wrapped(&that));
+
+            // Check that the computed product is not equal to witnessed product, in the base field.
+            // Note: The multiplication is safe as the field twice as large as the maximum integer type supported.
+            let computed_product = this.to_field() * that.to_field();
+            let witnessed_product = product.to_field();
+            let flag = computed_product.is_not_equal(&witnessed_product);
+
+            // Return the product of `self` and `other` and the overflow flag.
+            (product, flag)
+        }
+        // Case 2 - 1.5 integers fit in 1 field element (u128, i128).
+        else if (I::BITS + I::BITS / 2) < (E::BaseField::size_in_bits() - 1) as u64 {
+            // Use Karatsuba multiplication to compute the product of `self` and `other` and the carry bits.
+            let (product, z_1_upper_bits, z2) = Self::karatsuba_multiply(this, that);
+            // Reconstruct the upper bits of z_1 in the field.
+            let z_1_upper_field = Field::from_bits_le(&z_1_upper_bits);
+            // Compute whether the sum of z_1_field and z_2 is zero.
+            let z_1_upper_field_plus_z_2 = &z_1_upper_field + &z2;
+            let flag = z_1_upper_field_plus_z_2.is_equal(&Field::zero());
+
+            // Return the product of `self` and `other` and the overflow flag.
+            (product, flag)
+        } else {
+            E::halt(format!("Multiplication of integers of size {} is not supported", I::BITS))
         }
     }
 }

--- a/circuit/types/integers/src/pow_checked.rs
+++ b/circuit/types/integers/src/pow_checked.rs
@@ -86,7 +86,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> PowChecked<Integer<E, M>> for
                     let (product, overflow) = Self::mul_with_flags(&result, self);
 
                     // For unsigned multiplication, check that the overflow flag is not set.
-                    E::assert_eq(overlow & bit, E::zero());
+                    E::assert_eq(overflow & bit, E::zero());
 
                     // Return the product of `self` and `other`.
                     product


### PR DESCRIPTION
This PR optimizes the checked multiplication circuits in snarkVM by:
- Efficiently using witnesses to reduce constraints for integers smaller than 128 bits.
- Use Karatsuba's algorithm.
- Return flags for overflow, rather than a bit decomposition.

This depends on #2046.

