### PR TITLE
Use evaluate_function for CallStack::PackageRun; Sample response for CallStack::CheckDeployment

### DIFF
--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -283,15 +283,11 @@ impl<N: Network> CallTrait<N> for Call<N> {
                             .iter()
                             .map(|output| substack.sample_value(&address, output.value_type(), rng))
                             .collect::<Result<Vec<_>>>()?;
-
-                        // Retrieve the output operands.
-                        let output_operands =
-                            &function.outputs().iter().map(|output| output.operand()).collect::<Vec<_>>();
-
                         // Map the output operands to registers.
-                        let output_registers = output_operands
+                        let output_registers = function
+                            .outputs()
                             .iter()
-                            .map(|operand| match operand {
+                            .map(|output| match output.operand() {
                                 Operand::Register(register) => Some(register.clone()),
                                 _ => None,
                             })

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -295,7 +295,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                                 ExternalRecord(locator) => {
                                     // Retrieve the external stack.
                                     let stack = substack.get_external_stack(locator.program_id())?;
-                                    // Sample the input.
+                                    // Sample the output.
                                     stack.sample_value(&address, &Record(*locator.resource()), rng)
                                 }
                                 _ => substack.sample_value(&address, output.value_type(), rng),

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -22,7 +22,6 @@ use crate::{
     RegistersCall,
     StackEvaluate,
     StackExecute,
-    StackProgramTypes,
 };
 use aleo_std::prelude::{finish, lap, timer};
 use console::{network::prelude::*, program::Request};
@@ -51,7 +50,7 @@ pub trait CallTrait<N: Network> {
     /// Executes the instruction.
     fn execute<A: circuit::Aleo<Network = N>, R: CryptoRng + Rng>(
         &self,
-        stack: &(impl StackEvaluate<N> + StackExecute<N> + StackMatches<N> + StackProgram<N> + StackProgramTypes<N>),
+        stack: &(impl StackEvaluate<N> + StackExecute<N> + StackMatches<N> + StackProgram<N>),
         registers: &mut (
                  impl RegistersCall<N>
                  + RegistersSignerCircuit<N, A>
@@ -144,7 +143,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
     #[inline]
     fn execute<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
         &self,
-        stack: &(impl StackEvaluate<N> + StackExecute<N> + StackMatches<N> + StackProgram<N> + StackProgramTypes<N>),
+        stack: &(impl StackEvaluate<N> + StackExecute<N> + StackMatches<N> + StackProgram<N>),
         registers: &mut (
                  impl RegistersCall<N>
                  + RegistersSignerCircuit<N, A>

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -268,7 +268,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         // Push the request onto the call stack.
                         call_stack.push(request.clone())?;
 
-                        // Execute the request.
+                        // Evaluate the request.
                         let response = substack.evaluate_function::<A>(call_stack, console_caller)?;
 
                         // Return the request and response.

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -12,17 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    stack::{
-        Address,
-        ValueType::{ExternalRecord, Record},
-    },
-    CallStack,
-    Registers,
-    RegistersCall,
-    StackEvaluate,
-    StackExecute,
-};
+use crate::{stack::Address, CallStack, Registers, RegistersCall, StackEvaluate, StackExecute};
 use aleo_std::prelude::{finish, lap, timer};
 use console::{network::prelude::*, program::Request};
 use synthesizer_program::{
@@ -291,15 +281,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         let outputs = function
                             .outputs()
                             .iter()
-                            .map(|output| match output.value_type() {
-                                ExternalRecord(locator) => {
-                                    // Retrieve the external stack.
-                                    let stack = substack.get_external_stack(locator.program_id())?;
-                                    // Sample the output.
-                                    stack.sample_value(&address, &Record(*locator.resource()), rng)
-                                }
-                                _ => substack.sample_value(&address, output.value_type(), rng),
-                            })
+                            .map(|output| substack.sample_value(&address, output.value_type(), rng))
                             .collect::<Result<Vec<_>>>()?;
 
                         // Retrieve the output operands.

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -106,6 +106,10 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         // Retrieve the next request, based on the call stack mode.
         let (request, call_stack) = match &call_stack {
             CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
+            CallStack::PackageRun(requests, _, _) => {
+                let last_request = requests.last().ok_or(anyhow!("CallStack does not contain request"))?.clone();
+                (last_request, call_stack)
+            }
             // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
             // This is done to ensure that evaluation during execution is performed consistently.
             CallStack::Execute(authorization, _) => {
@@ -116,7 +120,9 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                 let call_stack = CallStack::Evaluate(authorization);
                 (request, call_stack)
             }
-            _ => bail!("Illegal operation: call stack must be `Evaluate` or `Execute` in `evaluate_function`."),
+            _ => bail!(
+                "Illegal operation: call stack must be `PackageRun`, `Evaluate` or `Execute` in `evaluate_function`."
+            ),
         };
         lap!(timer, "Retrieve the next request");
 

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use console::program::{Argument, FinalizeType};
+pub use console::program::{Argument, FinalizeType};
 
 impl<N: Network> StackMatches<N> for Stack<N> {
     /// Checks that the given value matches the layout of the value type.

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::*;
-pub use console::program::{Argument, FinalizeType};
 
 impl<N: Network> StackMatches<N> for Stack<N> {
     /// Checks that the given value matches the layout of the value type.

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::*;
-use crate::stack::helpers::matches::{Argument, FinalizeType};
 
 impl<N: Network> Stack<N> {
     /// Returns a record for the given record name, with the given burner address.
@@ -49,9 +48,9 @@ impl<N: Network> Stack<N> {
     pub fn sample_future<R: Rng + CryptoRng>(&self, locator: &Locator<N>, rng: &mut R) -> Result<Future<N>> {
         // Sample a future value.
         let future = self.sample_future_internal(locator, 0, rng)?;
-        // Ensure the plaintext value matches the plaintext type.
+        // Ensure the future value matches the future type.
         self.matches_future(&future, locator)?;
-        // Return the plaintext value.
+        // Return the future value.
         Ok(future)
     }
 }
@@ -173,7 +172,7 @@ impl<N: Network> Stack<N> {
         Ok(plaintext)
     }
 
-    /// Returns a future for the given TODO.
+    /// Samples a future value according to the given locator.
     fn sample_future_internal<R: Rng + CryptoRng>(
         &self,
         locator: &Locator<N>,

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -13,29 +13,9 @@
 // limitations under the License.
 
 use super::*;
+use crate::stack::helpers::matches::{Argument, FinalizeType};
 
 impl<N: Network> Stack<N> {
-    /// Returns a value for the given value type.
-    pub fn sample_value<R: Rng + CryptoRng>(
-        &self,
-        burner_address: &Address<N>,
-        value_type: &ValueType<N>,
-        rng: &mut R,
-    ) -> Result<Value<N>> {
-        match value_type {
-            ValueType::Constant(plaintext_type)
-            | ValueType::Public(plaintext_type)
-            | ValueType::Private(plaintext_type) => Ok(Value::Plaintext(self.sample_plaintext(plaintext_type, rng)?)),
-            ValueType::Record(record_name) => {
-                Ok(Value::Record(self.sample_record(burner_address, record_name, rng)?))
-            }
-            ValueType::ExternalRecord(locator) => {
-                bail!("Illegal operation: Cannot sample external records (for '{locator}.record').")
-            }
-            ValueType::Future(locator) => bail!("Illegal operation: Cannot sample futures (for '{locator}.future')."),
-        }
-    }
-
     /// Returns a record for the given record name, with the given burner address.
     pub fn sample_record<R: Rng + CryptoRng>(
         &self,
@@ -63,6 +43,16 @@ impl<N: Network> Stack<N> {
         self.matches_plaintext(&plaintext, plaintext_type)?;
         // Return the plaintext value.
         Ok(plaintext)
+    }
+
+    /// Samples a future value according to the given future type.
+    pub fn sample_future<R: Rng + CryptoRng>(&self, locator: &Locator<N>, rng: &mut R) -> Result<Future<N>> {
+        // Sample a future value.
+        let future = self.sample_future_internal(locator, 0, rng)?;
+        // Ensure the plaintext value matches the plaintext type.
+        self.matches_future(&future, locator)?;
+        // Return the plaintext value.
+        Ok(future)
     }
 }
 
@@ -181,5 +171,47 @@ impl<N: Network> Stack<N> {
         };
         // Return the plaintext.
         Ok(plaintext)
+    }
+
+    /// Returns a future for the given TODO.
+    fn sample_future_internal<R: Rng + CryptoRng>(
+        &self,
+        locator: &Locator<N>,
+        depth: usize,
+        rng: &mut R,
+    ) -> Result<Future<N>> {
+        // Retrieve the associated function.
+        let function = match locator.program_id() == self.program_id() {
+            true => self.get_function_ref(locator.resource())?,
+            false => self.get_external_program(locator.program_id())?.get_function_ref(locator.resource())?,
+        };
+
+        // Retrieve the finalize inputs.
+        let inputs = match function.finalize_logic() {
+            Some(finalize_logic) => finalize_logic.inputs(),
+            None => bail!("Function '{locator}' does not have a finalize block"),
+        };
+
+        let arguments = inputs
+            .into_iter()
+            .map(|input| {
+                match input.finalize_type() {
+                    FinalizeType::Plaintext(plaintext_type) => {
+                        // Sample the plaintext value.
+                        let plaintext = self.sample_plaintext_internal(plaintext_type, depth + 1, rng)?;
+                        // Return the argument.
+                        Ok(Argument::Plaintext(plaintext))
+                    }
+                    FinalizeType::Future(locator) => {
+                        // Sample the future value.
+                        let future = self.sample_future_internal(locator, depth + 1, rng)?;
+                        // Return the argument.
+                        Ok(Argument::Future(future))
+                    }
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Future::new(*locator.program_id(), *locator.resource(), arguments))
     }
 }

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -41,8 +41,10 @@ use console::{
     account::{Address, PrivateKey},
     network::prelude::*,
     program::{
+        Argument,
         Entry,
         EntryType,
+        FinalizeType,
         Future,
         Identifier,
         Literal,

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -292,6 +292,27 @@ impl<N: Network> StackProgram<N> for Stack<N> {
         }
         Ok(num_calls)
     }
+
+    /// Returns a value for the given value type.
+    fn sample_value<R: Rng + CryptoRng>(
+        &self,
+        burner_address: &Address<N>,
+        value_type: &ValueType<N>,
+        rng: &mut R,
+    ) -> Result<Value<N>> {
+        match value_type {
+            ValueType::Constant(plaintext_type)
+            | ValueType::Public(plaintext_type)
+            | ValueType::Private(plaintext_type) => Ok(Value::Plaintext(self.sample_plaintext(plaintext_type, rng)?)),
+            ValueType::Record(record_name) => {
+                Ok(Value::Record(self.sample_record(burner_address, record_name, rng)?))
+            }
+            ValueType::ExternalRecord(locator) => {
+                bail!("Illegal operation: Cannot sample external records (for '{locator}.record').")
+            }
+            ValueType::Future(locator) => Ok(Value::Future(self.sample_future(locator, rng)?)),
+        }
+    }
 }
 
 impl<N: Network> StackProgramTypes<N> for Stack<N> {

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -310,7 +310,10 @@ impl<N: Network> StackProgram<N> for Stack<N> {
                 Ok(Value::Record(self.sample_record(burner_address, record_name, rng)?))
             }
             ValueType::ExternalRecord(locator) => {
-                bail!("Illegal operation: Cannot sample external records (for '{locator}.record').")
+                // Retrieve the external stack.
+                let stack = self.get_external_stack(locator.program_id())?;
+                // Sample the output.
+                Ok(Value::Record(stack.sample_record(burner_address, locator.resource(), rng)?))
             }
             ValueType::Future(locator) => Ok(Value::Future(self.sample_future(locator, rng)?)),
         }

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -35,6 +35,7 @@ use console::{
     },
     types::{Address, Field},
 };
+use rand::{CryptoRng, Rng};
 
 pub trait StackMatches<N: Network> {
     /// Checks that the given value matches the layout of the value type.
@@ -83,6 +84,14 @@ pub trait StackProgram<N: Network> {
 
     /// Returns the expected number of calls for the given function name.
     fn get_number_of_calls(&self, function_name: &Identifier<N>) -> Result<usize>;
+
+    /// Samples a value for the given value_type
+    fn sample_value<R: Rng + CryptoRng>(
+        &self,
+        burner_address: &Address<N>,
+        value_type: &ValueType<N>,
+        rng: &mut R,
+    ) -> Result<Value<N>>;
 }
 
 pub trait FinalizeRegistersState<N: Network> {

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -85,7 +85,7 @@ pub trait StackProgram<N: Network> {
     /// Returns the expected number of calls for the given function name.
     fn get_number_of_calls(&self, function_name: &Identifier<N>) -> Result<usize>;
 
-    /// Samples a value for the given value_type
+    /// Samples a value for the given value_type.
     fn sample_value<R: Rng + CryptoRng>(
         &self,
         burner_address: &Address<N>,


### PR DESCRIPTION
## Motivation

If we `evaluate_function` during deployment, we risk hitting false positive failed constraints on our random assignment.

So instead, this PR proposes to sample a response. After sampling, construction of Response is handled the same way evaluate_function.

## Test Plan

In the future we will test a wider range of programs.

## Related PRs

https://github.com/AleoHQ/snarkVM/pull/2176
https://github.com/AleoHQ/snarkVM/pull/2224
https://github.com/AleoHQ/snarkVM/pull/2226