### PR TITLE
Fewer prove/verify allocations

### DIFF
--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -464,7 +464,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
         };
         let bits = self.get_bits(num_bits_per_nonnative * num_elements);
 
-        let mut lookup_table = Vec::<TargetField>::new();
+        let mut lookup_table = Vec::<TargetField>::with_capacity(num_bits_per_nonnative);
         let mut cur = TargetField::one();
         for _ in 0..num_bits_per_nonnative {
             lookup_table.push(cur);

--- a/algorithms/src/fft/polynomial/multiplier.rs
+++ b/algorithms/src/fft/polynomial/multiplier.rs
@@ -102,7 +102,7 @@ impl<'a, F: PrimeField> PolyMultiplier<'a, F> {
                 }
                 let fft_pc = &self.fft_precomputation.unwrap();
                 let ifft_pc = &self.ifft_precomputation.unwrap();
-                let mut pool = ExecutionPool::new();
+                let mut pool = ExecutionPool::with_capacity(self.polynomials.len() + self.evaluations.len());
                 for (_, p) in self.polynomials {
                     pool.add_job(move || {
                         let mut p = p.clone().into_owned().coeffs;
@@ -146,7 +146,7 @@ impl<'a, F: PrimeField> PolyMultiplier<'a, F> {
                 Some(Cow::Owned(self.fft_precomputation.as_ref().unwrap().to_ifft_precomputation()));
         }
         let fft_pc = self.fft_precomputation.as_ref().unwrap();
-        let mut pool = ExecutionPool::new();
+        let mut pool = ExecutionPool::with_capacity(self.polynomials.len() + self.evaluations.len());
         for (l, p) in self.polynomials {
             pool.add_job(move || {
                 let mut p = p.clone().into_owned().coeffs;

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -192,7 +192,7 @@ pub(super) fn batch_add<G: AffineCurve>(
     let mut number_of_bases_in_batch = 0;
 
     let mut instr = Vec::<(u32, u32)>::with_capacity(batch_size);
-    let mut new_bases = Vec::with_capacity(bases.len() * 3 / 8);
+    let mut new_bases = Vec::with_capacity(bases.len());
     let mut scratch_space = Vec::with_capacity(batch_size / 2);
 
     // In the first loop, copy the results of the first in-place addition tree to the vector `new_bases`.

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -32,7 +32,7 @@ use snarkvm_fields::{Field, PrimeField};
 
 use core::{borrow::Borrow, marker::PhantomData};
 use itertools::Itertools;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Write};
 
 /// The algebraic holographic proof defined in [CHMMVW19](https://eprint.iacr.org/2019/1047).
 /// Currently, this AHP only supports inputs of size one
@@ -43,7 +43,9 @@ pub struct AHPForR1CS<F: Field, SM: SNARKMode> {
 }
 
 pub(crate) fn witness_label(circuit_id: CircuitId, poly: &str, i: usize) -> String {
-    format!("circuit_{circuit_id}_{poly}_{i:0>8}")
+    let mut label = String::with_capacity(82 + poly.len());
+    let _ = write!(&mut label, "circuit_{circuit_id}_{poly}_{i:0>8}");
+    label
 }
 
 pub(crate) struct NonZeroDomains<F: PrimeField> {

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -92,7 +92,7 @@ impl<P: Bls12Parameters> G2Prepared<P> {
         let mut r = G2HomProjective { x: q.x, y: q.y, z: Fp2::one() };
 
         let bit_iterator = BitIteratorBE::new(P::X);
-        let mut ell_coeffs = Vec::with_capacity(bit_iterator.len());
+        let mut ell_coeffs = Vec::with_capacity(bit_iterator.len() * 3 / 2);
 
         // `one_half` = 1/2 in the field.
         let one_half = P::Fp::half();

--- a/fields/src/traits/poseidon_grain_lfsr.rs
+++ b/fields/src/traits/poseidon_grain_lfsr.rs
@@ -124,7 +124,11 @@ impl PoseidonGrainLFSR {
         let mut output = Vec::with_capacity(num_elems);
         for _ in 0..num_elems {
             // Obtain `n` bits and make it most-significant-bit first.
-            let mut bits = self.get_bits(self.field_size_in_bits as usize).collect::<Vec<_>>();
+            let bits_iter = self.get_bits(self.field_size_in_bits as usize);
+            let mut bits = Vec::with_capacity(bits_iter.len());
+            for bit in bits_iter {
+                bits.push(bit);
+            }
             bits.reverse();
 
             let bytes = bits

--- a/fields/src/traits/poseidon_grain_lfsr.rs
+++ b/fields/src/traits/poseidon_grain_lfsr.rs
@@ -199,3 +199,9 @@ impl<'a> Iterator for LFSRIter<'a> {
         }
     }
 }
+
+impl<'a> ExactSizeIterator for LFSRIter<'a> {
+    fn len(&self) -> usize {
+        self.num_bits
+    }
+}

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -424,6 +424,7 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Vec<T> {
     ) -> Result<Self, SerializationError> {
         let len = u64::deserialize_with_mode(&mut reader, compress, validate)?;
         let mut values = Vec::new();
+        let _ = values.try_reserve(len as usize);
         for _ in 0..len {
             values.push(T::deserialize_with_mode(&mut reader, compress, Validate::No)?);
         }


### PR DESCRIPTION
The changes in this PR were driven by heap profiling applied to a single iteration of the Varuna `snark_verify` benchmark; they are mostly quite straightforward and provide the following benefits:
```
allocations:    13,504 -> 12,237 (-9.4%)
reallocations:  1,979 -> 712 (-64%)
max memory use: 14.13 MiB -> 13.70 MiB (-3%)
runtime:        202.3 ms -> 196.8 ms (-2.7%)
runtime σ:      3.0 ms -> 1.4 ms (-53.3%)
```
(the runtime was measured with `hyperfine`)