### PR TITLE
[NCC-ADN] Prevent ignoring proving/verifying tasks #2

### DIFF
--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -314,9 +314,6 @@ impl<N: Network> Trace<N> {
             verifier_inputs.push((verifying_key, batch_inclusion_inputs));
         }
         // Verify the proof.
-        match VerifyingKey::verify_batch(locator, verifier_inputs, proof) {
-            Ok(()) => Ok(()),
-            Err(_) => bail!("Failed to verify proof"),
-        }
+        VerifyingKey::verify_batch(locator, verifier_inputs, proof).map_err(|e| anyhow!("Failed to verify proof - {e}"))
     }
 }

--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -315,8 +315,8 @@ impl<N: Network> Trace<N> {
         }
         // Verify the proof.
         match VerifyingKey::verify_batch(locator, verifier_inputs, proof) {
-            true => Ok(()),
-            false => bail!("Failed to verify proof"),
+            Ok(()) => Ok(()),
+            Err(_) => bail!("Failed to verify proof"),
         }
     }
 }

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -70,7 +70,7 @@ impl<N: Network> ProvingKey<N> {
             .iter()
             .map(|(proving_key, assignments)| (proving_key.deref(), assignments.as_slice()))
             .collect();
-        ensure!(instances.len() == num_expected_instances, "Found duplicate proving keys");
+        ensure!(instances.len() == num_expected_instances, "Incorrect number of proving keys for batch proof");
 
         // Retrieve the proving parameters.
         let universal_prover = N::varuna_universal_prover();

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -70,7 +70,7 @@ impl<N: Network> ProvingKey<N> {
             .iter()
             .map(|(proving_key, assignments)| (proving_key.deref(), assignments.as_slice()))
             .collect();
-        ensure!(instances.len() == num_expected_instances, "duplicate proving keys found");
+        ensure!(instances.len() == num_expected_instances, "Found duplicate proving keys");
 
         // Retrieve the proving parameters.
         let universal_prover = N::varuna_universal_prover();

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -65,10 +65,12 @@ impl<N: Network> ProvingKey<N> {
         let timer = std::time::Instant::now();
 
         // Prepare the instances.
+        let num_expected_instances = assignments.len();
         let instances: BTreeMap<_, _> = assignments
             .iter()
             .map(|(proving_key, assignments)| (proving_key.deref(), assignments.as_slice()))
             .collect();
+        ensure!(instances.len() == num_expected_instances, "duplicate proving keys found");
 
         // Retrieve the proving parameters.
         let universal_prover = N::varuna_universal_prover();

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -61,13 +61,19 @@ impl<N: Network> VerifyingKey<N> {
 
     /// Returns `true` if the batch proof is valid for the given public inputs.
     #[allow(clippy::type_complexity)]
-    pub fn verify_batch(locator: &str, inputs: Vec<(VerifyingKey<N>, Vec<Vec<N::Field>>)>, proof: &Proof<N>) -> bool {
+    pub fn verify_batch(
+        locator: &str,
+        inputs: Vec<(VerifyingKey<N>, Vec<Vec<N::Field>>)>,
+        proof: &Proof<N>,
+    ) -> Result<()> {
         #[cfg(feature = "aleo-cli")]
         let timer = std::time::Instant::now();
 
         // Convert the instances.
+        let num_expected_keys = inputs.len();
         let keys_to_inputs: BTreeMap<_, _> =
             inputs.iter().map(|(verifying_key, inputs)| (verifying_key.deref(), inputs.as_slice())).collect();
+        ensure!(keys_to_inputs.len() == num_expected_keys, "invalid number of keys for batch proof");
 
         // Retrieve the verification parameters.
         let universal_verifier = N::varuna_universal_verifier();
@@ -77,13 +83,16 @@ impl<N: Network> VerifyingKey<N> {
         match Varuna::<N>::verify_batch(universal_verifier, fiat_shamir, &keys_to_inputs, proof) {
             Ok(is_valid) => {
                 #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Verified '{locator}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
-                is_valid
+                println!(
+                    "{}",
+                    format!(" • Verified '{locator}': {is_valid} (in {} ms)", timer.elapsed().as_millis()).dimmed()
+                );
+                if is_valid { Ok(()) } else { bail!("batch proof is invalid") }
             }
             Err(error) => {
                 #[cfg(feature = "aleo-cli")]
                 println!("{}", format!(" • Verifier failed: {error}").dimmed());
-                false
+                bail!(error)
             }
         }
     }

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -73,7 +73,7 @@ impl<N: Network> VerifyingKey<N> {
         let num_expected_keys = inputs.len();
         let keys_to_inputs: BTreeMap<_, _> =
             inputs.iter().map(|(verifying_key, inputs)| (verifying_key.deref(), inputs.as_slice())).collect();
-        ensure!(keys_to_inputs.len() == num_expected_keys, "invalid number of keys for batch proof");
+        ensure!(keys_to_inputs.len() == num_expected_keys, "Incorrect number of verifying keys for batch proof");
 
         // Retrieve the verification parameters.
         let universal_verifier = N::varuna_universal_verifier();

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -87,7 +87,7 @@ impl<N: Network> VerifyingKey<N> {
                     "{}",
                     format!(" • Verified '{locator}': {is_valid} (in {} ms)", timer.elapsed().as_millis()).dimmed()
                 );
-                if is_valid { Ok(()) } else { bail!("batch proof is invalid") }
+                if is_valid { Ok(()) } else { bail!("'verify_batch' failed") }
             }
             Err(error) => {
                 #[cfg(feature = "aleo-cli")]


### PR DESCRIPTION
## Motivation

Cleanup based on NCC's finding, we should make sure that we don't silently ignore proving/verifying tasks.

## Test Plan

No new tests were added because the current codebase would not have triggered this issue anyway, it is defense in depth.

## Related PRs

Successor to: https://github.com/AleoHQ/snarkVM/pull/2032 which had a bunch of unrelated and unclear changes.