### PR TITLE
Clean up `ConfirmedTransactionsMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,6 +3268,7 @@ dependencies = [
  "rayon",
  "rocksdb",
  "serde",
+ "serde_json",
  "serial_test",
  "snarkvm-console",
  "snarkvm-ledger-authority",

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -99,7 +99,7 @@ pub mod test_helpers {
     type CurrentNetwork = MainnetV0;
 
     /// Samples a rejected deployment.
-    pub(crate) fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    pub fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
         // Sample a deploy transaction.
         let deployment = match crate::transaction::test_helpers::sample_deployment_transaction(is_fee_private, rng) {
             Transaction::Deploy(_, _, deployment, _) => (*deployment).clone(),
@@ -116,7 +116,7 @@ pub mod test_helpers {
     }
 
     /// Samples a rejected execution.
-    pub(crate) fn sample_rejected_execution(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    pub fn sample_rejected_execution(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
         // Sample an execute transaction.
         let execution =
             match crate::transaction::test_helpers::sample_execution_transaction_with_fee(is_fee_private, rng) {

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -99,7 +99,7 @@ pub mod test_helpers {
     type CurrentNetwork = MainnetV0;
 
     /// Samples a rejected deployment.
-    pub fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    pub(crate) fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
         // Sample a deploy transaction.
         let deployment = match crate::transaction::test_helpers::sample_deployment_transaction(is_fee_private, rng) {
             Transaction::Deploy(_, _, deployment, _) => (*deployment).clone(),
@@ -116,7 +116,7 @@ pub mod test_helpers {
     }
 
     /// Samples a rejected execution.
-    pub fn sample_rejected_execution(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    pub(crate) fn sample_rejected_execution(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
         // Sample an execute transaction.
         let execution =
             match crate::transaction::test_helpers::sample_execution_transaction_with_fee(is_fee_private, rng) {

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -113,6 +113,10 @@ optional = true
 [dependencies.serde]
 version = "1.0"
 
+[dependencies.serde_json]
+version = "1.0"
+features = [ "preserve_order" ]
+
 [dependencies.tracing]
 version = "0.1"
 optional = true

--- a/ledger/store/src/block/confirmed_tx_type/bytes.rs
+++ b/ledger/store/src/block/confirmed_tx_type/bytes.rs
@@ -43,7 +43,7 @@ impl<N: Network> ToBytes for ConfirmedTxType<N> {
             }
             Self::AcceptedExecute(index) => {
                 // Write the variant.
-                0u8.write_le(&mut writer)?;
+                1u8.write_le(&mut writer)?;
                 // Write the index.
                 index.write_le(&mut writer)
             }

--- a/ledger/store/src/block/confirmed_tx_type/bytes.rs
+++ b/ledger/store/src/block/confirmed_tx_type/bytes.rs
@@ -1,0 +1,82 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for ConfirmedTxType<N> {
+    /// Reads the confirmed transaction type from the buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the variant.
+        let variant = u8::read_le(&mut reader)?;
+        // Match the variant.
+        match variant {
+            0 => Ok(Self::AcceptedDeploy(u32::read_le(&mut reader)?)),
+            1 => Ok(Self::AcceptedExecute(u32::read_le(&mut reader)?)),
+            2 => Ok(Self::RejectedDeploy(u32::read_le(&mut reader)?, Rejected::read_le(&mut reader)?)),
+            3 => Ok(Self::RejectedExecute(u32::read_le(&mut reader)?, Rejected::read_le(&mut reader)?)),
+            4.. => Err(error("Invalid confirmed transaction type variant")),
+        }
+    }
+}
+
+impl<N: Network> ToBytes for ConfirmedTxType<N> {
+    /// Writes the confirmed transaction type to the buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the confirmed transaction type.
+        match self {
+            Self::AcceptedDeploy(index) => {
+                // Write the variant.
+                0u8.write_le(&mut writer)?;
+                // Write the index.
+                index.write_le(&mut writer)
+            }
+            Self::AcceptedExecute(index) => {
+                // Write the variant.
+                0u8.write_le(&mut writer)?;
+                // Write the index.
+                index.write_le(&mut writer)
+            }
+            Self::RejectedDeploy(index, rejected) => {
+                // Write the variant.
+                2u8.write_le(&mut writer)?;
+                // Write the index.
+                index.write_le(&mut writer)?;
+                // Write the rejected transaction.
+                rejected.write_le(&mut writer)
+            }
+            Self::RejectedExecute(index, rejected) => {
+                // Write the variant.
+                3u8.write_le(&mut writer)?;
+                // Write the index.
+                index.write_le(&mut writer)?;
+                // Write the rejected transaction.
+                rejected.write_le(&mut writer)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bytes() {
+        for expected in crate::confirmed_tx_type::test_helpers::sample_confirmed_tx_types() {
+            // Check the byte representation.
+            let expected_bytes = expected.to_bytes_le().unwrap();
+            assert_eq!(expected, ConfirmedTxType::read_le(&expected_bytes[..]).unwrap());
+        }
+    }
+}

--- a/ledger/store/src/block/confirmed_tx_type/mod.rs
+++ b/ledger/store/src/block/confirmed_tx_type/mod.rs
@@ -1,0 +1,79 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod serialize;
+mod string;
+
+use super::*;
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum ConfirmedTxType<N: Network> {
+    /// A deploy transaction that was accepted.
+    AcceptedDeploy(u32),
+    /// An execute transaction that was accepted.
+    AcceptedExecute(u32),
+    /// A deploy transaction that was rejected.
+    RejectedDeploy(u32, Rejected<N>),
+    /// An execute transaction that was rejected.
+    RejectedExecute(u32, Rejected<N>),
+}
+
+#[cfg(test)]
+pub mod test_helpers {
+    use super::*;
+    use console::network::MainnetV0;
+
+    type CurrentNetwork = MainnetV0;
+
+    /// Samples an accepted deploy.
+    pub(crate) fn sample_accepted_deploy(rng: &mut TestRng) -> ConfirmedTxType<CurrentNetwork> {
+        // Return the accepted deploy.
+        ConfirmedTxType::AcceptedDeploy(rng.gen())
+    }
+
+    /// Samples an accepted execution.
+    pub(crate) fn sample_accepted_execution(rng: &mut TestRng) -> ConfirmedTxType<CurrentNetwork> {
+        // Return the accepted execution.
+        ConfirmedTxType::AcceptedExecute(rng.gen())
+    }
+
+    /// Samples a rejected deploy.
+    pub(crate) fn sample_rejected_deploy(rng: &mut TestRng) -> ConfirmedTxType<CurrentNetwork> {
+        // Sample the rejected deployment.
+        let rejected = ledger_test_helpers::sample_rejected_deployment(rng.gen(), rng);
+        // Return the rejected deploy.
+        ConfirmedTxType::RejectedDeploy(rng.gen(), rejected)
+    }
+
+    /// Samples a rejected execution.
+    pub(crate) fn sample_rejected_execute(rng: &mut TestRng) -> ConfirmedTxType<CurrentNetwork> {
+        // Sample the rejected execution.
+        let rejected = ledger_test_helpers::sample_rejected_execution(rng.gen(), rng);
+        // Return the rejected execution.
+        ConfirmedTxType::RejectedExecute(rng.gen(), rejected)
+    }
+
+    /// Sample a list of randomly rejected transactions.
+    pub(crate) fn sample_confirmed_tx_types() -> Vec<ConfirmedTxType<CurrentNetwork>> {
+        let rng = &mut TestRng::default();
+
+        vec![
+            sample_accepted_deploy(rng),
+            sample_accepted_execution(rng),
+            sample_rejected_deploy(rng),
+            sample_rejected_execute(rng),
+        ]
+    }
+}

--- a/ledger/store/src/block/confirmed_tx_type/serialize.rs
+++ b/ledger/store/src/block/confirmed_tx_type/serialize.rs
@@ -20,30 +20,30 @@ impl<N: Network> Serialize for ConfirmedTxType<N> {
         match serializer.is_human_readable() {
             true => match self {
                 Self::AcceptedDeploy(index) => {
-                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 2)?;
-                    transmission.serialize_field("type", "AcceptedDeploy")?;
-                    transmission.serialize_field("index", index)?;
-                    transmission.end()
+                    let mut confirmed_tx_type = serializer.serialize_struct("ConfirmedTxType", 2)?;
+                    confirmed_tx_type.serialize_field("type", "AcceptedDeploy")?;
+                    confirmed_tx_type.serialize_field("index", index)?;
+                    confirmed_tx_type.end()
                 }
                 Self::AcceptedExecute(index) => {
-                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 2)?;
-                    transmission.serialize_field("type", "AcceptedExecute")?;
-                    transmission.serialize_field("index", index)?;
-                    transmission.end()
+                    let mut confirmed_tx_type = serializer.serialize_struct("ConfirmedTxType", 2)?;
+                    confirmed_tx_type.serialize_field("type", "AcceptedExecute")?;
+                    confirmed_tx_type.serialize_field("index", index)?;
+                    confirmed_tx_type.end()
                 }
                 Self::RejectedDeploy(index, rejected) => {
-                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 3)?;
-                    transmission.serialize_field("type", "RejectedDeploy")?;
-                    transmission.serialize_field("index", index)?;
-                    transmission.serialize_field("rejected", rejected)?;
-                    transmission.end()
+                    let mut confirmed_tx_type = serializer.serialize_struct("ConfirmedTxType", 3)?;
+                    confirmed_tx_type.serialize_field("type", "RejectedDeploy")?;
+                    confirmed_tx_type.serialize_field("index", index)?;
+                    confirmed_tx_type.serialize_field("rejected", rejected)?;
+                    confirmed_tx_type.end()
                 }
                 Self::RejectedExecute(index, rejected) => {
-                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 3)?;
-                    transmission.serialize_field("type", "transaction")?;
-                    transmission.serialize_field("index", index)?;
-                    transmission.serialize_field("rejected", rejected)?;
-                    transmission.end()
+                    let mut confirmed_tx_type = serializer.serialize_struct("ConfirmedTxType", 3)?;
+                    confirmed_tx_type.serialize_field("type", "transaction")?;
+                    confirmed_tx_type.serialize_field("index", index)?;
+                    confirmed_tx_type.serialize_field("rejected", rejected)?;
+                    confirmed_tx_type.end()
                 }
             },
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
@@ -56,28 +56,30 @@ impl<'de, N: Network> Deserialize<'de> for ConfirmedTxType<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => {
-                let mut transmission = serde_json::Value::deserialize(deserializer)?;
-                let type_: String = DeserializeExt::take_from_value::<D>(&mut transmission, "type")?;
+                let mut confirmed_tx_type = serde_json::Value::deserialize(deserializer)?;
+                let type_: String = DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "type")?;
 
-                // Recover the transmission.
+                // Recover the confirmed transmission type.
                 match type_.as_str() {
                     "AcceptedDeploy" => Ok(Self::AcceptedDeploy(
-                        DeserializeExt::take_from_value::<D>(&mut transmission, "index").map_err(de::Error::custom)?,
+                        DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "index")
+                            .map_err(de::Error::custom)?,
                     )),
                     "AcceptedExecute" => Ok(Self::AcceptedExecute(
-                        DeserializeExt::take_from_value::<D>(&mut transmission, "index").map_err(de::Error::custom)?,
+                        DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "index")
+                            .map_err(de::Error::custom)?,
                     )),
                     "RejectedDeploy" => {
-                        let index = DeserializeExt::take_from_value::<D>(&mut transmission, "index")
+                        let index = DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "index")
                             .map_err(de::Error::custom)?;
-                        let rejected = DeserializeExt::take_from_value::<D>(&mut transmission, "rejected")
+                        let rejected = DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "rejected")
                             .map_err(de::Error::custom)?;
                         Ok(Self::RejectedDeploy(index, rejected))
                     }
                     "RejectedExecute" => {
-                        let index = DeserializeExt::take_from_value::<D>(&mut transmission, "index")
+                        let index = DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "index")
                             .map_err(de::Error::custom)?;
-                        let rejected = DeserializeExt::take_from_value::<D>(&mut transmission, "rejected")
+                        let rejected = DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "rejected")
                             .map_err(de::Error::custom)?;
                         Ok(Self::RejectedExecute(index, rejected))
                     }

--- a/ledger/store/src/block/confirmed_tx_type/serialize.rs
+++ b/ledger/store/src/block/confirmed_tx_type/serialize.rs
@@ -1,0 +1,145 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Serialize for ConfirmedTxType<N> {
+    #[inline]
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => match self {
+                Self::AcceptedDeploy(index) => {
+                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 2)?;
+                    transmission.serialize_field("type", "AcceptedDeploy")?;
+                    transmission.serialize_field("index", index)?;
+                    transmission.end()
+                }
+                Self::AcceptedExecute(index) => {
+                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 2)?;
+                    transmission.serialize_field("type", "AcceptedExecute")?;
+                    transmission.serialize_field("index", index)?;
+                    transmission.end()
+                }
+                Self::RejectedDeploy(index, rejected) => {
+                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 3)?;
+                    transmission.serialize_field("type", "RejectedDeploy")?;
+                    transmission.serialize_field("index", index)?;
+                    transmission.serialize_field("rejected", rejected)?;
+                    transmission.end()
+                }
+                Self::RejectedExecute(index, rejected) => {
+                    let mut transmission = serializer.serialize_struct("ConfirmedTxType", 3)?;
+                    transmission.serialize_field("type", "transaction")?;
+                    transmission.serialize_field("index", index)?;
+                    transmission.serialize_field("rejected", rejected)?;
+                    transmission.end()
+                }
+            },
+            false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
+        }
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for ConfirmedTxType<N> {
+    #[inline]
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => {
+                let mut transmission = serde_json::Value::deserialize(deserializer)?;
+                let type_: String = DeserializeExt::take_from_value::<D>(&mut transmission, "type")?;
+
+                // Recover the transmission.
+                match type_.as_str() {
+                    "AcceptedDeploy" => Ok(Self::AcceptedDeploy(
+                        DeserializeExt::take_from_value::<D>(&mut transmission, "index").map_err(de::Error::custom)?,
+                    )),
+                    "AcceptedExecute" => Ok(Self::AcceptedExecute(
+                        DeserializeExt::take_from_value::<D>(&mut transmission, "index").map_err(de::Error::custom)?,
+                    )),
+                    "RejectedDeploy" => {
+                        let index = DeserializeExt::take_from_value::<D>(&mut transmission, "index")
+                            .map_err(de::Error::custom)?;
+                        let rejected = DeserializeExt::take_from_value::<D>(&mut transmission, "rejected")
+                            .map_err(de::Error::custom)?;
+                        Ok(Self::RejectedDeploy(index, rejected))
+                    }
+                    "RejectedExecute" => {
+                        let index = DeserializeExt::take_from_value::<D>(&mut transmission, "index")
+                            .map_err(de::Error::custom)?;
+                        let rejected = DeserializeExt::take_from_value::<D>(&mut transmission, "rejected")
+                            .map_err(de::Error::custom)?;
+                        Ok(Self::RejectedExecute(index, rejected))
+                    }
+                    _ => Err(error("Invalid confirmed transaction type")).map_err(de::Error::custom),
+                }
+            }
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(
+                deserializer,
+                "confirmed transaction type",
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check_serde_json<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_string = expected.to_string();
+        let candidate_string = serde_json::to_string(&expected).unwrap();
+        let candidate = serde_json::from_str::<T>(&candidate_string).unwrap();
+        assert_eq!(expected, candidate);
+        assert_eq!(expected_string, candidate_string);
+        assert_eq!(expected_string, candidate.to_string());
+
+        // Deserialize
+        assert_eq!(expected, T::from_str(&expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
+        assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+    }
+
+    fn check_bincode<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_bytes = expected.to_bytes_le().unwrap();
+        let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(expected, T::read_le(&expected_bytes[..]).unwrap());
+        assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json() {
+        for rejected in crate::confirmed_tx_type::test_helpers::sample_confirmed_tx_types() {
+            check_serde_json(rejected);
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        for rejected in crate::confirmed_tx_type::test_helpers::sample_confirmed_tx_types() {
+            check_bincode(rejected);
+        }
+    }
+}

--- a/ledger/store/src/block/confirmed_tx_type/serialize.rs
+++ b/ledger/store/src/block/confirmed_tx_type/serialize.rs
@@ -59,7 +59,7 @@ impl<'de, N: Network> Deserialize<'de> for ConfirmedTxType<N> {
                 let mut confirmed_tx_type = serde_json::Value::deserialize(deserializer)?;
                 let type_: String = DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "type")?;
 
-                // Recover the confirmed transmission type.
+                // Recover the confirmed transaction type.
                 match type_.as_str() {
                     "AcceptedDeploy" => Ok(Self::AcceptedDeploy(
                         DeserializeExt::take_from_value::<D>(&mut confirmed_tx_type, "index")

--- a/ledger/store/src/block/confirmed_tx_type/serialize.rs
+++ b/ledger/store/src/block/confirmed_tx_type/serialize.rs
@@ -40,7 +40,7 @@ impl<N: Network> Serialize for ConfirmedTxType<N> {
                 }
                 Self::RejectedExecute(index, rejected) => {
                     let mut confirmed_tx_type = serializer.serialize_struct("ConfirmedTxType", 3)?;
-                    confirmed_tx_type.serialize_field("type", "transaction")?;
+                    confirmed_tx_type.serialize_field("type", "RejectedExecute")?;
                     confirmed_tx_type.serialize_field("index", index)?;
                     confirmed_tx_type.serialize_field("rejected", rejected)?;
                     confirmed_tx_type.end()

--- a/ledger/store/src/block/confirmed_tx_type/string.rs
+++ b/ledger/store/src/block/confirmed_tx_type/string.rs
@@ -1,0 +1,38 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromStr for ConfirmedTxType<N> {
+    type Err = Error;
+
+    /// Initializes the confirmed transaction type- from a JSON-string.
+    fn from_str(status: &str) -> Result<Self, Self::Err> {
+        Ok(serde_json::from_str(status)?)
+    }
+}
+
+impl<N: Network> Debug for ConfirmedTxType<N> {
+    /// Prints the confirmed transaction type as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for ConfirmedTxType<N> {
+    /// Displays the confirmed transaction type as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).map_err::<fmt::Error, _>(ser::Error::custom)?)
+    }
+}

--- a/ledger/store/src/helpers/memory/block.rs
+++ b/ledger/store/src/helpers/memory/block.rs
@@ -23,11 +23,13 @@ use console::{prelude::*, types::Field};
 use ledger_authority::Authority;
 use ledger_block::{Header, Ratifications, Rejected, Solutions};
 use ledger_coinbase::PuzzleCommitment;
+use synthesizer_program::FinalizeOperation;
 
 use aleo_std_storage::StorageMode;
 
 /// An in-memory block storage.
 #[derive(Clone)]
+#[allow(clippy::type_complexity)]
 pub struct BlockMemory<N: Network> {
     /// The mapping of `block height` to `state root`.
     state_root_map: MemoryMap<u32, N::StateRoot>,
@@ -60,7 +62,8 @@ pub struct BlockMemory<N: Network> {
     /// The rejected transaction ID or aborted transaction ID map.
     rejected_or_aborted_transaction_id_map: MemoryMap<N::TransactionID, N::BlockHash>,
     /// The confirmed transactions map.
-    confirmed_transactions_map: MemoryMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>,
+    confirmed_transactions_map:
+        MemoryMap<N::TransactionID, (N::BlockHash, ConfirmedTxType<N>, Vec<FinalizeOperation<N>>)>,
     /// The rejected deployment or execution map.
     rejected_deployment_or_execution_map: MemoryMap<Field<N>, Rejected<N>>,
     /// The transaction store.
@@ -84,7 +87,7 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     type TransactionsMap = MemoryMap<N::BlockHash, Vec<N::TransactionID>>;
     type AbortedTransactionIDsMap = MemoryMap<N::BlockHash, Vec<N::TransactionID>>;
     type RejectedOrAbortedTransactionIDMap = MemoryMap<N::TransactionID, N::BlockHash>;
-    type ConfirmedTransactionsMap = MemoryMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>;
+    type ConfirmedTransactionsMap = MemoryMap<N::TransactionID, (N::BlockHash, ConfirmedTxType<N>, Vec<FinalizeOperation<N>>)>;
     type RejectedDeploymentOrExecutionMap = MemoryMap<Field<N>, Rejected<N>>;
     type TransactionStorage = TransactionMemory<N>;
     type TransitionStorage = TransitionMemory<N>;

--- a/ledger/store/src/helpers/rocksdb/block.rs
+++ b/ledger/store/src/helpers/rocksdb/block.rs
@@ -29,11 +29,13 @@ use console::{prelude::*, types::Field};
 use ledger_authority::Authority;
 use ledger_block::{Header, Ratifications, Rejected, Solutions};
 use ledger_coinbase::PuzzleCommitment;
+use synthesizer_program::FinalizeOperation;
 
 use aleo_std_storage::StorageMode;
 
 /// A RocksDB block storage.
 #[derive(Clone)]
+#[allow(clippy::type_complexity)]
 pub struct BlockDB<N: Network> {
     /// The mapping of `block height` to `state root`.
     state_root_map: DataMap<u32, N::StateRoot>,
@@ -66,7 +68,8 @@ pub struct BlockDB<N: Network> {
     /// The rejected or aborted transaction ID map.
     rejected_or_aborted_transaction_id_map: DataMap<N::TransactionID, N::BlockHash>,
     /// The confirmed transactions map.
-    confirmed_transactions_map: DataMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>,
+    confirmed_transactions_map:
+        DataMap<N::TransactionID, (N::BlockHash, ConfirmedTxType<N>, Vec<FinalizeOperation<N>>)>,
     /// The rejected deployment or execution map.
     rejected_deployment_or_execution_map: DataMap<Field<N>, Rejected<N>>,
     /// The transaction store.
@@ -90,7 +93,7 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
     type TransactionsMap = DataMap<N::BlockHash, Vec<N::TransactionID>>;
     type AbortedTransactionIDsMap = DataMap<N::BlockHash, Vec<N::TransactionID>>;
     type RejectedOrAbortedTransactionIDMap = DataMap<N::TransactionID, N::BlockHash>;
-    type ConfirmedTransactionsMap = DataMap<N::TransactionID, (N::BlockHash, ConfirmedTxType, Vec<u8>)>;
+    type ConfirmedTransactionsMap = DataMap<N::TransactionID, (N::BlockHash, ConfirmedTxType<N>, Vec<FinalizeOperation<N>>)>;
     type RejectedDeploymentOrExecutionMap = DataMap<Field<N>, Rejected<N>>;
     type TransactionStorage = TransactionDB<N>;
     type TransitionStorage = TransitionDB<N>;

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -220,6 +220,8 @@ pub enum TestMap {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u16)]
 enum DataID {
+    // BFT
+    BFTTransmissionsMap,
     // Block
     BlockStateRootMap,
     BlockReverseStateRootMap,
@@ -237,6 +239,7 @@ enum DataID {
     BlockAbortedTransactionIDsMap,
     BlockRejectedOrAbortedTransactionIDMap,
     BlockConfirmedTransactionsMap,
+    BlockRejectedDeploymentOrExecutionMap,
     // Committee
     CurrentRoundMap,
     RoundToHeightMap,
@@ -287,10 +290,6 @@ enum DataID {
     // Program
     ProgramIDMap,
     KeyValueMap,
-
-    // TODO (howardwu): For mainnet - Reorder this up above.
-    BlockRejectedDeploymentOrExecutionMap,
-    BFTTransmissionsMap,
 
     // Testing
     #[cfg(test)]

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -28,6 +28,7 @@ use ledger_block::{
     Input,
     Output,
     Ratifications,
+    Rejected,
     Transaction,
     Transactions,
     Transition,
@@ -158,6 +159,23 @@ function compute:
         .clone()
 }
 
+/// Samples a rejected deployment.
+pub fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    // Sample a deploy transaction.
+    let deployment = match crate::sample_deployment_transaction(is_fee_private, rng) {
+        Transaction::Deploy(_, _, deployment, _) => (*deployment).clone(),
+        _ => unreachable!(),
+    };
+
+    // Sample a new program owner.
+    let private_key = PrivateKey::new(rng).unwrap();
+    let deployment_id = deployment.to_deployment_id().unwrap();
+    let program_owner = ProgramOwner::new(&private_key, deployment_id, rng).unwrap();
+
+    // Return the rejected deployment.
+    Rejected::new_deployment(program_owner, deployment)
+}
+
 /******************************************* Execution ********************************************/
 
 /// Samples a random execution.
@@ -168,6 +186,18 @@ pub fn sample_execution(rng: &mut TestRng) -> Execution<CurrentNetwork> {
     let transaction = block.transactions().iter().next().unwrap().deref().clone();
     // Retrieve the execution.
     if let Transaction::Execute(_, execution, _) = transaction { execution } else { unreachable!() }
+}
+
+/// Samples a rejected execution.
+pub fn sample_rejected_execution(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    // Sample an execute transaction.
+    let execution = match crate::sample_execution_transaction_with_fee(is_fee_private, rng) {
+        Transaction::Execute(_, execution, _) => execution,
+        _ => unreachable!(),
+    };
+
+    // Return the rejected execution.
+    Rejected::new_execution(execution)
 }
 
 /********************************************** Fee ***********************************************/


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR cleans up the `ConfirmedTransactionsMap` by moving the `Rejected` object into the `ConfirmedTxType` and replacing the blob with a list of `FinalizeOperation`s.