### PR TITLE
Avoid indexing issues when iterating over NestedDataMaps

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -195,6 +195,7 @@ pub enum TestMap {
     Test2 = DataID::Test2 as u16,
     Test3 = DataID::Test3 as u16,
     Test4 = DataID::Test4 as u16,
+    Test5 = DataID::Test5 as u16,
 }
 
 /// The RocksDB map prefix.
@@ -282,4 +283,6 @@ enum DataID {
     Test3,
     #[cfg(test)]
     Test4,
+    #[cfg(test)]
+    Test5,
 }


### PR DESCRIPTION
While we're iterating over a `NestedDataMap`, we may run into indexing issues when we reach the end of its records and attempt to read the map length from a record that belongs to a plain `DataMap`; this PR prevents this, and also breaks the iteration gracefully instead of returning early.