### PR TITLE
Update inputs in genesis transactions 

### DIFF
--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -2022,7 +2022,7 @@ finalize compute:
         // Reset the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators =
-            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize / 4, rng);
+            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize, rng);
 
         // Construct the committee.
         // Track the allocated amount.
@@ -2066,7 +2066,7 @@ finalize compute:
         // Construct the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators =
-            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize / 4, rng);
+            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize, rng);
 
         // Construct the delegators, greater than the maximum delegator size.
         let delegators = (0..MAX_DELEGATORS + 1)

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -2066,7 +2066,7 @@ finalize compute:
         // Construct the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators =
-            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize, rng);
+            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize / 4, rng);
 
         // Construct the delegators, greater than the maximum delegator size.
         let delegators = (0..MAX_DELEGATORS + 1)
@@ -2226,7 +2226,7 @@ finalize compute:
             // Note that the first validator is used to execute additional transactions in `VM::genesis_quorum`.
             // Therefore, the balance of the first validator will be different from the expected balance.
             if entry.0 == Plaintext::from_str(&first_validator.to_string()).unwrap() {
-                assert_eq!(entry.1, Value::from_str("249983999894244u64").unwrap());
+                assert_eq!(entry.1, Value::from_str("144991999894244u64").unwrap());
             } else {
                 assert!(expected_account.contains(entry));
             }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1004,7 +1004,7 @@ function a:
             // Note: `deployment_transaction_ids` is sorted lexicographically by transaction ID, so the order may change if we update internal methods.
             assert_eq!(
                 deployment_transaction_ids,
-                vec![deployment_3.id(), deployment_4.id(), deployment_1.id(), deployment_2.id()],
+                vec![deployment_1.id(), deployment_4.id(), deployment_3.id(), deployment_2.id()],
                 "Update me if serialization has changed"
             );
         }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -296,7 +296,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Prepare the locator.
         let locator = ("credits.aleo", "transfer_public_to_private");
         // Prepare the amount for each call to the function.
-        let amount = ledger_committee::MIN_VALIDATOR_STAKE;
+        let amount = ledger_committee::MIN_DELEGATOR_STAKE;
         // Prepare the function inputs.
         let inputs = [caller.to_string(), format!("{amount}_u64")];
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -296,7 +296,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Prepare the locator.
         let locator = ("credits.aleo", "transfer_public_to_private");
         // Prepare the amount for each call to the function.
-        let amount = ledger_committee::MIN_DELEGATOR_STAKE;
+        let amount = public_balances
+            .get(&caller)
+            .ok_or_else(|| anyhow!("Missing public balance for {caller}"))?
+            .saturating_div(Block::<N>::NUM_GENESIS_TRANSACTIONS.saturating_mul(2) as u64);
         // Prepare the function inputs.
         let inputs = [caller.to_string(), format!("{amount}_u64")];
 

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/test_rand.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/test_rand.out
@@ -26,7 +26,7 @@ outputs:
     test_rand.aleo/rand_chacha_check:
       outputs:
       - '{"type":"future","id":"818878742790741579153893179075772445872751227433677932822653185952935999557field","value":"{\n  program_id: test_rand.aleo,\n  function_name: rand_chacha_check,\n  arguments: [\n    1field,\n    true\n  ]\n}"}'
-  speculate: the execution was accepted
+  speculate: the execution was rejected
   add_next_block: succeeded.
 additional:
 - child_outputs:


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the amount input in the `transfer_public_to_private` genesis transactions. This change is necessary because with the new committee requirements, there is not enough public balance to pay for the initial transfers in test scenarios of 100 validators.

Initial values for testing w/ 100 validators:
Stake: 10 million credits * 100 validators = 1 billion credits
Public: 500 million credits / 100 validators = 5 million credits each

Previously we were sending `MIN_VALIDATOR_STAKE` amount for each of these `transfer_public_to_private` transactions, which greatly exceeds the available public balance. The change is to update this amount to reflect an equal distribution of public credits and private credits (distributed in `NUM_GENESIS_TRANSACTIONS` records).

NOTE: This does **NOT** affect the total supply of credits, and is merely a change in the distribution of the initial public and private credits.
