### PR TITLE
[ZKS-02] Use committee lookback at `anchor_round - 1` for timestamp calculation

### DIFF
--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -240,21 +240,23 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Determine the timestamp for the next block.
         let next_timestamp = match subdag {
             Some(subdag) => {
-                // Calculate the penultimate round, which is the round before the anchor round.
-                let penultimate_round = subdag.anchor_round().saturating_sub(1);
-                // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
-                // because committees are updated in even rounds.
-                let previous_penultimate_round = match penultimate_round % 2 == 0 {
-                    true => penultimate_round.saturating_sub(1),
-                    false => penultimate_round.saturating_sub(2),
-                };
-                // Get the previous committee lookback round.
-                let penultimate_committee_lookback_round =
-                    previous_penultimate_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
                 // Retrieve the previous committee lookback.
-                let previous_committee_lookback =
+                let previous_committee_lookback = {
+                    // Calculate the penultimate round, which is the round before the anchor round.
+                    let penultimate_round = subdag.anchor_round().saturating_sub(1);
+                    // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
+                    // because committees are updated in even rounds.
+                    let previous_penultimate_round = match penultimate_round % 2 == 0 {
+                        true => penultimate_round.saturating_sub(1),
+                        false => penultimate_round.saturating_sub(2),
+                    };
+                    // Get the previous committee lookback round.
+                    let penultimate_committee_lookback_round =
+                        previous_penultimate_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
+                    // Output the previous committee lookback.
                     self.get_committee_for_round(penultimate_committee_lookback_round)?
-                        .ok_or(anyhow!("Failed to fetch committee for round {penultimate_committee_lookback_round}"))?;
+                        .ok_or(anyhow!("Failed to fetch committee for round {penultimate_committee_lookback_round}"))?
+                };
                 // Return the timestamp for the given committee lookback.
                 subdag.timestamp(&previous_committee_lookback)
             }

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -244,16 +244,18 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 let penultimate_round = subdag.anchor_round().saturating_sub(1);
                 // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
                 // because committees are updated in even rounds.
-                let committee_lookback_round = match penultimate_round % 2 == 0 {
+                let previous_penultimate_round = match penultimate_round % 2 == 0 {
                     true => penultimate_round.saturating_sub(1),
                     false => penultimate_round.saturating_sub(2),
                 };
+                let penultimate_committee_lookback_round =
+                    previous_penultimate_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
                 // Retrieve the committee lookback.
-                let committee_lookback = self
-                    .get_committee_for_round(committee_lookback_round)?
-                    .ok_or(anyhow!("Failed to fetch committee for round {committee_lookback_round}"))?;
+                let previous_committee_lookback =
+                    self.get_committee_for_round(penultimate_committee_lookback_round)?
+                        .ok_or(anyhow!("Failed to fetch committee for round {penultimate_committee_lookback_round}"))?;
                 // Return the timestamp for the given committee lookback.
-                subdag.timestamp(&committee_lookback)
+                subdag.timestamp(&previous_committee_lookback)
             }
             None => OffsetDateTime::now_utc().unix_timestamp(),
         };

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -248,9 +248,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                     true => penultimate_round.saturating_sub(1),
                     false => penultimate_round.saturating_sub(2),
                 };
+                // Get the previous committee lookback round.
                 let penultimate_committee_lookback_round =
                     previous_penultimate_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
-                // Retrieve the committee lookback.
+                // Retrieve the previous committee lookback.
                 let previous_committee_lookback =
                     self.get_committee_for_round(penultimate_committee_lookback_round)?
                         .ok_or(anyhow!("Failed to fetch committee for round {penultimate_committee_lookback_round}"))?;

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -240,9 +240,14 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Determine the timestamp for the next block.
         let next_timestamp = match subdag {
             Some(subdag) => {
-                // Get the committee lookback round.
-                let committee_lookback_round =
-                    subdag.anchor_round().saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
+                // Calculate the penultimate round, which is the round before the anchor round.
+                let penultimate_round = subdag.anchor_round().saturating_sub(1);
+                // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
+                // because committees are updated in even rounds.
+                let committee_lookback_round = match penultimate_round % 2 == 0 {
+                    true => penultimate_round.saturating_sub(1),
+                    false => penultimate_round.saturating_sub(2),
+                };
                 // Retrieve the committee lookback.
                 let committee_lookback = self
                     .get_committee_for_round(committee_lookback_round)?

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -99,10 +99,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let penultimate_round = block.round().saturating_sub(1);
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.
-        let penultimate_committee_lookback_round = match penultimate_round % 2 == 0 {
+        let previous_penultimate_round = match penultimate_round % 2 == 0 {
             true => penultimate_round.saturating_sub(1),
             false => penultimate_round.saturating_sub(2),
         };
+        // Get the previous committee lookback round.
+        let penultimate_committee_lookback_round =
+            previous_penultimate_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
         // Retrieve the previous committee lookback.
         let previous_committee_lookback = self
             .get_committee_for_round(penultimate_committee_lookback_round)?

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -82,34 +82,38 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let ratified_finalize_operations =
             self.vm.check_speculate(state, block.ratifications(), block.solutions(), block.transactions())?;
 
-        // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
-        // because committees are updated in even rounds.
-        let previous_round = match block.round() % 2 == 0 {
-            true => block.round().saturating_sub(1),
-            false => block.round().saturating_sub(2),
-        };
-        // Get the committee lookback round.
-        let committee_lookback_round = previous_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
         // Retrieve the committee lookback.
-        let committee_lookback = self
-            .get_committee_for_round(committee_lookback_round)?
-            .ok_or(anyhow!("Failed to fetch committee for round {committee_lookback_round}"))?;
-
-        // Calculate the penultimate round, which is the round before the anchor round.
-        let penultimate_round = block.round().saturating_sub(1);
-        // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
-        // because committees are updated in even rounds.
-        let previous_penultimate_round = match penultimate_round % 2 == 0 {
-            true => penultimate_round.saturating_sub(1),
-            false => penultimate_round.saturating_sub(2),
+        let committee_lookback = {
+            // Determine the round number for the previous committee. Note, we subtract 2 from odd rounds,
+            // because committees are updated in even rounds.
+            let previous_round = match block.round() % 2 == 0 {
+                true => block.round().saturating_sub(1),
+                false => block.round().saturating_sub(2),
+            };
+            // Determine the committee lookback round.
+            let committee_lookback_round = previous_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
+            // Output the committee lookback.
+            self.get_committee_for_round(committee_lookback_round)?
+                .ok_or(anyhow!("Failed to fetch committee for round {committee_lookback_round}"))?
         };
-        // Get the previous committee lookback round.
-        let penultimate_committee_lookback_round =
-            previous_penultimate_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
+
         // Retrieve the previous committee lookback.
-        let previous_committee_lookback = self
-            .get_committee_for_round(penultimate_committee_lookback_round)?
-            .ok_or(anyhow!("Failed to fetch committee for round {penultimate_committee_lookback_round}"))?;
+        let previous_committee_lookback = {
+            // Calculate the penultimate round, which is the round before the anchor round.
+            let penultimate_round = block.round().saturating_sub(1);
+            // Determine the round number for the previous committee. Note, we subtract 2 from odd rounds,
+            // because committees are updated in even rounds.
+            let previous_penultimate_round = match penultimate_round % 2 == 0 {
+                true => penultimate_round.saturating_sub(1),
+                false => penultimate_round.saturating_sub(2),
+            };
+            // Determine the previous committee lookback round.
+            let penultimate_committee_lookback_round =
+                previous_penultimate_round.saturating_sub(Committee::<N>::COMMITTEE_LOOKBACK_RANGE);
+            // Output the previous committee lookback.
+            self.get_committee_for_round(penultimate_committee_lookback_round)?
+                .ok_or(anyhow!("Failed to fetch committee for round {penultimate_committee_lookback_round}"))?
+        };
 
         // Ensure the block is correct.
         let (expected_existing_solution_ids, expected_existing_transaction_ids) = block.verify(


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR is a continuation of https://github.com/AleoHQ/snarkVM/pull/2353, and fixes the committee usage for timestamp calculation. Previously, we were selecting the committee lookback based on the anchor round, however we should have been using the committee lookback based on `anchor_round - 1`. 

This is needed because the timestamp is calculated with the weighted median using certificates in `anchor_round - 1` for the committed subdag. Note that the previous approach was not an issue with static committees, however with more complex bond/unbond state, it was insufficient.

Audit Finding: **[zksecurity 02] Dynamic Committee Feature is Not Safe**
