### PR TITLE
Allow the ledger to be loaded from a custom location

### DIFF
--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -257,7 +257,7 @@ mod tests {
         let genesis = Block::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();
 
         // Initialize a new ledger.
-        let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
+        let ledger = CurrentLedger::load(genesis.clone(), StorageMode::Production).unwrap();
         // Retrieve the genesis block.
         let candidate = ledger.get_block(0).unwrap();
         // Ensure the genesis block matches.

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -62,7 +62,10 @@ use synthesizer::{
     vm::VM,
 };
 
-use aleo_std::prelude::{finish, lap, timer};
+use aleo_std::{
+    prelude::{finish, lap, timer},
+    StorageMode,
+};
 use anyhow::Result;
 use core::ops::Range;
 use indexmap::IndexMap;
@@ -108,13 +111,13 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Loads the ledger from storage.
-    pub fn load(genesis_block: Block<N>, dev: Option<u16>) -> Result<Self> {
+    pub fn load(genesis_block: Block<N>, storage_mode: StorageMode) -> Result<Self> {
         let timer = timer!("Ledger::load");
 
         // Retrieve the genesis hash.
         let genesis_hash = genesis_block.hash();
         // Initialize the ledger.
-        let ledger = Self::load_unchecked(genesis_block, dev)?;
+        let ledger = Self::load_unchecked(genesis_block, storage_mode)?;
 
         // Ensure the ledger contains the correct genesis block.
         if !ledger.contains_block_hash(&genesis_hash)? {
@@ -140,12 +143,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Loads the ledger from storage, without performing integrity checks.
-    pub fn load_unchecked(genesis_block: Block<N>, dev: Option<u16>) -> Result<Self> {
+    pub fn load_unchecked(genesis_block: Block<N>, storage_mode: StorageMode) -> Result<Self> {
         let timer = timer!("Ledger::load_unchecked");
 
         info!("Loading the ledger from storage...");
         // Initialize the consensus store.
-        let store = match ConsensusStore::<N, C>::open(dev) {
+        let store = match ConsensusStore::<N, C>::open(storage_mode) {
             Ok(store) => store,
             Err(e) => bail!("Failed to load ledger (run 'snarkos clean' and try again)\n\n{e}\n"),
         };
@@ -383,6 +386,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use crate::Ledger;
+    use aleo_std::StorageMode;
     use console::{
         account::{Address, PrivateKey, ViewKey},
         network::Testnet3,
@@ -439,7 +443,7 @@ pub(crate) mod test_helpers {
         // Create a genesis block.
         let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
         // Initialize the ledger with the genesis block.
-        let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
+        let ledger = CurrentLedger::load(genesis.clone(), StorageMode::Production).unwrap();
         // Ensure the genesis block is correct.
         assert_eq!(genesis, ledger.get_block(0).unwrap());
         // Return the ledger.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -17,6 +17,7 @@ use crate::{
     test_helpers::{CurrentLedger, CurrentNetwork},
     RecordsFilter,
 };
+use aleo_std::StorageMode;
 use console::{
     account::{Address, PrivateKey},
     network::prelude::*,
@@ -38,7 +39,7 @@ fn test_load() {
     let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
 
     // Initialize the ledger with the genesis block.
-    let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
+    let ledger = CurrentLedger::load(genesis.clone(), StorageMode::Production).unwrap();
     assert_eq!(ledger.latest_hash(), genesis.hash());
     assert_eq!(ledger.latest_height(), genesis.height());
     assert_eq!(ledger.latest_round(), genesis.round());
@@ -51,14 +52,14 @@ fn test_load_unchecked() {
     let genesis = crate::test_helpers::sample_genesis_block();
 
     // Initialize the ledger without checks.
-    let ledger = CurrentLedger::load_unchecked(genesis.clone(), None).unwrap();
+    let ledger = CurrentLedger::load_unchecked(genesis.clone(), StorageMode::Production).unwrap();
     assert_eq!(ledger.latest_hash(), genesis.hash());
     assert_eq!(ledger.latest_height(), genesis.height());
     assert_eq!(ledger.latest_round(), genesis.round());
     assert_eq!(ledger.latest_block(), genesis);
 
     // Initialize the ledger with the genesis block.
-    let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
+    let ledger = CurrentLedger::load(genesis.clone(), StorageMode::Production).unwrap();
     assert_eq!(ledger.latest_hash(), genesis.hash());
     assert_eq!(ledger.latest_height(), genesis.height());
     assert_eq!(ledger.latest_round(), genesis.round());


### PR DESCRIPTION
A small follow-up to https://github.com/AleoHQ/snarkVM/pull/2314.

Note: making `aleo-std` a workspace dependency might be a good idea (as it has been proposed in https://github.com/AleoHQ/snarkOS/pull/3044).