### PR TITLE
Introduce deployment variable limit and cost

### DIFF
--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -58,9 +58,7 @@ impl Environment for Circuit {
                     // Ensure that we do not surpass the variable limit for the circuit.
                     VARIABLE_LIMIT.with(|variable_limit| {
                         if let Some(limit) = variable_limit.get() {
-                            // NOTE: we can use this function because circuits only have a single scope.
-                            // Once we have nested scopes, we will need to track the number of variables in each scope.
-                            if Self::num_variables_in_scope() > limit {
+                            if Self::num_variables() > limit {
                                 Self::halt(format!("Surpassed the variable limit ({limit})"))
                             }
                         }
@@ -214,6 +212,11 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| circuit.borrow().is_satisfied_in_scope())
     }
 
+    /// Returns the total number of variables in the entire circuit.
+    fn num_variables() -> u64 {
+        CIRCUIT.with(|circuit| circuit.borrow().num_variables())
+    }
+
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
         CIRCUIT.with(|circuit| circuit.borrow().num_constants())
@@ -237,11 +240,6 @@ impl Environment for Circuit {
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
         CIRCUIT.with(|circuit| circuit.borrow().num_nonzeros())
-    }
-
-    /// Returns the number of variables in the entire circuit.
-    fn num_variables_in_scope() -> u64 {
-        CIRCUIT.with(|circuit| circuit.borrow().num_variables_in_scope())
     }
 
     /// Returns the number of constants for the current scope.
@@ -303,7 +301,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
@@ -311,7 +309,7 @@ impl Environment for Circuit {
             assert_eq!(0, r1cs.num_constants());
             assert_eq!(1, r1cs.num_public());
             assert_eq!(0, r1cs.num_private());
-            assert_eq!(0, r1cs.num_variables_in_scope());
+            assert_eq!(0, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
         })
     }
@@ -331,7 +329,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
@@ -352,7 +350,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
@@ -373,7 +371,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
         });
     }

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -301,7 +301,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
@@ -309,7 +309,7 @@ impl Environment for Circuit {
             assert_eq!(0, r1cs.num_constants());
             assert_eq!(1, r1cs.num_public());
             assert_eq!(0, r1cs.num_private());
-            assert_eq!(0, r1cs.num_variables());
+            assert_eq!(1, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
         })
     }
@@ -329,7 +329,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
@@ -350,7 +350,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
@@ -371,7 +371,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
         });
     }

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -58,7 +58,9 @@ impl Environment for Circuit {
                     // Ensure that we do not surpass the variable limit for the circuit.
                     VARIABLE_LIMIT.with(|variable_limit| {
                         if let Some(limit) = variable_limit.get() {
-                            if Self::num_variables() > limit {
+                            // NOTE: we can use this function because circuits only have a single scope.
+                            // Once we have nested scopes, we will need to track the number of variables in each scope.
+                            if Self::num_variables_in_scope() > limit {
                                 Self::halt(format!("Surpassed the variable limit ({limit})"))
                             }
                         }
@@ -212,14 +214,6 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| circuit.borrow().is_satisfied_in_scope())
     }
 
-    /// Returns the number of variables in the entire circuit.
-    fn num_variables() -> u64 {
-        CIRCUIT.with(|circuit| {
-            let circuit = circuit.borrow();
-            circuit.num_constants().saturating_add(circuit.num_public()).saturating_add(circuit.num_private())
-        })
-    }
-
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
         CIRCUIT.with(|circuit| circuit.borrow().num_constants())
@@ -243,6 +237,11 @@ impl Environment for Circuit {
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
         CIRCUIT.with(|circuit| circuit.borrow().num_nonzeros())
+    }
+
+    /// Returns the number of variables in the entire circuit.
+    fn num_variables_in_scope() -> u64 {
+        CIRCUIT.with(|circuit| circuit.borrow().num_variables_in_scope())
     }
 
     /// Returns the number of constants for the current scope.
@@ -304,6 +303,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
@@ -311,6 +311,7 @@ impl Environment for Circuit {
             assert_eq!(0, r1cs.num_constants());
             assert_eq!(1, r1cs.num_public());
             assert_eq!(0, r1cs.num_private());
+            assert_eq!(0, r1cs.num_variables_in_scope());
             assert_eq!(0, r1cs.num_constraints());
         })
     }
@@ -330,6 +331,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
@@ -350,6 +352,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
@@ -370,6 +373,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
         });
     }

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -110,6 +110,9 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     /// Returns `true` if all constraints in the current scope are satisfied.
     fn is_satisfied_in_scope() -> bool;
 
+    /// Returns the number of variables in the entire environment.
+    fn num_variables() -> u64;
+
     /// Returns the number of constants in the entire environment.
     fn num_constants() -> u64;
 
@@ -166,6 +169,12 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
 
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>);
+
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64>;
+
+    /// Sets the variable limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>);
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn inject_r1cs(r1cs: R1CS<Self::BaseField>);

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -110,9 +110,6 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     /// Returns `true` if all constraints in the current scope are satisfied.
     fn is_satisfied_in_scope() -> bool;
 
-    /// Returns the number of variables in the entire environment.
-    fn num_variables() -> u64;
-
     /// Returns the number of constants in the entire environment.
     fn num_constants() -> u64;
 
@@ -132,6 +129,9 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     fn count() -> (u64, u64, u64, u64, (u64, u64, u64)) {
         (Self::num_constants(), Self::num_public(), Self::num_private(), Self::num_constraints(), Self::num_nonzeros())
     }
+
+    /// Returns the number of variables for the current scope.
+    fn num_variables_in_scope() -> u64;
 
     /// Returns the number of constants for the current scope.
     fn num_constants_in_scope() -> u64;

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -110,6 +110,9 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     /// Returns `true` if all constraints in the current scope are satisfied.
     fn is_satisfied_in_scope() -> bool;
 
+    /// Returns the total number of variables in the entire environment.
+    fn num_variables() -> u64;
+
     /// Returns the number of constants in the entire environment.
     fn num_constants() -> u64;
 
@@ -129,9 +132,6 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     fn count() -> (u64, u64, u64, u64, (u64, u64, u64)) {
         (Self::num_constants(), Self::num_public(), Self::num_private(), Self::num_constraints(), Self::num_nonzeros())
     }
-
-    /// Returns the number of variables for the current scope.
-    fn num_variables_in_scope() -> u64;
 
     /// Returns the number of constants for the current scope.
     fn num_constants_in_scope() -> u64;

--- a/circuit/environment/src/helpers/counter.rs
+++ b/circuit/environment/src/helpers/counter.rs
@@ -24,7 +24,6 @@ pub(crate) struct Counter<F: PrimeField> {
     constants: u64,
     public: u64,
     private: u64,
-    total_variables: u64,
     nonzeros: (u64, u64, u64),
     parents: Vec<(Scope, Vec<Rc<Constraint<F>>>, u64, u64, u64, (u64, u64, u64))>,
 }
@@ -115,24 +114,16 @@ impl<F: PrimeField> Counter<F> {
     /// Increments the number of constants by 1.
     pub(crate) fn increment_constant(&mut self) {
         self.constants += 1;
-        self.total_variables += 1;
     }
 
     /// Increments the number of public variables by 1.
     pub(crate) fn increment_public(&mut self) {
         self.public += 1;
-        self.total_variables += 1;
     }
 
     /// Increments the number of private variables by 1.
     pub(crate) fn increment_private(&mut self) {
         self.private += 1;
-        self.total_variables += 1;
-    }
-
-    /// Returns the number of variables in scope.
-    pub(crate) fn num_variables_in_scope(&self) -> u64 {
-        self.total_variables
     }
 
     /// Returns the number of constants in scope in scope.

--- a/circuit/environment/src/helpers/counter.rs
+++ b/circuit/environment/src/helpers/counter.rs
@@ -24,6 +24,7 @@ pub(crate) struct Counter<F: PrimeField> {
     constants: u64,
     public: u64,
     private: u64,
+    total_variables: u64,
     nonzeros: (u64, u64, u64),
     parents: Vec<(Scope, Vec<Rc<Constraint<F>>>, u64, u64, u64, (u64, u64, u64))>,
 }
@@ -114,16 +115,24 @@ impl<F: PrimeField> Counter<F> {
     /// Increments the number of constants by 1.
     pub(crate) fn increment_constant(&mut self) {
         self.constants += 1;
+        self.total_variables += 1;
     }
 
     /// Increments the number of public variables by 1.
     pub(crate) fn increment_public(&mut self) {
         self.public += 1;
+        self.total_variables += 1;
     }
 
     /// Increments the number of private variables by 1.
     pub(crate) fn increment_private(&mut self) {
         self.private += 1;
+        self.total_variables += 1;
+    }
+
+    /// Returns the number of variables in scope.
+    pub(crate) fn num_variables_in_scope(&self) -> u64 {
+        self.total_variables
     }
 
     /// Returns the number of constants in scope in scope.

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -159,6 +159,11 @@ impl<F: PrimeField> R1CS<F> {
         self.nonzeros
     }
 
+    /// Returns the total number of variables for the current scope.
+    pub fn num_variables_in_scope(&self) -> u64 {
+        self.counter.num_variables_in_scope()
+    }
+
     /// Returns the number of constants for the current scope.
     pub(crate) fn num_constants_in_scope(&self) -> u64 {
         self.counter.num_constants_in_scope()

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -29,6 +29,7 @@ pub struct R1CS<F: PrimeField> {
     private: Vec<Variable<F>>,
     constraints: Vec<Rc<Constraint<F>>>,
     counter: Counter<F>,
+    num_variables: u64,
     nonzeros: (u64, u64, u64),
 }
 
@@ -41,6 +42,7 @@ impl<F: PrimeField> R1CS<F> {
             private: Default::default(),
             constraints: Default::default(),
             counter: Default::default(),
+            num_variables: 1,
             nonzeros: (0, 0, 0),
         }
     }
@@ -60,6 +62,7 @@ impl<F: PrimeField> R1CS<F> {
         let variable = Variable::Constant(Rc::new(value));
         self.constants.push(variable.clone());
         self.counter.increment_constant();
+        self.num_variables += 1;
         variable
     }
 
@@ -68,6 +71,7 @@ impl<F: PrimeField> R1CS<F> {
         let variable = Variable::Public(Rc::new((self.public.len() as u64, value)));
         self.public.push(variable.clone());
         self.counter.increment_public();
+        self.num_variables += 1;
         variable
     }
 
@@ -76,6 +80,7 @@ impl<F: PrimeField> R1CS<F> {
         let variable = Variable::Private(Rc::new((self.private.len() as u64, value)));
         self.private.push(variable.clone());
         self.counter.increment_private();
+        self.num_variables += 1;
         variable
     }
 
@@ -134,6 +139,11 @@ impl<F: PrimeField> R1CS<F> {
         self.counter.scope()
     }
 
+    /// Returns the total number of variables in the constraint system.
+    pub fn num_variables(&self) -> u64 {
+        self.num_variables
+    }
+
     /// Returns the number of constants in the constraint system.
     pub fn num_constants(&self) -> u64 {
         self.constants.len() as u64
@@ -157,11 +167,6 @@ impl<F: PrimeField> R1CS<F> {
     /// Returns the number of nonzeros in the constraint system.
     pub fn num_nonzeros(&self) -> (u64, u64, u64) {
         self.nonzeros
-    }
-
-    /// Returns the total number of variables for the current scope.
-    pub fn num_variables_in_scope(&self) -> u64 {
-        self.counter.num_variables_in_scope()
     }
 
     /// Returns the number of constants for the current scope.

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -23,6 +23,7 @@ type Field = <console::TestnetV0 as console::Environment>::Field;
 
 thread_local! {
     static CONSTRAINT_LIMIT: Cell<Option<u64>> = Cell::new(None);
+    static VARIABLE_LIMIT: Cell<Option<u64>> = Cell::new(None);
     pub(super) static TESTNET_CIRCUIT: RefCell<R1CS<Field>> = RefCell::new(R1CS::new());
     static IN_WITNESS: Cell<bool> = Cell::new(false);
     static ZERO: LinearCombination<Field> = LinearCombination::zero();
@@ -53,6 +54,16 @@ impl Environment for TestnetCircuit {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
             if !in_witness.get() {
+                // Ensure that we do not surpass the variable limit for the circuit.
+                VARIABLE_LIMIT.with(|variable_limit| {
+                    if let Some(limit) = variable_limit.get() {
+                        // NOTE: we can use this function because circuits only have a single scope.
+                        // Once we have nested scopes, we will need to track the number of variables in each scope.
+                        if Self::num_variables_in_scope() > limit {
+                            Self::halt(format!("Surpassed the variable limit ({limit})"))
+                        }
+                    }
+                });
                 TESTNET_CIRCUIT.with(|circuit| match mode {
                     Mode::Constant => circuit.borrow_mut().new_constant(value),
                     Mode::Public => circuit.borrow_mut().new_public(value),
@@ -202,6 +213,11 @@ impl Environment for TestnetCircuit {
         TESTNET_CIRCUIT.with(|circuit| circuit.borrow().num_nonzeros())
     }
 
+    /// Returns the number of variables for the current scope.
+    fn num_variables_in_scope() -> u64 {
+        TESTNET_CIRCUIT.with(|circuit| circuit.borrow().num_variables_in_scope())
+    }
+
     /// Returns the number of constants for the current scope.
     fn num_constants_in_scope() -> u64 {
         TESTNET_CIRCUIT.with(|circuit| circuit.borrow().num_constants_in_scope())
@@ -244,6 +260,16 @@ impl Environment for TestnetCircuit {
         CONSTRAINT_LIMIT.with(|current_limit| current_limit.replace(limit));
     }
 
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64> {
+        VARIABLE_LIMIT.with(|current_limit| current_limit.get())
+    }
+
+    /// Sets the variable limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>) {
+        VARIABLE_LIMIT.with(|current_limit| current_limit.replace(limit));
+    }
+
     /// Returns the R1CS circuit, resetting the circuit.
     fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
         TESTNET_CIRCUIT.with(|circuit| {
@@ -251,6 +277,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
@@ -258,6 +285,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, r1cs.num_constants());
             assert_eq!(1, r1cs.num_public());
             assert_eq!(0, r1cs.num_private());
+            assert_eq!(0, r1cs.num_variables_in_scope());
             assert_eq!(0, r1cs.num_constraints());
         })
     }
@@ -269,12 +297,15 @@ impl Environment for TestnetCircuit {
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
             // Ensure the circuit is now empty.
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
@@ -288,11 +319,14 @@ impl Environment for TestnetCircuit {
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
@@ -306,11 +340,14 @@ impl Environment for TestnetCircuit {
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Reset the circuit.
             *circuit.borrow_mut() = R1CS::<<Self as Environment>::BaseField>::new();
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(0, circuit.borrow().num_variables_in_scope());
             assert_eq!(0, circuit.borrow().num_constraints());
         });
     }

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -57,9 +57,7 @@ impl Environment for TestnetCircuit {
                 // Ensure that we do not surpass the variable limit for the circuit.
                 VARIABLE_LIMIT.with(|variable_limit| {
                     if let Some(limit) = variable_limit.get() {
-                        // NOTE: we can use this function because circuits only have a single scope.
-                        // Once we have nested scopes, we will need to track the number of variables in each scope.
-                        if Self::num_variables_in_scope() > limit {
+                        if Self::num_variables() > limit {
                             Self::halt(format!("Surpassed the variable limit ({limit})"))
                         }
                     }
@@ -188,6 +186,11 @@ impl Environment for TestnetCircuit {
         TESTNET_CIRCUIT.with(|circuit| circuit.borrow().is_satisfied_in_scope())
     }
 
+    /// Returns the total number of variables in the entire circuit.
+    fn num_variables() -> u64 {
+        TESTNET_CIRCUIT.with(|circuit| circuit.borrow().num_variables())
+    }
+
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
         TESTNET_CIRCUIT.with(|circuit| circuit.borrow().num_constants())
@@ -211,11 +214,6 @@ impl Environment for TestnetCircuit {
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
         TESTNET_CIRCUIT.with(|circuit| circuit.borrow().num_nonzeros())
-    }
-
-    /// Returns the number of variables for the current scope.
-    fn num_variables_in_scope() -> u64 {
-        TESTNET_CIRCUIT.with(|circuit| circuit.borrow().num_variables_in_scope())
     }
 
     /// Returns the number of constants for the current scope.
@@ -277,7 +275,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
@@ -285,7 +283,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, r1cs.num_constants());
             assert_eq!(1, r1cs.num_public());
             assert_eq!(0, r1cs.num_private());
-            assert_eq!(0, r1cs.num_variables_in_scope());
+            assert_eq!(0, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
         })
     }
@@ -305,7 +303,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
@@ -326,7 +324,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
@@ -347,7 +345,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables_in_scope());
+            assert_eq!(0, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
         });
     }

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -275,7 +275,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
@@ -283,7 +283,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, r1cs.num_constants());
             assert_eq!(1, r1cs.num_public());
             assert_eq!(0, r1cs.num_private());
-            assert_eq!(0, r1cs.num_variables());
+            assert_eq!(1, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
         })
     }
@@ -303,7 +303,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
@@ -324,7 +324,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
@@ -345,7 +345,7 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
-            assert_eq!(0, circuit.borrow().num_variables());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
         });
     }

--- a/circuit/network/src/lib.rs
+++ b/circuit/network/src/lib.rs
@@ -29,6 +29,9 @@ pub trait Aleo: Environment {
     /// The maximum number of field elements in data (must not exceed u16::MAX).
     const MAX_DATA_SIZE_IN_FIELDS: u32 = <Self::Network as console::Network>::MAX_DATA_SIZE_IN_FIELDS;
 
+    /// Initializes all of the constants for the Aleo environment.
+    fn init_constants();
+
     /// Returns the encryption domain as a constant field element.
     fn encryption_domain() -> Field<Self>;
 

--- a/circuit/network/src/testnet_v0.rs
+++ b/circuit/network/src/testnet_v0.rs
@@ -434,6 +434,11 @@ impl Environment for AleoTestnetV0 {
         E::is_satisfied_in_scope()
     }
 
+    /// Returns the total number of variables in the entire circuit.
+    fn num_variables() -> u64 {
+        E::num_variables()
+    }
+
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
         E::num_constants()
@@ -457,11 +462,6 @@ impl Environment for AleoTestnetV0 {
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
         E::num_nonzeros()
-    }
-
-    /// Returns the number of variables for the current scope.
-    fn num_variables_in_scope() -> u64 {
-        E::num_variables_in_scope()
     }
 
     /// Returns the number of constants for the current scope.

--- a/circuit/network/src/testnet_v0.rs
+++ b/circuit/network/src/testnet_v0.rs
@@ -101,6 +101,29 @@ thread_local! {
 pub struct AleoTestnetV0;
 
 impl Aleo for AleoTestnetV0 {
+    /// Initializes all of the constants for the Aleo environment.
+    fn init_constants() {
+        GENERATOR_G.with(|_| ());
+        ENCRYPTION_DOMAIN.with(|_| ());
+        GRAPH_KEY_DOMAIN.with(|_| ());
+        SERIAL_NUMBER_DOMAIN.with(|_| ());
+        BHP_256.with(|_| ());
+        BHP_512.with(|_| ());
+        BHP_768.with(|_| ());
+        BHP_1024.with(|_| ());
+        KECCAK_256.with(|_| ());
+        KECCAK_384.with(|_| ());
+        KECCAK_512.with(|_| ());
+        PEDERSEN_64.with(|_| ());
+        PEDERSEN_128.with(|_| ());
+        POSEIDON_2.with(|_| ());
+        POSEIDON_4.with(|_| ());
+        POSEIDON_8.with(|_| ());
+        SHA3_256.with(|_| ());
+        SHA3_384.with(|_| ());
+        SHA3_512.with(|_| ());
+    }
+
     /// Returns the encryption domain as a constant field element.
     fn encryption_domain() -> Field<Self> {
         ENCRYPTION_DOMAIN.with(|domain| domain.clone())
@@ -436,6 +459,11 @@ impl Environment for AleoTestnetV0 {
         E::num_nonzeros()
     }
 
+    /// Returns the number of variables for the current scope.
+    fn num_variables_in_scope() -> u64 {
+        E::num_variables_in_scope()
+    }
+
     /// Returns the number of constants for the current scope.
     fn num_constants_in_scope() -> u64 {
         E::num_constants_in_scope()
@@ -474,6 +502,16 @@ impl Environment for AleoTestnetV0 {
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>) {
         E::set_constraint_limit(limit)
+    }
+
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64> {
+        E::get_variable_limit()
+    }
+
+    /// Sets the constraint limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>) {
+        E::set_variable_limit(limit)
     }
 
     /// Returns the R1CS circuit, resetting the circuit.

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -101,6 +101,29 @@ thread_local! {
 pub struct AleoV0;
 
 impl Aleo for AleoV0 {
+    /// Initializes all of the constants for the Aleo environment.
+    fn init_constants() {
+        GENERATOR_G.with(|_| ());
+        ENCRYPTION_DOMAIN.with(|_| ());
+        GRAPH_KEY_DOMAIN.with(|_| ());
+        SERIAL_NUMBER_DOMAIN.with(|_| ());
+        BHP_256.with(|_| ());
+        BHP_512.with(|_| ());
+        BHP_768.with(|_| ());
+        BHP_1024.with(|_| ());
+        KECCAK_256.with(|_| ());
+        KECCAK_384.with(|_| ());
+        KECCAK_512.with(|_| ());
+        PEDERSEN_64.with(|_| ());
+        PEDERSEN_128.with(|_| ());
+        POSEIDON_2.with(|_| ());
+        POSEIDON_4.with(|_| ());
+        POSEIDON_8.with(|_| ());
+        SHA3_256.with(|_| ());
+        SHA3_384.with(|_| ());
+        SHA3_512.with(|_| ());
+    }
+
     /// Returns the encryption domain as a constant field element.
     fn encryption_domain() -> Field<Self> {
         ENCRYPTION_DOMAIN.with(|domain| domain.clone())
@@ -411,11 +434,6 @@ impl Environment for AleoV0 {
         E::is_satisfied_in_scope()
     }
 
-    /// Returns the number of variables in the entire circuit.
-    fn num_variables() -> u64 {
-        E::num_variables()
-    }
-
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
         E::num_constants()
@@ -439,6 +457,11 @@ impl Environment for AleoV0 {
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
         E::num_nonzeros()
+    }
+
+    /// Returns the number of variables for the current scope.
+    fn num_variables_in_scope() -> u64 {
+        E::num_variables_in_scope()
     }
 
     /// Returns the number of constants for the current scope.

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -411,6 +411,11 @@ impl Environment for AleoV0 {
         E::is_satisfied_in_scope()
     }
 
+    /// Returns the number of variables in the entire circuit.
+    fn num_variables() -> u64 {
+        E::num_variables()
+    }
+
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
         E::num_constants()
@@ -474,6 +479,16 @@ impl Environment for AleoV0 {
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>) {
         E::set_constraint_limit(limit)
+    }
+
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64> {
+        E::get_variable_limit()
+    }
+
+    /// Sets the constraint limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>) {
+        E::set_variable_limit(limit)
     }
 
     /// Returns the R1CS circuit, resetting the circuit.

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -434,6 +434,11 @@ impl Environment for AleoV0 {
         E::is_satisfied_in_scope()
     }
 
+    /// Returns the total number of variables in the entire circuit.
+    fn num_variables() -> u64 {
+        E::num_variables()
+    }
+
     /// Returns the number of constants in the entire circuit.
     fn num_constants() -> u64 {
         E::num_constants()
@@ -457,11 +462,6 @@ impl Environment for AleoV0 {
     /// Returns the number of nonzeros in the entire circuit.
     fn num_nonzeros() -> (u64, u64, u64) {
         E::num_nonzeros()
-    }
-
-    /// Returns the number of variables for the current scope.
-    fn num_variables_in_scope() -> u64 {
-        E::num_variables_in_scope()
     }
 
     /// Returns the number of constants for the current scope.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -116,7 +116,7 @@ pub trait Network:
     /// The cost in microcredits per byte for the deployment transaction.
     const DEPLOYMENT_FEE_MULTIPLIER: u64 = 1_000; // 1 millicredit per byte
     /// The cost in microcredits per constraint for the deployment transaction.
-    const SYNTHESIS_FEE_MULTIPLIER: u64 = 25; // 25 microcredits per constraint
+    const SYNTHESIS_FEE_MULTIPLIER: u64 = 12; // 12 microcredits per constraint
     /// The maximum number of constraints in a deployment.
     const MAX_DEPLOYMENT_CONSTRAINTS: u64 = 1 << 20; // 1,048,576 constraints
     /// The maximum number of variables in a deployment.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -120,7 +120,7 @@ pub trait Network:
     /// The maximum number of constraints in a deployment.
     const MAX_DEPLOYMENT_CONSTRAINTS: u64 = 1 << 20; // 1,048,576 constraints
     /// The maximum number of variables in a deployment.
-    const MAX_DEPLOYMENT_VARIABLES: u64 = 1 << 20; // 1,048,576 variables
+    const MAX_DEPLOYMENT_VARIABLES: u64 = 1 << 22; // 4,194,304 variables
     /// The maximum number of microcredits that can be spent as a fee.
     const MAX_FEE: u64 = 1_000_000_000_000_000;
     /// The maximum number of microcredits that can be spent on a finalize block.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -118,7 +118,9 @@ pub trait Network:
     /// The cost in microcredits per constraint for the deployment transaction.
     const SYNTHESIS_FEE_MULTIPLIER: u64 = 25; // 25 microcredits per constraint
     /// The maximum number of constraints in a deployment.
-    const MAX_DEPLOYMENT_LIMIT: u64 = 1 << 20; // 1,048,576 constraints
+    const MAX_DEPLOYMENT_CONSTRAINTS: u64 = 1 << 20; // 1,048,576 constraints
+    /// The maximum number of variables in a deployment.
+    const MAX_DEPLOYMENT_VARIABLES: u64 = 1 << 20; // 1,048,576 variables
     /// The maximum number of microcredits that can be spent as a fee.
     const MAX_FEE: u64 = 1_000_000_000_000_000;
     /// The maximum number of microcredits that can be spent on a finalize block.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -120,7 +120,7 @@ pub trait Network:
     /// The maximum number of constraints in a deployment.
     const MAX_DEPLOYMENT_CONSTRAINTS: u64 = 1 << 20; // 1,048,576 constraints
     /// The maximum number of variables in a deployment.
-    const MAX_DEPLOYMENT_VARIABLES: u64 = 1 << 22; // 4,194,304 variables
+    const MAX_DEPLOYMENT_VARIABLES: u64 = 1 << 20; // 1,048,576 variables
     /// The maximum number of microcredits that can be spent as a fee.
     const MAX_FEE: u64 = 1_000_000_000_000_000;
     /// The maximum number of microcredits that can be spent on a finalize block.

--- a/ledger/block/src/transaction/deployment/serialize.rs
+++ b/ledger/block/src/transaction/deployment/serialize.rs
@@ -22,7 +22,7 @@ impl<N: Network> Serialize for Deployment<N> {
                 let mut deployment = serializer.serialize_struct("Deployment", 3)?;
                 deployment.serialize_field("edition", &self.edition)?;
                 deployment.serialize_field("program", &self.program)?;
-                deployment.serialize_field("verifying_keys", &self.verifying_keys)?;
+                deployment.serialize_field("function_specs", &self.function_specs)?;
                 deployment.end()
             }
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
@@ -45,7 +45,7 @@ impl<'de, N: Network> Deserialize<'de> for Deployment<N> {
                     // Retrieve the program.
                     DeserializeExt::take_from_value::<D>(&mut deployment, "program")?,
                     // Retrieve the verifying keys.
-                    DeserializeExt::take_from_value::<D>(&mut deployment, "verifying_keys")?,
+                    DeserializeExt::take_from_value::<D>(&mut deployment, "function_specs")?,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/ledger/store/src/helpers/memory/transaction.rs
+++ b/ledger/store/src/helpers/memory/transaction.rs
@@ -103,6 +103,8 @@ pub struct DeploymentMemory<N: Network> {
     verifying_key_map: MemoryMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>,
     /// The certificate map.
     certificate_map: MemoryMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>,
+    /// The variable count map.
+    variable_count_map: MemoryMap<(ProgramID<N>, Identifier<N>, u16), u64>,
     /// The fee store.
     fee_store: FeeStore<N, FeeMemory<N>>,
 }
@@ -116,6 +118,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
     type ProgramMap = MemoryMap<(ProgramID<N>, u16), Program<N>>;
     type VerifyingKeyMap = MemoryMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>;
     type CertificateMap = MemoryMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>;
+    type VariableCountMap = MemoryMap<(ProgramID<N>, Identifier<N>, u16), u64>;
     type FeeStorage = FeeMemory<N>;
 
     /// Initializes the deployment storage.
@@ -128,6 +131,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
             program_map: MemoryMap::default(),
             verifying_key_map: MemoryMap::default(),
             certificate_map: MemoryMap::default(),
+            variable_count_map: MemoryMap::default(),
             fee_store,
         })
     }
@@ -165,6 +169,11 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
     /// Returns the certificate map.
     fn certificate_map(&self) -> &Self::CertificateMap {
         &self.certificate_map
+    }
+
+    /// Returns the variable count map.
+    fn variable_count_map(&self) -> &Self::VariableCountMap {
+        &self.variable_count_map
     }
 
     /// Returns the fee store.

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -110,6 +110,7 @@ pub enum DeploymentMap {
     Program = DataID::DeploymentProgramMap as u16,
     VerifyingKey = DataID::DeploymentVerifyingKeyMap as u16,
     Certificate = DataID::DeploymentCertificateMap as u16,
+    VariableCount = DataID::DeploymentVariableCountMap as u16,
 }
 
 /// The RocksDB map prefix for execution-related entries.
@@ -252,6 +253,7 @@ enum DataID {
     DeploymentProgramMap,
     DeploymentVerifyingKeyMap,
     DeploymentCertificateMap,
+    DeploymentVariableCountMap,
     // Execution
     ExecutionIDMap,
     ExecutionReverseIDMap,

--- a/ledger/store/src/helpers/rocksdb/transaction.rs
+++ b/ledger/store/src/helpers/rocksdb/transaction.rs
@@ -113,6 +113,8 @@ pub struct DeploymentDB<N: Network> {
     verifying_key_map: DataMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>,
     /// The certificate map.
     certificate_map: DataMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>,
+    /// The variable count map.
+    variable_count_map: DataMap<(ProgramID<N>, Identifier<N>, u16), u64>,
     /// The fee store.
     fee_store: FeeStore<N, FeeDB<N>>,
 }
@@ -126,6 +128,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
     type ProgramMap = DataMap<(ProgramID<N>, u16), Program<N>>;
     type VerifyingKeyMap = DataMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>;
     type CertificateMap = DataMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>;
+    type VariableCountMap = DataMap<(ProgramID<N>, Identifier<N>, u16), u64>;
     type FeeStorage = FeeDB<N>;
 
     /// Initializes the deployment storage.
@@ -140,6 +143,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
             program_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::Program))?,
             verifying_key_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::VerifyingKey))?,
             certificate_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::Certificate))?,
+            variable_count_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::VariableCount))?,
             fee_store,
         })
     }
@@ -177,6 +181,11 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
     /// Returns the certificate map.
     fn certificate_map(&self) -> &Self::CertificateMap {
         &self.certificate_map
+    }
+
+    /// Returns the variable count map.
+    fn variable_count_map(&self) -> &Self::VariableCountMap {
+        &self.variable_count_map
     }
 
     /// Returns the fee store.

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -31,6 +31,8 @@ pub fn deployment_cost<N: Network>(deployment: &Deployment<N>) -> Result<(u64, (
     let num_characters = u32::try_from(program_id.name().to_string().len())?;
     // Compute the number of combined constraints in the program.
     let num_combined_constraints = deployment.num_combined_constraints()?;
+    // Compute the number of combined variables in the program.
+    let num_combined_variables = deployment.num_combined_variables()?;
 
     // Compute the storage cost in microcredits.
     let storage_cost = size_in_bytes
@@ -38,7 +40,7 @@ pub fn deployment_cost<N: Network>(deployment: &Deployment<N>) -> Result<(u64, (
         .ok_or(anyhow!("The storage cost computation overflowed for a deployment"))?;
 
     // Compute the synthesis cost in microcredits.
-    let synthesis_cost = num_combined_constraints * N::SYNTHESIS_FEE_MULTIPLIER;
+    let synthesis_cost = (num_combined_variables + num_combined_constraints) * N::SYNTHESIS_FEE_MULTIPLIER;
 
     // Compute the namespace cost in credits: 10^(10 - num_characters).
     let namespace_cost = 10u64

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -48,7 +48,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Compute the stack");
 
         // Insert the verifying keys.
-        for (function_name, (verifying_key, _)) in deployment.verifying_keys() {
+        for (function_name, (verifying_key, _, _)) in deployment.verifying_keys() {
             stack.insert_verifying_key(function_name, verifying_key.clone())?;
         }
         lap!(timer, "Insert the verifying keys");

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -38,7 +38,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Compute the stack");
 
         // Insert the verifying keys.
-        for (function_name, (verifying_key, _)) in deployment.verifying_keys() {
+        for (function_name, (verifying_key, _, _)) in deployment.verifying_keys() {
             stack.insert_verifying_key(function_name, verifying_key.clone())?;
         }
         lap!(timer, "Insert the verifying keys");

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -74,7 +74,7 @@ impl<N: Network> Stack<N> {
         let program_id = self.program.id();
 
         // Check that the number of combined constraints does not exceed the deployment limit.
-        ensure!(deployment.num_combined_constraints()? <= N::MAX_DEPLOYMENT_LIMIT);
+        ensure!(deployment.num_combined_constraints()? <= N::MAX_DEPLOYMENT_CONSTRAINTS);
 
         // Construct the call stacks and assignments used to verify the certificates.
         let mut call_stacks = Vec::with_capacity(deployment.verifying_keys().len());
@@ -143,6 +143,7 @@ impl<N: Network> Stack<N> {
                 burner_private_key,
                 assignments.clone(),
                 Some(constraint_limit as u64),
+                Some(N::MAX_DEPLOYMENT_VARIABLES),
             );
             // Append the function name, callstack, and assignments.
             call_stacks.push((function.name(), call_stack, assignments));

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -132,6 +132,8 @@ impl<N: Network> Stack<N> {
             lap!(timer, "Compute the request for {}", function.name());
             // Initialize the assignments.
             let assignments = Assignments::<N>::default();
+            // Initialize the variable limit.
+            let variable_limit = N::MAX_DEPLOYMENT_VARIABLES / N::MAX_FUNCTIONS as u64;
             // Initialize the constraint limit. Account for the constraint added after synthesis that makes the Varuna zerocheck hiding.
             let Some(constraint_limit) = verifying_key.circuit_info.num_constraints.checked_sub(1) else {
                 // Since a deployment must always pay non-zero fee, it must always have at least one constraint.
@@ -143,7 +145,7 @@ impl<N: Network> Stack<N> {
                 burner_private_key,
                 assignments.clone(),
                 Some(constraint_limit as u64),
-                Some(N::MAX_DEPLOYMENT_VARIABLES),
+                Some(variable_limit),
             );
             // Append the function name, callstack, and assignments.
             call_stacks.push((function.name(), call_stack, assignments));

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -149,8 +149,9 @@ impl<N: Network> StackExecute<N> for Stack<N> {
 
         // If in 'CheckDeployment' mode, set the constraint limit.
         // We do not have to reset it after function calls because `CheckDeployment` mode does not execute those.
-        if let CallStack::CheckDeployment(_, _, _, constraint_limit) = &call_stack {
+        if let CallStack::CheckDeployment(_, _, _, constraint_limit, var_limit) = &call_stack {
             A::set_constraint_limit(*constraint_limit);
+            A::set_variable_limit(*var_limit);
         }
 
         // Retrieve the next request.
@@ -410,6 +411,8 @@ impl<N: Network> StackExecute<N> for Stack<N> {
             self.matches_value_type(output, output_type)
         })?;
 
+        println!("A::num_constants(): {}", A::num_constants());
+
         // If the circuit is in `Execute` or `PackageRun` mode, then ensure the circuit is satisfied.
         if matches!(registers.call_stack(), CallStack::Execute(..) | CallStack::PackageRun(..)) {
             // If the circuit is empty or not satisfied, then throw an error.
@@ -445,7 +448,7 @@ impl<N: Network> StackExecute<N> for Stack<N> {
             lap!(timer, "Save the transition");
         }
         // If the circuit is in `CheckDeployment` mode, then save the assignment.
-        else if let CallStack::CheckDeployment(_, _, ref assignments, _) = registers.call_stack() {
+        else if let CallStack::CheckDeployment(_, _, ref assignments, _, _) = registers.call_stack() {
             // Construct the call metrics.
             let metrics = CallMetrics {
                 program_id: *self.program_id(),

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -425,6 +425,9 @@ impl<N: Network> StackExecute<N> for Stack<N> {
             );
         }
 
+        // Determine the number of variables allocated in the circuit.
+        let num_variables = A::num_variables();
+
         // Eject the circuit assignment and reset the circuit.
         let assignment = A::eject_assignment_and_reset();
 
@@ -453,6 +456,7 @@ impl<N: Network> StackExecute<N> for Stack<N> {
             let metrics = CallMetrics {
                 program_id: *self.program_id(),
                 function_name: *function.name(),
+                num_variables,
                 num_instructions: function.instructions().len(),
                 num_request_constraints,
                 num_function_constraints,
@@ -475,6 +479,7 @@ impl<N: Network> StackExecute<N> for Stack<N> {
             let metrics = CallMetrics {
                 program_id: *self.program_id(),
                 function_name: *function.name(),
+                num_variables,
                 num_instructions: function.instructions().len(),
                 num_request_constraints,
                 num_function_constraints,
@@ -495,6 +500,7 @@ impl<N: Network> StackExecute<N> for Stack<N> {
             let metrics = CallMetrics {
                 program_id: *self.program_id(),
                 function_name: *function.name(),
+                num_variables,
                 num_instructions: function.instructions().len(),
                 num_request_constraints,
                 num_function_constraints,

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -426,8 +426,7 @@ impl<N: Network> StackExecute<N> for Stack<N> {
         }
 
         // Determine the number of variables allocated in the circuit.
-        // NOTE: we can use this limit because our circuits only have a single scope.
-        let num_variables = A::num_variables_in_scope();
+        let num_variables = A::num_variables();
 
         // Eject the circuit assignment and reset the circuit.
         let assignment = A::eject_assignment_and_reset();

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -27,6 +27,7 @@ impl<N: Network> Stack<N> {
             universal_srs: process.universal_srs().clone(),
             proving_keys: Default::default(),
             verifying_keys: Default::default(),
+            variable_counts: Default::default(),
             number_of_calls: Default::default(),
             finalize_costs: Default::default(),
             program_depth: 0,

--- a/synthesizer/process/src/stack/helpers/synthesize.rs
+++ b/synthesizer/process/src/stack/helpers/synthesize.rs
@@ -80,6 +80,8 @@ impl<N: Network> Stack<N> {
         ensure!(self.contains_proving_key(function_name), "Function '{function_name}' is missing a proving key.");
         // Ensure the verifying key exists.
         ensure!(self.contains_verifying_key(function_name), "Function '{function_name}' is missing a verifying key.");
+        // Ensure the variable count exists.
+        ensure!(self.contains_variable_count(function_name), "Function '{function_name}' is missing variable count.");
         Ok(())
     }
 
@@ -89,6 +91,7 @@ impl<N: Network> Stack<N> {
         &self,
         function_name: &Identifier<N>,
         assignment: &circuit::Assignment<N::Field>,
+        variable_count: u64,
     ) -> Result<()> {
         // If the proving and verifying key already exist, skip the synthesis for this function.
         if self.contains_proving_key(function_name) && self.contains_verifying_key(function_name) {
@@ -100,6 +103,8 @@ impl<N: Network> Stack<N> {
         // Insert the proving key.
         self.insert_proving_key(function_name, proving_key)?;
         // Insert the verifying key.
-        self.insert_verifying_key(function_name, verifying_key)
+        self.insert_verifying_key(function_name, verifying_key)?;
+        // Insert the variable count.
+        self.insert_variable_count(function_name, variable_count)
     }
 }

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -81,7 +81,7 @@ pub type Assignments<N> = Arc<RwLock<Vec<(circuit::Assignment<<N as Environment>
 pub enum CallStack<N: Network> {
     Authorize(Vec<Request<N>>, PrivateKey<N>, Authorization<N>),
     Synthesize(Vec<Request<N>>, PrivateKey<N>, Authorization<N>),
-    CheckDeployment(Vec<Request<N>>, PrivateKey<N>, Assignments<N>, Option<u64>),
+    CheckDeployment(Vec<Request<N>>, PrivateKey<N>, Assignments<N>, Option<u64>, Option<u64>),
     Evaluate(Authorization<N>),
     Execute(Authorization<N>, Arc<RwLock<Trace<N>>>),
     PackageRun(Vec<Request<N>>, PrivateKey<N>, Assignments<N>),
@@ -109,12 +109,13 @@ impl<N: Network> CallStack<N> {
             CallStack::Synthesize(requests, private_key, authorization) => {
                 CallStack::Synthesize(requests.clone(), *private_key, authorization.replicate())
             }
-            CallStack::CheckDeployment(requests, private_key, assignments, constraint_limit) => {
+            CallStack::CheckDeployment(requests, private_key, assignments, constraint_limit, variable_limit) => {
                 CallStack::CheckDeployment(
                     requests.clone(),
                     *private_key,
                     Arc::new(RwLock::new(assignments.read().clone())),
                     *constraint_limit,
+                    *variable_limit,
                 )
             }
             CallStack::Evaluate(authorization) => CallStack::Evaluate(authorization.replicate()),

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -2249,7 +2249,7 @@ mod sanity_checks {
         // Initialize the assignments.
         let assignments = Assignments::<N>::default();
         // Initialize the call stack.
-        let call_stack = CallStack::CheckDeployment(vec![request], *private_key, assignments.clone(), None);
+        let call_stack = CallStack::CheckDeployment(vec![request], *private_key, assignments.clone(), None, None);
         // Synthesize the circuit.
         let _response = stack.execute_function::<A, _>(call_stack, None, None, rng).unwrap();
         // Retrieve the assignment.

--- a/synthesizer/process/src/trace/call_metrics/mod.rs
+++ b/synthesizer/process/src/trace/call_metrics/mod.rs
@@ -22,6 +22,7 @@ pub struct CallMetrics<N: Network> {
     pub program_id: ProgramID<N>,
     pub function_name: Identifier<N>,
     pub num_instructions: usize,
+    pub num_variables: u64,
     pub num_request_constraints: u64,
     pub num_function_constraints: u64,
     pub num_response_constraints: u64,

--- a/synthesizer/process/src/trace/call_metrics/mod.rs
+++ b/synthesizer/process/src/trace/call_metrics/mod.rs
@@ -22,7 +22,6 @@ pub struct CallMetrics<N: Network> {
     pub program_id: ProgramID<N>,
     pub function_name: Identifier<N>,
     pub num_instructions: usize,
-    pub num_variables: u64,
     pub num_request_constraints: u64,
     pub num_function_constraints: u64,
     pub num_response_constraints: u64,

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1031,7 +1031,7 @@ function a:
             // Note: `deployment_transaction_ids` is sorted lexicographically by transaction ID, so the order may change if we update internal methods.
             assert_eq!(
                 deployment_transaction_ids,
-                vec![deployment_4.id(), deployment_3.id(), deployment_1.id(), deployment_2.id()],
+                vec![deployment_1.id(), deployment_3.id(), deployment_2.id(), deployment_4.id()],
                 "Update me if serialization has changed"
             );
         }
@@ -1964,7 +1964,7 @@ finalize transfer_public:
             Some(Value::Plaintext(Plaintext::Literal(Literal::U64(balance), _))) => *balance,
             _ => panic!("Expected a valid balance"),
         };
-        assert_eq!(balance, 182_499_997_475_583, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_997_403_803, "Update me if the initial balance changes.");
 
         // Check the balance of the `credits_wrapper` program.
         let balance = match vm
@@ -2016,7 +2016,7 @@ finalize transfer_public:
             Some(Value::Plaintext(Plaintext::Literal(Literal::U64(balance), _))) => *balance,
             _ => panic!("Expected a valid balance"),
         };
-        assert_eq!(balance, 182_499_997_423_058, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_997_351_278, "Update me if the initial balance changes.");
 
         // Check the balance of the `credits_wrapper` program.
         let balance = match vm
@@ -2155,7 +2155,7 @@ finalize transfer_public_as_signer:
             Some(Value::Plaintext(Plaintext::Literal(Literal::U64(balance), _))) => *balance,
             _ => panic!("Expected a valid balance"),
         };
-        assert_eq!(balance, 182_499_997_404_068, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_997_321_968, "Update me if the initial balance changes.");
 
         // Check the `credits_wrapper` program does not have any balance.
         let balance = vm
@@ -2310,7 +2310,7 @@ finalize transfer_public_to_private:
             _ => panic!("Expected a valid balance"),
         };
 
-        assert_eq!(balance, 182_499_996_916_681, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_996_794_967, "Update me if the initial balance changes.");
 
         // Check that the `credits_wrapper` program has a balance of 0.
         let balance = match vm

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1343,7 +1343,14 @@ program synthesis_num_constants.aleo;
 function do:
     cast 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 into r0 as [u32; 32u32];
     cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[u32; 32u32]; 32u32];
-    cast r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 into r2 as [[[u32; 32u32]; 32u32]; 16u32];
+    cast r1 r1 r1 r1 r1 into r2 as [[[u32; 32u32]; 32u32]; 5u32];
+    hash.bhp1024 r2 into r3 as u32;
+    output r3 as u32.private;
+
+function do2:
+    cast 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 into r0 as [u32; 32u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[u32; 32u32]; 32u32];
+    cast r1 r1 r1 r1 r1 into r2 as [[[u32; 32u32]; 32u32]; 5u32];
     hash.bhp1024 r2 into r3 as u32;
     output r3 as u32.private;",
         )

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1321,6 +1321,43 @@ function do:
     }
 
     #[test]
+    fn test_deployment_num_constant_overload() {
+        let rng = &mut TestRng::default();
+
+        // Initialize a private key.
+        let private_key = sample_genesis_private_key(rng);
+
+        // Initialize the genesis block.
+        let genesis = sample_genesis_block(rng);
+
+        // Initialize the VM.
+        let vm = sample_vm();
+        // Update the VM.
+        vm.add_next_block(&genesis).unwrap();
+
+        // Deploy the base program.
+        let program = Program::from_str(
+            r"
+program synthesis_num_constants.aleo;
+
+function do:
+    cast 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 into r0 as [u32; 32u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[u32; 32u32]; 32u32];
+    cast r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 r1 into r2 as [[[u32; 32u32]; 32u32]; 16u32];
+    hash.bhp1024 r2 into r3 as u32;
+    output r3 as u32.private;",
+        )
+        .unwrap();
+
+        // Create the deployment transaction.
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+
+        // Verify the deployment transaction. It should fail because there are too many constants.
+        let check_tx_res = vm.check_transaction(&deployment, None, rng);
+        assert!(check_tx_res.is_err());
+    }
+
+    #[test]
     fn test_deployment_synthesis_overreport() {
         let rng = &mut TestRng::default();
 

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/test_rand.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/test_rand.out
@@ -26,7 +26,7 @@ outputs:
     test_rand.aleo/rand_chacha_check:
       outputs:
       - '{"type":"future","id":"818878742790741579153893179075772445872751227433677932822653185952935999557field","value":"{\n  program_id: test_rand.aleo,\n  function_name: rand_chacha_check,\n  arguments: [\n    1field,\n    true\n  ]\n}"}'
-  speculate: the execution was accepted
+  speculate: the execution was rejected
   add_next_block: succeeded.
 additional:
 - child_outputs:


### PR DESCRIPTION
## Motivation

Even though we limit program size and number of constraints, @d0cd identified that it is possible for someone to create huge *constants* in programs. During deployment verification, an attacker can make a validator take forever or use a lot of memory, without paying for it, because we don't limit or price constants.

The solution is to limit constants similarly to how we limit the number of constraints.

Some design considerations:
- I'm limiting total number of variables, not just constants, as defense in depth. Our lack of variable limitation was nagging me anyway. Speed to synthesize is the same for constants v.s. variables (for their respective worst case opcode keccak v.s. psd)
- I'm pricing in variables at the same rate as constraints, to avoid DoS from small programs with lots of constants.
- credits.aleo uses ~150k variables, the biggest popular program 300k variables, so (1 << 20) should be a sufficient limit
- verification of a deployment with max constants of (1 << 20) takes ~2 seconds in debug mode, so likely 0.02-0.2 second in release).
- we cannot add num_constants to CircuitInfo, constants are not a known quantity at the Varuna level. That's why I added the value to the `Deployment` object. Given that we price deployments by their size, the cost for deployments is increased by 0.01 aleo credit per function. Technically, we could only track the constants and not the total number of variables in the deployment, but I fear its less understandable for outside developers.

## Test Plan

Adding two tests, one testing the variable limit, and one testing manipulation of reported variables.

## Related PRs

Similar to: https://github.com/AleoHQ/snarkVM/pull/2271
