### PR TITLE
[Fix] Don't re-seed the TestRng when calling check_merkle_tree

### DIFF
--- a/console/collections/src/merkle_tree/tests/append.rs
+++ b/console/collections/src/merkle_tree/tests/append.rs
@@ -30,12 +30,11 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
     path_hasher: &PH,
     leaves: &[LH::Leaf],
     additional_leaves: &[LH::Leaf],
+    rng: &mut TestRng,
 ) -> Result<()> {
     // Construct the Merkle tree for the given leaves.
     let mut merkle_tree = MerkleTree::<E, LH, PH, DEPTH>::new(leaf_hasher, path_hasher, leaves)?;
     assert_eq!(leaves.len(), merkle_tree.number_of_leaves);
-
-    let mut rng = TestRng::default();
 
     // Check each leaf in the Merkle tree.
     if !leaves.is_empty() {
@@ -47,7 +46,7 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
             // Verify the Merkle proof **fails** on an invalid root.
             assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::zero(), leaf));
             assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::one(), leaf));
-            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(&mut rng), leaf));
+            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(rng), leaf));
         }
     }
     // If additional leaves are provided, check that the Merkle tree is consistent with them.
@@ -63,7 +62,7 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
             // Verify the Merkle proof **fails** on an invalid root.
             assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::zero(), leaf));
             assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::one(), leaf));
-            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(&mut rng), leaf));
+            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(rng), leaf));
         }
     }
     Ok(())
@@ -388,6 +387,7 @@ fn test_merkle_tree_bhp() -> Result<()> {
                     &(0..num_additional_leaves)
                         .map(|_| Field::<CurrentEnvironment>::rand(rng).to_bits_le())
                         .collect::<Vec<Vec<bool>>>(),
+                    rng,
                 )?;
             }
         }
@@ -439,6 +439,7 @@ fn test_merkle_tree_poseidon() -> Result<()> {
                     &path_hasher,
                     &(0..num_leaves).map(|_| vec![Uniform::rand(rng)]).collect::<Vec<_>>(),
                     &(0..num_additional_leaves).map(|_| vec![Uniform::rand(rng)]).collect::<Vec<_>>(),
+                    rng,
                 )?;
             }
         }

--- a/console/collections/src/merkle_tree/tests/update.rs
+++ b/console/collections/src/merkle_tree/tests/update.rs
@@ -32,12 +32,11 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
     path_hasher: &PH,
     leaves: &[LH::Leaf],
     updates: &[(usize, LH::Leaf)],
+    rng: &mut TestRng,
 ) -> Result<()> {
     // Construct the Merkle tree for the given leaves.
     let mut merkle_tree = MerkleTree::<E, LH, PH, DEPTH>::new(leaf_hasher, path_hasher, leaves)?;
     assert_eq!(leaves.len(), merkle_tree.number_of_leaves);
-
-    let mut rng = TestRng::default();
 
     // Check each leaf in the Merkle tree.
     for (leaf_index, leaf) in leaves.iter().enumerate() {
@@ -48,7 +47,7 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
         // Verify the Merkle proof **fails** on an invalid root.
         assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::zero(), leaf));
         assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::one(), leaf));
-        assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(&mut rng), leaf));
+        assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(rng), leaf));
     }
 
     // Update the leaves of the Merkle tree.
@@ -65,7 +64,7 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
         // Verify the Merkle proof **fails** on an invalid root.
         assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::zero(), leaf));
         assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::one(), leaf));
-        assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(&mut rng), leaf));
+        assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(rng), leaf));
     }
     Ok(())
 }
@@ -236,6 +235,7 @@ fn test_merkle_tree_bhp() -> Result<()> {
                     &(0..num_updates)
                         .map(|i| ((i % num_leaves) as usize, Field::<CurrentEnvironment>::rand(rng).to_bits_le()))
                         .collect::<Vec<(usize, Vec<bool>)>>(),
+                    rng,
                 )?;
             }
         }
@@ -275,6 +275,7 @@ fn test_merkle_tree_poseidon() -> Result<()> {
                     &(0..num_additional_leaves)
                         .map(|i| ((i % num_leaves) as usize, vec![Uniform::rand(rng)]))
                         .collect::<Vec<_>>(),
+                    rng,
                 )?;
             }
         }

--- a/console/collections/src/merkle_tree/tests/update_many.rs
+++ b/console/collections/src/merkle_tree/tests/update_many.rs
@@ -32,12 +32,11 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
     path_hasher: &PH,
     leaves: &[LH::Leaf],
     updates: &BTreeMap<usize, LH::Leaf>,
+    rng: &mut TestRng,
 ) -> Result<()> {
     // Construct the Merkle tree for the given leaves.
     let mut merkle_tree = MerkleTree::<E, LH, PH, DEPTH>::new(leaf_hasher, path_hasher, leaves)?;
     assert_eq!(leaves.len(), merkle_tree.number_of_leaves);
-
-    let mut rng = TestRng::default();
 
     // Check each leaf in the Merkle tree.
     for (leaf_index, leaf) in leaves.iter().enumerate() {
@@ -48,7 +47,7 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
         // Verify the Merkle proof **fails** on an invalid root.
         assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::zero(), leaf));
         assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::one(), leaf));
-        assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(&mut rng), leaf));
+        assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(rng), leaf));
     }
 
     // If additional leaves are provided, check that the Merkle tree is consistent with them.
@@ -64,7 +63,7 @@ fn check_merkle_tree<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash
             // Verify the Merkle proof **fails** on an invalid root.
             assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::zero(), leaf));
             assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::one(), leaf));
-            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(&mut rng), leaf));
+            assert!(!proof.verify(leaf_hasher, path_hasher, &PH::Hash::rand(rng), leaf));
         }
     }
     Ok(())
@@ -235,6 +234,7 @@ fn test_merkle_tree_bhp() -> Result<()> {
                         .rev()
                         .map(|i| ((i % num_leaves) as usize, Field::<CurrentEnvironment>::rand(rng).to_bits_le()))
                         .collect::<BTreeMap<usize, Vec<bool>>>(),
+                    rng,
                 )?;
             }
         }
@@ -275,6 +275,7 @@ fn test_merkle_tree_poseidon() -> Result<()> {
                         .rev()
                         .map(|i| ((i % num_leaves) as usize, vec![Uniform::rand(rng)]))
                         .collect::<BTreeMap<_, _>>(),
+                    rng,
                 )?;
             }
         }


### PR DESCRIPTION
This PR fixes a small issue I've found when looking into the performance of `MerkleTree` - instead of reusing a single `TestRng` for the entirety of a single test, we are currently re-seeding it whenever we run `check_merkle_tree`, which makes the affected tests slower and more difficult to reproduce.

This is a test-only change and its introduction can be delayed for as long as necessary.