### PR TITLE
Optimize field (in)equality circuit.

### DIFF
--- a/circuit/types/boolean/src/lib.rs
+++ b/circuit/types/boolean/src/lib.rs
@@ -39,6 +39,13 @@ pub struct Boolean<E: Environment>(LinearCombination<E::BaseField>);
 
 impl<E: Environment> BooleanTrait for Boolean<E> {}
 
+impl<E: Environment> Boolean<E> {
+    /// Initializes a boolean from a variable.
+    pub fn from_variable(var: Variable<E::BaseField>) -> Self {
+        Boolean(var.into())
+    }
+}
+
 #[cfg(console)]
 impl<E: Environment> Inject for Boolean<E> {
     type Primitive = bool;


### PR DESCRIPTION
To calculate `z = x != y`, instead of
```
(z) (1 - z) = (0)
(x - y) (w) = (z)
(x - y) (1 - z) = (0)
```
(where `w` is an internal variable) we just need
```
(x - y) (w) = (z)
(x - y) (1 - z) = (0)
```
i.e. just the 2nd and 3rd constraints, because they imply the 1st one. So we save one constraint for every field (in)equality.

This optimization has been already verified in the ACL2 theorem prover.

To avoid generating the boolean constraint, we need to avoid `Boolean::new`, and instead generate the `Boolean` directly, as in boolean AND for example. However, boolean AND has access to the private `LinearCombination` component of `Boolean`, while field (in)equality does not. So I've added a `from_variable` constructor to `Boolean`, but if there is a better or more desirable approach, we can revise this part.

This PR depends on #2052 
