### PR TITLE
Reduce max RAM when verifying deployment transactions

### DIFF
--- a/algorithms/src/fft/polynomial/multiplier.rs
+++ b/algorithms/src/fft/polynomial/multiplier.rs
@@ -105,7 +105,7 @@ impl<'a, F: PrimeField> PolyMultiplier<'a, F> {
                 let mut pool = ExecutionPool::with_capacity(self.polynomials.len() + self.evaluations.len());
                 for (_, p) in self.polynomials {
                     pool.add_job(move || {
-                        let mut p = p.clone().into_owned().coeffs;
+                        let mut p = p.into_owned().coeffs;
                         p.resize(domain.size(), F::zero());
                         domain.out_order_fft_in_place_with_pc(&mut p, fft_pc);
                         p
@@ -113,7 +113,7 @@ impl<'a, F: PrimeField> PolyMultiplier<'a, F> {
                 }
                 for (_, e) in self.evaluations {
                     pool.add_job(move || {
-                        let mut e = e.clone().into_owned().evaluations;
+                        let mut e = e.into_owned().evaluations;
                         e.resize(domain.size(), F::zero());
                         crate::fft::domain::derange(&mut e);
                         e

--- a/algorithms/src/snark/varuna/ahp/indexer/constraint_system.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/constraint_system.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    r1cs::{errors::SynthesisError, ConstraintSystem as CS, Index as VarIndex, LinearCombination, Variable},
-    snark::varuna::ahp::matrices::to_matrix_helper,
-};
+use crate::r1cs::{errors::SynthesisError, ConstraintSystem as CS, Index as VarIndex, LinearCombination, Variable};
 use snarkvm_fields::Field;
 use snarkvm_utilities::serialize::*;
 
@@ -42,24 +39,6 @@ impl<F: Field> ConstraintSystem<F> {
             num_private_variables: 0,
             num_constraints: 0,
         }
-    }
-
-    #[inline]
-    /// Returns the sparse A matrix as Vec of rows, where each row is a Vec of assigned value and variable index
-    pub(crate) fn a_matrix(&self) -> Result<Vec<Vec<(F, usize)>>> {
-        to_matrix_helper(&self.a, self.num_public_variables)
-    }
-
-    #[inline]
-    /// Returns the sparse B matrix as Vec of rows, where each row is a Vec of assigned value and variable index
-    pub(crate) fn b_matrix(&self) -> Result<Vec<Vec<(F, usize)>>> {
-        to_matrix_helper(&self.b, self.num_public_variables)
-    }
-
-    #[inline]
-    /// Returns the sparse C matrix as Vec of rows, where each row is a Vec of assigned value and variable index
-    pub(crate) fn c_matrix(&self) -> Result<Vec<Vec<(F, usize)>>> {
-        to_matrix_helper(&self.c, self.num_public_variables)
     }
 
     #[inline]

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -15,13 +15,13 @@
 use crate::{
     fft::EvaluationDomain,
     polycommit::sonic_pc::{LinearCombination, PolynomialInfo, PolynomialLabel},
-    r1cs::{errors::SynthesisError, ConstraintSynthesizer, ConstraintSystem},
+    r1cs::{errors::SynthesisError, ConstraintSynthesizer},
     snark::varuna::{
         ahp::{
             indexer::{Circuit, CircuitId, CircuitInfo, ConstraintSystem as IndexerConstraintSystem},
             AHPForR1CS,
         },
-        matrices::{matrix_evals, MatrixEvals},
+        matrices::{into_matrix_helper, matrix_evals, MatrixEvals},
         num_non_zero,
         SNARKMode,
     },
@@ -140,15 +140,15 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 
         crate::snark::varuna::ahp::matrices::pad_input_for_indexer_and_prover(&mut ics)?;
 
-        let a = ics.a_matrix()?;
-        let b = ics.b_matrix()?;
-        let c = ics.c_matrix()?;
+        let IndexerConstraintSystem { a, b, c, num_public_variables, num_private_variables, num_constraints } = ics;
+
+        let a = into_matrix_helper(a, num_public_variables)?;
+        let b = into_matrix_helper(b, num_public_variables)?;
+        let c = into_matrix_helper(c, num_public_variables)?;
 
         end_timer!(padding_time);
 
-        let num_padded_public_variables = ics.num_public_variables();
-        let num_private_variables = ics.num_private_variables();
-        let num_constraints = ics.num_constraints();
+        let num_padded_public_variables = num_public_variables;
         let num_non_zero_a = num_non_zero(&a);
         let num_non_zero_b = num_non_zero(&b);
         let num_non_zero_c = num_non_zero(&c);

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 use snarkvm_fields::{Field, PrimeField};
-use snarkvm_utilities::{cfg_iter, cfg_iter_mut, serialize::*};
+use snarkvm_utilities::{cfg_into_iter, cfg_iter, cfg_iter_mut, serialize::*};
 
 use anyhow::{anyhow, ensure, Result};
 
@@ -35,23 +35,23 @@ use rayon::prelude::*;
 
 // This function converts a matrix output by Zexe's constraint infrastructure
 // to the one used in this crate.
-pub(crate) fn to_matrix_helper<F: Field>(
-    matrix: &[Vec<(F, VarIndex)>],
+pub(crate) fn into_matrix_helper<F: Field>(
+    matrix: Vec<Vec<(F, VarIndex)>>,
     num_input_variables: usize,
 ) -> Result<Matrix<F>> {
-    cfg_iter!(matrix)
+    cfg_into_iter!(matrix)
         .map(|row| {
             let mut row_map = Vec::with_capacity(row.len());
-            for (val, column) in row.iter() {
-                ensure!(*val != F::zero(), "matrix entries should be non-zero");
+            for (val, column) in row {
+                ensure!(val != F::zero(), "matrix entries should be non-zero");
                 let column = match column {
-                    VarIndex::Public(i) => *i,
+                    VarIndex::Public(i) => i,
                     VarIndex::Private(i) => num_input_variables + i,
                 };
                 match row_map.binary_search_by_key(&column, |(_, c)| *c) {
                     Ok(idx) => row_map[idx].0 += val,
                     Err(idx) => {
-                        row_map.insert(idx, (*val, column));
+                        row_map.insert(idx, (val, column));
                     }
                 }
             }

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -27,7 +27,6 @@ use snarkvm_fields::{Field, PrimeField};
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, serialize::*};
 
 use anyhow::{anyhow, ensure, Result};
-use std::collections::BTreeMap;
 
 #[cfg(feature = "serial")]
 use itertools::Itertools;
@@ -42,16 +41,21 @@ pub(crate) fn to_matrix_helper<F: Field>(
 ) -> Result<Matrix<F>> {
     cfg_iter!(matrix)
         .map(|row| {
-            let mut row_map = BTreeMap::new();
+            let mut row_map = Vec::with_capacity(row.len());
             for (val, column) in row.iter() {
                 ensure!(*val != F::zero(), "matrix entries should be non-zero");
                 let column = match column {
                     VarIndex::Public(i) => *i,
                     VarIndex::Private(i) => num_input_variables + i,
                 };
-                *row_map.entry(column).or_insert_with(F::zero) += *val;
+                match row_map.binary_search_by_key(&column, |(_, c)| *c) {
+                    Ok(idx) => row_map[idx].0 += val,
+                    Err(idx) => {
+                        row_map.insert(idx, (*val, column));
+                    }
+                }
             }
-            Ok(row_map.into_iter().map(|(column, coeff)| (coeff, column)).collect())
+            Ok(row_map)
         })
         .collect()
 }

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -16,6 +16,7 @@ use crate::Index;
 use snarkvm_fields::PrimeField;
 
 use indexmap::IndexMap;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum AssignmentVariable<F: PrimeField> {
@@ -84,9 +85,9 @@ impl<F: PrimeField> AssignmentLC<F> {
 /// and constraint assignments.
 #[derive(Clone, Debug)]
 pub struct Assignment<F: PrimeField> {
-    public: Vec<(Index, F)>,
-    private: Vec<(Index, F)>,
-    constraints: Vec<(AssignmentLC<F>, AssignmentLC<F>, AssignmentLC<F>)>,
+    public: Arc<[(Index, F)]>,
+    private: Arc<[(Index, F)]>,
+    constraints: Arc<[(AssignmentLC<F>, AssignmentLC<F>, AssignmentLC<F>)]>,
 }
 
 impl<F: PrimeField> From<crate::R1CS<F>> for Assignment<F> {
@@ -109,17 +110,17 @@ impl<F: PrimeField> From<crate::R1CS<F>> for Assignment<F> {
 
 impl<F: PrimeField> Assignment<F> {
     /// Returns the public inputs of the assignment.
-    pub const fn public_inputs(&self) -> &Vec<(Index, F)> {
+    pub const fn public_inputs(&self) -> &Arc<[(Index, F)]> {
         &self.public
     }
 
     /// Returns the private inputs of the assignment.
-    pub const fn private_inputs(&self) -> &Vec<(Index, F)> {
+    pub const fn private_inputs(&self) -> &Arc<[(Index, F)]> {
         &self.private
     }
 
     /// Returns the constraints of the assignment.
-    pub const fn constraints(&self) -> &Vec<(AssignmentLC<F>, AssignmentLC<F>, AssignmentLC<F>)> {
+    pub const fn constraints(&self) -> &Arc<[(AssignmentLC<F>, AssignmentLC<F>, AssignmentLC<F>)]> {
         &self.constraints
     }
 


### PR DESCRIPTION
Using a subset of the `sir_hashalot` program containing 4096 transitions and running up until (and including) verification, I get the following improvements with this PR:

baseline:
```
Verification took: 22.020414433s
number of allocations: 113,112,661
max RAM: 8.20 GiB
```

this PR:
```
Verification took: 21.518246351s
number of allocations: 101,757,273 (-10%)
max RAM: 6.60 GiB (-20%)
```

There is one issue, though; despite getting a consistent, small performance improvement when running the test program, I'm seeing a small (~4%) degradation in the `Transaction::Deploy - verify` benchmark, and I can't tie it to any of the commits belonging to this PR (with the only real potential candidate being https://github.com/AleoHQ/snarkVM/commit/0053471d84dffa91722a55c183e92aa23374c3dc). I'd appreciate if someone else could also give it a go to check if they observe it locally as well.