### PR TITLE
Fix bug in Poseidon internal squeezing function.

### DIFF
--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -130,10 +130,9 @@ impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
             let num_squeezed = RATE - squeeze_index;
             remaining[..num_squeezed].clone_from_slice(&state[start..(start + num_squeezed)]);
 
-            // Unless we are done with squeezing in this call, permute.
-            if remaining.len() != RATE {
-                self.permute(state);
-            }
+            // Permute.
+            self.permute(state);
+
             // Repeat with the updated output slice and squeeze index.
             remaining = &mut remaining[num_squeezed..];
             squeeze_index = 0;


### PR DESCRIPTION
The permutation must be done unconditionally at this point of the code, which is reached if there are more field elements to squeeze than are left in the current state vector (i.e. if `squeeze_index + remaining.len() > RATE` holds). Whether the remaining elements to squeeze happen to be the same number as the rate or not, is irrelevant here.

[This code](https://github.com/AleoHQ/snarkVM/compare/testnet3...poseidon-squeeze-internal-bug) demonstrates the issue: it prints `Permutation.` once instead of twice.

This is an illustration, where the small arrows indicate the current squeeze index:
![poseidon](https://github.com/AleoHQ/snarkVM/assets/2409151/93ae9079-1685-4c05-90dc-c7cf232c4d6c)

This should not be exploitable by executing Aleo instructions because those should make a single call to the sponge function, while triggering the bug requires two calls. Nonetheless, this should be fixed because:
1. The `squeeze_internal` function violates its own specification. And we may get in trouble if we use this function for other purposes in the future.
2. The `if` condition takes extra time and generates extra R1CS constraints.

The other two implementations of Poseidon in snarkVM, one under `algorithms` and one under `console`, look fine.
