### PR TITLE
Optimize the split into (un)verified solutions

### DIFF
--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -108,7 +108,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 }
 
 /// Splits candidate solutions into a collection of accepted ones and aborted ones.
-fn split_candidate_solutions<T, F>(
+pub fn split_candidate_solutions<T, F>(
     mut candidate_solutions: Vec<T>,
     max_solutions: usize,
     verification_fn: F,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -107,6 +107,61 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 }
 
+/// Splits candidate solutions into a collection of accepted ones and aborted ones.
+fn split_candidate_solutions<T, F>(
+    mut candidate_solutions: Vec<T>,
+    max_solutions: usize,
+    verification_fn: F,
+) -> (Vec<T>, Vec<T>)
+where
+    T: Sized + Send,
+    F: Fn(&T) -> bool + Send + Sync,
+{
+    // Separate the candidate solutions into valid and aborted solutions.
+    let mut valid_candidate_solutions = Vec::with_capacity(max_solutions);
+    let mut aborted_candidate_solutions = Vec::new();
+    // Reverse the candidate solutions in order to be able to chunk them more efficiently.
+    candidate_solutions.reverse();
+    // Verify the candidate solutions in chunks. This is done so that we can potentially
+    // perform these operations in parallel while keeping the end result deterministic.
+    let chunk_size = 16;
+    while !candidate_solutions.is_empty() {
+        // Check if the collection of valid solutions is full.
+        if valid_candidate_solutions.len() >= max_solutions {
+            // If that's the case, mark the rest of the candidates as aborted.
+            aborted_candidate_solutions.extend(candidate_solutions.into_iter().rev());
+            break;
+        }
+
+        // Split off a chunk of the candidate solutions.
+        let candidates_chunk = if candidate_solutions.len() > chunk_size {
+            candidate_solutions.split_off(candidate_solutions.len() - chunk_size)
+        } else {
+            std::mem::take(&mut candidate_solutions)
+        };
+
+        // Verify the solutions in the chunk.
+        let verification_results: Vec<_> = cfg_into_iter!(candidates_chunk)
+            .rev()
+            .map(|solution| {
+                let verified = verification_fn(&solution);
+                (solution, verified)
+            })
+            .collect();
+
+        // Process the results of the verification.
+        for (solution, is_valid) in verification_results.into_iter() {
+            if is_valid && valid_candidate_solutions.len() < max_solutions {
+                valid_candidate_solutions.push(solution);
+            } else {
+                aborted_candidate_solutions.push(solution);
+            }
+        }
+    }
+
+    (valid_candidate_solutions, aborted_candidate_solutions)
+}
+
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Constructs a block template for the next block in the ledger.
     #[allow(clippy::type_complexity)]
@@ -115,7 +170,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         previous_block: &Block<N>,
         subdag: Option<&Subdag<N>>,
         candidate_ratifications: Vec<Ratify<N>>,
-        mut candidate_solutions: Vec<ProverSolution<N>>,
+        candidate_solutions: Vec<ProverSolution<N>>,
         candidate_transactions: Vec<Transaction<N>>,
     ) -> Result<(Header<N>, Ratifications<N>, Option<CoinbaseSolution<N>>, Transactions<N>, Vec<N::TransactionID>)>
     {
@@ -129,48 +184,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 let latest_epoch_challenge = self.latest_epoch_challenge()?;
                 // TODO: For mainnet - Add `aborted_solution_ids` to the block.
                 // Separate the candidate solutions into valid and aborted solutions.
-                let mut valid_candidate_solutions = Vec::with_capacity(N::MAX_SOLUTIONS);
-                let mut aborted_candidate_solutions = Vec::new();
-                // Reverse the candidate solutions in order to be able to chunk them more efficiently.
-                candidate_solutions.reverse();
-                // Verify the candidate solutions in chunks. This is done so that we can potentially
-                // perform these operations in parallel while keeping the end result deterministic.
-                let chunk_size = 16;
-                while !candidate_solutions.is_empty() {
-                    // Check if the collection of valid solutions is full.
-                    if valid_candidate_solutions.len() >= N::MAX_SOLUTIONS {
-                        // If that's the case, mark the rest of the candidates as aborted.
-                        aborted_candidate_solutions.extend(candidate_solutions.into_iter().rev());
-                        break;
-                    }
-
-                    // Split off a chunk of the candidate solutions.
-                    let candidates_chunk = if candidate_solutions.len() > chunk_size {
-                        candidate_solutions.split_off(candidate_solutions.len() - chunk_size)
-                    } else {
-                        std::mem::take(&mut candidate_solutions)
-                    };
-                    // Verify the solutions in the chunk.
-                    let verification_results: Vec<_> = cfg_into_iter!(candidates_chunk)
-                        .rev()
-                        .map(|solution| {
-                            (
-                                solution,
-                                solution
-                                    .verify(coinbase_verifying_key, &latest_epoch_challenge, self.latest_proof_target())
-                                    .unwrap_or(false),
-                            )
-                        })
-                        .collect();
-                    // Process the results of the verification.
-                    for (solution, is_valid) in verification_results.into_iter() {
-                        if is_valid && valid_candidate_solutions.len() < N::MAX_SOLUTIONS {
-                            valid_candidate_solutions.push(solution);
-                        } else {
-                            aborted_candidate_solutions.push(solution);
-                        }
-                    }
-                }
+                let (valid_candidate_solutions, _aborted_candidate_solutions) =
+                    split_candidate_solutions(candidate_solutions, N::MAX_SOLUTIONS, |solution| {
+                        solution
+                            .verify(coinbase_verifying_key, &latest_epoch_challenge, self.latest_proof_target())
+                            .unwrap_or(false)
+                    });
 
                 // Check if there are any valid solutions.
                 match valid_candidate_solutions.is_empty() {

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{
+    advance::split_candidate_solutions,
     test_helpers::{CurrentLedger, CurrentNetwork},
     RecordsFilter,
 };
@@ -827,4 +828,21 @@ finalize foo2:
     assert_eq!(ledger.get_program(*program_1.id()).unwrap(), program_1);
     assert!(ledger.vm.transaction_store().contains_transaction_id(&deployment_1_id).unwrap());
     assert!(ledger.vm.block_store().contains_rejected_or_aborted_transaction_id(&deployment_2_id).unwrap());
+}
+
+#[test]
+fn test_split_candidate_solutions() {
+    let rng = &mut TestRng::default();
+
+    let max_solutions = CurrentNetwork::MAX_SOLUTIONS;
+
+    const ITERATIONS: usize = 1_000;
+
+    for _ in 0..ITERATIONS {
+        let num_candidates = rng.gen_range(0..max_solutions * 2);
+        let candidate_solutions: Vec<u8> = rng.sample_iter(Standard).take(num_candidates).collect();
+
+        let (_accepted, _aborted) =
+            split_candidate_solutions(candidate_solutions, max_solutions, |candidate| candidate % 2 == 0);
+    }
 }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/AleoHQ/snarkVM/pull/2250 that _limits_ the verification of further solutions once the protocol maximum is reached. In theory - since the solutions are being processed in parallel - this logic can still result in a few calls to `ProverSolution::verify` being performed beyond the `N::MAX_SOLUTIONS` limit, but since we can't known if the next candidate is valid in advance, we can't go around it. Nevertheless, this change should result in a tangible performance improvement whenever the number of candidate solutions is greater than `N::MAX_SOLUTIONS`.