### PR TITLE
Add additional support for finding rejected and aborted transactions

### DIFF
--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -628,7 +628,11 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         match self.confirmed_transactions_map().get_confirmed(transaction_id)? {
             Some(Cow::Borrowed((block_hash, _, _))) => Ok(Some(*block_hash)),
             Some(Cow::Owned((block_hash, _, _))) => Ok(Some(block_hash)),
-            None => Ok(None),
+            None => match self.rejected_or_aborted_transaction_id_map().get_confirmed(transaction_id)? {
+                Some(Cow::Borrowed(block_hash)) => Ok(Some(*block_hash)),
+                Some(Cow::Owned(block_hash)) => Ok(Some(block_hash)),
+                None => Ok(None),
+            },
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the `get_transaction` function to search for aborted transactions and returns a more descriptive error. This will improve the messaging for the snarkOS endpoint `/testnet3/transaction/<tx_id>`.

In addition, the `find_block_hash` function will now be able to retrieve a block hash for `TransactionID`s that have been rejected or aborted, not just for those that have been confirmed.