### PR TITLE
Fix `max_write` error message

### DIFF
--- a/synthesizer/program/src/finalize/mod.rs
+++ b/synthesizer/program/src/finalize/mod.rs
@@ -113,7 +113,7 @@ impl<N: Network, Command: CommandTrait<N>> FinalizeCore<N, Command> {
         // Ensure the maximum number of commands has not been exceeded.
         ensure!(self.commands.len() < N::MAX_COMMANDS, "Cannot add more than {} commands", N::MAX_COMMANDS);
         // Ensure the number of write commands has not been exceeded.
-        ensure!(self.num_writes < N::MAX_WRITES, "Cannot add more than {} 'set' commands", N::MAX_WRITES);
+        ensure!(self.num_writes < N::MAX_WRITES, "Cannot add more than {} 'set' & 'remove' commands", N::MAX_WRITES);
 
         // Ensure the command is not a call instruction.
         ensure!(!command.is_call(), "Forbidden operation: Finalize cannot invoke a 'call'");


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes the `max_write` error message.

Closes #2248