### PR TITLE
[Feature] Parse `ProgramID` as `Literal`.

### DIFF
--- a/console/program/src/data/literal/mod.rs
+++ b/console/program/src/data/literal/mod.rs
@@ -28,7 +28,7 @@ mod to_bits;
 mod to_type;
 mod variant;
 
-use crate::LiteralType;
+use crate::{LiteralType, ProgramID};
 use snarkvm_console_account::{ComputeKey, PrivateKey, Signature};
 use snarkvm_console_network::Network;
 use snarkvm_console_types::{prelude::*, Boolean};

--- a/console/program/src/data/literal/parse.rs
+++ b/console/program/src/data/literal/parse.rs
@@ -36,6 +36,8 @@ impl<N: Network> Parser for Literal<N> {
             map(Scalar::<N>::parse, |literal| Self::Scalar(literal)),
             map(Signature::<N>::parse, |literal| Self::Signature(Box::new(literal))),
             map(StringType::<N>::parse, |literal| Self::String(literal)),
+            // This allows users to implicitly declare program IDs as literals.
+            map_res(ProgramID::<N>::parse, |program_id| Ok::<Self, Error>(Self::Address(program_id.to_address()?))),
         ))(string)
     }
 }
@@ -85,5 +87,29 @@ impl<N: Network> Display for Literal<N> {
             Self::Signature(literal) => Display::fmt(literal, f),
             Self::String(literal) => Display::fmt(literal, f),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network::Testnet3;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_parse_program_id() -> Result<()> {
+        let (remainder, candidate) = Literal::<CurrentNetwork>::parse("credits.aleo")?;
+        assert!(matches!(candidate, Literal::Address(_)));
+        assert_eq!(candidate.to_string(), "aleo1lqmly7ez2k48ajf5hs92ulphaqr05qm4n8qwzj8v0yprmasgpqgsez59gg");
+        assert_eq!("", remainder);
+
+        let result = Literal::<CurrentNetwork>::parse("credits.ale");
+        assert!(result.is_err());
+
+        let result = Literal::<CurrentNetwork>::parse("credits.aleo1");
+        assert!(result.is_err());
+
+        Ok(())
     }
 }

--- a/synthesizer/program/src/logic/instruction/operand/parse.rs
+++ b/synthesizer/program/src/logic/instruction/operand/parse.rs
@@ -26,9 +26,11 @@ impl<N: Network> Parser for Operand<N> {
             map(tag("self.signer"), |_| Self::Signer),
             map(tag("self.caller"), |_| Self::Caller),
             map(tag("block.height"), |_| Self::BlockHeight),
+            // Note that `Operand::ProgramID`s must be parsed before `Operand::Literal`s, since a program ID can be implicitly parsed as a literal address.
+            // This ensures that the string representation of a program uses the `Operand::ProgramID` variant.
+            map(ProgramID::parse, |program_id| Self::ProgramID(program_id)),
             map(Literal::parse, |literal| Self::Literal(literal)),
             map(Register::parse, |register| Self::Register(register)),
-            map(ProgramID::parse, |program_id| Self::ProgramID(program_id)),
         ))(string)
     }
 }

--- a/vm/cli/commands/run.rs
+++ b/vm/cli/commands/run.rs
@@ -106,12 +106,16 @@ mod tests {
 
     #[test]
     fn clap_snarkvm_run() {
-        let arg_vec = vec!["snarkvm", "run", "hello", "1u32", "2u32"];
+        let arg_vec = vec!["snarkvm", "run", "hello", "1u32", "2u32", "foo.aleo"];
         let cli = CLI::parse_from(&arg_vec);
 
         if let Command::Run(run) = cli.command {
             assert_eq!(run.function, Identifier::try_from(arg_vec[2]).unwrap());
-            assert_eq!(run.inputs, vec![Value::try_from(arg_vec[3]).unwrap(), Value::try_from(arg_vec[4]).unwrap()]);
+            assert_eq!(run.inputs, vec![
+                Value::try_from(arg_vec[3]).unwrap(),
+                Value::try_from(arg_vec[4]).unwrap(),
+                Value::try_from(arg_vec[5]).unwrap()
+            ]);
         } else {
             panic!("Unexpected result of clap parsing!");
         }


### PR DESCRIPTION
This PR supports parsing `ProgramID`s as `Literal`s. 
This allows users to use program IDs directly via the CLI and other input interfaces.
