### PR TITLE
Fix algorithms dependency version

### DIFF
--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -69,7 +69,7 @@ harness = false
 [dependencies.algorithms]
 package = "snarkvm-algorithms"
 path = "../algorithms"
-version = "=0.15.1"
+version = "=0.15.4"
 
 [dependencies.circuit]
 package = "snarkvm-circuit"


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR is a simple fix where we update the dependency version of `snarkvm-algorithms` to the latest version, `0.15.4`.
