### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please follow the instructions below when filing a pull request:
 
 ## Coding conventions
 
-snarkVM is a big project, so (non-)adherence to best practices related to performance can have a considerable impact; below are the rules we try to follow at all times in order to ensure high quality of the code:
+snarkVM is a big project, so (non-)adherence to best practices related to performance can have a considerable impact; below are the rules we try to follow at all times in order to ensure the high quality of the code:
 
 ### Error handling
 - prefer the use of `checked_div` when dividing polynomials.
@@ -41,6 +41,6 @@ snarkVM is a big project, so (non-)adherence to best practices related to perfor
   * `&[T]` instead of `&Vec<T>`
   * `&str` instead of `&String`
   * `&Path` instead of `&PathBuf`
-- if a lot of computational power is needed, consider parallelizing that workload with [`rayon`](https://crates.io/crates/rayon) - it's not always a viable solution, but can yield great performance improvements when used in the right context
+- if a lot of computational power is needed, consider parallelizing that workload with [`rayon`](https://crates.io/crates/rayon) - it's not always a viable solution, but it can yield great performance improvements when used in the right context
 - for `struct`s that can be compared/discerned based on some specific field(s), consider hand-written implementations of `PartialEq` **and** `Hash` ([they must match](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq)) for faster comparison and hashing
 - if possible, ensure that the results of your changes are not detrimental to performance using [`criterion`](https://crates.io/crates/criterion) (for smaller, fine-grained adjustments) and [`valgrind --tool={cachegrind | massif}`](https://valgrind.org/info/tools.html) (for larger-scale changes)

--- a/algorithms/cuda/LICENSE.md
+++ b/algorithms/cuda/LICENSE.md
@@ -160,7 +160,7 @@ been advised of the possibility of such damages.
 
 While redistributing the Work or Derivative Works thereof, You may choose to
 offer, and charge a fee for, acceptance of support, warranty, indemnity, or
-other liability obligations and/or rights consistent with this License. However,
+other liability obligations and/or rights are consistent with this License. However,
 in accepting such obligations, You may act only on Your own behalf and on Your
 sole responsibility, not on behalf of any other Contributor, and only if You
 agree to indemnify, defend, and hold each Contributor harmless for any liability


### PR DESCRIPTION

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.
Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.