### PR TITLE
Abort transactions with duplicated `TransitionID`s 

### DIFF
--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -896,6 +896,142 @@ function create_duplicate_record:
 }
 
 #[test]
+fn test_execute_duplicate_transition_ids() {
+    let rng = &mut TestRng::default();
+
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, private_key, address, .. } = crate::test_helpers::sample_test_env(rng);
+
+    // Deploy a test program to the ledger.
+    let program = Program::<CurrentNetwork>::from_str(
+        "
+program dummy_program.aleo;
+
+function empty_function:
+    ",
+    )
+    .unwrap();
+
+    // Deploy.
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    // Verify.
+    ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
+
+    // Construct the next block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_transaction], rng)
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Create a transaction with different transaction ids, but with a fixed transition id.
+    let mut create_transaction_with_duplicate_transition_id = || -> Transaction<CurrentNetwork> {
+        // Use a fixed seed RNG.
+        let fixed_rng = &mut TestRng::from_seed(1);
+
+        // Create a transaction with a fixed rng.
+        let inputs: [Value<_>; 0] = [];
+        let transaction = ledger
+            .vm
+            .execute(
+                &private_key,
+                ("dummy_program.aleo", "empty_function"),
+                inputs.into_iter(),
+                None,
+                0,
+                None,
+                fixed_rng,
+            )
+            .unwrap();
+        // Extract the execution.
+        let execution = transaction.execution().unwrap().clone();
+
+        // Create a new fee for the execution.
+        let fee_authorization = ledger
+            .vm
+            .authorize_fee_public(
+                &private_key,
+                *transaction.fee_amount().unwrap(),
+                0,
+                execution.to_execution_id().unwrap(),
+                rng,
+            )
+            .unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+
+        Transaction::from_execution(execution, Some(fee)).unwrap()
+    };
+
+    // Create the first transaction.
+    let transaction_1 = create_transaction_with_duplicate_transition_id();
+    let transaction_1_id = transaction_1.id();
+
+    // Create a second transaction with the same transition id.
+    let transaction_2 = create_transaction_with_duplicate_transition_id();
+    let transaction_2_id = transaction_2.id();
+
+    // Create a third transaction with the same transition_id
+    let transaction_3 = create_transaction_with_duplicate_transition_id();
+    let transaction_3_id = transaction_3.id();
+
+    // Ensure that each transaction has a duplicate transition id.
+    let tx_1_transition_id = transaction_1.transition_ids().next().unwrap();
+    let tx_2_transition_id = transaction_2.transition_ids().next().unwrap();
+    let tx_3_transition_id = transaction_3.transition_ids().next().unwrap();
+    assert_eq!(tx_1_transition_id, tx_2_transition_id);
+    assert_eq!(tx_1_transition_id, tx_3_transition_id);
+
+    // Create a block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction_1, transaction_2], rng)
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Enforce that the block transactions were correct.
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transaction_1_id]);
+    assert_eq!(block.aborted_transaction_ids(), &vec![transaction_2_id]);
+
+    // Prepare a transfer that will succeed for the subsequent block.
+    let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
+    let transfer_transaction = ledger
+        .vm
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .unwrap();
+    let transfer_transaction_id = transfer_transaction.id();
+
+    // Create a block.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(
+            &private_key,
+            vec![],
+            vec![],
+            vec![transaction_3, transfer_transaction],
+            rng,
+        )
+        .unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Enforce that the block transactions were correct.
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_transaction_id]);
+    assert_eq!(block.aborted_transaction_ids(), &vec![transaction_3_id]);
+}
+
+#[test]
 fn test_deployment_duplicate_program_id() {
     let rng = &mut TestRng::default();
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds logic to `VM::atomic_speculate` to track `TransitionID`s and abort transactions that attempt to create an `TransitionID` that was already included in this block or previous blocks.

## Test Plan

A test has been added to check that different transactions can't produce the same `TransitionID`

## Related PRs

Related to: #2229 and #2301 
Fixes: #2262 