### PR TITLE
Adds locks for speculate/finalize & on advancing to next block

### DIFF
--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -159,6 +159,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         Vec<(Transaction<N>, String)>,
         Vec<FinalizeOperation<N>>,
     )> {
+        // Acquire the atomic lock, which is needed to ensure this function is not called concurrently
+        // with other `atomic_finalize!` macro calls, which will cause a `bail!` to be triggered erroneously.
+        // Note: This lock must be held for the entire scope of the call to `atomic_finalize!`.
+        let _atomic_lock = self.atomic_lock.lock();
+
         let timer = timer!("VM::atomic_speculate");
 
         // Retrieve the number of transactions.
@@ -448,6 +453,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         solutions: Option<&CoinbaseSolution<N>>,
         transactions: &Transactions<N>,
     ) -> Result<Vec<FinalizeOperation<N>>> {
+        // Acquire the atomic lock, which is needed to ensure this function is not called concurrently
+        // with other `atomic_finalize!` macro calls, which will cause a `bail!` to be triggered erroneously.
+        // Note: This lock must be held for the entire scope of the call to `atomic_finalize!`.
+        let _atomic_lock = self.atomic_lock.lock();
+
         let timer = timer!("VM::atomic_finalize");
 
         // Perform the finalize operation on the preset finalize mode.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -72,8 +72,8 @@ pub struct VM<N: Network, C: ConsensusStorage<N>> {
     process: Arc<RwLock<Process<N>>>,
     /// The VM store.
     store: ConsensusStore<N, C>,
-    /// The lock for advancing blocks.
-    block_lock: Arc<Mutex<()>>,
+    /// The lock to guarantee atomicity over calls to speculate and finalize.
+    atomic_lock: Arc<Mutex<()>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
@@ -171,7 +171,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         }
 
         // Return the new VM.
-        Ok(Self { process: Arc::new(RwLock::new(process)), store, block_lock: Arc::new(Mutex::new(())) })
+        Ok(Self { process: Arc::new(RwLock::new(process)), store, atomic_lock: Arc::new(Mutex::new(())) })
     }
 
     /// Returns `true` if a program with the given program ID exists.
@@ -312,10 +312,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Adds the given block into the VM.
     #[inline]
     pub fn add_next_block(&self, block: &Block<N>) -> Result<()> {
-        // Acquire the block lock, which is needed to ensure this function is not called concurrently.
-        // Note: This lock must be held for the entire scope of this function.
-        let _block_lock = self.block_lock.lock();
-
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(
             block.round(),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds locks for speculate/finalize & on advancing to next block.

The primary fix here is because we run into:
```
Cannot start an atomic batch write operation while another one is already in progress.
```
This issue was caused by multiple calls to `speculate`, `check_speculate`, and `finalize` happening simultaneously, when they should have been triggering independently (not concurrently).