### PR TITLE
Use a parallel sort to order txs while speculating

### DIFF
--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -268,3 +268,15 @@ macro_rules! cfg_zip_fold {
         result
     }};
 }
+
+/// Performs an unstable sort
+#[macro_export]
+macro_rules! cfg_sort_unstable_by {
+    ($self: expr, $closure: expr) => {{
+        #[cfg(feature = "serial")]
+        $self.sort_unstable_by($closure);
+
+        #[cfg(not(feature = "serial"))]
+        $self.par_sort_unstable_by($closure);
+    }};
+}


### PR DESCRIPTION
A small follow-up to https://github.com/AleoHQ/snarkVM/pull/2421. The changes are:
- a `cfg_sort_unstable_by` macro for parallel sorting using a closure is introduced (note: the `unstable` part only means that **equal** elements may be reordered, and transaction IDs are never equal)
- the aforementioned macro is used to sort transactions when speculating
- the parallel iteration for the collection is removed, as it is slower than single-threaded iteration (since `Transaction::id` is basically free)
- instead of enumerating and collecting indices, [IndexSet::get_index_of](https://docs.rs/indexmap/latest/indexmap/set/struct.IndexSet.html#method.get_index_of) is used