### PR TITLE
[Fix] Unpause atomic writes on block insert error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3395,6 +3395,7 @@ dependencies = [
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "tempfile",
  "tracing",
  "walkdir",
 ]

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -198,5 +198,8 @@ features = [ "preserve_order" ]
 [dev-dependencies.serde_yaml]
 version = "0.9"
 
+[dev-dependencies.tempfile]
+version = "3"
+
 [dev-dependencies.walkdir]
 version = "2"

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -406,21 +406,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Disable the atomic batch override.
                 // Note: This call is guaranteed to succeed (without error), because `DISCARD_BATCH == true`.
                 self.block_store().unpause_atomic_writes::<true>()?;
-                // Rollback the Merkle tree.
-                self.block_store().remove_last_n_from_tree_only(1).map_err(|removal_error| {
-                    // Log the insert error.
-                    error!("Failed to insert block {} - {insert_error}", block.height());
-                    // Return the removal error.
-                    removal_error
-                })?;
-            } else {
-                // Rollback the block.
-                self.block_store().remove_last_n(1).map_err(|removal_error| {
-                    // Log the insert error.
-                    error!("Failed to insert block {} - {insert_error}", block.height());
-                    // Return the removal error.
-                    removal_error
-                })?;
             }
 
             return Err(insert_error);


### PR DESCRIPTION
This PR contains a _potential_ fix to one of the atomic panics we've seen on the devnet:
```
May 15 15:55:28 ip-172-31-42-88 snarkos[58891]: 2024-05-15T15:55:28.771227Z  WARN snarkos_node_sync::block_sync: Attempted to insert a block at the incorrect height into storage
May 15 15:55:29 ip-172-31-42-88 snarkos[58891]: thread 'tokio-runtime-worker' panicked at /Users/nkls/dev/snarkVM/ledger/store/src/helpers/rocksdb/internal/mod.rs:235:9:
May 15 15:55:29 ip-172-31-42-88 snarkos[58891]: assertion failed: !already_paused
```
I initially thought the error might suggest the occurrence of simultaneous block inserts from different threads (there are no `await` points so it can't be from the same task) but the block lock ruled this out. This leaves us with improper handling of unpausing which this changeset aims to fix. 

Drafting this PR as I haven't yet been able to confirm this fix is sufficient to resolve the issue entirely. 
