### PR TITLE
[Fix] Add check for the correct number of commands and inputs in a `closure` and `finalize`.

### DIFF
--- a/synthesizer/program/src/closure/bytes.rs
+++ b/synthesizer/program/src/closure/bytes.rs
@@ -23,6 +23,9 @@ impl<N: Network, Instruction: InstructionTrait<N>> FromBytes for ClosureCore<N, 
 
         // Read the inputs.
         let num_inputs = u16::read_le(&mut reader)?;
+        if num_inputs.is_zero() {
+            return Err(error(format!("Failed to deserialize a closure: needs at least one input")));
+        }
         if num_inputs > u16::try_from(N::MAX_INPUTS).map_err(error)? {
             return Err(error(format!("Failed to deserialize a closure: too many inputs ({num_inputs})")));
         }
@@ -33,6 +36,9 @@ impl<N: Network, Instruction: InstructionTrait<N>> FromBytes for ClosureCore<N, 
 
         // Read the instructions.
         let num_instructions = u32::read_le(&mut reader)?;
+        if num_instructions.is_zero() {
+            return Err(error(format!("Failed to deserialize a closure: needs at least one instruction")));
+        }
         if num_instructions > u32::try_from(N::MAX_INSTRUCTIONS).map_err(error)? {
             return Err(error(format!("Failed to deserialize a closure: too many instructions ({num_instructions})")));
         }
@@ -70,7 +76,7 @@ impl<N: Network, Instruction: InstructionTrait<N>> ToBytes for ClosureCore<N, In
 
         // Write the number of inputs for the closure.
         let num_inputs = self.inputs.len();
-        match num_inputs <= N::MAX_INPUTS {
+        match 0 < num_inputs && num_inputs <= N::MAX_INPUTS {
             true => u16::try_from(num_inputs).map_err(error)?.write_le(&mut writer)?,
             false => return Err(error(format!("Failed to write {num_inputs} inputs as bytes"))),
         }
@@ -82,7 +88,7 @@ impl<N: Network, Instruction: InstructionTrait<N>> ToBytes for ClosureCore<N, In
 
         // Write the number of instructions for the closure.
         let num_instructions = self.instructions.len();
-        match num_instructions <= N::MAX_INSTRUCTIONS {
+        match 0 < num_instructions && num_instructions <= N::MAX_INSTRUCTIONS {
             true => u32::try_from(num_instructions).map_err(error)?.write_le(&mut writer)?,
             false => return Err(error(format!("Failed to write {num_instructions} instructions as bytes"))),
         }

--- a/synthesizer/program/src/closure/bytes.rs
+++ b/synthesizer/program/src/closure/bytes.rs
@@ -24,7 +24,7 @@ impl<N: Network, Instruction: InstructionTrait<N>> FromBytes for ClosureCore<N, 
         // Read the inputs.
         let num_inputs = u16::read_le(&mut reader)?;
         if num_inputs.is_zero() {
-            return Err(error(format!("Failed to deserialize a closure: needs at least one input")));
+            return Err(error("Failed to deserialize a closure: needs at least one input".to_string()));
         }
         if num_inputs > u16::try_from(N::MAX_INPUTS).map_err(error)? {
             return Err(error(format!("Failed to deserialize a closure: too many inputs ({num_inputs})")));
@@ -37,7 +37,7 @@ impl<N: Network, Instruction: InstructionTrait<N>> FromBytes for ClosureCore<N, 
         // Read the instructions.
         let num_instructions = u32::read_le(&mut reader)?;
         if num_instructions.is_zero() {
-            return Err(error(format!("Failed to deserialize a closure: needs at least one instruction")));
+            return Err(error("Failed to deserialize a closure: needs at least one instruction".to_string()));
         }
         if num_instructions > u32::try_from(N::MAX_INSTRUCTIONS).map_err(error)? {
             return Err(error(format!("Failed to deserialize a closure: too many instructions ({num_instructions})")));

--- a/synthesizer/program/src/closure/parse.rs
+++ b/synthesizer/program/src/closure/parse.rs
@@ -32,7 +32,7 @@ impl<N: Network, Instruction: InstructionTrait<N>> Parser for ClosureCore<N, Ins
         let (string, _) = tag(":")(string)?;
 
         // Parse the inputs from the string.
-        let (string, inputs) = many0(Input::parse)(string)?;
+        let (string, inputs) = many1(Input::parse)(string)?;
         // Parse the instructions from the string.
         let (string, instructions) = many1(Instruction::parse)(string)?;
         // Parse the outputs from the string.

--- a/synthesizer/program/src/finalize/bytes.rs
+++ b/synthesizer/program/src/finalize/bytes.rs
@@ -33,6 +33,9 @@ impl<N: Network, Command: CommandTrait<N>> FromBytes for FinalizeCore<N, Command
 
         // Read the commands.
         let num_commands = u16::read_le(&mut reader)?;
+        if num_commands.is_zero() {
+            return Err(error(format!("Failed to deserialize finalize: needs at least one command")));
+        }
         if num_commands > u16::try_from(N::MAX_COMMANDS).map_err(error)? {
             return Err(error(format!("Failed to deserialize finalize: too many commands ({num_commands})")));
         }
@@ -71,7 +74,7 @@ impl<N: Network, Command: CommandTrait<N>> ToBytes for FinalizeCore<N, Command> 
 
         // Write the number of commands for the finalize.
         let num_commands = self.commands.len();
-        match num_commands <= N::MAX_COMMANDS {
+        match 0 < num_commands && num_commands <= N::MAX_COMMANDS {
             true => u16::try_from(num_commands).map_err(error)?.write_le(&mut writer)?,
             false => return Err(error(format!("Failed to write {num_commands} commands as bytes"))),
         }

--- a/synthesizer/program/src/finalize/bytes.rs
+++ b/synthesizer/program/src/finalize/bytes.rs
@@ -34,7 +34,7 @@ impl<N: Network, Command: CommandTrait<N>> FromBytes for FinalizeCore<N, Command
         // Read the commands.
         let num_commands = u16::read_le(&mut reader)?;
         if num_commands.is_zero() {
-            return Err(error(format!("Failed to deserialize finalize: needs at least one command")));
+            return Err(error("Failed to deserialize finalize: needs at least one command".to_string()));
         }
         if num_commands > u16::try_from(N::MAX_COMMANDS).map_err(error)? {
             return Err(error(format!("Failed to deserialize finalize: too many commands ({num_commands})")));


### PR DESCRIPTION
This PR adds:
- a check for nonzero commands in `FinalizeCore::write_le`
- a check for nonzero commands in `FinalizeCore::read_le`
- a check for nonzero inputs in `ClosureCore::parse`
- a check for nonzero inputs in `ClosureCore::write_le`
- a check for nonzero inputs in `ClosureCore::read_le`
- a check for nonzero instructions in `ClosureCore::write_le`
- a check for nonzero instructions in `ClosureCore::read_le`
