### PR TITLE
[ZKS-00] Reverts election certificates

### DIFF
--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -20,8 +20,7 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
-        // TODO (howardwu): For mainnet - Change the version back to 1.
-        if version != 1 && version != 2 {
+        if version != 1 {
             return Err(error("Invalid batch header version"));
         }
 
@@ -66,44 +65,12 @@ impl<N: Network> FromBytes for BatchHeader<N> {
             previous_certificate_ids.insert(Field::read_le(&mut reader)?);
         }
 
-        // TODO (howardwu): For mainnet - Change this to always encode the number of committed certificate IDs.
-        //  We currently only encode the size and certificates in the new version, for backwards compatibility.
-        let num_last_election_certificate_ids = if version == 2 {
-            // Read the number of last election certificate IDs.
-            u16::read_le(&mut reader)?
-        } else {
-            // Set the number of last election certificate IDs to zero.
-            0
-        };
-        // Ensure the number of last election certificate IDs is within bounds.
-        if num_last_election_certificate_ids > Self::MAX_CERTIFICATES {
-            return Err(error(format!(
-                "Number of last election certificate IDs ({num_last_election_certificate_ids}) exceeds the maximum ({})",
-                Self::MAX_CERTIFICATES
-            )));
-        }
-        // Read the last election certificate IDs.
-        let mut last_election_certificate_ids = IndexSet::new();
-        for _ in 0..num_last_election_certificate_ids {
-            // Read the certificate ID.
-            last_election_certificate_ids.insert(Field::read_le(&mut reader)?);
-        }
-
         // Read the signature.
         let signature = Signature::read_le(&mut reader)?;
 
         // Construct the batch.
-        let batch = Self::from(
-            version,
-            author,
-            round,
-            timestamp,
-            transmission_ids,
-            previous_certificate_ids,
-            last_election_certificate_ids,
-            signature,
-        )
-        .map_err(|e| error(e.to_string()))?;
+        let batch = Self::from(author, round, timestamp, transmission_ids, previous_certificate_ids, signature)
+            .map_err(error)?;
 
         // Return the batch.
         match batch.batch_id == batch_id {
@@ -117,8 +84,7 @@ impl<N: Network> ToBytes for BatchHeader<N> {
     /// Writes the batch header to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the version.
-        // TODO (howardwu): For mainnet - Change this back to '1u8.write_le(&mut writer)?';
-        self.version.write_le(&mut writer)?;
+        1u8.write_le(&mut writer)?;
         // Write the batch ID.
         self.batch_id.write_le(&mut writer)?;
         // Write the author.
@@ -140,19 +106,6 @@ impl<N: Network> ToBytes for BatchHeader<N> {
         for certificate_id in &self.previous_certificate_ids {
             // Write the certificate ID.
             certificate_id.write_le(&mut writer)?;
-        }
-        // TODO (howardwu): For mainnet - Change this to always encode the number of committed certificate IDs.
-        //  We currently only encode the size and certificates in the new version, for backwards compatibility.
-        if self.version != 1 {
-            // Write the number of last election certificate IDs.
-            u16::try_from(self.last_election_certificate_ids.len())
-                .map_err(|e| error(e.to_string()))?
-                .write_le(&mut writer)?;
-            // Write the last election certificate IDs.
-            for certificate_id in &self.last_election_certificate_ids {
-                // Write the certificate ID.
-                certificate_id.write_le(&mut writer)?;
-            }
         }
         // Write the signature.
         self.signature.write_le(&mut writer)

--- a/ledger/narwhal/batch-header/src/serialize.rs
+++ b/ledger/narwhal/batch-header/src/serialize.rs
@@ -19,16 +19,13 @@ impl<N: Network> Serialize for BatchHeader<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut header = serializer.serialize_struct("BatchHeader", 9)?;
-                // TODO (howardwu): For mainnet - Remove the version field, and update the 'len' above to 8.
-                header.serialize_field("version", &self.version)?;
+                let mut header = serializer.serialize_struct("BatchHeader", 7)?;
                 header.serialize_field("batch_id", &self.batch_id)?;
                 header.serialize_field("author", &self.author)?;
                 header.serialize_field("round", &self.round)?;
                 header.serialize_field("timestamp", &self.timestamp)?;
                 header.serialize_field("transmission_ids", &self.transmission_ids)?;
                 header.serialize_field("previous_certificate_ids", &self.previous_certificate_ids)?;
-                header.serialize_field("last_election_certificate_ids", &self.last_election_certificate_ids)?;
                 header.serialize_field("signature", &self.signature)?;
                 header.end()
             }
@@ -45,31 +42,13 @@ impl<'de, N: Network> Deserialize<'de> for BatchHeader<N> {
                 let mut header = serde_json::Value::deserialize(deserializer)?;
                 let batch_id: Field<N> = DeserializeExt::take_from_value::<D>(&mut header, "batch_id")?;
 
-                // TODO (howardwu): For mainnet - Remove the version parsing.
-                // If the version field is present, then parse the version.
-                let version = DeserializeExt::take_from_value::<D>(&mut header, "version").unwrap_or(1);
-                // TODO (howardwu): For mainnet - Remove the version checking.
-                // Ensure the version is valid.
-                if version != 1 && version != 2 {
-                    return Err(error("Invalid batch header version")).map_err(de::Error::custom);
-                }
-                // TODO (howardwu): For mainnet - Always take from the 'header', no need to use this match case anymore.
-                // If the version is not 1, then parse the last election certificate IDs.
-                let last_election_certificate_ids = match version {
-                    1 => IndexSet::new(),
-                    2 => DeserializeExt::take_from_value::<D>(&mut header, "last_election_certificate_ids")?,
-                    _ => unreachable!(),
-                };
-
                 // Recover the header.
                 let batch_header = Self::from(
-                    version,
                     DeserializeExt::take_from_value::<D>(&mut header, "author")?,
                     DeserializeExt::take_from_value::<D>(&mut header, "round")?,
                     DeserializeExt::take_from_value::<D>(&mut header, "timestamp")?,
                     DeserializeExt::take_from_value::<D>(&mut header, "transmission_ids")?,
                     DeserializeExt::take_from_value::<D>(&mut header, "previous_certificate_ids")?,
-                    last_election_certificate_ids,
                     DeserializeExt::take_from_value::<D>(&mut header, "signature")?,
                 )
                 .map_err(de::Error::custom)?;

--- a/ledger/narwhal/batch-header/src/to_id.rs
+++ b/ledger/narwhal/batch-header/src/to_id.rs
@@ -18,13 +18,11 @@ impl<N: Network> BatchHeader<N> {
     /// Returns the batch ID.
     pub fn to_id(&self) -> Result<Field<N>> {
         Self::compute_batch_id(
-            self.version,
             self.author,
             self.round,
             self.timestamp,
             &self.transmission_ids,
             &self.previous_certificate_ids,
-            &self.last_election_certificate_ids,
         )
     }
 }
@@ -32,13 +30,11 @@ impl<N: Network> BatchHeader<N> {
 impl<N: Network> BatchHeader<N> {
     /// Returns the batch ID.
     pub fn compute_batch_id(
-        version: u8,
         author: Address<N>,
         round: u64,
         timestamp: i64,
         transmission_ids: &IndexSet<TransmissionID<N>>,
         previous_certificate_ids: &IndexSet<Field<N>>,
-        last_election_certificate_ids: &IndexSet<Field<N>>,
     ) -> Result<Field<N>> {
         let mut preimage = Vec::new();
         // Insert the author.
@@ -59,17 +55,6 @@ impl<N: Network> BatchHeader<N> {
         for certificate_id in previous_certificate_ids {
             // Insert the certificate ID.
             certificate_id.write_le(&mut preimage)?;
-        }
-        // TODO (howardwu): For mainnet - Change this to always encode the number of committed certificate IDs.
-        //  We currently only encode the size and certificates only in the new version, for backwards compatibility.
-        if version != 1 {
-            // Insert the number of last election certificate IDs.
-            u32::try_from(last_election_certificate_ids.len())?.write_le(&mut preimage)?;
-            // Insert the last election certificate IDs.
-            for certificate_id in last_election_certificate_ids {
-                // Insert the certificate ID.
-                certificate_id.write_le(&mut preimage)?;
-            }
         }
         // Hash the preimage.
         N::hash_bhp1024(&preimage.to_bits_le())

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -20,8 +20,7 @@ impl<N: Network> FromBytes for Subdag<N> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
-        // TODO (howardwu): For mainnet - Change the version back to 1.
-        if version != 1 && version != 2 {
+        if version != 1 {
             return Err(error(format!("Invalid subdag version ({version})")));
         }
 
@@ -55,27 +54,8 @@ impl<N: Network> FromBytes for Subdag<N> {
             subdag.insert(round, certificates);
         }
 
-        // Read the election certificate IDs.
-        let mut election_certificate_ids = IndexSet::new();
-        // TODO (howardwu): For mainnet - Always attempt to deserialize the election certificate IDs.
-        if version != 1 {
-            // Read the number of election certificate IDs.
-            let num_election_certificate_ids = u16::read_le(&mut reader)?;
-            // Ensure the number of election certificate IDs is within bounds.
-            if num_election_certificate_ids > BatchHeader::<N>::MAX_CERTIFICATES {
-                return Err(error(format!(
-                    "Number of election certificate IDs ({num_election_certificate_ids}) exceeds the maximum ({})",
-                    BatchHeader::<N>::MAX_CERTIFICATES
-                )));
-            }
-            for _ in 0..num_election_certificate_ids {
-                // Read the election certificate ID.
-                election_certificate_ids.insert(Field::read_le(&mut reader)?);
-            }
-        }
-
         // Return the subdag.
-        Self::from(subdag, election_certificate_ids).map_err(error)
+        Self::from(subdag).map_err(error)
     }
 }
 
@@ -83,8 +63,7 @@ impl<N: Network> ToBytes for Subdag<N> {
     /// Writes the subdag to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the version.
-        // TODO (howardwu): For mainnet - Change the version back to 1.
-        2u8.write_le(&mut writer)?;
+        1u8.write_le(&mut writer)?;
         // Write the number of rounds.
         u32::try_from(self.subdag.len()).map_err(error)?.write_le(&mut writer)?;
         // Write the round certificates.
@@ -98,13 +77,6 @@ impl<N: Network> ToBytes for Subdag<N> {
                 // Write the certificate.
                 certificate.write_le(&mut writer)?;
             }
-        }
-        // Write the number of election certificate IDs.
-        u16::try_from(self.election_certificate_ids.len()).map_err(error)?.write_le(&mut writer)?;
-        // Write the election certificate IDs.
-        for election_certificate_id in &self.election_certificate_ids {
-            // Write the election certificate ID.
-            election_certificate_id.write_le(&mut writer)?;
         }
         Ok(())
     }

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -113,8 +113,6 @@ fn weighted_median(timestamps_and_stake: Vec<(i64, u64)>) -> i64 {
 pub struct Subdag<N: Network> {
     /// The subdag of round certificates.
     subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>,
-    /// The election certificate IDs.
-    election_certificate_ids: IndexSet<Field<N>>,
 }
 
 impl<N: Network> PartialEq for Subdag<N> {
@@ -128,10 +126,7 @@ impl<N: Network> Eq for Subdag<N> {}
 
 impl<N: Network> Subdag<N> {
     /// Initializes a new subdag.
-    pub fn from(
-        subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>,
-        election_certificate_ids: IndexSet<Field<N>>,
-    ) -> Result<Self> {
+    pub fn from(subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>) -> Result<Self> {
         // Ensure the subdag is not empty.
         ensure!(!subdag.is_empty(), "Subdag cannot be empty");
         // Ensure the subdag does not exceed the maximum number of rounds.
@@ -143,17 +138,12 @@ impl<N: Network> Subdag<N> {
         ensure!(subdag.iter().next_back().map_or(0, |(r, _)| *r) % 2 == 0, "Anchor round must be even");
         // Ensure there is only one leader certificate.
         ensure!(subdag.iter().next_back().map_or(0, |(_, c)| c.len()) == 1, "Subdag cannot have multiple leaders");
-        // Ensure the number of election certificate IDs is within bounds.
-        ensure!(
-            election_certificate_ids.len() <= usize::try_from(BatchHeader::<N>::MAX_CERTIFICATES)?,
-            "Number of election certificate IDs exceeds the maximum"
-        );
         // Ensure the rounds are sequential.
         ensure!(is_sequential(&subdag), "Subdag rounds must be sequential");
         // Ensure the subdag structure matches the commit.
         ensure!(sanity_check_subdag_with_dfs(&subdag), "Subdag structure does not match commit");
         // Ensure the leader certificate is an even round.
-        Ok(Self { subdag, election_certificate_ids })
+        Ok(Self { subdag })
     }
 }
 
@@ -215,11 +205,6 @@ impl<N: Network> Subdag<N> {
                 weighted_median(timestamps_and_stakes)
             }
         }
-    }
-
-    /// Returns the election certificate IDs.
-    pub fn election_certificate_ids(&self) -> &IndexSet<Field<N>> {
-        &self.election_certificate_ids
     }
 
     /// Returns the subdag root of the certificates.
@@ -300,14 +285,8 @@ pub mod test_helpers {
             );
         subdag.insert(starting_round + 2, indexset![certificate]);
 
-        // Initialize the election certificate IDs.
-        let mut election_certificate_ids = IndexSet::new();
-        for _ in 0..AVAILABILITY_THRESHOLD {
-            election_certificate_ids.insert(rng.gen());
-        }
-
         // Return the subdag.
-        Subdag::from(subdag, election_certificate_ids).unwrap()
+        Subdag::from(subdag).unwrap()
     }
 
     /// Returns a list of sample subdags, sampled at random.

--- a/ledger/narwhal/subdag/src/serialize.rs
+++ b/ledger/narwhal/subdag/src/serialize.rs
@@ -19,9 +19,8 @@ impl<N: Network> Serialize for Subdag<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut certificate = serializer.serialize_struct("Subdag", 2)?;
+                let mut certificate = serializer.serialize_struct("Subdag", 1)?;
                 certificate.serialize_field("subdag", &self.subdag)?;
-                certificate.serialize_field("election_certificate_ids", &self.election_certificate_ids)?;
                 certificate.end()
             }
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
@@ -36,11 +35,7 @@ impl<'de, N: Network> Deserialize<'de> for Subdag<N> {
             true => {
                 let mut value = serde_json::Value::deserialize(deserializer)?;
 
-                // TODO (howardwu): For mainnet - Directly take the value, do not check if its missing.
-                let election_certificate_ids =
-                    DeserializeExt::take_from_value::<D>(&mut value, "election_certificate_ids").unwrap_or_default();
-
-                Ok(Self::from(DeserializeExt::take_from_value::<D>(&mut value, "subdag")?, election_certificate_ids)
+                Ok(Self::from(DeserializeExt::take_from_value::<D>(&mut value, "subdag")?)
                     .map_err(de::Error::custom)?)
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "subdag"),


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This change was made as part of a potential fix for the BFT, however it became clear we actually do not need it. So we are removing it to bring this back to vanilla Bullshark.

The sister PR can be found here: https://github.com/AleoHQ/snarkOS/pull/3081

This was originally a fix intended for Audit Finding: **[zksecurity 00] Commit Flow Can Lead to Safety Violation**, however it is now unnecessary with the new fixes.