### PR TITLE
[zksecurity 00 01] Use committing encryption to commit to inputs and outputs

### DIFF
--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -306,8 +306,8 @@ impl<N: Network> CallTrait<N> for Call<N> {
             let tcm = circuit::Field::new(circuit::Mode::Public, *request.tcm());
             // Compute the transition commitment as `Hash(tvk)`.
             let candidate_tcm = A::hash_psd2(&[tvk.clone()]);
-            // Ensure the transition commitment is computed as expected
-            A::assert(tcm.is_equal(&candidate_tcm));
+            // Ensure the transition commitment matches the computed transition commitment.
+            A::assert_eq(&tcm, &candidate_tcm);
             // Inject the input IDs (from the request) as `Mode::Public`.
             let input_ids = request
                 .input_ids()
@@ -331,7 +331,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             );
             A::assert(check_input_ids);
 
-            // Inject the outputs as `Mode::Private` (with the output IDs and tcm as `Mode::Public`).
+            // Inject the outputs as `Mode::Private` (with the 'tcm' and output IDs as `Mode::Public`).
             let outputs = circuit::Response::process_outputs_from_callback(
                 &network_id,
                 &program_id,

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -302,8 +302,12 @@ impl<N: Network> CallTrait<N> for Call<N> {
             let sk_tag = circuit::Field::new(circuit::Mode::Private, *request.sk_tag());
             // Inject the `tvk` (from the request) as `Mode::Private`.
             let tvk = circuit::Field::new(circuit::Mode::Private, *request.tvk());
-            // Inject the `tcm` (from the request) as `Mode::Private`.
-            let tcm = circuit::Field::new(circuit::Mode::Private, *request.tcm());
+            // Inject the `tcm` (from the request) as `Mode::Public`.
+            let tcm = circuit::Field::new(circuit::Mode::Public, *request.tcm());
+            // Compute the transition commitment as `Hash(tvk)`.
+            let candidate_tcm = A::hash_psd2(&[tvk.clone()]);
+            // Ensure the transition commitment is computed as expected
+            A::assert(tcm.is_equal(&candidate_tcm));
             // Inject the input IDs (from the request) as `Mode::Public`.
             let input_ids = request
                 .input_ids()
@@ -327,7 +331,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             );
             A::assert(check_input_ids);
 
-            // Inject the outputs as `Mode::Private` (with the output IDs as `Mode::Public`).
+            // Inject the outputs as `Mode::Private` (with the output IDs and tcm as `Mode::Public`).
             let outputs = circuit::Response::process_outputs_from_callback(
                 &network_id,
                 &program_id,

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -184,6 +184,8 @@ impl<N: Network> Process<N> {
             // Note: This unwrap is safe, as we are processing transitions in post-order,
             // which implies that all child transition IDs have been added to `transition_map`.
             let transition: &&Transition<N> = transition_map.get(transition_id).unwrap();
+            // [Inputs] Extend the verifier inputs with the transition commitment of the external call.
+            inputs.extend([**transition.tcm()]);
             // [Inputs] Extend the verifier inputs with the input IDs of the external call.
             inputs.extend(transition.inputs().iter().flat_map(|input| input.verifier_inputs()));
             // [Inputs] Extend the verifier inputs with the output IDs of the external call.


### PR DESCRIPTION
## Motivation

We were not properly committing to the inputs and outputs of our Requests and Responses.

The issue at hand only arises at the boundary of circuits calling other circuits. So the `check_input_ids(...)` and `process_outputs_from_callback(...)` in call/mod.rs is where this issue appears the first time. We now publicly witness `tcm` of the callee in the caller circuits.

Sidenote: we were already publicly witnessing function's own [request.tcm](https://github.com/AleoHQ/snarkVM/blob/user_committing_encryption/circuit/program/src/request/mod.rs#L148).

## Test Plan

Locally the tests succeed.
