### PR TITLE
[TOB] Remove possible truncation in `block_reward`

### DIFF
--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -27,7 +27,7 @@ pub const fn block_reward(total_supply: u64, block_time: u16, coinbase_reward: u
     // Compute the expected block height at year 1.
     let block_height_at_year_1 = block_height_at_year(block_time, 1);
     // Compute the annual reward: (0.05 * S).
-    let annual_reward = (total_supply / 1000) * 50;
+    let annual_reward = total_supply / 20;
     // Compute the block reward: (0.05 * S) / H_Y1.
     let block_reward = annual_reward / block_height_at_year_1 as u64;
     // Return the sum of the block reward, coinbase reward, and transaction fees.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR simplifies and removes possible truncation from the `annual_reward` calculation in the `block_reward` function.

We choose not to use `checked_add` for overflow checks in `block_reward + coinbase_reward / 2 + transaction_fee`, because an overflow should never be hit with our current parameters. 

Also note that with our current parameters, we would never hit a truncation case for `annual_reward`, however we elect to make this change out of an abundance of caution.

Finding: TOB-ALEO-26
