### PR TITLE
Derive Ord + PartialOrd to compare Address

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -76,6 +76,8 @@ pub trait Network:
     + for<'a> Deserialize<'a>
     + Send
     + Sync
+    + Ord
+    + PartialOrd
 {
     /// The network ID.
     const ID: u16;

--- a/console/network/src/testnet3.rs
+++ b/console/network/src/testnet3.rs
@@ -81,7 +81,7 @@ lazy_static! {
 
 pub const TRANSACTION_PREFIX: &str = "at";
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub struct Testnet3;
 
 impl Testnet3 {

--- a/console/types/address/src/lib.rs
+++ b/console/types/address/src/lib.rs
@@ -35,7 +35,7 @@ pub use snarkvm_console_types_boolean::Boolean;
 pub use snarkvm_console_types_field::Field;
 pub use snarkvm_console_types_group::Group;
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Address<E: Environment> {
     /// The underlying address.
     address: Group<E>,

--- a/console/types/group/src/lib.rs
+++ b/console/types/group/src/lib.rs
@@ -41,7 +41,7 @@ pub use snarkvm_console_types_boolean::Boolean;
 pub use snarkvm_console_types_field::Field;
 pub use snarkvm_console_types_scalar::Scalar;
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct Group<E: Environment> {
     /// The underlying group element.
     group: E::Projective,

--- a/curves/src/bls12_377/g1.rs
+++ b/curves/src/bls12_377/g1.rs
@@ -29,7 +29,7 @@ use crate::{
 
 use std::ops::Neg;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Bls12_377G1Parameters;
 
 impl ModelParameters for Bls12_377G1Parameters {

--- a/curves/src/bls12_377/g2.rs
+++ b/curves/src/bls12_377/g2.rs
@@ -28,7 +28,7 @@ use crate::{
 
 use std::ops::Neg;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Bls12_377G2Parameters;
 
 impl ModelParameters for Bls12_377G2Parameters {

--- a/curves/src/edwards_bls12/parameters.rs
+++ b/curves/src/edwards_bls12/parameters.rs
@@ -26,7 +26,7 @@ use std::str::FromStr;
 pub type EdwardsAffine = Affine<EdwardsParameters>;
 pub type EdwardsProjective = Projective<EdwardsParameters>;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct EdwardsParameters;
 
 impl ModelParameters for EdwardsParameters {

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -32,7 +32,7 @@ use rand::{
 use rayon::prelude::*;
 use std::io::{Read, Result as IoResult, Write};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialOrd, Ord)]
 pub struct Projective<P: Parameters> {
     pub x: P::BaseField,
     pub y: P::BaseField,

--- a/curves/src/templates/twisted_edwards_extended/projective.rs
+++ b/curves/src/templates/twisted_edwards_extended/projective.rs
@@ -30,7 +30,7 @@ use rand::{
 };
 use std::io::{Read, Result as IoResult, Write};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Ord, PartialOrd)]
 pub struct Projective<P: Parameters> {
     pub x: P::BaseField,
     pub y: P::BaseField,

--- a/curves/src/traits/group.rs
+++ b/curves/src/traits/group.rs
@@ -57,6 +57,8 @@ pub trait ProjectiveCurve:
     + ToBytes
     + iter::Sum
     + From<<Self as ProjectiveCurve>::Affine>
+    + Ord
+    + PartialOrd
 {
     type Affine: AffineCurve<Projective = Self, ScalarField = Self::ScalarField> + From<Self> + Into<Self>;
     type BaseField: Field;
@@ -253,7 +255,9 @@ pub trait PairingCurve: AffineCurve {
     fn pairing_with(&self, other: &Self::PairWith) -> Self::PairingResult;
 }
 
-pub trait ModelParameters: 'static + Copy + Clone + Debug + PartialEq + Eq + Hash + Send + Sync + Sized {
+pub trait ModelParameters:
+    'static + Copy + Clone + Debug + PartialEq + Eq + Hash + Send + Sync + Sized + Ord + PartialOrd
+{
     type BaseField: Field + SquareRootField;
     type ScalarField: PrimeField + SquareRootField + Into<<Self::ScalarField as PrimeField>::BigInteger>;
 }


### PR DESCRIPTION
## Motivation

I wanted to compare `Address<N>`. Which is not a typed, so we need to also be able to compare its type.

## Related PRs

We also hit this problem in the past when hand implementing `Ord/PartialOrd` for the ProvingKey. If this is approved, I may change it to auto derive them.