### PR TITLE
[TOB] Fix length in `Serialize` impl for `Transition`

### DIFF
--- a/ledger/block/src/transition/serialize.rs
+++ b/ledger/block/src/transition/serialize.rs
@@ -19,7 +19,7 @@ impl<N: Network> Serialize for Transition<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut transition = serializer.serialize_struct("Transition", 7)?;
+                let mut transition = serializer.serialize_struct("Transition", 8)?;
                 transition.serialize_field("id", &self.id)?;
                 transition.serialize_field("program", &self.program_id)?;
                 transition.serialize_field("function", &self.function_name)?;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR fixes the `Serialize` implementation for `Transition`s by correcting the number of struct fields.

Finding: TOB-PUZZLE-3
