### PR TITLE
Add zip_eq safeguards to prevent panic

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -345,7 +345,6 @@ impl<F: FftField> EvaluationDomain<F> {
     /// Perform O(n) multiplication of two polynomials that are presented by their
     /// evaluations in the domain.
     /// Returns the evaluations of the product over the domain.
-    #[must_use]
     pub fn mul_polynomials_in_evaluation_domain(&self, self_evals: Vec<F>, other_evals: &[F]) -> Result<Vec<F>> {
         let mut result = self_evals;
 

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -346,12 +346,13 @@ impl<F: FftField> EvaluationDomain<F> {
     /// evaluations in the domain.
     /// Returns the evaluations of the product over the domain.
     #[must_use]
-    pub fn mul_polynomials_in_evaluation_domain(&self, self_evals: Vec<F>, other_evals: &[F]) -> Vec<F> {
+    pub fn mul_polynomials_in_evaluation_domain(&self, self_evals: Vec<F>, other_evals: &[F]) -> Result<Vec<F>> {
         let mut result = self_evals;
 
+        ensure!(result.len() == other_evals.len());
         cfg_iter_mut!(result).zip_eq(other_evals).for_each(|(a, b)| *a *= b);
 
-        result
+        Ok(result)
     }
 }
 

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -38,7 +38,9 @@ pub struct Evaluations<F: PrimeField> {
 
 impl<F: PrimeField> Evaluations<F> {
     /// Construct `Self` from evaluations and a domain.
-    pub fn from_vec_and_domain(evaluations: Vec<F>, domain: EvaluationDomain<F>) -> Self {
+    pub fn from_vec_and_domain(mut evaluations: Vec<F>, domain: EvaluationDomain<F>) -> Self {
+        // Pad evaluations to ensure we can always evaluate
+        evaluations.resize(domain.size(), F::zero());
         Self { evaluations, domain }
     }
 

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -15,6 +15,7 @@
 //! A polynomial represented in evaluations form.
 
 use crate::fft::{DensePolynomial, EvaluationDomain};
+use anyhow::Result;
 #[cfg(feature = "serial")]
 use itertools::Itertools;
 #[cfg(not(feature = "serial"))]

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -15,7 +15,6 @@
 //! A polynomial represented in evaluations form.
 
 use crate::fft::{DensePolynomial, EvaluationDomain};
-use anyhow::Result;
 #[cfg(feature = "serial")]
 use itertools::Itertools;
 #[cfg(not(feature = "serial"))]

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     msm::VariableBase,
     polycommit::PCError,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, ensure, Result};
 use snarkvm_curves::traits::{AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve};
 use snarkvm_fields::{One, PrimeField, Zero};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, rand::Uniform, BitIteratorBE};
@@ -276,7 +276,7 @@ impl<E: PairingEngine> KZG10<E> {
         evaluations: &[E::Fr],
         point: E::Fr,
         evaluation_at_point: E::Fr,
-    ) -> Result<KZGProof<E>, PCError> {
+    ) -> Result<KZGProof<E>> {
         Self::check_degree_is_too_large(evaluations.len() - 1, lagrange_basis.size())?;
         // Ensure that the point is not in the domain
         if lagrange_basis.domain.evaluate_vanishing_polynomial(point).is_zero() {
@@ -290,6 +290,7 @@ impl<E: PairingEngine> KZG10<E> {
 
         let mut divisor_evals = cfg_iter!(domain_elements).map(|&e| e - point).collect::<Vec<_>>();
         snarkvm_fields::batch_inversion(&mut divisor_evals);
+        ensure!(divisor_evals.len() == evaluations.len());
         cfg_iter_mut!(divisor_evals).zip_eq(evaluations).for_each(|(divisor_eval, &eval)| {
             *divisor_eval *= eval - evaluation_at_point;
         });
@@ -351,7 +352,7 @@ impl<E: PairingEngine> KZG10<E> {
         values: &[E::Fr],
         proofs: &[KZGProof<E>],
         rng: &mut R,
-    ) -> Result<bool, PCError> {
+    ) -> Result<bool> {
         let check_time = start_timer!(|| format!("Checking {} evaluation proofs", commitments.len()));
         let g = vk.g.to_projective();
         let gamma_g = vk.gamma_g.to_projective();
@@ -365,6 +366,9 @@ impl<E: PairingEngine> KZG10<E> {
         // their coefficients and perform a final multiplication at the end.
         let mut g_multiplier = E::Fr::zero();
         let mut gamma_g_multiplier = E::Fr::zero();
+        ensure!(commitments.len() == points.len());
+        ensure!(commitments.len() == values.len());
+        ensure!(commitments.len() == proofs.len());
         for (((c, z), v), proof) in commitments.iter().zip_eq(points).zip_eq(values).zip_eq(proofs) {
             let w = proof.w;
             let mut temp = w.mul(*z);

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -24,11 +24,11 @@ use crate::{
     msm::VariableBase,
     polycommit::PCError,
 };
-use anyhow::{anyhow, ensure, Result};
 use snarkvm_curves::traits::{AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve};
 use snarkvm_fields::{One, PrimeField, Zero};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, rand::Uniform, BitIteratorBE};
 
+use anyhow::{anyhow, ensure, Result};
 use core::{marker::PhantomData, ops::Mul};
 use itertools::Itertools;
 use rand_core::RngCore;

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -24,7 +24,7 @@ use itertools::Itertools;
 use snarkvm_curves::traits::{AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve};
 use snarkvm_fields::{One, Zero};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, ensure, Result};
 use core::{convert::TryInto, marker::PhantomData, ops::Mul};
 use rand_core::{RngCore, SeedableRng};
 use std::{
@@ -211,7 +211,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                 ));
 
                 let (comm, rand) = p
-                    .sum()
+                    .sum()?
                     .map(move |p| {
                         let rng_ref = rng.as_mut().map(|s| s as _);
                         match p {
@@ -266,14 +266,15 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
     pub fn combine_for_open<'a>(
         universal_prover: &UniversalProver<E>,
         ck: &CommitterUnionKey<E>,
-        labeled_polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<E::Fr>>,
-        rands: impl IntoIterator<Item = &'a Randomness<E>>,
+        labeled_polynomials: impl ExactSizeIterator<Item = &'a LabeledPolynomial<E::Fr>>,
+        rands: impl ExactSizeIterator<Item = &'a Randomness<E>>,
         fs_rng: &mut S,
-    ) -> Result<(DensePolynomial<E::Fr>, Randomness<E>), PCError>
+    ) -> Result<(DensePolynomial<E::Fr>, Randomness<E>)>
     where
         Randomness<E>: 'a,
         Commitment<E>: 'a,
     {
+        ensure!(labeled_polynomials.len() == rands.len());
         Ok(Self::combine_polynomials(labeled_polynomials.into_iter().zip_eq(rands).map(|(p, r)| {
             let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
@@ -289,15 +290,16 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
     pub fn batch_open<'a>(
         universal_prover: &UniversalProver<E>,
         ck: &CommitterUnionKey<E>,
-        labeled_polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<E::Fr>>,
+        labeled_polynomials: impl ExactSizeIterator<Item = &'a LabeledPolynomial<E::Fr>>,
         query_set: &QuerySet<E::Fr>,
-        rands: impl IntoIterator<Item = &'a Randomness<E>>,
+        rands: impl ExactSizeIterator<Item = &'a Randomness<E>>,
         fs_rng: &mut S,
-    ) -> Result<BatchProof<E>, PCError>
+    ) -> Result<BatchProof<E>>
     where
         Randomness<E>: 'a,
         Commitment<E>: 'a,
     {
+        ensure!(labeled_polynomials.len() == rands.len());
         let poly_rand: HashMap<_, _> =
             labeled_polynomials.into_iter().zip_eq(rands).map(|(poly, r)| (poly.label(), (poly, r))).collect();
 
@@ -326,7 +328,8 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                 query_polys.push(*polynomial);
                 query_rands.push(*rand);
             }
-            let (polynomial, rand) = Self::combine_for_open(universal_prover, ck, query_polys, query_rands, fs_rng)?;
+            let (polynomial, rand) =
+                Self::combine_for_open(universal_prover, ck, query_polys.into_iter(), query_rands.into_iter(), fs_rng)?;
             let _randomizer = fs_rng.squeeze_short_nonnative_field_element::<E::Fr>();
 
             pool.add_job(move || {
@@ -336,7 +339,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                 proof
             });
         }
-        let batch_proof = pool.execute_all().into_iter().collect::<Result<_, _>>().map(BatchProof);
+        let batch_proof = pool.execute_all().into_iter().collect::<Result<_, _>>().map(BatchProof).map_err(Into::into);
         end_timer!(open_time);
 
         batch_proof
@@ -349,7 +352,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         values: &Evaluations<E::Fr>,
         proof: &BatchProof<E>,
         fs_rng: &mut S,
-    ) -> Result<bool, PCError>
+    ) -> Result<bool>
     where
         Commitment<E>: 'a,
     {
@@ -374,6 +377,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         let mut combined_witness = E::G1Projective::zero();
         let mut combined_adjusted_witness = E::G1Projective::zero();
 
+        ensure!(query_to_labels_map.len() == proof.0.len());
         for ((_query_name, (query, labels)), p) in query_to_labels_map.into_iter().zip_eq(&proof.0) {
             let mut comms_to_combine: Vec<&'_ LabeledCommitment<_>> = Vec::new();
             let mut values_to_combine = Vec::new();
@@ -400,14 +404,14 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                 p,
                 Some(randomizer),
                 fs_rng,
-            );
+            )?;
 
             randomizer = fs_rng.squeeze_short_nonnative_field_element::<E::Fr>();
         }
 
         let result = Self::check_elems(vk, combined_comms, combined_witness, combined_adjusted_witness);
         end_timer!(batch_check_time);
-        result
+        result.map_err(Into::into)
     }
 
     pub fn open_combinations<'a>(
@@ -418,7 +422,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         rands: impl IntoIterator<Item = &'a Randomness<E>>,
         query_set: &QuerySet<E::Fr>,
         fs_rng: &mut S,
-    ) -> Result<BatchLCProof<E>, PCError>
+    ) -> Result<BatchLCProof<E>>
     where
         Randomness<E>: 'a,
         Commitment<E>: 'a,
@@ -445,7 +449,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                     label_map.get(label as &str).ok_or(PCError::MissingPolynomial { label: label.to_string() })?;
                 if let Some(cur_degree_bound) = cur_poly.degree_bound() {
                     if num_polys != 1 {
-                        return Err(PCError::EquationHasDegreeBounds(lc_label));
+                        bail!(PCError::EquationHasDegreeBounds(lc_label));
                     }
                     assert!(coeff.is_one(), "Coefficient must be one for degree-bounded equations");
                     if let Some(old_degree_bound) = degree_bound {
@@ -482,7 +486,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         evaluations: &Evaluations<E::Fr>,
         proof: &BatchLCProof<E>,
         fs_rng: &mut S,
-    ) -> Result<bool, PCError>
+    ) -> Result<bool>
     where
         Commitment<E>: 'a,
     {
@@ -516,7 +520,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
 
                     if cur_comm.degree_bound().is_some() {
                         if num_polys != 1 || !coeff.is_one() {
-                            return Err(PCError::EquationHasDegreeBounds(lc_label));
+                            bail!(PCError::EquationHasDegreeBounds(lc_label));
                         }
                         degree_bound = cur_comm.degree_bound();
                     }
@@ -532,6 +536,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
 
         let combined_comms_norm_time = start_timer!(|| "Normalizing commitments");
         let comms = Self::normalize_commitments(lc_commitments);
+        ensure!(lc_info.len() == comms.len());
         let lc_commitments = lc_info
             .into_iter()
             .zip_eq(comms)
@@ -570,7 +575,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         VariableBase::msm(&bases, &scalars)
     }
 
-    fn normalize_commitments(commitments: Vec<E::G1Projective>) -> impl Iterator<Item = Commitment<E>> {
+    fn normalize_commitments(commitments: Vec<E::G1Projective>) -> impl ExactSizeIterator<Item = Commitment<E>> {
         let comms = E::G1Projective::batch_normalization_into_affine(commitments);
         comms.into_iter().map(|c| kzg10::KZGCommitment(c))
     }
@@ -583,18 +588,19 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         combined_witness: &mut E::G1Projective,
         combined_adjusted_witness: &mut E::G1Projective,
         vk: &UniversalVerifier<E>,
-        commitments: impl IntoIterator<Item = &'a LabeledCommitment<Commitment<E>>>,
+        commitments: impl ExactSizeIterator<Item = &'a LabeledCommitment<Commitment<E>>>,
         point: E::Fr,
-        values: impl IntoIterator<Item = E::Fr>,
+        values: impl ExactSizeIterator<Item = E::Fr>,
         proof: &kzg10::KZGProof<E>,
         randomizer: Option<E::Fr>,
         fs_rng: &mut S,
-    ) {
+    ) -> Result<()> {
         let acc_time = start_timer!(|| "Accumulating elements");
         // Keeps track of running combination of values
         let mut combined_values = E::Fr::zero();
 
         // Iterates through all of the commitments and accumulates common degree_bound elements in a BTreeMap
+        ensure!(commitments.len() == values.len());
         for (labeled_comm, value) in commitments.into_iter().zip_eq(values) {
             let acc_timer = start_timer!(|| format!("Accumulating {}", labeled_comm.label()));
             let curr_challenge = fs_rng.squeeze_short_nonnative_field_element::<E::Fr>();
@@ -629,6 +635,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         let coeffs = coeffs.into_iter().map(|c| c.into()).collect::<Vec<_>>();
         *combined_adjusted_witness += VariableBase::msm(&bases, &coeffs);
         end_timer!(acc_time);
+        Ok(())
     }
 
     fn check_elems(
@@ -636,7 +643,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         combined_comms: BTreeMap<Option<usize>, E::G1Projective>,
         combined_witness: E::G1Projective,
         combined_adjusted_witness: E::G1Projective,
-    ) -> Result<bool, PCError> {
+    ) -> Result<bool> {
         let check_time = start_timer!(|| "Checking elems");
         let mut g1_projective_elems = Vec::with_capacity(combined_comms.len() + 2);
         let mut g2_prepared_elems = Vec::with_capacity(combined_comms.len() + 2);
@@ -667,6 +674,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
             .map(|a| a.prepare())
             .collect::<Vec<_>>();
 
+        ensure!(g1_prepared_elems_iter.len() == g2_prepared_elems.len());
         let g1_g2_prepared = g1_prepared_elems_iter.iter().zip_eq(g2_prepared_elems.iter());
         let is_one: bool = E::product_of_pairings(g1_g2_prepared).is_one();
         end_timer!(check_time);

--- a/algorithms/src/polycommit/sonic_pc/polynomial.rs
+++ b/algorithms/src/polycommit/sonic_pc/polynomial.rs
@@ -14,10 +14,10 @@
 
 use super::PolynomialLabel;
 use crate::fft::{DensePolynomial, EvaluationDomain, Evaluations as EvaluationsOnDomain, Polynomial, SparsePolynomial};
-use anyhow::{ensure, Result};
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, CanonicalDeserialize, CanonicalSerialize};
 
+use anyhow::{ensure, Result};
 use hashbrown::HashMap;
 use std::borrow::Cow;
 

--- a/algorithms/src/polycommit/sonic_pc/polynomial.rs
+++ b/algorithms/src/polycommit/sonic_pc/polynomial.rs
@@ -235,8 +235,9 @@ impl<'a, F: PrimeField> LabeledPolynomialWithBasis<'a, F> {
                         match polynomial.as_ref() {
                             Dense(p) => {
                                 if let Some(e) = dense_polys.get_mut(degree_bound) {
-                                    // Zip safety: `p` could be of smaller degree than `e` (or vice versa),
+                                    // Zip safety: `p` could be of smaller degree than `e`,
                                     // so it's okay to just use `zip` here.
+                                    ensure!(e.len() >= p.coeffs.len());
                                     cfg_iter_mut!(e).zip(&p.coeffs).for_each(|(e, f)| *e += *c * f)
                                 } else {
                                     let mut e: DensePolynomial<F> = p.clone().into_owned();

--- a/algorithms/src/polycommit/sonic_pc/polynomial.rs
+++ b/algorithms/src/polycommit/sonic_pc/polynomial.rs
@@ -14,6 +14,7 @@
 
 use super::PolynomialLabel;
 use crate::fft::{DensePolynomial, EvaluationDomain, Evaluations as EvaluationsOnDomain, Polynomial, SparsePolynomial};
+use anyhow::{ensure, Result};
 use snarkvm_fields::{Field, PrimeField};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, CanonicalDeserialize, CanonicalSerialize};
 
@@ -215,9 +216,9 @@ impl<'a, F: PrimeField> LabeledPolynomialWithBasis<'a, F> {
 
     /// Compute a linear combination of the terms in `self.polynomial`, producing an iterator
     /// over polynomials of the same time.
-    pub fn sum(&self) -> impl Iterator<Item = PolynomialWithBasis<'a, F>> {
+    pub fn sum(&self) -> Result<impl Iterator<Item = PolynomialWithBasis<'a, F>>> {
         if self.polynomial.len() == 1 && self.polynomial[0].0.is_one() {
-            vec![self.polynomial[0].1.clone()].into_iter()
+            Ok(vec![self.polynomial[0].1.clone()].into_iter())
         } else {
             use PolynomialWithBasis::*;
             let mut lagrange_polys = HashMap::<usize, Vec<_>>::new();
@@ -249,6 +250,7 @@ impl<'a, F: PrimeField> LabeledPolynomialWithBasis<'a, F> {
                     Lagrange { evaluations } => {
                         let domain = evaluations.domain().size();
                         if let Some(e) = lagrange_polys.get_mut(&domain) {
+                            ensure!(e.len() == evaluations.evaluations.len());
                             cfg_iter_mut!(e).zip_eq(&evaluations.evaluations).for_each(|(e, f)| *e += *c * f)
                         } else {
                             let mut e = evaluations.clone().into_owned().evaluations;
@@ -260,7 +262,7 @@ impl<'a, F: PrimeField> LabeledPolynomialWithBasis<'a, F> {
             }
             let sparse_poly = Polynomial::from(sparse_poly);
             let sparse_poly = Monomial { polynomial: Cow::Owned(sparse_poly), degree_bound: None };
-            lagrange_polys
+            Ok(lagrange_polys
                 .into_iter()
                 .map(|(k, v)| {
                     let domain = EvaluationDomain::new(k).unwrap();
@@ -273,7 +275,7 @@ impl<'a, F: PrimeField> LabeledPolynomialWithBasis<'a, F> {
                 })
                 .chain([sparse_poly])
                 .collect::<Vec<_>>()
-                .into_iter()
+                .into_iter())
         }
     }
 

--- a/algorithms/src/polycommit/test_templates.rs
+++ b/algorithms/src/polycommit/test_templates.rs
@@ -113,8 +113,14 @@ pub fn bad_degree_bound_test<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>() -
         println!("Generated query set");
 
         let mut sponge_for_open = S::new();
-        let proof =
-            SonicKZG10::batch_open(universal_prover, &ck, &polynomials, &query_set, &rands, &mut sponge_for_open)?;
+        let proof = SonicKZG10::batch_open(
+            universal_prover,
+            &ck,
+            polynomials.iter(),
+            &query_set,
+            rands.iter(),
+            &mut sponge_for_open,
+        )?;
         let mut sponge_for_check = S::new();
         let result = SonicKZG10::batch_check(&vk, &comms, &query_set, &values, &proof, &mut sponge_for_check)?;
         assert!(result, "proof was incorrect, Query set: {query_set:#?}");
@@ -203,8 +209,14 @@ pub fn lagrange_test_template<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>>()
         println!("Generated query set");
 
         let mut sponge_for_open = S::new();
-        let proof =
-            SonicKZG10::batch_open(universal_prover, &ck, &polynomials, &query_set, &rands, &mut sponge_for_open)?;
+        let proof = SonicKZG10::batch_open(
+            universal_prover,
+            &ck,
+            polynomials.iter(),
+            &query_set,
+            rands.iter(),
+            &mut sponge_for_open,
+        )?;
         let mut sponge_for_check = S::new();
         let result = SonicKZG10::batch_check(&vk, &comms, &query_set, &values, &proof, &mut sponge_for_check)?;
         if !result {
@@ -327,8 +339,14 @@ where
         println!("Generated query set");
 
         let mut sponge_for_open = S::new();
-        let proof =
-            SonicKZG10::batch_open(universal_prover, &ck, &polynomials, &query_set, &rands, &mut sponge_for_open)?;
+        let proof = SonicKZG10::batch_open(
+            universal_prover,
+            &ck,
+            polynomials.iter(),
+            &query_set,
+            rands.iter(),
+            &mut sponge_for_open,
+        )?;
         let mut sponge_for_check = S::new();
         let result = SonicKZG10::batch_check(&vk, &comms, &query_set, &values, &proof, &mut sponge_for_check)?;
         if !result {

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -359,6 +359,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             let non_zero_domains = [&state_i.non_zero_a_domain, &state_i.non_zero_b_domain, &state_i.non_zero_c_domain];
             let sums = sums_fourth_msg[i].iter();
 
+            ensure!(matrices.len() == sums.len());
+            ensure!(matrices.len() == deltas.len());
+            ensure!(matrices.len() == non_zero_domains.len());
             for (((m, sum), delta), non_zero_domain) in
                 matrices.into_iter().zip_eq(sums).zip_eq(deltas).zip_eq(non_zero_domains)
             {

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
@@ -139,12 +139,11 @@ impl<F: PrimeField, SM: SNARKMode> Circuit<F, SM> {
     }
 
     pub fn interpolate_matrix_evals(&self) -> Result<impl Iterator<Item = LabeledPolynomial<F>>> {
-        Ok([("a", &self.a_arith), ("b", &self.b_arith), ("c", &self.c_arith)]
-            .into_iter()
-            .map(|(label, evals)| MatrixArithmetization::new(&self.id, label, evals))
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .flat_map(|arith| arith.into_iter()))
+        let mut iters = Vec::with_capacity(3);
+        for (label, evals) in [("a", &self.a_arith), ("b", &self.b_arith), ("c", &self.c_arith)] {
+            iters.push(MatrixArithmetization::new(&self.id, label, evals)?.into_iter());
+        }
+        Ok(iters.into_iter().flatten())
     }
 
     /// After indexing, we drop these evaluations to save space in the ProvingKey.

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     fft::EvaluationDomain,
-    polycommit::sonic_pc::{PolynomialInfo, PolynomialLabel},
+    polycommit::sonic_pc::{LinearCombination, PolynomialInfo, PolynomialLabel},
     r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem},
     snark::varuna::{
         ahp::{
@@ -110,18 +110,15 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             format!("circuit_{id}_col_{matrix}"),
             format!("circuit_{id}_row_col_{matrix}"),
             format!("circuit_{id}_row_col_val_{matrix}"),
-        ].into_iter()
+        ]
+        .into_iter()
     }
 
     pub fn index_polynomial_labels<'a>(
         matrices: &'a [&str],
         ids: impl Iterator<Item = &'a CircuitId> + 'a,
     ) -> impl Iterator<Item = PolynomialLabel> + 'a {
-        ids.flat_map(move |id| {
-            matrices.iter().flat_map(move |matrix| {
-                Self::index_polynomial_labels_single(matrix, id)
-            })
-        })
+        ids.flat_map(move |id| matrices.iter().flat_map(move |matrix| Self::index_polynomial_labels_single(matrix, id)))
     }
 
     /// Generate the indexed circuit evaluations for this constraint system.
@@ -230,12 +227,17 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         result
     }
 
+    /// Evaluate the index polynomials for this constraint system at the given point.
+    /// Return the LinearCombination of the index polynomials and the sum of the evaluations.
     pub(crate) fn evaluate_index_polynomials(
         state: IndexerState<F>,
         id: &CircuitId,
         point: F,
-    ) -> Result<impl ExactSizeIterator<Item = F>> {
-        let mut all_evals = Vec::with_capacity(12);
+        mut combiners: impl Iterator<Item = F>,
+    ) -> Result<(LinearCombination<F>, F)> {
+        let mut lc = LinearCombination::empty("circuit_check");
+        let mut all_evals = Vec::with_capacity(3);
+        let mut sum = F::zero();
         for (evals, domain, label) in [
             (state.a_arith, state.non_zero_a_domain, "a"),
             (state.b_arith, state.non_zero_b_domain, "b"),
@@ -245,10 +247,15 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             let lagrange_coefficients_at_point = domain.evaluate_all_lagrange_coefficients(point);
             let evals_at_point = evals.evaluate(&lagrange_coefficients_at_point)?;
             ensure!(labels.len() == evals_at_point.len());
-            all_evals.extend(labels.into_iter().zip_eq(evals_at_point.into_iter()));
+            all_evals.push(labels.into_iter().zip_eq(evals_at_point.into_iter()));
         }
-        all_evals.sort_by(|(l1, _), (l2, _)| l1.cmp(l2));
-        Ok(all_evals.into_iter().map(|(_, eval)| eval))
+        let sorted_evals = all_evals.into_iter().flatten().sorted_unstable_by(|(l1, _), (l2, _)| l1.cmp(l2));
+        for (label, eval) in sorted_evals {
+            let combiner = combiners.next().ok_or(anyhow!("No combiner left"))?;
+            lc.add(combiner, label.as_str());
+            sum += eval * combiner;
+        }
+        Ok((lc, sum))
     }
 }
 

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -243,7 +243,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             (state.b_arith, state.non_zero_b_domain, "b"),
             (state.c_arith, state.non_zero_c_domain, "c"),
         ] {
-            let labels = Self::index_polynomial_labels_single(label, &id);
+            let labels = Self::index_polynomial_labels_single(label, id);
             let lagrange_coefficients_at_point = domain.evaluate_all_lagrange_coefficients(point);
             let evals_at_point = evals.evaluate(&lagrange_coefficients_at_point)?;
             ensure!(labels.len() == evals_at_point.len());

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -223,7 +223,7 @@ impl<F: PrimeField> MatrixArithmetization<F> {
         let row_col_val = matrix_evals.row_col_val.clone().interpolate();
         end_timer!(interpolate_time);
 
-        let mut labels = AHPForR1CS::<F, VarunaHidingMode>::index_polynomial_labels_single(&label, &id);
+        let mut labels = AHPForR1CS::<F, VarunaHidingMode>::index_polynomial_labels_single(label, id);
         ensure!(labels.len() == 4);
 
         Ok(MatrixArithmetization {

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -223,15 +223,14 @@ impl<F: PrimeField> MatrixArithmetization<F> {
         let row_col_val = matrix_evals.row_col_val.clone().interpolate();
         end_timer!(interpolate_time);
 
-        let label = &[label];
-        let mut labels = AHPForR1CS::<F, VarunaHidingMode>::index_polynomial_labels(label, std::iter::once(id));
+        let mut labels = AHPForR1CS::<F, VarunaHidingMode>::index_polynomial_labels_single(&label, &id);
         ensure!(labels.len() == 4);
 
         Ok(MatrixArithmetization {
-            row_col_val: LabeledPolynomial::new(labels.pop().unwrap(), row_col_val, None, None),
-            row_col: LabeledPolynomial::new(labels.pop().unwrap(), row_col, None, None),
-            col: LabeledPolynomial::new(labels.pop().unwrap(), col, None, None),
-            row: LabeledPolynomial::new(labels.pop().unwrap(), row, None, None),
+            row: LabeledPolynomial::new(labels.next().unwrap(), row, None, None),
+            col: LabeledPolynomial::new(labels.next().unwrap(), col, None, None),
+            row_col: LabeledPolynomial::new(labels.next().unwrap(), row_col, None, None),
+            row_col_val: LabeledPolynomial::new(labels.next().unwrap(), row_col_val, None, None),
         })
     }
 

--- a/algorithms/src/snark/varuna/ahp/prover/message.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/message.rs
@@ -27,7 +27,7 @@ pub struct MatrixSums<F: PrimeField> {
 
 impl<F: PrimeField> MatrixSums<F> {
     /// Iterate over the sums
-    pub fn iter(&self) -> impl Iterator<Item = F> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = F> {
         [self.sum_a, self.sum_b, self.sum_c].into_iter()
     }
 }

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -836,12 +836,10 @@ where
         // degree bounds because we know the committed index polynomial has the
         // correct degree.
 
-        // Gather commitments in one vector.
-        let poly_infos = AHPForR1CS::<E::Fr, SM>::index_polynomial_info(circuit_ids.iter());
         let commitments: Vec<_> = circuit_commitments
             .into_iter()
             .flatten()
-            .zip_eq(poly_infos.values())
+            .zip_eq(AHPForR1CS::<E::Fr, SM>::index_polynomial_info(circuit_ids.iter()).values())
             .map(|(c, info)| LabeledCommitment::new_with_info(info, *c))
             .chain(first_commitments)
             .chain(second_commitments)

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -302,28 +302,19 @@ where
         // (since the first coeff is 1), and so we squeeze out `num_polynomials` points.
         let mut challenges = sponge.squeeze_nonnative_field_elements(verifying_key.circuit_commitments.len());
         let point = challenges.pop().ok_or(anyhow!("Failed to squeeze random element"))?;
-        let one = E::Fr::one();
-        let linear_combination_challenges = core::iter::once(&one).chain(challenges.iter());
+        let combiners = core::iter::once(E::Fr::one()).chain(challenges.into_iter());
 
         // We will construct a linear combination and provide a proof of evaluation of the lc at `point`.
-        let poly_info = AHPForR1CS::<E::Fr, SM>::index_polynomial_info(std::iter::once(circuit_id));
-        let evaluations_at_point = AHPForR1CS::<E::Fr, SM>::evaluate_index_polynomials(state, circuit_id, point)?;
-        let mut lc = crate::polycommit::sonic_pc::LinearCombination::empty("circuit_check");
-        let mut evaluation = E::Fr::zero();
-        ensure!(poly_info.len() == challenges.len() + 1);
-        ensure!(poly_info.len() == evaluations_at_point.len());
-        for ((label, &c), eval) in poly_info.keys().zip_eq(linear_combination_challenges).zip_eq(evaluations_at_point) {
-            lc.add(c, label.as_str());
-            evaluation += c * eval;
-        }
+        let (lc, evaluation) =
+            AHPForR1CS::<E::Fr, SM>::evaluate_index_polynomials(state, circuit_id, point, combiners)?;
 
-        ensure!(verifying_key.circuit_commitments.len() == poly_info.len());
+        ensure!(verifying_key.circuit_commitments.len() == lc.terms.len());
         let commitments = verifying_key
             .iter()
             .cloned()
-            .zip_eq(poly_info.values())
-            .map(|(c, info)| LabeledCommitment::new_with_info(info, c))
-            .collect::<Vec<_>>();
+            .zip_eq(lc.terms.keys())
+            .map(|(c, label)| LabeledCommitment::new(format!("{label:?}"), c, None))
+            .collect_vec();
         let evaluations = Evaluations::from_iter([(("circuit_check".into(), point), evaluation)]);
         let query_set = QuerySet::from_iter([("circuit_check".into(), ("challenge".into(), point))]);
 

--- a/ledger/coinbase/src/lib.rs
+++ b/ledger/coinbase/src/lib.rs
@@ -125,7 +125,7 @@ impl<N: Network> CoinbasePuzzle<N> {
             let product_evaluations = pk.product_domain.mul_polynomials_in_evaluation_domain(
                 polynomial_evaluations,
                 &epoch_challenge.epoch_polynomial_evaluations().evaluations,
-            );
+            )?;
             product_evaluations
         };
         let (commitment, _rand) = KZG10::commit_lagrange(&pk.lagrange_basis(), &product_evaluations, None, None)?;

--- a/ledger/coinbase/src/lib.rs
+++ b/ledger/coinbase/src/lib.rs
@@ -122,11 +122,10 @@ impl<N: Network> CoinbasePuzzle<N> {
 
         let product_evaluations = {
             let polynomial_evaluations = pk.product_domain.in_order_fft_with_pc(&polynomial, &pk.fft_precomputation);
-            let product_evaluations = pk.product_domain.mul_polynomials_in_evaluation_domain(
+            pk.product_domain.mul_polynomials_in_evaluation_domain(
                 polynomial_evaluations,
                 &epoch_challenge.epoch_polynomial_evaluations().evaluations,
-            )?;
-            product_evaluations
+            )?
         };
         let (commitment, _rand) = KZG10::commit_lagrange(&pk.lagrange_basis(), &product_evaluations, None, None)?;
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/AleoHQ/snarkVM/issues/2195
Closes https://github.com/AleoHQ/snarkVM/issues/2216

For cases where we `zip_eq` on values (derived) from user-input, it is prudent to add an extra check that the values are of equal length to prevent panic.
Note that we can't easily make a new generic `zip_eq` impl which `ensure!`'s the length because in various places in the code we work with iterators which don't know their length at compile-time. See also this interesting discussion: https://internals.rust-lang.org/t/should-we-implement-exactsizeiterator-for-chain/12556/7
