### PR TITLE
Reserve the exact capacity in more ToBits impls

### DIFF
--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -583,6 +583,10 @@ impl<P: Fp256Parameters> ToBits for Fp256<P> {
         self.write_bits_le(vec);
         vec[initial_len..].reverse();
     }
+
+    fn num_bits() -> Option<usize> {
+        Some(256)
+    }
 }
 
 impl<P: Fp256Parameters> ToBytes for Fp256<P> {

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -612,6 +612,10 @@ impl<P: Fp384Parameters> ToBits for Fp384<P> {
         self.write_bits_le(vec);
         vec[initial_len..].reverse();
     }
+
+    fn num_bits() -> Option<usize> {
+        Some(384)
+    }
 }
 
 impl<P: Fp384Parameters> ToBytes for Fp384<P> {


### PR DESCRIPTION
The top-level `ToBits` operations typically call into inner implementations that end up operating on slices of integers of different sizes; while we already reserve the capacity needed to hold the number of bits that represent each of them, we can do a lot better: reserve the capacity needed to hold the bits of all the values in the aforementioned slices.

This PR introduces a new associated function, `ToBits::num_bits`, which can indicate the number of bits that are needed to represent the related object, and provides an implementation for all the `std` integers, `Fp256`, and `Fp384`. This means that calling `to_bits_le` or `write_bits_le`  on a vector or slice containing any of them will now require only a single allocation.

I tested this change by calling `ToBits::to_bits_le` on a vector containing 1k of `u64` elements and one containing 1k of `Fp384` and the differences are as follows:
```
u64

allocations:    12 -> 1
avg alloc size: 10.66 KiB -> 62.50 KiB
reallocations:  11 -> 0
max mem use:    104.86 KiB -> 71.36 KiB
```
```
Fp384

allocations:    15 -> 1
avg alloc size: 68.26 KiB -> 375 KiB
reallocations:  14 -> 0
max mem use:    815.93 KiB -> 422.93 KiB
```