### PR TITLE
Introduce field-related benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,11 +3036,13 @@ version = "0.16.18"
 dependencies = [
  "aleo-std",
  "anyhow",
+ "criterion",
  "itertools 0.11.0",
  "num-traits",
  "rand",
  "rayon",
  "serde",
+ "snarkvm-curves",
  "snarkvm-utilities",
  "thiserror",
  "zeroize",

--- a/fields/Cargo.toml
+++ b/fields/Cargo.toml
@@ -23,6 +23,11 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "Apache-2.0"
 edition = "2021"
 
+[[bench]]
+name = "fields"
+path = "benches/fields.rs"
+harness = false
+
 [dependencies.snarkvm-utilities]
 path = "../utilities"
 version = "=0.16.18"
@@ -59,6 +64,14 @@ version = "1.0"
 [dependencies.zeroize]
 version = "1"
 features = [ "derive" ]
+
+[dev-dependencies.criterion]
+version = "0.5"
+
+[dev-dependencies.snarkvm-curves]
+path = "../curves"
+version = "=0.16.18"
+default-features = false
 
 [features]
 default = [ "snarkvm-utilities/default" ]

--- a/fields/benches/fields.rs
+++ b/fields/benches/fields.rs
@@ -1,0 +1,163 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Silences the false positives caused by black_box.
+#![allow(clippy::unit_arg)]
+
+use snarkvm_fields::{Field, Fp256, Fp384, PrimeField};
+use snarkvm_utilities::TestRng;
+
+use criterion::*;
+use rand::Rng;
+use std::{
+    hint::black_box,
+    ops::{AddAssign, MulAssign, SubAssign},
+};
+
+fn fp256(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    const N: usize = 1_000;
+
+    let mut values = Vec::with_capacity(N);
+    let mut arr = [0u8; 32];
+
+    while values.len() < N {
+        rng.fill(&mut arr);
+        if let Some(v) = Fp256::<snarkvm_curves::bls12_377::FrParameters>::from_random_bytes(&arr) {
+            values.push(v);
+        }
+    }
+
+    c.bench_function("fp256_add_assign", |b| {
+        b.iter(|| {
+            for (mut v1, v2) in values.iter().cloned().zip(values.iter().skip(1)) {
+                black_box(v1.add_assign(v2));
+            }
+        })
+    });
+
+    c.bench_function("fp256_sub_assign", |b| {
+        b.iter(|| {
+            for (mut v1, v2) in values.iter().cloned().zip(values.iter().skip(1)) {
+                black_box(v1.sub_assign(v2));
+            }
+        })
+    });
+
+    c.bench_function("fp256_mul_assign", |b| {
+        b.iter(|| {
+            for (mut v1, v2) in values.iter().cloned().zip(values.iter().skip(1)) {
+                black_box(v1.mul_assign(v2));
+            }
+        })
+    });
+
+    c.bench_function("fp256_inverse", |b| {
+        b.iter(|| {
+            for v in values.iter() {
+                black_box(v.inverse());
+            }
+        })
+    });
+
+    c.bench_function("fp256_square_in_place", |b| {
+        b.iter(|| {
+            for mut v in values.iter().cloned() {
+                black_box(v.square_in_place());
+            }
+        })
+    });
+
+    c.bench_function("fp256_to_bigint", |b| {
+        b.iter(|| {
+            for v in values.iter() {
+                black_box(v.to_bigint());
+            }
+        })
+    });
+}
+
+fn fp384(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    const N: usize = 1_000;
+
+    let mut values = Vec::with_capacity(N);
+    let mut arr = [0u8; 48];
+
+    while values.len() < N {
+        rng.fill(&mut arr[..32]);
+        rng.fill(&mut arr[32..]);
+        if let Some(v) = Fp384::<snarkvm_curves::bls12_377::FqParameters>::from_random_bytes(&arr) {
+            values.push(v);
+        }
+    }
+
+    c.bench_function("fp384_add_assign", |b| {
+        b.iter(|| {
+            for (mut v1, v2) in values.iter().cloned().zip(values.iter().skip(1)) {
+                black_box(v1.add_assign(v2));
+            }
+        })
+    });
+
+    c.bench_function("fp384_sub_assign", |b| {
+        b.iter(|| {
+            for (mut v1, v2) in values.iter().cloned().zip(values.iter().skip(1)) {
+                black_box(v1.sub_assign(v2));
+            }
+        })
+    });
+
+    c.bench_function("fp384_mul_assign", |b| {
+        b.iter(|| {
+            for (mut v1, v2) in values.iter().cloned().zip(values.iter().skip(1)) {
+                black_box(v1.mul_assign(v2));
+            }
+        })
+    });
+
+    c.bench_function("fp384_inverse", |b| {
+        b.iter(|| {
+            for v in values.iter() {
+                black_box(v.inverse());
+            }
+        })
+    });
+
+    c.bench_function("fp384_square_in_place", |b| {
+        b.iter(|| {
+            for mut v in values.iter().cloned() {
+                black_box(v.square_in_place());
+            }
+        })
+    });
+
+    c.bench_function("fp384_to_bigint", |b| {
+        b.iter(|| {
+            for v in values.iter() {
+                black_box(v.to_bigint());
+            }
+        })
+    });
+}
+
+criterion_group! {
+    name = fields;
+    config = Criterion::default();
+    targets = fp256, fp384
+}
+
+criterion_main!(fields);

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -156,7 +156,7 @@ impl<P: Fp384Parameters> Fp384<P> {
 impl<P: Fp384Parameters> Zero for Fp384<P> {
     #[inline]
     fn zero() -> Self {
-        Fp384::<P>(BigInteger::from(0), PhantomData)
+        Self(BigInteger::from(0), PhantomData)
     }
 
     #[inline]
@@ -168,7 +168,7 @@ impl<P: Fp384Parameters> Zero for Fp384<P> {
 impl<P: Fp384Parameters> One for Fp384<P> {
     #[inline]
     fn one() -> Self {
-        Fp384::<P>(P::R, PhantomData)
+        Self(P::R, PhantomData)
     }
 
     #[inline]
@@ -357,7 +357,7 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
 
             let mut u = self.0;
             let mut v = P::MODULUS;
-            let mut b = Fp384::<P>(P::R2, PhantomData); // Avoids unnecessary reduction step.
+            let mut b = Self(P::R2, PhantomData); // Avoids unnecessary reduction step.
             let mut c = Self::zero();
 
             while u != one && v != one {
@@ -433,7 +433,6 @@ impl<P: Fp384Parameters> PrimeField for Fp384<P> {
         let mut tmp = self.0;
         let mut r = tmp.0;
         // Montgomery Reduction
-        // Iteration 0
         let k = r[0].wrapping_mul(P::INV);
         let mut carry = 0;
         fa::mac_with_carry(r[0], k, P::MODULUS.0[0], &mut carry);
@@ -538,6 +537,7 @@ impl<P: Fp384Parameters> SquareRootField for Fp384<P> {
 
         // s = self^((MODULUS - 1) // 2)
         let s = self.pow(P::MODULUS_MINUS_ONE_DIV_TWO);
+
         if s.is_zero() {
             Zero
         } else if s.is_one() {
@@ -560,6 +560,7 @@ impl<P: Fp384Parameters> SquareRootField for Fp384<P> {
     }
 }
 
+/// `Fp` elements are ordered lexicographically.
 impl<P: Fp384Parameters> Ord for Fp384<P> {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
@@ -691,7 +692,7 @@ impl<P: Fp384Parameters> Neg for Fp384<P> {
         if !self.is_zero() {
             let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
-            Fp384::<P>(tmp, PhantomData)
+            Self(tmp, PhantomData)
         } else {
             self
         }
@@ -747,7 +748,7 @@ impl<'a, P: Fp384Parameters> AddAssign<&'a Self> for Fp384<P> {
     fn add_assign(&mut self, other: &Self) {
         // This cannot exceed the backing capacity.
         self.0.add_nocarry(&other.0);
-        // However, it may need to be reduced
+        // However, it may need to be reduced.
         self.reduce();
     }
 }
@@ -771,6 +772,7 @@ impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
         let mut carry1 = 0u64;
         let mut carry2 = 0u64;
 
+        // Iteration 0.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[0], &mut carry1);
         let k = r[0].wrapping_mul(P::INV);
         fa::mac_discard(r[0], k, P::MODULUS.0[0], &mut carry2);


### PR DESCRIPTION
Since these are some of the most fundamental operations popping up in snarkOS profiles, I decided to take a closer look at their implementations and introduce some benchmarks for them. In addition, I aligned a few of the implementations (via minor refactoring and reordering), so that it's easier to compare the `fp_256` and `fp_384` files.

Some notes:
- the `Fp384::*_assign` operations seem to be faster than what one might expect, compared to the `Fp256` counterparts
- on the other hand, the other benchmarked operations are slower (by a factor of >2x instead of 1.3x) than I expected
- at least on `x86_64`, some of the unrolled loops can be made into loops without any performance penalty (I checked it, as these days cache friendliness may be more beneficial); I'm happy to file such changes as a follow-up if it's desired (it does make the code significantly shorter and more readable)