### PR TITLE
[Fix] Add `signature` to reserved keywords.

### DIFF
--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -575,6 +575,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         "u64",
         "u128",
         "scalar",
+        "signature",
         "string",
         // Boolean
         "true",


### PR DESCRIPTION
^
