### PR TITLE
perf: optimize console field and scalar from_bits_le

### DIFF
--- a/console/types/field/src/from_bits.rs
+++ b/console/types/field/src/from_bits.rs
@@ -47,7 +47,7 @@ impl<E: Environment> FromBits for Field<E> {
         } else {
             // Construct the sanitized list of bits padded with `false`
             let mut sanitized_bits = vec![false; size_in_bits];
-            // this is safe, because we just checked that the length of bits isn't bigger
+            // Note: This is safe, because we just checked that the length of bits isn't bigger
             // than `size_in_data_bits` which is equal to `size_in_bits - 1`.
             sanitized_bits[..num_bits].copy_from_slice(bits_le);
 

--- a/console/types/field/src/from_bits.rs
+++ b/console/types/field/src/from_bits.rs
@@ -45,12 +45,14 @@ impl<E: Environment> FromBits for Field<E> {
             // Return the field.
             Ok(Field { field: E::Field::from_bigint(field).ok_or_else(|| anyhow!("Invalid field from bits"))? })
         } else {
-            // Construct the sanitized list of bits, resizing up if necessary.
-            let mut bits_le = bits_le.iter().take(size_in_bits).cloned().collect::<Vec<_>>();
-            bits_le.resize(size_in_bits, false);
+            // Construct the sanitized list of bits padded with `false`
+            let mut sanitized_bits = vec![false; size_in_bits];
+            // this is safe, because we just checked that the length of bits isn't bigger
+            // than `size_in_data_bits` which is equal to `size_in_bits - 1`.
+            sanitized_bits[..num_bits].copy_from_slice(bits_le);
 
             // Recover the native field.
-            let field = E::Field::from_bigint(E::BigInteger::from_bits_le(&bits_le)?)
+            let field = E::Field::from_bigint(E::BigInteger::from_bits_le(&sanitized_bits)?)
                 .ok_or_else(|| anyhow!("Invalid field from bits"))?;
 
             // Return the field.

--- a/console/types/scalar/src/from_bits.rs
+++ b/console/types/scalar/src/from_bits.rs
@@ -50,7 +50,7 @@ impl<E: Environment> FromBits for Scalar<E> {
         } else {
             // Construct the sanitized list of bits padded with `false`
             let mut sanitized_bits = vec![false; size_in_bits];
-            // this is safe, because we just checked that the length of bits isn't bigger
+            // Note: This is safe, because we just checked that the length of bits isn't bigger
             // than `size_in_data_bits` which is equal to `size_in_bits - 1`.
             sanitized_bits[..num_bits].copy_from_slice(bits_le);
 

--- a/console/types/scalar/src/from_bits.rs
+++ b/console/types/scalar/src/from_bits.rs
@@ -48,12 +48,14 @@ impl<E: Environment> FromBits for Scalar<E> {
             // Return the scalar.
             Ok(Scalar { scalar: E::Scalar::from_bigint(scalar).ok_or_else(|| anyhow!("Invalid scalar from bits"))? })
         } else {
-            // Construct the sanitized list of bits, resizing up if necessary.
-            let mut bits_le = bits_le.iter().take(size_in_bits).cloned().collect::<Vec<_>>();
-            bits_le.resize(size_in_bits, false);
+            // Construct the sanitized list of bits padded with `false`
+            let mut sanitized_bits = vec![false; size_in_bits];
+            // this is safe, because we just checked that the length of bits isn't bigger
+            // than `size_in_data_bits` which is equal to `size_in_bits - 1`.
+            sanitized_bits[..num_bits].copy_from_slice(bits_le);
 
             // Recover the native scalar.
-            let scalar = E::Scalar::from_bigint(E::BigInteger::from_bits_le(&bits_le)?)
+            let scalar = E::Scalar::from_bigint(E::BigInteger::from_bits_le(&sanitized_bits)?)
                 .ok_or_else(|| anyhow!("Invalid scalar from bits"))?;
 
             // Return the scalar.


### PR DESCRIPTION
## Motivation

Another idea for optimization. Instead `.iter().take().cloned().collect()` followed by resize, we can just allocate whole vec at once and copy data to it, as we are sure that it's length is less than `size_in_bits`.
This assumption is also utilized in the previous `if` branch.

I've made some messy benchmarking and it reports around 20% gain with this approach. I may polish and include them later

## Test Plan

regular test run