### PR TITLE
Add check for ratification uniqueness

### DIFF
--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -237,6 +237,14 @@ impl<N: Network> Block<N> {
         // Ensure there are sufficient ratifications.
         ensure!(!self.ratifications.len() >= 2, "Block {height} must contain at least 2 ratifications");
 
+        // Ensure that the ratification types are unique.
+        let number_of_ratification_types =
+            self.ratifications.iter().map(|r| std::mem::discriminant(r)).collect::<HashSet<_>>().len();
+        ensure!(
+            number_of_ratification_types == self.ratifications.len(),
+            "Block {height} must contain at most 1 of each ratification type"
+        );
+
         // Initialize a ratifications iterator.
         let mut ratifications_iter = self.ratifications.iter();
 

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -239,7 +239,7 @@ impl<N: Network> Block<N> {
 
         // Ensure that the ratification types are unique.
         let number_of_ratification_types =
-            self.ratifications.iter().map(|r| std::mem::discriminant(r)).collect::<HashSet<_>>().len();
+            self.ratifications.iter().map(std::mem::discriminant).collect::<HashSet<_>>().len();
         ensure!(
             number_of_ratification_types == self.ratifications.len(),
             "Block {height} must contain at most 1 of each ratification type"

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -242,7 +242,7 @@ impl<N: Network> Block<N> {
             self.ratifications.iter().map(std::mem::discriminant).collect::<HashSet<_>>().len();
         ensure!(
             number_of_ratification_types == self.ratifications.len(),
-            "Block {height} must contain at most 1 of each ratification type"
+            "Block {height} must contain unique ratification types"
         );
 
         // Initialize a ratifications iterator.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a simple check to enforce that each block may not contain multiple of the same ratification type. 

- See https://doc.rust-lang.org/std/mem/fn.discriminant.html for handling of enum variants.