### PR TITLE
Add test for double nested imports

### DIFF
--- a/vm/package/run.rs
+++ b/vm/package/run.rs
@@ -116,6 +116,30 @@ mod tests {
         std::fs::remove_dir_all(directory).unwrap();
     }
 
+    #[test]
+    fn test_run_with_nested_imports() {
+        // Samples a new package at a temporary directory.
+        let (directory, package) = crate::package::test_helpers::sample_nested_package();
+
+        // Ensure the build directory does *not* exist.
+        assert!(!package.build_directory().exists());
+        // Build the package.
+        package.build::<CurrentAleo>(None).unwrap();
+        // Ensure the build directory exists.
+        assert!(package.build_directory().exists());
+
+        // Initialize an RNG.
+        let rng = &mut TestRng::default();
+        // Sample the function inputs.
+        let (private_key, function_name, inputs) =
+            crate::package::test_helpers::sample_package_run(package.program_id());
+        // Run the program function.
+        let (_response, _metrics) = package.run::<CurrentAleo, _>(&private_key, function_name, &inputs, rng).unwrap();
+
+        // Proactively remove the temporary directory (to conserve space).
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
     /// Use `cargo test profiler --features timer` to run this test.
     #[ignore]
     #[test]


### PR DESCRIPTION
# Motivation
- SnarkVM  [v0.16.12](https://github.com/AleoHQ/snarkVM/releases/tag/v0.16.12) fails to run when dealing with programs that contain multiple layers of nesting.
- Although the issue has been resolved in the latest commit, this PR is intended to provide a concrete test case to prevent a similar break from happening in the future. 

# Test plan
- Test created that involves a grandparent program making an external call to a parent program which makes a nested call to a child program. 
- Original issue:
```
$ snarkvm run double_wrapper_mint aleo1q30lfyggefvzzxqaaclzrn3wd94q4u8zzy8jhhfrcqrf306ayvqsdvj7s4 1u32    

⚠️  Failed to execute instruction (call parent.aleo/wrapper_mint r0 r1 into r2;): Failed to evaluate instruction (call child.aleo/mint r0 r1 into r2;): Function 'wrapper_mint' is not defined.
```