### PR TITLE
[NCC-76W] Add uniqueness checks for BatchCertificate signature authors

### DIFF
--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -106,12 +106,12 @@ impl<N: Network> BatchCertificate<N> {
         ensure!(signatures.len() <= Self::MAX_SIGNATURES, "Invalid number of signatures");
 
         // Ensure that the signature is from a unique signer and not from the author.
-        let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<Vec<_>>();
+        let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<IndexSet<_>>();
         ensure!(
             !signature_authors.contains(&batch_header.author()),
             "The author's signature was included in the signers"
         );
-        ensure!(!has_duplicates(signature_authors), "A duplicate author was found in the set of signatures");
+        ensure!(signature_authors.len() == signatures.len(), "A duplicate author was found in the set of signatures");
 
         // Verify the signatures are valid.
         cfg_iter!(signatures).try_for_each(|signature| {

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -29,6 +29,7 @@ use narwhal_transmission_id::TransmissionID;
 
 use core::hash::{Hash, Hasher};
 use indexmap::{IndexMap, IndexSet};
+use std::collections::HashSet;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -106,7 +107,7 @@ impl<N: Network> BatchCertificate<N> {
         ensure!(signatures.len() <= Self::MAX_SIGNATURES, "Invalid number of signatures");
 
         // Ensure that the signature is from a unique signer and not from the author.
-        let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<IndexSet<_>>();
+        let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<HashSet<_>>();
         ensure!(
             !signature_authors.contains(&batch_header.author()),
             "The author's signature was included in the signers"


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds additional safety checks to each `BatchCertificate` to ensure that the signatures come from unique signers and also that the author doesn't have a signature in the set.
