### PR TITLE
Reduce overhead of programs with deep nested imports

### DIFF
--- a/algorithms/src/snark/varuna/tests.rs
+++ b/algorithms/src/snark/varuna/tests.rs
@@ -778,8 +778,7 @@ mod varuna_test_vectors {
             create_test_vector("domain", "C", &format!("{:?}", variable_domain_elements), circuit);
         }
 
-        let fifth_oracles =
-            AHPForR1CS::<_, MM>::prover_fifth_round(verifier_fourth_msg, prover_state, rng).unwrap();
+        let fifth_oracles = AHPForR1CS::<_, MM>::prover_fifth_round(verifier_fourth_msg, prover_state, rng).unwrap();
 
         // Get coefficients of final oracle polynomial from round 5.
         let h_2 = format!("{:?}", fifth_oracles.h_2.coeffs().map(|(_, coeff)| coeff).collect::<Vec<_>>());

--- a/algorithms/src/snark/varuna/tests.rs
+++ b/algorithms/src/snark/varuna/tests.rs
@@ -779,7 +779,7 @@ mod varuna_test_vectors {
         }
 
         let fifth_oracles =
-            AHPForR1CS::<_, MM>::prover_fifth_round(verifier_fourth_msg.clone(), prover_state, rng).unwrap();
+            AHPForR1CS::<_, MM>::prover_fifth_round(verifier_fourth_msg, prover_state, rng).unwrap();
 
         // Get coefficients of final oracle polynomial from round 5.
         let h_2 = format!("{:?}", fifth_oracles.h_2.coeffs().map(|(_, coeff)| coeff).collect::<Vec<_>>());

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -49,7 +49,7 @@ impl<N: Network> Process<N> {
             /* Finalize the fee. */
 
             // Retrieve the fee stack.
-            let fee_stack = self.get_stack_ref(fee.program_id())?;
+            let fee_stack = self.get_stack(fee.program_id())?;
             // Finalize the fee transition.
             finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
             lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -90,7 +90,7 @@ impl<N: Network> Process<N> {
         // Retrieve the root transition (without popping it).
         let transition = execution.peek()?;
         // Retrieve the stack.
-        let stack = self.get_stack_ref(transition.program_id())?;
+        let stack = self.get_stack(transition.program_id())?;
         // Ensure the number of calls matches the number of transitions.
         let number_of_calls = stack.get_number_of_calls(transition.function_name())?;
         ensure!(
@@ -113,7 +113,7 @@ impl<N: Network> Process<N> {
 
             if let Some(fee) = fee {
                 // Retrieve the fee stack.
-                let fee_stack = self.get_stack_ref(fee.program_id())?;
+                let fee_stack = self.get_stack(fee.program_id())?;
                 // Finalize the fee transition.
                 finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
                 lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -139,7 +139,7 @@ impl<N: Network> Process<N> {
 
         atomic_batch_scope!(store, {
             // Retrieve the stack.
-            let stack = self.get_stack_ref(fee.program_id())?;
+            let stack = self.get_stack(fee.program_id())?;
             // Finalize the fee transition.
             let result = finalize_fee_transition(state, store, stack, fee);
             finish!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -356,7 +356,7 @@ fn initialize_finalize_state<'a, N: Network>(
     let (finalize, stack) = match stack.program_id() == future.program_id() {
         true => (stack.get_function_ref(future.function_name())?.finalize_logic(), stack),
         false => {
-            let stack = stack.get_external_stack_ref(future.program_id())?;
+            let stack = stack.get_external_stack_ref(future.program_id())?.as_ref();
             (stack.get_function_ref(future.function_name())?.finalize_logic(), stack)
         }
     };

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -356,7 +356,7 @@ fn initialize_finalize_state<'a, N: Network>(
     let (finalize, stack) = match stack.program_id() == future.program_id() {
         true => (stack.get_function_ref(future.function_name())?.finalize_logic(), stack),
         false => {
-            let stack = stack.get_external_stack_ref(future.program_id())?.as_ref();
+            let stack = stack.get_external_stack(future.program_id())?.as_ref();
             (stack.get_function_ref(future.function_name())?.finalize_logic(), stack)
         }
     };

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -49,7 +49,7 @@ impl<N: Network> Process<N> {
             /* Finalize the fee. */
 
             // Retrieve the fee stack.
-            let fee_stack = self.get_stack(fee.program_id())?;
+            let fee_stack = self.get_stack_ref(fee.program_id())?;
             // Finalize the fee transition.
             finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
             lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -90,7 +90,7 @@ impl<N: Network> Process<N> {
         // Retrieve the root transition (without popping it).
         let transition = execution.peek()?;
         // Retrieve the stack.
-        let stack = self.get_stack(transition.program_id())?;
+        let stack = self.get_stack_ref(transition.program_id())?;
         // Ensure the number of calls matches the number of transitions.
         let number_of_calls = stack.get_number_of_calls(transition.function_name())?;
         ensure!(
@@ -113,7 +113,7 @@ impl<N: Network> Process<N> {
 
             if let Some(fee) = fee {
                 // Retrieve the fee stack.
-                let fee_stack = self.get_stack(fee.program_id())?;
+                let fee_stack = self.get_stack_ref(fee.program_id())?;
                 // Finalize the fee transition.
                 finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
                 lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -139,7 +139,7 @@ impl<N: Network> Process<N> {
 
         atomic_batch_scope!(store, {
             // Retrieve the stack.
-            let stack = self.get_stack(fee.program_id())?;
+            let stack = self.get_stack_ref(fee.program_id())?;
             // Finalize the fee transition.
             let result = finalize_fee_transition(state, store, stack, fee);
             finish!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -356,7 +356,7 @@ fn initialize_finalize_state<'a, N: Network>(
     let (finalize, stack) = match stack.program_id() == future.program_id() {
         true => (stack.get_function_ref(future.function_name())?.finalize_logic(), stack),
         false => {
-            let stack = stack.get_external_stack(future.program_id())?;
+            let stack = stack.get_external_stack_ref(future.program_id())?;
             (stack.get_function_ref(future.function_name())?.finalize_logic(), stack)
         }
     };

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -75,7 +75,7 @@ pub struct Process<N: Network> {
     /// The universal SRS.
     universal_srs: Arc<UniversalSRS<N>>,
     /// The mapping of program IDs to stacks.
-    stacks: IndexMap<ProgramID<N>, Stack<N>>,
+    stacks: IndexMap<ProgramID<N>, Arc<Stack<N>>>,
 }
 
 impl<N: Network> Process<N> {
@@ -129,7 +129,7 @@ impl<N: Network> Process<N> {
     #[inline]
     pub fn add_stack(&mut self, stack: Stack<N>) {
         // Add the stack to the process.
-        self.stacks.insert(*stack.program_id(), stack);
+        self.stacks.insert(*stack.program_id(), Arc::new(stack));
     }
 }
 
@@ -202,11 +202,24 @@ impl<N: Network> Process<N> {
 
     /// Returns the stack for the given program ID.
     #[inline]
-    pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Stack<N>> {
+    pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<Arc<Stack<N>>> {
         // Prepare the program ID.
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
         // Retrieve the stack.
-        let stack = self.stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
+        let stack = self.stacks.get(&program_id).cloned().ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
+        // Ensure the program ID matches.
+        ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
+        // Return the stack.
+        Ok(stack)
+    }
+
+    /// Returns the stack for the given program ID.
+    #[inline]
+    pub fn get_stack_ref(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Stack<N>> {
+        // Prepare the program ID.
+        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        // Retrieve the stack.
+        let stack = self.stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?.deref();
         // Ensure the program ID matches.
         ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
         // Return the stack.
@@ -216,7 +229,7 @@ impl<N: Network> Process<N> {
     /// Returns the program for the given program ID.
     #[inline]
     pub fn get_program(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Program<N>> {
-        self.get_stack(program_id).map(Stack::program)
+        self.get_stack_ref(program_id).map(Stack::program)
     }
 
     /// Returns the proving key for the given program ID and function name.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -203,25 +203,16 @@ impl<N: Network> Process<N> {
     /// Returns the stack for the given program ID.
     #[inline]
     pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<Arc<Stack<N>>> {
-        // Prepare the program ID.
-        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
-        // Retrieve the stack.
-        let stack =
-            self.stacks.get(&program_id).cloned().ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
-        // Ensure the program ID matches.
-        ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
-        // Return the stack.
-        Ok(stack)
+        self.get_stack_ref(program_id).map(Arc::clone)
     }
 
     /// Returns the stack for the given program ID.
     #[inline]
-    pub fn get_stack_ref(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Stack<N>> {
+    pub fn get_stack_ref(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Arc<Stack<N>>> {
         // Prepare the program ID.
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
         // Retrieve the stack.
-        let stack =
-            self.stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?.deref();
+        let stack = self.stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
         // Ensure the program ID matches.
         ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
         // Return the stack.
@@ -231,7 +222,7 @@ impl<N: Network> Process<N> {
     /// Returns the program for the given program ID.
     #[inline]
     pub fn get_program(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Program<N>> {
-        self.get_stack_ref(program_id).map(Stack::program)
+        Ok(self.get_stack_ref(program_id)?.program())
     }
 
     /// Returns the proving key for the given program ID and function name.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -206,7 +206,8 @@ impl<N: Network> Process<N> {
         // Prepare the program ID.
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
         // Retrieve the stack.
-        let stack = self.stacks.get(&program_id).cloned().ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
+        let stack =
+            self.stacks.get(&program_id).cloned().ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
         // Ensure the program ID matches.
         ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
         // Return the stack.
@@ -219,7 +220,8 @@ impl<N: Network> Process<N> {
         // Prepare the program ID.
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
         // Retrieve the stack.
-        let stack = self.stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?.deref();
+        let stack =
+            self.stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?.deref();
         // Ensure the program ID matches.
         ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
         // Return the stack.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -202,13 +202,7 @@ impl<N: Network> Process<N> {
 
     /// Returns the stack for the given program ID.
     #[inline]
-    pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<Arc<Stack<N>>> {
-        self.get_stack_ref(program_id).map(Arc::clone)
-    }
-
-    /// Returns the stack for the given program ID.
-    #[inline]
-    pub fn get_stack_ref(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Arc<Stack<N>>> {
+    pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Arc<Stack<N>>> {
         // Prepare the program ID.
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
         // Retrieve the stack.
@@ -222,7 +216,7 @@ impl<N: Network> Process<N> {
     /// Returns the program for the given program ID.
     #[inline]
     pub fn get_program(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Program<N>> {
-        Ok(self.get_stack_ref(program_id)?.program())
+        Ok(self.get_stack(program_id)?.program())
     }
 
     /// Returns the proving key for the given program ID and function name.

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -68,7 +68,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         let (substack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
             CallOperator::Locator(locator) => {
-                (stack.get_external_stack_ref(locator.program_id())?.as_ref(), locator.resource())
+                (stack.get_external_stack(locator.program_id())?.as_ref(), locator.resource())
             }
             CallOperator::Resource(resource) => {
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
@@ -163,7 +163,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 if is_credits_program && (is_fee_private || is_fee_public) {
                     bail!("Cannot perform an external call to 'credits.aleo/fee_private' or 'credits.aleo/fee_public'.")
                 } else {
-                    (stack.get_external_stack_ref(locator.program_id())?.as_ref(), locator.resource())
+                    (stack.get_external_stack(locator.program_id())?.as_ref(), locator.resource())
                 }
             }
             CallOperator::Resource(resource) => {

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -67,7 +67,9 @@ impl<N: Network> CallTrait<N> for Call<N> {
         // Retrieve the substack and resource.
         let (substack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
-            CallOperator::Locator(locator) => (stack.get_external_stack_ref(locator.program_id())?, locator.resource()),
+            CallOperator::Locator(locator) => {
+                (stack.get_external_stack_ref(locator.program_id())?.as_ref(), locator.resource())
+            }
             CallOperator::Resource(resource) => {
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
                 //  But there are legitimate uses for passing a record through to an internal function.
@@ -161,7 +163,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 if is_credits_program && (is_fee_private || is_fee_public) {
                     bail!("Cannot perform an external call to 'credits.aleo/fee_private' or 'credits.aleo/fee_public'.")
                 } else {
-                    (stack.get_external_stack_ref(locator.program_id())?, locator.resource())
+                    (stack.get_external_stack_ref(locator.program_id())?.as_ref(), locator.resource())
                 }
             }
             CallOperator::Resource(resource) => {

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -81,7 +81,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 (stack, resource)
             }
         };
-        lap!(timer, "get substack and resource");
+        lap!(timer, "Retrieved the substack and resource");
 
         // If the operator is a closure, retrieve the closure and compute the output.
         let outputs = if let Ok(closure) = substack.program().get_closure(resource) {
@@ -116,7 +116,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         else {
             bail!("Call operator '{}' is invalid or unsupported.", self.operator())
         };
-        lap!(timer, "got outputs");
+        lap!(timer, "Computed outputs");
 
         // Assign the outputs to the destination registers.
         for (output, register) in outputs.into_iter().zip_eq(&self.destinations()) {
@@ -151,8 +151,6 @@ impl<N: Network> CallTrait<N> for Call<N> {
         let (substack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
             CallOperator::Locator(locator) => {
-                lap!(timer, "Locator");
-
                 // Check the external call locator.
                 let function_name = locator.name().to_string();
                 let is_credits_program = &locator.program_id().to_string() == "credits.aleo";
@@ -167,7 +165,6 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 }
             }
             CallOperator::Resource(resource) => {
-                lap!(timer, "Resource");
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
                 //  But there are legitimate uses for passing a record through to an internal function.
                 //  We could invoke the internal function without a state transition, but need to match visibility.
@@ -178,10 +175,11 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 (stack, resource)
             }
         };
+        lap!(timer, "Retrieve the substack and resource");
 
         // If the operator is a closure, retrieve the closure and compute the output.
         let outputs = if let Ok(closure) = substack.program().get_closure(resource) {
-            lap!(timer, "execute_closure");
+            lap!(timer, "Execute the closure");
             // Execute the closure, and load the outputs.
             substack.execute_closure(
                 &closure,
@@ -194,7 +192,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         }
         // If the operator is a function, retrieve the function and compute the output.
         else if let Ok(function) = substack.program().get_function(resource) {
-            lap!(timer, "execute_function");
+            lap!(timer, "Execute the function");
             // Retrieve the number of inputs.
             let num_inputs = function.inputs().len();
             // Ensure the number of inputs matches the number of input statements.
@@ -219,7 +217,6 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     // If the circuit is in authorize or synthesize mode, then add any external calls to the stack.
                     CallStack::Authorize(_, private_key, authorization)
                     | CallStack::Synthesize(_, private_key, authorization) => {
-                        lap!(timer, "CallStack::Authorize,Synthesize");
                         // Compute the request.
                         let request = Request::sign(
                             &private_key,
@@ -245,7 +242,6 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         (request, response)
                     }
                     CallStack::CheckDeployment(_, private_key, ..) | CallStack::PackageRun(_, private_key, ..) => {
-                        lap!(timer, "CallStack::CheckDeployment,PackageRun");
                         // Compute the request.
                         let request = Request::sign(
                             &private_key,
@@ -272,7 +268,6 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     }
                     // If the circuit is in execute mode, then evaluate and execute the instructions.
                     CallStack::Execute(authorization, ..) => {
-                        lap!(timer, "CallStack::Execute");
                         // Retrieve the next request (without popping it).
                         let request = authorization.peek_next()?;
                         // Ensure the inputs match the original inputs.
@@ -298,7 +293,8 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     }
                 }
             };
-            lap!(timer, "got request and response");
+            lap!(timer, "Computed the request and response");
+
             // Inject the existing circuit.
             A::inject_r1cs(r1cs);
 
@@ -348,7 +344,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 None,
             );
             A::assert(check_input_ids);
-            lap!(timer, "checked input ids");
+            lap!(timer, "Checked the input ids");
 
             // Inject the outputs as `Mode::Private` (with the 'tcm' and output IDs as `Mode::Public`).
             let outputs = circuit::Response::process_outputs_from_callback(
@@ -361,7 +357,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 response.outputs().to_vec(),
                 &function.output_types(),
             );
-            lap!(timer, "checked outputs");
+            lap!(timer, "Checked the outputs");
             // Return the circuit outputs.
             outputs
         }
@@ -375,7 +371,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             // Assign the output to the register.
             registers.store_circuit(stack, register, output)?;
         }
-        lap!(timer, "assigned outputs to registers");
+        lap!(timer, "Assigned the outputs to registers");
 
         finish!(timer);
 

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -260,8 +260,8 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         // Push the request onto the call stack.
                         call_stack.push(request.clone())?;
 
-                        // Execute the request.
-                        let response = substack.execute_function::<A, R>(call_stack, console_caller, rng)?;
+                        // Evaluate the request.
+                        let response = substack.evaluate_function::<A>(call_stack, console_caller)?;
                         // Return the request and response.
                         (request, response)
                     }

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::{CallStack, Registers, RegistersCall, StackEvaluate, StackExecute};
-use aleo_std::prelude::{timer, lap, finish};
+use aleo_std::prelude::{finish, lap, timer};
 use console::{network::prelude::*, program::Request};
 use synthesizer_program::{
     Call,
@@ -61,14 +61,13 @@ impl<N: Network> CallTrait<N> for Call<N> {
         let timer = timer!("Call::evaluate");
 
         // Load the operands values.
-        let inputs: Vec<_> = self.operands().iter().map(|operand| registers.load(stack.deref(), operand)).try_collect()?;
+        let inputs: Vec<_> =
+            self.operands().iter().map(|operand| registers.load(stack.deref(), operand)).try_collect()?;
 
         // Retrieve the substack and resource.
         let (substack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
-            CallOperator::Locator(locator) => {
-                (stack.get_external_stack_ref(locator.program_id())?, locator.resource())
-            }
+            CallOperator::Locator(locator) => (stack.get_external_stack_ref(locator.program_id())?, locator.resource()),
             CallOperator::Resource(resource) => {
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
                 //  But there are legitimate uses for passing a record through to an internal function.

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{CallStack, Registers, RegistersCall, StackEvaluate, StackExecute};
+use aleo_std::prelude::{timer, lap, finish};
 use console::{network::prelude::*, program::Request};
 use synthesizer_program::{
     Call,
@@ -57,14 +58,16 @@ impl<N: Network> CallTrait<N> for Call<N> {
         stack: &(impl StackEvaluate<N> + StackMatches<N> + StackProgram<N>),
         registers: &mut Registers<N, A>,
     ) -> Result<()> {
+        let timer = timer!("Call::evaluate");
+
         // Load the operands values.
-        let inputs: Vec<_> = self.operands().iter().map(|operand| registers.load(stack, operand)).try_collect()?;
+        let inputs: Vec<_> = self.operands().iter().map(|operand| registers.load(stack.deref(), operand)).try_collect()?;
 
         // Retrieve the substack and resource.
         let (substack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
             CallOperator::Locator(locator) => {
-                (stack.get_external_stack(locator.program_id())?.clone(), locator.resource())
+                (stack.get_external_stack_ref(locator.program_id())?, locator.resource())
             }
             CallOperator::Resource(resource) => {
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
@@ -74,9 +77,10 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
                 }
 
-                (stack.clone(), resource)
+                (stack, resource)
             }
         };
+        lap!(timer, "get substack and resource");
 
         // If the operator is a closure, retrieve the closure and compute the output.
         let outputs = if let Ok(closure) = substack.program().get_closure(resource) {
@@ -111,12 +115,14 @@ impl<N: Network> CallTrait<N> for Call<N> {
         else {
             bail!("Call operator '{}' is invalid or unsupported.", self.operator())
         };
+        lap!(timer, "got outputs");
 
         // Assign the outputs to the destination registers.
         for (output, register) in outputs.into_iter().zip_eq(&self.destinations()) {
             // Assign the output to the register.
             registers.store(stack, register, output)?;
         }
+        finish!(timer);
 
         Ok(())
     }
@@ -134,6 +140,8 @@ impl<N: Network> CallTrait<N> for Call<N> {
              ),
         rng: &mut R,
     ) -> Result<()> {
+        let timer = timer!("Call::execute");
+
         // Load the operands values.
         let inputs: Vec<_> =
             self.operands().iter().map(|operand| registers.load_circuit(stack, operand)).try_collect()?;
@@ -142,6 +150,8 @@ impl<N: Network> CallTrait<N> for Call<N> {
         let (substack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
             CallOperator::Locator(locator) => {
+                lap!(timer, "Locator");
+
                 // Check the external call locator.
                 let function_name = locator.name().to_string();
                 let is_credits_program = &locator.program_id().to_string() == "credits.aleo";
@@ -152,10 +162,11 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 if is_credits_program && (is_fee_private || is_fee_public) {
                     bail!("Cannot perform an external call to 'credits.aleo/fee_private' or 'credits.aleo/fee_public'.")
                 } else {
-                    (stack.get_external_stack(locator.program_id())?.clone(), locator.resource())
+                    (stack.get_external_stack_ref(locator.program_id())?, locator.resource())
                 }
             }
             CallOperator::Resource(resource) => {
+                lap!(timer, "Resource");
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
                 //  But there are legitimate uses for passing a record through to an internal function.
                 //  We could invoke the internal function without a state transition, but need to match visibility.
@@ -163,12 +174,13 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
                 }
 
-                (stack.clone(), resource)
+                (stack, resource)
             }
         };
 
         // If the operator is a closure, retrieve the closure and compute the output.
         let outputs = if let Ok(closure) = substack.program().get_closure(resource) {
+            lap!(timer, "execute_closure");
             // Execute the closure, and load the outputs.
             substack.execute_closure(
                 &closure,
@@ -181,6 +193,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         }
         // If the operator is a function, retrieve the function and compute the output.
         else if let Ok(function) = substack.program().get_function(resource) {
+            lap!(timer, "execute_function");
             // Retrieve the number of inputs.
             let num_inputs = function.inputs().len();
             // Ensure the number of inputs matches the number of input statements.
@@ -205,6 +218,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     // If the circuit is in authorize or synthesize mode, then add any external calls to the stack.
                     CallStack::Authorize(_, private_key, authorization)
                     | CallStack::Synthesize(_, private_key, authorization) => {
+                        lap!(timer, "CallStack::Authorize,Synthesize");
                         // Compute the request.
                         let request = Request::sign(
                             &private_key,
@@ -230,6 +244,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         (request, response)
                     }
                     CallStack::CheckDeployment(_, private_key, ..) | CallStack::PackageRun(_, private_key, ..) => {
+                        lap!(timer, "CallStack::CheckDeployment,PackageRun");
                         // Compute the request.
                         let request = Request::sign(
                             &private_key,
@@ -256,6 +271,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     }
                     // If the circuit is in execute mode, then evaluate and execute the instructions.
                     CallStack::Execute(authorization, ..) => {
+                        lap!(timer, "CallStack::Execute");
                         // Retrieve the next request (without popping it).
                         let request = authorization.peek_next()?;
                         // Ensure the inputs match the original inputs.
@@ -281,6 +297,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     }
                 }
             };
+            lap!(timer, "got request and response");
             // Inject the existing circuit.
             A::inject_r1cs(r1cs);
 
@@ -330,6 +347,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 None,
             );
             A::assert(check_input_ids);
+            lap!(timer, "checked input ids");
 
             // Inject the outputs as `Mode::Private` (with the 'tcm' and output IDs as `Mode::Public`).
             let outputs = circuit::Response::process_outputs_from_callback(
@@ -342,6 +360,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 response.outputs().to_vec(),
                 &function.output_types(),
             );
+            lap!(timer, "checked outputs");
             // Return the circuit outputs.
             outputs
         }
@@ -355,6 +374,9 @@ impl<N: Network> CallTrait<N> for Call<N> {
             // Assign the output to the register.
             registers.store_circuit(stack, register, output)?;
         }
+        lap!(timer, "assigned outputs to registers");
+
+        finish!(timer);
 
         Ok(())
     }

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -106,7 +106,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         // Retrieve the next request, based on the call stack mode.
         let (request, call_stack) = match &call_stack {
             CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
-            // CallStack::Synthesize(_, _, authorization) => (authorization.peek_next()?, call_stack),
             CallStack::CheckDeployment(requests, _, _) | CallStack::PackageRun(requests, _, _) => {
                 let last_request = requests.last().ok_or(anyhow!("CallStack does not contain request"))?.clone();
                 (last_request, call_stack)

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -106,6 +106,11 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         // Retrieve the next request, based on the call stack mode.
         let (request, call_stack) = match &call_stack {
             CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
+            // CallStack::Synthesize(_, _, authorization) => (authorization.peek_next()?, call_stack),
+            CallStack::CheckDeployment(requests, _, _) | CallStack::PackageRun(requests, _, _) => {
+                let last_request = requests.last().ok_or(anyhow!("CallStack does not contain request"))?.clone();
+                (last_request, call_stack)
+            },
             // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
             // This is done to ensure that evaluation during execution is performed consistently.
             CallStack::Execute(authorization, _) => {
@@ -116,7 +121,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                 let call_stack = CallStack::Evaluate(authorization);
                 (request, call_stack)
             }
-            _ => bail!("Illegal operation: call stack must be `Evaluate` or `Execute` in `evaluate_function`."),
+            _ => bail!("Illegal operation: call stack must not be `Synthesize` or `Authorize` in `evaluate_function`."),
         };
         lap!(timer, "Retrieve the next request");
 

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -218,7 +218,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
             .collect::<Result<Vec<_>>>()?;
         lap!(timer, "Load the outputs");
 
-        finish!(timer);
 
         // Map the output operands to registers.
         let output_registers = output_operands
@@ -228,9 +227,10 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                 _ => None,
             })
             .collect::<Vec<_>>();
+        lap!(timer, "Load the output_registers");
 
         // Compute the response.
-        Response::new(
+        let response = Response::new(
             request.network_id(),
             self.program.id(),
             function.name(),
@@ -240,6 +240,9 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
             outputs,
             &function.output_types(),
             &output_registers,
-        )
+        );
+        finish!(timer);
+
+        response 
     }
 }

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -230,7 +230,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        lap!(timer, "Load the output_registers");
+        lap!(timer, "Loaded the output registers");
 
         // Compute the response.
         let response = Response::new(

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -110,7 +110,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
             CallStack::CheckDeployment(requests, _, _) | CallStack::PackageRun(requests, _, _) => {
                 let last_request = requests.last().ok_or(anyhow!("CallStack does not contain request"))?.clone();
                 (last_request, call_stack)
-            },
+            }
             // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
             // This is done to ensure that evaluation during execution is performed consistently.
             CallStack::Execute(authorization, _) => {
@@ -223,7 +223,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
             .collect::<Result<Vec<_>>>()?;
         lap!(timer, "Load the outputs");
 
-
         // Map the output operands to registers.
         let output_registers = output_operands
             .iter()
@@ -248,6 +247,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         );
         finish!(timer);
 
-        response 
+        response
     }
 }

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -58,7 +58,7 @@ impl<N: Network> Stack<N> {
 impl<N: Network> Stack<N> {
     /// Inserts the given external stack to the stack.
     #[inline]
-    fn insert_external_stack(&mut self, external_stack: Stack<N>) -> Result<()> {
+    fn insert_external_stack(&mut self, external_stack: Arc<Stack<N>>) -> Result<()> {
         // Retrieve the program ID.
         let program_id = *external_stack.program_id();
         // Ensure the external stack is not already added.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -169,7 +169,7 @@ pub struct Stack<N: Network> {
     /// The program (record types, structs, functions).
     program: Program<N>,
     /// The mapping of external stacks as `(program ID, stack)`.
-    external_stacks: IndexMap<ProgramID<N>, Stack<N>>,
+    external_stacks: IndexMap<ProgramID<N>, Arc<Stack<N>>>,
     /// The mapping of closure and function names to their register types.
     register_types: IndexMap<Identifier<N>, RegisterTypes<N>>,
     /// The mapping of finalize names to their register types.
@@ -235,9 +235,19 @@ impl<N: Network> StackProgram<N> for Stack<N> {
 
     /// Returns the external stack for the given program ID.
     #[inline]
-    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Stack<N>> {
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Stack<N>>> {
         // Retrieve the external stack.
-        self.external_stacks.get(program_id).ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
+        self.external_stacks.get(program_id).cloned().ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
+    }
+
+    /// Returns the external stack ref for the given program ID.
+    #[inline]
+    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Stack<N>> {
+        // Retrieve the external stack.
+        self.external_stacks.get(program_id).ok_or_else(|| anyhow!("External program '{program_id}' does not exist.")).map(|stack| {
+            // Return the external stack.
+            stack.as_ref()
+        })
     }
 
     /// Returns the external program for the given program ID.
@@ -246,7 +256,7 @@ impl<N: Network> StackProgram<N> for Stack<N> {
         match self.program.id() == program_id {
             true => bail!("Attempted to get the main program '{}' as an external program", self.program.id()),
             // Retrieve the external stack, and return the external program.
-            false => Ok(self.get_external_stack(program_id)?.program()),
+            false => Ok(self.get_external_stack_ref(program_id)?.program()),
         }
     }
 

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -233,15 +233,9 @@ impl<N: Network> StackProgram<N> for Stack<N> {
         }
     }
 
-    /// Returns the external stack for the given program ID.
-    #[inline]
-    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Stack<N>>> {
-        self.get_external_stack_ref(program_id).map(Arc::clone)
-    }
-
     /// Returns the external stack ref for the given program ID.
     #[inline]
-    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Arc<Stack<N>>> {
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Arc<Stack<N>>> {
         // Retrieve the external stack.
         self.external_stacks.get(program_id).ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
     }
@@ -252,7 +246,7 @@ impl<N: Network> StackProgram<N> for Stack<N> {
         match self.program.id() == program_id {
             true => bail!("Attempted to get the main program '{}' as an external program", self.program.id()),
             // Retrieve the external stack, and return the external program.
-            false => Ok(self.get_external_stack_ref(program_id)?.program()),
+            false => Ok(self.get_external_stack(program_id)?.program()),
         }
     }
 

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -236,24 +236,14 @@ impl<N: Network> StackProgram<N> for Stack<N> {
     /// Returns the external stack for the given program ID.
     #[inline]
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Stack<N>>> {
-        // Retrieve the external stack.
-        self.external_stacks
-            .get(program_id)
-            .cloned()
-            .ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
+        self.get_external_stack_ref(program_id).map(Arc::clone)
     }
 
     /// Returns the external stack ref for the given program ID.
     #[inline]
-    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Stack<N>> {
+    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Arc<Stack<N>>> {
         // Retrieve the external stack.
-        self.external_stacks
-            .get(program_id)
-            .ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
-            .map(|stack| {
-                // Return the external stack.
-                stack.as_ref()
-            })
+        self.external_stacks.get(program_id).ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
     }
 
     /// Returns the external program for the given program ID.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -237,17 +237,23 @@ impl<N: Network> StackProgram<N> for Stack<N> {
     #[inline]
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Stack<N>>> {
         // Retrieve the external stack.
-        self.external_stacks.get(program_id).cloned().ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
+        self.external_stacks
+            .get(program_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
     }
 
     /// Returns the external stack ref for the given program ID.
     #[inline]
     fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Stack<N>> {
         // Retrieve the external stack.
-        self.external_stacks.get(program_id).ok_or_else(|| anyhow!("External program '{program_id}' does not exist.")).map(|stack| {
-            // Return the external stack.
-            stack.as_ref()
-        })
+        self.external_stacks
+            .get(program_id)
+            .ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
+            .map(|stack| {
+                // Return the external stack.
+                stack.as_ref()
+            })
     }
 
     /// Returns the external program for the given program ID.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -233,7 +233,7 @@ impl<N: Network> StackProgram<N> for Stack<N> {
         }
     }
 
-    /// Returns the external stack ref for the given program ID.
+    /// Returns the external stack for the given program ID.
     #[inline]
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Arc<Stack<N>>> {
         // Retrieve the external stack.

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -1544,7 +1544,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("transfer_private").unwrap();
@@ -1577,7 +1577,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("transfer_public").unwrap();
@@ -1605,7 +1605,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("fee_private").unwrap();
@@ -1638,7 +1638,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("fee_public").unwrap();

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -1544,7 +1544,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("transfer_private").unwrap();
@@ -1577,7 +1577,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("transfer_public").unwrap();
@@ -1605,7 +1605,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("fee_private").unwrap();
@@ -1638,7 +1638,7 @@ mod sanity_checks {
         // Construct a new process.
         let process = Process::load().unwrap();
         // Retrieve the stack.
-        let stack = process.get_stack_ref(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+        let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
 
         // Declare the function name.
         let function_name = Identifier::from_str("fee_public").unwrap();

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use crate::{FinalizeGlobalState, Function, Operand, Program};
 use console::{
     network::Network,
@@ -65,7 +67,10 @@ pub trait StackProgram<N: Network> {
     fn contains_external_record(&self, locator: &Locator<N>) -> bool;
 
     /// Returns the external stack for the given program ID.
-    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Self>;
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Self>>;
+
+    /// Returns the external stack ref for the given program ID.
+    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Self>;
 
     /// Returns the external program for the given program ID.
     fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>>;

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -66,7 +66,7 @@ pub trait StackProgram<N: Network> {
     /// Returns `true` if the stack contains the external record.
     fn contains_external_record(&self, locator: &Locator<N>) -> bool;
 
-    /// Returns the external stack ref for the given program ID.
+    /// Returns the external stack for the given program ID.
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Arc<Self>>;
 
     /// Returns the external program for the given program ID.

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -66,11 +66,8 @@ pub trait StackProgram<N: Network> {
     /// Returns `true` if the stack contains the external record.
     fn contains_external_record(&self, locator: &Locator<N>) -> bool;
 
-    /// Returns the external stack for the given program ID.
-    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Self>>;
-
     /// Returns the external stack ref for the given program ID.
-    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Arc<Self>>;
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Arc<Self>>;
 
     /// Returns the external program for the given program ID.
     fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>>;

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -70,7 +70,7 @@ pub trait StackProgram<N: Network> {
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Self>>;
 
     /// Returns the external stack ref for the given program ID.
-    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Self>;
+    fn get_external_stack_ref(&self, program_id: &ProgramID<N>) -> Result<&Arc<Self>>;
 
     /// Returns the external program for the given program ID.
     fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>>;

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1057,23 +1057,18 @@ finalize do:
         }
 
         // Fetch the unspent records.
-        let records =
-            genesis.transitions().cloned().flat_map(Transition::into_records).collect::<IndexMap<_, _>>();
+        let records = genesis.transitions().cloned().flat_map(Transition::into_records).collect::<IndexMap<_, _>>();
         trace!("Unspent Records:\n{:#?}", records);
 
         // Select a record to spend.
         let record = Some(records.values().next().unwrap().decrypt(&view_key).unwrap());
 
         // Prepare the inputs.
-        let inputs = [
-            Value::<CurrentNetwork>::from_str("1u32").unwrap(),
-        ]
-        .into_iter();
+        let inputs = [Value::<CurrentNetwork>::from_str("1u32").unwrap()].into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&private_key, ("program_layer_30.aleo", "do"), inputs, record, 0, None, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("program_layer_30.aleo", "do"), inputs, record, 0, None, rng).unwrap();
 
         // Verify.
         vm.check_transaction(&transaction, None).unwrap();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1071,6 +1071,6 @@ finalize do:
             vm.execute(&private_key, ("program_layer_30.aleo", "do"), inputs, record, 0, None, rng).unwrap();
 
         // Verify.
-        vm.check_transaction(&transaction, None).unwrap();
+        vm.check_transaction(&transaction, None, rng).unwrap();
     }
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -605,6 +605,7 @@ function compute:
         // Construct the new block header.
         let (ratifications, transactions, aborted_transaction_ids, ratified_finalize_operations) =
             vm.speculate(sample_finalize_state(1), None, vec![], None, transactions.iter())?;
+        assert!(aborted_transaction_ids.is_empty());
 
         // Construct the metadata associated with the block.
         let metadata = Metadata::new(


### PR DESCRIPTION
## Motivation

When we deployed/executed a program with many nested imports, this requires *lots* of memory. Why did this happen for nested imports? Actually, it would have happened for any large amount of nested function calls, imports are the only way in which we support them.

Two optimizations:
- we were needlessly cloning trees of stacks, each of which contained all of the imported stacks as external_stacks.
- during CheckDeployment, the verifier was running `execute_function` instead of `evaluate_function` for each nested call, even though it only needs to compute the circuit for the top level circuit.

I would have assumed during Authorization/Synthesis we could similarly replace calls in Call to `execute_function` by `evaluate_function` too, but this fails in mysterious ways (after resampling, integer addition fails).

## Test Plan

Added a test deploying and executing a program with the maximum of 31 nested imports, which is our maximum.

Also manually tested four scenario's:
- proving execution: not killed by OOM
- proving deployment: not killed by OOM, for 23 nested deployments this went from 1550s to 60s
- verifying execution: 100ms for 31 nested deployments
- verifying deployment: now 300ms for 20 nested deployments, 400ms for 31 nested deployments

Fun fact, the synthesizer only lets me execute a function using 30 nested imports. Together with the base function and fee execution, this reaches our limit of 32 transitions per execution.

I did not extensively test `PackageRun`, I assume the existing test suite covers it.