### PR TITLE
Fix an off-by-one in a VarunaSNARK::verify_batch allocation

### DIFF
--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -676,7 +676,7 @@ where
                     .iter()
                     .map(|input| {
                         let input = input.borrow().to_field_elements().unwrap();
-                        let mut new_input = Vec::with_capacity(input.len().max(input_domain.size()));
+                        let mut new_input = Vec::with_capacity((1 + input.len()).max(input_domain.size()));
                         new_input.push(E::Fr::one());
                         new_input.extend_from_slice(&input);
                         new_input.resize(input.len().max(input_domain.size()), E::Fr::zero());


### PR DESCRIPTION
Noticed by @zvolin in https://github.com/AleoHQ/snarkVM/pull/2036.