### PR TITLE
Add check that combiners.len() == sorted_evals.len()

### DIFF
--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -255,6 +255,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             lc.add(combiner, label.as_str());
             sum += eval * combiner;
         }
+        ensure!(combiners.next().is_none(), "Found more combiners than sorted_evals");
         Ok((lc, sum))
     }
 }


### PR DESCRIPTION
## Motivation

Closes https://github.com/AleoHQ/snarkVM/issues/2251
Because we length of the iterator is unknown, we can only check if it is empty after it has been used.
