### PR TITLE
Reduce zero-padding and cache zero-hashes in MerkleTree

### DIFF
--- a/console/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/path_hash.rs
@@ -31,20 +31,11 @@ pub trait PathHash: Clone + Send + Sync {
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Result<Self::Hash>;
 
     /// Returns the hash for each tuple of child nodes.
-    /// If there are no children, the supplied empty hash is used.
-    fn hash_all_children(
-        &self,
-        child_nodes: &[Option<(Self::Hash, Self::Hash)>],
-        empty_node_hash: Self::Hash,
-    ) -> Result<Vec<Self::Hash>> {
-        let hash_children = |children: &Option<(Self::Hash, Self::Hash)>| {
-            if let Some((left, right)) = children { self.hash_children(left, right) } else { Ok(empty_node_hash) }
-        };
-
+    fn hash_all_children(&self, child_nodes: &[(Self::Hash, Self::Hash)]) -> Result<Vec<Self::Hash>> {
         match child_nodes.len() {
             0 => Ok(vec![]),
-            1..=100 => child_nodes.iter().map(hash_children).collect(),
-            _ => cfg_iter!(child_nodes).map(hash_children).collect(),
+            1..=100 => child_nodes.iter().map(|(left, right)| self.hash_children(left, right)).collect(),
+            _ => cfg_iter!(child_nodes).map(|(left, right)| self.hash_children(left, right)).collect(),
         }
     }
 }

--- a/console/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/path_hash.rs
@@ -31,11 +31,20 @@ pub trait PathHash: Clone + Send + Sync {
     fn hash_children(&self, left: &Self::Hash, right: &Self::Hash) -> Result<Self::Hash>;
 
     /// Returns the hash for each tuple of child nodes.
-    fn hash_all_children(&self, child_nodes: &[(Self::Hash, Self::Hash)]) -> Result<Vec<Self::Hash>> {
+    /// If there are no children, the supplied empty hash is used.
+    fn hash_all_children(
+        &self,
+        child_nodes: &[Option<(Self::Hash, Self::Hash)>],
+        empty_node_hash: Self::Hash,
+    ) -> Result<Vec<Self::Hash>> {
+        let hash_children = |children: &Option<(Self::Hash, Self::Hash)>| {
+            if let Some((left, right)) = children { self.hash_children(left, right) } else { Ok(empty_node_hash) }
+        };
+
         match child_nodes.len() {
             0 => Ok(vec![]),
-            1..=100 => child_nodes.iter().map(|(left, right)| self.hash_children(left, right)).collect(),
-            _ => cfg_iter!(child_nodes).map(|(left, right)| self.hash_children(left, right)).collect(),
+            1..=100 => child_nodes.iter().map(hash_children).collect(),
+            _ => cfg_iter!(child_nodes).map(hash_children).collect(),
         }
     }
 }

--- a/console/collections/src/merkle_tree/mod.rs
+++ b/console/collections/src/merkle_tree/mod.rs
@@ -101,12 +101,8 @@ impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>
                 .filter_map(|i| {
                     // Procure the children of the node.
                     let tuple = (tree.get(left_child(i)).copied(), tree.get(right_child(i)).copied());
-                    // If both children are missing, return `None`.
-                    if tuple.0.is_none() && tuple.1.is_none() {
-                        None
-                    } else {
-                        Some((tuple.0.unwrap(), tuple.1.unwrap()))
-                    }
+                    // If the left child is missing (in which case the right one also is), return `None`.
+                    if tuple.0.is_none() { None } else { Some((tuple.0.unwrap(), tuple.1.unwrap())) }
                 })
                 .collect::<Vec<_>>();
             // Compute and store the hashes for each node in the current level.

--- a/console/collections/src/merkle_tree/tests/append.rs
+++ b/console/collections/src/merkle_tree/tests/append.rs
@@ -157,7 +157,7 @@ fn check_merkle_tree_depth_3_padded<E: Environment, LH: LeafHash<Hash = PH::Hash
 
     // Rebuild the Merkle tree with the additional leaf.
     merkle_tree.append(additional_leaves)?;
-    assert_eq!(15, merkle_tree.tree.len());
+    assert_eq!(13, merkle_tree.tree.len());
     // assert_eq!(0, merkle_tree.padding_tree.len());
     assert_eq!(5, merkle_tree.number_of_leaves);
 
@@ -173,8 +173,6 @@ fn check_merkle_tree_depth_3_padded<E: Environment, LH: LeafHash<Hash = PH::Hash
     assert_eq!(expected_leaf3, merkle_tree.tree[10]);
     assert_eq!(expected_leaf4, merkle_tree.tree[11]);
     assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[12]);
-    assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[13]);
-    assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[14]);
 
     // Depth 2.
     let expected_left0 = PathHash::hash_children(path_hasher, &expected_leaf0, &expected_leaf1)?;
@@ -258,7 +256,7 @@ fn check_merkle_tree_depth_4_padded<E: Environment, LH: LeafHash<Hash = PH::Hash
 
     // Rebuild the Merkle tree with the additional leaf.
     merkle_tree.append(&[additional_leaves[0].clone()])?;
-    assert_eq!(15, merkle_tree.tree.len());
+    assert_eq!(13, merkle_tree.tree.len());
     // assert_eq!(0, merkle_tree.padding_tree.len());
     assert_eq!(5, merkle_tree.number_of_leaves);
 
@@ -274,8 +272,6 @@ fn check_merkle_tree_depth_4_padded<E: Environment, LH: LeafHash<Hash = PH::Hash
     assert_eq!(expected_leaf3, merkle_tree.tree[10]);
     assert_eq!(expected_leaf4, merkle_tree.tree[11]);
     assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[12]);
-    assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[13]);
-    assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[14]);
 
     // Depth 3.
     let expected_left0 = PathHash::hash_children(path_hasher, &expected_leaf0, &expected_leaf1)?;
@@ -308,13 +304,13 @@ fn check_merkle_tree_depth_4_padded<E: Environment, LH: LeafHash<Hash = PH::Hash
     // ------------------------------------------------------------------------------------------ //
 
     // Ensure we're starting where we left off from the previous rebuild.
-    assert_eq!(15, merkle_tree.tree.len());
+    assert_eq!(13, merkle_tree.tree.len());
     // assert_eq!(0, merkle_tree.padding_tree.len());
     assert_eq!(5, merkle_tree.number_of_leaves);
 
     // Rebuild the Merkle tree with the additional leaf.
     merkle_tree.append(&[additional_leaves[1].clone()])?;
-    assert_eq!(15, merkle_tree.tree.len());
+    assert_eq!(13, merkle_tree.tree.len());
     // assert_eq!(0, merkle_tree.padding_tree.len());
     assert_eq!(6, merkle_tree.number_of_leaves);
 
@@ -331,8 +327,6 @@ fn check_merkle_tree_depth_4_padded<E: Environment, LH: LeafHash<Hash = PH::Hash
     assert_eq!(expected_leaf3, merkle_tree.tree[10]);
     assert_eq!(expected_leaf4, merkle_tree.tree[11]);
     assert_eq!(expected_leaf5, merkle_tree.tree[12]);
-    assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[13]);
-    assert_eq!(path_hasher.hash_empty()?, merkle_tree.tree[14]);
 
     // Depth 3.
     let expected_left0 = PathHash::hash_children(path_hasher, &expected_leaf0, &expected_leaf1)?;


### PR DESCRIPTION
This PR is the "plain" Merkle tree counterpart to https://github.com/AleoHQ/snarkVM/pull/2407.

While some of the `console/collections/merkle_tree` benchmark results are mixed, any regressions are small; however, I also ran a custom benchmark locally, and that one shows a clear improvement in extreme scenarios:
```
creation of a BHP MerkleTree with DEPTH = 23 and 2^22 + 1 random leaves

before:

alloc count: 38,230,906
heap use:    1.59 GiB
max heap:    2.10 GiB
time:        51.88s

after:

alloc count: 31,932,664 (-16.5%)
heap use:    1.47 GiB (-7.5%)
max heap:    2.00 GiB (-4.8%)
time:        42.61s (-17.9%)
```