### PR TITLE
Reduces the maximum transmissions per batch

### DIFF
--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -340,18 +340,3 @@ pub mod test_helpers {
         crate::test_helpers::sample_genesis_block(rng).transactions().clone()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    type CurrentNetwork = console::network::Testnet3;
-
-    #[test]
-    fn test_max_transactions() {
-        assert_eq!(
-            Transactions::<CurrentNetwork>::MAX_TRANSACTIONS,
-            ledger_narwhal_batch_header::BatchHeader::<CurrentNetwork>::MAX_TRANSACTIONS
-        );
-    }
-}

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -36,10 +36,10 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         // Read the number of transmission IDs.
         let num_transmission_ids = u32::read_le(&mut reader)?;
         // Ensure the number of transmission IDs is within bounds.
-        if num_transmission_ids as usize > Self::MAX_TRANSMISSIONS {
+        if num_transmission_ids as usize > Self::MAX_TRANSMISSIONS_PER_BATCH {
             return Err(error(format!(
                 "Number of transmission IDs ({num_transmission_ids}) exceeds the maximum ({})",
-                Self::MAX_TRANSMISSIONS,
+                Self::MAX_TRANSMISSIONS_PER_BATCH,
             )));
         }
         // Read the transmission IDs.

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -49,12 +49,11 @@ pub struct BatchHeader<N: Network> {
 impl<N: Network> BatchHeader<N> {
     /// The maximum number of certificates in a batch.
     pub const MAX_CERTIFICATES: usize = 200;
-    /// The maximum number of solutions in a batch.
-    pub const MAX_SOLUTIONS: usize = N::MAX_SOLUTIONS;
-    /// The maximum number of transactions in a batch.
-    pub const MAX_TRANSACTIONS: usize = usize::pow(2, console::program::TRANSACTIONS_DEPTH as u32).saturating_sub(1);
     /// The maximum number of transmissions in a batch.
-    pub const MAX_TRANSMISSIONS: usize = Self::MAX_SOLUTIONS + Self::MAX_TRANSACTIONS;
+    /// Note: This limit is set to 100 as part of safety measures to prevent DoS attacks.
+    /// This limit can be increased in the future as performance improves. Alternatively,
+    /// the rate of block production can be sped up to compensate for the limit set here.
+    pub const MAX_TRANSMISSIONS_PER_BATCH: usize = 50;
 }
 
 impl<N: Network> BatchHeader<N> {

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -50,7 +50,7 @@ impl<N: Network> BatchHeader<N> {
     /// The maximum number of certificates in a batch.
     pub const MAX_CERTIFICATES: usize = 200;
     /// The maximum number of transmissions in a batch.
-    /// Note: This limit is set to 100 as part of safety measures to prevent DoS attacks.
+    /// Note: This limit is set to 50 as part of safety measures to prevent DoS attacks.
     /// This limit can be increased in the future as performance improves. Alternatively,
     /// the rate of block production can be sped up to compensate for the limit set here.
     pub const MAX_TRANSMISSIONS_PER_BATCH: usize = 50;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Reduces the maximum transmissions per batch.

This limit is set to 50 as part of safety measures to prevent DoS attacks.
This limit can be increased in the future as performance improves. Alternatively,
the rate of block production can be sped up to compensate for the limit set here.
