### PR TITLE
Parallelize signature verification in `BatchCertification` constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,7 @@ version = "0.16.13"
 dependencies = [
  "bincode",
  "indexmap 2.0.2",
+ "rayon",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-narwhal-batch-certificate",

--- a/ledger/narwhal/batch-certificate/Cargo.toml
+++ b/ledger/narwhal/batch-certificate/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = [ ]
+default = [ "rayon" ]
 serial = [ "console/serial" ]
 wasm = [ "console/wasm" ]
 test-helpers = [ "narwhal-batch-header/test-helpers" ]
@@ -50,6 +50,7 @@ features = [ "serde" ]
 
 [dependencies.rayon]
 version = "1"
+optional = true
 
 [dependencies.serde_json]
 version = "1.0"

--- a/ledger/narwhal/batch-certificate/Cargo.toml
+++ b/ledger/narwhal/batch-certificate/Cargo.toml
@@ -50,7 +50,6 @@ features = [ "serde" ]
 
 [dependencies.rayon]
 version = "1"
-optional = true
 
 [dependencies.serde_json]
 version = "1.0"

--- a/ledger/narwhal/batch-certificate/Cargo.toml
+++ b/ledger/narwhal/batch-certificate/Cargo.toml
@@ -48,6 +48,10 @@ version = "=0.16.13"
 version = "2.0"
 features = [ "serde" ]
 
+[dependencies.rayon]
+version = "1"
+optional = true
+
 [dependencies.serde_json]
 version = "1.0"
 features = [ "preserve_order" ]

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -29,6 +29,7 @@ use narwhal_transmission_id::TransmissionID;
 
 use core::hash::{Hash, Hasher};
 use indexmap::{IndexMap, IndexSet};
+
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -29,6 +29,8 @@ use narwhal_transmission_id::TransmissionID;
 
 use core::hash::{Hash, Hasher};
 use indexmap::{IndexMap, IndexSet};
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
 
 #[derive(Clone)]
 pub enum BatchCertificate<N: Network> {
@@ -103,11 +105,12 @@ impl<N: Network> BatchCertificate<N> {
         ensure!(signatures.len() <= Self::MAX_SIGNATURES, "Invalid number of signatures");
 
         // Verify the signatures are valid.
-        for signature in &signatures {
+        cfg_iter!(signatures).try_for_each(|signature| {
             if !signature.verify(&signature.to_address(), &[batch_header.batch_id()]) {
                 bail!("Invalid batch certificate signature")
             }
-        }
+            Ok(())
+        })?;
         // Return the batch certificate.
         Self::from_unchecked(batch_header, signatures)
     }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR parallelizes the signature verification in the `BatchCertificate` constructor. This reduces the initialization time significantly for certificates with many signatures. 

Verifying 24 signatures:
 - Serial: 6ms
 - Parallel: <1ms
