### PR TITLE
[Fix] Use original transaction ordering in speculation

### DIFF
--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -834,6 +834,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             aborted_transactions.extend(invalid);
         }
 
+        // Sort the valid and aborted transactions based on their position in the original list.
+        let position: IndexMap<_, _> = cfg_iter!(transactions).enumerate().map(|(i, &tx)| (tx.id(), i)).collect();
+        valid_transactions.sort_by(|a, b| position.get(&a.id()).cmp(&position.get(&b.id())));
+        aborted_transactions.sort_by(|a, b| position.get(&a.0.id()).cmp(&position.get(&b.0.id())));
+
         // Return the valid and invalid transactions.
         Ok((valid_transactions, aborted_transactions))
     }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates `prepare_for_speculate` to output a sorted version of the valid and aborted transactions based on the order of the original transaction list. Previously, we were outputting the transactions based on our verification ordering.

## Test Plan

A test was added to ensure that the order of transactions is preserved correctly.