### PR TITLE
Reduce the constraint cost on `Group::from_xy_coordinates`

### DIFF
--- a/circuit/types/group/src/helpers/from_bits.rs
+++ b/circuit/types/group/src/helpers/from_bits.rs
@@ -82,12 +82,12 @@ mod tests {
 
     #[test]
     fn test_from_bits_le_public() {
-        check_from_bits_le(Mode::Public, 4, 0, 267, 268);
+        check_from_bits_le(Mode::Public, 4, 0, 267, 267);
     }
 
     #[test]
     fn test_from_bits_le_private() {
-        check_from_bits_le(Mode::Private, 4, 0, 267, 268);
+        check_from_bits_le(Mode::Private, 4, 0, 267, 267);
     }
 
     #[test]
@@ -97,11 +97,11 @@ mod tests {
 
     #[test]
     fn test_from_bits_be_public() {
-        check_from_bits_be(Mode::Public, 4, 0, 267, 268);
+        check_from_bits_be(Mode::Public, 4, 0, 267, 267);
     }
 
     #[test]
     fn test_from_bits_be_private() {
-        check_from_bits_be(Mode::Private, 4, 0, 267, 268);
+        check_from_bits_be(Mode::Private, 4, 0, 267, 267);
     }
 }

--- a/circuit/types/group/src/helpers/from_x_coordinate.rs
+++ b/circuit/types/group/src/helpers/from_x_coordinate.rs
@@ -67,11 +67,11 @@ mod tests {
 
     #[test]
     fn test_from_x_coordinate_public() {
-        check_from_x_coordinate(Mode::Public, 4, 0, 15, 15);
+        check_from_x_coordinate(Mode::Public, 4, 0, 15, 14);
     }
 
     #[test]
     fn test_from_x_coordinate_private() {
-        check_from_x_coordinate(Mode::Private, 4, 0, 15, 15);
+        check_from_x_coordinate(Mode::Private, 4, 0, 15, 14);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR reduces the constraint cost on `Group::from_xy_coordinates`.

The most notable change in the algorithm is: instead of enforcing `point_inv.enforce_on_curve()`, we now enforce `point.enforce_on_curve()`.