### PR TITLE
[Feature] Adds a histogram label

### DIFF
--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -98,3 +98,7 @@ pub fn histogram<V: Into<f64>>(name: &'static str, value: V) {
     let histogram = ::metrics::histogram!(name);
     histogram.record(value.into());
 }
+
+pub fn histogram_label<V: Into<f64>>(name: &'static str, label_key: &'static str, label_value: String, value: V) {
+    ::metrics::histogram!(name, label_key => label_value).record(value.into());
+}


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This adds a `histogram_label` method to allow passing a label to the histogram. A limitation is that you can only attach one label.


