### PR TITLE
[Fix/Optimize] Fixes and optimizes calculation of execution cost. 

### DIFF
--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -28,7 +28,7 @@ use indexmap::IndexMap;
 use ledger_block::{ConfirmedTransaction, Rejected, Transaction};
 use ledger_committee::{Committee, MIN_VALIDATOR_STAKE};
 use ledger_store::{helpers::memory::ConsensusMemory, ConsensusStore};
-use synthesizer::{prelude::cost_in_microcredits, program::Program, vm::VM, Stack};
+use synthesizer::{program::Program, vm::VM, Stack};
 
 #[test]
 fn test_load() {

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1525,15 +1525,9 @@ fn test_deployment_exceeding_max_transaction_spend() {
         ))
         .unwrap();
 
-        // Initialize a stack for the program.
-        let stack = Stack::<CurrentNetwork>::new(&ledger.vm().process().read(), &program).unwrap();
-
-        // Check the finalize cost.
-        let finalize_cost = cost_in_microcredits(&stack, &Identifier::from_str("foo").unwrap()).unwrap();
-
-        // If the finalize cost exceeds the maximum transaction spend, assign the program to the exceeding program and break.
-        // Otherwise, assign the program to the allowed program and continue.
-        if finalize_cost > <CurrentNetwork as Network>::TRANSACTION_SPEND_LIMIT {
+        // Attempt to initialize a `Stack` for the program.
+        // If this fails, then by `Stack::initialize` the finalize cost exceeds the `TRANSACTION_SPEND_LIMIT`.
+        if Stack::<CurrentNetwork>::new(&ledger.vm().process().read(), &program).is_err() {
             exceeding_program = Some(program);
             break;
         } else {
@@ -1567,9 +1561,9 @@ fn test_deployment_exceeding_max_transaction_spend() {
     // Check that the program exists in the VM.
     assert!(ledger.vm().contains_program(allowed_program.id()));
 
-    // Deploy the exceeding program.
-    let deployment = ledger.vm().deploy(&private_key, &exceeding_program, None, 0, None, rng).unwrap();
+    // Attempt to deploy the exceeding program.
+    let result = ledger.vm().deploy(&private_key, &exceeding_program, None, 0, None, rng);
 
-    // Verify the deployment transaction.
-    assert!(ledger.vm().check_transaction(&deployment, None, rng).is_err());
+    // Check that the deployment failed.
+    assert!(result.is_err());
 }

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -367,7 +367,9 @@ pub fn cost_in_microcredits<N: Network>(stack: &Stack<N>, function_name: &Identi
             // Get the external stack for the future.
             let stack = stack.get_external_stack(future.program_id())?;
             // Accumulate the finalize cost of the future.
-            future_cost += stack.get_finalize_cost(future.resource())?;
+            future_cost = future_cost
+                .checked_add(stack.get_finalize_cost(future.resource())?)
+                .ok_or(anyhow!("Finalize cost overflowed"))?;
         }
     }
 

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -367,7 +367,7 @@ pub fn cost_in_microcredits<N: Network>(stack: &Stack<N>, function_name: &Identi
             // Get the external stack for the future.
             let stack = stack.get_external_stack(future.program_id())?;
             // Accumulate the finalize cost of the future.
-            future_cost += cost_in_microcredits(stack, future.resource())?;
+            future_cost += stack.get_finalize_cost(future.resource())?;
         }
     }
 

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -84,8 +84,15 @@ impl<N: Network> Stack<N> {
             // Add the number of calls to the stack.
             stack.number_of_calls.insert(*function.name(), num_calls);
 
-            // Add the finalize cost to the stack.
+            // Get the finalize cost.
             let finalize_cost = cost_in_microcredits(&stack, function.name())?;
+            // Check that the finalize cost does not exceed the maximum.
+            ensure!(
+                finalize_cost <= N::TRANSACTION_SPEND_LIMIT,
+                "Finalize block '{}' has a cost '{finalize_cost}' which exceeds the transaction spend limit '{}'",
+                function.name(),
+                N::TRANSACTION_SPEND_LIMIT
+            );
             stack.finalize_costs.insert(*function.name(), finalize_cost);
         }
 

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -28,6 +28,7 @@ impl<N: Network> Stack<N> {
             proving_keys: Default::default(),
             verifying_keys: Default::default(),
             number_of_calls: Default::default(),
+            finalize_costs: Default::default(),
             program_depth: 0,
         };
 
@@ -82,6 +83,10 @@ impl<N: Network> Stack<N> {
             );
             // Add the number of calls to the stack.
             stack.number_of_calls.insert(*function.name(), num_calls);
+
+            // Add the finalize cost to the stack.
+            let finalize_cost = cost_in_microcredits(&stack, function.name())?;
+            stack.finalize_costs.insert(*function.name(), finalize_cost);
         }
 
         // Return the stack.

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -16,6 +16,7 @@ use crate::{
     traits::{StackEvaluate, StackExecute},
     CallStack,
     Process,
+    Stack,
     Trace,
 };
 use circuit::{network::AleoV0, Aleo};
@@ -2609,5 +2610,34 @@ fn test_max_imports() {
         "{import_string}program test{}.aleo; function c:",
         CurrentNetwork::MAX_IMPORTS + 1
     ));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_program_exceeding_transaction_spend_limit() {
+    // Construct a finalize body whose finalize cost is excessively large.
+    let finalize_body = (0..<CurrentNetwork as Network>::MAX_COMMANDS)
+        .map(|i| format!("hash.bhp256 0field into r{i} as field;"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Construct the program.
+    let program = Program::from_str(&format!(
+        r"program test_max_spend_limit.aleo;
+      function foo:
+      async foo into r0;
+      output r0 as test_max_spend_limit.aleo/foo.future;
+      finalize foo:{finalize_body}",
+    ))
+    .unwrap();
+
+    // Initialize a `Process`.
+    let mut process = Process::<CurrentNetwork>::load().unwrap();
+
+    // Attempt to add the program to the process, which should fail.
+    let result = process.add_program(&program);
+    assert!(result.is_err());
+
+    // Attempt to initialize a `Stack` directly with the program, which should fail.
+    let result = Stack::initialize(&process, &program);
     assert!(result.is_err());
 }

--- a/synthesizer/process/src/verify_deployment.rs
+++ b/synthesizer/process/src/verify_deployment.rs
@@ -33,16 +33,6 @@ impl<N: Network> Process<N> {
         let stack = Stack::new(self, deployment.program())?;
         lap!(timer, "Compute the stack");
 
-        // Ensure that each finalize block does not exceed the `TRANSACTION_SPEND_LIMIT`.
-        for (function_name, _) in deployment.program().functions() {
-            let finalize_cost = cost_in_microcredits(&stack, function_name)?;
-            ensure!(
-                finalize_cost <= N::TRANSACTION_SPEND_LIMIT,
-                "Finalize block '{function_name}' has a cost '{finalize_cost}' which exceeds the transaction spend limit '{}'",
-                N::TRANSACTION_SPEND_LIMIT
-            );
-        }
-
         // Ensure the verifying keys are well-formed and the certificates are valid.
         let verification = stack.verify_deployment::<A, R>(deployment, rng);
         lap!(timer, "Verify the deployment");

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -80,6 +80,9 @@ pub trait StackProgram<N: Network> {
     /// Returns `true` if the stack contains the external record.
     fn get_external_record(&self, locator: &Locator<N>) -> Result<&RecordType<N>>;
 
+    /// Returns the expected finalize cost for the given function name.
+    fn get_finalize_cost(&self, function_name: &Identifier<N>) -> Result<u64>;
+
     /// Returns the function with the given function name.
     fn get_function(&self, function_name: &Identifier<N>) -> Result<Function<N>>;
 


### PR DESCRIPTION
This PR,
- modifies `cost_in_microcredits` to account for the cost of finalizing futures.
- caches the cost in microcredits for each function in `Stack`.

This PR depends on #2368.
