### PR TITLE
[Nit] Update `println` messages

### DIFF
--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -225,8 +225,6 @@ fn test_insufficient_public_fees() {
         ledger.advance_to_next_block(&block).unwrap();
     }
 
-    println!("-----------");
-
     // Attempt to bond the node with insufficient public fees.
     {
         let inputs = [

--- a/utilities/src/error.rs
+++ b/utilities/src/error.rs
@@ -40,7 +40,7 @@ impl Error for crate::io::Error {}
 
 /// This macro provides a VM runtime environment which will safely halt
 /// without producing logs that look like unexpected behavior.
-/// It prints to stderr using the format: "VM safely halted at <location>: <halt message>".
+/// In debug mode, it prints to stderr using the format: "VM safely halted at <location>: <halt message>".
 #[macro_export]
 macro_rules! try_vm_runtime {
     ($e:expr) => {{
@@ -53,6 +53,7 @@ macro_rules! try_vm_runtime {
             let msg = msg.split_ascii_whitespace().skip_while(|&word| word != "panicked").collect::<Vec<&str>>();
             let mut msg = msg.join(" ");
             msg = msg.replacen("panicked", "VM safely halted", 1);
+            #[cfg(debug_assertions)]
             eprintln!("{msg}");
         }));
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes and updates unnecessary `println`'s. The output in `try_vm_runtime` is expected behavior to reject transactions, however the message may be misleading to node operators who don't have context for what the output refers to.