### PR TITLE
Increase aborted transaction limit

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -111,6 +111,8 @@ pub trait Network:
     const COINBASE_PUZZLE_DEGREE: u32 = (1 << 13) - 1; // 8,191
     /// The maximum number of solutions that can be included per block.
     const MAX_SOLUTIONS: usize = 1 << 8; // 256 solutions
+    /// The maximum number of transactions and solutions that can be included per block per round per validator.
+    const MAX_TRANSMISSIONS_PER_BATCH: usize = 250;
     /// The number of blocks per epoch.
     const NUM_BLOCKS_PER_EPOCH: u32 = 3600 / Self::BLOCK_TIME as u32; // 360 blocks == ~1 hour
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -111,8 +111,6 @@ pub trait Network:
     const COINBASE_PUZZLE_DEGREE: u32 = (1 << 13) - 1; // 8,191
     /// The maximum number of solutions that can be included per block.
     const MAX_SOLUTIONS: usize = 1 << 8; // 256 solutions
-    /// The maximum number of transactions and solutions that can be included per block per round per validator.
-    const MAX_TRANSMISSIONS_PER_BATCH: usize = 250;
     /// The number of blocks per epoch.
     const NUM_BLOCKS_PER_EPOCH: u32 = 3600 / Self::BLOCK_TIME as u32; // 360 blocks == ~1 hour
 

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -56,6 +56,11 @@ package = "snarkvm-ledger-committee"
 path = "../../ledger/committee"
 version = "=0.16.16"
 
+[dependencies.ledger-narwhal-batch-header]
+package = "snarkvm-ledger-narwhal-batch-header"
+path = "../narwhal/batch-header"
+version = "=0.16.16"
+
 [dependencies.ledger-narwhal-subdag]
 package = "snarkvm-ledger-narwhal-subdag"
 path = "../narwhal/subdag"

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -52,7 +52,7 @@ impl<N: Network> FromBytes for Block<N> {
         // Read the number of aborted transaction IDs.
         let num_aborted = u32::read_le(&mut reader)?;
         // Ensure the number of aborted transaction IDs is within bounds (this is an early safety check).
-        if num_aborted as usize > Transactions::<N>::MAX_TRANSACTIONS {
+        if num_aborted as usize > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
             return Err(error("Invalid number of aborted transaction IDs in the block"));
         }
         // Read the aborted transaction IDs.

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -137,10 +137,10 @@ impl<N: Network> Block<N> {
         }
 
         // Ensure the number of aborted transaction IDs is within the allowed range.
-        if aborted_transaction_ids.len() > Transactions::<N>::MAX_TRANSACTIONS {
+        if aborted_transaction_ids.len() > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
             bail!(
                 "Cannot initialize a block with more than {} aborted transaction IDs",
-                Transactions::<N>::MAX_TRANSACTIONS
+                Transactions::<N>::MAX_ABORTED_TRANSACTIONS
             );
         }
 

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -41,6 +41,8 @@ use synthesizer_program::FinalizeOperation;
 
 use indexmap::IndexMap;
 
+use ledger_committee::Committee;
+use ledger_narwhal_subdag::Subdag;
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 
@@ -166,6 +168,9 @@ impl<N: Network> Transactions<N> {
 }
 
 impl<N: Network> Transactions<N> {
+    /// The maximum number of aborted transactions allowed in a block.
+    pub const MAX_ABORTED_TRANSACTIONS: usize =
+        Subdag::<N>::MAX_ROUNDS * Committee::<N>::MAX_COMMITTEE_SIZE as usize * N::MAX_TRANSMISSIONS_PER_BATCH;
     /// The maximum number of transactions allowed in a block.
     pub const MAX_TRANSACTIONS: usize = usize::pow(2, TRANSACTIONS_DEPTH as u32);
 

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -37,12 +37,13 @@ use console::{
     },
     types::{Field, Group, U64},
 };
+use ledger_committee::Committee;
+use ledger_narwhal_batch_header::BatchHeader;
+use ledger_narwhal_subdag::Subdag;
 use synthesizer_program::FinalizeOperation;
 
 use indexmap::IndexMap;
 
-use ledger_committee::Committee;
-use ledger_narwhal_subdag::Subdag;
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 
@@ -169,8 +170,9 @@ impl<N: Network> Transactions<N> {
 
 impl<N: Network> Transactions<N> {
     /// The maximum number of aborted transactions allowed in a block.
-    pub const MAX_ABORTED_TRANSACTIONS: usize =
-        Subdag::<N>::MAX_ROUNDS * Committee::<N>::MAX_COMMITTEE_SIZE as usize * N::MAX_TRANSMISSIONS_PER_BATCH;
+    pub const MAX_ABORTED_TRANSACTIONS: usize = Subdag::<N>::MAX_ROUNDS
+        * Committee::<N>::MAX_COMMITTEE_SIZE as usize
+        * BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH;
     /// The maximum number of transactions allowed in a block.
     pub const MAX_TRANSACTIONS: usize = usize::pow(2, TRANSACTIONS_DEPTH as u32);
 

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -393,10 +393,10 @@ impl<N: Network> Block<N> {
         }
 
         // Ensure the number of aborted transaction IDs is within the allowed range.
-        if self.aborted_transaction_ids.len() > Transactions::<N>::MAX_TRANSACTIONS {
+        if self.aborted_transaction_ids.len() > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
             bail!(
                 "Cannot validate a block with more than {} aborted transaction IDs",
-                Transactions::<N>::MAX_TRANSACTIONS
+                Transactions::<N>::MAX_ABORTED_TRANSACTIONS
             );
         }
 

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -63,6 +63,11 @@ impl<N: Network> BatchHeader<N> {
     pub const MAX_TRANSACTIONS: usize = usize::pow(2, console::program::TRANSACTIONS_DEPTH as u32);
     /// The maximum number of transmissions in a batch.
     pub const MAX_TRANSMISSIONS: usize = Self::MAX_SOLUTIONS + Self::MAX_TRANSACTIONS;
+    /// The maximum number of transmissions in a batch.
+    /// Note: This limit is set to 50 as part of safety measures to prevent DoS attacks.
+    /// This limit can be increased in the future as performance improves. Alternatively,
+    /// the rate of block production can be sped up to compensate for the limit set here.
+    pub const MAX_TRANSMISSIONS_PER_BATCH: usize = 50;
 }
 
 impl<N: Network> BatchHeader<N> {

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -172,11 +172,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Perform the finalize operation on the preset finalize mode.
         atomic_finalize!(self.finalize_store(), FinalizeMode::DryRun, {
             // Ensure the number of transactions does not exceed the maximum.
-            if num_transactions > 2 * Transactions::<N>::MAX_TRANSACTIONS {
+            if num_transactions > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
                 // Note: This will abort the entire atomic batch.
                 return Err(format!(
                     "Too many transactions in the block - {num_transactions} (max: {})",
-                    2 * Transactions::<N>::MAX_TRANSACTIONS
+                    Transactions::<N>::MAX_ABORTED_TRANSACTIONS
                 ));
             }
 


### PR DESCRIPTION
# Motivation
- The existing limit on the maximum number of aborted transactions is too small. 
- This PR bumps it from `65,536` to `2,500,000`, as is calculated by `MAX_GC_ROUNDS * MAX_COMMITTEE_SIZE * MAX_TRANSMISSIONS_PER_BATCH` 
- Although there is a negligible probability of encountering this theoretical worst case, the ramifications of being maximally safe only increase the block size by 18%. 
	- Worse case storage increase:
		- 80MB to store all aborted transactions
	- But we would already be paying: 
		- 254MB to store the subDAG
		- 185MB to store all executions at the very minimum
		- Having to store the subdag is the main storage cost in extreme cases like this as we are storing all the batch headers and signatures that any validator has seen from any other validator. 
