### PR TITLE
Parallelize signature deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,7 @@ version = "0.16.13"
 dependencies = [
  "bincode",
  "indexmap 2.0.2",
+ "rayon",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-narwhal-batch-certificate",

--- a/console/account/src/compute_key/mod.rs
+++ b/console/account/src/compute_key/mod.rs
@@ -17,6 +17,7 @@ mod bytes;
 mod from_bits;
 mod serialize;
 mod size_in_bits;
+mod size_in_bytes;
 mod to_address;
 mod to_bits;
 mod to_fields;

--- a/console/account/src/compute_key/size_in_bytes.rs
+++ b/console/account/src/compute_key/size_in_bytes.rs
@@ -1,0 +1,23 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> SizeInBytes for ComputeKey<N> {
+    /// Returns the compute key size in bytes.
+    #[inline]
+    fn size_in_bytes() -> usize {
+        Group::<N>::size_in_bytes() + Group::<N>::size_in_bytes()
+    }
+}

--- a/console/account/src/signature/mod.rs
+++ b/console/account/src/signature/mod.rs
@@ -18,6 +18,7 @@ mod from_bits;
 mod parse;
 mod serialize;
 mod size_in_bits;
+mod size_in_bytes;
 mod to_bits;
 mod to_fields;
 mod verify;

--- a/console/account/src/signature/size_in_bytes.rs
+++ b/console/account/src/signature/size_in_bytes.rs
@@ -1,0 +1,23 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> SizeInBytes for Signature<N> {
+    /// Returns the signature size in bytes.
+    #[inline]
+    fn size_in_bytes() -> usize {
+        Scalar::<N>::size_in_bytes() + Scalar::<N>::size_in_bytes() + ComputeKey::<N>::size_in_bytes()
+    }
+}

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -30,6 +30,7 @@ pub mod prelude {
     pub use snarkvm_curves::{AffineCurve, MontgomeryParameters, ProjectiveCurve, TwistedEdwardsParameters};
     pub use snarkvm_fields::{Field as _, PrimeField as _, SquareRootField as _, Zero as _};
     pub use snarkvm_utilities::{
+        cfg_chunks,
         cfg_find,
         cfg_find_map,
         cfg_into_iter,

--- a/ledger/narwhal/batch-certificate/Cargo.toml
+++ b/ledger/narwhal/batch-certificate/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = [ ]
+default = [ "rayon" ]
 serial = [ "console/serial" ]
 wasm = [ "console/wasm" ]
 test-helpers = [ "narwhal-batch-header/test-helpers" ]
@@ -47,6 +47,10 @@ version = "=0.16.13"
 [dependencies.indexmap]
 version = "2.0"
 features = [ "serde" ]
+
+[dependencies.rayon]
+version = "1"
+optional = true
 
 [dependencies.serde_json]
 version = "1.0"

--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -62,14 +62,14 @@ impl<N: Network> FromBytes for BatchCertificate<N> {
                     Self::MAX_SIGNATURES
                 )));
             }
+            // Read the signature bytes.
+            let signature_size_in_bytes = (Signature::<N>::size_in_bits() + 7) / 8;
+            let mut signature_bytes = vec![0u8; num_signatures as usize * signature_size_in_bytes];
+            reader.read_exact(&mut signature_bytes)?;
             // Read the signatures.
-            let mut signatures = IndexSet::with_capacity(num_signatures as usize);
-            for _ in 0..num_signatures {
-                // Read the signature.
-                let signature = Signature::read_le(&mut reader)?;
-                // Insert the signature.
-                signatures.insert(signature);
-            }
+            let signatures = cfg_chunks!(signature_bytes, signature_size_in_bytes)
+                .map(Signature::read_le)
+                .collect::<Result<IndexSet<_>, _>>()?;
             // Return the batch certificate.
             Self::from(batch_header, signatures).map_err(error)
         } else {

--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -63,11 +63,10 @@ impl<N: Network> FromBytes for BatchCertificate<N> {
                 )));
             }
             // Read the signature bytes.
-            let signature_size_in_bytes = (Signature::<N>::size_in_bits() + 7) / 8;
-            let mut signature_bytes = vec![0u8; num_signatures as usize * signature_size_in_bytes];
+            let mut signature_bytes = vec![0u8; num_signatures as usize * Signature::<N>::size_in_bytes()];
             reader.read_exact(&mut signature_bytes)?;
             // Read the signatures.
-            let signatures = cfg_chunks!(signature_bytes, signature_size_in_bytes)
+            let signatures = cfg_chunks!(signature_bytes, Signature::<N>::size_in_bytes())
                 .map(Signature::read_le)
                 .collect::<Result<IndexSet<_>, _>>()?;
             // Return the batch certificate.

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -30,6 +30,9 @@ use narwhal_transmission_id::TransmissionID;
 use core::hash::{Hash, Hasher};
 use indexmap::{IndexMap, IndexSet};
 
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
+
 #[derive(Clone)]
 pub enum BatchCertificate<N: Network> {
     // TODO (howardwu): For mainnet - Delete V1 and switch everyone to V2 as the default.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR speeds up signature deserialization in the `BatchCertificate` by first reading the fixed number of bytes required for the signatures, then deserializes them in parallel. 
