### PR TITLE
Avoid indexing out of range in skip_leading_zeros_and_convert_to_bigints

### DIFF
--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -451,11 +451,12 @@ fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField>(p: &DensePolynomial<
     if p.coeffs.is_empty() {
         (0, vec![])
     } else {
-        let mut num_leading_zeros = 0;
-        while p.coeffs[num_leading_zeros].is_zero() && num_leading_zeros < p.coeffs.len() {
-            num_leading_zeros += 1;
-        }
-        let coeffs = convert_to_bigints(&p.coeffs[num_leading_zeros..]);
+        let num_leading_zeros = p.coeffs.iter().take_while(|c| c.is_zero()).count();
+        let coeffs = if num_leading_zeros == p.coeffs.len() {
+            vec![]
+        } else {
+            convert_to_bigints(&p.coeffs[num_leading_zeros..])
+        };
         (num_leading_zeros, coeffs)
     }
 }


### PR DESCRIPTION
Fixes #2121 and makes the calculation of leading zeros a bit cleaner.