### PR TITLE
fix: don't use 3 for mainnet

### DIFF
--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -66,7 +66,9 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
             Self::REST(url) => match N::ID {
-                0 => Ok(Self::get_request(&format!("{url}/mainnet/latest/stateRoot"))?.into_json()?),
+                console::network::MainnetV0::ID => {
+                    Ok(Self::get_request(&format!("{url}/mainnet/latest/stateRoot"))?.into_json()?)
+                }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -78,7 +80,9 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
             Self::REST(url) => match N::ID {
-                0 => Ok(Self::get_request_async(&format!("{url}/mainnet/latest/stateRoot")).await?.json().await?),
+                console::network::MainnetV0::ID => {
+                    Ok(Self::get_request_async(&format!("{url}/mainnet/latest/stateRoot")).await?.json().await?)
+                }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -89,7 +93,9 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
             Self::REST(url) => match N::ID {
-                0 => Ok(Self::get_request(&format!("{url}/mainnet/statePath/{commitment}"))?.into_json()?),
+                console::network::MainnetV0::ID => {
+                    Ok(Self::get_request(&format!("{url}/mainnet/statePath/{commitment}"))?.into_json()?)
+                }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -101,7 +107,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
             Self::REST(url) => match N::ID {
-                0 => {
+                console::network::MainnetV0::ID => {
                     Ok(Self::get_request_async(&format!("{url}/mainnet/statePath/{commitment}")).await?.json().await?)
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
@@ -118,7 +124,9 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
             }
             Self::REST(url) => match N::ID {
-                0 => Ok(Self::get_request(&format!("{url}/mainnet/program/{program_id}"))?.into_json()?),
+                console::network::MainnetV0::ID => {
+                    Ok(Self::get_request(&format!("{url}/mainnet/program/{program_id}"))?.into_json()?)
+                }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -132,7 +140,9 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
             }
             Self::REST(url) => match N::ID {
-                0 => Ok(Self::get_request_async(&format!("{url}/mainnet/program/{program_id}")).await?.json().await?),
+                console::network::MainnetV0::ID => {
+                    Ok(Self::get_request_async(&format!("{url}/mainnet/program/{program_id}")).await?.json().await?)
+                }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -66,7 +66,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
             Self::REST(url) => match N::ID {
-                3 => Ok(Self::get_request(&format!("{url}/mainnet/latest/stateRoot"))?.into_json()?),
+                0 => Ok(Self::get_request(&format!("{url}/mainnet/latest/stateRoot"))?.into_json()?),
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -78,7 +78,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
             Self::REST(url) => match N::ID {
-                3 => Ok(Self::get_request_async(&format!("{url}/mainnet/latest/stateRoot")).await?.json().await?),
+                0 => Ok(Self::get_request_async(&format!("{url}/mainnet/latest/stateRoot")).await?.json().await?),
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -89,7 +89,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
             Self::REST(url) => match N::ID {
-                3 => Ok(Self::get_request(&format!("{url}/mainnet/statePath/{commitment}"))?.into_json()?),
+                0 => Ok(Self::get_request(&format!("{url}/mainnet/statePath/{commitment}"))?.into_json()?),
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -101,7 +101,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         match self {
             Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
             Self::REST(url) => match N::ID {
-                3 => {
+                0 => {
                     Ok(Self::get_request_async(&format!("{url}/mainnet/statePath/{commitment}")).await?.json().await?)
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
@@ -118,7 +118,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
             }
             Self::REST(url) => match N::ID {
-                3 => Ok(Self::get_request(&format!("{url}/mainnet/program/{program_id}"))?.into_json()?),
+                0 => Ok(Self::get_request(&format!("{url}/mainnet/program/{program_id}"))?.into_json()?),
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }
@@ -132,7 +132,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
             }
             Self::REST(url) => match N::ID {
-                3 => Ok(Self::get_request_async(&format!("{url}/mainnet/program/{program_id}")).await?.json().await?),
+                0 => Ok(Self::get_request_async(&format!("{url}/mainnet/program/{program_id}")).await?.json().await?),
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
         }


### PR DESCRIPTION
The match statement is wrong for mainnet: should be `0`, not `3`. This causes REST calls to credits.aleo to fail.

Edit: also replace the magic number with a constant so this will not happen again.