### PR TITLE
[TOB] Fix the number of elements for serializers

### DIFF
--- a/console/program/src/request/serialize.rs
+++ b/console/program/src/request/serialize.rs
@@ -21,7 +21,7 @@ impl<N: Network> Serialize for Request<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut transition = serializer.serialize_struct("Request", 9)?;
+                let mut transition = serializer.serialize_struct("Request", 10)?;
                 transition.serialize_field("signer", &self.signer)?;
                 transition.serialize_field("network", &self.network_id)?;
                 transition.serialize_field("program", &self.program_id)?;

--- a/ledger/block/src/serialize.rs
+++ b/ledger/block/src/serialize.rs
@@ -19,7 +19,7 @@ impl<N: Network> Serialize for Block<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut block = serializer.serialize_struct("Block", 6)?;
+                let mut block = serializer.serialize_struct("Block", 7 + self.solutions.is_some() as usize)?;
                 block.serialize_field("block_hash", &self.block_hash)?;
                 block.serialize_field("previous_hash", &self.previous_hash)?;
                 block.serialize_field("header", &self.header)?;

--- a/ledger/block/src/transaction/execution/serialize.rs
+++ b/ledger/block/src/transaction/execution/serialize.rs
@@ -19,7 +19,7 @@ impl<N: Network> Serialize for Execution<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut execution = serializer.serialize_struct("Execution", 3)?;
+                let mut execution = serializer.serialize_struct("Execution", 2 + self.proof.is_some() as usize)?;
                 execution
                     .serialize_field("transitions", &self.transitions.values().collect::<Vec<&Transition<N>>>())?;
                 execution.serialize_field("global_state_root", &self.global_state_root)?;

--- a/ledger/block/src/transaction/fee/serialize.rs
+++ b/ledger/block/src/transaction/fee/serialize.rs
@@ -19,7 +19,7 @@ impl<N: Network> Serialize for Fee<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut fee = serializer.serialize_struct("Fee", 3)?;
+                let mut fee = serializer.serialize_struct("Fee", 2 + self.proof.is_some() as usize)?;
                 fee.serialize_field("transition", &self.transition)?;
                 fee.serialize_field("global_state_root", &self.global_state_root)?;
                 if let Some(proof) = &self.proof {

--- a/ledger/block/src/transaction/serialize.rs
+++ b/ledger/block/src/transaction/serialize.rs
@@ -29,7 +29,7 @@ impl<N: Network> Serialize for Transaction<N> {
                     transaction.end()
                 }
                 Self::Execute(id, execution, fee) => {
-                    let mut transaction = serializer.serialize_struct("Transaction", 4)?;
+                    let mut transaction = serializer.serialize_struct("Transaction", 3 + fee.is_some() as usize)?;
                     transaction.serialize_field("type", "execute")?;
                     transaction.serialize_field("id", &id)?;
                     transaction.serialize_field("execution", &execution)?;

--- a/ledger/block/src/transition/input/serialize.rs
+++ b/ledger/block/src/transition/input/serialize.rs
@@ -20,7 +20,7 @@ impl<N: Network> Serialize for Input<N> {
         match serializer.is_human_readable() {
             true => match self {
                 Self::Constant(id, value) => {
-                    let mut input = serializer.serialize_struct("Input", 3)?;
+                    let mut input = serializer.serialize_struct("Input", 2 + value.is_some() as usize)?;
                     input.serialize_field("type", "constant")?;
                     input.serialize_field("id", &id)?;
                     if let Some(value) = value {
@@ -29,7 +29,7 @@ impl<N: Network> Serialize for Input<N> {
                     input.end()
                 }
                 Self::Public(id, value) => {
-                    let mut input = serializer.serialize_struct("Input", 3)?;
+                    let mut input = serializer.serialize_struct("Input", 2 + value.is_some() as usize)?;
                     input.serialize_field("type", "public")?;
                     input.serialize_field("id", &id)?;
                     if let Some(value) = value {
@@ -38,7 +38,7 @@ impl<N: Network> Serialize for Input<N> {
                     input.end()
                 }
                 Self::Private(id, value) => {
-                    let mut input = serializer.serialize_struct("Input", 3)?;
+                    let mut input = serializer.serialize_struct("Input", 2 + value.is_some() as usize)?;
                     input.serialize_field("type", "private")?;
                     input.serialize_field("id", &id)?;
                     if let Some(value) = value {

--- a/ledger/block/src/transition/output/serialize.rs
+++ b/ledger/block/src/transition/output/serialize.rs
@@ -20,7 +20,7 @@ impl<N: Network> Serialize for Output<N> {
         match serializer.is_human_readable() {
             true => match self {
                 Self::Constant(id, value) => {
-                    let mut output = serializer.serialize_struct("Output", 3)?;
+                    let mut output = serializer.serialize_struct("Output", 2 + value.is_some() as usize)?;
                     output.serialize_field("type", "constant")?;
                     output.serialize_field("id", &id)?;
                     if let Some(value) = value {
@@ -29,7 +29,7 @@ impl<N: Network> Serialize for Output<N> {
                     output.end()
                 }
                 Self::Public(id, value) => {
-                    let mut output = serializer.serialize_struct("Output", 3)?;
+                    let mut output = serializer.serialize_struct("Output", 2 + value.is_some() as usize)?;
                     output.serialize_field("type", "public")?;
                     output.serialize_field("id", &id)?;
                     if let Some(value) = value {
@@ -38,7 +38,7 @@ impl<N: Network> Serialize for Output<N> {
                     output.end()
                 }
                 Self::Private(id, value) => {
-                    let mut output = serializer.serialize_struct("Output", 3)?;
+                    let mut output = serializer.serialize_struct("Output", 2 + value.is_some() as usize)?;
                     output.serialize_field("type", "private")?;
                     output.serialize_field("id", &id)?;
                     if let Some(value) = value {
@@ -47,7 +47,7 @@ impl<N: Network> Serialize for Output<N> {
                     output.end()
                 }
                 Self::Record(id, checksum, value) => {
-                    let mut output = serializer.serialize_struct("Output", 5)?;
+                    let mut output = serializer.serialize_struct("Output", 3 + value.is_some() as usize)?;
                     output.serialize_field("type", "record")?;
                     output.serialize_field("id", &id)?;
                     output.serialize_field("checksum", &checksum)?;
@@ -63,7 +63,7 @@ impl<N: Network> Serialize for Output<N> {
                     output.end()
                 }
                 Self::Future(id, value) => {
-                    let mut output = serializer.serialize_struct("Output", 3)?;
+                    let mut output = serializer.serialize_struct("Output", 2 + value.is_some() as usize)?;
                     output.serialize_field("type", "future")?;
                     output.serialize_field("id", &id)?;
                     if let Some(value) = value {

--- a/ledger/coinbase/src/helpers/prover_solution/serialize.rs
+++ b/ledger/coinbase/src/helpers/prover_solution/serialize.rs
@@ -21,7 +21,8 @@ impl<N: Network> Serialize for ProverSolution<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut prover_solution = serializer.serialize_struct("ProverSolution", 3)?;
+                let mut prover_solution =
+                    serializer.serialize_struct("ProverSolution", 2 + self.proof.random_v.is_some() as usize)?;
                 prover_solution.serialize_field("partial_solution", &self.partial_solution)?;
                 prover_solution.serialize_field("proof.w", &self.proof.w)?;
                 if let Some(random_v) = &self.proof.random_v {

--- a/ledger/narwhal/transmission/src/serialize.rs
+++ b/ledger/narwhal/transmission/src/serialize.rs
@@ -18,23 +18,25 @@ impl<N: Network> Serialize for Transmission<N> {
     #[inline]
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
-            true => {
-                let mut transmission = serializer.serialize_struct("Transmission", 2)?;
-                match self {
-                    Self::Ratification => {
-                        transmission.serialize_field("type", "ratification")?;
-                    }
-                    Self::Solution(solution) => {
-                        transmission.serialize_field("type", "solution")?;
-                        transmission.serialize_field("transmission", solution)?;
-                    }
-                    Self::Transaction(transaction) => {
-                        transmission.serialize_field("type", "transaction")?;
-                        transmission.serialize_field("transmission", transaction)?;
-                    }
+            true => match self {
+                Self::Ratification => {
+                    let mut transmission = serializer.serialize_struct("Transmission", 1)?;
+                    transmission.serialize_field("type", "ratification")?;
+                    transmission.end()
                 }
-                transmission.end()
-            }
+                Self::Solution(solution) => {
+                    let mut transmission = serializer.serialize_struct("Transmission", 2)?;
+                    transmission.serialize_field("type", "solution")?;
+                    transmission.serialize_field("transmission", solution)?;
+                    transmission.end()
+                }
+                Self::Transaction(transaction) => {
+                    let mut transmission = serializer.serialize_struct("Transmission", 2)?;
+                    transmission.serialize_field("type", "transaction")?;
+                    transmission.serialize_field("transmission", transaction)?;
+                    transmission.end()
+                }
+            },
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
         }
     }

--- a/synthesizer/program/src/logic/finalize_operation/serialize.rs
+++ b/synthesizer/program/src/logic/finalize_operation/serialize.rs
@@ -19,41 +19,51 @@ impl<N: Network> Serialize for FinalizeOperation<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut operation = serializer.serialize_struct("FinalizeOperation", 5)?;
                 // Serialize the components.
                 match self {
                     Self::InitializeMapping(mapping_id) => {
+                        let mut operation = serializer.serialize_struct("FinalizeOperation", 2)?;
                         operation.serialize_field("type", "initialize_mapping")?;
                         operation.serialize_field("mapping_id", mapping_id)?;
+                        operation.end()
                     }
                     Self::InsertKeyValue(mapping_id, key_id, value_id) => {
+                        let mut operation = serializer.serialize_struct("FinalizeOperation", 4)?;
                         operation.serialize_field("type", "insert_key_value")?;
                         operation.serialize_field("mapping_id", mapping_id)?;
                         operation.serialize_field("key_id", key_id)?;
                         operation.serialize_field("value_id", value_id)?;
+                        operation.end()
                     }
                     Self::UpdateKeyValue(mapping_id, index, key_id, value_id) => {
+                        let mut operation = serializer.serialize_struct("FinalizeOperation", 5)?;
                         operation.serialize_field("type", "update_key_value")?;
                         operation.serialize_field("mapping_id", mapping_id)?;
                         operation.serialize_field("index", index)?;
                         operation.serialize_field("key_id", key_id)?;
                         operation.serialize_field("value_id", value_id)?;
+                        operation.end()
                     }
                     Self::RemoveKeyValue(mapping_id, index) => {
+                        let mut operation = serializer.serialize_struct("FinalizeOperation", 3)?;
                         operation.serialize_field("type", "remove_key_value")?;
                         operation.serialize_field("mapping_id", mapping_id)?;
                         operation.serialize_field("index", index)?;
+                        operation.end()
                     }
                     Self::ReplaceMapping(mapping_id) => {
+                        let mut operation = serializer.serialize_struct("FinalizeOperation", 2)?;
                         operation.serialize_field("type", "replace_mapping")?;
                         operation.serialize_field("mapping_id", mapping_id)?;
+                        operation.end()
                     }
                     Self::RemoveMapping(mapping_id) => {
+                        let mut operation = serializer.serialize_struct("FinalizeOperation", 2)?;
                         operation.serialize_field("type", "remove_mapping")?;
                         operation.serialize_field("mapping_id", mapping_id)?;
+                        operation.end()
                     }
                 }
-                operation.end()
             }
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
         }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes the number of elements specified in the `<Object>::serialize` functions.

Finding: TOB-ALEO-13