### PR TITLE
Introduce cfg_sorted_by

### DIFF
--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -292,3 +292,19 @@ macro_rules! cfg_sort_by_cached_key {
         $self.par_sort_by_cached_key($closure);
     }};
 }
+
+/// Returns a sorted, by-value iterator for the given IndexMap/IndexSet
+#[macro_export]
+macro_rules! cfg_sorted_by {
+    ($self: expr, $closure: expr) => {{
+        #[cfg(feature = "serial")]
+        {
+            $self.sorted_by($closure)
+        }
+
+        #[cfg(not(feature = "serial"))]
+        {
+            $self.par_sorted_by($closure)
+        }
+    }};
+}


### PR DESCRIPTION
As requested in https://github.com/AleoHQ/snarkOS/issues/3251, and it works in the related scenario ([preview branch](https://github.com/ljedrz/snarkOS/tree/perf/faster_get_pending_certs)).

Note: there is also [par_sorted_unstable_by](https://docs.rs/indexmap/latest/indexmap/set/struct.IndexSet.html#method.par_sorted_unstable_by), which would likely be faster; happy to add/substitute if desirable.