### PR TITLE
Allow programs to import `credits.aleo` when using `snarkvm execute`

### DIFF
--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -115,8 +115,12 @@ impl<N: Network> Process<N> {
     /// If you intend to `execute` the program, use `deploy` and `finalize_deployment` instead.
     #[inline]
     pub fn add_program(&mut self, program: &Program<N>) -> Result<()> {
-        // Compute the program stack, and add it to the process.
-        self.add_stack(Stack::new(self, program)?);
+        // Initialize the 'credits.aleo' program ID.
+        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
+        // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
+        if program.id() != &credits_program_id {
+            self.add_stack(Stack::new(self, program)?);
+        }
         Ok(())
     }
 

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -318,4 +318,21 @@ mod tests {
         // Proactively remove the temporary directory (to conserve space).
         std::fs::remove_dir_all(directory).unwrap();
     }
+
+    #[test]
+    #[ignore]
+    fn test_build_with_import_credits() {
+        // Samples a new package at a temporary directory.
+        let (directory, package) = crate::package::test_helpers::sample_transfer_package();
+
+        // Ensure the build directory does *not* exist.
+        assert!(!package.build_directory().exists());
+        // Build the package.
+        package.build::<CurrentAleo>(None).unwrap();
+        // Ensure the build directory exists.
+        assert!(package.build_directory().exists());
+
+        // Proactively remove the temporary directory (to conserve space).
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 }

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -272,6 +272,32 @@ function transfer:
         sample_package_with_program_and_imports(&main_program, &[imported_program])
     }
 
+    /// Samples a (temporary) package containing a `transfer.aleo` program which imports `credits.aleo`.
+    pub(crate) fn sample_transfer_package() -> (PathBuf, Package<CurrentNetwork>) {
+        // Initialize the imported program.
+        let imported_program = Program::credits().unwrap();
+
+        // Initialize the main program.
+        let main_program = Program::<CurrentNetwork>::from_str(
+            "
+import credits.aleo;
+
+program transfer.aleo;
+
+function main:
+    input r0 as credits.aleo/credits.record;
+    input r1 as address.private;
+    input r2 as u64.private;
+    call credits.aleo/transfer_private r0 r1 r2 into r3 r4;
+    output r3 as credits.aleo/credits.record;
+    output r4 as credits.aleo/credits.record;",
+        )
+        .unwrap();
+
+        // Sample the package using the main program and imported program.
+        sample_package_with_program_and_imports(&main_program, &[imported_program])
+    }
+
     /// Samples a (temporary) package using a main program and imported programs.
     pub(crate) fn sample_package_with_program_and_imports(
         main_program: &Program<CurrentNetwork>,

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -157,10 +157,15 @@ impl<N: Network> Package<N> {
 
         // Add all import programs (in order) to the process.
         self.program().imports().keys().try_for_each(|program_id| {
-            // Open the Aleo program file.
-            let import_program_file = AleoFile::open(&imports_directory, program_id, false)?;
-            // Add the import program.
-            process.add_program(import_program_file.program())?;
+            // Don't add `credits.aleo` as the process is already loaded with it.
+            if !(program_id.is_aleo()
+                && program_id.name() == &Identifier::from_str("credits").expect("Failed to parse credits"))
+            {
+                // Open the Aleo program file.
+                let import_program_file = AleoFile::open(&imports_directory, program_id, false)?;
+                // Add the import program.
+                process.add_program(import_program_file.program())?;
+            }
             Ok::<_, Error>(())
         })?;
 

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -155,12 +155,13 @@ impl<N: Network> Package<N> {
         // Prepare the imports directory.
         let imports_directory = self.imports_directory();
 
+        // Initialize the 'credits.aleo' program ID.
+        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
+
         // Add all import programs (in order) to the process.
         self.program().imports().keys().try_for_each(|program_id| {
             // Don't add `credits.aleo` as the process is already loaded with it.
-            if !(program_id.is_aleo()
-                && program_id.name() == &Identifier::from_str("credits").expect("Failed to parse credits"))
-            {
+            if program_id != &credits_program_id {
                 // Open the Aleo program file.
                 let import_program_file = AleoFile::open(&imports_directory, program_id, false)?;
                 // Add the import program.


### PR DESCRIPTION
## Motivation
Resolves #2122

## Test Plan
Created a test that imports `credits.aleo` and now successfully builds without causing a duplicate name error. 

