### PR TITLE
[TOB] Remove unreachable check in `verify_authority`

### DIFF
--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -137,16 +137,11 @@ impl<N: Network> Block<N> {
         previous_height: u32,
         current_committee: &Committee<N>,
     ) -> Result<(u64, u32, i64)> {
+        #[cfg(not(any(test, feature = "test")))]
+        ensure!(self.authority.is_quorum(), "The next block must be a quorum block");
+
         // Determine the expected height.
         let expected_height = previous_height.saturating_add(1);
-        // Ensure the block type is correct.
-        match expected_height == 0 {
-            true => ensure!(self.authority.is_beacon(), "The genesis block must be a beacon block"),
-            false => {
-                #[cfg(not(any(test, feature = "test")))]
-                ensure!(self.authority.is_quorum(), "The next block must be a quorum block");
-            }
-        }
 
         // Determine the expected round.
         let expected_round = match &self.authority {


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes an unreachable check in `Block::verify_authority`. The genesis case will (and should) never be hit because the genesis block should not have a `previous_round` or previous_height`.


Finding: TOB-ALEO-20