### PR TITLE
[Optimize] Unsigned checked addition

### DIFF
--- a/circuit/types/integers/src/add_checked.rs
+++ b/circuit/types/integers/src/add_checked.rs
@@ -73,37 +73,38 @@ impl<E: Environment, I: IntegerType> AddChecked<Self> for Integer<E, I> {
                 Some(value) => Integer::constant(console::Integer::new(value)),
                 None => E::halt("Integer overflow on addition of two constants"),
             }
-        } else {
-            // TODO: Optimize
+        } else if I::is_signed() {
             // Instead of adding the bits of `self` and `other` directly, the integers are
             // converted into a field elements, and summed, before converting back to integers.
             // Note: This is safe as the field is larger than the maximum integer type supported.
             let sum = self.to_field() + other.to_field();
 
-            // Extract the integer bits from the field element, with a carry bit.
-            let (sum, carry) = match sum.to_lower_bits_le(I::BITS as usize + 1).split_last() {
-                Some((carry, bits_le)) => (Integer::from_bits_le(bits_le), carry.clone()),
+            // Extract the integer bits from the field element, ignoring the carry bit as it is not relevant for signed addition.
+            let sum = match sum.to_lower_bits_le(I::BITS as usize + 1).split_last() {
+                Some((_, bits_le)) => Integer::from_bits_le(bits_le),
                 // Note: `E::halt` should never be invoked as `I::BITS as usize + 1` is greater than zero.
                 None => E::halt("Malformed sum detected during integer addition"),
             };
 
-            // Check for overflow.
-            match I::is_signed() {
-                // For signed addition, overflow and underflow conditions are:
-                //   - a > 0 && b > 0 && a + b < 0 (Overflow)
-                //   - a < 0 && b < 0 && a + b > 0 (Underflow)
-                //   - Note: if sign(a) != sign(b) then over/underflow is impossible.
-                //   - Note: the result of an overflow and underflow must be negative and positive, respectively.
-                true => {
-                    let is_same_sign = self.msb().is_equal(other.msb());
-                    let is_overflow = is_same_sign & sum.msb().is_not_equal(self.msb());
-                    E::assert_eq(is_overflow, E::zero());
-                }
-                // For unsigned addition, ensure the carry bit is zero.
-                false => E::assert_eq(carry, E::zero()),
-            }
+            // For signed addition, overflow and underflow conditions are:
+            //   - a > 0 && b > 0 && a + b < 0 (Overflow)
+            //   - a < 0 && b < 0 && a + b > 0 (Underflow)
+            //   - Note: if sign(a) != sign(b) then over/underflow is impossible.
+            //   - Note: the result of an overflow and underflow must be negative and positive, respectively.
+            let is_same_sign = self.msb().is_equal(other.msb());
+            let is_overflow = is_same_sign & sum.msb().is_not_equal(self.msb());
+            E::assert_eq(is_overflow, E::zero());
 
-            // Return the sum of `self` and `other`.
+            sum
+        } else {
+            // Instead of adding the bits of `self` and `other` directly, witness the integer sum.
+            let sum: Integer<E, I> = witness!(|self, other| self.add_wrapped(&other));
+
+            // Check that the computed sum is equal to the witnessed sum, in the base field.
+            let computed_sum = self.to_field() + other.to_field();
+            let witnessed_sum = sum.to_field();
+            E::assert_eq(computed_sum, witnessed_sum);
+
             sum
         }
     }
@@ -138,7 +139,7 @@ impl<E: Environment, I: IntegerType> Metrics<dyn AddChecked<Integer<E, I>, Outpu
             },
             false => match (case.0, case.1) {
                 (Mode::Constant, Mode::Constant) => Count::is(I::BITS, 0, 0, 0),
-                (_, _) => Count::is(0, 0, I::BITS + 1, I::BITS + 3),
+                (_, _) => Count::is(0, 0, I::BITS, I::BITS + 1),
             },
         }
     }


### PR DESCRIPTION
This PR optimizes unsigned checked addition by directly witnessing the product and checking that the sum and witness match in the base field.

This PR depends on #2047 
