### PR TITLE
Use unconfirmed transaction ids in `check_subdag_transmissions`

### DIFF
--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -19,9 +19,10 @@ use super::*;
 use ledger_coinbase::{CoinbasePuzzle, EpochChallenge};
 use synthesizer_program::FinalizeOperation;
 
+use std::collections::HashSet;
+
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
-use std::collections::HashSet;
 
 impl<N: Network> Block<N> {
     /// Ensures the block is correct.

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -19,6 +19,8 @@ use super::*;
 use ledger_coinbase::{CoinbasePuzzle, EpochChallenge};
 use synthesizer_program::FinalizeOperation;
 
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
 use std::collections::HashSet;
 
 impl<N: Network> Block<N> {
@@ -486,8 +488,11 @@ impl<N: Network> Block<N> {
     ) -> Result<()> {
         // Prepare an iterator over the solution IDs.
         let mut solutions = solutions.as_ref().map(|s| s.deref()).into_iter().flatten().peekable();
-        // Prepare an iterator over the transaction IDs.
-        let mut transaction_ids = transactions.transaction_ids().peekable();
+        // Prepare an iterator over the unconfirmed transaction IDs.
+        let unconfirmed_transaction_ids = cfg_iter!(transactions)
+            .map(|confirmed| confirmed.to_unconfirmed_transaction_id())
+            .collect::<Result<Vec<_>>>()?;
+        let mut unconfirmed_transaction_ids = unconfirmed_transaction_ids.iter().peekable();
 
         // Initialize a list of already seen transmission IDs.
         let mut seen_transmission_ids = HashSet::new();
@@ -519,11 +524,11 @@ impl<N: Network> Block<N> {
                     }
                 }
                 TransmissionID::Transaction(transaction_id) => {
-                    match transaction_ids.peek() {
+                    match unconfirmed_transaction_ids.peek() {
                         // Check the next transaction matches the expected transaction.
                         Some(expected_id) if transaction_id == *expected_id => {
-                            // Increment the transaction ID iterator.
-                            transaction_ids.next();
+                            // Increment the unconfirmed transaction ID iterator.
+                            unconfirmed_transaction_ids.next();
                         }
                         // Otherwise, add the transaction ID to the aborted or existing list.
                         _ => aborted_or_existing_transaction_ids.push(*transaction_id),
@@ -535,7 +540,7 @@ impl<N: Network> Block<N> {
         // Ensure there are no more solutions in the block.
         ensure!(solutions.next().is_none(), "There exists more solutions than expected.");
         // Ensure there are no more transactions in the block.
-        ensure!(transaction_ids.next().is_none(), "There exists more transactions than expected.");
+        ensure!(unconfirmed_transaction_ids.next().is_none(), "There exists more transactions than expected.");
 
         // Ensure there are no aborted or existing solution IDs.
         ensure!(aborted_or_existing_solution_ids.is_empty(), "Block contains aborted or already-existing solutions.");


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates `check_subdag_transmissions` to iterate over the `unconfirmed_transaction_id`s. This is needed to account for the possibility of rejected transactions and their ID change.
