### PR TITLE
Update `get.or_use` usage in `trasfer_public*` functions

### DIFF
--- a/synthesizer/program/src/resources/credits.aleo
+++ b/synthesizer/program/src/resources/credits.aleo
@@ -621,9 +621,8 @@ finalize transfer_public:
     // Input the amount.
     input r2 as u64.public;
     // Decrements `account[r0]` by `r2`.
-    // If `account[r0]` does not exist, 0u64 is used.
     // If `account[r0] - r2` underflows, `transfer_public` is reverted.
-    get.or_use account[r0] 0u64 into r3;
+    get account[r0] into r3;
     sub r3 r2 into r4;
     set r4 into account[r0];
     // Increments `account[r1]` by `r2`.
@@ -691,7 +690,7 @@ finalize transfer_private_to_public:
     input r0 as address.public;
     // Input the amount.
     input r1 as u64.public;
-    // Retrieve the balance of the sender.
+    // Retrieve the balance of the receiver.
     // If `account[r0]` does not exist, 0u64 is used.
     get.or_use account[r0] 0u64 into r2;
     // Increments `account[r0]` by `r1`.
@@ -727,8 +726,7 @@ finalize transfer_public_to_private:
     // Input the amount.
     input r1 as u64.public;
     // Retrieve the balance of the sender.
-    // If `account[r0]` does not exist, 0u64 is used.
-    get.or_use account[r0] 0u64 into r2;
+    get account[r0] into r2;
     // Decrements `account[r0]` by `r1`.
     // If `r2 - r1` underflows, `transfer_public_to_private` is reverted.
     sub r2 r1 into r3;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the `get.or_use account` usage for senders in both `transfer_public` and `transfer_public_to_private`. This prevents non-initialized addresses from creating 0 transfers.
