### PR TITLE
[NCC XL9] Make sure we loop independent of order in map

### DIFF
--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -170,7 +170,7 @@ impl<F: PrimeField> Evaluations<F> {
 
         for (label, value) in map {
             if label == "g_1" {
-                break;
+                continue;
             }
 
             if label.contains("g_a") {


### PR DESCRIPTION
## Motivation

We need to always iterate over all values in the map. Previously, we were "lucky" that g_1 was the last element iterated over.
