### PR TITLE
Reduce zero-padding and cache zero-hashes in k-ary MerkleTree

### DIFF
--- a/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -34,19 +34,11 @@ pub trait PathHash: Clone + Send + Sync {
 
     /// Returns the hash for each child node.
     /// If there are no children, the supplied empty node hash is used instead.
-    fn hash_all_children(
-        &self,
-        child_nodes: &[Option<Vec<Self::Hash>>],
-        empty_node_hash: Self::Hash,
-    ) -> Result<Vec<Self::Hash>> {
-        let hash_children = |children: &Option<Vec<Self::Hash>>| {
-            if let Some(children) = children { self.hash_children(children) } else { Ok(empty_node_hash) }
-        };
-
+    fn hash_all_children(&self, child_nodes: &[Vec<Self::Hash>]) -> Result<Vec<Self::Hash>> {
         match child_nodes.len() {
             0 => Ok(vec![]),
-            1..=100 => child_nodes.iter().map(hash_children).collect(),
-            _ => cfg_iter!(child_nodes).map(hash_children).collect(),
+            1..=100 => child_nodes.iter().map(|children| self.hash_children(children)).collect(),
+            _ => cfg_iter!(child_nodes).map(|children| self.hash_children(children)).collect(),
         }
     }
 }

--- a/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -33,7 +33,6 @@ pub trait PathHash: Clone + Send + Sync {
     }
 
     /// Returns the hash for each child node.
-    /// If there are no children, the supplied empty node hash is used instead.
     fn hash_all_children(&self, child_nodes: &[Vec<Self::Hash>]) -> Result<Vec<Self::Hash>> {
         match child_nodes.len() {
             0 => Ok(vec![]),

--- a/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -33,7 +33,7 @@ pub trait PathHash: Clone + Send + Sync {
     }
 
     /// Returns the hash for each child node.
-    fn hash_all_children(&self, child_nodes: &[Vec<Self::Hash>]) -> Result<Vec<Self::Hash>> {
+    fn hash_all_children(&self, child_nodes: &[&[Self::Hash]]) -> Result<Vec<Self::Hash>> {
         match child_nodes.len() {
             0 => Ok(vec![]),
             1..=100 => child_nodes.iter().map(|children| self.hash_children(children)).collect(),

--- a/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -34,7 +34,7 @@ pub trait PathHash: Clone + Send + Sync {
 
     /// Returns the hash for each child node.
     /// If there are no children, the supplied empty node hash is used instead.
-    fn hash_all_children<const ARITY: u8>(
+    fn hash_all_children(
         &self,
         child_nodes: &[Option<Vec<Self::Hash>>],
         empty_node_hash: Self::Hash,

--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -120,11 +120,6 @@ impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: 
                     // Prepare an iterator over then children, being mindful of possible missing leaves.
                     let child_iter = || child_indexes::<ARITY>(i).map(|child_index| tree.get(child_index).copied());
 
-                    // At the leaf level just return the leaves, or `None` in case the node has none.
-                    if current_empty_node_hash == empty_hash {
-                        return child_iter().collect::<Option<Vec<_>>>();
-                    }
-
                     // Check if the children aren't all derived from empty hashes.
                     if child_iter().all(|hash| hash == Some(current_empty_node_hash)) {
                         return None;

--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -129,8 +129,8 @@ impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: 
             // Use the precomputed empty node hash for every empty node, if there are any.
             if start + num_full_nodes < end {
                 let empty_node_hash = path_hasher.hash_children(&vec![empty_hash; arity])?;
-                for idx in start + num_full_nodes..end {
-                    tree[idx] = empty_node_hash;
+                for node in tree.iter_mut().take(end).skip(start + num_full_nodes) {
+                    *node = empty_node_hash;
                 }
             }
             // Update the start index for the next level.

--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -115,12 +115,8 @@ impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: 
 
             // Construct the children for each node in the current level.
             let child_nodes = (start..end)
-                .filter_map(|i| {
-                    // Collect the children, being mindful of possible missing leaves.
-                    child_indexes::<ARITY>(i)
-                        .map(|child_index| tree.get(child_index).copied())
-                        .collect::<Option<Vec<_>>>()
-                })
+                .take_while(|&i| child_indexes::<ARITY>(i).next().and_then(|idx| tree.get(idx)).is_some())
+                .map(|i| child_indexes::<ARITY>(i).map(|child_index| tree[child_index]).collect::<Vec<_>>())
                 .collect::<Vec<_>>();
 
             // Compute and store the hashes for each node in the current level.

--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -90,10 +90,13 @@ impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: 
         let empty_hash = path_hasher.hash_empty::<ARITY>()?;
 
         // Calculate the size of the tree which excludes leafless nodes.
+        // The minimum tree size is either a single root node or the calculated number of nodes plus
+        // the supplied leaves, and empty hashes that pad up to the tree's arity (making every node full).
         let arity = ARITY as usize;
+        let all_nodes_are_full = leaves.len() % arity == 0;
         let minimum_tree_size = std::cmp::max(
             1,
-            num_nodes + leaves.len() + if leaves.len() % arity == 0 { 0 } else { arity - leaves.len() % arity },
+            num_nodes + leaves.len() + if all_nodes_are_full { 0 } else { arity - leaves.len() % arity },
         );
 
         // Initialize the Merkle tree.

--- a/console/collections/src/kary_merkle_tree/tests/mod.rs
+++ b/console/collections/src/kary_merkle_tree/tests/mod.rs
@@ -170,7 +170,7 @@ fn check_merkle_tree_depth_3_arity_3_padded<LH: LeafHash<Hash = PH::Hash>, PH: P
 
     // Construct the Merkle tree for the given leaves.
     let merkle_tree = KaryMerkleTree::<LH, PH, 3, ARITY>::new(leaf_hasher, path_hasher, &leaves)?;
-    assert_eq!(40, merkle_tree.tree.len());
+    assert_eq!(25, merkle_tree.tree.len());
     assert_eq!(10, merkle_tree.number_of_leaves);
 
     // Depth 3.
@@ -194,7 +194,7 @@ fn check_merkle_tree_depth_3_arity_3_padded<LH: LeafHash<Hash = PH::Hash>, PH: P
     assert_eq!(expected_leaf7, merkle_tree.tree[20]);
     assert_eq!(expected_leaf8, merkle_tree.tree[21]);
     assert_eq!(expected_leaf9, merkle_tree.tree[22]);
-    for i in 23..40 {
+    for i in 23..25 {
         assert_eq!(path_hasher.hash_empty::<ARITY>()?, merkle_tree.tree[i]);
     }
 


### PR DESCRIPTION
When creating k-ary Merkle trees, we currently pad all the "missing" leaves, which can result in a large number of empty hashes that all end up being allocated, and then repeatedly included in the calculation of further hashes. In order to improve performance for all such scenarios, we can omit some of the padding, and cache the hashes that derive from the zero hash, which is what this PR proposes.

While there are still ways in which the performance can be improved further, these changes aren't exactly trivial already, and it seems like a good moment to open them to discussion. Below are some benchmarks that I'll be referring to when outlining the potential for future improvement.

```
creation of a KaryMerkleTree with ARITY = 8, DEPTH = 8, NUM_LEAVES = ARITY^(DEPTH-1)+1, and SHA3 hashers

before:

alloc count: 48,061,051
heap use:    5.12 GiB
max heap:    10.17 GiB

after:

alloc count: 21,084,574 (-56%)
heap use:    1.62 GiB (-68%)
max heap:    3.17 GiB (-69%)

```
These are all wins, with a significantly lower both maximum and current (once the tree is created) heap use.
```
console/collections/benches/kary_merkle_tree:

KaryMerkleTree/new/0 (0% full)
                        time:   [21.247 µs 21.308 µs 21.383 µs]
                        change: [+93.568% +95.333% +96.860%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

Benchmarking KaryMerkleTree/new/4194304 (25% full): Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 20.4s.
KaryMerkleTree/new/4194304 (25% full)
                        time:   [2.0185 s 2.0246 s 2.0308 s]
                        change: [-51.205% -51.016% -50.847%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking KaryMerkleTree/new/8388608 (50% full): Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 38.2s.
KaryMerkleTree/new/8388608 (50% full)
                        time:   [3.8503 s 3.8668 s 3.8835 s]
                        change: [-25.467% -25.025% -24.593%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking KaryMerkleTree/new/12582912 (75% full): Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 57.7s.
KaryMerkleTree/new/12582912 (75% full)
                        time:   [5.7279 s 5.7525 s 5.7726 s]
                        change: [-8.8066% -8.3742% -7.9833%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low mild

Benchmarking KaryMerkleTree/new/16777216 (100% full): Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 75.1s.
KaryMerkleTree/new/16777216 (100% full)
                        time:   [7.5454 s 7.5707 s 7.5963 s]
                        change: [+3.6674% +4.2182% +4.7320%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
The creation of an empty and a full tree see regressions, as those scenarios don't benefit from the caching of empty hashes. I have an idea on how to improve them, which will be posted as an additional commit if the diff isn't too large.