### PR TITLE
[Test] Execution cost.

### DIFF
--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -76,6 +76,7 @@ pub fn execution_cost<N: Network>(process: &Process<N>, execution: &Execution<N>
 
 /// Finalize costs for compute heavy operations, derived as:
 /// `BASE_COST + (PER_BYTE_COST * SIZE_IN_BYTES)`.
+
 const CAST_BASE_COST: u64 = 500;
 const CAST_PER_BYTE_COST: u64 = 30;
 

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -21,150 +21,23 @@ use console::{
 use ledger_block::{Deployment, Execution};
 use synthesizer_program::{CastType, Command, Finalize, Instruction, Operand, StackProgram};
 
-/// Returns the *minimum* cost in microcredits to publish the given deployment (total cost, (storage cost, synthesis cost, namespace cost)).
-pub fn deployment_cost<N: Network>(deployment: &Deployment<N>) -> Result<(u64, (u64, u64, u64))> {
-    // Determine the number of bytes in the deployment.
-    let size_in_bytes = deployment.size_in_bytes()?;
-    // Retrieve the program ID.
-    let program_id = deployment.program_id();
-    // Determine the number of characters in the program ID.
-    let num_characters = u32::try_from(program_id.name().to_string().len())?;
-    // Compute the number of combined constraints in the program.
-    let num_combined_constraints = deployment.num_combined_constraints()?;
+/// The base and per byte costs for expensive operations.
+const CAST_BASE_COST: u64 = 500;
+const CAST_PER_BYTE_COST: u64 = 30;
+const HASH_BASE_COST: u64 = 10_000;
+const HASH_PER_BYTE_COST: u64 = 30;
+const HASH_BHP_BASE_COST: u64 = 50_000;
+const HASH_BHP_PER_BYTE_COST: u64 = 300;
+const HASH_PSD_BASE_COST: u64 = 40_000;
+const HASH_PSD_PER_BYTE_COST: u64 = 75;
+const MAPPING_BASE_COST: u64 = 10_000;
+const MAPPING_PER_BYTE_COST: u64 = 10;
+const SET_BASE_COST: u64 = 10_000;
+const SET_PER_BYTE_COST: u64 = 100;
 
-    // Compute the storage cost in microcredits.
-    let storage_cost = size_in_bytes
-        .checked_mul(N::DEPLOYMENT_FEE_MULTIPLIER)
-        .ok_or(anyhow!("The storage cost computation overflowed for a deployment"))?;
-
-    // Compute the synthesis cost in microcredits.
-    let synthesis_cost = num_combined_constraints * N::SYNTHESIS_FEE_MULTIPLIER;
-
-    // Compute the namespace cost in credits: 10^(10 - num_characters).
-    let namespace_cost = 10u64
-        .checked_pow(10u32.saturating_sub(num_characters))
-        .ok_or(anyhow!("The namespace cost computation overflowed for a deployment"))?
-        .saturating_mul(1_000_000); // 1 microcredit = 1e-6 credits.
-
-    // Compute the total cost in microcredits.
-    let total_cost = storage_cost
-        .checked_add(synthesis_cost)
-        .and_then(|x| x.checked_add(namespace_cost))
-        .ok_or(anyhow!("The total cost computation overflowed for a deployment"))?;
-
-    Ok((total_cost, (storage_cost, synthesis_cost, namespace_cost)))
-}
-
-/// Returns the *minimum* cost in microcredits to publish the given execution (total cost, (storage cost, finalize cost)).
-pub fn execution_cost<N: Network>(process: &Process<N>, execution: &Execution<N>) -> Result<(u64, (u64, u64))> {
-    // Compute the storage cost in microcredits.
-    let storage_cost = execution.size_in_bytes()?;
-
-    // Get the root transition.
-    let transition = execution.peek()?;
-
-    // Get the finalize cost for the root transition.
-    let finalize_cost = process.get_stack(transition.program_id())?.get_finalize_cost(transition.function_name())?;
-
-    // Compute the total cost in microcredits.
-    let total_cost = storage_cost
-        .checked_add(finalize_cost)
-        .ok_or(anyhow!("The total cost computation overflowed for an execution"))?;
-
-    Ok((total_cost, (storage_cost, finalize_cost)))
-}
-
-/// Returns the minimum number of microcredits required to run the finalize.
-pub fn cost_in_microcredits<N: Network>(stack: &Stack<N>, function_name: &Identifier<N>) -> Result<u64> {
-    /// A helper function to determine the plaintext type in bytes.
-    fn plaintext_size_in_bytes<N: Network>(stack: &Stack<N>, plaintext_type: &PlaintextType<N>) -> Result<u64> {
-        match plaintext_type {
-            PlaintextType::Literal(literal_type) => Ok(literal_type.size_in_bytes::<N>() as u64),
-            PlaintextType::Struct(struct_name) => {
-                // Retrieve the struct from the stack.
-                let struct_ = stack.program().get_struct(struct_name)?;
-                // Retrieve the size of the struct name.
-                let size_of_name = struct_.name().to_bytes_le()?.len() as u64;
-                // Retrieve the size of all the members of the struct.
-                let size_of_members = struct_.members().iter().try_fold(0u64, |acc, (_, member_type)| {
-                    acc.checked_add(plaintext_size_in_bytes(stack, member_type)?).ok_or(anyhow!(
-                        "Overflowed while computing the size of the struct '{}/{struct_name}' - {member_type}",
-                        stack.program_id()
-                    ))
-                })?;
-                // Return the size of the struct.
-                Ok(size_of_name.saturating_add(size_of_members))
-            }
-            PlaintextType::Array(array_type) => {
-                // Retrieve the number of elements in the array.
-                let num_elements = **array_type.length() as u64;
-                // Compute the size of an array element.
-                let size_of_element = plaintext_size_in_bytes(stack, array_type.next_element_type())?;
-                // Return the size of the array.
-                Ok(num_elements.saturating_mul(size_of_element))
-            }
-        }
-    }
-
-    /// A helper function to compute the following: base_cost + (byte_multiplier * size_of_operands).
-    fn cost_in_size<'a, N: Network>(
-        stack: &Stack<N>,
-        finalize: &Finalize<N>,
-        operands: impl IntoIterator<Item = &'a Operand<N>>,
-        byte_multiplier: u64,
-        base_cost: u64,
-    ) -> Result<u64> {
-        // Retrieve the finalize types.
-        let finalize_types = stack.get_finalize_types(finalize.name())?;
-        // Compute the size of the operands.
-        let size_of_operands = operands.into_iter().try_fold(0u64, |acc, operand| {
-            // Determine the size of the operand.
-            let operand_size = match finalize_types.get_type_from_operand(stack, operand)? {
-                FinalizeType::Plaintext(plaintext_type) => plaintext_size_in_bytes(stack, &plaintext_type)?,
-                FinalizeType::Future(future) => {
-                    bail!("Future '{future}' is not a valid operand in the finalize scope");
-                }
-            };
-            // Safely add the size to the accumulator.
-            acc.checked_add(operand_size).ok_or(anyhow!(
-                "Overflowed while computing the size of the operand '{operand}' in '{}/{}' (finalize)",
-                stack.program_id(),
-                finalize.name()
-            ))
-        })?;
-        // Return the cost.
-        Ok(base_cost.saturating_add(byte_multiplier.saturating_mul(size_of_operands)))
-    }
-
-    // Finalize costs for compute heavy operations, derived as:
-    // `BASE_COST + (PER_BYTE_COST * SIZE_IN_BYTES)`.
-
-    const CAST_BASE_COST: u64 = 500;
-    const CAST_PER_BYTE_COST: u64 = 30;
-
-    const HASH_BASE_COST: u64 = 10_000;
-    const HASH_PER_BYTE_COST: u64 = 30;
-
-    const HASH_BHP_BASE_COST: u64 = 50_000;
-    const HASH_BHP_PER_BYTE_COST: u64 = 300;
-
-    const HASH_PSD_BASE_COST: u64 = 40_000;
-    const HASH_PSD_PER_BYTE_COST: u64 = 75;
-
-    const MAPPING_BASE_COST: u64 = 10_000;
-    const MAPPING_PER_BYTE_COST: u64 = 10;
-
-    const SET_BASE_COST: u64 = 10_000;
-    const SET_PER_BYTE_COST: u64 = 100;
-
-    // Retrieve the finalize logic.
-    let Some(finalize) = stack.get_function_ref(function_name)?.finalize_logic() else {
-        // Return a finalize cost of 0, if the function does not have a finalize scope.
-        return Ok(0);
-    };
-
-    // Measure the cost of each command.
-    let cost = |command: &Command<N>| match command {
+/// Returns the the cost of a command in a finalize scope.
+pub fn command_cost<N: Network>(stack: &Stack<N>, finalize: &Finalize<N>, command: &Command<N>) -> Result<u64> {
+    match command {
         Command::Instruction(Instruction::Abs(_)) => Ok(500),
         Command::Instruction(Instruction::AbsWrapped(_)) => Ok(500),
         Command::Instruction(Instruction::Add(_)) => Ok(500),
@@ -358,6 +231,68 @@ pub fn cost_in_microcredits<N: Network>(stack: &Stack<N>, function_name: &Identi
         }
         Command::BranchEq(_) | Command::BranchNeq(_) => Ok(500),
         Command::Position(_) => Ok(100),
+    }
+}
+
+/// Returns the *minimum* cost in microcredits to publish the given deployment (total cost, (storage cost, synthesis cost, namespace cost)).
+pub fn deployment_cost<N: Network>(deployment: &Deployment<N>) -> Result<(u64, (u64, u64, u64))> {
+    // Determine the number of bytes in the deployment.
+    let size_in_bytes = deployment.size_in_bytes()?;
+    // Retrieve the program ID.
+    let program_id = deployment.program_id();
+    // Determine the number of characters in the program ID.
+    let num_characters = u32::try_from(program_id.name().to_string().len())?;
+    // Compute the number of combined constraints in the program.
+    let num_combined_constraints = deployment.num_combined_constraints()?;
+
+    // Compute the storage cost in microcredits.
+    let storage_cost = size_in_bytes
+        .checked_mul(N::DEPLOYMENT_FEE_MULTIPLIER)
+        .ok_or(anyhow!("The storage cost computation overflowed for a deployment"))?;
+
+    // Compute the synthesis cost in microcredits.
+    let synthesis_cost = num_combined_constraints * N::SYNTHESIS_FEE_MULTIPLIER;
+
+    // Compute the namespace cost in credits: 10^(10 - num_characters).
+    let namespace_cost = 10u64
+        .checked_pow(10u32.saturating_sub(num_characters))
+        .ok_or(anyhow!("The namespace cost computation overflowed for a deployment"))?
+        .saturating_mul(1_000_000); // 1 microcredit = 1e-6 credits.
+
+    // Compute the total cost in microcredits.
+    let total_cost = storage_cost
+        .checked_add(synthesis_cost)
+        .and_then(|x| x.checked_add(namespace_cost))
+        .ok_or(anyhow!("The total cost computation overflowed for a deployment"))?;
+
+    Ok((total_cost, (storage_cost, synthesis_cost, namespace_cost)))
+}
+
+/// Returns the *minimum* cost in microcredits to publish the given execution (total cost, (storage cost, finalize cost)).
+pub fn execution_cost<N: Network>(process: &Process<N>, execution: &Execution<N>) -> Result<(u64, (u64, u64))> {
+    // Compute the storage cost in microcredits.
+    let storage_cost = execution.size_in_bytes()?;
+
+    // Get the root transition.
+    let transition = execution.peek()?;
+
+    // Get the finalize cost for the root transition.
+    let finalize_cost = process.get_stack(transition.program_id())?.get_finalize_cost(transition.function_name())?;
+
+    // Compute the total cost in microcredits.
+    let total_cost = storage_cost
+        .checked_add(finalize_cost)
+        .ok_or(anyhow!("The total cost computation overflowed for an execution"))?;
+
+    Ok((total_cost, (storage_cost, finalize_cost)))
+}
+
+/// Returns the minimum number of microcredits required to run the finalize.
+pub fn cost_in_microcredits<N: Network>(stack: &Stack<N>, function_name: &Identifier<N>) -> Result<u64> {
+    // Retrieve the finalize logic.
+    let Some(finalize) = stack.get_function_ref(function_name)?.finalize_logic() else {
+        // Return a finalize cost of 0, if the function does not have a finalize scope.
+        return Ok(0);
     };
 
     // Get the cost of finalizing all futures.
@@ -374,7 +309,71 @@ pub fn cost_in_microcredits<N: Network>(stack: &Stack<N>, function_name: &Identi
     }
 
     // Aggregate the cost of all commands in the program.
-    finalize.commands().iter().map(cost).try_fold(future_cost, |acc, res| {
-        res.and_then(|x| acc.checked_add(x).ok_or(anyhow!("Finalize cost overflowed")))
-    })
+    finalize
+        .commands()
+        .iter()
+        .map(|command| command_cost(stack, finalize, command))
+        .try_fold(future_cost, |acc, res| {
+            res.and_then(|x| acc.checked_add(x).ok_or(anyhow!("Finalize cost overflowed")))
+        })
+}
+
+/// A helper function to determine the size of the plaintext type in bytes.
+fn plaintext_size_in_bytes<N: Network>(stack: &Stack<N>, plaintext_type: &PlaintextType<N>) -> Result<u64> {
+    match plaintext_type {
+        PlaintextType::Literal(literal_type) => Ok(literal_type.size_in_bytes::<N>() as u64),
+        PlaintextType::Struct(struct_name) => {
+            // Retrieve the struct from the stack.
+            let struct_ = stack.program().get_struct(struct_name)?;
+            // Retrieve the size of the struct name.
+            let size_of_name = struct_.name().to_bytes_le()?.len() as u64;
+            // Retrieve the size of all the members of the struct.
+            let size_of_members = struct_.members().iter().try_fold(0u64, |acc, (_, member_type)| {
+                acc.checked_add(plaintext_size_in_bytes(stack, member_type)?).ok_or(anyhow!(
+                    "Overflowed while computing the size of the struct '{}/{struct_name}' - {member_type}",
+                    stack.program_id()
+                ))
+            })?;
+            // Return the size of the struct.
+            Ok(size_of_name.saturating_add(size_of_members))
+        }
+        PlaintextType::Array(array_type) => {
+            // Retrieve the number of elements in the array.
+            let num_elements = **array_type.length() as u64;
+            // Compute the size of an array element.
+            let size_of_element = plaintext_size_in_bytes(stack, array_type.next_element_type())?;
+            // Return the size of the array.
+            Ok(num_elements.saturating_mul(size_of_element))
+        }
+    }
+}
+
+/// A helper function to compute the following: base_cost + (byte_multiplier * size_of_operands).
+fn cost_in_size<'a, N: Network>(
+    stack: &Stack<N>,
+    finalize: &Finalize<N>,
+    operands: impl IntoIterator<Item = &'a Operand<N>>,
+    byte_multiplier: u64,
+    base_cost: u64,
+) -> Result<u64> {
+    // Retrieve the finalize types.
+    let finalize_types = stack.get_finalize_types(finalize.name())?;
+    // Compute the size of the operands.
+    let size_of_operands = operands.into_iter().try_fold(0u64, |acc, operand| {
+        // Determine the size of the operand.
+        let operand_size = match finalize_types.get_type_from_operand(stack, operand)? {
+            FinalizeType::Plaintext(plaintext_type) => plaintext_size_in_bytes(stack, &plaintext_type)?,
+            FinalizeType::Future(future) => {
+                bail!("Future '{future}' is not a valid operand in the finalize scope");
+            }
+        };
+        // Safely add the size to the accumulator.
+        acc.checked_add(operand_size).ok_or(anyhow!(
+            "Overflowed while computing the size of the operand '{operand}' in '{}/{}' (finalize)",
+            stack.program_id(),
+            finalize.name()
+        ))
+    })?;
+    // Return the cost.
+    Ok(base_cost.saturating_add(byte_multiplier.saturating_mul(size_of_operands)))
 }

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -214,7 +214,7 @@ mod tests {
     };
     use ledger_block::Transition;
     use ledger_store::helpers::memory::ConsensusMemory;
-    use synthesizer_process::command_cost;
+    use synthesizer_process::cost_per_command;
     use synthesizer_program::StackProgram;
 
     use indexmap::IndexMap;
@@ -559,7 +559,7 @@ finalize test:
                     finalize_logic
                         .commands()
                         .iter()
-                        .map(|command| command_cost(&stack, finalize_logic, command))
+                        .map(|command| cost_per_command(&stack, finalize_logic, command))
                         .try_fold(0u64, |acc, res| {
                             res.and_then(|x| acc.checked_add(x).ok_or(anyhow!("Finalize cost overflowed")))
                         })
@@ -694,7 +694,7 @@ finalize test:
                     finalize_logic
                         .commands()
                         .iter()
-                        .map(|command| command_cost(&stack, finalize_logic, command))
+                        .map(|command| cost_per_command(&stack, finalize_logic, command))
                         .try_fold(0u64, |acc, res| {
                             res.and_then(|x| acc.checked_add(x).ok_or(anyhow!("Finalize cost overflowed")))
                         })


### PR DESCRIPTION
This PR follows on #2369 with two tests checking that the finalize cost is calculated correctly. 
The finalize cost of an execution is the finalize cost of its root transition.
This should be equal to the sum of the cost of **all** commands in **each** finalize block in **each** transition in the execution.
As a by product, this PR also refactors the cost utilities to support `command_cost` which returns the cost of a command.
