### PR TITLE
Merklize `subdag_root` derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ version = "0.15.4"
 dependencies = [
  "bincode",
  "indexmap 2.0.0",
+ "rayon",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-narwhal-batch-certificate",

--- a/console/program/src/state_path/configuration/mod.rs
+++ b/console/program/src/state_path/configuration/mod.rs
@@ -15,6 +15,8 @@
 use snarkvm_console_collections::merkle_tree::MerklePath;
 use snarkvm_console_network::BHPMerkleTree;
 
+/// The depth the Merkle tree for the subdag certificates in a block.
+pub const CERTIFICATES_DEPTH: u8 = 16;
 /// The depth of the Merkle tree for the blocks.
 pub const BLOCKS_DEPTH: u8 = 32;
 /// The depth of the Merkle tree for the block header.

--- a/console/program/src/state_path/configuration/mod.rs
+++ b/console/program/src/state_path/configuration/mod.rs
@@ -15,8 +15,6 @@
 use snarkvm_console_collections::merkle_tree::MerklePath;
 use snarkvm_console_network::BHPMerkleTree;
 
-/// The depth the Merkle tree for the subdag certificates in a block.
-pub const CERTIFICATES_DEPTH: u8 = 16;
 /// The depth of the Merkle tree for the blocks.
 pub const BLOCKS_DEPTH: u8 = 32;
 /// The depth of the Merkle tree for the block header.
@@ -25,6 +23,8 @@ pub const HEADER_DEPTH: u8 = 3;
 pub const FINALIZE_OPERATIONS_DEPTH: u8 = 20;
 /// The depth of the Merkle tree for the ratifications in a block.
 pub const RATIFICATIONS_DEPTH: u8 = 20;
+/// The depth the Merkle tree for the subdag certificates in a block.
+pub const SUBDAG_CERTIFICATES_DEPTH: u8 = 16;
 /// The depth of the Merkle tree for transactions in a block.
 pub const TRANSACTIONS_DEPTH: u8 = 16;
 /// The depth of the Merkle tree for the transaction.

--- a/ledger/block/src/header/verify.rs
+++ b/ledger/block/src/header/verify.rs
@@ -25,6 +25,7 @@ impl<N: Network> Header<N> {
         expected_finalize_root: Field<N>,
         expected_ratifications_root: Field<N>,
         expected_solutions_root: Field<N>,
+        expected_subdag_root: Field<N>,
         expected_round: u64,
         expected_height: u32,
         expected_cumulative_weight: u128,
@@ -72,6 +73,13 @@ impl<N: Network> Header<N> {
             "Solutions root is incorrect in block {expected_height} (found '{}', expected '{}')",
             self.solutions_root,
             expected_solutions_root
+        );
+        // Ensure the subdag root is correct.
+        ensure!(
+            self.subdag_root == expected_subdag_root,
+            "Subdag root is incorrect in block {expected_height} (found '{}', expected '{}')",
+            self.subdag_root,
+            expected_subdag_root
         );
         // Ensure the block metadata is correct.
         self.metadata.verify(

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -148,7 +148,12 @@ impl<N: Network> Block<N> {
         // Ensure that the subdag root matches the authority.
         let subdag_root = match &authority {
             Authority::Beacon(_) => Field::<N>::zero(),
-            Authority::Quorum(subdag) => subdag.leader_certificate().certificate_id(),
+            Authority::Quorum(subdag) => {
+                // Construct the subdag root preimage.
+                let subdag_root_preimage = subdag.certificate_ids().flat_map(|id| id.to_bits_le()).collect::<Vec<_>>();
+                // Compute the subdag root.
+                N::hash_bhp1024(&subdag_root_preimage)?
+            }
         };
         if header.subdag_root() != subdag_root {
             bail!("The subdag root in the block does not correspond to the authority");

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -148,12 +148,7 @@ impl<N: Network> Block<N> {
         // Ensure that the subdag root matches the authority.
         let subdag_root = match &authority {
             Authority::Beacon(_) => Field::<N>::zero(),
-            Authority::Quorum(subdag) => {
-                // Construct the subdag root preimage.
-                let subdag_root_preimage = subdag.certificate_ids().flat_map(|id| id.to_bits_le()).collect::<Vec<_>>();
-                // Compute the subdag root.
-                N::hash_bhp1024(&subdag_root_preimage)?
-            }
+            Authority::Quorum(subdag) => subdag.to_subdag_root()?,
         };
         if header.subdag_root() != subdag_root {
             bail!("The subdag root in the block does not correspond to the authority");

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -65,6 +65,8 @@ impl<N: Network> Block<N> {
         let expected_ratifications_root = self.compute_ratifications_root()?;
         // Compute the expected solutions root.
         let expected_solutions_root = self.compute_solutions_root()?;
+        // Compute the expected subdag root.
+        let expected_subdag_root = self.compute_subdag_root()?;
 
         // Ensure the block header is correct.
         self.header.verify(
@@ -73,6 +75,7 @@ impl<N: Network> Block<N> {
             expected_finalize_root,
             expected_ratifications_root,
             expected_solutions_root,
+            expected_subdag_root,
             expected_round,
             expected_height,
             expected_cumulative_weight,
@@ -458,6 +461,14 @@ impl<N: Network> Block<N> {
         match self.coinbase {
             Some(ref coinbase) => coinbase.to_accumulator_point(),
             None => Ok(Field::zero()),
+        }
+    }
+
+    /// Computes the subdag root for the block.
+    fn compute_subdag_root(&self) -> Result<Field<N>> {
+        match self.authority {
+            Authority::Quorum(ref subdag) => subdag.to_subdag_root(),
+            Authority::Beacon(_) => Ok(Field::zero()),
         }
     }
 

--- a/ledger/narwhal/subdag/Cargo.toml
+++ b/ledger/narwhal/subdag/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = [ ]
+default = [ "indexmap/rayon", "rayon" ]
 serial = [ "console/serial" ]
 wasm = [ "console/wasm" ]
 test-helpers = [ "narwhal-batch-certificate/test-helpers" ]
@@ -50,6 +50,7 @@ features = [ "serde" ]
 
 [dependencies.rayon]
 version = "1"
+optional = true
 
 [dependencies.serde_json]
 version = "1.0"

--- a/ledger/narwhal/subdag/Cargo.toml
+++ b/ledger/narwhal/subdag/Cargo.toml
@@ -48,6 +48,9 @@ version = "=0.15.4"
 version = "2.0"
 features = [ "serde" ]
 
+[dependencies.rayon]
+version = "1"
+
 [dependencies.serde_json]
 version = "1.0"
 features = [ "preserve_order" ]

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -19,7 +19,7 @@ mod bytes;
 mod serialize;
 mod string;
 
-use console::{account::Address, prelude::*, program::CERTIFICATES_DEPTH, types::Field};
+use console::{account::Address, prelude::*, program::SUBDAG_CERTIFICATES_DEPTH, types::Field};
 use narwhal_batch_certificate::BatchCertificate;
 use narwhal_transmission_id::TransmissionID;
 
@@ -142,7 +142,7 @@ impl<N: Network> Subdag<N> {
         // Prepare the leaves.
         let leaves = self.certificate_ids().map(|id| id.to_bits_le());
         // Compute the subdag tree.
-        let tree = N::merkle_tree_bhp::<CERTIFICATES_DEPTH>(&leaves.collect::<Vec<_>>())?;
+        let tree = N::merkle_tree_bhp::<SUBDAG_CERTIFICATES_DEPTH>(&leaves.collect::<Vec<_>>())?;
         // Return the subdag root.
         Ok(*tree.root())
     }

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -19,7 +19,7 @@ mod bytes;
 mod serialize;
 mod string;
 
-use console::{account::Address, prelude::*, types::Field};
+use console::{account::Address, prelude::*, program::CERTIFICATES_DEPTH, types::Field};
 use narwhal_batch_certificate::BatchCertificate;
 use narwhal_transmission_id::TransmissionID;
 
@@ -135,6 +135,16 @@ impl<N: Network> Subdag<N> {
     pub fn timestamp(&self) -> i64 {
         // Retrieve the median timestamp from the leader certificate.
         self.leader_certificate().median_timestamp()
+    }
+
+    /// Returns the subdag root of the transactions.
+    pub fn to_subdag_root(&self) -> Result<Field<N>> {
+        // Prepare the leaves.
+        let leaves = self.certificate_ids().map(|op| op.to_bits_le());
+        // Compute the subdag tree.
+        let tree = N::merkle_tree_bhp::<CERTIFICATES_DEPTH>(&leaves.collect::<Vec<_>>())?;
+        // Return the subdag root.
+        Ok(*tree.root())
     }
 }
 

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -140,7 +140,7 @@ impl<N: Network> Subdag<N> {
     /// Returns the subdag root of the transactions.
     pub fn to_subdag_root(&self) -> Result<Field<N>> {
         // Prepare the leaves.
-        let leaves = self.certificate_ids().map(|op| op.to_bits_le());
+        let leaves = self.certificate_ids().map(|id| id.to_bits_le());
         // Compute the subdag tree.
         let tree = N::merkle_tree_bhp::<CERTIFICATES_DEPTH>(&leaves.collect::<Vec<_>>())?;
         // Return the subdag root.

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -19,7 +19,7 @@ mod bytes;
 mod serialize;
 mod string;
 
-use console::{account::Address, prelude::*};
+use console::{account::Address, prelude::*, types::Field};
 use narwhal_batch_certificate::BatchCertificate;
 use narwhal_transmission_id::TransmissionID;
 
@@ -101,6 +101,11 @@ impl<N: Network> Subdag<N> {
     /// Returns the anchor round.
     pub fn anchor_round(&self) -> u64 {
         self.subdag.iter().next_back().map_or(0, |(round, _)| *round)
+    }
+
+    /// Returns the certificate IDs of the subdag (from earliest round to latest round).
+    pub fn certificate_ids(&self) -> impl Iterator<Item = Field<N>> + '_ {
+        self.values().flatten().map(BatchCertificate::certificate_id)
     }
 
     /// Returns the leader certificate.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -204,7 +204,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Construct the subdag root.
         let subdag_root = match subdag {
-            Some(subdag) => subdag.leader_certificate().certificate_id(),
+            Some(subdag) => {
+                // Construct the subdag root preimage.
+                let subdag_root_preimage = subdag.certificate_ids().flat_map(|id| id.to_bits_le()).collect::<Vec<_>>();
+                // Compute the subdag root.
+                N::hash_bhp1024(&subdag_root_preimage)?
+            }
             None => Field::zero(),
         };
 

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -204,12 +204,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Construct the subdag root.
         let subdag_root = match subdag {
-            Some(subdag) => {
-                // Construct the subdag root preimage.
-                let subdag_root_preimage = subdag.certificate_ids().flat_map(|id| id.to_bits_le()).collect::<Vec<_>>();
-                // Compute the subdag root.
-                N::hash_bhp1024(&subdag_root_preimage)?
-            }
+            Some(subdag) => subdag.to_subdag_root()?,
             None => Field::zero(),
         };
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Update the `subdag_root` derivation from the leader certificate ID to a merkle root, where the leaves are the certificate ids of the subdag.
