### PR TITLE
[HackerOne-2332566] Unify target calculations

### DIFF
--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -227,22 +227,29 @@ fn retarget(
 }
 
 /// This function calculates the next targets for the given attributes:
-///    `latest_cumulative_proof_target`: The latest cumulative proof target.
-///    `combined_proof_target`: The combined proof target of solutions in the block.
-///    `latest_coinbase_target`: The latest coinbase target.
-///    `last_coinbase_target`: The coinbase target for the last coinbase.
-///    `last_coinbase_timestamp`: The timestamp for the last coinbase.
-///    `next_timestamp`: The timestamp for the next block.
+///     `latest_cumulative_proof_target`: The latest cumulative proof target.
+///     `combined_proof_target`: The combined proof target of solutions in the block.
+///     `latest_coinbase_target`: The latest coinbase target.
+///     `last_coinbase_target`: The coinbase target for the last coinbase.
+///     `last_coinbase_timestamp`: The timestamp for the last coinbase.
+///     `next_timestamp`: The timestamp for the next block.
 ///
-/// Returns the `(next_coinbase_target, next_proof_target, next_cumulative_proof_target, next_last_coinbase_target, next_last_coinbase_timestamp)`.
+/// Returns the following as a tuple:
+///     `next_coinbase_target` - The next coinbase target.
+///     `next_proof_target` - The next proof target.
+///     `next_cumulative_proof_target` - The next cumulative proof target.
+///     `next_cumulative_weight` - The next cumulative weight.
+///     `next_last_coinbase_target` - The next last coinbase target.
+///     `next_last_coinbase_timestamp` - The next last coinbase timestamp.
 pub fn to_next_targets<N: Network>(
     latest_cumulative_proof_target: u128,
     combined_proof_target: u128,
     latest_coinbase_target: u64,
+    latest_cumulative_weight: u128,
     last_coinbase_target: u64,
     last_coinbase_timestamp: i64,
     next_timestamp: i64,
-) -> Result<(u64, u64, u128, u64, i64)> {
+) -> Result<(u64, u64, u128, u128, u64, i64)> {
     // Compute the coinbase target threshold.
     let latest_coinbase_threshold = latest_coinbase_target.saturating_div(2) as u128;
     // Compute the next cumulative proof target.
@@ -268,6 +275,9 @@ pub fn to_next_targets<N: Network>(
         false => next_cumulative_proof_target,
     };
 
+    // Compute the next cumulative weight.
+    let next_cumulative_weight = latest_cumulative_weight.saturating_add(combined_proof_target);
+
     // Construct the next last coinbase target and next last coinbase timestamp.
     let (next_last_coinbase_target, next_last_coinbase_timestamp) = match is_coinbase_threshold_reached {
         true => (next_coinbase_target, next_timestamp),
@@ -278,6 +288,7 @@ pub fn to_next_targets<N: Network>(
         next_coinbase_target,
         next_proof_target,
         next_cumulative_proof_target,
+        next_cumulative_weight,
         next_last_coinbase_target,
         next_last_coinbase_timestamp,
     ))

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -348,67 +348,40 @@ impl<N: Network> Block<N> {
             None => 0u128,
         };
 
-        // Compute the cumulative proof target.
-        let cumulative_proof_target = match self.solutions.deref() {
-            Some(coinbase) => {
-                // Ensure the puzzle proof is valid.
-                if let Err(e) =
-                    current_puzzle.check_solutions(coinbase, current_epoch_hash, previous_block.proof_target())
-                {
-                    bail!("Block {height} contains an invalid puzzle proof - {e}");
-                }
-
-                // Ensure that the block cumulative proof target is less than the previous block's coinbase target.
-                // Note: This is a sanity check, as the cumulative proof target resets to 0 if the
-                // coinbase target was reached in this block.
-                if self.cumulative_proof_target() >= previous_block.coinbase_target() as u128 {
-                    bail!(
-                        "The cumulative proof target in block {height} must be less than the previous coinbase target"
-                    )
-                }
-
-                // Compute the actual cumulative proof target (which can exceed the coinbase target).
-                previous_block.cumulative_proof_target().saturating_add(combined_proof_target)
+        // Verify the solutions.
+        if let Some(coinbase) = self.solutions.deref() {
+            // Ensure the puzzle proof is valid.
+            if let Err(e) = current_puzzle.check_solutions(coinbase, current_epoch_hash, previous_block.proof_target())
+            {
+                bail!("Block {height} contains an invalid puzzle proof - {e}");
             }
-            None => previous_block.cumulative_proof_target(),
-        };
 
-        // Compute the coinbase target threshold.
-        let coinbase_threshold = previous_block.coinbase_target().saturating_div(2) as u128;
-        // Determine if the coinbase target threshold is reached.
-        let is_coinbase_threshold_reached = cumulative_proof_target >= coinbase_threshold;
-        // Compute the block cumulative proof target (which cannot exceed the coinbase target).
-        let expected_cumulative_proof_target = match is_coinbase_threshold_reached {
-            true => 0u128,
-            false => cumulative_proof_target,
+            // Ensure that the block cumulative proof target is less than the previous block's coinbase target.
+            // Note: This is a sanity check, as the cumulative proof target resets to 0 if the
+            // coinbase target was reached in this block.
+            if self.cumulative_proof_target() >= previous_block.coinbase_target() as u128 {
+                bail!("The cumulative proof target in block {height} must be less than the previous coinbase target")
+            }
         };
 
         // Compute the expected cumulative weight.
         let expected_cumulative_weight = previous_block.cumulative_weight().saturating_add(combined_proof_target);
 
-        // Construct the next coinbase target.
-        let expected_coinbase_target = coinbase_target(
+        // Calculate the next coinbase targets and timestamps.
+        let (
+            expected_coinbase_target,
+            expected_proof_target,
+            expected_cumulative_proof_target,
+            expected_last_coinbase_target,
+            expected_last_coinbase_timestamp,
+        ) = to_next_targets::<N>(
+            self.cumulative_proof_target(),
+            combined_proof_target,
+            previous_block.coinbase_target(),
             previous_block.last_coinbase_target(),
             previous_block.last_coinbase_timestamp(),
             timestamp,
-            N::ANCHOR_TIME,
-            N::NUM_BLOCKS_PER_EPOCH,
-            N::GENESIS_COINBASE_TARGET,
         )?;
-        // Ensure the proof target is correct.
-        let expected_proof_target =
-            proof_target(expected_coinbase_target, N::GENESIS_PROOF_TARGET, N::MAX_SOLUTIONS_AS_POWER_OF_TWO);
-
-        // Determine the expected last coinbase target.
-        let expected_last_coinbase_target = match is_coinbase_threshold_reached {
-            true => expected_coinbase_target,
-            false => previous_block.last_coinbase_target(),
-        };
-        // Determine the expected last coinbase timestamp.
-        let expected_last_coinbase_timestamp = match is_coinbase_threshold_reached {
-            true => timestamp,
-            false => previous_block.last_coinbase_timestamp(),
-        };
 
         // Calculate the expected coinbase reward.
         let expected_coinbase_reward = coinbase_reward(

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -364,20 +364,19 @@ impl<N: Network> Block<N> {
             }
         };
 
-        // Compute the expected cumulative weight.
-        let expected_cumulative_weight = previous_block.cumulative_weight().saturating_add(combined_proof_target);
-
         // Calculate the next coinbase targets and timestamps.
         let (
             expected_coinbase_target,
             expected_proof_target,
             expected_cumulative_proof_target,
+            expected_cumulative_weight,
             expected_last_coinbase_target,
             expected_last_coinbase_timestamp,
         ) = to_next_targets::<N>(
             self.cumulative_proof_target(),
             combined_proof_target,
             previous_block.coinbase_target(),
+            previous_block.cumulative_weight(),
             previous_block.last_coinbase_target(),
             previous_block.last_coinbase_timestamp(),
             timestamp,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -224,6 +224,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let latest_cumulative_proof_target = previous_block.cumulative_proof_target();
         // Retrieve the latest coinbase target.
         let latest_coinbase_target = previous_block.coinbase_target();
+        // Retrieve the latest cumulative weight.
+        let latest_cumulative_weight = previous_block.cumulative_weight();
         // Retrieve the last coinbase target.
         let last_coinbase_target = previous_block.last_coinbase_target();
         // Retrieve the last coinbase timestamp.
@@ -261,20 +263,20 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
             None => OffsetDateTime::now_utc().unix_timestamp(),
         };
-        // Compute the next cumulative weight.
-        let next_cumulative_weight = previous_block.cumulative_weight().saturating_add(combined_proof_target);
 
         // Calculate the next coinbase targets and timestamps.
         let (
             next_coinbase_target,
             next_proof_target,
             next_cumulative_proof_target,
+            next_cumulative_weight,
             next_last_coinbase_target,
             next_last_coinbase_timestamp,
         ) = to_next_targets::<N>(
             latest_cumulative_proof_target,
             combined_proof_target,
             latest_coinbase_target,
+            latest_cumulative_weight,
             last_coinbase_target,
             last_coinbase_timestamp,
             next_timestamp,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -224,6 +224,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let latest_cumulative_proof_target = previous_block.cumulative_proof_target();
         // Retrieve the latest coinbase target.
         let latest_coinbase_target = previous_block.coinbase_target();
+        // Retrieve the last coinbase target.
+        let last_coinbase_target = previous_block.last_coinbase_target();
+        // Retrieve the last coinbase timestamp.
+        let last_coinbase_timestamp = previous_block.last_coinbase_timestamp();
 
         // Compute the next round number.
         let next_round = match subdag {
@@ -259,35 +263,22 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         };
         // Compute the next cumulative weight.
         let next_cumulative_weight = previous_block.cumulative_weight().saturating_add(combined_proof_target);
-        // Compute the next cumulative proof target.
-        let next_cumulative_proof_target = latest_cumulative_proof_target.saturating_add(combined_proof_target);
-        // Compute the coinbase target threshold.
-        let latest_coinbase_threshold = latest_coinbase_target.saturating_div(2) as u128;
-        // Determine if the coinbase target threshold is reached.
-        let is_coinbase_threshold_reached = next_cumulative_proof_target >= latest_coinbase_threshold;
-        // Update the next cumulative proof target, if necessary.
-        let next_cumulative_proof_target = match is_coinbase_threshold_reached {
-            true => 0,
-            false => next_cumulative_proof_target,
-        };
-        // Construct the next coinbase target.
-        let next_coinbase_target = coinbase_target(
-            previous_block.last_coinbase_target(),
-            previous_block.last_coinbase_timestamp(),
-            next_timestamp,
-            N::ANCHOR_TIME,
-            N::NUM_BLOCKS_PER_EPOCH,
-            N::GENESIS_COINBASE_TARGET,
-        )?;
-        // Construct the next proof target.
-        let next_proof_target =
-            proof_target(next_coinbase_target, N::GENESIS_PROOF_TARGET, N::MAX_SOLUTIONS_AS_POWER_OF_TWO);
 
-        // Construct the next last coinbase target and next last coinbase timestamp.
-        let (next_last_coinbase_target, next_last_coinbase_timestamp) = match is_coinbase_threshold_reached {
-            true => (next_coinbase_target, next_timestamp),
-            false => (previous_block.last_coinbase_target(), previous_block.last_coinbase_timestamp()),
-        };
+        // Calculate the next coinbase targets and timestamps.
+        let (
+            next_coinbase_target,
+            next_proof_target,
+            next_cumulative_proof_target,
+            next_last_coinbase_target,
+            next_last_coinbase_timestamp,
+        ) = to_next_targets::<N>(
+            latest_cumulative_proof_target,
+            combined_proof_target,
+            latest_coinbase_target,
+            last_coinbase_target,
+            last_coinbase_timestamp,
+            next_timestamp,
+        )?;
 
         // Calculate the coinbase reward.
         let coinbase_reward = coinbase_reward(


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR unifies the target calculations in both `Ledger::construct_block_template` and `Block::verify_solutions` into a singular `to_next_targets` helper method. Previously the two implementations were disjoint and could lead to differences in expected value. The unified helper method reduces the possibility of error and makes it easier to update if there are changes in the future.

## Test Plan

The use of a helper method also allows us to test the expected behavior outside the monolith of block production. Tests have been added to check that the expected values based on hitting/missing the target threshold are correct.


This PR is based on and merges into https://github.com/AleoHQ/snarkVM/pull/2410.
