### PR TITLE
Fix `contains_transaction_id` check

### DIFF
--- a/ledger/src/contains.rs
+++ b/ledger/src/contains.rs
@@ -58,10 +58,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns `true` if the given transaction ID exists.
     pub fn contains_transaction_id(&self, transaction_id: &N::TransactionID) -> Result<bool> {
-        self.vm
-            .transaction_store()
-            .contains_transaction_id(transaction_id)
-            .or(self.vm.block_store().contains_rejected_or_aborted_transaction_id(transaction_id))
+        self.vm.block_store().contains_transaction_id(transaction_id)
     }
 
     /* Transition */

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1238,6 +1238,12 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.reverse_id_map().contains_key_confirmed(block_hash)
     }
 
+    /// Returns `true` if the given transaction ID exists.
+    pub fn contains_transaction_id(&self, transaction_id: &N::TransactionID) -> Result<bool> {
+        Ok(self.transaction_store().contains_transaction_id(transaction_id)?
+            || self.contains_rejected_or_aborted_transaction_id(transaction_id)?)
+    }
+
     /// Returns `true` if the given rejected or aborted transaction ID exists.
     pub fn contains_rejected_or_aborted_transaction_id(&self, transaction_id: &N::TransactionID) -> Result<bool> {
         self.storage.rejected_or_aborted_transaction_id_map().contains_key_confirmed(transaction_id)

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -40,9 +40,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         /* Transaction */
 
         // Ensure the transaction ID is unique.
-        if self.transaction_store().contains_transaction_id(&transaction.id())?
-            || self.block_store().contains_rejected_or_aborted_transaction_id(&transaction.id())?
-        {
+        if self.block_store().contains_transaction_id(&transaction.id())? {
             bail!("Transaction '{}' already exists in the ledger", transaction.id())
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes the `contains_transaction_id` check, and cleans up the impl by adding an abstraction into `BlockStore`.