### PR TITLE
Introduce a few deep clone safeguards

### DIFF
--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -271,7 +271,7 @@ impl<E: PairingEngine> CommitterKey<E> {
 }
 
 /// `CommitterUnionKey` is a union of `CommitterKey`s, useful for multi-circuit batch proofs.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CommitterUnionKey<'a, E: PairingEngine> {
     /// The key used to commit to polynomials.
     pub powers_of_beta_g: Option<&'a Vec<E::G1Affine>>,

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -36,7 +36,7 @@ pub type Randomness<E> = kzg10::KZGRandomness<E>;
 pub type Commitment<E> = kzg10::KZGCommitment<E>;
 
 /// `CommitterKey` is used to commit to, and create evaluation proofs for, a given polynomial.
-#[derive(Clone, Debug, Default, Hash, CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct CommitterKey<E: PairingEngine> {
     /// The key used to commit to polynomials.
     pub powers_of_beta_g: Vec<E::G1Affine>,

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
@@ -62,7 +62,7 @@ impl CircuitId {
 ///     public input
 /// 2) `{a,b,c}` are the matrices defining the R1CS instance
 /// 3) `{a,b,c}_arith` are structs containing information about the arithmetized matrices
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Circuit<F: PrimeField, SM: SNARKMode> {
     /// Information about the indexed circuit.
     pub index_info: CircuitInfo,

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -93,7 +93,7 @@ pub(crate) fn pad_input_for_indexer_and_prover<F: PrimeField, CS: ConstraintSyst
     Ok(())
 }
 
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq)]
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq)]
 pub struct MatrixEvals<F: PrimeField> {
     /// Evaluations of the `row` polynomial.
     pub row: EvaluationsOnDomain<F>,

--- a/algorithms/src/snark/varuna/data_structures/circuit_proving_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_proving_key.rs
@@ -27,7 +27,7 @@ use snarkvm_utilities::{
 use std::{cmp::Ordering, sync::Arc};
 
 /// Proving key for a specific circuit (i.e., R1CS matrices).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct CircuitProvingKey<E: PairingEngine, SM: SNARKMode> {
     /// The circuit verifying key.
     pub circuit_verifying_key: CircuitVerifyingKey<E>,
@@ -57,6 +57,14 @@ impl<E: PairingEngine, SM: SNARKMode> FromBytes for CircuitProvingKey<E, SM> {
         Ok(Self { circuit_verifying_key, circuit, committer_key })
     }
 }
+
+impl<E: PairingEngine, SM: SNARKMode> PartialEq for CircuitProvingKey<E, SM> {
+    fn eq(&self, other: &Self) -> bool {
+        self.circuit.id == other.circuit.id
+    }
+}
+
+impl<E: PairingEngine, SM: SNARKMode> Eq for CircuitProvingKey<E, SM> {}
 
 impl<E: PairingEngine, SM: SNARKMode> Ord for CircuitProvingKey<E, SM> {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/parameters/src/testnet3/powers.rs
+++ b/parameters/src/testnet3/powers.rs
@@ -57,7 +57,7 @@ lazy_static::lazy_static! {
 }
 
 /// A vector of powers of beta G.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PowersOfG<E: PairingEngine> {
     /// The powers of beta G.
     powers_of_beta_g: PowersOfBetaG<E>,
@@ -224,7 +224,7 @@ impl<E: PairingEngine> ToBytes for PowersOfG<E> {
     }
 }
 
-#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct PowersOfBetaG<E: PairingEngine> {
     /// Group elements of form `[G, \beta * G, \beta^2 * G, ..., \beta^d G]`.
     powers_of_beta_g: Vec<E::G1Affine>,

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -306,7 +306,7 @@ impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for Rc<T> {
 //     }
 // }
 
-impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for Arc<T> {
+impl<T: CanonicalSerialize> CanonicalSerialize for Arc<T> {
     #[inline]
     fn serialize_with_mode<W: Write>(&self, mut writer: W, compress: Compress) -> Result<(), SerializationError> {
         self.as_ref().serialize_with_mode(&mut writer, compress)
@@ -334,7 +334,7 @@ impl<T: Valid + Sync + Send> Valid for Arc<T> {
     }
 }
 
-impl<T: CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize for Arc<T> {
+impl<T: CanonicalDeserialize + Sync + Send> CanonicalDeserialize for Arc<T> {
     #[inline]
     fn deserialize_with_mode<R: Read>(
         reader: R,


### PR DESCRIPTION
This PR contains a few changes that are mostly aimed at reducing the chance of us accidentally deep-cloning some of the larger objects. In addition, some of the unused `derive`d impls are removed, some unnecessary constraints lifted, and in one case, a `PartialEq` impl is simplified to follow the `PartialOrd` one (please advise if that one is undesirable for any reason).