### PR TITLE
Don't preallocate in G2Prepared::read_le

### DIFF
--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -65,7 +65,7 @@ impl<P: Bls12Parameters> ToBytes for G2Prepared<P> {
 impl<P: Bls12Parameters> FromBytes for G2Prepared<P> {
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let ell_coeffs_len: u32 = FromBytes::read_le(&mut reader)?;
-        let mut ell_coeffs = Vec::with_capacity(ell_coeffs_len as usize);
+        let mut ell_coeffs = Vec::new();
         for _ in 0..ell_coeffs_len {
             let coeff_1: Fp2<P::Fp2Params> = FromBytes::read_le(&mut reader)?;
             let coeff_2: Fp2<P::Fp2Params> = FromBytes::read_le(&mut reader)?;


### PR DESCRIPTION
This is a quick fix for https://github.com/AleoHQ/snarkVM/issues/2179. IMO imposing a specific limit would be a superior solution (since we could still preallocate without room for malicious misuse), but if we don't know what it should be (or - alternatively - what the average number is), this will do.