### PR TITLE
Clarify constraint limit logic

### DIFF
--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -382,7 +382,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             // Inject the existing circuit.
             A::inject_r1cs(r1cs);
 
-            // If in 'CheckDeployment' mode, set the expected constraint limit.
+            // If in 'CheckDeployment' mode, reset the constraint limit back to the parent circuit limit.
             if let CallStack::CheckDeployment(_, _, _, constraint_limit) = &registers.call_stack() {
                 A::set_constraint_limit(*constraint_limit);
             }


### PR DESCRIPTION
Closes https://github.com/AleoHQ/snarkVM/issues/2339

Recall how each function circuit in a call graph has their own verifying_key, and for *each* of those we need to track if we're not surpassing the constraint limit.

Here is an example of a *parent* circuit calling a *child* circuit:
1. `constraint_limit` of *parent* circuit is set in [execute_function](https://github.com/AleoHQ/snarkVM/blob/mainnet/synthesizer/process/src/stack/execute.rs#L147)
2. we `call` the *child* circuit, the `constraint_limit` is again set in [execute_function](https://github.com/AleoHQ/snarkVM/blob/mainnet/synthesizer/process/src/stack/execute.rs#L147)
3. we return from our call back into the *parent* circuit, so we need to reset the limit back in [call/mod.rs](https://github.com/AleoHQ/snarkVM/blob/mainnet/synthesizer/process/src/stack/call/mod.rs#L387)

A safer way to enforce this is to let `eject_r1cs` also emit the `constraint_limit`, so the compiler tells us to re-use it. However that might require a bigger refactor because the constraint limit is only relevant in `CheckDeployment` mode.