### PR TITLE
Enforce `ProgramID` uniqueness in a block

### DIFF
--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -412,10 +412,7 @@ impl<N: Network> Block<N> {
 
         // Ensure there are not duplicate program IDs.
         if has_duplicates(
-            self.transactions()
-                .iter()
-                .filter_map(|tx| tx.transaction().deployment())
-                .map(|deployment| deployment.program_id()),
+            self.transactions().iter().filter_map(|tx| tx.transaction().deployment().map(|d| d.program_id())),
         ) {
             bail!("Found a duplicate program ID in block {height}");
         }

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -410,7 +410,7 @@ impl<N: Network> Block<N> {
             bail!("Found a duplicate transition in block {height}");
         }
 
-        // Ensure there are not duplicate program IDs.
+        // Ensure there are no duplicate program IDs.
         if has_duplicates(
             self.transactions().iter().filter_map(|tx| tx.transaction().deployment().map(|d| d.program_id())),
         ) {

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -410,6 +410,16 @@ impl<N: Network> Block<N> {
             bail!("Found a duplicate transition in block {height}");
         }
 
+        // Ensure there are not duplicate program IDs.
+        if has_duplicates(
+            self.transactions()
+                .iter()
+                .filter_map(|tx| tx.transaction().deployment())
+                .map(|deployment| deployment.program_id()),
+        ) {
+            bail!("Found a duplicate program ID in block {height}");
+        }
+
         /* Input */
 
         // Ensure there are no duplicate input IDs.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -636,3 +636,60 @@ fn test_aborted_transaction_indexing() {
     // Add the deployment block to the ledger.
     ledger.advance_to_next_block(&block).unwrap();
 }
+
+#[test]
+fn test_deployment_duplicate_program_id() {
+    let rng = &mut TestRng::default();
+
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, private_key, .. } = crate::test_helpers::sample_test_env(rng);
+
+    // Create two programs with a duplicate program ID but different mappings
+    let program_1 = Program::<CurrentNetwork>::from_str(
+        r"
+program dummy_program.aleo;
+mapping abcd1:
+    key as address.public;
+    value as u64.public;
+function foo:
+    input r0 as u8.private;
+    async foo r0 into r1;
+    output r1 as dummy_program.aleo/foo.future;
+finalize foo:
+    input r0 as u8.public;
+    add r0 r0 into r1;",
+    )
+    .unwrap();
+
+    let program_2 = Program::<CurrentNetwork>::from_str(
+        r"
+program dummy_program.aleo;
+mapping abcd2:
+    key as address.public;
+    value as u64.public;
+function foo2:
+    input r0 as u8.private;
+    async foo2 r0 into r1;
+    output r1 as dummy_program.aleo/foo2.future;
+finalize foo2:
+    input r0 as u8.public;
+    add r0 r0 into r1;",
+    )
+    .unwrap();
+
+    // Create a deployment transaction for the first program.
+    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
+    assert!(ledger.check_transaction_basic(&deployment_1, None, rng).is_ok());
+
+    // Create a deployment transaction for the second program.
+    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, None, 0, None, rng).unwrap();
+    assert!(ledger.check_transaction_basic(&deployment_2, None, rng).is_ok());
+
+    // Create a block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_1, deployment_2], rng)
+        .unwrap();
+
+    // Check that the next block is valid.
+    assert!(ledger.check_next_block(&block, rng).is_err());
+}

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -255,7 +255,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         // Check if the program has already been deployed in this block.
                         match deployments.contains(deployment.program_id()) {
                             // If the program has already been deployed, construct the rejected deploy transaction.
-                            true => match process_rejected_deployment(&fee, *deployment.clone()) {
+                            true => match process_rejected_deployment(fee, *deployment.clone()) {
                                 Ok(result) => result,
                                 Err(error) => {
                                     // Note: On failure, skip this transaction, and continue speculation.
@@ -277,7 +277,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         .map_err(|e| e.to_string())
                                 }
                                 // Construct the rejected deploy transaction.
-                                Err(_error) => match process_rejected_deployment(&fee, *deployment.clone()) {
+                                Err(_error) => match process_rejected_deployment(fee, *deployment.clone()) {
                                     Ok(result) => result,
                                     Err(error) => {
                                         // Note: On failure, skip this transaction, and continue speculation.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -212,6 +212,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             let mut confirmed = Vec::with_capacity(num_transactions);
             // Initialize a list of the aborted transactions.
             let mut aborted = Vec::new();
+            // Initialize a list of the successful deployments.
+            let mut deployments = IndexSet::new();
             // Initialize a counter for the confirmed transaction index.
             let mut counter = 0u32;
 
@@ -233,25 +235,50 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     // The finalize operation here involves appending the 'stack',
                     // and adding the program to the finalize tree.
                     Transaction::Deploy(_, program_owner, deployment, fee) => {
-                        match process.finalize_deployment(state, store, deployment, fee) {
-                            // Construct the accepted deploy transaction.
-                            Ok((_, finalize)) => {
-                                ConfirmedTransaction::accepted_deploy(counter, transaction.clone(), finalize)
-                                    .map_err(|e| e.to_string())
-                            }
-                            // Construct the rejected deploy transaction.
-                            Err(_error) => {
-                                // Finalize the fee, to ensure it is valid.
-                                match process.finalize_fee(state, store, fee).and_then(|finalize| {
-                                    Transaction::from_fee(fee.clone()).map(|fee_tx| (fee_tx, finalize))
-                                }) {
-                                    Ok((fee_tx, finalize)) => {
-                                        // Construct the rejected deployment.
-                                        let rejected = Rejected::new_deployment(*program_owner, *deployment.clone());
-                                        // Construct the rejected deploy transaction.
+                        // Define the closure for processing a rejected deployment.
+                        let process_rejected_deployment =
+                            |fee: &Fee<N>,
+                             deployment: Deployment<N>|
+                             -> Result<Result<ConfirmedTransaction<N>, String>> {
+                                process
+                                    .finalize_fee(state, store, fee)
+                                    .and_then(|finalize| {
+                                        Transaction::from_fee(fee.clone()).map(|fee_tx| (fee_tx, finalize))
+                                    })
+                                    .map(|(fee_tx, finalize)| {
+                                        let rejected = Rejected::new_deployment(*program_owner, deployment);
                                         ConfirmedTransaction::rejected_deploy(counter, fee_tx, rejected, finalize)
                                             .map_err(|e| e.to_string())
-                                    }
+                                    })
+                            };
+
+                        // Check if the program has already been deployed in this block.
+                        match deployments.contains(deployment.program_id()) {
+                            // If the program has already been deployed, construct the rejected deploy transaction.
+                            true => match process_rejected_deployment(&fee, *deployment.clone()) {
+                                Ok(result) => result,
+                                Err(error) => {
+                                    // Note: On failure, skip this transaction, and continue speculation.
+                                    #[cfg(debug_assertions)]
+                                    eprintln!("Failed to finalize the fee in a rejected deploy - {error}");
+                                    // Store the aborted transaction.
+                                    aborted.push((transaction.clone(), error.to_string()));
+                                    // Continue to the next transaction.
+                                    continue 'outer;
+                                }
+                            },
+                            // If the program has not yet been deployed, attempt to deploy it.
+                            false => match process.finalize_deployment(state, store, deployment, fee) {
+                                // Construct the accepted deploy transaction.
+                                Ok((_, finalize)) => {
+                                    // Add the program id to the list of deployments.
+                                    deployments.insert(*deployment.program_id());
+                                    ConfirmedTransaction::accepted_deploy(counter, transaction.clone(), finalize)
+                                        .map_err(|e| e.to_string())
+                                }
+                                // Construct the rejected deploy transaction.
+                                Err(_error) => match process_rejected_deployment(&fee, *deployment.clone()) {
+                                    Ok(result) => result,
                                     Err(error) => {
                                         // Note: On failure, skip this transaction, and continue speculation.
                                         #[cfg(debug_assertions)]
@@ -261,8 +288,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         // Continue to the next transaction.
                                         continue 'outer;
                                     }
-                                }
-                            }
+                                },
+                            },
                         }
                     }
                     // The finalize operation here involves calling 'update_key_value',

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -59,7 +59,7 @@ use synthesizer_process::{Authorization, Process, Trace};
 use synthesizer_program::{FinalizeGlobalState, FinalizeOperation, FinalizeStoreTrait, Program};
 
 use aleo_std::prelude::{finish, lap, timer};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use parking_lot::RwLock;
 use std::sync::Arc;
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds checks to enforce that a block does not have duplicate program IDs.

In addition, we reject subsequent deployments with the same `ProgramID` during speculation.
