### PR TITLE
[Perf] Don't allocate all rocksdb keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,6 +3294,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "smallvec",
  "snarkvm-console",
  "snarkvm-ledger-authority",
  "snarkvm-ledger-block",

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [features]
 default = [ "indexmap/rayon", "rayon" ]
-rocks = [ "once_cell", "rocksdb", "tracing" ]
+rocks = [ "once_cell", "rocksdb", "smallvec", "tracing" ]
 serial = [
   "console/serial",
   "ledger-block/serial",
@@ -116,6 +116,12 @@ version = "1.0"
 [dependencies.serde_json]
 version = "1.0"
 features = [ "preserve_order" ]
+
+[dependencies.smallvec]
+version = "1.11"
+default-features = false
+features = [ "write" ]
+optional = true
 
 [dependencies.tracing]
 version = "0.1"


### PR DESCRIPTION
Most of the rocksdb keys are relatively small, and we can avoid allocating them by using a `SmallVec`. Based on the heap profiles `jemalloc` is able to reuse this memory, but it costs CPU time to do so; also, such a change will reduce the number of (alloc-related) syscalls in non-Linux nodes.

The size was chosen to be 64B, as this covers the most common key sizes (including the prefixes).