### PR TITLE
Feature-gate the test constraint system

### DIFF
--- a/algorithms/src/r1cs/mod.rs
+++ b/algorithms/src/r1cs/mod.rs
@@ -33,13 +33,19 @@ pub use linear_combination::*;
 mod namespace;
 pub use namespace::*;
 
+#[cfg(feature = "test")]
 mod optional_vec;
+#[cfg(feature = "test")]
 pub use optional_vec::*;
 
+#[cfg(feature = "test")]
 mod test_constraint_system;
+#[cfg(feature = "test")]
 pub use test_constraint_system::{Fr, TestConstraintSystem};
 
+#[cfg(feature = "test")]
 mod test_constraint_checker;
+#[cfg(feature = "test")]
 pub use test_constraint_checker::TestConstraintChecker;
 
 use snarkvm_utilities::serialize::*;

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -59,7 +59,7 @@ version = "1.18.0"
 
 [dev-dependencies.snarkvm-algorithms]
 path = "../../algorithms"
-features = [ "polycommit_full", "snark" ]
+features = [ "polycommit_full", "snark", "test" ]
 
 [dev-dependencies.snarkvm-circuit]
 path = "../../circuit"


### PR DESCRIPTION
This PR feature-gates 3 modules in `snarkvm-algorithms`, making them build only for tests.