### PR TITLE
feat: logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,7 @@ dependencies = [
  "colored",
  "dotenvy",
  "indexmap 2.0.2",
+ "log",
  "num-format",
  "once_cell",
  "parking_lot",
@@ -2629,6 +2630,7 @@ dependencies = [
  "indexmap 2.0.2",
  "itertools 0.11.0",
  "lazy_static",
+ "log",
  "num-traits",
  "parking_lot",
  "rand",
@@ -2678,6 +2680,7 @@ name = "snarkvm-circuit-account"
 version = "0.16.16"
 dependencies = [
  "anyhow",
+ "log",
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2690,6 +2693,7 @@ name = "snarkvm-circuit-algorithms"
 version = "0.16.16"
 dependencies = [
  "anyhow",
+ "log",
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
  "snarkvm-curves",
@@ -2702,6 +2706,7 @@ name = "snarkvm-circuit-collections"
 version = "0.16.16"
 dependencies = [
  "anyhow",
+ "log",
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2718,6 +2723,7 @@ dependencies = [
  "criterion",
  "indexmap 2.0.2",
  "itertools 0.11.0",
+ "log",
  "nom",
  "num-traits",
  "once_cell",
@@ -2752,6 +2758,7 @@ name = "snarkvm-circuit-program"
 version = "0.16.16"
 dependencies = [
  "anyhow",
+ "log",
  "paste",
  "rand",
  "snarkvm-circuit-account",
@@ -2769,6 +2776,7 @@ dependencies = [
 name = "snarkvm-circuit-types"
 version = "0.16.16"
 dependencies = [
+ "log",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
  "snarkvm-circuit-types-boolean",
@@ -2784,6 +2792,7 @@ dependencies = [
 name = "snarkvm-circuit-types-address"
 version = "0.16.16"
 dependencies = [
+ "log",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
@@ -2797,6 +2806,7 @@ name = "snarkvm-circuit-types-boolean"
 version = "0.16.16"
 dependencies = [
  "criterion",
+ "log",
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
 ]
@@ -2805,6 +2815,7 @@ dependencies = [
 name = "snarkvm-circuit-types-field"
 version = "0.16.16"
 dependencies = [
+ "log",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-console-types-field",
@@ -2814,6 +2825,7 @@ dependencies = [
 name = "snarkvm-circuit-types-group"
 version = "0.16.16"
 dependencies = [
+ "log",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
@@ -2826,6 +2838,7 @@ dependencies = [
 name = "snarkvm-circuit-types-integers"
 version = "0.16.16"
 dependencies = [
+ "log",
  "paste",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2839,6 +2852,7 @@ dependencies = [
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.16"
 dependencies = [
+ "log",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
@@ -2849,6 +2863,7 @@ dependencies = [
 name = "snarkvm-circuit-types-string"
 version = "0.16.16"
 dependencies = [
+ "log",
  "rand",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2877,6 +2892,7 @@ dependencies = [
  "bincode",
  "bs58",
  "criterion",
+ "log",
  "serde_json",
  "snarkvm-console-network",
  "snarkvm-console-types",
@@ -2908,6 +2924,7 @@ dependencies = [
  "aleo-std",
  "criterion",
  "indexmap 2.0.2",
+ "log",
  "rayon",
  "snarkvm-console-algorithms",
  "snarkvm-console-network",
@@ -2961,6 +2978,7 @@ dependencies = [
  "enum_index",
  "enum_index_derive",
  "indexmap 2.0.2",
+ "log",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -3146,6 +3164,7 @@ version = "0.16.16"
 dependencies = [
  "bincode",
  "indexmap 2.0.2",
+ "log",
  "once_cell",
  "rayon",
  "serde_json",
@@ -3372,6 +3391,7 @@ dependencies = [
  "itertools 0.11.0",
  "js-sys",
  "lazy_static",
+ "log",
  "parking_lot",
  "paste",
  "rand",
@@ -3428,6 +3448,7 @@ dependencies = [
  "bincode",
  "colored",
  "indexmap 2.0.2",
+ "log",
  "once_cell",
  "parking_lot",
  "rand",
@@ -3453,6 +3474,7 @@ dependencies = [
  "bincode",
  "criterion",
  "indexmap 2.0.2",
+ "log",
  "paste",
  "rand",
  "rand_chacha",
@@ -3468,6 +3490,7 @@ version = "0.16.16"
 dependencies = [
  "bincode",
  "colored",
+ "log",
  "once_cell",
  "serde_json",
  "snarkvm-algorithms",
@@ -3482,6 +3505,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
+ "log",
  "num-bigint",
  "num_cpus",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,9 @@ version = "2.7"
 features = [ "json" ]
 optional = true
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.bincode]
 version = "1.3"
 

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -156,6 +156,9 @@ optional = true
 [dependencies.num-traits]
 version = "0.2"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.expect-test]
 version = "1.4.1"
 

--- a/algorithms/src/r1cs/test_constraint_system.rs
+++ b/algorithms/src/r1cs/test_constraint_system.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::r1cs::{errors::SynthesisError, ConstraintSystem, Index, LinearCombination, OptionalVec, Variable};
+use log::trace;
 use snarkvm_fields::Field;
 
 use cfg_if::cfg_if;
@@ -151,23 +152,23 @@ impl<F: Field> TestConstraintSystem<F> {
             let self_interned_path = self_c.interned_path;
             let other_interned_path = other_c.interned_path;
             if self_c.a != other_c.a {
-                println!("A row {i} is different:");
-                println!("self: {}", self.unintern_path(self_interned_path));
-                println!("other: {}", other.unintern_path(other_interned_path));
+                trace!("A row {i} is different:");
+                trace!("self: {}", self.unintern_path(self_interned_path));
+                trace!("other: {}", other.unintern_path(other_interned_path));
                 break;
             }
 
             if self_c.b != other_c.b {
-                println!("B row {i} is different:");
-                println!("self: {}", self.unintern_path(self_interned_path));
-                println!("other: {}", other.unintern_path(other_interned_path));
+                trace!("B row {i} is different:");
+                trace!("self: {}", self.unintern_path(self_interned_path));
+                trace!("other: {}", other.unintern_path(other_interned_path));
                 break;
             }
 
             if self_c.c != other_c.c {
-                println!("C row {i} is different:");
-                println!("self: {}", self.unintern_path(self_interned_path));
-                println!("other: {}", other.unintern_path(other_interned_path));
+                trace!("C row {i} is different:");
+                trace!("self: {}", self.unintern_path(self_interned_path));
+                trace!("other: {}", other.unintern_path(other_interned_path));
                 break;
             }
         }
@@ -202,7 +203,7 @@ impl<F: Field> TestConstraintSystem<F> {
 
     pub fn print_named_objects(&self) {
         for TestConstraint { interned_path, .. } in self.constraints.iter() {
-            println!("{}", self.unintern_path(*interned_path));
+            trace!("{}", self.unintern_path(*interned_path));
         }
     }
 

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -26,6 +26,7 @@ use crate::{
         SNARKMode,
     },
 };
+use log::trace;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::cfg_into_iter;
 
@@ -36,8 +37,6 @@ use std::collections::BTreeMap;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
-#[cfg(not(feature = "std"))]
-use snarkvm_utilities::println;
 
 use super::Matrix;
 
@@ -156,12 +155,12 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let num_variables = num_padded_public_variables + num_private_variables;
 
         if cfg!(debug_assertions) {
-            println!("Number of padded public variables: {num_padded_public_variables}");
-            println!("Number of private variables: {num_private_variables}");
-            println!("Number of num_constraints: {num_constraints}");
-            println!("Number of non-zero entries in A: {num_non_zero_a}");
-            println!("Number of non-zero entries in B: {num_non_zero_b}");
-            println!("Number of non-zero entries in C: {num_non_zero_c}");
+            trace!("Number of padded public variables: {num_padded_public_variables}");
+            trace!("Number of private variables: {num_private_variables}");
+            trace!("Number of num_constraints: {num_constraints}");
+            trace!("Number of non-zero entries in A: {num_non_zero_a}");
+            trace!("Number of non-zero entries in B: {num_non_zero_b}");
+            trace!("Number of non-zero entries in C: {num_non_zero_c}");
         }
 
         Self::num_formatted_public_inputs_is_admissible(num_padded_public_variables)?;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         SNARKMode,
     },
 };
+use log::trace;
 use snarkvm_fields::PrimeField;
 
 use anyhow::Result;
@@ -29,8 +30,6 @@ use rand_core::CryptoRng;
 use std::collections::BTreeMap;
 
 use snarkvm_utilities::cfg_iter;
-#[cfg(not(feature = "std"))]
-use snarkvm_utilities::println;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -112,12 +111,12 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                         assert_eq!(private_variables.len(), num_private_variables);
 
                         if cfg!(debug_assertions) {
-                            println!("Number of padded public variables in Prover::Init: {num_public_variables}");
-                            println!("Number of private variables: {num_private_variables}");
-                            println!("Number of constraints: {num_constraints}");
-                            println!("Number of non-zero entries in A: {num_non_zero_a}");
-                            println!("Number of non-zero entries in B: {num_non_zero_b}");
-                            println!("Number of non-zero entries in C: {num_non_zero_c}");
+                            trace!("Number of padded public variables in Prover::Init: {num_public_variables}");
+                            trace!("Number of private variables: {num_private_variables}");
+                            trace!("Number of constraints: {num_constraints}");
+                            trace!("Number of non-zero entries in A: {num_non_zero_a}");
+                            trace!("Number of non-zero entries in B: {num_non_zero_b}");
+                            trace!("Number of non-zero entries in C: {num_non_zero_c}");
                         }
 
                         if circuit.index_info.num_constraints != num_constraints

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -54,7 +54,7 @@ use std::{borrow::Borrow, collections::BTreeMap, ops::Deref, sync::Arc};
 
 use crate::srs::UniversalProver;
 #[cfg(not(feature = "std"))]
-use snarkvm_utilities::println;
+use log::{trace, warn};
 
 /// The Varuna proof system.
 #[derive(Clone, Debug)]
@@ -682,7 +682,7 @@ where
                         new_input.extend_from_slice(input);
                         new_input.resize(input.len().max(input_domain.size()), E::Fr::zero());
                         if cfg!(debug_assertions) {
-                            println!("Number of padded public variables: {}", new_input.len());
+                            trace!("Number of padded public variables: {}", new_input.len());
                         }
                         let unformatted = prover::ConstraintSystem::unformat_public_input(&new_input);
                         (new_input, unformatted)
@@ -711,7 +711,7 @@ where
             !proof.pc_proof.is_hiding() & comms.mask_poly.is_none()
         };
         if !proof_has_correct_zk_mode {
-            eprintln!(
+            warn!(
                 "Found `mask_poly` in the first round when not expected, or proof has incorrect hiding mode ({})",
                 proof.pc_proof.is_hiding()
             );
@@ -902,7 +902,7 @@ where
 
         if !evaluations_are_correct {
             #[cfg(debug_assertions)]
-            eprintln!("SonicKZG10::Check failed using final challenge: {:?}", verifier_state.gamma);
+            warn!("SonicKZG10::Check failed using final challenge: {:?}", verifier_state.gamma);
         }
 
         end_timer!(verifier_time, || format!(

--- a/circuit/account/Cargo.toml
+++ b/circuit/account/Cargo.toml
@@ -24,6 +24,9 @@ version = "=0.16.16"
 path = "../types"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-utilities]
 path = "../../utilities"
 

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -24,6 +24,9 @@ default-features = false
 [dev-dependencies.anyhow]
 version = "1.0.73"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-curves]
 path = "../../curves"
 default-features = false

--- a/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -157,7 +157,8 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
                         // Otherwise, call `montgomery_add` to add  to the accumulating sum.
                         Some((sum_x, sum_y)) => {
                             // Sum the new Montgomery point into the accumulating sum.
-                            sum = Some(montgomery_add((sum_x, sum_y), (&montgomery_x, &montgomery_y))); // 3 constraints
+                            sum = Some(montgomery_add((sum_x, sum_y), (&montgomery_x, &montgomery_y)));
+                            // 3 constraints
                         }
                     }
                 });
@@ -168,7 +169,8 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
                         // Convert the accumulated sum into a point on the twisted Edwards curve.
                         let edwards_x = sum_x.div_unchecked(sum_y); // 1 constraint (`sum_y` is never 0)
                         let edwards_y = (sum_x - &one).div_unchecked(&(sum_x + &one)); // 1 constraint (numerator & denominator are never both 0)
-                        Group::from_xy_coordinates_unchecked(edwards_x, edwards_y) // 0 constraints (this is safe)
+                        Group::from_xy_coordinates_unchecked(edwards_x, edwards_y)
+                        // 0 constraints (this is safe)
                     }
                     None => E::halt("Invalid iteration of BHP detected, a window was not evaluated"),
                 }

--- a/circuit/algorithms/src/pedersen/commit.rs
+++ b/circuit/algorithms/src/pedersen/commit.rs
@@ -157,7 +157,7 @@ mod tests {
         second: C,
         rng: &mut TestRng,
     ) {
-        println!("Checking homomorphic addition on {first} + {second}");
+        log::trace!("Checking homomorphic addition on {first} + {second}");
 
         // Sample the circuit randomizers.
         let first_randomizer: Scalar<_> = Inject::new(Mode::Private, Uniform::rand(rng));

--- a/circuit/algorithms/src/pedersen/commit_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/commit_uncompressed.rs
@@ -163,7 +163,7 @@ mod tests {
         second: C,
         rng: &mut TestRng,
     ) {
-        println!("Checking homomorphic addition on {first} + {second}");
+        log::trace!("Checking homomorphic addition on {first} + {second}");
 
         // Sample the circuit randomizers.
         let first_randomizer: Scalar<_> = Inject::new(Mode::Private, Uniform::rand(rng));

--- a/circuit/collections/Cargo.toml
+++ b/circuit/collections/Cargo.toml
@@ -20,6 +20,9 @@ version = "=0.16.16"
 path = "../types"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-circuit-network]
 path = "../network"
 

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -57,6 +57,9 @@ version = "0.2"
 [dependencies.once_cell]
 version = "1.18.0"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-algorithms]
 path = "../../algorithms"
 features = [ "polycommit_full", "snark", "test" ]

--- a/circuit/environment/src/helpers/constraint.rs
+++ b/circuit/environment/src/helpers/constraint.rs
@@ -40,7 +40,7 @@ impl<F: PrimeField> Constraint<F> {
         match a * b == c {
             true => true,
             false => {
-                eprintln!("Failed constraint at {scope}:\n\t({a} * {b}) != {c}");
+                log::warn!("Failed constraint at {scope}:\n\t({a} * {b}) != {c}");
                 false
             }
         }

--- a/circuit/environment/src/helpers/count.rs
+++ b/circuit/environment/src/helpers/count.rs
@@ -117,7 +117,7 @@ impl<V: Copy + Debug + Display + Ord + Add<Output = V> + Sub<Output = V> + Mul<O
         };
 
         if !outcome {
-            eprintln!("Metrics claims the count should be {self:?}, found {candidate:?} during synthesis");
+            log::warn!("Metrics claims the count should be {self:?}, found {candidate:?} during synthesis");
         }
 
         outcome

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{Mode, *};
+use log::warn;
 use snarkvm_fields::PrimeField;
 
 use core::{
@@ -105,13 +106,13 @@ impl<F: PrimeField> LinearCombination<F> {
             // Enforce property 2.
             // Note: This branch is triggered if ANY term is not (zero or one).
             if self.terms.iter().any(|(v, _)| !(v.value().is_zero() || v.value().is_one())) {
-                eprintln!("Property 2 of the `Boolean` type was violated in {self}");
+                warn!("Property 2 of the `Boolean` type was violated in {self}");
                 return false;
             }
 
             // Enforce property 3.
             if !(self.value.is_zero() || self.value.is_one()) {
-                eprintln!("Property 3 of the `Boolean` type was violated");
+                warn!("Property 3 of the `Boolean` type was violated");
                 return false;
             }
 
@@ -119,7 +120,7 @@ impl<F: PrimeField> LinearCombination<F> {
         } else {
             // Property 1 of the `Boolean` type was violated.
             // Both self.constant and self.terms contain elements.
-            eprintln!("Both LC::constant and LC::terms contain elements, which is a violation");
+            warn!("Both LC::constant and LC::terms contain elements, which is a violation");
             false
         }
     }

--- a/circuit/environment/src/macros/scope.rs
+++ b/circuit/environment/src/macros/scope.rs
@@ -22,7 +22,7 @@ macro_rules! scope {
 #[macro_export]
 macro_rules! print_scope {
     () => {{
-        println!(
+        log::trace!(
             "Circuit::scope(Constants: {:?}, Public: {:?}, Private: {:?}, Constraints: {:?})\n",
             Circuit::num_constants_in_scope(),
             Circuit::num_public_in_scope(),

--- a/circuit/program/Cargo.toml
+++ b/circuit/program/Cargo.toml
@@ -43,6 +43,9 @@ version = "1.0"
 package = "snarkvm-console"
 path = "../../console"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.console]
 package = "snarkvm-console-program"
 path = "../../console/program"

--- a/circuit/types/Cargo.toml
+++ b/circuit/types/Cargo.toml
@@ -41,3 +41,7 @@ version = "=0.16.16"
 [dev-dependencies.console]
 package = "snarkvm-console"
 path = "../../console"
+
+[dependencies.log]
+version = "0.4.14"
+

--- a/circuit/types/address/Cargo.toml
+++ b/circuit/types/address/Cargo.toml
@@ -32,6 +32,9 @@ version = "=0.16.16"
 path = "../scalar"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [features]
 default = [ "enable_console" ]
 enable_console = [ "console" ]

--- a/circuit/types/boolean/Cargo.toml
+++ b/circuit/types/boolean/Cargo.toml
@@ -21,6 +21,9 @@ optional = true
 path = "../../environment"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.criterion]
 version = "0.5"
 

--- a/circuit/types/boolean/src/helpers/adder.rs
+++ b/circuit/types/boolean/src/helpers/adder.rs
@@ -256,7 +256,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Constant, Mode::Public, Mode::Constant, 0, 0, 0, 0);
         check_true_add_false_with_true(Mode::Constant, Mode::Public, Mode::Constant, 0, 0, 1, 1); // <- Differs
         check_true_add_true_with_false(Mode::Constant, Mode::Public, Mode::Constant, 0, 0, 0, 0);
-        check_true_add_true_with_true(Mode::Constant, Mode::Public, Mode::Constant, 0, 0, 1, 1); // <- Differs
+        check_true_add_true_with_true(Mode::Constant, Mode::Public, Mode::Constant, 0, 0, 1, 1);
+        // <- Differs
     }
 
     #[test]
@@ -268,7 +269,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Constant, Mode::Public, Mode::Public, 0, 0, 3, 3); // <- Differs
         check_true_add_false_with_true(Mode::Constant, Mode::Public, Mode::Public, 0, 0, 3, 3); // <- Differs
         check_true_add_true_with_false(Mode::Constant, Mode::Public, Mode::Public, 0, 0, 3, 3); // <- Differs
-        check_true_add_true_with_true(Mode::Constant, Mode::Public, Mode::Public, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Constant, Mode::Public, Mode::Public, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -280,7 +282,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Constant, Mode::Public, Mode::Private, 0, 0, 3, 3); // <- Differs
         check_true_add_false_with_true(Mode::Constant, Mode::Public, Mode::Private, 0, 0, 3, 3); // <- Differs
         check_true_add_true_with_false(Mode::Constant, Mode::Public, Mode::Private, 0, 0, 3, 3); // <- Differs
-        check_true_add_true_with_true(Mode::Constant, Mode::Public, Mode::Private, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Constant, Mode::Public, Mode::Private, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -292,7 +295,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Constant, Mode::Private, Mode::Constant, 0, 0, 0, 0);
         check_true_add_false_with_true(Mode::Constant, Mode::Private, Mode::Constant, 0, 0, 1, 1); // <- Differs
         check_true_add_true_with_false(Mode::Constant, Mode::Private, Mode::Constant, 0, 0, 0, 0);
-        check_true_add_true_with_true(Mode::Constant, Mode::Private, Mode::Constant, 0, 0, 1, 1); // <- Differs
+        check_true_add_true_with_true(Mode::Constant, Mode::Private, Mode::Constant, 0, 0, 1, 1);
+        // <- Differs
     }
 
     #[test]
@@ -304,7 +308,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Constant, Mode::Private, Mode::Public, 0, 0, 3, 3); // <- Differs
         check_true_add_false_with_true(Mode::Constant, Mode::Private, Mode::Public, 0, 0, 3, 3); // <- Differs
         check_true_add_true_with_false(Mode::Constant, Mode::Private, Mode::Public, 0, 0, 3, 3); // <- Differs
-        check_true_add_true_with_true(Mode::Constant, Mode::Private, Mode::Public, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Constant, Mode::Private, Mode::Public, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -316,7 +321,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Constant, Mode::Private, Mode::Private, 0, 0, 3, 3); // <- Differs
         check_true_add_false_with_true(Mode::Constant, Mode::Private, Mode::Private, 0, 0, 3, 3); // <- Differs
         check_true_add_true_with_false(Mode::Constant, Mode::Private, Mode::Private, 0, 0, 3, 3); // <- Differs
-        check_true_add_true_with_true(Mode::Constant, Mode::Private, Mode::Private, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Constant, Mode::Private, Mode::Private, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -328,7 +334,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
         check_true_add_false_with_true(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
         check_true_add_true_with_false(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
-        check_true_add_true_with_true(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 1, 1); // <- Differs
+        check_true_add_true_with_true(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 1, 1);
+        // <- Differs
     }
 
     #[test]
@@ -340,7 +347,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 2, 2);
         check_true_add_false_with_true(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 2, 2);
         check_true_add_true_with_false(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 3, 3); // <- Differs
-        check_true_add_true_with_true(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -352,7 +360,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 2, 2);
         check_true_add_false_with_true(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 2, 2);
         check_true_add_true_with_false(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 3, 3); // <- Differs
-        check_true_add_true_with_true(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -364,7 +373,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 2, 2);
         check_true_add_false_with_true(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 3, 3); // <- Differs
         check_true_add_true_with_false(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 2, 2);
-        check_true_add_true_with_true(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -400,7 +410,8 @@ mod tests {
         check_true_add_false_with_false(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 2, 2);
         check_true_add_false_with_true(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 3, 3); // <- Differs
         check_true_add_true_with_false(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 2, 2);
-        check_true_add_true_with_true(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 3, 3); // <- Differs
+        check_true_add_true_with_true(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]

--- a/circuit/types/boolean/src/helpers/subtractor.rs
+++ b/circuit/types/boolean/src/helpers/subtractor.rs
@@ -328,7 +328,8 @@ mod tests {
         check_true_sub_false_with_false(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
         check_true_sub_false_with_true(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
         check_true_sub_true_with_false(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 0, 0);
-        check_true_sub_true_with_true(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 1, 1); // <- Differs
+        check_true_sub_true_with_true(Mode::Public, Mode::Constant, Mode::Constant, 0, 0, 1, 1);
+        // <- Differs
     }
 
     #[test]
@@ -340,7 +341,8 @@ mod tests {
         check_true_sub_false_with_false(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 2, 2);
         check_true_sub_false_with_true(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 2, 2);
         check_true_sub_true_with_false(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 3, 3); // <- Differs
-        check_true_sub_true_with_true(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 3, 3); // <- Differs
+        check_true_sub_true_with_true(Mode::Public, Mode::Constant, Mode::Public, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -352,7 +354,8 @@ mod tests {
         check_true_sub_false_with_false(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 2, 2);
         check_true_sub_false_with_true(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 2, 2);
         check_true_sub_true_with_false(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 3, 3); // <- Differs
-        check_true_sub_true_with_true(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 3, 3); // <- Differs
+        check_true_sub_true_with_true(Mode::Public, Mode::Constant, Mode::Private, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -364,7 +367,8 @@ mod tests {
         check_true_sub_false_with_false(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 2, 2);
         check_true_sub_false_with_true(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 3, 3); // <- Differs
         check_true_sub_true_with_false(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 2, 2);
-        check_true_sub_true_with_true(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 3, 3); // <- Differs
+        check_true_sub_true_with_true(Mode::Public, Mode::Public, Mode::Constant, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]
@@ -400,7 +404,8 @@ mod tests {
         check_true_sub_false_with_false(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 2, 2);
         check_true_sub_false_with_true(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 3, 3); // <- Differs
         check_true_sub_true_with_false(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 2, 2);
-        check_true_sub_true_with_true(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 3, 3); // <- Differs
+        check_true_sub_true_with_true(Mode::Public, Mode::Private, Mode::Constant, 0, 0, 3, 3);
+        // <- Differs
     }
 
     #[test]

--- a/circuit/types/field/Cargo.toml
+++ b/circuit/types/field/Cargo.toml
@@ -20,6 +20,9 @@ version = "=0.16.16"
 path = "../boolean"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [features]
 default = [ "enable_console" ]
 enable_console = [ "console" ]

--- a/circuit/types/group/Cargo.toml
+++ b/circuit/types/group/Cargo.toml
@@ -28,6 +28,9 @@ version = "=0.16.16"
 path = "../scalar"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-utilities]
 path = "../../../utilities"
 default-features = false

--- a/circuit/types/integers/Cargo.toml
+++ b/circuit/types/integers/Cargo.toml
@@ -28,6 +28,9 @@ version = "=0.16.16"
 path = "../scalar"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-utilities]
 path = "../../../utilities"
 default-features = false

--- a/circuit/types/scalar/Cargo.toml
+++ b/circuit/types/scalar/Cargo.toml
@@ -24,6 +24,9 @@ version = "=0.16.16"
 path = "../field"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [features]
 default = [ "enable_console" ]
 enable_console = [ "console" ]

--- a/circuit/types/string/Cargo.toml
+++ b/circuit/types/string/Cargo.toml
@@ -28,6 +28,9 @@ version = "=0.16.16"
 path = "../integers"
 version = "=0.16.16"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-utilities]
 path = "../../../utilities"
 default-features = false

--- a/console/account/Cargo.toml
+++ b/console/account/Cargo.toml
@@ -28,6 +28,9 @@ version = "0.5"
 version = "1"
 features = [ "derive" ]
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.bincode]
 version = "1.3"
 

--- a/console/account/src/signature/verify.rs
+++ b/console/account/src/signature/verify.rs
@@ -20,7 +20,7 @@ impl<N: Network> Signature<N> {
     pub fn verify(&self, address: &Address<N>, message: &[Field<N>]) -> bool {
         // Ensure the number of field elements does not exceed the maximum allowed size.
         if message.len() > N::MAX_DATA_SIZE_IN_FIELDS as usize {
-            eprintln!("Cannot sign the signature: the signed message exceeds maximum allowed size");
+            log::warn!("Cannot sign the signature: the signed message exceeds maximum allowed size");
             return false;
         }
 
@@ -69,7 +69,7 @@ impl<N: Network> Signature<N> {
         match message.chunks(Field::<N>::size_in_data_bits()).map(Field::from_bits_le).collect::<Result<Vec<_>>>() {
             Ok(fields) => self.verify(address, &fields),
             Err(error) => {
-                eprintln!("Failed to verify signature: {error}");
+                log::warn!("Failed to verify signature: {error}");
                 false
             }
         }

--- a/console/collections/Cargo.toml
+++ b/console/collections/Cargo.toml
@@ -33,6 +33,9 @@ default-features = false
 [dependencies.rayon]
 version = "1"
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.snarkvm-console-network]
 path = "../network"
 

--- a/console/collections/src/merkle_tree/path/mod.rs
+++ b/console/collections/src/merkle_tree/path/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::warn;
+
 use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -61,12 +63,12 @@ impl<E: Environment, const DEPTH: u8> MerklePath<E, DEPTH> {
     ) -> bool {
         // Ensure the leaf index is within the tree depth.
         if (*self.leaf_index as u128) >= (1u128 << DEPTH) {
-            eprintln!("Found an out of bounds Merkle leaf index");
+            warn!("Found an out of bounds Merkle leaf index");
             return false;
         }
         // Ensure the path length matches the expected depth.
         else if self.siblings.len() != DEPTH as usize {
-            eprintln!("Found an incorrect Merkle path length");
+            warn!("Found an incorrect Merkle path length");
             return false;
         }
 
@@ -74,7 +76,7 @@ impl<E: Environment, const DEPTH: u8> MerklePath<E, DEPTH> {
         let mut current_hash = match leaf_hasher.hash_leaf(leaf) {
             Ok(candidate_leaf_hash) => candidate_leaf_hash,
             Err(error) => {
-                eprintln!("Failed to hash the Merkle leaf during verification: {error}");
+                warn!("Failed to hash the Merkle leaf during verification: {error}");
                 return false;
             }
         };
@@ -95,7 +97,7 @@ impl<E: Environment, const DEPTH: u8> MerklePath<E, DEPTH> {
             match path_hasher.hash_children(&left, &right) {
                 Ok(hash) => current_hash = hash,
                 Err(error) => {
-                    eprintln!("Failed to hash the Merkle path during verification: {error}");
+                    warn!("Failed to hash the Merkle path during verification: {error}");
                     return false;
                 }
             }

--- a/console/program/Cargo.toml
+++ b/console/program/Cargo.toml
@@ -59,5 +59,8 @@ version = "1.0"
 version = "1.0"
 features = [ "preserve_order" ]
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.bincode]
 version = "1.3"

--- a/console/program/src/request/verify.rs
+++ b/console/program/src/request/verify.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use log::warn;
 
 impl<N: Network> Request<N> {
     /// Returns `true` if the request is valid, and `false` otherwise.
@@ -27,12 +28,12 @@ impl<N: Network> Request<N> {
                 Ok(tcm) => {
                     // Ensure the computed transition commitment matches.
                     if tcm != self.tcm {
-                        eprintln!("Invalid transition commitment in request.");
+                        warn!("Invalid transition commitment in request.");
                         return false;
                     }
                 }
                 Err(error) => {
-                    eprintln!("Failed to compute transition commitment in request verification: {error}");
+                    warn!("Failed to compute transition commitment in request verification: {error}");
                     return false;
                 }
             }
@@ -50,7 +51,7 @@ impl<N: Network> Request<N> {
         ) {
             Ok(function_id) => function_id,
             Err(error) => {
-                eprintln!("Failed to construct the function ID: {error}");
+                warn!("Failed to construct the function ID: {error}");
                 return false;
             }
         };
@@ -197,7 +198,7 @@ impl<N: Network> Request<N> {
                 Ok(())
             },
         ) {
-            eprintln!("Request verification failed on input checks: {error}");
+            warn!("Request verification failed on input checks: {error}");
             return false;
         }
 

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -88,6 +88,9 @@ optional = true
 version = "1.0"
 features = [ "preserve_order" ]
 
+[dependencies.log]
+version = "0.4"
+
 [dev-dependencies.bincode]
 version = "1.3"
 

--- a/ledger/block/src/transition/input/mod.rs
+++ b/ledger/block/src/transition/input/mod.rs
@@ -21,6 +21,7 @@ use console::{
     program::{Ciphertext, Plaintext, TransitionLeaf},
     types::Field,
 };
+use log::warn;
 
 type Variant = u8;
 
@@ -170,7 +171,7 @@ impl<N: Network> Input<N> {
         match result() {
             Ok(is_hash_valid) => is_hash_valid,
             Err(error) => {
-                eprintln!("{error}");
+                warn!("{error}");
                 false
             }
         }

--- a/ledger/block/src/transition/output/mod.rs
+++ b/ledger/block/src/transition/output/mod.rs
@@ -21,6 +21,7 @@ use console::{
     program::{Ciphertext, Future, Plaintext, Record, TransitionLeaf},
     types::{Field, Group},
 };
+use log::warn;
 
 type Variant = u8;
 
@@ -247,7 +248,7 @@ impl<N: Network> Output<N> {
         match result() {
             Ok(is_hash_valid) => is_hash_valid,
             Err(error) => {
-                eprintln!("{error}");
+                warn!("{error}");
                 false
             }
         }

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -101,6 +101,9 @@ version = "0.3.64"
 features = [ "XmlHttpRequest" ]
 optional = true
 
+[dependencies.log]
+version = "0.4.14"
+
 [target."cfg(not(target_family = \"wasm\"))".dependencies.curl]
 version = "0.4.43"
 optional = true

--- a/parameters/examples/inclusion.rs
+++ b/parameters/examples/inclusion.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::trace;
 use snarkvm_algorithms::crypto_hash::sha256::sha256;
 use snarkvm_circuit::{Aleo, Assignment};
 use snarkvm_console::{
@@ -27,6 +28,7 @@ use snarkvm_synthesizer::{process::InclusionAssignment, snark::UniversalSRS, VM}
 use anyhow::{anyhow, Result};
 use rand::thread_rng;
 use serde_json::{json, Value};
+use snarkvm_utilities::SimplerLogger;
 use std::{
     fs::File,
     io::{BufWriter, Write},
@@ -139,7 +141,7 @@ pub fn inclusion<N: Network, A: Aleo<Network = N>>() -> Result<()> {
         "verifier_size": verifying_key_bytes.len(),
     });
 
-    println!("{}", serde_json::to_string_pretty(&metadata)?);
+    trace!("{}", serde_json::to_string_pretty(&metadata)?);
     write_metadata(&format!("{inclusion_function_name}.metadata"), &metadata)?;
     write_remote(&format!("{inclusion_function_name}.prover"), &proving_key_checksum, &proving_key_bytes)?;
     write_local(&format!("{inclusion_function_name}.verifier"), &verifying_key_bytes)?;
@@ -150,11 +152,11 @@ pub fn inclusion<N: Network, A: Aleo<Network = N>>() -> Result<()> {
     ));
 
     // Print the commands.
-    println!("\nNow, perform the following operations:\n");
+    trace!("\nNow, perform the following operations:\n");
     for command in commands {
-        println!("{command}");
+        trace!("{command}");
     }
-    println!();
+    trace!("");
 
     Ok(())
 }
@@ -162,10 +164,11 @@ pub fn inclusion<N: Network, A: Aleo<Network = N>>() -> Result<()> {
 /// Run the following command to generate the inclusion circuit keys.
 /// `cargo run --example inclusion [network]`
 pub fn main() -> Result<()> {
+    SimplerLogger::new().init()?;
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 2 {
-        println!("Invalid number of arguments. Given: {} - Required: 1", args.len() - 1);
+        trace!("Invalid number of arguments. Given: {} - Required: 1", args.len() - 1);
         return Ok(());
     }
 

--- a/parameters/examples/setup.rs
+++ b/parameters/examples/setup.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::{trace, warn};
 use snarkvm_algorithms::crypto_hash::sha256::sha256;
 use snarkvm_circuit::Aleo;
 use snarkvm_console::network::{prelude::ToBytes, Network, Testnet3};
@@ -19,6 +20,7 @@ use snarkvm_synthesizer::{Process, Program};
 
 use anyhow::Result;
 use serde_json::{json, Value};
+use snarkvm_utilities::SimplerLogger;
 use std::{
     fs,
     fs::File,
@@ -100,7 +102,7 @@ pub fn credits_program<N: Network, A: Aleo<Network = N>>() -> Result<()> {
     for (function_name, _) in program.functions().iter() {
         // let timer = std::time::Instant::now();
         // process.synthesize_key::<A, _>(program_id, function_name, rng)?;
-        // println!("Synthesized '{}': {} ms", function_name, timer.elapsed().as_millis());
+        // trace!("Synthesized '{}': {} ms", function_name, timer.elapsed().as_millis());
 
         let proving_key = process.get_proving_key(program_id, function_name)?;
         let proving_key_bytes = proving_key.to_bytes_le()?;
@@ -117,7 +119,7 @@ pub fn credits_program<N: Network, A: Aleo<Network = N>>() -> Result<()> {
             "verifier_size": verifying_key_bytes.len(),
         });
 
-        println!("{}", serde_json::to_string_pretty(&metadata)?);
+        trace!("{}", serde_json::to_string_pretty(&metadata)?);
         write_metadata(&format!("{function_name}.metadata"), &metadata)?;
         write_remote(&format!("{function_name}.prover"), &proving_key_checksum, &proving_key_bytes)?;
         write_local(&format!("{function_name}.verifier"), &verifying_key_bytes)?;
@@ -129,11 +131,11 @@ pub fn credits_program<N: Network, A: Aleo<Network = N>>() -> Result<()> {
     }
 
     // Print the commands.
-    println!("\nNow, perform the following operations:\n");
+    trace!("\nNow, perform the following operations:\n");
     for command in commands {
-        println!("{command}");
+        trace!("{command}");
     }
-    println!();
+    trace!("");
 
     Ok(())
 }
@@ -141,9 +143,10 @@ pub fn credits_program<N: Network, A: Aleo<Network = N>>() -> Result<()> {
 /// Run the following command to perform a setup.
 /// `cargo run --example setup [variant]`
 pub fn main() -> Result<()> {
+    SimplerLogger::new().init()?;
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("Invalid number of arguments. Given: {} - Required: 1", args.len() - 1);
+        warn!("Invalid number of arguments. Given: {} - Required: 1", args.len() - 1);
         return Ok(());
     }
 

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -34,8 +34,8 @@ macro_rules! remove_file {
         #[cfg(not(feature = "wasm"))]
         if std::path::PathBuf::from(&$filepath).exists() {
             match std::fs::remove_file(&$filepath) {
-                Ok(()) => println!("Removed {:?}. Please retry the command.", $filepath),
-                Err(err) => eprintln!("Failed to remove {:?}: {err}", $filepath),
+                Ok(()) => log::trace!("Removed {:?}. Please retry the command.", $filepath),
+                Err(err) => log::warn!("Failed to remove {:?}: {err}", $filepath),
             }
         }
     };
@@ -51,7 +51,7 @@ macro_rules! impl_store_and_remote_fetch {
             {
                 use colored::*;
                 let output = format!("{:>15} - Storing file in {:?}", "Installation", file_path);
-                println!("{}", output.dimmed());
+                log::trace!("{}", output.dimmed());
             }
 
             // Ensure the folders up to the file path all exist.
@@ -62,7 +62,7 @@ macro_rules! impl_store_and_remote_fetch {
             // Attempt to write the parameter buffer to a file.
             match std::fs::File::create(file_path) {
                 Ok(mut file) => file.write_all(&buffer)?,
-                Err(error) => eprintln!("{}", error),
+                Err(error) => log::warn!("{}", error),
             }
             Ok(())
         }
@@ -78,7 +78,7 @@ macro_rules! impl_store_and_remote_fetch {
                 use colored::*;
 
                 let output = format!("{:>15} - Downloading \"{}\"", "Installation", url);
-                println!("{}", output.dimmed());
+                log::trace!("{}", output.dimmed());
 
                 easy.progress(true)?;
                 easy.progress_function(|total_download, current_download, _, _| {
@@ -178,11 +178,11 @@ macro_rules! impl_load_bytes_logic_remote {
             std::fs::read(&file_path)?
         } else {
             // Downloads the missing parameters and stores it in the local directory for use.
-             #[cfg(not(feature = "no_std_out"))]
+            #[cfg(not(feature = "no_std_out"))]
             {
                 use colored::*;
                 let path = format!("(in {:?})", file_path);
-                eprintln!(
+                log::warn!(
                     "\n⚠️  \"{}\" does not exist. Downloading and storing it {}.\n",
                     $filename, path.dimmed()
                 );
@@ -206,7 +206,7 @@ macro_rules! impl_load_bytes_logic_remote {
                     match Self::store_bytes(&buffer, &file_path) {
                         Ok(()) => buffer,
                         Err(_) => {
-                            eprintln!(
+                            log::warn!(
                                 "\n❗ Error - Failed to store \"{}\" locally. Please download this file manually and ensure it is stored in {:?}.\n",
                                 $filename, file_path
                             );

--- a/parameters/src/testnet3/powers.rs
+++ b/parameters/src/testnet3/powers.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use log::trace;
 use snarkvm_curves::traits::{PairingCurve, PairingEngine};
 use snarkvm_utilities::{
     CanonicalDeserialize,
@@ -398,7 +399,7 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
         // Download the powers of two.
         for num_powers in &download_queue {
             #[cfg(debug_assertions)]
-            println!("Loading {num_powers} powers");
+            trace!("Loading {num_powers} powers");
 
             // Download the universal SRS powers if they're not already on disk.
             let additional_bytes = match *num_powers {
@@ -476,7 +477,7 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
         // If the `target_degree` exceeds the current `degree`, proceed to download the new powers.
         for num_powers in &download_queue {
             #[cfg(debug_assertions)]
-            println!("Loading {num_powers} shifted powers");
+            trace!("Loading {num_powers} shifted powers");
 
             // Download the universal SRS powers if they're not already on disk.
             let additional_bytes = match *num_powers {

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -116,6 +116,9 @@ optional = true
 version = "1.0"
 features = [ "preserve_order" ]
 
+[dependencies.log]
+version = "0.4"
+
 [dev-dependencies.bincode]
 version = "1.3"
 

--- a/synthesizer/process/src/evaluate.rs
+++ b/synthesizer/process/src/evaluate.rs
@@ -14,6 +14,9 @@
 
 use super::*;
 
+#[cfg(feature = "aleo-cli")]
+use log::trace;
+
 impl<N: Network> Process<N> {
     /// Evaluates a program function on the given request.
     #[inline]
@@ -24,7 +27,7 @@ impl<N: Network> Process<N> {
         let request = authorization.peek_next()?;
 
         #[cfg(feature = "aleo-cli")]
-        println!("{}", format!(" • Evaluating '{}/{}'...", request.program_id(), request.function_name()).dimmed());
+        trace!("{}", format!(" • Evaluating '{}/{}'...", request.program_id(), request.function_name()).dimmed());
 
         // Retrieve the stack.
         let stack = self.get_stack(request.program_id())?;

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -485,6 +485,7 @@ impl<N: Network> Stack<N> {
     #[cfg(debug_assertions)]
     pub(crate) fn log_circuit<A: circuit::Aleo<Network = N>, S: Into<String>>(scope: S) {
         use colored::Colorize;
+        use log::trace;
 
         // Determine if the circuit is satisfied.
         let is_satisfied = if A::is_satisfied() { "✅".green() } else { "❌".red() };
@@ -492,7 +493,7 @@ impl<N: Network> Stack<N> {
         let (num_constant, num_public, num_private, num_constraints, num_nonzeros) = A::count();
 
         // Print the log.
-        println!(
+        trace!(
             "{is_satisfied} {:width$} (Constant: {num_constant}, Public: {num_public}, Private: {num_private}, Constraints: {num_constraints}, NonZeros: {num_nonzeros:?})",
             scope.into().bold(),
             width = 20

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use super::*;
+#[cfg(feature = "aleo-cli")]
+use log::warn;
+
 use synthesizer_program::CastType;
 
 impl<N: Network> RegisterTypes<N> {
@@ -309,11 +312,11 @@ impl<N: Network> RegisterTypes<N> {
         match operand {
             // Inform the user the output operand is an input register, to ensure this is intended behavior.
             Operand::Register(register) if self.is_input(register) => {
-                eprintln!("Output {operand} in '{}' is an input register, ensure this is intended", stack.program_id())
+                warn!("Output {operand} in '{}' is an input register, ensure this is intended", stack.program_id())
             }
             // Inform the user the output operand is a literal, to ensure this is intended behavior.
             Operand::Literal(..) => {
-                eprintln!("Output {operand} in '{}' is a literal, ensure this is intended", stack.program_id())
+                warn!("Output {operand} in '{}' is a literal, ensure this is intended", stack.program_id())
             }
             // Otherwise, do nothing.
             _ => (),

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -34,6 +34,7 @@ use ledger_store::{
     FinalizeStorage,
     FinalizeStore,
 };
+use log::trace;
 use synthesizer_program::{FinalizeGlobalState, FinalizeStoreTrait, Program};
 use synthesizer_snark::UniversalSRS;
 
@@ -1130,7 +1131,7 @@ function transfer:
         .authorize::<CurrentAleo, _>(&caller0_private_key, program1.id(), function_name, [r0, r1, r2].iter(), rng)
         .unwrap();
     assert_eq!(authorization.len(), 5);
-    println!("\nAuthorize\n{:#?}\n\n", authorization.to_vec_deque());
+    trace!("\nAuthorize\n{:#?}\n\n", authorization.to_vec_deque());
 
     let (output_a, output_b) = {
         // Fetch the first request.

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -57,6 +57,9 @@ version = "0.3"
 version = "1.0"
 features = [ "preserve_order" ]
 
+[dependencies.log]
+version = "0.4"
+
 [dev-dependencies.bincode]
 version = "1"
 

--- a/synthesizer/program/src/closure/bytes.rs
+++ b/synthesizer/program/src/closure/bytes.rs
@@ -119,6 +119,7 @@ mod tests {
     use super::*;
     use crate::Closure;
     use console::network::Testnet3;
+    use log::trace;
 
     type CurrentNetwork = Testnet3;
 
@@ -142,7 +143,7 @@ closure main:
 
         let expected = Closure::<CurrentNetwork>::from_str(closure_string)?;
         let expected_bytes = expected.to_bytes_le()?;
-        println!("String size: {:?}, Bytecode size: {:?}", closure_string.as_bytes().len(), expected_bytes.len());
+        trace!("String size: {:?}, Bytecode size: {:?}", closure_string.as_bytes().len(), expected_bytes.len());
 
         let candidate = Closure::<CurrentNetwork>::from_bytes_le(&expected_bytes)?;
         assert_eq!(expected.to_string(), candidate.to_string());

--- a/synthesizer/program/src/finalize/bytes.rs
+++ b/synthesizer/program/src/finalize/bytes.rs
@@ -93,6 +93,7 @@ mod tests {
     use super::*;
     use crate::Finalize;
     use console::network::Testnet3;
+    use log::trace;
 
     type CurrentNetwork = Testnet3;
 
@@ -117,7 +118,7 @@ finalize main:
 
         let expected = Finalize::<CurrentNetwork>::from_str(finalize_string)?;
         let expected_bytes = expected.to_bytes_le()?;
-        println!("String size: {:?}, Bytecode size: {:?}", finalize_string.as_bytes().len(), expected_bytes.len());
+        trace!("String size: {:?}, Bytecode size: {:?}", finalize_string.as_bytes().len(), expected_bytes.len());
 
         let candidate = Finalize::<CurrentNetwork>::from_bytes_le(&expected_bytes)?;
         assert_eq!(expected.to_string(), candidate.to_string());

--- a/synthesizer/program/src/finalize/parse.rs
+++ b/synthesizer/program/src/finalize/parse.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use log::warn;
+
 impl<N: Network, Command: CommandTrait<N>> Parser for FinalizeCore<N, Command> {
     /// Parses a string into finalize.
     #[inline]
@@ -40,11 +42,11 @@ impl<N: Network, Command: CommandTrait<N>> Parser for FinalizeCore<N, Command> {
             // Initialize a new finalize.
             let mut finalize = Self::new(name);
             if let Err(error) = inputs.iter().cloned().try_for_each(|input| finalize.add_input(input)) {
-                eprintln!("{error}");
+                warn!("{error}");
                 return Err(error);
             }
             if let Err(error) = commands.iter().cloned().try_for_each(|command| finalize.add_command(command)) {
-                eprintln!("{error}");
+                warn!("{error}");
                 return Err(error);
             }
             Ok::<_, Error>(finalize)

--- a/synthesizer/program/src/function/bytes.rs
+++ b/synthesizer/program/src/function/bytes.rs
@@ -136,6 +136,7 @@ mod tests {
     use super::*;
     use crate::Function;
     use console::network::Testnet3;
+    use log::trace;
 
     type CurrentNetwork = Testnet3;
 
@@ -159,7 +160,7 @@ function main:
 
         let expected = Function::<CurrentNetwork>::from_str(function_string)?;
         let expected_bytes = expected.to_bytes_le()?;
-        println!("String size: {:?}, Bytecode size: {:?}", function_string.as_bytes().len(), expected_bytes.len());
+        trace!("String size: {:?}, Bytecode size: {:?}", function_string.as_bytes().len(), expected_bytes.len());
 
         let candidate = Function::<CurrentNetwork>::from_bytes_le(&expected_bytes)?;
         assert_eq!(expected.to_string(), candidate.to_string());

--- a/synthesizer/program/src/function/parse.rs
+++ b/synthesizer/program/src/function/parse.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use log::warn;
+
 impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Parser
     for FunctionCore<N, Instruction, Command>
 {
@@ -47,22 +49,22 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Par
             // Initialize a new function.
             let mut function = Self::new(name);
             if let Err(error) = inputs.iter().cloned().try_for_each(|input| function.add_input(input)) {
-                eprintln!("{error}");
+                warn!("{error}");
                 return Err(error);
             }
             if let Err(error) =
                 instructions.iter().cloned().try_for_each(|instruction| function.add_instruction(instruction))
             {
-                eprintln!("{error}");
+                warn!("{error}");
                 return Err(error);
             }
             if let Err(error) = outputs.iter().cloned().try_for_each(|output| function.add_output(output)) {
-                eprintln!("{error}");
+                warn!("{error}");
                 return Err(error);
             }
             if let Some(finalize) = &finalize {
                 if let Err(error) = function.add_finalize(finalize.clone()) {
-                    eprintln!("{error}");
+                    warn!("{error}");
                     return Err(error);
                 }
             }

--- a/synthesizer/program/src/mapping/bytes.rs
+++ b/synthesizer/program/src/mapping/bytes.rs
@@ -46,6 +46,7 @@ impl<N: Network> ToBytes for Mapping<N> {
 mod tests {
     use super::*;
     use console::network::Testnet3;
+    use log::trace;
 
     type CurrentNetwork = Testnet3;
 
@@ -58,7 +59,7 @@ mapping main:
 
         let expected = Mapping::<CurrentNetwork>::from_str(mapping_string)?;
         let expected_bytes = expected.to_bytes_le()?;
-        println!("String size: {:?}, Bytecode size: {:?}", mapping_string.as_bytes().len(), expected_bytes.len());
+        trace!("String size: {:?}, Bytecode size: {:?}", mapping_string.as_bytes().len(), expected_bytes.len());
 
         let candidate = Mapping::<CurrentNetwork>::from_bytes_le(&expected_bytes)?;
         assert_eq!(expected.to_string(), candidate.to_string());

--- a/synthesizer/program/src/parse.rs
+++ b/synthesizer/program/src/parse.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use log::warn;
+
 impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Parser
     for ProgramCore<N, Instruction, Command>
 {
@@ -61,7 +63,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Par
             let mut program = match ProgramCore::<N, Instruction, Command>::new(id) {
                 Ok(program) => program,
                 Err(error) => {
-                    eprintln!("{error}");
+                    warn!("{error}");
                     return Err(error);
                 }
             };
@@ -78,7 +80,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Par
                 match result {
                     Ok(_) => (),
                     Err(error) => {
-                        eprintln!("{error}");
+                        warn!("{error}");
                         return Err(error);
                     }
                 }
@@ -88,7 +90,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Par
                 match program.add_import(import.clone()) {
                     Ok(_) => (),
                     Err(error) => {
-                        eprintln!("{error}");
+                        warn!("{error}");
                         return Err(error);
                     }
                 }

--- a/synthesizer/snark/Cargo.toml
+++ b/synthesizer/snark/Cargo.toml
@@ -60,6 +60,9 @@ version = "1.18"
 version = "1.0"
 features = [ "preserve_order" ]
 
+[dependencies.log]
+version = "0.4.14"
+
 [dev-dependencies.console]
 package = "snarkvm-console"
 path = "../../console"

--- a/synthesizer/snark/src/certificate/mod.rs
+++ b/synthesizer/snark/src/certificate/mod.rs
@@ -17,6 +17,8 @@ use super::*;
 mod bytes;
 mod parse;
 mod serialize;
+#[cfg(feature = "aleo-cli")]
+use log::trace;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Certificate<N: Network> {
@@ -47,7 +49,7 @@ impl<N: Network> Certificate<N> {
         let certificate = Varuna::<N>::prove_vk(universal_prover, fiat_shamir, verifying_key, proving_key)?;
 
         #[cfg(feature = "aleo-cli")]
-        println!("{}", format!(" • Certified '{function_name}': {} ms", timer.elapsed().as_millis()).dimmed());
+        trace!("{}", format!(" • Certified '{function_name}': {} ms", timer.elapsed().as_millis()).dimmed());
 
         Ok(Self::new(certificate))
     }
@@ -72,14 +74,14 @@ impl<N: Network> Certificate<N> {
                 #[cfg(feature = "aleo-cli")]
                 {
                     let elapsed = timer.elapsed().as_millis();
-                    println!("{}", format!(" • Verified certificate for '{function_name}': {elapsed} ms").dimmed());
+                    trace!("{}", format!(" • Verified certificate for '{function_name}': {elapsed} ms").dimmed());
                 }
 
                 is_valid
             }
             Err(error) => {
                 #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Certificate verification failed: {error}").dimmed());
+                trace!("{}", format!(" • Certificate verification failed: {error}").dimmed());
                 false
             }
         }

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -17,6 +17,8 @@ use super::*;
 mod bytes;
 mod parse;
 mod serialize;
+#[cfg(feature = "aleo-cli")]
+use log::trace;
 
 use std::collections::BTreeMap;
 
@@ -50,7 +52,7 @@ impl<N: Network> ProvingKey<N> {
         let proof = Proof::new(Varuna::<N>::prove(universal_prover, fiat_shamir, self, assignment, rng)?);
 
         #[cfg(feature = "aleo-cli")]
-        println!("{}", format!(" • Executed '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
+        trace!("{}", format!(" • Executed '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
         Ok(proof)
     }
 
@@ -78,7 +80,7 @@ impl<N: Network> ProvingKey<N> {
         let batch_proof = Proof::new(Varuna::<N>::prove_batch(universal_prover, fiat_shamir, &instances, rng)?);
 
         #[cfg(feature = "aleo-cli")]
-        println!("{}", format!(" • Executed '{locator}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
+        trace!("{}", format!(" • Executed '{locator}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
 
         Ok(batch_proof)
     }

--- a/synthesizer/snark/src/universal_srs.rs
+++ b/synthesizer/snark/src/universal_srs.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use super::*;
+#[cfg(feature = "aleo-cli")]
+use log::trace;
 
 #[derive(Clone)]
 pub struct UniversalSRS<N: Network> {
@@ -38,7 +40,7 @@ impl<N: Network> UniversalSRS<N> {
         let (proving_key, verifying_key) = Varuna::<N>::circuit_setup(self, assignment)?;
 
         #[cfg(feature = "aleo-cli")]
-        println!("{}", format!(" • Built '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
+        trace!("{}", format!(" • Built '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
 
         Ok((ProvingKey::new(Arc::new(proving_key)), VerifyingKey::new(Arc::new(verifying_key))))
     }
@@ -71,7 +73,7 @@ impl<N: Network> Deref for UniversalSRS<N> {
             let universal_srs = varuna::UniversalSRS::load().expect("Failed to load the universal SRS");
 
             #[cfg(feature = "aleo-cli")]
-            println!("{}", format!(" • Loaded universal setup (in {} ms)", timer.elapsed().as_millis()).dimmed());
+            trace!("{}", format!(" • Loaded universal setup (in {} ms)", timer.elapsed().as_millis()).dimmed());
 
             universal_srs
         })

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use super::*;
+#[cfg(feature = "aleo-cli")]
+use log::trace;
 
 mod bytes;
 mod parse;
@@ -45,15 +47,12 @@ impl<N: Network> VerifyingKey<N> {
         match Varuna::<N>::verify(universal_verifier, fiat_shamir, self, inputs, proof) {
             Ok(is_valid) => {
                 #[cfg(feature = "aleo-cli")]
-                println!(
-                    "{}",
-                    format!(" • Verified '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed()
-                );
+                trace!("{}", format!(" • Verified '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
                 is_valid
             }
             Err(error) => {
                 #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Verifier failed: {error}").dimmed());
+                trace!("{}", format!(" • Verifier failed: {error}").dimmed());
                 false
             }
         }
@@ -77,12 +76,12 @@ impl<N: Network> VerifyingKey<N> {
         match Varuna::<N>::verify_batch(universal_verifier, fiat_shamir, &keys_to_inputs, proof) {
             Ok(is_valid) => {
                 #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Verified '{locator}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
+                trace!("{}", format!(" • Verified '{locator}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
                 is_valid
             }
             Err(error) => {
                 #[cfg(feature = "aleo-cli")]
-                println!("{}", format!(" • Verifier failed: {error}").dimmed());
+                trace!("{}", format!(" • Verifier failed: {error}").dimmed());
                 false
             }
         }

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -387,7 +387,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     }
                     // If the transaction failed, abort the entire batch.
                     Err(error) => {
-                        eprintln!("Critical bug in speculate: {error}\n\n{transaction}");
+                        warn!("Critical bug in speculate: {error}\n\n{transaction}");
                         // Note: This will abort the entire atomic batch.
                         return Err(format!("Failed to speculate on transaction - {error}"));
                     }
@@ -670,7 +670,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     Ok(()) => (),
                     // If the transaction failed to finalize, abort and continue to the next transaction.
                     Err(error) => {
-                        eprintln!("Critical bug in finalize: {error}\n\n{transaction}");
+                        warn!("Critical bug in finalize: {error}\n\n{transaction}");
                         // Note: This will abort the entire atomic batch.
                         return Err(format!("Failed to finalize on transaction - {error}"));
                     }
@@ -1598,7 +1598,7 @@ finalize compute:
             .finalize_store()
             .get_value_speculative(program_id, mapping_name, &Plaintext::from(Literal::Address(address)))
             .unwrap();
-        println!("{:?}", value);
+        trace!("{:?}", value);
         assert!(
             !vm.finalize_store()
                 .contains_key_confirmed(program_id, mapping_name, &Plaintext::from(Literal::Address(address)))

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -76,6 +76,10 @@ default-features = false
 version = "1"
 features = [ "derive" ]
 
+[dependencies.log]
+version = "0.4.18"
+features = ["std"]
+
 [features]
 default = [ "aleo-std/cpu", "derive", "num_cpus", "std" ]
 derive = [ "snarkvm-utilities-derives" ]

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -71,6 +71,9 @@ pub use self::rand::*;
 pub mod serialize;
 pub use serialize::*;
 
+pub mod simpler_logger;
+pub use simpler_logger::*;
+
 #[cfg(not(feature = "std"))]
 pub mod io;
 

--- a/utilities/src/simpler_logger.rs
+++ b/utilities/src/simpler_logger.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A logger that prints to stdout and stderr.
+//!
+//! All records with a level of `Info` or higher are printed as-is to stdout, and all
+//! records with a level of `Warn` or Lower are printed to stderr.
+//!
+//! # Example
+//! ```rust
+//! use snarkvm_utilities::simpler_logger::SimplerLogger;
+//!
+//! SimplerLogger::new().init().unwrap();
+//! log::trace!("trace"); // -> stdout
+//! log::debug!("debug"); // -> stdout
+//! log::info!("info"); // -> stdout
+//! log::warn!("warn"); // -> stderr
+//! log::error!("error"); // -> stderr
+//! ```
+//!
+use log::{Log, Metadata, Record};
+
+pub struct SimplerLogger;
+
+impl SimplerLogger {
+    pub fn new() -> SimplerLogger {
+        SimplerLogger {}
+    }
+
+    pub fn init(self) -> Result<(), log::SetLoggerError> {
+        log::set_boxed_logger(Box::new(self))?;
+        log::set_max_level(log::LevelFilter::Trace);
+        Ok(())
+    }
+}
+
+impl Default for SimplerLogger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Log for SimplerLogger {
+    fn log(&self, message: &Record) {
+        // Confusingly, Level::Error is `1`, and Level::Trace is `5`.
+        if message.level() >= log::Level::Info {
+            println!("{}", message.args());
+        } else if message.level() < log::Level::Info {
+            eprintln!("{}", message.args());
+        }
+    }
+
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn flush(&self) {}
+}

--- a/vm/cli/commands/run.rs
+++ b/vm/cli/commands/run.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::trace;
+
 use super::*;
 
 /// Runs an Aleo program function
@@ -65,7 +67,7 @@ impl Run {
         // Log the metrics.
         use num_format::ToFormattedString;
 
-        println!("⛓  Constraints\n");
+        trace!("⛓  Constraints\n");
         for (function_constraints, counter) in program_frequency {
             // Log the constraints
             let counter_string = match counter {
@@ -73,19 +75,19 @@ impl Run {
                 counter => format!("(called {counter} times)").dimmed(),
             };
 
-            println!(" •  {function_constraints} {counter_string}",)
+            trace!(" •  {function_constraints} {counter_string}",)
         }
 
         // Log the outputs.
         match response.outputs().len() {
             0 => (),
-            1 => println!("\n➡️  Output\n"),
-            _ => println!("\n➡️  Outputs\n"),
+            1 => trace!("\n➡️  Output\n"),
+            _ => trace!("\n➡️  Outputs\n"),
         };
         for output in response.outputs() {
-            println!("{}", format!(" • {output}"));
+            trace!("{}", format!(" • {output}"));
         }
-        println!();
+        trace!("");
 
         // Prepare the locator.
         let locator = Locator::<CurrentNetwork>::from_str(&format!("{}/{}", package.program_id(), self.function))?;

--- a/vm/cli/main.rs
+++ b/vm/cli/main.rs
@@ -12,19 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkvm::cli::{Updater, CLI};
-
 use clap::Parser;
+use log::info;
+use snarkvm::{
+    cli::{Updater, CLI},
+    utilities::simpler_logger::SimplerLogger,
+};
 
 fn main() -> anyhow::Result<()> {
+    SimplerLogger::new().init()?;
     // Parse the given arguments.
     let cli = CLI::parse();
     // Run the updater.
-    println!("{}", Updater::print_cli());
+    info!("{}", Updater::print_cli());
     // Run the CLI.
     match cli.command.parse() {
-        Ok(output) => println!("{output}\n"),
-        Err(error) => println!("⚠️  {error}\n"),
+        Ok(output) => info!("{output}\n"),
+        Err(error) => info!("⚠️  {error}\n"),
     }
     Ok(())
 }

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use crate::ledger::block::Deployment;
+#[cfg(feature = "aleo-cli")]
+use log::trace;
 use snarkvm_console::prelude::DeserializeExt;
 
 use super::*;
@@ -120,7 +122,7 @@ impl<N: Network> Package<N> {
         let program_id = program.id();
 
         #[cfg(feature = "aleo-cli")]
-        println!("⏳ Deploying '{}'...\n", program_id.to_string().bold());
+        trace!("⏳ Deploying '{}'...\n", program_id.to_string().bold());
 
         // Construct the process.
         let mut process = Process::<N>::load()?;

--- a/vm/package/run.rs
+++ b/vm/package/run.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use super::*;
+#[cfg(feature = "aleo-cli")]
+use log::trace;
 
 impl<N: Network> Package<N> {
     /// Runs a program function with the given inputs.
@@ -36,7 +38,7 @@ impl<N: Network> Package<N> {
         let _locator = Locator::<N>::from_str(&format!("{program_id}/{function_name}"))?;
 
         #[cfg(feature = "aleo-cli")]
-        println!("🚀 Running '{}'...\n", _locator.to_string().bold());
+        trace!("🚀 Running '{}'...\n", _locator.to_string().bold());
 
         // Construct the process.
         let process = self.get_process()?;


### PR DESCRIPTION
Using println! for logging is annoying when snarkVM is used as library (like snarkOS).

- Replace println and friends with logging
- install simple_logger impl in binaries where appropriate

Draft, to be revisited after mainnet.
