### PR TITLE
A handful of PowersOfG tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,6 +3371,7 @@ dependencies = [
  "itertools 0.11.0",
  "js-sys",
  "lazy_static",
+ "parking_lot",
  "paste",
  "rand",
  "serde_json",

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -95,7 +95,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                     max_degree - lowest_shift_degree + 1
                 ));
 
-                let shifted_powers_of_beta_g = pp.powers_of_beta_g(lowest_shift_degree, pp.max_degree() + 1)?.to_vec();
+                let shifted_powers_of_beta_g = pp.powers_of_beta_g(lowest_shift_degree, pp.max_degree() + 1)?;
                 let mut shifted_powers_of_beta_times_gamma_g = BTreeMap::new();
                 // Also add degree 0.
                 for degree_bound in enforced_degree_bounds {
@@ -118,7 +118,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
             (None, None)
         };
 
-        let powers_of_beta_g = pp.powers_of_beta_g(0, supported_degree + 1)?.to_vec();
+        let powers_of_beta_g = pp.powers_of_beta_g(0, supported_degree + 1)?;
         let powers_of_beta_times_gamma_g = (0..=(supported_hiding_bound + 1))
             .map(|i| {
                 pp.powers_of_beta_times_gamma_g()

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -76,6 +76,9 @@ optional = true
 [dependencies.lazy_static]
 version = "1.4"
 
+[dependencies.parking_lot]
+version = "0.12"
+
 [dependencies.paste]
 version = "1"
 

--- a/parameters/src/testnet3/powers.rs
+++ b/parameters/src/testnet3/powers.rs
@@ -499,11 +499,7 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
             // Deserialize the group elements.
             let additional_powers = Vec::deserialize_uncompressed_unchecked(&*additional_bytes)?;
 
-            if final_powers.is_empty() {
-                final_powers = additional_powers;
-            } else {
-                final_powers.extend(additional_powers);
-            }
+            final_powers.extend(additional_powers.iter());
         }
         final_powers.extend(self.shifted_powers_of_beta_g.iter());
         self.shifted_powers_of_beta_g = final_powers;

--- a/parameters/src/testnet3/powers.rs
+++ b/parameters/src/testnet3/powers.rs
@@ -28,6 +28,7 @@ use snarkvm_utilities::{
 };
 
 use anyhow::{anyhow, bail, ensure, Result};
+use parking_lot::RwLock;
 use std::{collections::BTreeMap, ops::Range, sync::Arc};
 
 const NUM_POWERS_15: usize = 1 << 15;
@@ -60,13 +61,13 @@ lazy_static::lazy_static! {
 #[derive(Debug)]
 pub struct PowersOfG<E: PairingEngine> {
     /// The powers of beta G.
-    powers_of_beta_g: PowersOfBetaG<E>,
+    powers_of_beta_g: RwLock<PowersOfBetaG<E>>,
     /// Group elements of form `{ \beta^i \gamma G }`, where `i` is from 0 to `degree`,
     /// This is used for hiding.
-    powers_of_beta_times_gamma_g: Arc<BTreeMap<usize, E::G1Affine>>,
+    powers_of_beta_times_gamma_g: BTreeMap<usize, E::G1Affine>,
     /// Group elements of form `{ \beta^{max_degree - i} H }`, where `i`
     /// is of the form `2^k - 1` for `k` in `1` to `log_2(max_degree)`.
-    negative_powers_of_beta_h: Arc<BTreeMap<usize, E::G2Affine>>,
+    negative_powers_of_beta_h: BTreeMap<usize, E::G2Affine>,
     /// Information required to enforce degree bounds. Each pair is of the form `(degree_bound, shifting_advice)`.
     /// Each pair is in the form `(degree_bound, \beta^{max_degree - i} H),` where `H` is the generator of G2,
     /// and `i` is of the form `2^k - 1` for `k` in `1` to `log_2(max_degree)`.
@@ -78,15 +79,14 @@ pub struct PowersOfG<E: PairingEngine> {
 impl<E: PairingEngine> PowersOfG<E> {
     /// Initializes the hard-coded instance of the powers.
     pub fn load() -> Result<Self> {
-        let powers_of_beta_g = PowersOfBetaG::load()?;
+        let powers_of_beta_g = RwLock::new(PowersOfBetaG::load()?);
 
         // Reconstruct powers of beta_times_gamma_g.
-        let powers_of_beta_times_gamma_g =
-            Arc::new(BTreeMap::deserialize_uncompressed_unchecked(&**POWERS_OF_BETA_GAMMA_G)?);
+        let powers_of_beta_times_gamma_g = BTreeMap::deserialize_uncompressed_unchecked(&**POWERS_OF_BETA_GAMMA_G)?;
 
         // Reconstruct negative powers of beta_h.
-        let negative_powers_of_beta_h: Arc<BTreeMap<usize, E::G2Affine>> =
-            Arc::new(BTreeMap::deserialize_uncompressed_unchecked(&**NEG_POWERS_OF_BETA_H)?);
+        let negative_powers_of_beta_h: BTreeMap<usize, E::G2Affine> =
+            BTreeMap::deserialize_uncompressed_unchecked(&**NEG_POWERS_OF_BETA_H)?;
 
         // Compute the prepared negative powers of beta_h.
         let prepared_negative_powers_of_beta_h: Arc<BTreeMap<usize, <E::G2Affine as PairingCurve>::Prepared>> =
@@ -105,13 +105,13 @@ impl<E: PairingEngine> PowersOfG<E> {
     }
 
     /// Download the powers of beta G specified by `range`.
-    pub fn download_powers_for(&mut self, range: Range<usize>) -> Result<()> {
-        self.powers_of_beta_g.download_powers_for(&range)
+    pub fn download_powers_for(&self, range: Range<usize>) -> Result<()> {
+        self.powers_of_beta_g.write().download_powers_for(&range)
     }
 
     /// Returns the number of contiguous powers of beta G starting from the 0-th power.
     pub fn num_powers(&self) -> usize {
-        self.powers_of_beta_g.num_powers()
+        self.powers_of_beta_g.read().num_powers()
     }
 
     /// Returns the maximum possible number of contiguous powers of beta G starting from the 0-th power.
@@ -120,22 +120,22 @@ impl<E: PairingEngine> PowersOfG<E> {
     }
 
     /// Returns the powers of beta * gamma G.
-    pub fn powers_of_beta_gamma_g(&self) -> Arc<BTreeMap<usize, E::G1Affine>> {
-        self.powers_of_beta_times_gamma_g.clone()
+    pub fn powers_of_beta_gamma_g(&self) -> &BTreeMap<usize, E::G1Affine> {
+        &self.powers_of_beta_times_gamma_g
     }
 
     /// Returns the `index`-th power of beta * G.
-    pub fn power_of_beta_g(&mut self, index: usize) -> Result<E::G1Affine> {
-        self.powers_of_beta_g.power(index)
+    pub fn power_of_beta_g(&self, index: usize) -> Result<E::G1Affine> {
+        self.powers_of_beta_g.write().power(index)
     }
 
     /// Returns the powers of `beta * G` that lie within `range`.
-    pub fn powers_of_beta_g(&mut self, range: Range<usize>) -> Result<&[E::G1Affine]> {
-        self.powers_of_beta_g.powers(range)
+    pub fn powers_of_beta_g(&self, range: Range<usize>) -> Result<Vec<E::G1Affine>> {
+        Ok(self.powers_of_beta_g.write().powers(range)?.to_vec())
     }
 
-    pub fn negative_powers_of_beta_h(&self) -> Arc<BTreeMap<usize, E::G2Affine>> {
-        self.negative_powers_of_beta_h.clone()
+    pub fn negative_powers_of_beta_h(&self) -> &BTreeMap<usize, E::G2Affine> {
+        &self.negative_powers_of_beta_h
     }
 
     pub fn prepared_negative_powers_of_beta_h(&self) -> Arc<BTreeMap<usize, <E::G2Affine as PairingCurve>::Prepared>> {
@@ -149,7 +149,7 @@ impl<E: PairingEngine> PowersOfG<E> {
 
 impl<E: PairingEngine> CanonicalSerialize for PowersOfG<E> {
     fn serialize_with_mode<W: Write>(&self, mut writer: W, mode: Compress) -> Result<(), SerializationError> {
-        self.powers_of_beta_g.serialize_with_mode(&mut writer, mode)?;
+        self.powers_of_beta_g.read().serialize_with_mode(&mut writer, mode)?;
         self.powers_of_beta_times_gamma_g.serialize_with_mode(&mut writer, mode)?;
         self.negative_powers_of_beta_h.serialize_with_mode(&mut writer, mode)?;
         self.beta_h.serialize_with_mode(&mut writer, mode)?;
@@ -157,7 +157,7 @@ impl<E: PairingEngine> CanonicalSerialize for PowersOfG<E> {
     }
 
     fn serialized_size(&self, mode: Compress) -> usize {
-        self.powers_of_beta_g.serialized_size(mode)
+        self.powers_of_beta_g.read().serialized_size(mode)
             + self.powers_of_beta_times_gamma_g.serialized_size(mode)
             + self.negative_powers_of_beta_h.serialized_size(mode)
             + self.beta_h.serialized_size(mode)
@@ -170,15 +170,14 @@ impl<E: PairingEngine> CanonicalDeserialize for PowersOfG<E> {
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, SerializationError> {
-        let powers_of_beta_g = PowersOfBetaG::deserialize_with_mode(&mut reader, compress, Validate::No)?;
+        let powers_of_beta_g = RwLock::new(PowersOfBetaG::deserialize_with_mode(&mut reader, compress, Validate::No)?);
 
         // Reconstruct powers of beta_times_gamma_g.
-        let powers_of_beta_times_gamma_g =
-            Arc::new(BTreeMap::deserialize_with_mode(&mut reader, compress, Validate::No)?);
+        let powers_of_beta_times_gamma_g = BTreeMap::deserialize_with_mode(&mut reader, compress, Validate::No)?;
 
         // Reconstruct negative powers of beta_h.
-        let negative_powers_of_beta_h: Arc<BTreeMap<usize, E::G2Affine>> =
-            Arc::new(BTreeMap::deserialize_with_mode(&mut reader, compress, Validate::No)?);
+        let negative_powers_of_beta_h: BTreeMap<usize, E::G2Affine> =
+            BTreeMap::deserialize_with_mode(&mut reader, compress, Validate::No)?;
 
         // Compute the prepared negative powers of beta_h.
         let prepared_negative_powers_of_beta_h: Arc<BTreeMap<usize, <E::G2Affine as PairingCurve>::Prepared>> =
@@ -202,7 +201,7 @@ impl<E: PairingEngine> CanonicalDeserialize for PowersOfG<E> {
 
 impl<E: PairingEngine> Valid for PowersOfG<E> {
     fn check(&self) -> Result<(), SerializationError> {
-        self.powers_of_beta_g.check()?;
+        self.powers_of_beta_g.read().check()?;
         self.powers_of_beta_times_gamma_g.check()?;
         self.negative_powers_of_beta_h.check()?;
         self.prepared_negative_powers_of_beta_h.check()?;


### PR DESCRIPTION
This PR contains 2 changes:
1. it adjusts the locking and `Arc`ing around `PowersOfG` so that the lock only applies to the actually mutable bits, and the `Arc`s to the objects that get cloned
2. there was a pre-allocation that was not actually utilized, which is now fixed