### PR TITLE
Fix the panic in Transaction::execute(transfer_public)- benchmark

### DIFF
--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -104,7 +104,7 @@ fn execute(c: &mut Criterion) {
     // Retrieve the execution ID.
     let execution_id = execute_authorization.to_execution_id().unwrap();
     // Authorize the fee.
-    let fee_authorization = vm.authorize_fee_public(&private_key, 100000, 1000, execution_id, rng).unwrap();
+    let fee_authorization = vm.authorize_fee_public(&private_key, 300000, 1000, execution_id, rng).unwrap();
 
     c.bench_function("Transaction::Execute(transfer_public)", |b| {
         b.iter(|| {


### PR DESCRIPTION
This PR fixes the following panic in `Transaction::Execute(transfer_public)` benchmark, by increasing the base fee sufficiently:

```
Benchmarking Transaction::Execute(transfer_public) - verify: Warming up for 3.0000 s
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: 
Transaction 'at1gskd4t9t558kecudkc0a28pe44l09tmtfxxjdws499vqc5wslvzqa6hk8r' has an 
insufficient base fee (execution) - requires 263388 microcredits', ledger/benches/transaction.rs:121:65
```