### PR TITLE
Adds a variable limit for deployments

### DIFF
--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -107,7 +107,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 
     /// Get all the strict degree bounds enforced in the AHP.
     pub fn get_degree_bounds(info: &CircuitInfo) -> Result<[usize; 4]> {
-        let num_variables = info.num_variables;
+        let num_variables = info.num_public_and_private_variables;
         let num_non_zero_a = info.num_non_zero_a;
         let num_non_zero_b = info.num_non_zero_b;
         let num_non_zero_c = info.num_non_zero_c;

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
@@ -133,7 +133,7 @@ impl<F: PrimeField, SM: SNARKMode> Circuit<F, SM> {
 
     /// The size of the variable domain in this R1CS instance.
     pub fn variable_domain_size(&self) -> Result<usize> {
-        Ok(crate::fft::EvaluationDomain::<F>::new(self.index_info.num_variables)
+        Ok(crate::fft::EvaluationDomain::<F>::new(self.index_info.num_public_and_private_variables)
             .ok_or(anyhow!("Cannot create EvaluationDomain"))?
             .size())
     }
@@ -197,8 +197,9 @@ impl<F: PrimeField, SM: SNARKMode> CanonicalDeserialize for Circuit<F, SM> {
         let index_info: CircuitInfo = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
         let constraint_domain_size = EvaluationDomain::<F>::compute_size_of_domain(index_info.num_constraints)
             .ok_or(SerializationError::InvalidData)?;
-        let variable_domain_size = EvaluationDomain::<F>::compute_size_of_domain(index_info.num_variables)
-            .ok_or(SerializationError::InvalidData)?;
+        let variable_domain_size =
+            EvaluationDomain::<F>::compute_size_of_domain(index_info.num_public_and_private_variables)
+                .ok_or(SerializationError::InvalidData)?;
         let non_zero_a_domain_size = EvaluationDomain::<F>::compute_size_of_domain(index_info.num_non_zero_a)
             .ok_or(SerializationError::InvalidData)?;
         let non_zero_b_domain_size = EvaluationDomain::<F>::compute_size_of_domain(index_info.num_non_zero_b)

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
@@ -26,7 +26,7 @@ pub struct CircuitInfo {
     pub num_public_inputs: usize,
     /// The number of public and private variables in the constraint system.
     /// Note: This does *NOT* include the number of constants in the constraint system.
-    pub num_variables: usize,
+    pub num_public_and_private_variables: usize,
     /// The number of constraints.
     pub num_constraints: usize,
     /// The number of non-zero entries in the A matrix.
@@ -41,14 +41,14 @@ impl CircuitInfo {
     /// The maximum degree of polynomial required to represent this index in the AHP.
     pub fn max_degree<F: PrimeField, SM: SNARKMode>(&self) -> Result<usize> {
         let max_non_zero = self.num_non_zero_a.max(self.num_non_zero_b).max(self.num_non_zero_c);
-        AHPForR1CS::<F, SM>::max_degree(self.num_constraints, self.num_variables, max_non_zero)
+        AHPForR1CS::<F, SM>::max_degree(self.num_constraints, self.num_public_and_private_variables, max_non_zero)
     }
 }
 
 impl ToBytes for CircuitInfo {
     fn write_le<W: Write>(&self, mut w: W) -> Result<(), io::Error> {
         (self.num_public_inputs as u64).write_le(&mut w)?;
-        (self.num_variables as u64).write_le(&mut w)?;
+        (self.num_public_and_private_variables as u64).write_le(&mut w)?;
         (self.num_constraints as u64).write_le(&mut w)?;
         (self.num_non_zero_a as u64).write_le(&mut w)?;
         (self.num_non_zero_b as u64).write_le(&mut w)?;

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
@@ -24,7 +24,8 @@ use snarkvm_utilities::{serialize::*, ToBytes};
 pub struct CircuitInfo {
     /// The number of public inputs after padding.
     pub num_public_inputs: usize,
-    /// The total number of variables in the constraint system.
+    /// The number of public and private variables in the constraint system.
+    /// Note: This does *NOT* include the number of constants in the constraint system.
     pub num_variables: usize,
     /// The number of constraints.
     pub num_constraints: usize,

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -168,7 +168,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 
         let index_info = CircuitInfo {
             num_public_inputs: num_padded_public_variables,
-            num_variables,
+            num_public_and_private_variables: num_variables,
             num_constraints,
             num_non_zero_a,
             num_non_zero_b,

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -121,7 +121,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                         }
 
                         if circuit.index_info.num_constraints != num_constraints
-                            || circuit.index_info.num_variables != (num_public_variables + num_private_variables)
+                            || circuit.index_info.num_public_and_private_variables
+                                != (num_public_variables + num_private_variables)
                         {
                             return Err(AHPError::InstanceDoesNotMatchIndex);
                         }

--- a/algorithms/src/snark/varuna/ahp/prover/state.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/state.rs
@@ -122,9 +122,9 @@ impl<'a, F: PrimeField, SM: SNARKMode> State<'a, F, SM> {
                     EvaluationDomain::new(index_info.num_constraints).ok_or(SynthesisError::PolyTooLarge)?;
                 max_num_constraints = max_num_constraints.max(index_info.num_constraints);
 
-                let variable_domain =
-                    EvaluationDomain::new(index_info.num_variables).ok_or(SynthesisError::PolyTooLarge)?;
-                max_num_variables = max_num_variables.max(index_info.num_variables);
+                let variable_domain = EvaluationDomain::new(index_info.num_public_and_private_variables)
+                    .ok_or(SynthesisError::PolyTooLarge)?;
+                max_num_variables = max_num_variables.max(index_info.num_public_and_private_variables);
 
                 let non_zero_domains = AHPForR1CS::<_, SM>::cmp_non_zero_domains(index_info, max_non_zero_domain)?;
                 max_non_zero_domain = non_zero_domains.max_non_zero_domain;

--- a/algorithms/src/snark/varuna/ahp/verifier/verifier.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/verifier.rs
@@ -71,7 +71,8 @@ impl<TargetField: PrimeField, SM: SNARKMode> AHPForR1CS<TargetField, SM> {
             end_timer!(constraint_domain_time);
 
             let variable_domain_time = start_timer!(|| format!("Constructing constraint domain for {circuit_id}"));
-            let variable_domain = EvaluationDomain::new(circuit_info.num_variables).ok_or(AHPError::PolyTooLarge)?;
+            let variable_domain =
+                EvaluationDomain::new(circuit_info.num_public_and_private_variables).ok_or(AHPError::PolyTooLarge)?;
             end_timer!(variable_domain_time);
 
             let non_zero_a_time = start_timer!(|| format!("Constructing non-zero-a domain for {circuit_id}"));

--- a/algorithms/src/snark/varuna/tests.rs
+++ b/algorithms/src/snark/varuna/tests.rs
@@ -740,7 +740,8 @@ mod varuna_test_vectors {
         let non_zero_a_domain = EvaluationDomain::<Fr>::new(index_pk.circuit.index_info.num_non_zero_a).unwrap();
         let non_zero_b_domain = EvaluationDomain::<Fr>::new(index_pk.circuit.index_info.num_non_zero_b).unwrap();
         let non_zero_c_domain = EvaluationDomain::<Fr>::new(index_pk.circuit.index_info.num_non_zero_c).unwrap();
-        let variable_domain = EvaluationDomain::<Fr>::new(index_pk.circuit.index_info.num_variables).unwrap();
+        let variable_domain =
+            EvaluationDomain::<Fr>::new(index_pk.circuit.index_info.num_public_and_private_variables).unwrap();
         let constraint_domain = EvaluationDomain::<Fr>::new(index_pk.circuit.index_info.num_constraints).unwrap();
         let input_domain = EvaluationDomain::<Fr>::new(index_pk.circuit.index_info.num_public_inputs).unwrap();
 

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -659,7 +659,7 @@ where
         let mut circuit_ids = Vec::with_capacity(keys_to_inputs.len());
         for (&vk, &public_inputs_i) in keys_to_inputs.iter() {
             max_num_constraints = max_num_constraints.max(vk.circuit_info.num_constraints);
-            max_num_variables = max_num_variables.max(vk.circuit_info.num_variables);
+            max_num_variables = max_num_variables.max(vk.circuit_info.num_public_and_private_variables);
 
             let non_zero_domains = AHPForR1CS::<_, SM>::cmp_non_zero_domains(&vk.circuit_info, max_non_zero_domain)?;
             max_non_zero_domain = non_zero_domains.max_non_zero_domain;

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -317,6 +317,8 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
             // Eject the R1CS instance.
@@ -337,6 +339,8 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
             // Eject the R1CS instance.
@@ -356,6 +360,8 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
             // Reset the circuit.

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -22,11 +22,12 @@ use core::{
 type Field = <console::MainnetV0 as console::Environment>::Field;
 
 thread_local! {
-    pub(super) static CONSTRAINT_LIMIT: Cell<Option<u64>> = Cell::new(None);
+    static VARIABLE_LIMIT: Cell<Option<u64>> = Cell::new(None);
+    static CONSTRAINT_LIMIT: Cell<Option<u64>> = Cell::new(None);
     pub(super) static CIRCUIT: RefCell<R1CS<Field>> = RefCell::new(R1CS::new());
-    pub(super) static IN_WITNESS: Cell<bool> = Cell::new(false);
-    pub(super) static ZERO: LinearCombination<Field> = LinearCombination::zero();
-    pub(super) static ONE: LinearCombination<Field> = LinearCombination::one();
+    static IN_WITNESS: Cell<bool> = Cell::new(false);
+    static ZERO: LinearCombination<Field> = LinearCombination::zero();
+    static ONE: LinearCombination<Field> = LinearCombination::one();
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -53,6 +54,14 @@ impl Environment for Circuit {
         IN_WITNESS.with(|in_witness| {
             // Ensure we are not in witness mode.
             if !in_witness.get() {
+                // Ensure that we do not surpass the variable limit for the circuit.
+                VARIABLE_LIMIT.with(|variable_limit| {
+                    if let Some(limit) = variable_limit.get() {
+                        if Self::num_variables() > limit {
+                            Self::halt(format!("Surpassed the variable limit ({limit})"))
+                        }
+                    }
+                });
                 CIRCUIT.with(|circuit| match mode {
                     Mode::Constant => circuit.borrow_mut().new_constant(value),
                     Mode::Public => circuit.borrow_mut().new_public(value),
@@ -216,6 +225,11 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| circuit.borrow().num_private())
     }
 
+    /// Returns the number of constant, public, and private variables in the entire circuit.
+    fn num_variables() -> u64 {
+        CIRCUIT.with(|circuit| circuit.borrow().num_variables())
+    }
+
     /// Returns the number of constraints in the entire circuit.
     fn num_constraints() -> u64 {
         CIRCUIT.with(|circuit| circuit.borrow().num_constraints())
@@ -251,11 +265,14 @@ impl Environment for Circuit {
         CIRCUIT.with(|circuit| circuit.borrow().num_nonzeros_in_scope())
     }
 
-    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
-    fn halt<S: Into<String>, T>(message: S) -> T {
-        let error = message.into();
-        // eprintln!("{}", &error);
-        panic!("{}", &error)
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64> {
+        VARIABLE_LIMIT.with(|current_limit| current_limit.get())
+    }
+
+    /// Sets the variable limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>) {
+        VARIABLE_LIMIT.with(|current_limit| current_limit.replace(limit));
     }
 
     /// Returns the constraint limit for the circuit, if one exists.
@@ -268,6 +285,13 @@ impl Environment for Circuit {
         CONSTRAINT_LIMIT.with(|current_limit| current_limit.replace(limit));
     }
 
+    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
+    fn halt<S: Into<String>, T>(message: S) -> T {
+        let error = message.into();
+        // eprintln!("{}", &error);
+        panic!("{}", &error)
+    }
+
     /// Returns the R1CS circuit, resetting the circuit.
     fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
         CIRCUIT.with(|circuit| {
@@ -275,6 +299,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Inject the R1CS instance.
             let r1cs = circuit.replace(r1cs);
@@ -282,6 +307,7 @@ impl Environment for Circuit {
             assert_eq!(0, r1cs.num_constants());
             assert_eq!(1, r1cs.num_public());
             assert_eq!(0, r1cs.num_private());
+            assert_eq!(1, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
         })
     }
@@ -299,6 +325,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Return the R1CS instance.
             r1cs
@@ -317,6 +344,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
@@ -335,6 +363,7 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_constants());
             assert_eq!(1, circuit.borrow().num_public());
             assert_eq!(0, circuit.borrow().num_private());
+            assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
         });
     }

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -119,6 +119,9 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     /// Returns the number of private variables in the entire environment.
     fn num_private() -> u64;
 
+    /// Returns the number of constant, public, and private variables in the entire environment.
+    fn num_variables() -> u64;
+
     /// Returns the number of constraints in the entire environment.
     fn num_constraints() -> u64;
 
@@ -156,16 +159,22 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
         )
     }
 
-    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
-    fn halt<S: Into<String>, T>(message: S) -> T {
-        <Self::Network as console::Environment>::halt(message)
-    }
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64>;
+
+    /// Sets the variable limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>);
 
     /// Returns the constraint limit for the circuit, if one exists.
     fn get_constraint_limit() -> Option<u64>;
 
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>);
+
+    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
+    fn halt<S: Into<String>, T>(message: S) -> T {
+        <Self::Network as console::Environment>::halt(message)
+    }
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn inject_r1cs(r1cs: R1CS<Self::BaseField>);

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -85,9 +85,14 @@ impl<F: PrimeField> AssignmentLC<F> {
 /// and constraint assignments.
 #[derive(Clone, Debug)]
 pub struct Assignment<F: PrimeField> {
+    /// The public variables.
     public: Arc<[(Index, F)]>,
+    /// The private variables.
     private: Arc<[(Index, F)]>,
+    /// The constraints.
     constraints: Arc<[(AssignmentLC<F>, AssignmentLC<F>, AssignmentLC<F>)]>,
+    /// The number of constants, public, and private variables in the assignment.
+    num_variables: u64,
 }
 
 impl<F: PrimeField> From<crate::R1CS<F>> for Assignment<F> {
@@ -104,6 +109,7 @@ impl<F: PrimeField> From<crate::R1CS<F>> for Assignment<F> {
                 let (a, b, c) = constraint.to_terms();
                 (a.into(), b.into(), c.into())
             })),
+            num_variables: r1cs.num_variables(),
         }
     }
 }
@@ -132,6 +138,11 @@ impl<F: PrimeField> Assignment<F> {
     /// Returns the number of private variables in the assignment.
     pub fn num_private(&self) -> u64 {
         self.private.len() as u64
+    }
+
+    /// Returns the number of constants, public, and private variables in the assignment.
+    pub fn num_variables(&self) -> u64 {
+        self.num_variables
     }
 
     /// Returns the number of constraints in the assignment.

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -29,6 +29,7 @@ pub struct R1CS<F: PrimeField> {
     private: Vec<Variable<F>>,
     constraints: Vec<Rc<Constraint<F>>>,
     counter: Counter<F>,
+    num_variables: u64,
     nonzeros: (u64, u64, u64),
 }
 
@@ -41,6 +42,7 @@ impl<F: PrimeField> R1CS<F> {
             private: Default::default(),
             constraints: Default::default(),
             counter: Default::default(),
+            num_variables: 1u64,
             nonzeros: (0, 0, 0),
         }
     }
@@ -60,6 +62,7 @@ impl<F: PrimeField> R1CS<F> {
         let variable = Variable::Constant(Rc::new(value));
         self.constants.push(variable.clone());
         self.counter.increment_constant();
+        self.num_variables += 1;
         variable
     }
 
@@ -68,6 +71,7 @@ impl<F: PrimeField> R1CS<F> {
         let variable = Variable::Public(Rc::new((self.public.len() as u64, value)));
         self.public.push(variable.clone());
         self.counter.increment_public();
+        self.num_variables += 1;
         variable
     }
 
@@ -76,6 +80,7 @@ impl<F: PrimeField> R1CS<F> {
         let variable = Variable::Private(Rc::new((self.private.len() as u64, value)));
         self.private.push(variable.clone());
         self.counter.increment_private();
+        self.num_variables += 1;
         variable
     }
 
@@ -147,6 +152,11 @@ impl<F: PrimeField> R1CS<F> {
     /// Returns the number of private variables in the constraint system.
     pub fn num_private(&self) -> u64 {
         self.private.len() as u64
+    }
+
+    /// Returns the number of constant, public, and private variables in the constraint system.
+    pub fn num_variables(&self) -> u64 {
+        self.num_variables
     }
 
     /// Returns the number of constraints in the constraint system.

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -293,6 +293,8 @@ impl Environment for TestnetCircuit {
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
             // Eject the R1CS instance.
@@ -313,6 +315,8 @@ impl Environment for TestnetCircuit {
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
             // Eject the R1CS instance.
@@ -332,6 +336,8 @@ impl Environment for TestnetCircuit {
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
+            // Reset the variable limit.
+            Self::set_variable_limit(None);
             // Reset the constraint limit.
             Self::set_constraint_limit(None);
             // Reset the circuit.

--- a/circuit/network/src/lib.rs
+++ b/circuit/network/src/lib.rs
@@ -29,6 +29,9 @@ pub trait Aleo: Environment {
     /// The maximum number of field elements in data (must not exceed u16::MAX).
     const MAX_DATA_SIZE_IN_FIELDS: u32 = <Self::Network as console::Network>::MAX_DATA_SIZE_IN_FIELDS;
 
+    /// Initializes the global constants for the Aleo environment.
+    fn initialize_global_constants();
+
     /// Returns the encryption domain as a constant field element.
     fn encryption_domain() -> Field<Self>;
 

--- a/circuit/network/src/testnet_v0.rs
+++ b/circuit/network/src/testnet_v0.rs
@@ -101,6 +101,29 @@ thread_local! {
 pub struct AleoTestnetV0;
 
 impl Aleo for AleoTestnetV0 {
+    /// Initializes the global constants for the Aleo environment.
+    fn initialize_global_constants() {
+        GENERATOR_G.with(|_| ());
+        ENCRYPTION_DOMAIN.with(|_| ());
+        GRAPH_KEY_DOMAIN.with(|_| ());
+        SERIAL_NUMBER_DOMAIN.with(|_| ());
+        BHP_256.with(|_| ());
+        BHP_512.with(|_| ());
+        BHP_768.with(|_| ());
+        BHP_1024.with(|_| ());
+        KECCAK_256.with(|_| ());
+        KECCAK_384.with(|_| ());
+        KECCAK_512.with(|_| ());
+        PEDERSEN_64.with(|_| ());
+        PEDERSEN_128.with(|_| ());
+        POSEIDON_2.with(|_| ());
+        POSEIDON_4.with(|_| ());
+        POSEIDON_8.with(|_| ());
+        SHA3_256.with(|_| ());
+        SHA3_384.with(|_| ());
+        SHA3_512.with(|_| ());
+    }
+
     /// Returns the encryption domain as a constant field element.
     fn encryption_domain() -> Field<Self> {
         ENCRYPTION_DOMAIN.with(|domain| domain.clone())

--- a/circuit/network/src/testnet_v0.rs
+++ b/circuit/network/src/testnet_v0.rs
@@ -426,6 +426,11 @@ impl Environment for AleoTestnetV0 {
         E::num_private()
     }
 
+    /// Returns the number of constant, public, and private variables in the entire circuit.
+    fn num_variables() -> u64 {
+        E::num_variables()
+    }
+
     /// Returns the number of constraints in the entire circuit.
     fn num_constraints() -> u64 {
         E::num_constraints()
@@ -461,9 +466,14 @@ impl Environment for AleoTestnetV0 {
         E::num_nonzeros_in_scope()
     }
 
-    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
-    fn halt<S: Into<String>, T>(message: S) -> T {
-        E::halt(message)
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64> {
+        E::get_variable_limit()
+    }
+
+    /// Sets the variable limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>) {
+        E::set_variable_limit(limit)
     }
 
     /// Returns the constraint limit for the circuit, if one exists.
@@ -474,6 +484,11 @@ impl Environment for AleoTestnetV0 {
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>) {
         E::set_constraint_limit(limit)
+    }
+
+    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
+    fn halt<S: Into<String>, T>(message: S) -> T {
+        E::halt(message)
     }
 
     /// Returns the R1CS circuit, resetting the circuit.

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -101,6 +101,29 @@ thread_local! {
 pub struct AleoV0;
 
 impl Aleo for AleoV0 {
+    /// Initializes the global constants for the Aleo environment.
+    fn initialize_global_constants() {
+        GENERATOR_G.with(|_| ());
+        ENCRYPTION_DOMAIN.with(|_| ());
+        GRAPH_KEY_DOMAIN.with(|_| ());
+        SERIAL_NUMBER_DOMAIN.with(|_| ());
+        BHP_256.with(|_| ());
+        BHP_512.with(|_| ());
+        BHP_768.with(|_| ());
+        BHP_1024.with(|_| ());
+        KECCAK_256.with(|_| ());
+        KECCAK_384.with(|_| ());
+        KECCAK_512.with(|_| ());
+        PEDERSEN_64.with(|_| ());
+        PEDERSEN_128.with(|_| ());
+        POSEIDON_2.with(|_| ());
+        POSEIDON_4.with(|_| ());
+        POSEIDON_8.with(|_| ());
+        SHA3_256.with(|_| ());
+        SHA3_384.with(|_| ());
+        SHA3_512.with(|_| ());
+    }
+
     /// Returns the encryption domain as a constant field element.
     fn encryption_domain() -> Field<Self> {
         ENCRYPTION_DOMAIN.with(|domain| domain.clone())

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -426,6 +426,11 @@ impl Environment for AleoV0 {
         E::num_private()
     }
 
+    /// Returns the number of constant, public, and private variables in the entire circuit.
+    fn num_variables() -> u64 {
+        E::num_variables()
+    }
+
     /// Returns the number of constraints in the entire circuit.
     fn num_constraints() -> u64 {
         E::num_constraints()
@@ -461,9 +466,14 @@ impl Environment for AleoV0 {
         E::num_nonzeros_in_scope()
     }
 
-    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
-    fn halt<S: Into<String>, T>(message: S) -> T {
-        E::halt(message)
+    /// Returns the variable limit for the circuit, if one exists.
+    fn get_variable_limit() -> Option<u64> {
+        E::get_variable_limit()
+    }
+
+    /// Sets the variable limit for the circuit.
+    fn set_variable_limit(limit: Option<u64>) {
+        E::set_variable_limit(limit)
     }
 
     /// Returns the constraint limit for the circuit, if one exists.
@@ -474,6 +484,11 @@ impl Environment for AleoV0 {
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>) {
         E::set_constraint_limit(limit)
+    }
+
+    /// Halts the program from further synthesis, evaluation, and execution in the current environment.
+    fn halt<S: Into<String>, T>(message: S) -> T {
+        E::halt(message)
     }
 
     /// Returns the R1CS circuit, resetting the circuit.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -117,8 +117,10 @@ pub trait Network:
     const DEPLOYMENT_FEE_MULTIPLIER: u64 = 1_000; // 1 millicredit per byte
     /// The cost in microcredits per constraint for the deployment transaction.
     const SYNTHESIS_FEE_MULTIPLIER: u64 = 25; // 25 microcredits per constraint
+    /// The maximum number of variables in a deployment.
+    const MAX_DEPLOYMENT_VARIABLES: u64 = 1 << 20; // 1,048,576 variables
     /// The maximum number of constraints in a deployment.
-    const MAX_DEPLOYMENT_LIMIT: u64 = 1 << 20; // 1,048,576 constraints
+    const MAX_DEPLOYMENT_CONSTRAINTS: u64 = 1 << 20; // 1,048,576 constraints
     /// The maximum number of microcredits that can be spent as a fee.
     const MAX_FEE: u64 = 1_000_000_000_000_000;
     /// The maximum number of microcredits that can be spent on a finalize block.

--- a/ledger/block/src/transaction/deployment/mod.rs
+++ b/ledger/block/src/transaction/deployment/mod.rs
@@ -124,6 +124,23 @@ impl<N: Network> Deployment<N> {
         &self.verifying_keys
     }
 
+    /// Returns the sum of the variable counts for all functions in this deployment.
+    pub fn num_combined_variables(&self) -> Result<u64> {
+        // Initialize the accumulator.
+        let mut num_combined_variables = 0u64;
+        // Iterate over the functions.
+        for (_, (vk, _)) in &self.verifying_keys {
+            // Add the number of variables.
+            // Note: This method must be *checked* because the claimed variable count
+            // is from the user, not the synthesizer.
+            num_combined_variables = num_combined_variables
+                .checked_add(vk.num_variables())
+                .ok_or_else(|| anyhow!("Overflow when counting variables for '{}'", self.program_id()))?;
+        }
+        // Return the number of combined variables.
+        Ok(num_combined_variables)
+    }
+
     /// Returns the sum of the constraint counts for all functions in this deployment.
     pub fn num_combined_constraints(&self) -> Result<u64> {
         // Initialize the accumulator.

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -223,6 +223,7 @@ pub enum TestMap {
 enum DataID {
     // BFT
     BFTTransmissionsMap,
+    BFTAbortedTransmissionIDsMap,
     // Block
     BlockStateRootMap,
     BlockReverseStateRootMap,
@@ -291,10 +292,6 @@ enum DataID {
     // Program
     ProgramIDMap,
     KeyValueMap,
-
-    // TODO (raychu86): Move this up to the BFT section.
-    // BFT
-    BFTAbortedTransmissionIDsMap,
 
     // Testing
     #[cfg(test)]

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -342,7 +342,12 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         if program_id == &ProgramID::from_str("credits.aleo")? {
             // Load the verifying key.
             let verifying_key = N::get_credits_verifying_key(function_name.to_string())?;
-            return Ok(Some(VerifyingKey::new(verifying_key.clone())));
+            // Retrieve the number of public and private variables.
+            // Note: This number does *NOT* include the number of constants. This is safe because
+            // this program is never deployed, as it is a first-class citizen of the protocol.
+            let num_variables = verifying_key.circuit_info.num_variables as u64;
+            // Return the verifying key.
+            return Ok(Some(VerifyingKey::new(verifying_key.clone(), num_variables)));
         }
 
         // Retrieve the edition.

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -345,7 +345,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
             // Retrieve the number of public and private variables.
             // Note: This number does *NOT* include the number of constants. This is safe because
             // this program is never deployed, as it is a first-class citizen of the protocol.
-            let num_variables = verifying_key.circuit_info.num_variables as u64;
+            let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
             // Return the verifying key.
             return Ok(Some(VerifyingKey::new(verifying_key.clone(), num_variables)));
         }

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -315,11 +315,11 @@ pub fn sample_fee_public(deployment_or_execution_id: Field<CurrentNetwork>, rng:
 
 /******************************************** Program *********************************************/
 
-/// Deploy a program that produces large transitions.
-pub fn small_and_large_transaction_program() -> Program<CurrentNetwork> {
+/// Deploy a program that produces large transactions under the maximum transaction size.
+pub fn small_transaction_program() -> Program<CurrentNetwork> {
     Program::from_str(
-            r"
-program testing.aleo;
+        r"
+program testing_small.aleo;
 function small_transaction:
     cast 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field into r0 as [field; 32u32];
     cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[field; 32u32]; 32u32];
@@ -327,18 +327,24 @@ function small_transaction:
     cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r3 as [[field; 32u32]; 32u32];
     output r1 as [[field; 32u32]; 32u32].public;
     output r2 as [[field; 32u32]; 32u32].public;
-    output r3 as [[field; 32u32]; 32u32].public;
+    output r3 as [[field; 32u32]; 32u32].public;").unwrap()
+}
 
+/// Deploy a program that produces large transactions above the maximum transaction size.
+pub fn large_transaction_program() -> Program<CurrentNetwork> {
+    Program::from_str(
+        r"
+program testing_large.aleo;
 function large_transaction:
     cast 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field 0field into r0 as [field; 32u32];
-    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[field; 32u32]; 32u32];
-    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r2 as [[field; 32u32]; 32u32];
-    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r3 as [[field; 32u32]; 32u32];
-    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r4 as [[field; 32u32]; 32u32];
-    output r1 as [[field; 32u32]; 32u32].public;
-    output r2 as [[field; 32u32]; 32u32].public;
-    output r3 as [[field; 32u32]; 32u32].public;
-    output r4 as [[field; 32u32]; 32u32].public;").unwrap()
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[field; 32u32]; 27u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r2 as [[field; 32u32]; 27u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r3 as [[field; 32u32]; 27u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r4 as [[field; 32u32]; 27u32];
+    output r1 as [[field; 32u32]; 27u32].public;
+    output r2 as [[field; 32u32]; 27u32].public;
+    output r3 as [[field; 32u32]; 27u32].public;
+    output r4 as [[field; 32u32]; 27u32].public;").unwrap()
 }
 
 /****************************************** Transaction *******************************************/
@@ -389,7 +395,7 @@ pub fn sample_large_execution_transaction(rng: &mut TestRng) -> Transaction<Curr
     let execution = INSTANCE
         .get_or_init(|| {
             // Initialize a program that produces large transactions.
-            let program = small_and_large_transaction_program();
+            let program = large_transaction_program();
 
             // Construct the process.
             let mut process = synthesizer_process::Process::load().unwrap();
@@ -403,7 +409,7 @@ pub fn sample_large_execution_transaction(rng: &mut TestRng) -> Transaction<Curr
             let authorization = process
                 .authorize::<CurrentAleo, _>(
                     &private_key,
-                    "testing.aleo",
+                    "testing_large.aleo",
                     "large_transaction",
                     Vec::<Value<CurrentNetwork>>::new().iter(),
                     rng,

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -29,6 +29,8 @@ pub fn deployment_cost<N: Network>(deployment: &Deployment<N>) -> Result<(u64, (
     let program_id = deployment.program_id();
     // Determine the number of characters in the program ID.
     let num_characters = u32::try_from(program_id.name().to_string().len())?;
+    // Compute the number of combined variables in the program.
+    let num_combined_variables = deployment.num_combined_variables()?;
     // Compute the number of combined constraints in the program.
     let num_combined_constraints = deployment.num_combined_constraints()?;
 
@@ -38,7 +40,7 @@ pub fn deployment_cost<N: Network>(deployment: &Deployment<N>) -> Result<(u64, (
         .ok_or(anyhow!("The storage cost computation overflowed for a deployment"))?;
 
     // Compute the synthesis cost in microcredits.
-    let synthesis_cost = num_combined_constraints * N::SYNTHESIS_FEE_MULTIPLIER;
+    let synthesis_cost = num_combined_variables.saturating_add(num_combined_constraints) * N::SYNTHESIS_FEE_MULTIPLIER;
 
     // Compute the namespace cost in credits: 10^(10 - num_characters).
     let namespace_cost = 10u64

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -158,7 +158,12 @@ impl<N: Network> Process<N> {
         for function_name in program.functions().keys() {
             // Load the verifying key.
             let verifying_key = N::get_credits_verifying_key(function_name.to_string())?;
-            stack.insert_verifying_key(function_name, VerifyingKey::new(verifying_key.clone()))?;
+            // Retrieve the number of public and private variables.
+            // Note: This number does *NOT* include the number of constants. This is safe because
+            // this program is never deployed, as it is a first-class citizen of the protocol.
+            let num_variables = verifying_key.circuit_info.num_variables as u64;
+            // Insert the verifying key.
+            stack.insert_verifying_key(function_name, VerifyingKey::new(verifying_key.clone(), num_variables))?;
             lap!(timer, "Load verifying key for {function_name}");
         }
         lap!(timer, "Load circuit keys");

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -161,7 +161,7 @@ impl<N: Network> Process<N> {
             // Retrieve the number of public and private variables.
             // Note: This number does *NOT* include the number of constants. This is safe because
             // this program is never deployed, as it is a first-class citizen of the protocol.
-            let num_variables = verifying_key.circuit_info.num_variables as u64;
+            let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
             // Insert the verifying key.
             stack.insert_verifying_key(function_name, VerifyingKey::new(verifying_key.clone(), num_variables))?;
             lap!(timer, "Load verifying key for {function_name}");

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -147,10 +147,11 @@ impl<N: Network> StackExecute<N> for Stack<N> {
         // Ensure the circuit environment is clean.
         A::reset();
 
-        // If in 'CheckDeployment' mode, set the constraint limit.
+        // If in 'CheckDeployment' mode, set the constraint limit and variable limit.
         // We do not have to reset it after function calls because `CheckDeployment` mode does not execute those.
-        if let CallStack::CheckDeployment(_, _, _, constraint_limit) = &call_stack {
+        if let CallStack::CheckDeployment(_, _, _, constraint_limit, variable_limit) = &call_stack {
             A::set_constraint_limit(*constraint_limit);
+            A::set_variable_limit(*variable_limit);
         }
 
         // Retrieve the next request.
@@ -445,7 +446,7 @@ impl<N: Network> StackExecute<N> for Stack<N> {
             lap!(timer, "Save the transition");
         }
         // If the circuit is in `CheckDeployment` mode, then save the assignment.
-        else if let CallStack::CheckDeployment(_, _, ref assignments, _) = registers.call_stack() {
+        else if let CallStack::CheckDeployment(_, _, ref assignments, _, _) = registers.call_stack() {
             // Construct the call metrics.
             let metrics = CallMetrics {
                 program_id: *self.program_id(),

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -144,6 +144,8 @@ impl<N: Network> StackExecute<N> for Stack<N> {
     ) -> Result<Response<N>> {
         let timer = timer!("Stack::execute_function");
 
+        // Ensure the global constants for the Aleo environment are initialized.
+        A::initialize_global_constants();
         // Ensure the circuit environment is clean.
         A::reset();
 

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -81,7 +81,7 @@ pub type Assignments<N> = Arc<RwLock<Vec<(circuit::Assignment<<N as Environment>
 pub enum CallStack<N: Network> {
     Authorize(Vec<Request<N>>, PrivateKey<N>, Authorization<N>),
     Synthesize(Vec<Request<N>>, PrivateKey<N>, Authorization<N>),
-    CheckDeployment(Vec<Request<N>>, PrivateKey<N>, Assignments<N>, Option<u64>),
+    CheckDeployment(Vec<Request<N>>, PrivateKey<N>, Assignments<N>, Option<u64>, Option<u64>),
     Evaluate(Authorization<N>),
     Execute(Authorization<N>, Arc<RwLock<Trace<N>>>),
     PackageRun(Vec<Request<N>>, PrivateKey<N>, Assignments<N>),
@@ -109,12 +109,13 @@ impl<N: Network> CallStack<N> {
             CallStack::Synthesize(requests, private_key, authorization) => {
                 CallStack::Synthesize(requests.clone(), *private_key, authorization.replicate())
             }
-            CallStack::CheckDeployment(requests, private_key, assignments, constraint_limit) => {
+            CallStack::CheckDeployment(requests, private_key, assignments, constraint_limit, variable_limit) => {
                 CallStack::CheckDeployment(
                     requests.clone(),
                     *private_key,
                     Arc::new(RwLock::new(assignments.read().clone())),
                     *constraint_limit,
+                    *variable_limit,
                 )
             }
             CallStack::Evaluate(authorization) => CallStack::Evaluate(authorization.replicate()),

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -2249,7 +2249,7 @@ mod sanity_checks {
         // Initialize the assignments.
         let assignments = Assignments::<N>::default();
         // Initialize the call stack.
-        let call_stack = CallStack::CheckDeployment(vec![request], *private_key, assignments.clone(), None);
+        let call_stack = CallStack::CheckDeployment(vec![request], *private_key, assignments.clone(), None, None);
         // Synthesize the circuit.
         let _response = stack.execute_function::<A, _>(call_stack, None, None, rng).unwrap();
         // Retrieve the assignment.

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -2376,7 +2376,7 @@ fn test_process_deploy_credits_program() {
     let deployment = empty_process.deploy::<CurrentAleo, _>(&program, rng).unwrap();
 
     // Ensure the deployment is valid on the empty process.
-    assert!(empty_process.verify_deployment::<CurrentAleo, _>(&deployment, rng).is_ok());
+    empty_process.verify_deployment::<CurrentAleo, _>(&deployment, rng).unwrap();
     // Ensure the deployment is not valid on the standard process.
     assert!(process.verify_deployment::<CurrentAleo, _>(&deployment, rng).is_err());
 
@@ -2400,7 +2400,7 @@ function compute:
     let deployment = empty_process.deploy::<CurrentAleo, _>(&program, rng).unwrap();
 
     // Ensure the deployment is valid on the empty process.
-    assert!(empty_process.verify_deployment::<CurrentAleo, _>(&deployment, rng).is_ok());
+    empty_process.verify_deployment::<CurrentAleo, _>(&deployment, rng).unwrap();
     // Ensure the deployment is not valid on the standard process.
     assert!(process.verify_deployment::<CurrentAleo, _>(&deployment, rng).is_err());
 }

--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -313,7 +313,7 @@ impl<N: Network> Trace<N> {
             // Retrieve the number of public and private variables.
             // Note: This number does *NOT* include the number of constants. This is safe because
             // this program is never deployed, as it is a first-class citizen of the protocol.
-            let num_variables = verifying_key.circuit_info.num_variables as u64;
+            let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
             // Insert the inclusion verifier inputs.
             verifier_inputs.push((VerifyingKey::<N>::new(verifying_key, num_variables), batch_inclusion_inputs));
         }

--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -308,10 +308,14 @@ impl<N: Network> Trace<N> {
         let batch_inclusion_inputs = Inclusion::prepare_verifier_inputs(global_state_root, transitions)?;
         // Insert the batch of inclusion verifier inputs to the verifier inputs.
         if !batch_inclusion_inputs.is_empty() {
-            // Fetch the inclusion verifying key.
-            let verifying_key = VerifyingKey::<N>::new(N::inclusion_verifying_key().clone());
+            // Retrieve the inclusion verifying key.
+            let verifying_key = N::inclusion_verifying_key().clone();
+            // Retrieve the number of public and private variables.
+            // Note: This number does *NOT* include the number of constants. This is safe because
+            // this program is never deployed, as it is a first-class citizen of the protocol.
+            let num_variables = verifying_key.circuit_info.num_variables as u64;
             // Insert the inclusion verifier inputs.
-            verifier_inputs.push((verifying_key, batch_inclusion_inputs));
+            verifier_inputs.push((VerifyingKey::<N>::new(verifying_key, num_variables), batch_inclusion_inputs));
         }
         // Verify the proof.
         VerifyingKey::verify_batch(locator, verifier_inputs, proof).map_err(|e| anyhow!("Failed to verify proof - {e}"))

--- a/synthesizer/snark/src/universal_srs.rs
+++ b/synthesizer/snark/src/universal_srs.rs
@@ -40,7 +40,10 @@ impl<N: Network> UniversalSRS<N> {
         #[cfg(feature = "aleo-cli")]
         println!("{}", format!(" • Built '{function_name}' (in {} ms)", timer.elapsed().as_millis()).dimmed());
 
-        Ok((ProvingKey::new(Arc::new(proving_key)), VerifyingKey::new(Arc::new(verifying_key))))
+        Ok((
+            ProvingKey::new(Arc::new(proving_key)),
+            VerifyingKey::new(Arc::new(verifying_key), assignment.num_variables()),
+        ))
     }
 }
 

--- a/synthesizer/snark/src/verifying_key/bytes.rs
+++ b/synthesizer/snark/src/verifying_key/bytes.rs
@@ -25,8 +25,10 @@ impl<N: Network> FromBytes for VerifyingKey<N> {
         }
         // Read the verifying key.
         let verifying_key = Arc::new(FromBytes::read_le(&mut reader)?);
+        // Read the number of variables.
+        let num_variables = u64::read_le(&mut reader)?;
         // Return the verifying key.
-        Ok(Self { verifying_key })
+        Ok(Self { verifying_key, num_variables })
     }
 }
 
@@ -35,7 +37,9 @@ impl<N: Network> ToBytes for VerifyingKey<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the version.
         1u8.write_le(&mut writer)?;
-        // Write the bytes.
-        self.verifying_key.write_le(&mut writer)
+        // Write the verifying key.
+        self.verifying_key.write_le(&mut writer)?;
+        // Write the number of variables.
+        self.num_variables.write_le(&mut writer)
     }
 }

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -24,12 +24,19 @@ use std::collections::BTreeMap;
 pub struct VerifyingKey<N: Network> {
     /// The verifying key for the function.
     verifying_key: Arc<varuna::CircuitVerifyingKey<N::PairingCurve>>,
+    /// The number of constant, public, and private variables for the circuit.
+    num_variables: u64,
 }
 
 impl<N: Network> VerifyingKey<N> {
     /// Initializes a new verifying key.
-    pub const fn new(verifying_key: Arc<varuna::CircuitVerifyingKey<N::PairingCurve>>) -> Self {
-        Self { verifying_key }
+    pub const fn new(verifying_key: Arc<varuna::CircuitVerifyingKey<N::PairingCurve>>, num_variables: u64) -> Self {
+        Self { verifying_key, num_variables }
+    }
+
+    /// Returns the number of constant, public, and private variables for the circuit.
+    pub fn num_variables(&self) -> u64 {
+        self.num_variables
     }
 
     /// Returns `true` if the proof is valid for the given public inputs.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1032,7 +1032,7 @@ function a:
             // Note: `deployment_transaction_ids` is sorted lexicographically by transaction ID, so the order may change if we update internal methods.
             assert_eq!(
                 deployment_transaction_ids,
-                vec![deployment_1.id(), deployment_4.id(), deployment_3.id(), deployment_2.id()],
+                vec![deployment_4.id(), deployment_3.id(), deployment_2.id(), deployment_1.id()],
                 "Update me if serialization has changed"
             );
         }
@@ -1963,7 +1963,7 @@ finalize transfer_public:
             Some(Value::Plaintext(Plaintext::Literal(Literal::U64(balance), _))) => *balance,
             _ => panic!("Expected a valid balance"),
         };
-        assert_eq!(balance, 182_499_997_483_583, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_996_914_808, "Update me if the initial balance changes.");
 
         // Check the balance of the `credits_wrapper` program.
         let balance = match vm
@@ -2015,7 +2015,7 @@ finalize transfer_public:
             Some(Value::Plaintext(Plaintext::Literal(Literal::U64(balance), _))) => *balance,
             _ => panic!("Expected a valid balance"),
         };
-        assert_eq!(balance, 182_499_997_431_058, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_996_862_283, "Update me if the initial balance changes.");
 
         // Check the balance of the `credits_wrapper` program.
         let balance = match vm
@@ -2154,7 +2154,7 @@ finalize transfer_public_as_signer:
             Some(Value::Plaintext(Plaintext::Literal(Literal::U64(balance), _))) => *balance,
             _ => panic!("Expected a valid balance"),
         };
-        assert_eq!(balance, 182_499_997_412_068, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_996_821_793, "Update me if the initial balance changes.");
 
         // Check the `credits_wrapper` program does not have any balance.
         let balance = vm
@@ -2309,7 +2309,7 @@ finalize transfer_public_to_private:
             _ => panic!("Expected a valid balance"),
         };
 
-        assert_eq!(balance, 182_499_996_924_681, "Update me if the initial balance changes.");
+        assert_eq!(balance, 182_499_996_071_881, "Update me if the initial balance changes.");
 
         // Check that the `credits_wrapper` program has a balance of 0.
         let balance = match vm
@@ -2393,6 +2393,13 @@ finalize transfer_public_to_private:
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+
+        println!(
+            "@@@@@@@block num accepted {}, num rejected {}, num aborted {}",
+            block.transactions().num_accepted(),
+            block.transactions().num_rejected(),
+            block.aborted_transaction_ids().len()
+        );
 
         // Update the VM.
         vm.add_next_block(&block).unwrap();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1322,6 +1322,48 @@ function do:
     }
 
     #[test]
+    fn test_deployment_num_constant_overload() {
+        let rng = &mut TestRng::default();
+
+        // Initialize a private key.
+        let private_key = sample_genesis_private_key(rng);
+
+        // Initialize the genesis block.
+        let genesis = sample_genesis_block(rng);
+
+        // Initialize the VM.
+        let vm = sample_vm();
+        // Update the VM.
+        vm.add_next_block(&genesis).unwrap();
+
+        // Deploy the base program.
+        let program = Program::from_str(
+            r"
+program synthesis_num_constants.aleo;
+function do:
+    cast 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 into r0 as [u32; 32u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[u32; 32u32]; 32u32];
+    cast r1 r1 r1 r1 r1 into r2 as [[[u32; 32u32]; 32u32]; 5u32];
+    hash.bhp1024 r2 into r3 as u32;
+    output r3 as u32.private;
+function do2:
+    cast 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 0u32 into r0 as [u32; 32u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [[u32; 32u32]; 32u32];
+    cast r1 r1 r1 r1 r1 into r2 as [[[u32; 32u32]; 32u32]; 5u32];
+    hash.bhp1024 r2 into r3 as u32;
+    output r3 as u32.private;",
+        )
+            .unwrap();
+
+        // Create the deployment transaction.
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+
+        // Verify the deployment transaction. It should fail because there are too many constants.
+        let check_tx_res = vm.check_transaction(&deployment, None, rng);
+        assert!(check_tx_res.is_err());
+    }
+
+    #[test]
     fn test_deployment_synthesis_overreport() {
         let rng = &mut TestRng::default();
 
@@ -1359,9 +1401,9 @@ function do:
         // Increase the number of constraints in the verifying keys.
         let mut vks_with_overreport = Vec::with_capacity(deployment.verifying_keys().len());
         for (id, (vk, cert)) in deployment.verifying_keys() {
-            let mut vk = vk.deref().clone();
-            vk.circuit_info.num_constraints += 1;
-            let vk = VerifyingKey::new(Arc::new(vk));
+            let mut vk_deref = vk.deref().clone();
+            vk_deref.circuit_info.num_constraints += 1;
+            let vk = VerifyingKey::new(Arc::new(vk_deref), vk.num_variables());
             vks_with_overreport.push((*id, (vk, cert.clone())));
         }
 
@@ -1423,9 +1465,9 @@ function do:
         // Decrease the number of constraints in the verifying keys.
         let mut vks_with_underreport = Vec::with_capacity(deployment.verifying_keys().len());
         for (id, (vk, cert)) in deployment.verifying_keys() {
-            let mut vk = vk.deref().clone();
-            vk.circuit_info.num_constraints -= 2;
-            let vk = VerifyingKey::new(Arc::new(vk));
+            let mut vk_deref = vk.deref().clone();
+            vk_deref.circuit_info.num_constraints -= 2;
+            let vk = VerifyingKey::new(Arc::new(vk_deref), vk.num_variables());
             vks_with_underreport.push((*id, (vk, cert.clone())));
         }
 
@@ -1435,6 +1477,79 @@ function do:
         let adjusted_transaction = Transaction::Deploy(txid, program_owner, Box::new(adjusted_deployment), fee);
 
         // Verify the deployment transaction. It should error when enforcing the first constraint over the vk limit.
+        let result = vm.check_transaction(&adjusted_transaction, None, rng);
+        assert!(result.is_err());
+
+        // Create a standard transaction
+        // Prepare the inputs.
+        let inputs = [
+            Value::<CurrentNetwork>::from_str(&address.to_string()).unwrap(),
+            Value::<CurrentNetwork>::from_str("1u64").unwrap(),
+        ]
+        .into_iter();
+
+        // Execute.
+        let transaction =
+            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
+
+        // Check that the deployment transaction will be aborted if injected into a block.
+        let block = sample_next_block(&vm, &private_key, &[transaction, adjusted_transaction.clone()], rng).unwrap();
+
+        // Check that the block aborts the deployment transaction.
+        assert_eq!(block.aborted_transaction_ids(), &vec![adjusted_transaction.id()]);
+
+        // Update the VM.
+        vm.add_next_block(&block).unwrap();
+    }
+
+    #[test]
+    fn test_deployment_variable_underreport() {
+        let rng = &mut TestRng::default();
+
+        // Initialize a private key.
+        let private_key = sample_genesis_private_key(rng);
+        let address = Address::try_from(&private_key).unwrap();
+
+        // Initialize the genesis block.
+        let genesis = sample_genesis_block(rng);
+
+        // Initialize the VM.
+        let vm = sample_vm();
+        // Update the VM.
+        vm.add_next_block(&genesis).unwrap();
+
+        // Deploy the base program.
+        let program = Program::from_str(
+            r"
+program synthesis_underreport.aleo;
+function do:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    output r1 as u32.public;",
+        )
+        .unwrap();
+
+        // Create the deployment transaction.
+        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+
+        // Destructure the deployment transaction.
+        let Transaction::Deploy(txid, program_owner, deployment, fee) = transaction else {
+            panic!("Expected a deployment transaction");
+        };
+
+        // Decrease the number of reported variables in the verifying keys.
+        let mut vks_with_underreport = Vec::with_capacity(deployment.verifying_keys().len());
+        for (id, (vk, cert)) in deployment.verifying_keys() {
+            let vk = VerifyingKey::new(Arc::new(vk.deref().clone()), vk.num_variables() - 2);
+            vks_with_underreport.push((*id, (vk.clone(), cert.clone())));
+        }
+
+        // Create a new deployment transaction with the underreported verifying keys.
+        let adjusted_deployment =
+            Deployment::new(deployment.edition(), deployment.program().clone(), vks_with_underreport).unwrap();
+        let adjusted_transaction = Transaction::Deploy(txid, program_owner, Box::new(adjusted_deployment), fee);
+
+        // Verify the deployment transaction. It should error when synthesizing the first variable over the vk limit.
         let result = vm.check_transaction(&adjusted_transaction, None, rng);
         assert!(result.is_err());
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -450,7 +450,7 @@ pub(crate) mod test_helpers {
     };
     use ledger_block::{Block, Header, Metadata, Transition};
     use ledger_store::helpers::memory::ConsensusMemory;
-    use ledger_test_helpers::small_and_large_transaction_program;
+    use ledger_test_helpers::{large_transaction_program, small_transaction_program};
     use synthesizer_program::Program;
 
     use indexmap::IndexMap;
@@ -2385,8 +2385,8 @@ finalize transfer_public_to_private:
         // Update the VM.
         vm.add_next_block(&genesis).unwrap();
 
-        // Deploy a program that produces large transactions.
-        let program = small_and_large_transaction_program();
+        // Deploy a program that produces small transactions.
+        let program = small_transaction_program();
 
         // Deploy the program.
         let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
@@ -2394,12 +2394,17 @@ finalize transfer_public_to_private:
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
 
-        println!(
-            "@@@@@@@block num accepted {}, num rejected {}, num aborted {}",
-            block.transactions().num_accepted(),
-            block.transactions().num_rejected(),
-            block.aborted_transaction_ids().len()
-        );
+        // Update the VM.
+        vm.add_next_block(&block).unwrap();
+
+        // Deploy a program that produces large transactions.
+        let program = large_transaction_program();
+
+        // Deploy the program.
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+
+        // Add the deployment to a block and update the VM.
+        let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
 
         // Update the VM.
         vm.add_next_block(&block).unwrap();
@@ -2408,7 +2413,7 @@ finalize transfer_public_to_private:
         let transaction = vm
             .execute(
                 &caller_private_key,
-                ("testing.aleo", "small_transaction"),
+                ("testing_small.aleo", "small_transaction"),
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,
@@ -2433,7 +2438,7 @@ finalize transfer_public_to_private:
         let transaction = vm
             .execute(
                 &caller_private_key,
-                ("testing.aleo", "large_transaction"),
+                ("testing_large.aleo", "large_transaction"),
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Note: This PR contains breaking changes. First, all verifying keys are serialized with 8 extra bytes to account for the `num_variables`, which represents the number of *constant*, public, and private variables in the circuit. In addition, the `DataID` was updated to address an open `TODO` which involves reordering the map IDs (and also a breaking change).

Original motivation from @vicsn :

> Even though we limit program size and number of constraints, @d0cd identified that it is possible for someone to create huge constants in programs. During deployment verification, an attacker can make a validator take forever or use a lot of memory, without paying for it, because we don't limit or price constants.
>
> The solution is to limit constants similarly to how we limit the number of constraints.
>
> Some design considerations:
>
> - I'm limiting total number of variables, not just constants, as defense in depth. Our lack of variable limitation was nagging me anyway. Speed to synthesize is the same for constants v.s. variables (for their respective worst case opcode keccak v.s. psd)
> - I'm pricing in variables at the same rate as constraints, to avoid DoS from small programs with lots of constants.
> - credits.aleo uses ~150k variables, the biggest popular program 300k variables, so (1 << 20) should be a sufficient limit
> - verification of a deployment with max constants of (1 << 20) takes ~2 seconds in debug mode, so likely 0.02-0.2 second in release).
> - we cannot add num_constants to CircuitInfo, constants are not a known quantity at the Varuna level. That's why I added the value to the Deployment object. Given that we price deployments by their size, the cost for deployments is increased by 0.01 aleo credit per function. Technically, we could only track the constants and not the total number of variables in the deployment, but I fear its less understandable for outside developers.

## Test Plan

Adding two tests, one testing the variable limit, and one testing manipulation of reported variables.

## Related PRs

Supersedes #2431.

Similar to: https://github.com/AleoHQ/snarkVM/pull/2271.
