### PR TITLE
Add parallelism to `BatchHeader` and `Committee` deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,6 +3196,7 @@ version = "0.16.19"
 dependencies = [
  "bincode",
  "indexmap 2.1.0",
+ "rayon",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-narwhal-batch-header",

--- a/ledger/committee/Cargo.toml
+++ b/ledger/committee/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = [ ]
+default = [ "rayon" ]
 serial = [ "console/serial" ]
 wasm = [ "console/wasm" ]
 metrics = [ "dep:metrics" ]
@@ -72,6 +72,10 @@ optional = true
 
 [dependencies.rand_distr]
 version = "0.4"
+optional = true
+
+[dependencies.rayon]
+version = "1"
 optional = true
 
 [dependencies.test-strategy]

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -352,7 +352,6 @@ mod tests {
     use console::prelude::TestRng;
 
     use parking_lot::RwLock;
-    use rayon::prelude::*;
     use std::sync::Arc;
 
     type CurrentNetwork = console::network::MainnetV0;
@@ -362,7 +361,7 @@ mod tests {
         // Initialize a tracker for the leaders.
         let leaders = Arc::new(RwLock::new(IndexMap::<Address<CurrentNetwork>, i64>::new()));
         // Iterate through the rounds.
-        (1..=num_rounds).into_par_iter().for_each(|round| {
+        cfg_into_iter!(1..=num_rounds).for_each(|round| {
             // Compute the leader.
             let leader = committee.get_leader(round).unwrap();
             // Increment the leader count for the current leader.

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -28,10 +28,13 @@ use console::{
     program::{Literal, LiteralType},
     types::{Address, Field},
 };
+use ledger_narwhal_batch_header::BatchHeader;
 
 use indexmap::IndexMap;
-use ledger_narwhal_batch_header::BatchHeader;
 use std::collections::HashSet;
+
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
 
 /// The minimum amount of stake required for a validator to bond.
 pub const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000_000u64; // microcredits

--- a/ledger/narwhal/batch-header/Cargo.toml
+++ b/ledger/narwhal/batch-header/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = [ ]
+default = [ "rayon" ]
 serial = [ "console/serial" ]
 wasm = [ "console/wasm" ]
 test-helpers = [ "narwhal-transmission-id/test-helpers", "time" ]
@@ -42,6 +42,10 @@ version = "=0.16.19"
 [dependencies.indexmap]
 version = "2.0"
 features = [ "serde" ]
+
+[dependencies.rayon]
+version = "1"
+optional = true
 
 [dependencies.serde_json]
 version = "1.0"

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -26,8 +26,12 @@ use console::{
     prelude::*,
     types::Field,
 };
-use indexmap::IndexSet;
 use narwhal_transmission_id::TransmissionID;
+
+use indexmap::IndexSet;
+
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct BatchHeader<N: Network> {


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR optimizes the deserialization of `BatchHeader` and `Committee` by first reading the fixed number of bytes required for the subcomponents, then deserializes them in parallel.

Issue: https://github.com/AleoHQ/snarkVM/issues/2393

## Related PRs

Related to https://github.com/AleoHQ/snarkVM/pull/2258.
