### PR TITLE
Use a custom panic hook for caught halting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,6 +3323,7 @@ dependencies = [
  "snarkvm-ledger-test-helpers",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
  "tempfile",
 ]
 

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -83,6 +83,11 @@ package = "snarkvm-synthesizer-snark"
 path = "../../synthesizer/snark"
 version = "=0.16.8"
 
+[dependencies.utilities]
+package = "snarkvm-utilities"
+path = "../../utilities"
+version = "=0.16.8"
+
 [dependencies.aleo-std]
 version = "0.1.18"
 default-features = false

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -15,6 +15,7 @@
 use super::*;
 use console::program::{Future, Register};
 use synthesizer_program::{Await, FinalizeRegistersState, Operand};
+use utilities::handle_halting;
 
 impl<N: Network> Process<N> {
     /// Finalizes the deployment and fee.
@@ -224,7 +225,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
             // Finalize the command.
             match &command {
                 Command::BranchEq(branch_eq) => {
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let result = handle_halting!(panic::AssertUnwindSafe(|| {
                         branch_to(counter, branch_eq, finalize, stack, &registers)
                     }));
                     match result {
@@ -238,7 +239,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     }
                 }
                 Command::BranchNeq(branch_neq) => {
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let result = handle_halting!(panic::AssertUnwindSafe(|| {
                         branch_to(counter, branch_neq, finalize, stack, &registers)
                     }));
                     match result {
@@ -276,7 +277,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                         None => bail!("Transition ID '{transition_id}' not found in call graph"),
                     };
 
-                    let callee_state = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let callee_state = match handle_halting!(panic::AssertUnwindSafe(|| {
                         // Set up the finalize state for the await.
                         setup_await(state, await_, stack, &registers, child_transition_id)
                     })) {
@@ -306,9 +307,8 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     break;
                 }
                 _ => {
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        command.finalize(stack, store, &mut registers)
-                    }));
+                    let result =
+                        handle_halting!(panic::AssertUnwindSafe(|| { command.finalize(stack, store, &mut registers) }));
                     match result {
                         // If the evaluation succeeds with an operation, add it to the list.
                         Ok(Ok(Some(finalize_operation))) => finalize_operations.push(finalize_operation),


### PR DESCRIPTION
This PR addresses the potentially misleading panic messages and backtraces that are currently produced whenever a program's execution is halted. To do this, a custom hook is set right before those callsites and restored to the standard one right afterwards.

While these messages still stand out a bit due to not being part of the `tracing` setup (since `snarkvm-utilities` doesn't depend on `tracing`, they are written directly to `stderr`), this is still a big win for clarity.