### PR TITLE
[Optimize] Right shift.

### DIFF
--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -67,7 +67,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
 
                     // Calculate the result directly in the field.
                     // Since 2^{rhs} < Integer::MAX and 2 * I::BITS is less than E::BaseField::size in data bits,
-                    // we know that the operation will not overflow Integer::MAX or the field modulus.
+                    // we know that the operation will not overflow the field modulus.
                     for (i, bit) in rhs.bits_le[..first_upper_bit_index].iter().enumerate() {
                         // In each iteration, multiply the result by 2^(1<<i), if the bit is set.
                         // Note that instantiating the field from a u128 is safe since it is larger than all eligible integer types.

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -73,8 +73,13 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
                         // Note that instantiating the field from a u128 is safe since it is larger than all eligible integer types.
                         let constant = Field::constant(console::Field::from_u128(2u128.pow(1 << i)));
                         let product = &result * &constant;
+
+                        // If `self` is negative, mask the value with 2^{1<<i} - 1.
+                        // For example, in the first, second, and third iterations, the mask is 0b1, 0b11, and 0b111, respectively.
+                        // This serves to appropriately sign-extend the result.
                         let mask = Field::constant(console::Field::from_u128(2u128.pow(1 << i) - 1));
                         let masked = product.add(mask * &msb_field);
+
                         result = Field::ternary(bit, &masked, &result);
                     }
                     // Extract the bits of the result, including the carry bits.

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -56,6 +56,54 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
                 bits_le.reverse();
 
                 Self { bits_le, phantom: Default::default() }
+            } else if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64 {
+                if I::is_signed() {
+                    // Initialize the msb of `self` as a field element.
+                    let msb_field = Field::from((**self.msb()).clone());
+
+                    // The signed right-shift is implemented as an unsigned right-shift followed by a sign-extension.
+                    // Initialize the result from the reversed bits of `self`.
+                    let mut result = Field::from_bits_be(&self.bits_le);
+
+                    // Calculate the result directly in the field.
+                    // Since 2^{rhs} < Integer::MAX and 2 * I::BITS is less than E::BaseField::size in data bits,
+                    // we know that the operation will not overflow Integer::MAX or the field modulus.
+                    for (i, bit) in rhs.bits_le[..first_upper_bit_index].iter().enumerate() {
+                        // In each iteration, multiply the result by 2^(1<<i), if the bit is set.
+                        // Note that instantiating the field from a u128 is safe since it is larger than all eligible integer types.
+                        let constant = Field::constant(console::Field::from_u128(2u128.pow(1 << i)));
+                        let product = &result * &constant;
+                        let mask = Field::constant(console::Field::from_u128(2u128.pow(1 << i) - 1));
+                        let masked = product.add(mask * &msb_field);
+                        result = Field::ternary(bit, &masked, &result);
+                    }
+                    // Extract the bits of the result, including the carry bits.
+                    let mut bits_le = result.to_lower_bits_le(2 * I::BITS as usize)[..I::BITS as usize].to_vec();
+                    // Reverse the bits.
+                    bits_le.reverse();
+                    // Initialize the integer, ignoring the carry bits.
+                    Self { bits_le, phantom: Default::default() }
+                } else {
+                    // The unsigned right-shift is implemented as a left-shift over the reversed bits of `self`.
+                    // Initialize the result from the reversed bits of `self`.
+                    let mut result = Field::from_bits_be(&self.bits_le);
+                    // Calculate the result directly in the field.
+                    // Since 2^{rhs} < Integer::MAX and 2 * I::BITS is less than E::BaseField::size in data bits,
+                    // we know that the operation will not overflow Integer::MAX or the field modulus.
+                    for (i, bit) in rhs.bits_le[..first_upper_bit_index].iter().enumerate() {
+                        // In each iteration, multiply the result by 2^(1<<i), if the bit is set.
+                        // Note that instantiating the field from a u128 is safe since it is larger than all eligible integer types.
+                        let constant = Field::constant(console::Field::from_u128(2u128.pow(1 << i)));
+                        let product = &result * &constant;
+                        result = Field::ternary(bit, &product, &result);
+                    }
+                    // Extract the bits of the result, including the carry bits.
+                    let mut bits_le = result.to_lower_bits_le(2 * I::BITS as usize)[..I::BITS as usize].to_vec();
+                    // Reverse the bits.
+                    bits_le.reverse();
+                    // Initialize the integer, ignoring the carry bits.
+                    Self { bits_le, phantom: Default::default() }
+                }
             } else {
                 // Calculate the value of the shift directly in the field.
                 // Since 2^{rhs} < Integer::MAX, we know that the operation will not overflow Integer::MAX or the field modulus.
@@ -120,16 +168,16 @@ impl<E: Environment, I: IntegerType, M: Magnitude> Metrics<dyn ShrWrapped<Intege
             (_, Mode::Constant) => Count::is(0, 0, 0, 0),
             (Mode::Constant, _) => {
                 match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
-                    (true, true) => Count::less_than(5 * I::BITS, 0, (10 * I::BITS) + (2 * index(I::BITS)) + 11, (10 * I::BITS) + (2 * index(I::BITS)) + 19),
+                    (true, true) => Count::less_than(6 + 2 * index(I::BITS), 0, (2 * I::BITS) + index(I::BITS) + 3, (2 * I::BITS) + index(I::BITS) + 4),
                     (true, false) => Count::less_than(5 * I::BITS, 0, 1752, 1957),
-                    (false, true) => Count::less_than(I::BITS, 0, (4 * I::BITS) + (2 * index(I::BITS)) + 6, (4 * I::BITS) + (2 * index(I::BITS)) + 10),
+                    (false, true) => Count::less_than(3 + index(I::BITS), 0, (2 * I::BITS) + index(I::BITS) + 3, (2 * I::BITS) + index(I::BITS) + 4),
                     (false, false) => Count::less_than(I::BITS, 0, 979, 1180),
                 }
             }
             (_, _) => match (I::is_signed(), 2 * I::BITS < E::BaseField::size_in_data_bits() as u64) {
-                (true, true) => Count::is(4 * I::BITS, 0, (10 * I::BITS) + (2 * index(I::BITS)) + 11, (10 * I::BITS) + (2 * index(I::BITS)) + 19),
+                (true, true) => Count::is(6 + 2 * index(I::BITS), 0, (2 * I::BITS) + index(I::BITS) + 3, (2 * I::BITS) + index(I::BITS) + 4),
                 (true, false) => Count::is(4 * I::BITS, 0, 1752, 1957),
-                (false, true) => Count::is(I::BITS, 0, (4 * I::BITS) + (2 * index(I::BITS)) + 6, (4 * I::BITS) + (2 * index(I::BITS)) + 10),
+                (false, true) => Count::is(3 + index(I::BITS), 0, (2 * I::BITS) + index(I::BITS) + 3, (2 * I::BITS) + index(I::BITS) + 4),
                 (false, false) => Count::is(I::BITS, 0, 979, 1180),
             },
         }

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -89,7 +89,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShrWrapped<Integer<E, M>> for
                     let mut result = Field::from_bits_be(&self.bits_le);
                     // Calculate the result directly in the field.
                     // Since 2^{rhs} < Integer::MAX and 2 * I::BITS is less than E::BaseField::size in data bits,
-                    // we know that the operation will not overflow Integer::MAX or the field modulus.
+                    // we know that the operation will not overflow the field modulus.
                     for (i, bit) in rhs.bits_le[..first_upper_bit_index].iter().enumerate() {
                         // In each iteration, multiply the result by 2^(1<<i), if the bit is set.
                         // Note that instantiating the field from a u128 is safe since it is larger than all eligible integer types.


### PR DESCRIPTION
This PR optimizes right shifts for all integers except for `i/u128`.

This PR depends on #2050 