### PR TITLE
Modify scope of the hash module in the coinbase module to pub use

### DIFF
--- a/ledger/coinbase/src/lib.rs
+++ b/ledger/coinbase/src/lib.rs
@@ -20,7 +20,7 @@ mod helpers;
 pub use helpers::*;
 
 mod hash;
-use hash::*;
+pub use hash::*;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
In the current code, the hash module is imported privately within the coinbase module. This prevents external modules from directly accessing and utilizing the functionalities of the hash module. This could be inconvenient for developers. I propose modifying the scope of the hash module to be public (pub use).