### PR TITLE
[nit] Use `checked_add` for account supply calculation

### DIFF
--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -275,7 +275,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Retrieve the total stake.
         let total_stake = committee.total_stake();
         // Compute the account supply.
-        let account_supply = public_balances.values().fold(0u64, |acc, x| acc.saturating_add(*x));
+        let account_supply = public_balances
+            .values()
+            .try_fold(0u64, |acc, x| acc.checked_add(*x).ok_or(anyhow!("Invalid account supply")))?;
         // Compute the total supply.
         let total_supply = total_stake.checked_add(account_supply).ok_or_else(|| anyhow!("Invalid total supply"))?;
         // Ensure the total supply matches.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR replaces the use of `saturating_add` with `checked_add` for added security and assurance.
