### PR TITLE
[NCC VBV] Clarify wrapped documentation

### DIFF
--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -181,11 +181,11 @@ pub enum Instruction<N: Network> {
     RemWrapped(RemWrapped<N>),
     /// Shifts `first` left by `second` bits, storing the outcome in `destination`.
     Shl(Shl<N>),
-    /// Shifts `first` left by `second` bits, continuing past the boundary of the type, storing the outcome in `destination`.
+    /// Shifts `first` left by `second` bits, wrapping around at the boundary of the type, storing the outcome in `destination`.
     ShlWrapped(ShlWrapped<N>),
     /// Shifts `first` right by `second` bits, storing the outcome in `destination`.
     Shr(Shr<N>),
-    /// Shifts `first` right by `second` bits, continuing past the boundary of the type, storing the outcome in `destination`.
+    /// Shifts `first` right by `second` bits, wrapping around at the boundary of the type, storing the outcome in `destination`.
     ShrWrapped(ShrWrapped<N>),
     /// Computes whether `signature` is valid for the given `address` and `message`.
     SignVerify(SignVerify<N>),


### PR DESCRIPTION
## Motivation

Since [Rust's documentation](https://doc.rust-lang.org/std/primitive.u64.html#method.wrapping_shl) is not very concise, I used the same wording as [our developer docs](https://developer.aleo.org/leo/operators#shl_wrapped).
