### PR TITLE
[Perf] Don't recreate ReadOptions when querying the database

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -535,7 +535,7 @@ impl<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> DataMap<K
         Q: Serialize + ?Sized,
     {
         let raw_key = self.create_prefixed_key(key)?;
-        match self.database.get_pinned(&raw_key)? {
+        match self.database.get_pinned_opt(&raw_key, &self.database.default_readopts)? {
             Some(data) => Ok(Some(data)),
             None => Ok(None),
         }

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -75,7 +75,6 @@ pub trait Database {
 }
 
 /// An instance of a RocksDB database.
-#[derive(Clone)]
 pub struct RocksDB {
     /// The RocksDB instance.
     rocksdb: Arc<rocksdb::DB>,
@@ -91,6 +90,22 @@ pub struct RocksDB {
     pub(super) atomic_depth: Arc<AtomicUsize>,
     /// A flag indicating whether the atomic writes are currently paused.
     pub(super) atomic_writes_paused: Arc<AtomicBool>,
+    /// This is an optimization that avoids some allocations when querying the database.
+    pub(super) default_readopts: rocksdb::ReadOptions,
+}
+
+impl Clone for RocksDB {
+    fn clone(&self) -> Self {
+        Self {
+            rocksdb: self.rocksdb.clone(),
+            network_id: self.network_id,
+            storage_mode: self.storage_mode.clone(),
+            atomic_batch: self.atomic_batch.clone(),
+            atomic_depth: self.atomic_depth.clone(),
+            atomic_writes_paused: self.atomic_writes_paused.clone(),
+            default_readopts: Default::default(),
+        }
+    }
 }
 
 impl Deref for RocksDB {
@@ -136,6 +151,7 @@ impl Database for RocksDB {
                     atomic_batch: Default::default(),
                     atomic_depth: Default::default(),
                     atomic_writes_paused: Default::default(),
+                    default_readopts: Default::default(),
                 })
             })?
             .clone();
@@ -309,6 +325,7 @@ impl RocksDB {
                 atomic_batch: Default::default(),
                 atomic_depth: Default::default(),
                 atomic_writes_paused: Default::default(),
+                default_readopts: Default::default(),
             })
         }?;
 

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -75,7 +75,7 @@ impl<M: Serialize + DeserializeOwned, K: Serialize + DeserializeOwned, V: Serial
     #[inline]
     fn get_map_key_raw(&self, map: &M, key: &K) -> Result<Option<rocksdb::DBPinnableSlice>> {
         let raw_map_key = self.create_prefixed_map_key(map, key)?;
-        match self.database.get_pinned(&raw_map_key)? {
+        match self.database.get_pinned_opt(&raw_map_key, &self.database.default_readopts)? {
             Some(data) => Ok(Some(data)),
             None => Ok(None),
         }


### PR DESCRIPTION
Heap profiling indicates that plenty of allocations currently come from the use of `rocksdb_readoptions_create`, which is an FFI function called internally from `get_pinned`. This can easily be avoided by creating an instance of `ReadOptions` just once and reusing it via `get_pinned_opt`, which is the equivalent of `get_pinned` with a `&ReadOptions` parameter.

This change reduces (in a 15-minute run consisting of 4 `--dev` validators) the average number of allocations per second in a `dev` node that doesn't produce txs by roughly 30%, which is beneficial for the performance of any heap allocator.