### PR TITLE
Remove flakiness caused by subslice assertions

### DIFF
--- a/console/program/src/data/ciphertext/bytes.rs
+++ b/console/program/src/data/ciphertext/bytes.rs
@@ -66,7 +66,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Ciphertext::read_le(&expected_bytes[..])?);
-            // assert!(Ciphertext::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/program/src/data/future/bytes.rs
+++ b/console/program/src/data/future/bytes.rs
@@ -84,7 +84,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Future::read_le(&expected_bytes[..])?);
-        assert!(Future::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         Ok(())
     }

--- a/console/program/src/data/identifier/bytes.rs
+++ b/console/program/src/data/identifier/bytes.rs
@@ -72,7 +72,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Identifier::read_le(&expected_bytes[..])?);
-            assert!(Identifier::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/program/src/data/literal/bytes.rs
+++ b/console/program/src/data/literal/bytes.rs
@@ -132,8 +132,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Literal::read_le(&expected_bytes[..])?);
-        assert!(Literal::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
-        // assert!(Literal::<CurrentNetwork>::read_le(&expected_bytes[2..]).is_err());
         Ok(())
     }
 

--- a/console/program/src/data/plaintext/bytes.rs
+++ b/console/program/src/data/plaintext/bytes.rs
@@ -131,9 +131,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Plaintext::read_le(&expected_bytes[..])?);
-        // assert!(Plaintext::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
-        // assert!(Plaintext::<CurrentNetwork>::read_le(&expected_bytes[2..]).is_err());
-        // assert!(Plaintext::<CurrentNetwork>::read_le(&expected_bytes[3..]).is_err());
         Ok(())
     }
 
@@ -225,7 +222,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Plaintext::read_le(&expected_bytes[..])?);
-        assert!(Plaintext::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         // Check the array manually.
         let expected = Plaintext::<CurrentNetwork>::from_str("[ 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8, 10u8 ]")?;
@@ -233,7 +229,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Plaintext::read_le(&expected_bytes[..])?);
-        assert!(Plaintext::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         Ok(())
     }

--- a/console/program/src/data/record/bytes.rs
+++ b/console/program/src/data/record/bytes.rs
@@ -95,7 +95,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Record::read_le(&expected_bytes[..])?);
-        assert!(Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::read_le(&expected_bytes[1..]).is_err());
         Ok(())
     }
 }

--- a/console/program/src/data/value/bytes.rs
+++ b/console/program/src/data/value/bytes.rs
@@ -67,7 +67,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Value::read_le(&expected_bytes[..])?);
-        assert!(Value::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         Ok(())
     }
 
@@ -81,7 +80,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Value::read_le(&expected_bytes[..])?);
-        assert!(Value::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         Ok(())
     }
 }

--- a/console/program/src/request/bytes.rs
+++ b/console/program/src/request/bytes.rs
@@ -100,9 +100,6 @@ impl<N: Network> ToBytes for Request<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm_console_network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -112,7 +109,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Request::read_le(&expected_bytes[..]).unwrap());
-            assert!(Request::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/console/program/src/state_path/header_leaf/bytes.rs
+++ b/console/program/src/state_path/header_leaf/bytes.rs
@@ -39,9 +39,6 @@ impl<N: Network> ToBytes for HeaderLeaf<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm_console_network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     const ITERATIONS: u64 = 1000;
 
@@ -56,7 +53,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, HeaderLeaf::read_le(&expected_bytes[..])?);
-            assert!(HeaderLeaf::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/program/src/state_path/transaction_leaf/bytes.rs
+++ b/console/program/src/state_path/transaction_leaf/bytes.rs
@@ -43,9 +43,6 @@ impl<N: Network> ToBytes for TransactionLeaf<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm_console_network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     const ITERATIONS: u64 = 1000;
 
@@ -60,7 +57,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, TransactionLeaf::read_le(&expected_bytes[..])?);
-            assert!(TransactionLeaf::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/program/src/state_path/transition_leaf/bytes.rs
+++ b/console/program/src/state_path/transition_leaf/bytes.rs
@@ -51,9 +51,6 @@ impl<N: Network> ToBytes for TransitionLeaf<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm_console_network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     const ITERATIONS: u64 = 1000;
 
@@ -68,7 +65,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, TransitionLeaf::read_le(&expected_bytes[..])?);
-            assert!(TransitionLeaf::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/types/string/src/bytes.rs
+++ b/console/types/string/src/bytes.rs
@@ -67,7 +67,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, StringType::read_le(&expected_bytes[..])?);
-            assert!(StringType::<CurrentEnvironment>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/ledger/authority/src/bytes.rs
+++ b/ledger/authority/src/bytes.rs
@@ -52,9 +52,7 @@ impl<N: Network> ToBytes for Authority<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::{network::Testnet3, prelude::TestRng};
-
-    type CurrentNetwork = Testnet3;
+    use console::prelude::TestRng;
 
     #[test]
     fn test_bytes() {
@@ -64,7 +62,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Authority::read_le(&expected_bytes[..]).unwrap());
-            assert!(Authority::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -134,7 +134,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Block::read_le(&expected_bytes[..])?);
-            assert!(Block::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }
@@ -147,7 +146,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = genesis_block.to_bytes_le()?;
         assert_eq!(genesis_block, Block::read_le(&expected_bytes[..])?);
-        assert!(Block::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         Ok(())
     }

--- a/ledger/block/src/ratifications/bytes.rs
+++ b/ledger/block/src/ratifications/bytes.rs
@@ -53,9 +53,6 @@ impl<N: Network> ToBytes for Ratifications<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     const ITERATIONS: u32 = 100;
 
@@ -68,7 +65,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Ratifications::read_le(&expected_bytes[..])?);
-            assert!(Ratifications::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/ledger/block/src/ratify/bytes.rs
+++ b/ledger/block/src/ratify/bytes.rs
@@ -94,9 +94,6 @@ impl<N: Network> ToBytes for Ratify<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -106,7 +103,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Ratify::read_le(&expected_bytes[..]).unwrap());
-            assert!(Ratify::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/block/src/transaction/bytes.rs
+++ b/ledger/block/src/transaction/bytes.rs
@@ -139,9 +139,6 @@ impl<N: Network> ToBytes for Transaction<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -158,7 +155,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Transaction::read_le(&expected_bytes[..])?);
-            assert!(Transaction::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/ledger/block/src/transaction/deployment/bytes.rs
+++ b/ledger/block/src/transaction/deployment/bytes.rs
@@ -76,9 +76,6 @@ impl<N: Network> ToBytes for Deployment<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -90,7 +87,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Deployment::read_le(&expected_bytes[..])?);
-        assert!(Deployment::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         Ok(())
     }
 }

--- a/ledger/block/src/transaction/execution/bytes.rs
+++ b/ledger/block/src/transaction/execution/bytes.rs
@@ -75,9 +75,6 @@ impl<N: Network> ToBytes for Execution<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -89,7 +86,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Execution::read_le(&expected_bytes[..])?);
-        assert!(Execution::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         Ok(())
     }
 }

--- a/ledger/block/src/transaction/fee/bytes.rs
+++ b/ledger/block/src/transaction/fee/bytes.rs
@@ -64,9 +64,6 @@ impl<N: Network> ToBytes for Fee<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -78,7 +75,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Fee::read_le(&expected_bytes[..])?);
-        assert!(Fee::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         // Construct a new public fee.
         let expected = crate::transaction::fee::test_helpers::sample_fee_public_hardcoded(rng);
@@ -86,7 +82,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Fee::read_le(&expected_bytes[..])?);
-        assert!(Fee::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         Ok(())
     }

--- a/ledger/block/src/transactions/bytes.rs
+++ b/ledger/block/src/transactions/bytes.rs
@@ -53,9 +53,6 @@ impl<N: Network> ToBytes for Transactions<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -65,7 +62,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Transactions::read_le(&expected_bytes[..])?);
-            assert!(Transactions::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/ledger/block/src/transactions/confirmed/bytes.rs
+++ b/ledger/block/src/transactions/confirmed/bytes.rs
@@ -143,9 +143,6 @@ impl<N: Network> ToBytes for ConfirmedTransaction<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -153,7 +150,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, ConfirmedTransaction::read_le(&expected_bytes[..]).unwrap());
-            assert!(ConfirmedTransaction::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/block/src/transactions/rejected/bytes.rs
+++ b/ledger/block/src/transactions/rejected/bytes.rs
@@ -63,9 +63,6 @@ impl<N: Network> ToBytes for Rejected<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -73,7 +70,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Rejected::read_le(&expected_bytes[..]).unwrap());
-            assert!(Rejected::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/block/src/transition/bytes.rs
+++ b/ledger/block/src/transition/bytes.rs
@@ -98,9 +98,6 @@ impl<N: Network> ToBytes for Transition<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -112,7 +109,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Transition::read_le(&expected_bytes[..])?);
-        assert!(Transition::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         Ok(())
     }

--- a/ledger/block/src/transition/input/bytes.rs
+++ b/ledger/block/src/transition/input/bytes.rs
@@ -115,9 +115,6 @@ impl<N: Network> ToBytes for Input<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -125,7 +122,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Input::read_le(&expected_bytes[..]).unwrap());
-            assert!(Input::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/block/src/transition/output/bytes.rs
+++ b/ledger/block/src/transition/output/bytes.rs
@@ -148,9 +148,6 @@ impl<N: Network> ToBytes for Output<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -158,7 +155,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Output::read_le(&expected_bytes[..]).unwrap());
-            assert!(Output::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/committee/src/bytes.rs
+++ b/ledger/committee/src/bytes.rs
@@ -78,9 +78,6 @@ impl<N: Network> ToBytes for Committee<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -90,7 +87,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Committee::read_le(&expected_bytes[..]).unwrap());
-            assert!(Committee::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -70,9 +70,6 @@ impl<N: Network> ToBytes for BatchCertificate<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -82,7 +79,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, BatchCertificate::read_le(&expected_bytes[..]).unwrap());
-            assert!(BatchCertificate::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -101,9 +101,6 @@ impl<N: Network> ToBytes for BatchHeader<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -113,7 +110,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, BatchHeader::read_le(&expected_bytes[..]).unwrap());
-            assert!(BatchHeader::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -73,9 +73,6 @@ impl<N: Network> ToBytes for Subdag<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -85,7 +82,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Subdag::read_le(&expected_bytes[..]).unwrap());
-            assert!(Subdag::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/narwhal/transmission-id/src/bytes.rs
+++ b/ledger/narwhal/transmission-id/src/bytes.rs
@@ -50,9 +50,6 @@ impl<N: Network> ToBytes for TransmissionID<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -62,7 +59,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, TransmissionID::read_le(&expected_bytes[..]).unwrap());
-            assert!(TransmissionID::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/ledger/narwhal/transmission/src/bytes.rs
+++ b/ledger/narwhal/transmission/src/bytes.rs
@@ -59,9 +59,6 @@ impl<N: Network> ToBytes for Transmission<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -71,7 +68,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Transmission::read_le(&expected_bytes[..]).unwrap());
-            assert!(Transmission::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/synthesizer/process/src/stack/authorization/bytes.rs
+++ b/synthesizer/process/src/stack/authorization/bytes.rs
@@ -71,9 +71,6 @@ impl<N: Network> ToBytes for Authorization<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -85,7 +82,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Authorization::read_le(&expected_bytes[..])?);
-        assert!(Authorization::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         Ok(())
     }
 }

--- a/synthesizer/program/src/logic/finalize_operation/bytes.rs
+++ b/synthesizer/program/src/logic/finalize_operation/bytes.rs
@@ -134,9 +134,6 @@ impl<N: Network> ToBytes for FinalizeOperation<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() {
@@ -144,7 +141,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, FinalizeOperation::read_le(&expected_bytes[..]).unwrap());
-            assert!(FinalizeOperation::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/synthesizer/program/src/logic/instruction/operation/call.rs
+++ b/synthesizer/program/src/logic/instruction/operation/call.rs
@@ -544,7 +544,6 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Call::read_le(&expected_bytes[..]).unwrap());
-            assert!(Call::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
         }
     }
 }

--- a/synthesizer/snark/src/certificate/bytes.rs
+++ b/synthesizer/snark/src/certificate/bytes.rs
@@ -43,9 +43,6 @@ impl<N: Network> ToBytes for Certificate<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -55,7 +52,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Certificate::read_le(&expected_bytes[..])?);
-        assert!(Certificate::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         Ok(())
     }

--- a/synthesizer/snark/src/proof/bytes.rs
+++ b/synthesizer/snark/src/proof/bytes.rs
@@ -43,9 +43,6 @@ impl<N: Network> ToBytes for Proof<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::Testnet3;
-
-    type CurrentNetwork = Testnet3;
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -55,7 +52,6 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Proof::read_le(&expected_bytes[..])?);
-        assert!(Proof::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
 
         Ok(())
     }


### PR DESCRIPTION
This PR removes all test assertions of the following kind:
```
assert!(T::read_le(&expected_bytes[1..]).is_err());
```
The reason is that they often break CI jobs due to a relatively high chance of deserialization still working fine with a single byte missing (unless the length of the entire object is constant).