### PR TITLE
[TOB] Guard overflow in finalize cost calculation

### DIFF
--- a/synthesizer/src/vm/helpers/cost.rs
+++ b/synthesizer/src/vm/helpers/cost.rs
@@ -202,6 +202,6 @@ pub fn cost_in_microcredits<N: Network>(finalize: &Finalize<N>) -> Result<u64> {
     finalize
         .commands()
         .iter()
-        .map(|command| cost(command))
+        .map(cost)
         .try_fold(0u64, |acc, res| res.and_then(|x| acc.checked_add(x).ok_or(anyhow!("Finalize cost overflowed"))))
 }

--- a/synthesizer/src/vm/helpers/cost.rs
+++ b/synthesizer/src/vm/helpers/cost.rs
@@ -199,5 +199,9 @@ pub fn cost_in_microcredits<N: Network>(finalize: &Finalize<N>) -> Result<u64> {
         Command::BranchEq(_) | Command::BranchNeq(_) => Ok(5_000),
         Command::Position(_) => Ok(1_000),
     };
-    finalize.commands().iter().map(|command| cost(command)).sum()
+    finalize
+        .commands()
+        .iter()
+        .map(|command| cost(command))
+        .try_fold(0u64, |acc, res| res.map(|x| acc.saturating_add(x)))
 }

--- a/synthesizer/src/vm/helpers/cost.rs
+++ b/synthesizer/src/vm/helpers/cost.rs
@@ -203,5 +203,5 @@ pub fn cost_in_microcredits<N: Network>(finalize: &Finalize<N>) -> Result<u64> {
         .commands()
         .iter()
         .map(|command| cost(command))
-        .try_fold(0u64, |acc, res| res.map(|x| acc.saturating_add(x)))
+        .try_fold(0u64, |acc, res| res.and_then(|x| acc.checked_add(x).ok_or(anyhow!("Finalize cost overflowed"))))
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the use of `.sum()` in the finalize cost calculator to a `try_fold` + `checked_add` approach that will catch overflows. 

This change was made to be extra cautious. Note that in the previous model, the maximum number of finalize operations at `u16::MAX` * most expensive finalize operation would never cause an overflow with `.sum()`.

Finding: TOB-ALEO-14
