### PR TITLE
[TOB] Fix off-by-one `N::MAX_FEE` check

### DIFF
--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -255,7 +255,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // Ensure the fee does not exceed the limit.
         let fee_amount = fee.amount()?;
-        ensure!(*fee_amount < N::MAX_FEE, "Fee verification failed: fee exceeds the maximum limit");
+        ensure!(*fee_amount <= N::MAX_FEE, "Fee verification failed: fee exceeds the maximum limit");
 
         // Verify the fee.
         let verification = self.process.read().verify_fee(fee, deployment_or_execution_id);


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes the `N::MAX_FEE` check in `check_fee_internal` which was off by one.


Finding: TOB-ALEO-25