### PR TITLE
[NCC CDE] Add to reserved keywords

### DIFF
--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -589,6 +589,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         "owner",
         // Program
         "transition",
+        "import",
         "function",
         "struct",
         "closure",


### PR DESCRIPTION
## Motivation

NCC noted we might be missing certain reserved keywords. Besides import, they also noticed  `bool`, `inline` and `transition` but those only exist in Leo. Let me know if you want me to add those.
