### PR TITLE
Fix compilation warnings

### DIFF
--- a/circuit/environment/src/lib.rs
+++ b/circuit/environment/src/lib.rs
@@ -29,6 +29,7 @@ pub mod helpers;
 pub use helpers::*;
 
 pub mod macros;
+#[allow(unused_imports)]
 pub use macros::*;
 
 pub mod traits;

--- a/circuit/environment/src/macros/mod.rs
+++ b/circuit/environment/src/macros/mod.rs
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 mod metrics;
+#[allow(unused_imports)]
 pub use metrics::*;
 
 mod scope;
+#[allow(unused_imports)]
 pub use scope::*;
 
 mod witness;
+#[allow(unused_imports)]
 pub use witness::*;

--- a/fields/src/lib.rs
+++ b/fields/src/lib.rs
@@ -42,6 +42,7 @@ mod legendre;
 pub use legendre::*;
 
 mod to_field_vec;
+#[allow(unused_imports)]
 pub use to_field_vec::*;
 
 pub mod traits;

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -66,8 +66,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         let timer = timer!("Call::evaluate");
 
         // Load the operands values.
-        let inputs: Vec<_> =
-            self.operands().iter().map(|operand| registers.load(stack.deref(), operand)).try_collect()?;
+        let inputs: Vec<_> = self.operands().iter().map(|operand| registers.load(stack, operand)).try_collect()?;
 
         // Retrieve the substack and resource.
         let (substack, resource) = match self.operator() {

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 pub use crate::{
-    io::{self, Read, Write},
+    io::{Read, Write},
     FromBytes,
     ToBytes,
     Vec,

--- a/utilities/src/serialize/mod.rs
+++ b/utilities/src/serialize/mod.rs
@@ -19,6 +19,7 @@ mod helpers;
 pub use helpers::*;
 
 mod impls;
+#[allow(unused_imports)]
 pub use impls::*;
 
 mod flags;

--- a/utilities/src/serialize/traits.rs
+++ b/utilities/src/serialize/traits.rs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use crate::io::{Read, Write};
 use crate::SerializationError;
-pub use crate::{
-    io::{self, Read, Write},
-    FromBytes,
-    ToBytes,
-    Vec,
-};
 
 use serde::de::{self, DeserializeOwned, Deserializer};
 


### PR DESCRIPTION
These include:
- unused imports
- ineffective reexports of impls and macros
- one redundant call to `deref`