### PR TITLE
Use execute_function for nested calls in CallStack::PackageRun

### DIFF
--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -259,7 +259,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         call_stack.push(request.clone())?;
 
                         // Evaluate the request.
-                        let response = substack.evaluate_function::<A>(call_stack, console_caller)?;
+                        let response = substack.execute_function::<A, _>(call_stack, console_caller, rng)?;
 
                         // Return the request and response.
                         (request, response)

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -106,10 +106,6 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
         // Retrieve the next request, based on the call stack mode.
         let (request, call_stack) = match &call_stack {
             CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
-            CallStack::PackageRun(requests, _, _) => {
-                let last_request = requests.last().ok_or(anyhow!("CallStack does not contain request"))?.clone();
-                (last_request, call_stack)
-            }
             // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
             // This is done to ensure that evaluation during execution is performed consistently.
             CallStack::Execute(authorization, _) => {
@@ -120,9 +116,7 @@ impl<N: Network> StackEvaluate<N> for Stack<N> {
                 let call_stack = CallStack::Evaluate(authorization);
                 (request, call_stack)
             }
-            _ => bail!(
-                "Illegal operation: call stack must be `PackageRun`, `Evaluate` or `Execute` in `evaluate_function`."
-            ),
+            _ => bail!("Illegal operation: call stack must be `Evaluate` or `Execute` in `evaluate_function`."),
         };
         lap!(timer, "Retrieve the next request");
 


### PR DESCRIPTION
## Motivation

We only need to use `execute_function` instead of `evaluate_function` when using `PackageRun`.

Why did this happen? Because we "simply" never properly set up `evaluate_function` to properly handle nested calls, and I didn't spot the failed test in the previous PR. Made an issue in case we want to fix this in the future: https://github.com/AleoHQ/snarkVM/issues/2287

Fortunately, this adjustment won't have a performance hit for `CheckDeployment`s.

## Test Plan

Existing test suite should pass. Locally everything succeeds but CI has a flaky test, made an issue for it: https://github.com/AleoHQ/snarkVM/issues/2286

## Related PRs

https://github.com/AleoHQ/snarkVM/pull/2230
