### PR TITLE
[Perf] Faster Poseidon permutation and Field multiplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,7 @@ dependencies = [
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
 dependencies = [
+ "criterion",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-console-types-field",

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -17,7 +17,7 @@ use snarkvm_fields::PrimeField;
 
 use core::{
     fmt,
-    ops::{Add, AddAssign, Mul, Neg, Sub},
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
 };
 
 // Before high level program operations are converted into constraints, they are first tracked as linear combinations.
@@ -433,14 +433,10 @@ impl<F: PrimeField> Mul<&F> for LinearCombination<F> {
     fn mul(self, coefficient: &F) -> Self::Output {
         let mut output = self;
         output.constant *= coefficient;
-        output.terms = output
-            .terms
-            .into_iter()
-            .filter_map(|(v, current_coefficient)| {
-                let res = current_coefficient * coefficient;
-                (!res.is_zero()).then_some((v, res))
-            })
-            .collect();
+        output.terms.iter_mut().for_each(|(_v, current_coefficient)| {
+            *current_coefficient *= coefficient;
+        });
+        output.terms.retain(|(_v, res)| !res.is_zero());
         output.value *= coefficient;
         output
     }
@@ -460,6 +456,17 @@ impl<F: PrimeField> Mul<&F> for &LinearCombination<F> {
 
     fn mul(self, coefficient: &F) -> Self::Output {
         self.clone() * coefficient
+    }
+}
+
+impl<F: PrimeField> MulAssign<&F> for LinearCombination<F> {
+    fn mul_assign(&mut self, coefficient: &F) {
+        self.constant *= coefficient;
+        self.terms.iter_mut().for_each(|(_v, current_coefficient)| {
+            *current_coefficient *= coefficient;
+        });
+        self.terms.retain(|(_v, res)| !res.is_zero());
+        self.value *= coefficient;
     }
 }
 

--- a/circuit/types/field/Cargo.toml
+++ b/circuit/types/field/Cargo.toml
@@ -6,6 +6,11 @@ description = "Field circuit for a decentralized virtual machine"
 license = "Apache-2.0"
 edition = "2021"
 
+[[bench]]
+name = "mul"
+path = "benches/mul.rs"
+harness = false
+
 [dependencies.console]
 package = "snarkvm-console-types-field"
 path = "../../../console/types/field"
@@ -19,6 +24,9 @@ version = "=0.16.19"
 [dependencies.snarkvm-circuit-types-boolean]
 path = "../boolean"
 version = "=0.16.19"
+
+[dev-dependencies.criterion]
+version = "0.5"
 
 [features]
 default = [ "enable_console" ]

--- a/circuit/types/field/benches/mul.rs
+++ b/circuit/types/field/benches/mul.rs
@@ -1,0 +1,41 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate criterion;
+
+use snarkvm_circuit_environment::*;
+use snarkvm_circuit_types_field::Field;
+
+use criterion::Criterion;
+
+fn bench_mul(c: &mut Criterion) {
+    c.bench_function("Field::mul_assign", move |b| {
+        let one = Field::<Circuit>::one();
+        let two = one.clone() + &one;
+        let mut base = two.clone();
+
+        b.iter(|| {
+            base *= &two;
+        })
+    });
+}
+
+criterion_group! {
+    name = mul;
+    config = Criterion::default();
+    targets = bench_mul
+}
+
+criterion_main!(mul);

--- a/circuit/types/field/src/mul.rs
+++ b/circuit/types/field/src/mul.rs
@@ -59,7 +59,7 @@ impl<E: Environment> MulAssign<Field<E>> for Field<E> {
 impl<E: Environment> MulAssign<&Field<E>> for Field<E> {
     fn mul_assign(&mut self, other: &Field<E>) {
         match (self.is_constant(), other.is_constant()) {
-            (true, true) | (false, true) => *self = (&self.linear_combination * *other.eject_value()).into(),
+            (true, true) | (false, true) => self.linear_combination *= &*other.eject_value(),
             (true, false) => *self = (&other.linear_combination * *self.eject_value()).into(),
             (false, false) => {
                 let product = witness!(|self, other| self * other);


### PR DESCRIPTION
This was something that I found while heap-profiling a large deployment and execution; `Poseidon::hash_many` is prominent, and responsible for many allocations. Most of these are caused by the `pow` operations involved, and by adjusting one of their internals (switching from `Mul` to `MulAssign` specifically), we can avoid some of them. The preexisting `Mul` operation is also adjusted for a small improvement.

In addition, the `new_state` allocation used in `apply_mds` can be reused, and its contents can be swapped with - instead of cloned to - the `state`.

These changes result in a decrease in allocs/s by ~**6%** (likely more if adjusted for node startup) in a `--dev` node during a large deployment+execution. In addition, the new `mul_assign` operation is ~**36%** faster than the `mul` one, which will positively impact node performance.

Note: we currently don't seem to have a benchmark for `Field` multiplication (I tested it by introducing an ad-hoc benchmark for `MulAssign<&Field<E>> for Field<E>`); I can add one or more of those if we'd like.