### PR TITLE
Add length methods to MapRead & NestedMapRead

### DIFF
--- a/ledger/store/src/helpers/memory/internal/map.rs
+++ b/ledger/store/src/helpers/memory/internal/map.rs
@@ -243,6 +243,13 @@ impl<
     type Values = core::iter::Map<btree_map::IntoValues<Vec<u8>, V>, fn(V) -> Cow<'a, V>>;
 
     ///
+    /// Returns the number of confirmed entries in the map.
+    ///
+    fn len_confirmed(&self) -> usize {
+        self.map.read().len()
+    }
+
+    ///
     /// Returns `true` if the given key exists in the map.
     ///
     fn contains_key_confirmed<Q>(&self, key: &Q) -> Result<bool>

--- a/ledger/store/src/helpers/memory/internal/nested_map.rs
+++ b/ledger/store/src/helpers/memory/internal/nested_map.rs
@@ -264,6 +264,16 @@ impl<
     type Values = core::iter::Map<btree_map::IntoValues<Vec<u8>, V>, fn(V) -> Cow<'a, V>>;
 
     ///
+    /// Returns the number of confirmed entries in the map.
+    ///
+    fn len_map_confirmed(&self, map: &M) -> Result<usize> {
+        // Serialize 'm'.
+        let m = bincode::serialize(map)?;
+        // Retrieve the keys for the serialized map.
+        Ok(self.map.read().get(&m).map(|keys| keys.len()).unwrap_or_default())
+    }
+
+    ///
     /// Returns `true` if the given key exists in the map.
     ///
     fn contains_key_confirmed(&self, map: &M, key: &K) -> Result<bool> {

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -244,6 +244,33 @@ impl<
     type Values = Values<'a, V>;
 
     ///
+    /// Returns the number of confirmed entries in the map.
+    ///
+    fn len_confirmed(&self) -> usize {
+        // A raw iterator doesn't allocate.
+        let mut iter = self.database.raw_iterator();
+        // Find the first key with the map prefix.
+        iter.seek(&self.context);
+
+        // Count the number of keys belonging to the map.
+        let mut len = 0usize;
+        while let Some(key) = iter.key() {
+            // Only compare the map ID - the network ID is guaranteed to
+            // remain the same as long as there is more than a single map.
+            if key[2..][..2] != self.context[2..][..2] {
+                // If the map ID is different, it's the end of iteration.
+                break;
+            }
+
+            // Increment the length and go to the next record.
+            len += 1;
+            iter.next();
+        }
+
+        len
+    }
+
+    ///
     /// Returns `true` if the given key exists in the map.
     ///
     fn contains_key_confirmed<Q>(&self, key: &Q) -> Result<bool>
@@ -1387,9 +1414,13 @@ mod tests {
 
         // Ensure that all the items are present.
         assert_eq!(test_storage.own_map.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.own_map.len_confirmed(), 1);
         assert_eq!(test_storage.extra_maps.own_map1.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.extra_maps.own_map1.len_confirmed(), 1);
         assert_eq!(test_storage.extra_maps.own_map2.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.extra_maps.own_map2.len_confirmed(), 1);
         assert_eq!(test_storage.extra_maps.extra_maps.own_map.iter_confirmed().count(), 1);
+        assert_eq!(test_storage.extra_maps.extra_maps.own_map.len_confirmed(), 1);
 
         // The atomic_write_batch macro uses ?, so the test returns a Result for simplicity.
         Ok(())

--- a/ledger/store/src/helpers/test_helpers/map/check_insert_and_get_speculative.rs
+++ b/ledger/store/src/helpers/test_helpers/map/check_insert_and_get_speculative.rs
@@ -30,6 +30,9 @@ pub fn check_insert_and_get_speculative(map: impl for<'a> Map<'a, usize, String>
 
     // Check that the item is not yet in the map.
     assert!(map.get_confirmed(&0).unwrap().is_none());
+    // Check that the map has no entries.
+    assert_eq!(map.len_confirmed(), 0);
+    assert!(map.is_empty_confirmed());
     // Check that the item is in the batch.
     assert_eq!(map.get_pending(&0), Some(Some("0".to_string())));
     // Check that the item can be speculatively retrieved.
@@ -50,12 +53,16 @@ pub fn check_insert_and_get_speculative(map: impl for<'a> Map<'a, usize, String>
 
     // The map should still contain no items.
     assert!(map.iter_confirmed().next().is_none());
+    assert_eq!(map.len_confirmed(), 0);
+    assert!(map.is_empty_confirmed());
 
     // Finish the current atomic write batch.
     map.finish_atomic().unwrap();
 
     // Check that the item is present in the map now.
     assert_eq!(map.get_confirmed(&0).unwrap(), Some(Cow::Owned("9".to_string())));
+    assert_eq!(map.len_confirmed(), 1);
+    assert!(!map.is_empty_confirmed());
     // Check that the item is not in the batch.
     assert_eq!(map.get_pending(&0), None);
     // Check that the item can be speculatively retrieved.

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_insert_and_get_value_speculative.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_insert_and_get_value_speculative.rs
@@ -30,6 +30,8 @@ pub fn check_insert_and_get_value_speculative(map: impl for<'a> NestedMap<'a, us
 
     // Check that the item is not yet in the map.
     assert!(map.get_value_confirmed(&0, &0).unwrap().is_none());
+    assert_eq!(map.len_map_confirmed(&0).unwrap(), 0);
+    assert!(map.is_empty_map_confirmed(&0).unwrap());
     // Check that the item is in the batch.
     assert_eq!(map.get_value_pending(&0, &0), Some(Some("0".to_string())));
     // Check that the item can be speculatively retrieved.
@@ -50,12 +52,16 @@ pub fn check_insert_and_get_value_speculative(map: impl for<'a> NestedMap<'a, us
 
     // The map should still contain no items.
     assert!(map.iter_confirmed().next().is_none());
+    assert_eq!(map.len_map_confirmed(&0).unwrap(), 0);
+    assert!(map.is_empty_map_confirmed(&0).unwrap());
 
     // Finish the current atomic write batch.
     map.finish_atomic().unwrap();
 
     // Check that the item is present in the map now.
     assert_eq!(map.get_value_confirmed(&0, &0).unwrap(), Some(Cow::Owned("9".to_string())));
+    assert_eq!(map.len_map_confirmed(&0).unwrap(), 1);
+    assert!(!map.is_empty_map_confirmed(&0).unwrap());
     // Check that the item is not in the batch.
     assert_eq!(map.get_value_pending(&0, &0), None);
     // Check that the item can be speculatively retrieved.

--- a/ledger/store/src/helpers/traits/map.rs
+++ b/ledger/store/src/helpers/traits/map.rs
@@ -88,6 +88,18 @@ pub trait MapRead<
     type Values: Iterator<Item = Cow<'a, V>>;
 
     ///
+    /// Returns the number of confirmed entries in the map.
+    ///
+    fn len_confirmed(&self) -> usize;
+
+    ///
+    /// Checks whether there are any confirmed entries in the map.
+    ///
+    fn is_empty_confirmed(&self) -> bool {
+        self.len_confirmed() == 0
+    }
+
+    ///
     /// Returns `true` if the given key exists in the map.
     ///
     fn contains_key_confirmed<Q>(&self, key: &Q) -> Result<bool>

--- a/ledger/store/src/helpers/traits/nested_map.rs
+++ b/ledger/store/src/helpers/traits/nested_map.rs
@@ -95,6 +95,18 @@ pub trait NestedMapRead<
     type Values: Iterator<Item = Cow<'a, V>>;
 
     ///
+    /// Returns the number of confirmed entries in the map.
+    ///
+    fn len_map_confirmed(&self, map: &M) -> Result<usize>;
+
+    ///
+    /// Checks whether there are any confirmed entries in the map.
+    ///
+    fn is_empty_map_confirmed(&self, map: &M) -> Result<bool> {
+        Ok(self.len_map_confirmed(map)? == 0)
+    }
+
+    ///
     /// Returns `true` if the given key exists in the map.
     ///
     fn contains_key_confirmed(&self, map: &M, key: &K) -> Result<bool>;


### PR DESCRIPTION
This PR adds the following new methods to the store-related traits:
- `MapRead::{len_confirmed, len_pending, is_empty_confirmed, is_empty_pending}`
- `NestedMapRead::{len_map_confirmed, len_map_pending, is_empty_map_confirmed, is_empty_map_pending}`

The logic of the new impls follows the existing `iter_{confirmed, pending}` implementations (e.g. it performs filtering for `MapRead::iter_pending` impls and doesn't for `NestedMapRead::iter_pending`); this means the new methods return the same values as `iter_{confirmed, pending}().count()`, **but** they don't perform any deserialization, which makes them much faster.

Some of the existing test cases were extended to utilize the new methods.