### PR TITLE
Circuit-related tweaks

### DIFF
--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -18,13 +18,12 @@ use core::{
     cell::{Cell, RefCell},
     fmt,
 };
-use std::rc::Rc;
 
 type Field = <console::Testnet3 as console::Environment>::Field;
 
 thread_local! {
-    pub(super) static CIRCUIT: Rc<RefCell<R1CS<Field>>> = Rc::new(RefCell::new(R1CS::new()));
-    pub(super) static IN_WITNESS: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+    pub(super) static CIRCUIT: RefCell<R1CS<Field>> = RefCell::new(R1CS::new());
+    pub(super) static IN_WITNESS: Cell<bool> = Cell::new(false);
     pub(super) static ZERO: LinearCombination<Field> = LinearCombination::zero();
     pub(super) static ONE: LinearCombination<Field> = LinearCombination::one();
 }
@@ -52,11 +51,11 @@ impl Environment for Circuit {
     fn new_variable(mode: Mode, value: Self::BaseField) -> Variable<Self::BaseField> {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
-            if !(**in_witness).get() {
+            if !(*in_witness).get() {
                 CIRCUIT.with(|circuit| match mode {
-                    Mode::Constant => (**circuit).borrow_mut().new_constant(value),
-                    Mode::Public => (**circuit).borrow_mut().new_public(value),
-                    Mode::Private => (**circuit).borrow_mut().new_private(value),
+                    Mode::Constant => (*circuit).borrow_mut().new_constant(value),
+                    Mode::Public => (*circuit).borrow_mut().new_public(value),
+                    Mode::Private => (*circuit).borrow_mut().new_private(value),
                 })
             } else {
                 Self::halt("Tried to initialize a new variable in witness mode")
@@ -111,11 +110,11 @@ impl Environment for Circuit {
     {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
-            if !(**in_witness).get() {
+            if !(*in_witness).get() {
                 CIRCUIT.with(|circuit| {
                     // Set the entire environment to the new scope.
                     let name = name.into();
-                    if let Err(error) = (**circuit).borrow_mut().push_scope(&name) {
+                    if let Err(error) = (*circuit).borrow_mut().push_scope(&name) {
                         Self::halt(error)
                     }
 
@@ -123,7 +122,7 @@ impl Environment for Circuit {
                     let output = logic();
 
                     // Return the entire environment to the previous scope.
-                    if let Err(error) = (**circuit).borrow_mut().pop_scope(name) {
+                    if let Err(error) = (*circuit).borrow_mut().pop_scope(name) {
                         Self::halt(error)
                     }
 
@@ -145,7 +144,7 @@ impl Environment for Circuit {
     {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
-            if !(**in_witness).get() {
+            if !(*in_witness).get() {
                 CIRCUIT.with(|circuit| {
                     let (a, b, c) = constraint();
                     let (a, b, c) = (a.into(), b.into(), c.into());
@@ -170,9 +169,9 @@ impl Environment for Circuit {
                         }
                         false => {
                             // Construct the constraint object.
-                            let constraint = Constraint((**circuit).borrow().scope(), a, b, c);
+                            let constraint = Constraint((*circuit).borrow().scope(), a, b, c);
                             // Append the constraint.
-                            (**circuit).borrow_mut().enforce(constraint)
+                            (*circuit).borrow_mut().enforce(constraint)
                         }
                     }
                 });
@@ -184,62 +183,62 @@ impl Environment for Circuit {
 
     /// Returns `true` if all constraints in the environment are satisfied.
     fn is_satisfied() -> bool {
-        CIRCUIT.with(|circuit| (**circuit).borrow().is_satisfied())
+        CIRCUIT.with(|circuit| (*circuit).borrow().is_satisfied())
     }
 
     /// Returns `true` if all constraints in the current scope are satisfied.
     fn is_satisfied_in_scope() -> bool {
-        CIRCUIT.with(|circuit| (**circuit).borrow().is_satisfied_in_scope())
+        CIRCUIT.with(|circuit| (*circuit).borrow().is_satisfied_in_scope())
     }
 
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_constants())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_constants())
     }
 
     /// Returns the number of public variables in the entire circuit.
     fn num_public() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_public())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_public())
     }
 
     /// Returns the number of private variables in the entire circuit.
     fn num_private() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_private())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_private())
     }
 
     /// Returns the number of constraints in the entire circuit.
     fn num_constraints() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_constraints())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_constraints())
     }
 
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_nonzeros())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_nonzeros())
     }
 
     /// Returns the number of constants for the current scope.
     fn num_constants_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_constants_in_scope())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_constants_in_scope())
     }
 
     /// Returns the number of public variables for the current scope.
     fn num_public_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_public_in_scope())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_public_in_scope())
     }
 
     /// Returns the number of private variables for the current scope.
     fn num_private_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_private_in_scope())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_private_in_scope())
     }
 
     /// Returns the number of constraints for the current scope.
     fn num_constraints_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_constraints_in_scope())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_constraints_in_scope())
     }
 
     /// Returns the number of nonzeros for the current scope.
     fn num_nonzeros_in_scope() -> (u64, u64, u64) {
-        CIRCUIT.with(|circuit| (**circuit).borrow().num_nonzeros_in_scope())
+        CIRCUIT.with(|circuit| (*circuit).borrow().num_nonzeros_in_scope())
     }
 
     /// Halts the program from further synthesis, evaluation, and execution in the current environment.
@@ -255,10 +254,10 @@ impl Environment for Circuit {
     fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
         CIRCUIT.with(|circuit| {
             // Ensure the circuit is empty before injecting.
-            assert_eq!(0, (**circuit).borrow().num_constants());
-            assert_eq!(1, (**circuit).borrow().num_public());
-            assert_eq!(0, (**circuit).borrow().num_private());
-            assert_eq!(0, (**circuit).borrow().num_constraints());
+            assert_eq!(0, (*circuit).borrow().num_constants());
+            assert_eq!(1, (*circuit).borrow().num_public());
+            assert_eq!(0, (*circuit).borrow().num_private());
+            assert_eq!(0, (*circuit).borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
             // Ensure the circuit that was replaced is empty.
@@ -279,10 +278,10 @@ impl Environment for Circuit {
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
             // Ensure the circuit is now empty.
-            assert_eq!(0, (**circuit).borrow().num_constants());
-            assert_eq!(1, (**circuit).borrow().num_public());
-            assert_eq!(0, (**circuit).borrow().num_private());
-            assert_eq!(0, (**circuit).borrow().num_constraints());
+            assert_eq!(0, (*circuit).borrow().num_constants());
+            assert_eq!(1, (*circuit).borrow().num_public());
+            assert_eq!(0, (*circuit).borrow().num_private());
+            assert_eq!(0, (*circuit).borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
         })
@@ -297,10 +296,10 @@ impl Environment for Circuit {
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
-            assert_eq!(0, (**circuit).borrow().num_constants());
-            assert_eq!(1, (**circuit).borrow().num_public());
-            assert_eq!(0, (**circuit).borrow().num_private());
-            assert_eq!(0, (**circuit).borrow().num_constraints());
+            assert_eq!(0, (*circuit).borrow().num_constants());
+            assert_eq!(1, (*circuit).borrow().num_public());
+            assert_eq!(0, (*circuit).borrow().num_private());
+            assert_eq!(0, (*circuit).borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
         })
@@ -311,18 +310,18 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
-            *(**circuit).borrow_mut() = R1CS::<<Self as Environment>::BaseField>::new();
-            assert_eq!(0, (**circuit).borrow().num_constants());
-            assert_eq!(1, (**circuit).borrow().num_public());
-            assert_eq!(0, (**circuit).borrow().num_private());
-            assert_eq!(0, (**circuit).borrow().num_constraints());
+            *(*circuit).borrow_mut() = R1CS::<<Self as Environment>::BaseField>::new();
+            assert_eq!(0, (*circuit).borrow().num_constants());
+            assert_eq!(1, (*circuit).borrow().num_public());
+            assert_eq!(0, (*circuit).borrow().num_private());
+            assert_eq!(0, (*circuit).borrow().num_constraints());
         });
     }
 }
 
 impl fmt::Display for Circuit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        CIRCUIT.with(|circuit| write!(f, "{}", (**circuit).borrow()))
+        CIRCUIT.with(|circuit| write!(f, "{}", (*circuit).borrow()))
     }
 }
 

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -53,9 +53,9 @@ impl Environment for Circuit {
             // Ensure we are not in witness mode.
             if !in_witness.get() {
                 CIRCUIT.with(|circuit| match mode {
-                    Mode::Constant => (*circuit).borrow_mut().new_constant(value),
-                    Mode::Public => (*circuit).borrow_mut().new_public(value),
-                    Mode::Private => (*circuit).borrow_mut().new_private(value),
+                    Mode::Constant => circuit.borrow_mut().new_constant(value),
+                    Mode::Public => circuit.borrow_mut().new_public(value),
+                    Mode::Private => circuit.borrow_mut().new_private(value),
                 })
             } else {
                 Self::halt("Tried to initialize a new variable in witness mode")
@@ -114,7 +114,7 @@ impl Environment for Circuit {
                 CIRCUIT.with(|circuit| {
                     // Set the entire environment to the new scope.
                     let name = name.into();
-                    if let Err(error) = (*circuit).borrow_mut().push_scope(&name) {
+                    if let Err(error) = circuit.borrow_mut().push_scope(&name) {
                         Self::halt(error)
                     }
 
@@ -122,7 +122,7 @@ impl Environment for Circuit {
                     let output = logic();
 
                     // Return the entire environment to the previous scope.
-                    if let Err(error) = (*circuit).borrow_mut().pop_scope(name) {
+                    if let Err(error) = circuit.borrow_mut().pop_scope(name) {
                         Self::halt(error)
                     }
 
@@ -169,9 +169,9 @@ impl Environment for Circuit {
                         }
                         false => {
                             // Construct the constraint object.
-                            let constraint = Constraint((*circuit).borrow().scope(), a, b, c);
+                            let constraint = Constraint(circuit.borrow().scope(), a, b, c);
                             // Append the constraint.
-                            (*circuit).borrow_mut().enforce(constraint)
+                            circuit.borrow_mut().enforce(constraint)
                         }
                     }
                 });
@@ -183,62 +183,62 @@ impl Environment for Circuit {
 
     /// Returns `true` if all constraints in the environment are satisfied.
     fn is_satisfied() -> bool {
-        CIRCUIT.with(|circuit| (*circuit).borrow().is_satisfied())
+        CIRCUIT.with(|circuit| circuit.borrow().is_satisfied())
     }
 
     /// Returns `true` if all constraints in the current scope are satisfied.
     fn is_satisfied_in_scope() -> bool {
-        CIRCUIT.with(|circuit| (*circuit).borrow().is_satisfied_in_scope())
+        CIRCUIT.with(|circuit| circuit.borrow().is_satisfied_in_scope())
     }
 
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_constants())
+        CIRCUIT.with(|circuit| circuit.borrow().num_constants())
     }
 
     /// Returns the number of public variables in the entire circuit.
     fn num_public() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_public())
+        CIRCUIT.with(|circuit| circuit.borrow().num_public())
     }
 
     /// Returns the number of private variables in the entire circuit.
     fn num_private() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_private())
+        CIRCUIT.with(|circuit| circuit.borrow().num_private())
     }
 
     /// Returns the number of constraints in the entire circuit.
     fn num_constraints() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_constraints())
+        CIRCUIT.with(|circuit| circuit.borrow().num_constraints())
     }
 
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_nonzeros())
+        CIRCUIT.with(|circuit| circuit.borrow().num_nonzeros())
     }
 
     /// Returns the number of constants for the current scope.
     fn num_constants_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_constants_in_scope())
+        CIRCUIT.with(|circuit| circuit.borrow().num_constants_in_scope())
     }
 
     /// Returns the number of public variables for the current scope.
     fn num_public_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_public_in_scope())
+        CIRCUIT.with(|circuit| circuit.borrow().num_public_in_scope())
     }
 
     /// Returns the number of private variables for the current scope.
     fn num_private_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_private_in_scope())
+        CIRCUIT.with(|circuit| circuit.borrow().num_private_in_scope())
     }
 
     /// Returns the number of constraints for the current scope.
     fn num_constraints_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_constraints_in_scope())
+        CIRCUIT.with(|circuit| circuit.borrow().num_constraints_in_scope())
     }
 
     /// Returns the number of nonzeros for the current scope.
     fn num_nonzeros_in_scope() -> (u64, u64, u64) {
-        CIRCUIT.with(|circuit| (*circuit).borrow().num_nonzeros_in_scope())
+        CIRCUIT.with(|circuit| circuit.borrow().num_nonzeros_in_scope())
     }
 
     /// Halts the program from further synthesis, evaluation, and execution in the current environment.
@@ -254,10 +254,10 @@ impl Environment for Circuit {
     fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
         CIRCUIT.with(|circuit| {
             // Ensure the circuit is empty before injecting.
-            assert_eq!(0, (*circuit).borrow().num_constants());
-            assert_eq!(1, (*circuit).borrow().num_public());
-            assert_eq!(0, (*circuit).borrow().num_private());
-            assert_eq!(0, (*circuit).borrow().num_constraints());
+            assert_eq!(0, circuit.borrow().num_constants());
+            assert_eq!(1, circuit.borrow().num_public());
+            assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
             // Ensure the circuit that was replaced is empty.
@@ -278,10 +278,10 @@ impl Environment for Circuit {
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
             // Ensure the circuit is now empty.
-            assert_eq!(0, (*circuit).borrow().num_constants());
-            assert_eq!(1, (*circuit).borrow().num_public());
-            assert_eq!(0, (*circuit).borrow().num_private());
-            assert_eq!(0, (*circuit).borrow().num_constraints());
+            assert_eq!(0, circuit.borrow().num_constants());
+            assert_eq!(1, circuit.borrow().num_public());
+            assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
         })
@@ -296,10 +296,10 @@ impl Environment for Circuit {
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
-            assert_eq!(0, (*circuit).borrow().num_constants());
-            assert_eq!(1, (*circuit).borrow().num_public());
-            assert_eq!(0, (*circuit).borrow().num_private());
-            assert_eq!(0, (*circuit).borrow().num_constraints());
+            assert_eq!(0, circuit.borrow().num_constants());
+            assert_eq!(1, circuit.borrow().num_public());
+            assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
         })
@@ -310,18 +310,18 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
-            *(*circuit).borrow_mut() = R1CS::<<Self as Environment>::BaseField>::new();
-            assert_eq!(0, (*circuit).borrow().num_constants());
-            assert_eq!(1, (*circuit).borrow().num_public());
-            assert_eq!(0, (*circuit).borrow().num_private());
-            assert_eq!(0, (*circuit).borrow().num_constraints());
+            *circuit.borrow_mut() = R1CS::<<Self as Environment>::BaseField>::new();
+            assert_eq!(0, circuit.borrow().num_constants());
+            assert_eq!(1, circuit.borrow().num_public());
+            assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_constraints());
         });
     }
 }
 
 impl fmt::Display for Circuit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        CIRCUIT.with(|circuit| write!(f, "{}", (*circuit).borrow()))
+        CIRCUIT.with(|circuit| write!(f, "{}", circuit.borrow()))
     }
 }
 

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -51,7 +51,7 @@ impl Environment for Circuit {
     fn new_variable(mode: Mode, value: Self::BaseField) -> Variable<Self::BaseField> {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
-            if !(*in_witness).get() {
+            if !in_witness.get() {
                 CIRCUIT.with(|circuit| match mode {
                     Mode::Constant => (*circuit).borrow_mut().new_constant(value),
                     Mode::Public => (*circuit).borrow_mut().new_public(value),
@@ -110,7 +110,7 @@ impl Environment for Circuit {
     {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
-            if !(*in_witness).get() {
+            if !in_witness.get() {
                 CIRCUIT.with(|circuit| {
                     // Set the entire environment to the new scope.
                     let name = name.into();
@@ -144,7 +144,7 @@ impl Environment for Circuit {
     {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
-            if !(*in_witness).get() {
+            if !in_witness.get() {
                 CIRCUIT.with(|circuit| {
                     let (a, b, c) = constraint();
                     let (a, b, c) = (a.into(), b.into(), c.into());

--- a/circuit/environment/src/helpers/converter.rs
+++ b/circuit/environment/src/helpers/converter.rs
@@ -30,7 +30,7 @@ impl snarkvm_algorithms::r1cs::ConstraintSynthesizer<Fq> for Circuit {
         &self,
         cs: &mut CS,
     ) -> Result<(), snarkvm_algorithms::r1cs::SynthesisError> {
-        crate::circuit::CIRCUIT.with(|circuit| (*(**circuit).borrow()).generate_constraints(cs))
+        crate::circuit::CIRCUIT.with(|circuit| (*(*circuit).borrow()).generate_constraints(cs))
     }
 }
 

--- a/circuit/environment/src/helpers/converter.rs
+++ b/circuit/environment/src/helpers/converter.rs
@@ -30,7 +30,7 @@ impl snarkvm_algorithms::r1cs::ConstraintSynthesizer<Fq> for Circuit {
         &self,
         cs: &mut CS,
     ) -> Result<(), snarkvm_algorithms::r1cs::SynthesisError> {
-        crate::circuit::CIRCUIT.with(|circuit| (*(*circuit).borrow()).generate_constraints(cs))
+        crate::circuit::CIRCUIT.with(|circuit| circuit.borrow().generate_constraints(cs))
     }
 }
 


### PR DESCRIPTION
While this should technically be a tiny performance improvement, it's mostly a win for readability. These changes also make it clear that the intention is for `R1CS` to not be cloned around.