### PR TITLE
[TOB] Update documentation for `matches_record`

### DIFF
--- a/synthesizer/process/src/stack/register_types/matches.rs
+++ b/synthesizer/process/src/stack/register_types/matches.rs
@@ -168,8 +168,6 @@ impl<N: Network> RegisterTypes<N> {
     }
 
     /// Checks that the given record matches the layout of the record type.
-    /// Note: Ordering for `owner` **does** matter, however ordering
-    /// for record data does **not** matter, as long as all defined members are present.
     pub fn matches_record(
         &self,
         stack: &(impl StackMatches<N> + StackProgram<N>),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the incorrect documentation "note" regarding ordering for the `matches_record` function.

Finding: TOB-ALEO-8