### PR TITLE
Only declare the public 1 variable once

### DIFF
--- a/algorithms/src/snark/varuna/ahp/indexer/constraint_system.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/constraint_system.rs
@@ -38,7 +38,7 @@ impl<F: Field> ConstraintSystem<F> {
             a: Vec::new(),
             b: Vec::new(),
             c: Vec::new(),
-            num_public_variables: 1,
+            num_public_variables: 0,
             num_private_variables: 0,
             num_constraints: 0,
         }

--- a/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
@@ -26,9 +26,9 @@ pub(crate) struct ConstraintSystem<F: Field> {
 impl<F: Field> ConstraintSystem<F> {
     pub(crate) fn new() -> Self {
         Self {
-            public_variables: vec![F::one()],
+            public_variables: Vec::new(),
             private_variables: Vec::new(),
-            num_public_variables: 1usize,
+            num_public_variables: 0usize,
             num_private_variables: 0usize,
             num_constraints: 0usize,
         }

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -162,7 +162,7 @@ impl<F: PrimeField> snarkvm_algorithms::r1cs::ConstraintSynthesizer<F> for Assig
         let mut converter = Converter { public: Default::default(), private: Default::default() };
 
         // Ensure the given `cs` is starting off clean.
-        assert_eq!(1, cs.num_public_variables());
+        assert_eq!(0, cs.num_public_variables());
         assert_eq!(0, cs.num_private_variables());
         assert_eq!(0, cs.num_constraints());
 
@@ -173,7 +173,7 @@ impl<F: PrimeField> snarkvm_algorithms::r1cs::ConstraintSynthesizer<F> for Assig
             let gadget = cs.alloc_input(|| format!("Public {i}"), || Ok(*value))?;
 
             assert_eq!(
-                snarkvm_algorithms::r1cs::Index::Public((index + 1) as usize),
+                snarkvm_algorithms::r1cs::Index::Public((*index) as usize),
                 gadget.get_unchecked(),
                 "Public variables in the second system must match the first system (with an off-by-1 for the public case)"
             );
@@ -218,7 +218,7 @@ impl<F: PrimeField> snarkvm_algorithms::r1cs::ConstraintSynthesizer<F> for Assig
                         AssignmentVariable::Public(index) => {
                             let gadget = converter.public.get(index).unwrap();
                             assert_eq!(
-                                snarkvm_algorithms::r1cs::Index::Public((index + 1) as usize),
+                                snarkvm_algorithms::r1cs::Index::Public((*index) as usize),
                                 gadget.get_unchecked(),
                                 "Failed during constraint translation. The public variable in the second system must match the first system (with an off-by-1 for the public case)"
                             );
@@ -257,7 +257,7 @@ impl<F: PrimeField> snarkvm_algorithms::r1cs::ConstraintSynthesizer<F> for Assig
         }
 
         // Ensure the given `cs` matches in size with the first system.
-        assert_eq!(self.num_public() + 1, cs.num_public_variables() as u64);
+        assert_eq!(self.num_public(), cs.num_public_variables() as u64);
         assert_eq!(self.num_private(), cs.num_private_variables() as u64);
         assert_eq!(self.num_constraints(), cs.num_constraints() as u64);
 


### PR DESCRIPTION
## Motivation

Our constraint system has not just one but a superfluous second public 1 variable. Because the R1CS spits it out, and the ConstraintSystem subsequently already has one hardcoded. However this never materially impacted proving or verifying. 

[The prover hardcodes it here](https://github.com/AleoHQ/snarkVM/blob/testnet3/circuit/environment/src/helpers/r1cs.rs#L40).
[The verifier hardcodes it here](https://github.com/AleoHQ/snarkVM/blob/declare_public_once/algorithms/src/snark/varuna/varuna.rs#L682).
[The verifier also hardcodes it here](https://github.com/AleoHQ/snarkVM/blob/testnet3/synthesizer/process/src/verify_execution.rs#L176).

## Test Plan

Requires resampling