### PR TITLE
Reduce the size of Variable

### DIFF
--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -29,8 +29,14 @@ impl<F: PrimeField> From<&crate::Variable<F>> for AssignmentVariable<F> {
     fn from(variable: &crate::Variable<F>) -> Self {
         match variable {
             crate::Variable::Constant(value) => Self::Constant(**value),
-            crate::Variable::Public(index, _) => Self::Public(*index),
-            crate::Variable::Private(index, _) => Self::Private(*index),
+            crate::Variable::Public(index_value) => {
+                let (index, _value) = index_value.as_ref();
+                Self::Public(*index)
+            }
+            crate::Variable::Private(index_value) => {
+                let (index, _value) = index_value.as_ref();
+                Self::Private(*index)
+            }
         }
     }
 }

--- a/circuit/environment/src/helpers/converter.rs
+++ b/circuit/environment/src/helpers/converter.rs
@@ -50,13 +50,15 @@ impl<F: PrimeField> R1CS<F> {
         // Allocate the public variables.
         for (i, public) in self.to_public_variables().iter().enumerate() {
             match public {
-                Variable::Public(index, value) => {
+                Variable::Public(index_value) => {
+                    let (index, value) = index_value.as_ref();
+
                     assert_eq!(
                         i as u64, *index,
                         "Public variables in first system must be processed in lexicographic order"
                     );
 
-                    let gadget = cs.alloc_input(|| format!("Public {i}"), || Ok(**value))?;
+                    let gadget = cs.alloc_input(|| format!("Public {i}"), || Ok(*value))?;
 
                     assert_eq!(
                         snarkvm_algorithms::r1cs::Index::Public((index + 1) as usize),
@@ -75,13 +77,15 @@ impl<F: PrimeField> R1CS<F> {
         // Allocate the private variables.
         for (i, private) in self.to_private_variables().iter().enumerate() {
             match private {
-                Variable::Private(index, value) => {
+                Variable::Private(index_value) => {
+                    let (index, value) = index_value.as_ref();
+
                     assert_eq!(
                         i as u64, *index,
                         "Private variables in first system must be processed in lexicographic order"
                     );
 
-                    let gadget = cs.alloc(|| format!("Private {i}"), || Ok(**value))?;
+                    let gadget = cs.alloc(|| format!("Private {i}"), || Ok(*value))?;
 
                     assert_eq!(
                         snarkvm_algorithms::r1cs::Index::Private(i),
@@ -113,7 +117,8 @@ impl<F: PrimeField> R1CS<F> {
                                     "Failed during constraint translation. The first system by definition cannot have constant variables in the terms"
                                 )
                             }
-                            Variable::Public(index, _) => {
+                            Variable::Public(index_value) => {
+                                let (index, _value) = index_value.as_ref();
                                 let gadget = converter.public.get(index).unwrap();
                                 assert_eq!(
                                     snarkvm_algorithms::r1cs::Index::Public((index + 1) as usize),
@@ -122,7 +127,8 @@ impl<F: PrimeField> R1CS<F> {
                                 );
                                 linear_combination += (*coefficient, *gadget);
                             }
-                            Variable::Private(index, _) => {
+                            Variable::Private(index_value) => {
+                                let (index, _value) = index_value.as_ref();
                                 let gadget = converter.private.get(index).unwrap();
                                 assert_eq!(
                                     snarkvm_algorithms::r1cs::Index::Private(*index as usize),

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -549,7 +549,7 @@ mod tests {
         let two = one + one;
         let four = two + two;
 
-        let start = LinearCombination::from(Variable::Public(1, Rc::new(one)));
+        let start = LinearCombination::from(Variable::Public(Rc::new((1, one))));
         assert!(!start.is_constant());
         assert_eq!(one, start.value());
 

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -37,7 +37,7 @@ impl<F: PrimeField> R1CS<F> {
     pub(crate) fn new() -> Self {
         Self {
             constants: Default::default(),
-            public: vec![Variable::Public(0u64, Rc::new(F::one()))],
+            public: vec![Variable::Public(Rc::new((0u64, F::one())))],
             private: Default::default(),
             constraints: Default::default(),
             counter: Default::default(),
@@ -65,7 +65,7 @@ impl<F: PrimeField> R1CS<F> {
 
     /// Returns a new public variable with the given value and scope.
     pub(crate) fn new_public(&mut self, value: F) -> Variable<F> {
-        let variable = Variable::Public(self.public.len() as u64, Rc::new(value));
+        let variable = Variable::Public(Rc::new((self.public.len() as u64, value)));
         self.public.push(variable.clone());
         self.counter.increment_public();
         variable
@@ -73,7 +73,7 @@ impl<F: PrimeField> R1CS<F> {
 
     /// Returns a new private variable with the given value and scope.
     pub(crate) fn new_private(&mut self, value: F) -> Variable<F> {
-        let variable = Variable::Private(self.private.len() as u64, Rc::new(value));
+        let variable = Variable::Private(Rc::new((self.private.len() as u64, value)));
         self.private.push(variable.clone());
         self.counter.increment_private();
         variable

--- a/circuit/types/boolean/src/not.rs
+++ b/circuit/types/boolean/src/not.rs
@@ -38,7 +38,7 @@ impl<E: Environment> Not for &Boolean<E> {
             // Public and private cases.
             // Note: We directly instantiate a public variable to correctly represent a boolean in a linear combination.
             // For more information, see `LinearCombination::is_boolean_type`.
-            false => Boolean(Variable::Public(0, Rc::new(E::BaseField::one())) - &self.0),
+            false => Boolean(Variable::Public(Rc::new((0, E::BaseField::one()))) - &self.0),
         }
     }
 }


### PR DESCRIPTION
Pulling the `Index` inside the `Rc` in the `Variable` reduces the size of that enum from 24B to 16B, resulting in a nice performance improvement in several benchmarks:

`circuit/environment`
```
LinearCombination::add  time:   [2.2728 ms 2.2769 ms 2.2840 ms]
                        change: [-58.436% -58.095% -57.763%] (p = 0.00 < 0.05)
                        Performance has improved.

LinearCombination::add_assign
                        time:   [219.72 µs 220.57 µs 221.90 µs]
                        change: [-3.1905% -2.6603% -2.0857%] (p = 0.00 < 0.05)
                        Performance has improved.

to_value                time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-48.029% +1.1035% +101.41%] (p = 0.98 > 0.05)
                        No change in performance detected.

debug                   time:   [417.03 ms 420.51 ms 423.85 ms]
                        change: [-4.5927% -3.0961% -1.7239%] (p = 0.00 < 0.05)
                        Performance has improved.
```

`circuit/types/boolean`
```
Boolean::and            time:   [877.96 ns 886.63 ns 892.48 ns]
                        change: [-4.6482% -3.6667% -2.6739%] (p = 0.00 < 0.05)
                        Performance has improved.

Boolean::and_assign     time:   [831.10 ns 839.55 ns 849.31 ns]
                        change: [-7.9881% -7.3659% -6.5878%] (p = 0.00 < 0.05)
                        Performance has improved.
```

`ledger/transaction`
```
Transaction::Deploy     time:   [5.9257 s 5.9582 s 5.9904 s]
                        change: [-1.3415% -0.5244% +0.3169%] (p = 0.26 > 0.05)
                        No change in performance detected.

Transaction::Deploy - verify
                        time:   [251.80 ms 253.85 ms 255.89 ms]
                        change: [-5.9006% -4.6712% -3.4559%] (p = 0.00 < 0.05)
                        Performance has improved.

Transaction::Execute(transfer_public)
                        time:   [1.4063 s 1.4137 s 1.4212 s]
                        change: [-1.7184% -0.7350% +0.2030%] (p = 0.18 > 0.05)
                        No change in performance detected.
```