### PR TITLE
[TOB-1] Adds check for possible panics in FromBytes impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,6 +3049,7 @@ dependencies = [
  "snarkvm-ledger-authority",
  "snarkvm-ledger-coinbase",
  "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-transmission-id",
  "snarkvm-ledger-query",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,6 +3096,7 @@ dependencies = [
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-header",
  "test-strategy",
 ]
 
@@ -3158,6 +3159,7 @@ dependencies = [
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-transmission-id",
 ]

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -109,8 +109,8 @@ pub trait Network:
     const BLOCK_TIME: u16 = 10;
     /// The coinbase puzzle degree.
     const COINBASE_PUZZLE_DEGREE: u32 = (1 << 13) - 1; // 8,191
-    /// The maximum number of prover solutions that can be included per block.
-    const MAX_PROVER_SOLUTIONS: usize = 1 << 8; // 256 prover solutions
+    /// The maximum number of solutions that can be included per block.
+    const MAX_SOLUTIONS: usize = 1 << 8; // 256 solutions
     /// The number of blocks per epoch.
     const NUM_BLOCKS_PER_EPOCH: u32 = 3600 / Self::BLOCK_TIME as u32; // 360 blocks == ~1 hour
 

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -100,6 +100,10 @@ package = "snarkvm-ledger-committee"
 path = "../../ledger/committee"
 features = [ "test-helpers" ]
 
+[dev-dependencies.ledger-narwhal-batch-header]
+package = "snarkvm-ledger-narwhal-batch-header"
+path = "../narwhal/batch-header"
+
 [dev-dependencies.ledger-query]
 package = "snarkvm-ledger-query"
 path = "../query"

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -339,3 +339,18 @@ pub mod test_helpers {
         crate::test_helpers::sample_genesis_block(rng).transactions().clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type CurrentNetwork = console::network::Testnet3;
+
+    #[test]
+    fn test_max_transactions() {
+        assert_eq!(
+            Transactions::<CurrentNetwork>::MAX_TRANSACTIONS,
+            ledger_narwhal_batch_header::BatchHeader::<CurrentNetwork>::MAX_TRANSACTIONS
+        );
+    }
+}

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -271,10 +271,10 @@ impl<N: Network> Block<N> {
             Some(coinbase) => {
                 // Ensure the number of solutions is within the allowed range.
                 ensure!(
-                    coinbase.len() <= N::MAX_PROVER_SOLUTIONS,
+                    coinbase.len() <= N::MAX_SOLUTIONS,
                     "Block {height} contains too many prover solutions (found '{}', expected '{}')",
                     coinbase.len(),
-                    N::MAX_PROVER_SOLUTIONS
+                    N::MAX_SOLUTIONS
                 );
                 // Ensure the solutions are not accepted after the block height at year 10.
                 if height > block_height_at_year(N::BLOCK_TIME, 10) {

--- a/ledger/coinbase/benches/coinbase_puzzle.rs
+++ b/ledger/coinbase/benches/coinbase_puzzle.rs
@@ -95,7 +95,7 @@ fn coinbase_puzzle_verify(c: &mut Criterion) {
         let puzzle = CoinbasePuzzleInst::trim(&universal_srs, config).unwrap();
         let epoch_challenge = sample_epoch_challenge(degree, rng);
 
-        for batch_size in [10, 100, <Testnet3 as Network>::MAX_PROVER_SOLUTIONS] {
+        for batch_size in [10, 100, <Testnet3 as Network>::MAX_SOLUTIONS] {
             let solutions = (0..batch_size)
                 .map(|_| {
                     let (address, nonce) = sample_address_and_nonce(rng);

--- a/ledger/coinbase/src/helpers/coinbase_solution/mod.rs
+++ b/ledger/coinbase/src/helpers/coinbase_solution/mod.rs
@@ -33,11 +33,11 @@ impl<N: Network> CoinbaseSolution<N> {
         // Ensure the solutions are not empty.
         ensure!(!solutions.is_empty(), "There are no solutions to verify for the coinbase puzzle");
         // Ensure the number of partial solutions does not exceed `MAX_PROVER_SOLUTIONS`.
-        if solutions.len() > N::MAX_PROVER_SOLUTIONS {
+        if solutions.len() > N::MAX_SOLUTIONS {
             bail!(
                 "The solutions exceed the allowed number of partial solutions. ({} > {})",
                 solutions.len(),
-                N::MAX_PROVER_SOLUTIONS
+                N::MAX_SOLUTIONS
             );
         }
         // Ensure the puzzle commitments are unique.

--- a/ledger/coinbase/src/lib.rs
+++ b/ledger/coinbase/src/lib.rs
@@ -171,11 +171,11 @@ impl<N: Network> CoinbasePuzzle<N> {
         ensure!(!solutions.is_empty(), "There are no solutions to verify for the coinbase puzzle");
 
         // Ensure the number of partial solutions does not exceed `MAX_PROVER_SOLUTIONS`.
-        if solutions.len() > N::MAX_PROVER_SOLUTIONS {
+        if solutions.len() > N::MAX_SOLUTIONS {
             bail!(
                 "The solutions exceed the allowed number of partial solutions. ({} > {})",
                 solutions.len(),
-                N::MAX_PROVER_SOLUTIONS
+                N::MAX_SOLUTIONS
             );
         }
 

--- a/ledger/coinbase/src/tests.rs
+++ b/ledger/coinbase/src/tests.rs
@@ -133,7 +133,7 @@ fn test_profiler() -> Result<()> {
     // Generate proof inputs
     let epoch_challenge = EpochChallenge::new(rng.next_u32(), Default::default(), degree).unwrap();
 
-    for batch_size in [10, 100, <Testnet3 as Network>::MAX_PROVER_SOLUTIONS] {
+    for batch_size in [10, 100, <Testnet3 as Network>::MAX_SOLUTIONS] {
         // Generate the solutions.
         let solutions = (0..batch_size)
             .map(|_| {

--- a/ledger/committee/Cargo.toml
+++ b/ledger/committee/Cargo.toml
@@ -82,3 +82,7 @@ version = "1"
 [dev-dependencies.snarkvm-ledger-committee]
 path = "."
 features = [ "prop-tests" ]
+
+[dev-dependencies.ledger-narwhal-batch-header]
+package = "snarkvm-ledger-narwhal-batch-header"
+path = "../narwhal/batch-header"

--- a/ledger/committee/src/bytes.rs
+++ b/ledger/committee/src/bytes.rs
@@ -28,6 +28,7 @@ impl<N: Network> FromBytes for Committee<N> {
         let starting_round = u64::read_le(&mut reader)?;
         // Read the number of members.
         let num_members = u16::read_le(&mut reader)?;
+        // Ensure the number of members is within the allowed limit.
         if num_members > Self::MAX_COMMITTEE_SIZE {
             return Err(error(format!(
                 "Committee cannot exceed {} members, found {num_members}",

--- a/ledger/committee/src/bytes.rs
+++ b/ledger/committee/src/bytes.rs
@@ -28,6 +28,12 @@ impl<N: Network> FromBytes for Committee<N> {
         let starting_round = u64::read_le(&mut reader)?;
         // Read the number of members.
         let num_members = u16::read_le(&mut reader)?;
+        if num_members > Self::MAX_COMMITTEE_SIZE {
+            return Err(error(format!(
+                "Committee cannot exceed {} members, found {num_members}",
+                Self::MAX_COMMITTEE_SIZE,
+            )));
+        }
         // Read the members.
         let mut members = IndexMap::with_capacity(num_members as usize);
         for _ in 0..num_members {

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -405,4 +405,12 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_maximum_committee_size() {
+        assert_eq!(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize,
+            ledger_narwhal_batch_header::BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES
+        );
+    }
 }

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -36,8 +36,11 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         // Read the number of transmission IDs.
         let num_transmission_ids = u32::read_le(&mut reader)?;
         // Ensure the number of transmission IDs is within bounds.
-        if num_transmission_ids > i32::MAX as u32 {
-            return Err(error("Number of transmission ids exceeds maximum"));
+        if num_transmission_ids as usize > Self::MAX_TRANSMISSIONS {
+            return Err(error(format!(
+                "Number of transmission IDs ({num_transmission_ids}) exceeds the maximum ({})",
+                Self::MAX_TRANSMISSIONS,
+            )));
         }
         // Read the transmission IDs.
         let mut transmission_ids = IndexSet::new();

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -48,7 +48,7 @@ impl<N: Network> FromBytes for BatchHeader<N> {
 
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u32::read_le(&mut reader)?;
-        // Ensure the number of previous certificate ids is within bounds.
+        // Ensure the number of previous certificate IDs is within bounds.
         if num_previous_certificate_ids > i32::MAX as u32 {
             return Err(error("Number of previous certificate ids exceeds maximum"));
         }

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -34,16 +34,24 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         let timestamp = i64::read_le(&mut reader)?;
 
         // Read the number of transmission IDs.
-        let num_transmissions = u32::read_le(&mut reader)?;
+        let num_transmission_ids = u32::read_le(&mut reader)?;
+        // Ensure the number of transmission ids is within bounds.
+        if num_transmission_ids > i32::MAX as u32 {
+            return Err(error("Number of transmission ids exceeds maximum"));
+        }
         // Read the transmission IDs.
         let mut transmission_ids = IndexSet::new();
-        for _ in 0..num_transmissions {
+        for _ in 0..num_transmission_ids {
             // Insert the transmission ID.
             transmission_ids.insert(TransmissionID::read_le(&mut reader)?);
         }
 
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u32::read_le(&mut reader)?;
+        // Ensure the number of previous certificate ids is within bounds.
+        if num_previous_certificate_ids > i32::MAX as u32 {
+            return Err(error("Number of previous certificate ids exceeds maximum"));
+        }
         // Read the previous certificate IDs.
         let mut previous_certificate_ids = IndexSet::with_capacity(num_previous_certificate_ids as usize);
         for _ in 0..num_previous_certificate_ids {

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -35,7 +35,7 @@ impl<N: Network> FromBytes for BatchHeader<N> {
 
         // Read the number of transmission IDs.
         let num_transmission_ids = u32::read_le(&mut reader)?;
-        // Ensure the number of transmission ids is within bounds.
+        // Ensure the number of transmission IDs is within bounds.
         if num_transmission_ids > i32::MAX as u32 {
             return Err(error("Number of transmission ids exceeds maximum"));
         }

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -52,8 +52,11 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u32::read_le(&mut reader)?;
         // Ensure the number of previous certificate IDs is within bounds.
-        if num_previous_certificate_ids > i32::MAX as u32 {
-            return Err(error("Number of previous certificate ids exceeds maximum"));
+        if num_previous_certificate_ids as usize > Self::MAX_CERTIFICATES {
+            return Err(error(format!(
+                "Number of previous certificate IDs ({num_previous_certificate_ids}) exceeds the maximum ({})",
+                Self::MAX_CERTIFICATES
+            )));
         }
         // Read the previous certificate IDs.
         let mut previous_certificate_ids = IndexSet::new();

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -53,7 +53,7 @@ impl<N: Network> FromBytes for BatchHeader<N> {
             return Err(error("Number of previous certificate ids exceeds maximum"));
         }
         // Read the previous certificate IDs.
-        let mut previous_certificate_ids = IndexSet::with_capacity(num_previous_certificate_ids as usize);
+        let mut previous_certificate_ids = IndexSet::new();
         for _ in 0..num_previous_certificate_ids {
             // Read the certificate ID.
             previous_certificate_ids.insert(Field::read_le(&mut reader)?);

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -47,6 +47,8 @@ pub struct BatchHeader<N: Network> {
 }
 
 impl<N: Network> BatchHeader<N> {
+    /// The maximum number of certificates in a batch.
+    pub const MAX_CERTIFICATES: usize = 200;
     /// The maximum number of solutions in a batch.
     pub const MAX_SOLUTIONS: usize = N::MAX_SOLUTIONS;
     /// The maximum number of transactions in a batch.

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -47,6 +47,15 @@ pub struct BatchHeader<N: Network> {
 }
 
 impl<N: Network> BatchHeader<N> {
+    /// The maximum number of solutions in a batch.
+    pub const MAX_SOLUTIONS: usize = N::MAX_SOLUTIONS;
+    /// The maximum number of transactions in a batch.
+    pub const MAX_TRANSACTIONS: usize = usize::pow(2, console::program::TRANSACTIONS_DEPTH as u32);
+    /// The maximum number of transmissions in a batch.
+    pub const MAX_TRANSMISSIONS: usize = Self::MAX_SOLUTIONS + Self::MAX_TRANSACTIONS;
+}
+
+impl<N: Network> BatchHeader<N> {
     /// Initializes a new batch header.
     pub fn new<R: Rng + CryptoRng>(
         private_key: &PrivateKey<N>,

--- a/ledger/narwhal/subdag/Cargo.toml
+++ b/ledger/narwhal/subdag/Cargo.toml
@@ -39,6 +39,11 @@ package = "snarkvm-ledger-narwhal-batch-certificate"
 path = "../batch-certificate"
 version = "=0.16.8"
 
+[dependencies.narwhal-batch-header]
+package = "snarkvm-ledger-narwhal-batch-header"
+path = "../batch-header"
+version = "=0.16.8"
+
 [dependencies.narwhal-transmission-id]
 package = "snarkvm-ledger-narwhal-transmission-id"
 path = "../transmission-id"

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -26,6 +26,10 @@ impl<N: Network> FromBytes for Subdag<N> {
 
         // Read the number of rounds.
         let num_rounds = u32::read_le(&mut reader)?;
+        // Ensure the number of rounds is within bounds.
+        if num_rounds > i32::MAX as u32 {
+            return Err(error("Number of rounds exceeds maximum"));
+        }
         // Read the round certificates.
         let mut subdag = BTreeMap::new();
         for _ in 0..num_rounds {
@@ -33,6 +37,10 @@ impl<N: Network> FromBytes for Subdag<N> {
             let round = u64::read_le(&mut reader)?;
             // Read the number of certificates.
             let num_certificates = u32::read_le(&mut reader)?;
+            // Ensure the number of certificates is within bounds.
+            if num_certificates > i32::MAX as u32 {
+                return Err(error("Number of certificates exceeds maximum"));
+            }
             // Read the certificates.
             let mut certificates = IndexSet::with_capacity(num_certificates as usize);
             for _ in 0..num_certificates {

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -42,7 +42,7 @@ impl<N: Network> FromBytes for Subdag<N> {
                 return Err(error("Number of certificates exceeds maximum"));
             }
             // Read the certificates.
-            let mut certificates = IndexSet::with_capacity(num_certificates as usize);
+            let mut certificates = IndexSet::new();
             for _ in 0..num_certificates {
                 // Read the certificate.
                 certificates.insert(BatchCertificate::read_le(&mut reader)?);

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -21,6 +21,7 @@ mod string;
 
 use console::{account::Address, prelude::*, program::SUBDAG_CERTIFICATES_DEPTH, types::Field};
 use narwhal_batch_certificate::BatchCertificate;
+use narwhal_batch_header::BatchHeader;
 use narwhal_transmission_id::TransmissionID;
 
 use indexmap::IndexSet;
@@ -99,6 +100,11 @@ impl<N: Network> Subdag<N> {
         // Ensure the leader certificate is an even round.
         Ok(Self { subdag })
     }
+}
+
+impl<N: Network> Subdag<N> {
+    /// The maximum number of rounds in a subdag (bounded up to GC depth).
+    pub const MAX_ROUNDS: usize = 50;
 }
 
 impl<N: Network> Subdag<N> {

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -145,9 +145,9 @@ impl<'de, T: FromBytes> FromBytesDeserializer<T> {
             false => (size_b, size_a),
         };
 
-        // Ensure size_b is within bounds.
+        // Ensure 'size_b' is within bounds.
         if size_b > i32::MAX as usize {
-            return Err(D::Error::custom("size_b exceeds maximum"));
+            return Err(D::Error::custom(format!("size_b ({size_b}) exceeds maximum")));
         }
 
         // Reserve a new `Vec` with the larger size capacity.

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -145,6 +145,11 @@ impl<'de, T: FromBytes> FromBytesDeserializer<T> {
             false => (size_b, size_a),
         };
 
+        // Ensure size_b is within bounds.
+        if size_b > i32::MAX as usize {
+            return Err(D::Error::custom("size_b exceeds maximum"));
+        }
+
         // Reserve a new `Vec` with the larger size capacity.
         let mut buffer = Vec::with_capacity(size_b);
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds guards for possible denial of service vectors in `FromBytes` implementations.

Example:
```
let num_ratifications = u32::read_le(&mut reader)?;
let mut ratifications = Vec::with_capacity(num_ratifications as usize);
This will cause a panic in 32-bit architectures if num_ratifications exceeds i32::MAX.
```

Note: we are skipping some of the bound checks in `sonic_pc/data_structures` because it won't practically hit these larger values. 

Finding: TOB-ALEO-1
