### PR TITLE
Move transaction verification into `atomic_speculate`

### DIFF
--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -14,8 +14,6 @@
 
 use super::*;
 
-use rand::{rngs::StdRng, SeedableRng};
-
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Checks the given block is valid next block.
     pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
@@ -37,14 +35,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 bail!("Solution ID {solution_id} already exists in the ledger");
             }
         }
-
-        // Ensure each transaction is well-formed and unique.
-        let transactions = block.transactions();
-        let rngs = (0..transactions.len()).map(|_| StdRng::from_seed(rng.gen())).collect::<Vec<_>>();
-        cfg_iter!(transactions).zip(rngs).try_for_each(|(transaction, mut rng)| {
-            self.check_transaction_basic(transaction, transaction.to_rejected_id()?, &mut rng)
-                .map_err(|e| anyhow!("Invalid transaction found in the transactions list: {e}"))
-        })?;
 
         // TODO (howardwu): Remove this after moving the total supply into credits.aleo.
         {
@@ -78,9 +68,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             block.previous_hash(),
         )?;
 
-        // Ensure speculation over the unconfirmed transactions is correct.
+        // Ensure speculation over the unconfirmed transactions is correct and ensure each transaction is well-formed and unique.
         let ratified_finalize_operations =
-            self.vm.check_speculate(state, block.ratifications(), block.solutions(), block.transactions())?;
+            self.vm.check_speculate(state, block.ratifications(), block.solutions(), block.transactions(), rng)?;
 
         // Retrieve the committee lookback.
         let committee_lookback = {


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR is an extension of https://github.com/AleoHQ/snarkVM/pull/2376, where we move the pre-speculate transaction verification into `VM::atomic_speculate`. This will allow us to use the same TX verification logic in both `VM::speculate` and `VM::check_speculate`, which will reduce unnecessary duplication of transaction verification code.