### PR TITLE
Update spec.md: the `DEPTH` should be 9

### DIFF
--- a/ledger/puzzle/epoch/docs/spec.md
+++ b/ledger/puzzle/epoch/docs/spec.md
@@ -160,7 +160,7 @@ and Merkle Puzzle.
 
 ### K-ary Merkle Tree
 
--   Both versions of the puzzle use a K-ary Merkle Tree of `DEPTH` 8
+-   Both versions of the puzzle use a K-ary Merkle Tree of `DEPTH` 9
     and `ARITY` 8.
 
 -   The leaf and path hash functions is SHA-256.


### PR DESCRIPTION
According to: https://github.com/AleoNet/snarkVM/blob/d170a9f7c5ef980f9392301dc899dee355599ca6/ledger/puzzle/src/lib.rs#L69