### PR TITLE
[Fix] Add `BFTAbortedTransmissionIDsMap`

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -59,6 +59,7 @@ impl From<MapID> for u16 {
 #[repr(u16)]
 pub enum BFTMap {
     Transmissions = DataID::BFTTransmissionsMap as u16,
+    AbortedTransmissionIDs = DataID::BFTAbortedTransmissionIDsMap as u16,
 }
 
 /// The RocksDB map prefix for block-related entries.
@@ -290,6 +291,10 @@ enum DataID {
     // Program
     ProgramIDMap,
     KeyValueMap,
+
+    // TODO (raychu86): Move this up to the BFT section.
+    // BFT
+    BFTAbortedTransmissionIDsMap,
 
     // Testing
     #[cfg(test)]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a `BFTAbortedTransmissionIDsMap` entry to the `DataID` enum. This is appended to the back to prevent breaking existing networks, but should be moved up prior to launch.

The sister PR is here - https://github.com/AleoHQ/snarkOS/pull/3217