### PR TITLE
Fix circuit to create group from coordinates.

### DIFF
--- a/circuit/types/group/src/helpers/from_bits.rs
+++ b/circuit/types/group/src/helpers/from_bits.rs
@@ -82,12 +82,12 @@ mod tests {
 
     #[test]
     fn test_from_bits_le_public() {
-        check_from_bits_le(Mode::Public, 4, 0, 267, 266);
+        check_from_bits_le(Mode::Public, 4, 0, 267, 268);
     }
 
     #[test]
     fn test_from_bits_le_private() {
-        check_from_bits_le(Mode::Private, 4, 0, 267, 266);
+        check_from_bits_le(Mode::Private, 4, 0, 267, 268);
     }
 
     #[test]
@@ -97,11 +97,11 @@ mod tests {
 
     #[test]
     fn test_from_bits_be_public() {
-        check_from_bits_be(Mode::Public, 4, 0, 267, 266);
+        check_from_bits_be(Mode::Public, 4, 0, 267, 268);
     }
 
     #[test]
     fn test_from_bits_be_private() {
-        check_from_bits_be(Mode::Private, 4, 0, 267, 266);
+        check_from_bits_be(Mode::Private, 4, 0, 267, 268);
     }
 }

--- a/circuit/types/group/src/helpers/from_x_coordinate.rs
+++ b/circuit/types/group/src/helpers/from_x_coordinate.rs
@@ -67,11 +67,11 @@ mod tests {
 
     #[test]
     fn test_from_x_coordinate_public() {
-        check_from_x_coordinate(Mode::Public, 4, 0, 15, 13);
+        check_from_x_coordinate(Mode::Public, 4, 0, 15, 15);
     }
 
     #[test]
     fn test_from_x_coordinate_private() {
-        check_from_x_coordinate(Mode::Private, 4, 0, 15, 13);
+        check_from_x_coordinate(Mode::Private, 4, 0, 15, 15);
     }
 }

--- a/circuit/types/group/src/helpers/from_xy_coordinates.rs
+++ b/circuit/types/group/src/helpers/from_xy_coordinates.rs
@@ -23,7 +23,19 @@ impl<E: Environment> Group<E> {
         // Note: We use the **unchecked** ('console::Group::from_xy_coordinates_unchecked') variant
         // here so that the recovery does not halt in witness mode, and subsequently, the point is
         // enforced to be on the curve by injecting with `circuit::Group::new`.
-        witness!(|x, y| console::Group::from_xy_coordinates_unchecked(x, y))
+        let point = witness!(|x, y| console::Group::from_xy_coordinates_unchecked(x, y));
+
+        // Note that `point` above, returned by `witness!`,
+        // consists of new R1CS variables for the x and y components,
+        // unrelated to the `x` and `y` inputs of this `from_xy_coordinates` function.
+        // So we add R1CS constraints to enforce that
+        // the coordinates of `point` are equal to `x` and `y`.
+        // This is not the most efficient circuit,
+        // because it has more variables and constraints than necessary,
+        // but we will look into optimizing this later.
+        E::assert_eq(&x, point.x);
+        E::assert_eq(&y, point.y);
+        point
     }
 
     /// Initializes an affine group element from a given x- and y-coordinate field element.

--- a/circuit/types/group/src/helpers/from_xy_coordinates.rs
+++ b/circuit/types/group/src/helpers/from_xy_coordinates.rs
@@ -35,6 +35,7 @@ impl<E: Environment> Group<E> {
         // but we will look into optimizing this later.
         E::assert_eq(&x, &point.x);
         E::assert_eq(&y, &point.y);
+        
         point
     }
 

--- a/circuit/types/group/src/helpers/from_xy_coordinates.rs
+++ b/circuit/types/group/src/helpers/from_xy_coordinates.rs
@@ -23,7 +23,7 @@ impl<E: Environment> Group<E> {
         // Note: We use the **unchecked** ('console::Group::from_xy_coordinates_unchecked') variant
         // here so that the recovery does not halt in witness mode, and subsequently, the point is
         // enforced to be on the curve by injecting with `circuit::Group::new`.
-        let point = witness!(|x, y| console::Group::from_xy_coordinates_unchecked(x, y));
+        let point: Group<E> = witness!(|x, y| console::Group::from_xy_coordinates_unchecked(x, y));
 
         // Note that `point` above, returned by `witness!`,
         // consists of new R1CS variables for the x and y components,
@@ -33,8 +33,8 @@ impl<E: Environment> Group<E> {
         // This is not the most efficient circuit,
         // because it has more variables and constraints than necessary,
         // but we will look into optimizing this later.
-        E::assert_eq(&x, point.x);
-        E::assert_eq(&y, point.y);
+        E::assert_eq(&x, &point.x);
+        E::assert_eq(&y, &point.y);
         point
     }
 
@@ -110,12 +110,12 @@ mod tests {
 
     #[test]
     fn test_from_xy_coordinates_public() {
-        check_from_xy_coordinates(Mode::Public, 4, 0, 14, 13);
+        check_from_xy_coordinates(Mode::Public, 4, 0, 14, 15);
     }
 
     #[test]
     fn test_from_xy_coordinates_private() {
-        check_from_xy_coordinates(Mode::Private, 4, 0, 14, 13);
+        check_from_xy_coordinates(Mode::Private, 4, 0, 14, 15);
     }
 
     #[test]


### PR DESCRIPTION
This issue was discovered in the circuit to cast a field to a group, but it really affects the sub-circuit of that circuit that turns two field coordinates into a group element. The issue is not in the witness computation, but in the circuit, which generates constraints about the point being in the group (i.e. being on the curve, and being in the subgroup) that apply not to the given point, but to a freshly created point, i.e. two different R1CS variables than the ones given as input. This can be seen by generating sample circuits: there is no connection between the input variables and the point being constrained.

This commit fixes the issue by adding equality constraints that tie the input coordinates with the point that is constrained to be in the (sub)group. This is not the most efficient circuit, because it uses more variables and constraints than needed, but it is a simple fix for now.

This PR depends on #2055 
