### PR TITLE
Abort transactions with already spent `InputID`s

### DIFF
--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -690,9 +690,26 @@ fn test_execute_duplicate_input_ids() {
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("100u64").unwrap()];
     let transfer_3 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), Some(record_1), 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.into_iter(),
+            Some(record_1.clone()),
+            0,
+            None,
+            rng,
+        )
         .unwrap();
     let transfer_3_id = transfer_3.id();
+
+    // Prepare a transfer that attempts to spend the same record for the subsequent block.
+    let inputs =
+        [Value::Record(record_1), Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
+    let transfer_4 = ledger
+        .vm
+        .execute(&private_key, ("credits.aleo", "transfer_private"), inputs.into_iter(), None, 0, None, rng)
+        .unwrap();
+    let transfer_4_id = transfer_4.id();
 
     // Create a block.
     let block = ledger
@@ -715,4 +732,28 @@ fn test_execute_duplicate_input_ids() {
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_1_id]);
     assert_eq!(block.aborted_transaction_ids(), &vec![transfer_2_id, transfer_3_id]);
+
+    // Prepare a transfer that will succeed for the subsequent block.
+    let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
+    let transfer_5 = ledger
+        .vm
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .unwrap();
+    let transfer_5_id = transfer_5.id();
+
+    // Create a block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transfer_4, transfer_5], rng)
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Enforce that the block transactions were correct.
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_5_id]);
+    assert_eq!(block.aborted_transaction_ids(), &vec![transfer_4_id]);
 }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -636,3 +636,83 @@ fn test_aborted_transaction_indexing() {
     // Add the deployment block to the ledger.
     ledger.advance_to_next_block(&block).unwrap();
 }
+
+#[test]
+fn test_execute_duplicate_input_ids() {
+    let rng = &mut TestRng::default();
+
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, private_key, view_key, address, .. } =
+        crate::test_helpers::sample_test_env(rng);
+
+    // A helper function to find records.
+    let find_records = || {
+        let microcredits = Identifier::from_str("microcredits").unwrap();
+        ledger
+            .find_records(&view_key, RecordsFilter::SlowUnspent(private_key))
+            .unwrap()
+            .filter(|(_, record)| match record.data().get(&microcredits) {
+                Some(Entry::Private(Plaintext::Literal(Literal::U64(amount), _))) => !amount.is_zero(),
+                _ => false,
+            })
+            .collect::<indexmap::IndexMap<_, _>>()
+    };
+
+    // Fetch the unspent records.
+    let records = find_records();
+    let record_1 = records[0].clone();
+
+    // Prepare a transfer that spends the record.
+    let inputs = [
+        Value::Record(record_1.clone()),
+        Value::from_str(&format!("{address}")).unwrap(),
+        Value::from_str("100u64").unwrap(),
+    ];
+    let transfer_1 = ledger
+        .vm
+        .execute(&private_key, ("credits.aleo", "transfer_private"), inputs.into_iter(), None, 0, None, rng)
+        .unwrap();
+    let transfer_1_id = transfer_1.id();
+
+    // Prepare a transfer that attempts to spend the same record.
+    let inputs = [
+        Value::Record(record_1.clone()),
+        Value::from_str(&format!("{address}")).unwrap(),
+        Value::from_str("1000u64").unwrap(),
+    ];
+    let transfer_2 = ledger
+        .vm
+        .execute(&private_key, ("credits.aleo", "transfer_private"), inputs.into_iter(), None, 0, None, rng)
+        .unwrap();
+    let transfer_2_id = transfer_2.id();
+
+    // Prepare a transfer that attempts to spend the same record in the fee.
+    let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("100u64").unwrap()];
+    let transfer_3 = ledger
+        .vm
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), Some(record_1), 0, None, rng)
+        .unwrap();
+    let transfer_3_id = transfer_3.id();
+
+    // Create a block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(
+            &private_key,
+            vec![],
+            vec![],
+            vec![transfer_1, transfer_2, transfer_3],
+            rng,
+        )
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Enforce that the block transactions were correct.
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_1_id]);
+    assert_eq!(block.aborted_transaction_ids(), &vec![transfer_2_id, transfer_3_id]);
+}

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -237,7 +237,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 for input_id in transaction.input_ids() {
                     // If the input ID is already spent in this block or previous blocks, abort the transaction.
                     if input_ids.contains(input_id)
-                        || self.transition_store().contains_input_id(input_id).map_err(|e| e.to_string())?
+                        || self.transition_store().contains_input_id(input_id).unwrap_or(true)
                     {
                         // Store the aborted transaction.
                         aborted.push((transaction.clone(), format!("Double-spending input {input_id}")));

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -233,7 +233,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 //  a possible rejected transaction instead of always aborting.
                 // Ensure that the transaction is not double-spending an input.
                 for input_id in transaction.input_ids() {
-                    if input_ids.contains(input_id) {
+                    // If the input ID is already spent in this block or previous blocks, abort the transaction.
+                    if input_ids.contains(input_id)
+                        || self.transition_store().contains_input_id(input_id).map_err(|e| e.to_string())?
+                    {
                         // Store the aborted transaction.
                         aborted.push((transaction.clone(), format!("Double-spending input {input_id}")));
                         // Continue to the next transaction.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -230,9 +230,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     continue 'outer;
                 }
 
-                // TODO (raychu86): Consider using InputStore with contains_input_id_speculative instead.
-                //  This can be added to the `finalize_execution` and `finalize_fee` methods to allow for
-                //  a possible rejected transaction instead of always aborting.
                 // Ensure that the transaction is not double-spending an input.
                 for input_id in transaction.input_ids() {
                     // If the input ID is already spent in this block or previous blocks, abort the transaction.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -59,7 +59,7 @@ use synthesizer_process::{Authorization, Process, Trace};
 use synthesizer_program::{FinalizeGlobalState, FinalizeOperation, FinalizeStoreTrait, Program};
 
 use aleo_std::prelude::{finish, lap, timer};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use parking_lot::RwLock;
 use std::sync::Arc;
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds logic to `VM::atomic_speculate` to track spent `InputID`s and abort transactions that attempt to spend an `InputID` that was already spent in this block. 

Note: We may want to use the `InputStore::get_speculative` instead of per block trackers in `atomic_speculate`.

Related to: https://github.com/AleoHQ/snarkOS/pull/2852

## Test Plan

A test has been added to check that the possible double spends are caught and aborted.
