### PR TITLE
Evaluate calls during PackageRun, evaluate responses during CheckDeployment

### DIFF
--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -190,9 +190,23 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         }
         lap!(timer, "Evaluate the instructions");
 
+        let response = self.evaluate_function_response::<A>(&request, &function, &mut registers);
+
+        finish!(timer);
+
+        response
+    }
+
+    /// Evaluates a program function's outputs on the given inputs.
+    #[inline]
+    fn evaluate_function_response<A: circuit::Aleo<Network = N>>(
+        &self,
+        request: &Request<N>,
+        function: &Function<N>,
+        registers: &mut (impl RegistersCall<N> + RegistersSigner<N> + RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<Response<N>> {
         // Retrieve the output operands.
         let output_operands = &function.outputs().iter().map(|output| output.operand()).collect::<Vec<_>>();
-        lap!(timer, "Retrieve the output operands");
 
         // Load the outputs.
         let outputs = output_operands
@@ -216,7 +230,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                 }
             })
             .collect::<Result<Vec<_>>>()?;
-        lap!(timer, "Load the outputs");
 
         // Map the output operands to registers.
         let output_registers = output_operands
@@ -226,7 +239,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        lap!(timer, "Loaded the output registers");
 
         // Compute the response.
         let response = Response::new(
@@ -240,7 +252,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
             &function.output_types(),
             &output_registers,
         );
-        finish!(timer);
 
         response
     }

--- a/synthesizer/process/src/traits/mod.rs
+++ b/synthesizer/process/src/traits/mod.rs
@@ -17,9 +17,10 @@ use console::{
     account::Address,
     network::Network,
     prelude::{CryptoRng, Result, Rng},
-    program::{Identifier, ProgramID, Response, Value},
+    program::{Identifier, ProgramID, Request, Response, Value},
     types::Field,
 };
+use synthesizer_program::{Function, RegistersLoad, RegistersSigner, RegistersStore};
 
 pub trait StackEvaluate<N: Network>: Clone {
     /// Evaluates a program closure on the given inputs.
@@ -44,6 +45,14 @@ pub trait StackEvaluate<N: Network>: Clone {
         &self,
         call_stack: CallStack<N>,
         caller: Option<ProgramID<N>>,
+    ) -> Result<Response<N>>;
+
+    /// Computes a program function's response on the given inputs.
+    fn evaluate_function_response<A: circuit::Aleo<Network = N>>(
+        &self,
+        request: &Request<N>,
+        function: &Function<N>,
+        registers: &mut (impl RegistersCall<N> + RegistersSigner<N> + RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<Response<N>>;
 }
 


### PR DESCRIPTION
## Motivation

If we `evaluate_function` during deployment, we risk hitting false positive failed constraints on our random assignment.
But hopefully we can just evaluate the responses without hitting false positive failed constraints.

## Test Plan

In the future we will test a wider range of programs.

## Related PRs

https://github.com/AleoHQ/snarkVM/pull/2176
https://github.com/AleoHQ/snarkVM/pull/2224
https://github.com/AleoHQ/snarkVM/pull/2226