### PR TITLE
Remove the outdated version of `BatchCertificate`

### DIFF
--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -20,7 +20,7 @@ impl<N: Network> FromBytes for BatchCertificate<N> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
-        if version != 1 && version != 2 {
+        if version != 1 {
             return Err(error("Invalid batch certificate version"));
         }
 

--- a/ledger/narwhal/batch-certificate/src/serialize.rs
+++ b/ledger/narwhal/batch-certificate/src/serialize.rs
@@ -18,21 +18,12 @@ impl<N: Network> Serialize for BatchCertificate<N> {
     /// Serializes the batch certificate to a JSON-string or buffer.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
-            true => match self {
-                Self::V1 { certificate_id, batch_header, signatures } => {
-                    let mut state = serializer.serialize_struct("BatchCertificate", 3)?;
-                    state.serialize_field("certificate_id", certificate_id)?;
-                    state.serialize_field("batch_header", batch_header)?;
-                    state.serialize_field("signatures", signatures)?;
-                    state.end()
-                }
-                Self::V2 { batch_header, signatures } => {
-                    let mut state = serializer.serialize_struct("BatchCertificate", 2)?;
-                    state.serialize_field("batch_header", batch_header)?;
-                    state.serialize_field("signatures", signatures)?;
-                    state.end()
-                }
-            },
+            true => {
+                let mut state = serializer.serialize_struct("BatchCertificate", 2)?;
+                state.serialize_field("batch_header", &self.batch_header)?;
+                state.serialize_field("signatures", &self.signatures)?;
+                state.end()
+            }
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
         }
     }
@@ -44,28 +35,11 @@ impl<'de, N: Network> Deserialize<'de> for BatchCertificate<N> {
         match deserializer.is_human_readable() {
             true => {
                 let mut value = serde_json::Value::deserialize(deserializer)?;
-
-                // Check if a certificate ID field is present.
-                let certificate_id = match value.get("certificate_id") {
-                    Some(..) => Some(DeserializeExt::take_from_value::<D>(&mut value, "certificate_id")?),
-                    None => None,
-                };
-
-                // Parse for V1 and V2 batch certificates.
-                if let Some(certificate_id) = certificate_id {
-                    Self::from_v1_deprecated(
-                        certificate_id,
-                        DeserializeExt::take_from_value::<D>(&mut value, "batch_header")?,
-                        DeserializeExt::take_from_value::<D>(&mut value, "signatures")?,
-                    )
-                    .map_err(de::Error::custom)
-                } else {
-                    Self::from(
-                        DeserializeExt::take_from_value::<D>(&mut value, "batch_header")?,
-                        DeserializeExt::take_from_value::<D>(&mut value, "signatures")?,
-                    )
-                    .map_err(de::Error::custom)
-                }
+                Self::from(
+                    DeserializeExt::take_from_value::<D>(&mut value, "batch_header")?,
+                    DeserializeExt::take_from_value::<D>(&mut value, "signatures")?,
+                )
+                .map_err(de::Error::custom)
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "batch certificate"),
         }

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -188,23 +188,18 @@ impl<N: Network> Subdag<N> {
 
     /// Returns the timestamp of the anchor round, defined as the weighted median timestamp of the subdag.
     pub fn timestamp(&self, committee: &Committee<N>) -> i64 {
-        match self.leader_certificate() {
-            BatchCertificate::V1 { .. } => self.leader_certificate().timestamp(),
-            BatchCertificate::V2 { .. } => {
-                // Retrieve the anchor round.
-                let anchor_round = self.anchor_round();
-                // Retrieve the timestamps and stakes of the certificates for `anchor_round` - 1.
-                let timestamps_and_stakes = self
-                    .values()
-                    .flatten()
-                    .filter(|certificate| certificate.round() == anchor_round.saturating_sub(1))
-                    .map(|certificate| (certificate.timestamp(), committee.get_stake(certificate.author())))
-                    .collect::<Vec<_>>();
+        // Retrieve the anchor round.
+        let anchor_round = self.anchor_round();
+        // Retrieve the timestamps and stakes of the certificates for `anchor_round` - 1.
+        let timestamps_and_stakes = self
+            .values()
+            .flatten()
+            .filter(|certificate| certificate.round() == anchor_round.saturating_sub(1))
+            .map(|certificate| (certificate.timestamp(), committee.get_stake(certificate.author())))
+            .collect::<Vec<_>>();
 
-                // Return the weighted median timestamp.
-                weighted_median(timestamps_and_stakes)
-            }
-        }
+        // Return the weighted median timestamp.
+        weighted_median(timestamps_and_stakes)
     }
 
     /// Returns the subdag root of the certificates.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes the outdated `V1` version of `BatchCertificate` that was there to maintain backwards compatibility in `testnet3`.
