### PR TITLE
Use a parallel sort to order txs while speculating

### DIFF
--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -15,7 +15,7 @@
 use super::*;
 
 use ledger_committee::{MAX_DELEGATORS, MIN_DELEGATOR_STAKE, MIN_VALIDATOR_STAKE};
-use utilities::cfg_sort_unstable_by;
+use utilities::cfg_sort_by_cached_key;
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Speculates on the given list of transactions in the VM.
@@ -837,12 +837,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // Sort the valid and aborted transactions based on their position in the original list.
         let position: IndexSet<_> = transactions.iter().map(|tx| tx.id()).collect();
-        cfg_sort_unstable_by!(valid_transactions, |a, b| position
-            .get_index_of(&a.id())
-            .cmp(&position.get_index_of(&b.id())));
-        cfg_sort_unstable_by!(aborted_transactions, |a, b| position
-            .get_index_of(&a.0.id())
-            .cmp(&position.get_index_of(&b.0.id())));
+        cfg_sort_by_cached_key!(valid_transactions, |tx| position.get_index_of(&tx.id()));
+        cfg_sort_by_cached_key!(aborted_transactions, |tx| position.get_index_of(&tx.0.id()));
 
         // Return the valid and invalid transactions.
         Ok((valid_transactions, aborted_transactions))

--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -268,3 +268,15 @@ macro_rules! cfg_zip_fold {
         result
     }};
 }
+
+/// Performs an unstable sort
+#[macro_export]
+macro_rules! cfg_sort_unstable_by {
+    ($self: expr, $closure: expr) => {{
+        #[cfg(feature = "serial")]
+        $self.sort_unstable_by($closure);
+
+        #[cfg(not(feature = "serial"))]
+        $self.par_sort_unstable_by($closure);
+    }};
+}

--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -280,3 +280,15 @@ macro_rules! cfg_sort_unstable_by {
         $self.par_sort_unstable_by($closure);
     }};
 }
+
+/// Performs a sort that caches the extracted keys
+#[macro_export]
+macro_rules! cfg_sort_by_cached_key {
+    ($self: expr, $closure: expr) => {{
+        #[cfg(feature = "serial")]
+        $self.sort_by_cached_key($closure);
+
+        #[cfg(not(feature = "serial"))]
+        $self.par_sort_by_cached_key($closure);
+    }};
+}


### PR DESCRIPTION
A small follow-up to https://github.com/AleoHQ/snarkVM/pull/2421 and the replacement of https://github.com/AleoHQ/snarkVM/pull/2424. The changes are:
- a `cfg_sort_unstable_by` macro for parallel sorting using a closure is introduced (note: the `unstable` part only means that **equal** elements may be reordered, and transaction IDs are never equal)
- the aforementioned macro is used to sort transactions when speculating
- the parallel iteration for the collection is removed, as it is slower than single-threaded iteration (since `Transaction::id` is basically free)
- instead of enumerating and collecting indices, [IndexSet::get_index_of](https://docs.rs/indexmap/latest/indexmap/set/struct.IndexSet.html#method.get_index_of) is used