### PR TITLE
[Perf] Use SmallVec in the LinearCombination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,6 +2676,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "serial_test",
+ "smallvec",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-circuit-environment-witness",

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -57,6 +57,10 @@ version = "0.2"
 [dependencies.once_cell]
 version = "1.18.0"
 
+[dependencies.smallvec]
+version = "1.11"
+default-features = false
+
 [dev-dependencies.snarkvm-algorithms]
 path = "../../algorithms"
 features = [ "polycommit_full", "snark", "test" ]

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -19,6 +19,7 @@ use core::{
     fmt,
     ops::{Add, AddAssign, Mul, Neg, Sub},
 };
+use smallvec::SmallVec;
 
 // Before high level program operations are converted into constraints, they are first tracked as linear combinations.
 // Each linear combination corresponds to a portion or all of a single row of an R1CS matrix, and consists of:
@@ -34,7 +35,7 @@ use core::{
 pub struct LinearCombination<F: PrimeField> {
     constant: F,
     /// The list of terms is kept sorted in order to speed up lookups.
-    terms: Vec<(Variable<F>, F)>,
+    terms: SmallVec<[(Variable<F>, F); 1]>,
     /// The value of this linear combination, defined as the sum of the `terms` and `constant`.
     value: F,
 }


### PR DESCRIPTION
Despite the tiny diff and the somewhat conservative approach, this change has a large impact on deployment+execution runs. In a local test run using the tx cannon, `--dev` nodes, and a large transaction, it decreased the allocs/s in the target node by ~**32%**; it also made the 33-64B "allocation bucket" much less of an outlier in terms of the alloc count, which should improve the performance of specialized allocators like `jemalloc`.

I'm marking this PR as a draft, as I'd like to double-check it with a devnet run first.