### PR TITLE
Add filter for aborted solutions

### DIFF
--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -291,9 +291,11 @@ impl<N: Network> Block<N> {
                 }
 
                 // Ensure the puzzle proof is valid.
-                let is_valid =
-                    current_puzzle.verify(coinbase, current_epoch_challenge, previous_block.proof_target())?;
-                ensure!(is_valid, "Block {height} contains invalid puzzle proof");
+                if let Err(e) =
+                    current_puzzle.check_solutions(coinbase, current_epoch_challenge, previous_block.proof_target())
+                {
+                    bail!("Block {height} contains an invalid puzzle proof - {e}");
+                }
 
                 // Compute the combined proof target.
                 let combined_proof_target = coinbase.to_combined_proof_target()?;

--- a/ledger/coinbase/src/helpers/coinbase_solution/bytes.rs
+++ b/ledger/coinbase/src/helpers/coinbase_solution/bytes.rs
@@ -25,7 +25,7 @@ impl<N: Network> FromBytes for CoinbaseSolution<N> {
             prover_solutions.push(ProverSolution::read_le(&mut reader)?);
         }
         // Return the solutions.
-        Ok(Self::new(prover_solutions))
+        Self::new(prover_solutions).map_err(error)
     }
 }
 

--- a/ledger/coinbase/src/helpers/coinbase_solution/serialize.rs
+++ b/ledger/coinbase/src/helpers/coinbase_solution/serialize.rs
@@ -36,7 +36,7 @@ impl<'de, N: Network> Deserialize<'de> for CoinbaseSolution<N> {
         match deserializer.is_human_readable() {
             true => {
                 let mut solutions = serde_json::Value::deserialize(deserializer)?;
-                Ok(Self::new(DeserializeExt::take_from_value::<D>(&mut solutions, "solutions")?))
+                Self::new(DeserializeExt::take_from_value::<D>(&mut solutions, "solutions")?).map_err(de::Error::custom)
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "solutions"),
         }
@@ -60,7 +60,7 @@ pub(super) mod tests {
             let partial_solution = PartialSolution::new(address, u64::rand(rng), KZGCommitment(rng.gen()));
             prover_solutions.push(ProverSolution::new(partial_solution, KZGProof { w: rng.gen(), random_v: None }));
         }
-        CoinbaseSolution::new(prover_solutions)
+        CoinbaseSolution::new(prover_solutions).unwrap()
     }
 
     #[test]

--- a/ledger/coinbase/src/lib.rs
+++ b/ledger/coinbase/src/lib.rs
@@ -168,7 +168,7 @@ impl<N: Network> CoinbasePuzzle<N> {
         // Initialize the coinbase solution.
         let solutions = CoinbaseSolution::new(prover_solutions);
         // Verify the solutions.
-        self.verify(&solutions, epoch_challenge, proof_target)?;
+        ensure!(self.verify(&solutions, epoch_challenge, proof_target)?, "The prover solutions must be valid");
         // Return the solutions.
         Ok(solutions)
     }

--- a/ledger/coinbase/src/lib.rs
+++ b/ledger/coinbase/src/lib.rs
@@ -158,28 +158,13 @@ impl<N: Network> CoinbasePuzzle<N> {
         Ok(ProverSolution::new(partial_solution, proof))
     }
 
-    /// Returns the coinbase solution for the given prover solutions.
-    pub fn accumulate(
-        &self,
-        prover_solutions: Vec<ProverSolution<N>>,
-        epoch_challenge: &EpochChallenge<N>,
-        proof_target: u64,
-    ) -> Result<CoinbaseSolution<N>> {
-        // Initialize the coinbase solution.
-        let solutions = CoinbaseSolution::new(prover_solutions);
-        // Verify the solutions.
-        ensure!(self.verify(&solutions, epoch_challenge, proof_target)?, "The prover solutions must be valid");
-        // Return the solutions.
-        Ok(solutions)
-    }
-
     /// Returns `true` if the solutions are valid.
-    pub fn verify(
+    pub fn check_solutions(
         &self,
         solutions: &CoinbaseSolution<N>,
         epoch_challenge: &EpochChallenge<N>,
         proof_target: u64,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         let timer = timer!("CoinbasePuzzle::verify");
 
         // Ensure the solutions are not empty.
@@ -204,12 +189,11 @@ impl<N: Network> CoinbasePuzzle<N> {
         if !cfg_iter!(solutions).all(|(_, solution)| {
             solution.verify(self.coinbase_verifying_key(), epoch_challenge, proof_target).unwrap_or(false)
         }) {
-            return Ok(false);
+            bail!("The solutions contain an invalid prover solution");
         }
         finish!(timer, "Verify each solution");
 
-        // Return the verification result.
-        Ok(true)
+        Ok(())
     }
 
     /// Returns the coinbase proving key.

--- a/ledger/coinbase/src/tests.rs
+++ b/ledger/coinbase/src/tests.rs
@@ -43,11 +43,11 @@ fn test_coinbase_puzzle() {
                     puzzle.prove(&epoch_challenge, address, nonce, None).unwrap()
                 })
                 .collect::<Vec<_>>();
-            let full_solution = puzzle.accumulate(solutions, &epoch_challenge, 0).unwrap();
-            assert!(puzzle.verify(&full_solution, &epoch_challenge, 0u64).unwrap());
+            let full_solution = CoinbaseSolution::new(solutions).unwrap();
+            assert!(puzzle.check_solutions(&full_solution, &epoch_challenge, 0u64).is_ok());
 
             let bad_epoch_challenge = EpochChallenge::new(rng.next_u32(), Default::default(), degree).unwrap();
-            assert!(!puzzle.verify(&full_solution, &bad_epoch_challenge, 0u64).unwrap());
+            assert!(puzzle.check_solutions(&full_solution, &bad_epoch_challenge, 0u64).is_err());
         }
     }
 }
@@ -103,8 +103,8 @@ fn test_edge_case_for_degree() {
 
     // Generate a prover solution.
     let prover_solution = puzzle.prove(&epoch_challenge, address, rng.gen(), None).unwrap();
-    let coinbase_solution = puzzle.accumulate(vec![prover_solution], &epoch_challenge, 0).unwrap();
-    assert!(puzzle.verify(&coinbase_solution, &epoch_challenge, 0u64).unwrap());
+    let coinbase_solution = CoinbaseSolution::new(vec![prover_solution]).unwrap();
+    assert!(puzzle.check_solutions(&coinbase_solution, &epoch_challenge, 0u64).is_ok());
 }
 
 /// Use `cargo test profiler --features timer` to run this test.
@@ -141,11 +141,10 @@ fn test_profiler() -> Result<()> {
                 puzzle.prove(&epoch_challenge, address, nonce, None).unwrap()
             })
             .collect::<Vec<_>>();
-        // Accumulate the solutions.
-        let solution = puzzle.accumulate(solutions, &epoch_challenge, 0).unwrap();
-
-        // Verify the solution.
-        puzzle.verify(&solution, &epoch_challenge, 0u64).unwrap();
+        // Construct the solutions.
+        let solutions = CoinbaseSolution::new(solutions).unwrap();
+        // Verify the solutions.
+        puzzle.check_solutions(&solutions, &epoch_challenge, 0u64).unwrap();
     }
 
     bail!("\n\nRemember to #[ignore] this test!\n\n")

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -129,7 +129,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                     cfg_into_iter!(candidate_solutions).partition(|solution| {
                         solution
                             .verify(
-                                &self.coinbase_puzzle.coinbase_verifying_key(),
+                                self.coinbase_puzzle.coinbase_verifying_key(),
                                 &latest_epoch_challenge,
                                 self.latest_proof_target(),
                             )
@@ -139,7 +139,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 // Accumulate the prover solutions.
                 let solutions = self.coinbase_puzzle.accumulate(
                     valid_candidate_solutions,
-                    &self.latest_epoch_challenge()?,
+                    &latest_epoch_challenge,
                     self.latest_proof_target(),
                 )?;
                 // Compute the solutions root.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -128,6 +128,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 // Retrieve the latest epoch challenge.
                 let latest_epoch_challenge = self.latest_epoch_challenge()?;
                 // Separate the candidate solutions into valid and aborted solutions.
+                // TODO: Add `aborted_solution_ids` to the block.
                 let (valid_candidate_solutions, _aborted_candidate_solutions): (Vec<_>, Vec<_>) =
                     cfg_into_iter!(candidate_solutions).partition(|solution| {
                         solution


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a filter for solutions that should be aborted before creating the next block. 

NOTE: This fix is incomplete, as we need to track these aborted solution ids and verify them agains the subdag in `check_subdag_transmissions`.