### PR TITLE
[HackerOne-2332566] Update the target threshold

### DIFF
--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -348,7 +348,7 @@ impl<N: Network> Block<N> {
             None => 0u128,
         };
 
-        let (expected_cumulative_proof_target, is_coinbase_target_reached) = match self.solutions.deref() {
+        let (expected_cumulative_proof_target, is_coinbase_threshold_reached) = match self.solutions.deref() {
             Some(coinbase) => {
                 // Ensure the puzzle proof is valid.
                 if let Err(e) =
@@ -369,15 +369,17 @@ impl<N: Network> Block<N> {
                 // Compute the actual cumulative proof target (which can exceed the coinbase target).
                 let cumulative_proof_target =
                     previous_block.cumulative_proof_target().saturating_add(combined_proof_target);
-                // Determine if the coinbase target is reached.
-                let is_coinbase_target_reached = cumulative_proof_target >= previous_block.coinbase_target() as u128;
+                // Compute the coinbase target threshold.
+                let coinbase_threshold = previous_block.coinbase_target().saturating_div(2) as u128;
+                // Determine if the coinbase target threshold is reached.
+                let is_coinbase_threshold_reached = cumulative_proof_target >= coinbase_threshold;
                 // Compute the block cumulative proof target (which cannot exceed the coinbase target).
-                let expected_cumulative_proof_target = match is_coinbase_target_reached {
+                let expected_cumulative_proof_target = match is_coinbase_threshold_reached {
                     true => 0u128,
                     false => cumulative_proof_target,
                 };
 
-                (expected_cumulative_proof_target, is_coinbase_target_reached)
+                (expected_cumulative_proof_target, is_coinbase_threshold_reached)
             }
             None => {
                 // Determine the cumulative proof target.
@@ -404,12 +406,12 @@ impl<N: Network> Block<N> {
             proof_target(expected_coinbase_target, N::GENESIS_PROOF_TARGET, N::MAX_SOLUTIONS_AS_POWER_OF_TWO);
 
         // Determine the expected last coinbase target.
-        let expected_last_coinbase_target = match is_coinbase_target_reached {
+        let expected_last_coinbase_target = match is_coinbase_threshold_reached {
             true => expected_coinbase_target,
             false => previous_block.last_coinbase_target(),
         };
         // Determine the expected last coinbase timestamp.
-        let expected_last_coinbase_timestamp = match is_coinbase_target_reached {
+        let expected_last_coinbase_timestamp = match is_coinbase_threshold_reached {
             true => timestamp,
             false => previous_block.last_coinbase_timestamp(),
         };

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -261,10 +261,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let next_cumulative_weight = previous_block.cumulative_weight().saturating_add(combined_proof_target);
         // Compute the next cumulative proof target.
         let next_cumulative_proof_target = latest_cumulative_proof_target.saturating_add(combined_proof_target);
-        // Determine if the coinbase target is reached.
-        let is_coinbase_target_reached = next_cumulative_proof_target >= latest_coinbase_target as u128;
+        // Compute the coinbase target threshold.
+        let latest_coinbase_threshold = latest_coinbase_target.saturating_div(2) as u128;
+        // Determine if the coinbase target threshold is reached.
+        let is_coinbase_threshold_reached = next_cumulative_proof_target >= latest_coinbase_threshold;
         // Update the next cumulative proof target, if necessary.
-        let next_cumulative_proof_target = match is_coinbase_target_reached {
+        let next_cumulative_proof_target = match is_coinbase_threshold_reached {
             true => 0,
             false => next_cumulative_proof_target,
         };
@@ -282,7 +284,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             proof_target(next_coinbase_target, N::GENESIS_PROOF_TARGET, N::MAX_SOLUTIONS_AS_POWER_OF_TWO);
 
         // Construct the next last coinbase target and next last coinbase timestamp.
-        let (next_last_coinbase_target, next_last_coinbase_timestamp) = match is_coinbase_target_reached {
+        let (next_last_coinbase_target, next_last_coinbase_timestamp) = match is_coinbase_threshold_reached {
             true => (next_coinbase_target, next_timestamp),
             false => (previous_block.last_coinbase_target(), previous_block.last_coinbase_timestamp()),
         };


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates the condition of `is_coinbase_target_reached` to `is_coinbase_threshold_reached`, by adjusting the required `cumulative_proof_target` required to reset the `cumulative_proof_target` to 0 and "initializing a new bucket". 

Previously we were comparing the `cumulative_proof_target` with a dynamically changing `coinbase_target` as the requirement, now the change compares  `cumulative_proof_target` with a `coinbase_threshold`. 

This threshold is currently set to `coinbase_target / 2`.

**This change addresses 2 problems:**
1. Addresses edge-case where some blocks would not have coinbase rewards despite having solutions.
    - Previous model would have cases where the `cumulative_proof_target` could be greater than (or close enough to) the `latest_coinbase_target` at the end of a block due to the dynamic target adjustments. This effectively nullified the next block's coinbase rewards, no matter how many solutions were included.

2. Smooths out the distribution of rewards given per solution.
    - Previously, provers would be incentivized to hold their solutions until the `cumulative_proof_target` is reset to 0 before submitting to receive a larger pro-rata distribution of rewards. This would cause spikes in when solutions (particularly solutions with large targets) would enter the network.
    - Because we now reset the `cumulative_proof_target` more frequently, while retaining the same total payout potential with the `coinbase_target` pro-rata, there is less incentive to time the broadcast of solutions.

**Implications:**
- Previously we were adjusting the coinbase target based on how long it took to reach the latest coinbase target. But now the change will be adjusting the coinbase target based on how long it takes to reach the latest coinbase threshold.


Fixes https://github.com/AleoHQ/snarkVM/issues/2323