### PR TITLE
Prevent panics

### DIFF
--- a/algorithms/src/errors.rs
+++ b/algorithms/src/errors.rs
@@ -43,22 +43,10 @@ pub enum SNARKError {
 
     #[error("Circuit not found")]
     CircuitNotFound,
-
-    #[error("terminated")]
-    Terminated,
 }
 
 impl From<AHPError> for SNARKError {
     fn from(err: AHPError) -> Self {
         SNARKError::Crate("AHPError", format!("{err:?}"))
-    }
-}
-
-impl From<crate::polycommit::PCError> for SNARKError {
-    fn from(err: crate::polycommit::PCError) -> Self {
-        match err {
-            crate::polycommit::PCError::Terminated => SNARKError::Terminated,
-            err => SNARKError::Crate("PCError", format!("{err:?}")),
-        }
     }
 }

--- a/algorithms/src/polycommit/error.rs
+++ b/algorithms/src/polycommit/error.rs
@@ -13,33 +13,33 @@
 // limitations under the License.
 
 /// The error type for `PolynomialCommitment`.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum PCError {
-    AnyhowError(anyhow::Error),
+    #[error("{0}")]
+    AnyhowError(#[from] anyhow::Error),
 
-    /// The query set contains a label for a polynomial that was not provided as
-    /// input to the `PC::open`.
+    #[error("QuerySet` refers to polynomial \"{label}\", but it was not provided.")]
     MissingPolynomial {
-        /// The label of the missing polynomial.
+        /// The label of the missing polynomial
         label: String,
     },
 
-    /// `Evaluations` does not contain an evaluation for the polynomial labelled
-    /// `label` at a particular query.
+    #[error("`QuerySet` refers to polynomial \"{label}\", but `Evaluations` does not contain an evaluation for it.")]
     MissingEvaluation {
         /// The label of the missing polynomial.
         label: String,
     },
 
-    /// The provided polynomial was meant to be hiding, but `rng` was `None`.
+    #[error("The provided polynomial was meant to be hiding, but `rng` was `None`.")]
     MissingRng,
 
-    /// The degree provided in setup was too small; degree 0 polynomials
-    /// are not supported.
+    #[error("The degree provided in setup was too small; degree 0 polynomials are not supported.")]
     DegreeIsZero,
 
-    /// The degree of the polynomial passed to `commit` or `open`
-    /// was too large.
+    #[error(
+        "the number of coefficients in the polynomial ({num_coefficients:?}) is greater than \
+             the maximum number of powers in `Powers` ({num_powers:?})"
+    )]
     TooManyCoefficients {
         /// The number of coefficients in the polynomial.
         num_coefficients: usize,
@@ -47,10 +47,12 @@ pub enum PCError {
         num_powers: usize,
     },
 
-    /// The hiding bound was not `None`, but the hiding bound was zero.
+    #[error("The hiding bound was not `None`, but the hiding bound was zero.")]
     HidingBoundIsZero,
 
-    /// The hiding bound was too large for the given `Powers`.
+    #[error(
+        "the degree of the hiding poly ({hiding_poly_degree:?}) is not less than the maximum number of powers in `Powers` ({num_powers:?})"
+    )]
     HidingBoundToolarge {
         /// The hiding bound
         hiding_poly_degree: usize,
@@ -58,29 +60,28 @@ pub enum PCError {
         num_powers: usize,
     },
 
-    /// The lagrange basis is not a power of two.
+    #[error("The lagrange basis is not a power of two.")]
     LagrangeBasisSizeIsNotPowerOfTwo,
 
-    /// The lagrange basis is larger than the supported degree,
+    #[error("The lagrange basis is larger than the supported degree.")]
     LagrangeBasisSizeIsTooLarge,
 
-    /// The degree provided to `trim` was too large.
+    #[error("The degree provided to `trim` was too large.")]
     TrimmingDegreeTooLarge,
 
-    /// The provided equation contained multiple polynomials, of which least one
-    /// had a strict degree bound.
+    #[error("the eqaution \"{0}\" contained degree-bounded polynomials")]
     EquationHasDegreeBounds(String),
 
-    /// The required degree bound is not supported by ck/vk
+    #[error("the degree bound ({0}) is not supported by the parameters")]
     UnsupportedDegreeBound(usize),
 
-    /// The provided equation contained multiple polynomials, of which least one
-    /// had a strict degree bound.
+    #[error("the Lagrange basis size ({0}) is not supported by the parameters")]
     UnsupportedLagrangeBasisSize(usize),
 
-    /// The degree bound for the `index`-th polynomial passed to `commit`, `open`
-    /// or `check` was incorrect, that is, `degree_bound >= poly_degree` or
-    /// `degree_bound <= max_degree`.
+    #[error(
+        "the degree bound ({degree_bound}) for the polynomial {label} \
+        (having degree {poly_degree}) is greater than the maximum degree ({max_degree})"
+    )]
     IncorrectDegreeBound {
         /// Degree of the polynomial.
         poly_degree: usize,
@@ -91,63 +92,4 @@ pub enum PCError {
         /// Index of the offending polynomial.
         label: String,
     },
-
-    Terminated,
-}
-
-impl snarkvm_utilities::error::Error for PCError {}
-
-impl From<anyhow::Error> for PCError {
-    fn from(other: anyhow::Error) -> Self {
-        Self::AnyhowError(other)
-    }
-}
-
-impl core::fmt::Display for PCError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::AnyhowError(error) => write!(f, "{error}"),
-            Self::MissingPolynomial { label } => {
-                write!(f, "`QuerySet` refers to polynomial \"{label}\", but it was not provided.")
-            }
-            Self::MissingEvaluation { label } => write!(
-                f,
-                "`QuerySet` refers to polynomial \"{label}\", but `Evaluations` does not contain an evaluation for it."
-            ),
-            Self::MissingRng => write!(f, "hiding commitments require `Some(rng)`"),
-            Self::DegreeIsZero => write!(f, "this scheme does not support committing to degree 0 polynomials"),
-            Self::TooManyCoefficients { num_coefficients, num_powers } => write!(
-                f,
-                "the number of coefficients in the polynomial ({num_coefficients:?}) is greater than\
-                 the maximum number of powers in `Powers` ({num_powers:?})"
-            ),
-            Self::HidingBoundIsZero => write!(f, "this scheme does not support non-`None` hiding bounds that are 0"),
-            Self::HidingBoundToolarge { hiding_poly_degree, num_powers } => write!(
-                f,
-                "the degree of the hiding poly ({hiding_poly_degree:?}) is not less than the maximum number of powers in `Powers` ({num_powers:?})"
-            ),
-            Self::TrimmingDegreeTooLarge => write!(f, "the degree provided to `trim` was too large"),
-            Self::EquationHasDegreeBounds(e) => {
-                write!(f, "the eqaution \"{e}\" contained degree-bounded polynomials")
-            }
-            Self::UnsupportedDegreeBound(bound) => {
-                write!(f, "the degree bound ({bound:?}) is not supported by the parameters")
-            }
-            Self::LagrangeBasisSizeIsNotPowerOfTwo => {
-                write!(f, "the Lagrange Basis size is not a power of two")
-            }
-            Self::UnsupportedLagrangeBasisSize(size) => {
-                write!(f, "the Lagrange basis size ({size:?}) is not supported by the parameters")
-            }
-            Self::LagrangeBasisSizeIsTooLarge => {
-                write!(f, "the Lagrange Basis size larger than max supported degree")
-            }
-            Self::IncorrectDegreeBound { poly_degree, degree_bound, max_degree, label } => write!(
-                f,
-                "the degree bound ({degree_bound}) for the polynomial {label} \
-                 (having degree {poly_degree}) is greater than the maximum degree ({max_degree})"
-            ),
-            Self::Terminated => write!(f, "terminated"),
-        }
-    }
 }

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -515,10 +515,9 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                         .ok_or(PCError::MissingPolynomial { label: label.to_string() })?;
 
                     if cur_comm.degree_bound().is_some() {
-                        if num_polys != 1 {
+                        if num_polys != 1 || !coeff.is_one() {
                             return Err(PCError::EquationHasDegreeBounds(lc_label));
                         }
-                        assert!(coeff.is_one(), "Coefficient must be one for degree-bounded equations");
                         degree_bound = cur_comm.degree_bound();
                     }
                     coeffs_and_comms.push((*coeff, cur_comm.commitment()));

--- a/algorithms/src/r1cs/errors.rs
+++ b/algorithms/src/r1cs/errors.rs
@@ -34,7 +34,7 @@ pub enum SynthesisError {
     Unsatisfiable,
     /// During synthesis, our polynomials ended up being too high of degree
     #[error("Polynomial degree is too large")]
-    PolynomialDegreeTooLarge,
+    PolyTooLarge,
     /// During proof generation, we encountered an identity in the CRS
     #[error("Encountered an identity element in the CRS")]
     UnexpectedIdentity,

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -27,7 +27,7 @@ use crate::{
         SNARKMode,
     },
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, ensure, Result};
 use snarkvm_fields::{Field, PrimeField};
 
 use core::{borrow::Borrow, marker::PhantomData};
@@ -79,17 +79,17 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
     /// of this protocol.
     /// The number of the variables must include the "one" variable. That is, it
     /// must be with respect to the number of formatted public inputs.
-    pub fn max_degree(num_constraints: usize, num_variables: usize, num_non_zero: usize) -> Result<usize, AHPError> {
+    pub fn max_degree(num_constraints: usize, num_variables: usize, num_non_zero: usize) -> Result<usize> {
         let zk_bound = Self::zk_bound().unwrap_or(0);
         let constraint_domain_size =
-            EvaluationDomain::<F>::compute_size_of_domain(num_constraints).ok_or(AHPError::PolynomialDegreeTooLarge)?;
+            EvaluationDomain::<F>::compute_size_of_domain(num_constraints).ok_or(AHPError::PolyTooLarge)?;
         let variable_domain_size =
-            EvaluationDomain::<F>::compute_size_of_domain(num_variables).ok_or(AHPError::PolynomialDegreeTooLarge)?;
+            EvaluationDomain::<F>::compute_size_of_domain(num_variables).ok_or(AHPError::PolyTooLarge)?;
         let non_zero_domain_size =
-            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero).ok_or(AHPError::PolynomialDegreeTooLarge)?;
+            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero).ok_or(AHPError::PolyTooLarge)?;
 
         // these should correspond with the bounds set in the <round>.rs files
-        Ok(*[
+        [
             2 * constraint_domain_size + 2 * zk_bound - 2,
             2 * variable_domain_size + 2 * zk_bound - 2,
             if SM::ZK { variable_domain_size + 3 } else { 0 }, // mask_poly
@@ -99,34 +99,40 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         ]
         .iter()
         .max()
-        .unwrap())
+        .copied()
+        .ok_or(anyhow!("Could not find max_degree"))
     }
 
     /// Get all the strict degree bounds enforced in the AHP.
-    pub fn get_degree_bounds(info: &CircuitInfo) -> [usize; 4] {
+    pub fn get_degree_bounds(info: &CircuitInfo) -> Result<[usize; 4]> {
         let num_variables = info.num_variables;
         let num_non_zero_a = info.num_non_zero_a;
         let num_non_zero_b = info.num_non_zero_b;
         let num_non_zero_c = info.num_non_zero_c;
-        [
-            EvaluationDomain::<F>::compute_size_of_domain(num_variables).unwrap() - 2,
-            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero_a).unwrap() - 2,
-            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero_b).unwrap() - 2,
-            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero_c).unwrap() - 2,
-        ]
+        Ok([
+            EvaluationDomain::<F>::compute_size_of_domain(num_variables).ok_or(SynthesisError::PolyTooLarge)? - 2,
+            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero_a).ok_or(SynthesisError::PolyTooLarge)? - 2,
+            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero_b).ok_or(SynthesisError::PolyTooLarge)? - 2,
+            EvaluationDomain::<F>::compute_size_of_domain(num_non_zero_c).ok_or(SynthesisError::PolyTooLarge)? - 2,
+        ])
     }
 
     pub(crate) fn cmp_non_zero_domains(
         info: &CircuitInfo,
         max_candidate: Option<EvaluationDomain<F>>,
-    ) -> Result<NonZeroDomains<F>, SynthesisError> {
-        let domain_a = EvaluationDomain::new(info.num_non_zero_a).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let domain_b = EvaluationDomain::new(info.num_non_zero_b).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let domain_c = EvaluationDomain::new(info.num_non_zero_c).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let new_candidate = [domain_a, domain_b, domain_c].into_iter().max_by_key(|d| d.size()).unwrap();
+    ) -> Result<NonZeroDomains<F>> {
+        let domain_a = EvaluationDomain::new(info.num_non_zero_a).ok_or(SynthesisError::PolyTooLarge)?;
+        let domain_b = EvaluationDomain::new(info.num_non_zero_b).ok_or(SynthesisError::PolyTooLarge)?;
+        let domain_c = EvaluationDomain::new(info.num_non_zero_c).ok_or(SynthesisError::PolyTooLarge)?;
+        let new_candidate = [domain_a, domain_b, domain_c]
+            .into_iter()
+            .max_by_key(|d| d.size())
+            .ok_or(anyhow!("could not find max domain"))?;
         let mut max_non_zero_domain = Some(new_candidate);
-        if max_candidate.is_some() && max_candidate.unwrap().size() > new_candidate.size() {
-            max_non_zero_domain = max_candidate;
+        if let Some(max_candidate) = max_candidate {
+            if max_candidate.size() > new_candidate.size() {
+                max_non_zero_domain = Some(max_candidate);
+            }
         }
         Ok(NonZeroDomains { max_non_zero_domain, domain_a, domain_b, domain_c })
     }
@@ -167,8 +173,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         prover_third_message: &prover::ThirdMessage<F>,
         prover_fourth_message: &prover::FourthMessage<F>,
         state: &verifier::State<F, SM>,
-    ) -> Result<BTreeMap<String, LinearCombination<F>>, AHPError> {
-        assert!(!public_inputs.is_empty());
+    ) -> Result<BTreeMap<String, LinearCombination<F>>> {
+        ensure!(!public_inputs.is_empty());
         let max_constraint_domain = state.max_constraint_domain;
         let max_variable_domain = state.max_variable_domain;
         let max_non_zero_domain = state.max_non_zero_domain;
@@ -181,11 +187,12 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                     .iter()
                     .map(|p| {
                         let public_input = prover::ConstraintSystem::format_public_input(p);
-                        Self::formatted_public_input_is_admissible(&public_input).map(|_| public_input)
+                        Self::formatted_public_input_is_admissible(&public_input)?;
+                        Ok::<_, AHPError>(public_input)
                     })
-                    .collect::<Result<Vec<_>, _>>();
-                assert_eq!(public_inputs.as_ref().unwrap()[0].len(), input_domain.size());
-                public_inputs
+                    .collect::<Result<Vec<_>, _>>()?;
+                ensure!(public_inputs[0].len() == input_domain.size());
+                Ok(public_inputs)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -361,7 +368,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 let g_m = LinearCombination::new(g_m_label.clone(), [(F::one(), g_m_label)]);
                 let g_m_at_gamma = evals.get_lc_eval(&g_m, gamma)?;
 
-                let (a_poly, b_poly) = Self::construct_matrix_linear_combinations(evals, id, m, v_rc, challenges, rc);
+                let (a_poly, b_poly) = Self::construct_matrix_linear_combinations(evals, id, m, v_rc, challenges, rc)?;
                 let g_m_term = Self::construct_g_m_term(gamma, g_m_at_gamma, sum, *selector, a_poly, b_poly);
 
                 matrix_sumcheck += (delta, &g_m_term);
@@ -402,7 +409,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         v_rc_at_alpha_beta: F,
         challenges: QueryPoints<F>,
         rc_size: F,
-    ) -> (LinearCombination<F>, LinearCombination<F>) {
+    ) -> Result<(LinearCombination<F>, LinearCombination<F>)> {
         let label_a_poly = format!("circuit_{id}_a_poly_{matrix}");
         let label_b_poly = format!("circuit_{id}_b_poly_{matrix}");
         let QueryPoints { alpha, beta, gamma } = challenges;
@@ -412,9 +419,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let a_poly_eval_available = evals.get_lc_eval(&a_poly, gamma).is_ok();
         let b_poly = LinearCombination::new(label_b_poly.clone(), [(F::one(), label_b_poly.clone())]);
         let b_poly_eval_available = evals.get_lc_eval(&b_poly, gamma).is_ok();
-        assert_eq!(a_poly_eval_available, b_poly_eval_available);
+        ensure!(a_poly_eval_available == b_poly_eval_available);
         if a_poly_eval_available && b_poly_eval_available {
-            return (a_poly, b_poly);
+            return Ok((a_poly, b_poly));
         };
 
         // When running as the verifier, we need to construct a(X) and b(X) from the indexing polynomials
@@ -431,7 +438,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             (F::one(), (label_row_col).into()),
         ]);
         b *= rc_size;
-        (a, b)
+        Ok((a, b))
     }
 }
 
@@ -441,14 +448,14 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 /// when constructing linear combinations via `AHPForR1CS::construct_linear_combinations`.
 pub trait EvaluationsProvider<F: PrimeField>: core::fmt::Debug {
     /// Get the evaluation of linear combination `lc` at `point`.
-    fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F, AHPError>;
+    fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F>;
 }
 
 /// The `EvaluationsProvider` used by the verifier
 impl<F: PrimeField> EvaluationsProvider<F> for crate::polycommit::sonic_pc::Evaluations<F> {
-    fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F, AHPError> {
+    fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F> {
         let key = (lc.label.clone(), point);
-        self.get(&key).copied().ok_or_else(|| AHPError::MissingEval(lc.label.clone()))
+        self.get(&key).copied().ok_or_else(|| AHPError::MissingEval(lc.label.clone())).map_err(Into::into)
     }
 }
 
@@ -458,7 +465,7 @@ where
     F: PrimeField,
     T: Borrow<LabeledPolynomial<F>> + core::fmt::Debug,
 {
-    fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F, AHPError> {
+    fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F> {
         let mut eval = F::zero();
         for (coeff, term) in lc.iter() {
             let value = if let LCTerm::PolyLabel(label) = term {
@@ -468,7 +475,7 @@ where
                     .borrow()
                     .evaluate(point)
             } else {
-                assert!(term.is_one());
+                ensure!(term.is_one());
                 F::one()
             };
             eval += &(*coeff * value)

--- a/algorithms/src/snark/varuna/ahp/errors.rs
+++ b/algorithms/src/snark/varuna/ahp/errors.rs
@@ -13,34 +13,35 @@
 // limitations under the License.
 
 /// Describes the failure modes of the AHP scheme.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum AHPError {
-    /// Anyhow error
-    Anyhow(anyhow::Error),
-    /// The batch size is zero.
+    #[error("{}", _0)]
+    AnyhowError(#[from] anyhow::Error),
+
+    #[error("Batch size was zero; must be at least 1.")]
     BatchSizeIsZero,
-    /// An error occurred during constraint generation.
+
+    #[error("An error occurred during constraint generation.")]
     ConstraintSystemError(crate::r1cs::errors::SynthesisError),
-    /// The instance generated during proving does not match that in the index.
+
+    #[error("The instance generated during proving does not match that in the index.")]
     InstanceDoesNotMatchIndex,
-    /// The number of public inputs is incorrect.
+
+    #[error("The number of public inputs is incorrect.")]
     InvalidPublicInputLength,
-    /// During verification, a required evaluation is missing
+
+    #[error("During verification, a required evaluation is missing: {}", _0)]
     MissingEval(String),
-    /// Currently we only support square constraint matrices.
+
+    #[error("Currently we only support square constraint matrices.")]
     NonSquareMatrix,
-    /// During synthesis, our polynomials ended up being too high of degree
-    PolynomialDegreeTooLarge,
+
+    #[error("During synthesis, our polynomials ended up being too high of degree.")]
+    PolyTooLarge,
 }
 
 impl From<crate::r1cs::errors::SynthesisError> for AHPError {
     fn from(other: crate::r1cs::errors::SynthesisError) -> Self {
         AHPError::ConstraintSystemError(other)
-    }
-}
-
-impl From<anyhow::Error> for AHPError {
-    fn from(other: anyhow::Error) -> Self {
-        AHPError::Anyhow(other)
     }
 }

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::snark::varuna::{ahp::AHPForR1CS, SNARKMode};
+use anyhow::Result;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{serialize::*, ToBytes};
 
@@ -37,9 +38,9 @@ pub struct CircuitInfo {
 
 impl CircuitInfo {
     /// The maximum degree of polynomial required to represent this index in the AHP.
-    pub fn max_degree<F: PrimeField, SM: SNARKMode>(&self) -> usize {
+    pub fn max_degree<F: PrimeField, SM: SNARKMode>(&self) -> Result<usize> {
         let max_non_zero = self.num_non_zero_a.max(self.num_non_zero_b).max(self.num_non_zero_c);
-        AHPForR1CS::<F, SM>::max_degree(self.num_constraints, self.num_variables, max_non_zero).unwrap()
+        AHPForR1CS::<F, SM>::max_degree(self.num_constraints, self.num_variables, max_non_zero)
     }
 }
 

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -27,12 +27,12 @@ use crate::{
         SNARKMode,
     },
 };
-use itertools::Itertools;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::cfg_into_iter;
 
 use anyhow::{anyhow, Result};
 use core::marker::PhantomData;
+use itertools::Itertools;
 use std::collections::BTreeMap;
 
 #[cfg(not(feature = "serial"))]

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -27,6 +27,7 @@ use crate::{
         SNARKMode,
     },
 };
+use itertools::Itertools;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::cfg_into_iter;
 
@@ -119,7 +120,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 
     /// Generate the indexed circuit evaluations for this constraint system.
     /// Used by both the Prover and Verifier
-    pub(crate) fn index_helper<C: ConstraintSynthesizer<F>>(c: &C) -> Result<IndexerState<F>, AHPError> {
+    pub(crate) fn index_helper<C: ConstraintSynthesizer<F>>(c: &C) -> Result<IndexerState<F>> {
         let index_time = start_timer!(|| "AHP::Index");
 
         let constraint_time = start_timer!(|| "Generating constraints");
@@ -134,7 +135,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             crate::snark::varuna::ahp::matrices::add_randomizing_variables::<_, _>(&mut ics, random_assignments)
         });
 
-        crate::snark::varuna::ahp::matrices::pad_input_for_indexer_and_prover(&mut ics);
+        crate::snark::varuna::ahp::matrices::pad_input_for_indexer_and_prover(&mut ics)?;
 
         let a = ics.a_matrix()?;
         let b = ics.b_matrix()?;
@@ -171,18 +172,13 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             num_non_zero_c,
         };
 
-        let constraint_domain =
-            EvaluationDomain::new(num_constraints).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let variable_domain = EvaluationDomain::new(num_variables).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let input_domain =
-            EvaluationDomain::new(num_padded_public_variables).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+        let constraint_domain = EvaluationDomain::new(num_constraints).ok_or(SynthesisError::PolyTooLarge)?;
+        let variable_domain = EvaluationDomain::new(num_variables).ok_or(SynthesisError::PolyTooLarge)?;
+        let input_domain = EvaluationDomain::new(num_padded_public_variables).ok_or(SynthesisError::PolyTooLarge)?;
 
-        let non_zero_a_domain =
-            EvaluationDomain::new(num_non_zero_a).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let non_zero_b_domain =
-            EvaluationDomain::new(num_non_zero_b).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let non_zero_c_domain =
-            EvaluationDomain::new(num_non_zero_c).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+        let non_zero_a_domain = EvaluationDomain::new(num_non_zero_a).ok_or(SynthesisError::PolyTooLarge)?;
+        let non_zero_b_domain = EvaluationDomain::new(num_non_zero_b).ok_or(SynthesisError::PolyTooLarge)?;
+        let non_zero_c_domain = EvaluationDomain::new(num_non_zero_c).ok_or(SynthesisError::PolyTooLarge)?;
 
         let constraint_domain_elements = constraint_domain.elements().collect::<Vec<_>>();
         let variable_domain_elements = variable_domain.elements().collect::<Vec<_>>();
@@ -203,7 +199,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 .try_into()
                 .unwrap();
 
-        let id = Circuit::<F, SM>::hash(&index_info, &a, &b, &c).unwrap();
+        let id = Circuit::<F, SM>::hash(&index_info, &a, &b, &c)?;
 
         let result = Ok(IndexerState {
             constraint_domain,
@@ -233,16 +229,18 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         id: &CircuitId,
         point: F,
     ) -> Result<impl Iterator<Item = F>, AHPError> {
+        let labels = [["a"], ["b"], ["c"]];
         let mut evals = [
             (state.a_arith, state.non_zero_a_domain),
             (state.b_arith, state.non_zero_b_domain),
             (state.c_arith, state.non_zero_c_domain),
         ]
         .into_iter()
-        .flat_map(move |(evals, domain)| {
-            let labels = Self::index_polynomial_labels(&["a", "b", "c"], std::iter::once(id));
+        .zip_eq(&labels)
+        .flat_map(|((evals, domain), label)| {
+            let labels = Self::index_polynomial_labels(label, std::iter::once(id));
             let lagrange_coefficients_at_point = domain.evaluate_all_lagrange_coefficients(point);
-            labels.zip(evals.evaluate(&lagrange_coefficients_at_point).unwrap())
+            labels.zip_eq(evals.evaluate(&lagrange_coefficients_at_point).unwrap())
         })
         .collect::<Vec<_>>();
         evals.sort_by(|(l1, _), (l2, _)| l1.cmp(l2));

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -23,11 +23,11 @@ use crate::{
         VarunaHidingMode,
     },
 };
+use itertools::Itertools;
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, serialize::*};
 
-use anyhow::{ensure, Result};
-use itertools::Itertools;
+use anyhow::{anyhow, ensure, Result};
 use std::collections::BTreeMap;
 
 #[cfg(not(feature = "serial"))]
@@ -60,7 +60,7 @@ pub(crate) fn to_matrix_helper<F: Field>(
 pub(crate) fn add_randomizing_variables<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     rand_assignments: Option<[F; 3]>,
-) {
+) -> Result<()> {
     let mut assignments = [F::one(); 3];
     if let Some(r) = rand_assignments {
         assignments = r;
@@ -69,25 +69,27 @@ pub(crate) fn add_randomizing_variables<F: PrimeField, CS: ConstraintSystem<F>>(
     let zk_vars = assignments
         .into_iter()
         .enumerate()
-        .map(|(i, assignment)| cs.alloc(|| format!("random_{i}"), || Ok(assignment)).unwrap())
-        .collect_vec();
+        .map(|(i, assignment)| cs.alloc(|| format!("random_{i}"), || Ok(assignment)))
+        .collect::<Result<Vec<_>, _>>()?;
     cs.enforce(|| "constraint zk", |lc| lc + zk_vars[0], |lc| lc + zk_vars[1], |lc| lc + zk_vars[2]);
+    Ok(())
 }
 
 /// Pads the public variables up to the closest power of two.
-pub(crate) fn pad_input_for_indexer_and_prover<F: PrimeField, CS: ConstraintSystem<F>>(cs: &mut CS) {
+pub(crate) fn pad_input_for_indexer_and_prover<F: PrimeField, CS: ConstraintSystem<F>>(cs: &mut CS) -> Result<()> {
     let num_public_variables = cs.num_public_variables();
 
-    let power_of_two = EvaluationDomain::<F>::new(num_public_variables);
-    assert!(power_of_two.is_some());
+    let power_of_two =
+        EvaluationDomain::<F>::new(num_public_variables).ok_or(anyhow!("Could not create EvaluationDomain"))?;
 
     // Allocated `zero` variables to pad the public input up to the next power of two.
-    let padded_size = power_of_two.unwrap().size();
+    let padded_size = power_of_two.size();
     if padded_size > num_public_variables {
         for i in 0..(padded_size - num_public_variables) {
-            cs.alloc_input(|| format!("pad_input_{i}"), || Ok(F::zero())).unwrap();
+            cs.alloc_input(|| format!("pad_input_{i}"), || Ok(F::zero()))?;
         }
     }
+    Ok(())
 }
 
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq)]
@@ -105,11 +107,14 @@ pub struct MatrixEvals<F: PrimeField> {
 
 impl<F: PrimeField> MatrixEvals<F> {
     pub(crate) fn evaluate(&self, lagrange_coefficients_at_point: &[F]) -> Result<[F; 4]> {
-        ensure!(self.row_col.is_some(), "row_col evaluations are not available");
         Ok([
             self.row.evaluate_with_coeffs(lagrange_coefficients_at_point),
             self.col.evaluate_with_coeffs(lagrange_coefficients_at_point),
-            self.row_col.as_ref().unwrap().evaluate_with_coeffs(lagrange_coefficients_at_point),
+            self.row_col
+                .as_ref()
+                .ok_or("row_col evaluations are not available")
+                .map_err(anyhow::Error::msg)?
+                .evaluate_with_coeffs(lagrange_coefficients_at_point),
             self.row_col_val.evaluate_with_coeffs(lagrange_coefficients_at_point),
         ])
     }

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -23,11 +23,11 @@ use crate::{
         VarunaHidingMode,
     },
 };
-use itertools::Itertools;
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, serialize::*};
 
 use anyhow::{anyhow, ensure, Result};
+use itertools::Itertools;
 use std::collections::BTreeMap;
 
 #[cfg(not(feature = "serial"))]

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fifth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fifth.rs
@@ -23,11 +23,11 @@ use crate::{
         SNARKMode,
     },
 };
+use snarkvm_fields::PrimeField;
+use snarkvm_utilities::{cfg_par_bridge, cfg_reduce};
 
 use itertools::Itertools;
 use rand_core::RngCore;
-use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{cfg_par_bridge, cfg_reduce};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
-
 use crate::{
     fft::{DensePolynomial, EvaluationDomain, Evaluations as EvaluationsOnDomain, SparsePolynomial},
     polycommit::sonic_pc::{LabeledPolynomial, PolynomialInfo, PolynomialLabel},
@@ -26,10 +24,12 @@ use crate::{
         SNARKMode,
     },
 };
-use itertools::Itertools;
-use rand_core::RngCore;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::cfg_into_iter;
+
+use itertools::Itertools;
+use rand_core::RngCore;
+use std::collections::BTreeMap;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -94,7 +94,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                                 rand_assignments,
                             )
                         });
-                        crate::snark::varuna::ahp::matrices::pad_input_for_indexer_and_prover(&mut pcs);
+                        crate::snark::varuna::ahp::matrices::pad_input_for_indexer_and_prover(&mut pcs)?;
 
                         end_timer!(padding_time);
 

--- a/algorithms/src/snark/varuna/ahp/verifier/messages.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/messages.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::snark::varuna::{witness_label, CircuitId, SNARKMode};
 use snarkvm_fields::PrimeField;
 
-use crate::snark::varuna::{witness_label, CircuitId, SNARKMode};
 use itertools::Itertools;
 use std::collections::BTreeMap;
 

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -46,7 +46,7 @@ use snarkvm_curves::PairingEngine;
 use snarkvm_fields::{One, PrimeField, ToConstraintField, Zero};
 use snarkvm_utilities::{to_bytes_le, ToBytes};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use core::marker::PhantomData;
 use itertools::Itertools;
 use rand::{CryptoRng, Rng};
@@ -82,17 +82,17 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
             let mut indexed_circuit = AHPForR1CS::<_, SM>::index(*circuit)?;
             // TODO: Add check that c is in the correct mode.
             // Ensure the universal SRS supports the circuit size.
-            universal_srs
-                .download_powers_for(0..indexed_circuit.max_degree())
-                .map_err(|e| anyhow!("Failed to download powers for degree {}: {e}", indexed_circuit.max_degree()))?;
-            let coefficient_support = AHPForR1CS::<E::Fr, SM>::get_degree_bounds(&indexed_circuit.index_info);
+            universal_srs.download_powers_for(0..indexed_circuit.max_degree()?).map_err(|e| {
+                anyhow!("Failed to download powers for degree {}: {e}", indexed_circuit.max_degree().unwrap())
+            })?;
+            let coefficient_support = AHPForR1CS::<E::Fr, SM>::get_degree_bounds(&indexed_circuit.index_info)?;
 
             // Varuna only needs degree 2 random polynomials.
             let supported_hiding_bound = 1;
             let supported_lagrange_sizes = [].into_iter(); // TODO: consider removing lagrange_bases_at_beta_g from CommitterKey
             let (committer_key, _) = SonicKZG10::<E, FS>::trim(
                 universal_srs,
-                indexed_circuit.max_degree(),
+                indexed_circuit.max_degree()?,
                 supported_lagrange_sizes,
                 supported_hiding_bound,
                 Some(coefficient_support.as_slice()),
@@ -106,11 +106,11 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
             let (mut circuit_commitments, commitment_randomnesses): (_, _) = SonicKZG10::<E, FS>::commit(
                 universal_prover,
                 &ck,
-                indexed_circuit.interpolate_matrix_evals().map(Into::into),
+                indexed_circuit.interpolate_matrix_evals()?.map(Into::into),
                 setup_rng,
             )?;
             let empty_randomness = Randomness::<E>::empty();
-            assert!(commitment_randomnesses.iter().all(|r| r == &empty_randomness));
+            ensure!(commitment_randomnesses.iter().all(|r| r == &empty_randomness));
             end_timer!(commit_time);
 
             circuit_commitments.sort_by(|c1, c2| c1.label().cmp(c2.label()));
@@ -141,7 +141,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
         let mut sponge = FS::new_with_parameters(fs_parameters);
         sponge.absorb_bytes(Self::PROTOCOL_NAME);
         for (batch_size, inputs) in inputs_and_batch_sizes.values() {
-            sponge.absorb_bytes(&(u64::try_from(*batch_size).unwrap()).to_le_bytes());
+            sponge.absorb_bytes(&(*batch_size as u64).to_le_bytes());
             for input in inputs.iter() {
                 sponge.absorb_nonnative_field_elements(input.iter().copied());
             }
@@ -157,7 +157,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
         verifying_key: &CircuitVerifyingKey<E>,
     ) -> Result<FS> {
         let mut sponge = FS::new_with_parameters(fs_parameters);
-        sponge.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME].unwrap());
+        sponge.absorb_bytes(&to_bytes_le![&Self::PROTOCOL_NAME]?);
         sponge.absorb_bytes(&verifying_key.circuit_info.to_bytes_le()?);
         sponge.absorb_native_field_elements(&verifying_key.circuit_commitments);
         sponge.absorb_bytes(&verifying_key.id.0);
@@ -214,7 +214,7 @@ where
     type VerifierInput = [E::Fr];
     type VerifyingKey = CircuitVerifyingKey<E>;
 
-    fn universal_setup(max_degree: usize) -> Result<Self::UniversalSRS, SNARKError> {
+    fn universal_setup(max_degree: usize) -> Result<Self::UniversalSRS> {
         let setup_time = start_timer!(|| { format!("Varuna::UniversalSetup with max_degree {max_degree}",) });
         let srs = SonicKZG10::<E, FS>::load_srs(max_degree).map_err(Into::into);
         end_timer!(setup_time);
@@ -228,7 +228,7 @@ where
         circuit: &C,
     ) -> Result<(Self::ProvingKey, Self::VerifyingKey)> {
         let mut circuit_keys = Self::batch_circuit_setup::<C>(universal_srs, &[circuit])?;
-        assert_eq!(circuit_keys.len(), 1);
+        ensure!(circuit_keys.len() == 1);
         Ok(circuit_keys.pop().unwrap())
     }
 
@@ -238,14 +238,14 @@ where
         fs_parameters: &Self::FSParameters,
         verifying_key: &Self::VerifyingKey,
         proving_key: &Self::ProvingKey,
-    ) -> Result<Self::Certificate, SNARKError> {
+    ) -> Result<Self::Certificate> {
         // Initialize sponge
         let mut sponge = Self::init_sponge_for_certificate(fs_parameters, verifying_key)?;
         // Compute challenges for linear combination, and the point to evaluate the polynomials at.
         // The linear combination requires `num_polynomials - 1` coefficients
         // (since the first coeff is 1), and so we squeeze out `num_polynomials` points.
         let mut challenges = sponge.squeeze_nonnative_field_elements(verifying_key.circuit_commitments.len());
-        let point = challenges.pop().unwrap();
+        let point = challenges.pop().ok_or(anyhow!("Failed to squeeze random element"))?;
         let one = E::Fr::one();
         let linear_combination_challenges = core::iter::once(&one).chain(challenges.iter());
 
@@ -266,7 +266,7 @@ where
             universal_prover,
             &committer_key,
             &[lc],
-            proving_key.circuit.interpolate_matrix_evals(),
+            proving_key.circuit.interpolate_matrix_evals()?,
             &empty_randomness,
             &query_set,
             &mut sponge,
@@ -283,15 +283,15 @@ where
         circuit: &C,
         verifying_key: &Self::VerifyingKey,
         certificate: &Self::Certificate,
-    ) -> Result<bool, SNARKError> {
+    ) -> Result<bool> {
         // Ensure the VerifyingKey encodes the expected circuit.
         let circuit_id = &verifying_key.id;
         let state = AHPForR1CS::<E::Fr, SM>::index_helper(circuit)?;
         if state.index_info != verifying_key.circuit_info {
-            return Err(SNARKError::CircuitNotFound);
+            bail!(SNARKError::CircuitNotFound);
         }
         if state.id != *circuit_id {
-            return Err(SNARKError::CircuitNotFound);
+            bail!(SNARKError::CircuitNotFound);
         }
 
         // Initialize sponge.
@@ -301,7 +301,7 @@ where
         // The linear combination requires `num_polynomials - 1` coefficients
         // (since the first coeff is 1), and so we squeeze out `num_polynomials` points.
         let mut challenges = sponge.squeeze_nonnative_field_elements(verifying_key.circuit_commitments.len());
-        let point = challenges.pop().unwrap();
+        let point = challenges.pop().ok_or(anyhow!("Failed to squeeze random element"))?;
         let one = E::Fr::one();
         let linear_combination_challenges = core::iter::once(&one).chain(challenges.iter());
 
@@ -344,10 +344,10 @@ where
         fs_parameters: &Self::FSParameters,
         keys_to_constraints: &BTreeMap<&CircuitProvingKey<E, SM>, &[C]>,
         zk_rng: &mut R,
-    ) -> Result<Self::Proof, SNARKError> {
+    ) -> Result<Self::Proof> {
         let prover_time = start_timer!(|| "Varuna::Prover");
         if keys_to_constraints.is_empty() {
-            return Err(SNARKError::EmptyBatch);
+            bail!(SNARKError::EmptyBatch);
         }
 
         let mut circuits_to_constraints = BTreeMap::new();
@@ -378,7 +378,7 @@ where
 
             circuit_ids.push(circuit_id);
         }
-        assert_eq!(prover_state.total_instances, total_instances);
+        ensure!(prover_state.total_instances == total_instances);
 
         let committer_key = CommitterUnionKey::union(keys_to_constraints.keys().map(|pk| pk.committer_key.deref()));
 
@@ -522,7 +522,7 @@ where
             .chain(fourth_oracles.into_iter())
             .chain(fifth_oracles.into_iter())
             .collect();
-        assert!(
+        ensure!(
             polynomials.len()
                 == num_unique_circuits * 6 + // numerator and denominator for each matrix sumcheck
             AHPForR1CS::<E::Fr, SM>::num_first_round_oracles(total_instances) +
@@ -570,9 +570,9 @@ where
 
         let empty_randomness = Randomness::<E>::empty();
         if SM::ZK {
-            assert!(commitment_randomnesses.iter().any(|r| r != &empty_randomness));
+            ensure!(commitment_randomnesses.iter().any(|r| r != &empty_randomness));
         } else {
-            assert!(commitment_randomnesses.iter().all(|r| r == &empty_randomness));
+            ensure!(commitment_randomnesses.iter().all(|r| r == &empty_randomness));
         }
 
         // Compute the AHP verifier's query set.
@@ -619,7 +619,7 @@ where
             pc_proof,
         )?;
         proof.check_batch_sizes()?;
-        assert_eq!(proof.pc_proof.is_hiding(), SM::ZK);
+        ensure!(proof.pc_proof.is_hiding() == SM::ZK);
 
         end_timer!(prover_time);
         Ok(proof)
@@ -633,9 +633,9 @@ where
         fs_parameters: &Self::FSParameters,
         keys_to_inputs: &BTreeMap<&Self::VerifyingKey, &[B]>,
         proof: &Self::Proof,
-    ) -> Result<bool, SNARKError> {
+    ) -> Result<bool> {
         if keys_to_inputs.is_empty() {
-            return Err(SNARKError::EmptyBatch);
+            bail!(SNARKError::EmptyBatch);
         }
 
         proof.check_batch_sizes()?;
@@ -645,11 +645,11 @@ where
             batch_sizes.insert(vk.id, batch_sizes_vec[i]);
 
             if public_inputs_i.is_empty() {
-                return Err(SNARKError::EmptyBatch);
+                bail!(SNARKError::EmptyBatch);
             }
 
             if public_inputs_i.len() != batch_sizes_vec[i] {
-                return Err(SNARKError::BatchSizeMismatch);
+                bail!(SNARKError::BatchSizeMismatch);
             }
         }
 
@@ -670,17 +670,22 @@ where
             let non_zero_domains = AHPForR1CS::<_, SM>::cmp_non_zero_domains(&vk.circuit_info, max_non_zero_domain)?;
             max_non_zero_domain = non_zero_domains.max_non_zero_domain;
 
-            let input_domain = EvaluationDomain::<E::Fr>::new(vk.circuit_info.num_public_inputs).unwrap();
+            let input_domain = EvaluationDomain::<E::Fr>::new(vk.circuit_info.num_public_inputs)
+                .ok_or(anyhow!("Failed to create EvaluationDomain from num_public_inputs"))?;
             input_domains.insert(vk.id, input_domain);
 
+            let input_fields = public_inputs_i
+                .iter()
+                .map(|input| input.borrow().to_field_elements())
+                .collect::<Result<Vec<_>, _>>()?;
+
             let (padded_public_inputs_i, parsed_public_inputs_i): (Vec<_>, Vec<_>) = {
-                public_inputs_i
+                input_fields
                     .iter()
                     .map(|input| {
-                        let input = input.borrow().to_field_elements().unwrap();
                         let mut new_input = Vec::with_capacity((1 + input.len()).max(input_domain.size()));
                         new_input.push(E::Fr::one());
-                        new_input.extend_from_slice(&input);
+                        new_input.extend_from_slice(input);
                         new_input.resize(input.len().max(input_domain.size()), E::Fr::zero());
                         if cfg!(debug_assertions) {
                             println!("Number of padded public variables: {}", new_input.len());
@@ -700,10 +705,10 @@ where
             inputs_and_batch_sizes.insert(vk.id, (batch_size, padded_public_vec[i].as_slice()));
         }
         let max_constraint_domain =
-            EvaluationDomain::<E::Fr>::new(max_num_constraints).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+            EvaluationDomain::<E::Fr>::new(max_num_constraints).ok_or(SynthesisError::PolyTooLarge)?;
         let max_variable_domain =
-            EvaluationDomain::<E::Fr>::new(max_num_variables).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
-        let max_non_zero_domain = max_non_zero_domain.ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+            EvaluationDomain::<E::Fr>::new(max_num_variables).ok_or(SynthesisError::PolyTooLarge)?;
+        let max_non_zero_domain = max_non_zero_domain.ok_or(SynthesisError::PolyTooLarge)?;
 
         let comms = &proof.commitments;
         let proof_has_correct_zk_mode = if SM::ZK {
@@ -743,8 +748,8 @@ where
 
         if SM::ZK {
             first_commitments.push(LabeledCommitment::new_with_info(
-                first_round_info.get("mask_poly").unwrap(),
-                comms.mask_poly.unwrap(),
+                first_round_info.get("mask_poly").ok_or(anyhow!("Missing mask_poly"))?,
+                comms.mask_poly.ok_or(anyhow!("Missing mask_poly"))?,
             ));
         }
 

--- a/algorithms/src/traits/snark.rs
+++ b/algorithms/src/traits/snark.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{errors::SNARKError, r1cs::ConstraintSynthesizer, AlgebraicSponge};
+use crate::{r1cs::ConstraintSynthesizer, AlgebraicSponge};
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{CanonicalDeserialize, CanonicalSerialize, FromBytes, ToBytes};
 
@@ -54,7 +54,7 @@ pub trait SNARK {
     type FiatShamirRng: AlgebraicSponge<Self::BaseField, 2, Parameters = Self::FSParameters>;
     type FSParameters;
 
-    fn universal_setup(config: usize) -> Result<Self::UniversalSRS, SNARKError>;
+    fn universal_setup(config: usize) -> Result<Self::UniversalSRS>;
 
     fn circuit_setup<C: ConstraintSynthesizer<Self::ScalarField>>(
         srs: &Self::UniversalSRS,
@@ -66,7 +66,7 @@ pub trait SNARK {
         fs_parameters: &Self::FSParameters,
         verifying_key: &Self::VerifyingKey,
         proving_key: &Self::ProvingKey,
-    ) -> Result<Self::Certificate, SNARKError>;
+    ) -> Result<Self::Certificate>;
 
     fn prove<C: ConstraintSynthesizer<Self::ScalarField>, R: Rng + CryptoRng>(
         universal_prover: &Self::UniversalProver,
@@ -74,7 +74,7 @@ pub trait SNARK {
         proving_key: &Self::ProvingKey,
         constraints: &C,
         rng: &mut R,
-    ) -> Result<Self::Proof, SNARKError> {
+    ) -> Result<Self::Proof> {
         let mut keys_to_constraints = BTreeMap::new();
         keys_to_constraints.insert(proving_key, std::slice::from_ref(constraints));
         Self::prove_batch(universal_prover, fs_parameters, &keys_to_constraints, rng)
@@ -85,7 +85,7 @@ pub trait SNARK {
         fs_parameters: &Self::FSParameters,
         keys_to_constraints: &BTreeMap<&Self::ProvingKey, &[C]>,
         rng: &mut R,
-    ) -> Result<Self::Proof, SNARKError>;
+    ) -> Result<Self::Proof>;
 
     fn verify_vk<C: ConstraintSynthesizer<Self::ScalarField>>(
         universal_verifier: &Self::UniversalVerifier,
@@ -93,7 +93,7 @@ pub trait SNARK {
         circuit: &C,
         verifying_key: &Self::VerifyingKey,
         certificate: &Self::Certificate,
-    ) -> Result<bool, SNARKError>;
+    ) -> Result<bool>;
 
     fn verify<B: Borrow<Self::VerifierInput>>(
         universal_verifier: &Self::UniversalVerifier,
@@ -101,7 +101,7 @@ pub trait SNARK {
         verifying_key: &Self::VerifyingKey,
         input: B,
         proof: &Self::Proof,
-    ) -> Result<bool, SNARKError> {
+    ) -> Result<bool> {
         let mut keys_to_inputs = BTreeMap::new();
         let inputs = [input];
         keys_to_inputs.insert(verifying_key, &inputs[..]);
@@ -113,5 +113,5 @@ pub trait SNARK {
         fs_parameters: &Self::FSParameters,
         keys_to_inputs: &BTreeMap<&Self::VerifyingKey, &[B]>,
         proof: &Self::Proof,
-    ) -> Result<bool, SNARKError>;
+    ) -> Result<bool>;
 }


### PR DESCRIPTION
## Motivation

Given that anyone in the network can freely pass proof objects (as Execution, containing transitions, containing proofs) into the network, we should not panic easily.

I search for uses of `assert` and `unwrap` in the algorithms crate, and for now skipped most of the prover (which is not done by validators) or lower level FFT code.
