### PR TITLE
Fix genesis sampling for non-debug_assertions scenarios

### DIFF
--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -35,6 +35,7 @@ wasm = [
   "synthesizer-snark/wasm"
 ]
 test = [ ]
+test-helpers = [ ]
 
 [dependencies.console]
 package = "snarkvm-console"
@@ -113,6 +114,11 @@ path = "../store"
 [dev-dependencies.synthesizer-process]
 package = "snarkvm-synthesizer-process"
 path = "../../synthesizer/process"
+
+[dev-dependencies.synthesizer-program]
+package = "snarkvm-synthesizer-program"
+path = "../../synthesizer/program"
+features = [ "test-helpers" ]
 
 [dev-dependencies.once_cell]
 version = "1.18"

--- a/ledger/block/src/header/genesis.rs
+++ b/ledger/block/src/header/genesis.rs
@@ -22,9 +22,7 @@ impl<N: Network> Header<N> {
         ratified_finalize_operations: Vec<FinalizeOperation<N>>,
     ) -> Result<Self> {
         #[cfg(not(debug_assertions))]
-        ensure!(!ratifications.is_empty(), "The genesis block must not contain ratifications");
-        #[cfg(not(debug_assertions))]
-        ensure!(ratifications.len() == 1, "The genesis block must not contain 1 ratification");
+        ensure!(ratifications.len() == 1, "The genesis block must contain exactly 1 ratification");
         #[cfg(not(debug_assertions))]
         ensure!(!ratified_finalize_operations.is_empty(), "The genesis block must contain ratify-finalize operations");
 

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -549,10 +549,12 @@ impl<N: Network> Block<N> {
 #[cfg(test)]
 pub mod test_helpers {
     use super::*;
+    use crate::ratify::test_helpers::sample_ratifications;
     use console::account::{Address, PrivateKey};
     use ledger_query::Query;
     use ledger_store::{helpers::memory::BlockMemory, BlockStore};
     use synthesizer_process::Process;
+    use synthesizer_program::logic::test_helpers::sample_initialize_mapping;
 
     use once_cell::sync::OnceCell;
 
@@ -628,10 +630,12 @@ pub mod test_helpers {
         let transactions = Transactions::from_iter([confirmed].into_iter());
 
         // Construct the ratifications.
-        let ratifications = Ratifications::try_from(vec![]).unwrap();
+        let ratifications = vec![sample_ratifications(rng).swap_remove(0)].try_into().unwrap();
+
+        let ratified_finalize_ops = vec![sample_initialize_mapping(rng)];
 
         // Prepare the block header.
-        let header = Header::genesis(&ratifications, &transactions, vec![]).unwrap();
+        let header = Header::genesis(&ratifications, &transactions, ratified_finalize_ops).unwrap();
         // Prepare the previous block hash.
         let previous_hash = <CurrentNetwork as Network>::BlockHash::default();
 

--- a/ledger/block/src/ratify/mod.rs
+++ b/ledger/block/src/ratify/mod.rs
@@ -42,14 +42,14 @@ impl<N: Network> Ratify<N> {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod test_helpers {
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers {
     use super::*;
     use console::network::Testnet3;
 
     type CurrentNetwork = Testnet3;
 
-    pub(crate) fn sample_ratifications(rng: &mut TestRng) -> Vec<Ratify<CurrentNetwork>> {
+    pub fn sample_ratifications(rng: &mut TestRng) -> Vec<Ratify<CurrentNetwork>> {
         let committee = ledger_committee::test_helpers::sample_committee(rng);
         let mut public_balances = PublicBalances::new();
         for (address, _) in committee.members().iter() {

--- a/ledger/test-helpers/Cargo.toml
+++ b/ledger/test-helpers/Cargo.toml
@@ -30,6 +30,7 @@ version = "=0.16.3"
 package = "snarkvm-ledger-block"
 path = "../block"
 version = "=0.16.3"
+features = [ "test-helpers" ]
 
 [dependencies.ledger-query]
 package = "snarkvm-ledger-query"
@@ -47,6 +48,7 @@ version = "=0.16.3"
 package = "snarkvm-synthesizer-program"
 path = "../../synthesizer/program"
 version = "=0.16.3"
+features = [ "test-helpers" ]
 
 [dependencies.synthesizer-process]
 package = "snarkvm-synthesizer-process"

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -19,6 +19,7 @@ use console::{
     types::Field,
 };
 use ledger_block::{
+    ratify::test_helpers::sample_ratifications,
     Block,
     ConfirmedTransaction,
     Deployment,
@@ -27,7 +28,6 @@ use ledger_block::{
     Header,
     Input,
     Output,
-    Ratifications,
     Transaction,
     Transactions,
     Transition,
@@ -35,7 +35,7 @@ use ledger_block::{
 use ledger_query::Query;
 use ledger_store::{helpers::memory::BlockMemory, BlockStore};
 use synthesizer_process::Process;
-use synthesizer_program::Program;
+use synthesizer_program::{test_helpers::sample_initialize_mapping, Program};
 
 use once_cell::sync::OnceCell;
 
@@ -414,10 +414,12 @@ fn sample_genesis_block_and_components_raw(
     let transactions = Transactions::from_iter([confirmed].into_iter());
 
     // Construct the ratifications.
-    let ratifications = Ratifications::try_from(vec![]).unwrap();
+    let ratifications = vec![sample_ratifications(rng).swap_remove(0)].try_into().unwrap();
+
+    let ratified_finalize_ops = vec![sample_initialize_mapping(rng)];
 
     // Prepare the block header.
-    let header = Header::genesis(&ratifications, &transactions, vec![]).unwrap();
+    let header = Header::genesis(&ratifications, &transactions, ratified_finalize_ops).unwrap();
     // Prepare the previous block hash.
     let previous_hash = <CurrentNetwork as Network>::BlockHash::default();
 

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -26,6 +26,7 @@ edition = "2021"
 [features]
 default = [ ]
 serial = [ "console/serial" ]
+test-helpers = [ ]
 wasm = [ "console/wasm" ]
 
 [dependencies.circuit]

--- a/synthesizer/program/src/logic/finalize_operation/mod.rs
+++ b/synthesizer/program/src/logic/finalize_operation/mod.rs
@@ -39,45 +39,45 @@ pub enum FinalizeOperation<N: Network> {
     RemoveMapping(Field<N>),
 }
 
-#[cfg(test)]
-pub(crate) mod test_helpers {
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers {
     use super::*;
     use console::network::Testnet3;
 
     type CurrentNetwork = Testnet3;
 
     /// Samples a random `InitializeMapping`.
-    pub(crate) fn sample_initialize_mapping(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
+    pub fn sample_initialize_mapping(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
         FinalizeOperation::InitializeMapping(Uniform::rand(rng))
     }
 
     /// Samples a random `InsertKeyValue`.
-    pub(crate) fn sample_insert_key_value(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
+    pub fn sample_insert_key_value(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
         FinalizeOperation::InsertKeyValue(Uniform::rand(rng), Uniform::rand(rng), Uniform::rand(rng))
     }
 
     /// Samples a random `UpdateKeyValue`.
-    pub(crate) fn sample_update_key_value(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
+    pub fn sample_update_key_value(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
         FinalizeOperation::UpdateKeyValue(Uniform::rand(rng), rng.gen(), Uniform::rand(rng), Uniform::rand(rng))
     }
 
     /// Samples a random `RemoveKeyValue`.
-    pub(crate) fn sample_remove_key_value(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
+    pub fn sample_remove_key_value(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
         FinalizeOperation::RemoveKeyValue(Uniform::rand(rng), rng.gen())
     }
 
     /// Samples a random `ReplaceMapping`.
-    pub(crate) fn sample_replace_mapping(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
+    pub fn sample_replace_mapping(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
         FinalizeOperation::ReplaceMapping(Uniform::rand(rng))
     }
 
     /// Samples a random `RemoveMapping`.
-    pub(crate) fn sample_remove_mapping(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
+    pub fn sample_remove_mapping(rng: &mut TestRng) -> FinalizeOperation<CurrentNetwork> {
         FinalizeOperation::RemoveMapping(Uniform::rand(rng))
     }
 
     /// Samples a list of random `FinalizeOperation`.
-    pub(crate) fn sample_finalize_operations() -> Vec<FinalizeOperation<CurrentNetwork>> {
+    pub fn sample_finalize_operations() -> Vec<FinalizeOperation<CurrentNetwork>> {
         let rng = &mut TestRng::default();
 
         vec![


### PR DESCRIPTION
In addition, the existing 2 checks for genesis ratifications are merged into 1 and the related error message is fixed.

If there's a better ratification and finalization to use, I'm happy to adjust the PR.