### PR TITLE
Add Map for rejected and aborted transaction ids

### DIFF
--- a/ledger/src/contains.rs
+++ b/ledger/src/contains.rs
@@ -58,7 +58,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns `true` if the given transaction ID exists.
     pub fn contains_transaction_id(&self, transaction_id: &N::TransactionID) -> Result<bool> {
-        self.vm.transaction_store().contains_transaction_id(transaction_id)
+        self.vm
+            .transaction_store()
+            .contains_transaction_id(transaction_id)
+            .or(self.vm.block_store().contains_rejected_or_aborted_transaction_id(transaction_id))
     }
 
     /* Transition */

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1192,6 +1192,11 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.reverse_id_map().contains_key_confirmed(block_hash)
     }
 
+    /// Returns `true` if the given rejected or aborted transaction ID exists.
+    pub fn contains_rejected_or_aborted_transaction_id(&self, transaction_id: &N::TransactionID) -> Result<bool> {
+        self.storage.rejected_or_aborted_transaction_id_map().contains_key_confirmed(transaction_id)
+    }
+
     /// Returns `true` if the given certificate ID exists.
     pub fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         self.storage.certificate_map().contains_key_confirmed(certificate_id)

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -192,6 +192,8 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     type TransactionsMap: for<'a> Map<'a, N::BlockHash, Vec<N::TransactionID>>;
     /// The mapping of `block hash` to `[aborted transaction ID]`.
     type AbortedTransactionIDsMap: for<'a> Map<'a, N::BlockHash, Vec<N::TransactionID>>;
+    /// The mapping of rejected or aborted `transaction ID` to `block hash`.
+    type RejectedOrAbortedTransactionIDMap: for<'a> Map<'a, N::TransactionID, N::BlockHash>;
     /// The mapping of `transaction ID` to `(block hash, confirmed tx type, confirmed blob)`.
     type ConfirmedTransactionsMap: for<'a> Map<'a, N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>;
     /// The transaction storage.
@@ -226,6 +228,8 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     fn transactions_map(&self) -> &Self::TransactionsMap;
     /// Returns the aborted transaction IDs map.
     fn aborted_transaction_ids_map(&self) -> &Self::AbortedTransactionIDsMap;
+    /// Returns the rejected or aborted transaction ID map.
+    fn rejected_or_aborted_transaction_id_map(&self) -> &Self::RejectedOrAbortedTransactionIDMap;
     /// Returns the confirmed transactions map.
     fn confirmed_transactions_map(&self) -> &Self::ConfirmedTransactionsMap;
     /// Returns the transaction store.
@@ -255,6 +259,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.puzzle_commitments_map().start_atomic();
         self.transactions_map().start_atomic();
         self.aborted_transaction_ids_map().start_atomic();
+        self.rejected_or_aborted_transaction_id_map().start_atomic();
         self.confirmed_transactions_map().start_atomic();
         self.transaction_store().start_atomic();
     }
@@ -273,6 +278,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             || self.puzzle_commitments_map().is_atomic_in_progress()
             || self.transactions_map().is_atomic_in_progress()
             || self.aborted_transaction_ids_map().is_atomic_in_progress()
+            || self.rejected_or_aborted_transaction_id_map().is_atomic_in_progress()
             || self.confirmed_transactions_map().is_atomic_in_progress()
             || self.transaction_store().is_atomic_in_progress()
     }
@@ -291,6 +297,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.puzzle_commitments_map().atomic_checkpoint();
         self.transactions_map().atomic_checkpoint();
         self.aborted_transaction_ids_map().atomic_checkpoint();
+        self.rejected_or_aborted_transaction_id_map().atomic_checkpoint();
         self.confirmed_transactions_map().atomic_checkpoint();
         self.transaction_store().atomic_checkpoint();
     }
@@ -309,6 +316,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.puzzle_commitments_map().clear_latest_checkpoint();
         self.transactions_map().clear_latest_checkpoint();
         self.aborted_transaction_ids_map().clear_latest_checkpoint();
+        self.rejected_or_aborted_transaction_id_map().clear_latest_checkpoint();
         self.confirmed_transactions_map().clear_latest_checkpoint();
         self.transaction_store().clear_latest_checkpoint();
     }
@@ -327,6 +335,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.puzzle_commitments_map().atomic_rewind();
         self.transactions_map().atomic_rewind();
         self.aborted_transaction_ids_map().atomic_rewind();
+        self.rejected_or_aborted_transaction_id_map().atomic_rewind();
         self.confirmed_transactions_map().atomic_rewind();
         self.transaction_store().atomic_rewind();
     }
@@ -345,6 +354,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.puzzle_commitments_map().abort_atomic();
         self.transactions_map().abort_atomic();
         self.aborted_transaction_ids_map().abort_atomic();
+        self.rejected_or_aborted_transaction_id_map().abort_atomic();
         self.confirmed_transactions_map().abort_atomic();
         self.transaction_store().abort_atomic();
     }
@@ -363,6 +373,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.puzzle_commitments_map().finish_atomic()?;
         self.transactions_map().finish_atomic()?;
         self.aborted_transaction_ids_map().finish_atomic()?;
+        self.rejected_or_aborted_transaction_id_map().finish_atomic()?;
         self.confirmed_transactions_map().finish_atomic()?;
         self.transaction_store().finish_atomic()
     }
@@ -385,6 +396,14 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
                 .flat_map(|(round, certificates)| certificates.iter().map(|c| (c.certificate_id(), *round)))
                 .collect(),
         };
+
+        // Prepare the rejected transaction IDs and their corresponding unconfirmed transaction IDs.
+        let rejected_transaction_ids: Vec<_> = block
+            .transactions()
+            .iter()
+            .filter(|tx| tx.is_rejected())
+            .map(|tx| tx.to_unconfirmed_transaction_id())
+            .collect::<Result<Vec<_>>>()?;
 
         atomic_batch_scope!(self, {
             // Store the (block height, state root) pair.
@@ -425,6 +444,14 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
 
             // Store the aborted transaction IDs.
             self.aborted_transaction_ids_map().insert(block.hash(), block.aborted_transaction_ids().clone())?;
+            for aborted_transaction_id in block.aborted_transaction_ids() {
+                self.rejected_or_aborted_transaction_id_map().insert(*aborted_transaction_id, block.hash())?;
+            }
+
+            // Store the rejected transactions IDs.
+            for rejected_transaction_id in rejected_transaction_ids {
+                self.rejected_or_aborted_transaction_id_map().insert(rejected_transaction_id, block.hash())?;
+            }
 
             // Store the confirmed transactions.
             for (confirmed_type, transaction, blob) in confirmed {
@@ -461,6 +488,22 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             None => {
                 bail!("Failed to remove block: missing solutions for block '{block_height}' ('{block_hash}')")
             }
+        };
+
+        // Retrieve the aborted transaction IDs.
+        let aborted_transaction_ids = match self.get_block_aborted_transaction_ids(block_hash)? {
+            Some(transaction_ids) => transaction_ids,
+            None => Vec::new(),
+        };
+
+        // Retrieve the rejected transaction IDs.
+        let rejected_transaction_ids = match self.get_block_transactions(block_hash)? {
+            Some(transactions) => transactions
+                .iter()
+                .filter(|tx| tx.is_rejected())
+                .map(|tx| tx.to_unconfirmed_transaction_id())
+                .collect::<Result<Vec<_>>>()?,
+            None => Vec::new(),
         };
 
         // Determine the certificate IDs to remove.
@@ -513,6 +556,14 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
 
             // Remove the aborted transaction IDs.
             self.aborted_transaction_ids_map().remove(block_hash)?;
+            for aborted_transaction_id in aborted_transaction_ids {
+                self.rejected_or_aborted_transaction_id_map().remove(&aborted_transaction_id)?;
+            }
+
+            // Remove the rejected transaction IDs.
+            for rejected_transaction_id in rejected_transaction_ids {
+                self.rejected_or_aborted_transaction_id_map().remove(&rejected_transaction_id)?;
+            }
 
             // Remove the block transactions.
             for transaction_id in transaction_ids.iter() {

--- a/ledger/store/src/helpers/memory/block.rs
+++ b/ledger/store/src/helpers/memory/block.rs
@@ -51,6 +51,8 @@ pub struct BlockMemory<N: Network> {
     transactions_map: MemoryMap<N::BlockHash, Vec<N::TransactionID>>,
     /// The aborted transaction IDs map.
     aborted_transaction_ids_map: MemoryMap<N::BlockHash, Vec<N::TransactionID>>,
+    /// The rejected or aborted transaction ID map.
+    rejected_or_aborted_transaction_id_map: MemoryMap<N::TransactionID, N::BlockHash>,
     /// The confirmed transactions map.
     confirmed_transactions_map: MemoryMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>,
     /// The transaction store.
@@ -71,6 +73,7 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     type PuzzleCommitmentsMap = MemoryMap<PuzzleCommitment<N>, u32>;
     type TransactionsMap = MemoryMap<N::BlockHash, Vec<N::TransactionID>>;
     type AbortedTransactionIDsMap = MemoryMap<N::BlockHash, Vec<N::TransactionID>>;
+    type RejectedOrAbortedTransactionIDMap = MemoryMap<N::TransactionID, N::BlockHash>;
     type ConfirmedTransactionsMap = MemoryMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>;
     type TransactionStorage = TransactionMemory<N>;
     type TransitionStorage = TransitionMemory<N>;
@@ -95,6 +98,7 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
             puzzle_commitments_map: MemoryMap::default(),
             transactions_map: MemoryMap::default(),
             aborted_transaction_ids_map: MemoryMap::default(),
+            rejected_or_aborted_transaction_id_map: MemoryMap::default(),
             confirmed_transactions_map: MemoryMap::default(),
             transaction_store,
         })
@@ -158,6 +162,11 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     /// Returns the aborted transaction IDs map.
     fn aborted_transaction_ids_map(&self) -> &Self::AbortedTransactionIDsMap {
         &self.aborted_transaction_ids_map
+    }
+
+    /// Returns the rejected or aborted transaction ID map.
+    fn rejected_or_aborted_transaction_id_map(&self) -> &Self::RejectedOrAbortedTransactionIDMap {
+        &self.rejected_or_aborted_transaction_id_map
     }
 
     /// Returns the confirmed transactions map.

--- a/ledger/store/src/helpers/rocksdb/block.rs
+++ b/ledger/store/src/helpers/rocksdb/block.rs
@@ -57,6 +57,8 @@ pub struct BlockDB<N: Network> {
     transactions_map: DataMap<N::BlockHash, Vec<N::TransactionID>>,
     /// The aborted transaction IDs map.
     aborted_transaction_ids_map: DataMap<N::BlockHash, Vec<N::TransactionID>>,
+    /// The rejected or aborted transaction ID map.
+    rejected_or_aborted_transaction_id_map: DataMap<N::TransactionID, N::BlockHash>,
     /// The confirmed transactions map.
     confirmed_transactions_map: DataMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>,
     /// The transaction store.
@@ -77,6 +79,7 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
     type PuzzleCommitmentsMap = DataMap<PuzzleCommitment<N>, u32>;
     type TransactionsMap = DataMap<N::BlockHash, Vec<N::TransactionID>>;
     type AbortedTransactionIDsMap = DataMap<N::BlockHash, Vec<N::TransactionID>>;
+    type RejectedOrAbortedTransactionIDMap = DataMap<N::TransactionID, N::BlockHash>;
     type ConfirmedTransactionsMap = DataMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>;
     type TransactionStorage = TransactionDB<N>;
     type TransitionStorage = TransitionDB<N>;
@@ -101,6 +104,7 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
             puzzle_commitments_map: internal::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::PuzzleCommitments))?,
             transactions_map: internal::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::Transactions))?,
             aborted_transaction_ids_map: internal::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::AbortedTransactionIDs))?,
+            rejected_or_aborted_transaction_id_map: internal::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::RejectedOrAbortedTransactionID))?,
             confirmed_transactions_map: internal::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::ConfirmedTransactions))?,
             transaction_store,
         })
@@ -164,6 +168,11 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
     /// Returns the aborted transaction IDs map.
     fn aborted_transaction_ids_map(&self) -> &Self::AbortedTransactionIDsMap {
         &self.aborted_transaction_ids_map
+    }
+
+    /// Returns the rejected or aborted transaction ID map.
+    fn rejected_or_aborted_transaction_id_map(&self) -> &Self::RejectedOrAbortedTransactionIDMap {
+        &self.rejected_or_aborted_transaction_id_map
     }
 
     /// Returns the confirmed transactions map.

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -68,6 +68,7 @@ pub enum BlockMap {
     PuzzleCommitments = DataID::BlockPuzzleCommitmentsMap as u16,
     Transactions = DataID::BlockTransactionsMap as u16,
     AbortedTransactionIDs = DataID::BlockAbortedTransactionIDsMap as u16,
+    RejectedOrAbortedTransactionID = DataID::BlockRejectedOrAbortedTransactionIDMap as u16,
     ConfirmedTransactions = DataID::BlockConfirmedTransactionsMap as u16,
 }
 
@@ -216,6 +217,7 @@ enum DataID {
     BlockPuzzleCommitmentsMap,
     BlockTransactionsMap,
     BlockAbortedTransactionIDsMap,
+    BlockRejectedOrAbortedTransactionIDMap,
     BlockConfirmedTransactionsMap,
     // Committee
     CurrentRoundMap,

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -60,7 +60,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         /* Transaction */
 
         // Ensure the transaction ID is unique.
-        if self.transaction_store().contains_transaction_id(&transaction.id())? {
+        if self.transaction_store().contains_transaction_id(&transaction.id())?
+            || self.block_store().contains_rejected_or_aborted_transaction_id(&transaction.id())?
+        {
             bail!("Transaction '{}' already exists in the ledger", transaction.id())
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a new `RejectedOrAbortedTransactionID` Map to `BlockStorage`. The key of this map is the transaction id of any aborted transaction and the unconfirmed transaction id of any rejected transaction. The value is the block hash the transaction id was associated with. 

This will allow us to easily determine if incoming transactions were already rejected or aborted. 