### PR TITLE
[Fuzzing-ILT] Disallow `Identifier`s with the same form as `LiteralType`s.

### DIFF
--- a/console/program/src/data/identifier/parse.rs
+++ b/console/program/src/data/identifier/parse.rs
@@ -52,6 +52,12 @@ impl<N: Network> FromStr for Identifier<N> {
             bail!("Identifier is too large. Identifiers must be <= {max_bytes} bytes long")
         }
 
+        // Ensure that the identifier is not a literal.
+        ensure!(
+            crate::LiteralType::from_str(identifier).is_err(),
+            "Identifier '{identifier}' is a reserved literal type"
+        );
+
         // Note: The string bytes themselves are **not** little-endian. Rather, they are order-preserving
         // for reconstructing the string when recovering the field element back into bytes.
         Ok(Self(

--- a/console/program/src/data_types/plaintext_type/parse.rs
+++ b/console/program/src/data_types/plaintext_type/parse.rs
@@ -21,8 +21,8 @@ impl<N: Network> Parser for PlaintextType<N> {
         // Parse to determine the plaintext type (order matters).
         alt((
             map(ArrayType::parse, |type_| Self::Array(type_)),
-            map(LiteralType::parse, |type_| Self::Literal(type_)),
             map(Identifier::parse, |identifier| Self::Struct(identifier)),
+            map(LiteralType::parse, |type_| Self::Literal(type_)),
         ))(string)
     }
 }
@@ -85,6 +85,10 @@ mod tests {
         assert_eq!(
             PlaintextType::parse("foo"),
             Ok(("", PlaintextType::<CurrentNetwork>::Struct(Identifier::from_str("foo")?)))
+        );
+        assert_eq!(
+            PlaintextType::parse("u8jdsklaj"),
+            Ok(("", PlaintextType::<CurrentNetwork>::Struct(Identifier::from_str("u8jdsklaj")?)))
         );
         assert_eq!(
             PlaintextType::parse("[field; 1u32]"),

--- a/console/program/src/data_types/register_type/parse.rs
+++ b/console/program/src/data_types/register_type/parse.rs
@@ -88,6 +88,10 @@ mod tests {
             Ok(("", RegisterType::<CurrentNetwork>::Plaintext(PlaintextType::from_str("signature")?))),
             RegisterType::<CurrentNetwork>::parse("signature")
         );
+        assert_eq!(
+            Ok(("", RegisterType::<CurrentNetwork>::Plaintext(PlaintextType::from_str("u8kldsafj")?))),
+            RegisterType::<CurrentNetwork>::parse("u8kldsafj")
+        );
 
         // Record type.
         assert_eq!(

--- a/console/program/src/data_types/value_type/parse.rs
+++ b/console/program/src/data_types/value_type/parse.rs
@@ -105,6 +105,10 @@ mod tests {
             Ok(("", ValueType::<CurrentNetwork>::from_str("signature.private")?)),
             ValueType::<CurrentNetwork>::parse("signature.private")
         );
+        assert_eq!(
+            Ok(("", ValueType::<CurrentNetwork>::from_str("i8abc.constant")?)),
+            ValueType::<CurrentNetwork>::parse("i8abc.constant")
+        );
 
         // Record type.
         assert_eq!(


### PR DESCRIPTION
This PR closes #2239.
We could consider disallowing all [`KEYWORDS`](https://github.com/AleoHQ/snarkVM/blob/19b563f85497aff870a47fcd9c38f4ee01066860/synthesizer/program/src/lib.rs#L556) entirely.
