### PR TITLE
[Fix] Add limits on program struct definitions

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -148,6 +148,8 @@ pub trait Network:
     const MAX_MAPPINGS: usize = 31;
     /// The maximum number of functions in a program.
     const MAX_FUNCTIONS: usize = 31;
+    /// The maximum number of structs in a program.
+    const MAX_STRUCTS: usize = 31;
     /// The maximum number of operands in an instruction.
     const MAX_OPERANDS: usize = Self::MAX_INPUTS;
     /// The maximum number of instructions in a closure or function.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -362,6 +362,9 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         // Retrieve the struct name.
         let struct_name = *struct_.name();
 
+        // Ensure the program has not exceeded the maximum number of structs.
+        ensure!(self.functions.len() < N::MAX_STRUCTS, "Program exceeds the maximum number of structs.");
+
         // Ensure the struct name is new.
         ensure!(self.is_unique_name(&struct_name), "'{struct_name}' is already in use.");
         // Ensure the struct name is not a reserved opcode.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Implements a limit on the number of struct definitions in a given program per [SnarkOS issue 3141](https://github.com/AleoHQ/snarkOS/issues/3141). This limit of 31 in this PR is up for debate. We also may want implement limits on number of closures number of characters. 

(cc @vicsn) 

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM and https://github.com/AleoHQ/protocol-docs,
    and link to your PR here.
-->

(Link your related PRs here)
