### PR TITLE
Abort transactions with duplicated `OutputID`s

### DIFF
--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -760,6 +760,142 @@ fn test_execute_duplicate_input_ids() {
 }
 
 #[test]
+fn test_execute_duplicate_output_ids() {
+    let rng = &mut TestRng::default();
+
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, private_key, address, .. } = crate::test_helpers::sample_test_env(rng);
+
+    // Deploy a test program to the ledger.
+    let program = Program::<CurrentNetwork>::from_str(
+        "
+program dummy_program.aleo;
+
+record dummy_program:
+    owner as address.private;
+    rand_var as u64.private;
+
+function create_duplicate_record:
+    input r0 as u64.private;
+    cast self.caller 1u64 into r1 as dummy_program.record;
+    output r1 as dummy_program.record;",
+    )
+    .unwrap();
+
+    // Deploy.
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    // Verify.
+    ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
+
+    // Construct the next block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_transaction], rng)
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Create a transaction with different transition ids, but with a fixed output record (output ID).
+    let mut create_transaction_with_duplicate_output_id = |x: u64| -> Transaction<CurrentNetwork> {
+        // Use a fixed seed RNG.
+        let fixed_rng = &mut TestRng::from_seed(1);
+
+        // Create a transaction with a fixed rng.
+        let inputs = [Value::from_str(&format!("{x}u64")).unwrap()];
+        let transaction = ledger
+            .vm
+            .execute(
+                &private_key,
+                ("dummy_program.aleo", "create_duplicate_record"),
+                inputs.into_iter(),
+                None,
+                0,
+                None,
+                fixed_rng,
+            )
+            .unwrap();
+        // Extract the execution.
+        let execution = transaction.execution().unwrap().clone();
+
+        // Create a new fee for the execution.
+        let fee_authorization = ledger
+            .vm
+            .authorize_fee_public(
+                &private_key,
+                *transaction.fee_amount().unwrap(),
+                0,
+                execution.to_execution_id().unwrap(),
+                rng,
+            )
+            .unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+
+        Transaction::from_execution(execution, Some(fee)).unwrap()
+    };
+
+    // Create the first transfer.
+    let transfer_1 = create_transaction_with_duplicate_output_id(1);
+    let transfer_1_id = transfer_1.id();
+
+    // Create a second transfer with the same output id.
+    let transfer_2 = create_transaction_with_duplicate_output_id(2);
+    let transfer_2_id = transfer_2.id();
+
+    // Create a third transfer with the same output id.
+    let transfer_3 = create_transaction_with_duplicate_output_id(3);
+    let transfer_3_id = transfer_3.id();
+
+    // Ensure that each transaction has a duplicate output id.
+    let tx_1_output_id = transfer_1.output_ids().next().unwrap();
+    let tx_2_output_id = transfer_2.output_ids().next().unwrap();
+    let tx_3_output_id = transfer_3.output_ids().next().unwrap();
+    assert_eq!(tx_1_output_id, tx_2_output_id);
+    assert_eq!(tx_1_output_id, tx_3_output_id);
+
+    // Create a block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transfer_1, transfer_2], rng)
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Enforce that the block transactions were correct.
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_1_id]);
+    assert_eq!(block.aborted_transaction_ids(), &vec![transfer_2_id]);
+
+    // Prepare a transfer that will succeed for the subsequent block.
+    let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
+    let transfer_4 = ledger
+        .vm
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .unwrap();
+    let transfer_4_id = transfer_4.id();
+
+    // Create a block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transfer_3, transfer_4], rng)
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Enforce that the block transactions were correct.
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_4_id]);
+    assert_eq!(block.aborted_transaction_ids(), &vec![transfer_3_id]);
+}
+
+#[test]
 fn test_deployment_duplicate_program_id() {
     let rng = &mut TestRng::default();
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -223,6 +223,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             let mut counter = 0u32;
             // Initialize a list of spent input IDs.
             let mut input_ids: IndexSet<Field<N>> = IndexSet::new();
+            // Initialize a list of spent output IDs.
+            let mut output_ids: IndexSet<Field<N>> = IndexSet::new();
 
             // Finalize the transactions.
             'outer: for transaction in transactions {
@@ -243,6 +245,19 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     {
                         // Store the aborted transaction.
                         aborted.push((transaction.clone(), format!("Double-spending input {input_id}")));
+                        // Continue to the next transaction.
+                        continue 'outer;
+                    }
+                }
+
+                // Ensure that the transaction is not producing a duplicate output.
+                for output_id in transaction.output_ids() {
+                    // If the output ID is already spent in this block or previous blocks, abort the transaction.
+                    if output_ids.contains(output_id)
+                        || self.transition_store().contains_output_id(output_id).unwrap_or(true)
+                    {
+                        // Store the aborted transaction.
+                        aborted.push((transaction.clone(), format!("Duplicate output {output_id}")));
                         // Continue to the next transaction.
                         continue 'outer;
                     }
@@ -363,6 +378,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     Ok(confirmed_transaction) => {
                         // Add the input IDs to the set of spent input IDs.
                         input_ids.extend(confirmed_transaction.transaction().input_ids());
+                        // Add the output IDs to the set of spent output IDs.
+                        output_ids.extend(confirmed_transaction.transaction().output_ids());
                         // Store the confirmed transaction.
                         confirmed.push(confirmed_transaction);
                         // Increment the transaction index counter.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds logic to `VM::atomic_speculate` to track `OutputID`s and abort transactions that attempt to create an `OutputID` that was already included in this block or previous blocks.

Note: We may want to use `OutputStore::get_speculative` instead of per block trackers in `atomic_speculate`.

Related to: #2229 
Fixes: #2263 

## Test Plan

A test has been added to check that different transactions can't create outputs with the same OutputID.

TODO:
- [ ] Unify and clean up the `input_id` and `output_id` checks in `atomic_speculate`
