### PR TITLE
Update `Subdag` equality check

### DIFF
--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -78,13 +78,21 @@ fn sanity_check_subdag_with_dfs<N: Network>(subdag: &BTreeMap<u64, IndexSet<Batc
     &commit == subdag
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct Subdag<N: Network> {
     /// The subdag of round certificates.
     subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>,
     /// The election certificate IDs.
     election_certificate_ids: IndexSet<Field<N>>,
 }
+
+impl<N: Network> PartialEq for Subdag<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.subdag == other.subdag
+    }
+}
+
+impl<N: Network> Eq for Subdag<N> {}
 
 impl<N: Network> Subdag<N> {
     /// Initializes a new subdag.

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -88,6 +88,7 @@ pub struct Subdag<N: Network> {
 
 impl<N: Network> PartialEq for Subdag<N> {
     fn eq(&self, other: &Self) -> bool {
+        // Note: We do not check equality on `election_certificate_ids` as it would cause `Block::eq` to trigger false-positives.
         self.subdag == other.subdag
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR implements PartialEq and Eq for `Subdag`. The new change enforces equality only on the subdag component, and skips the check for the `election_certificate_ids`.
