### PR TITLE
[Fix] Add additional input/output checks to `Execution` verification

### DIFF
--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -91,6 +91,7 @@ impl<N: Network> Process<N> {
 
             // Ensure each output is valid.
             let num_inputs = transition.inputs().len();
+            let num_outputs = transition.outputs().len();
             if transition
                 .outputs()
                 .iter()
@@ -105,6 +106,10 @@ impl<N: Network> Process<N> {
             let stack = self.get_stack(transition.program_id())?;
             // Retrieve the function from the stack.
             let function = stack.get_function(transition.function_name())?;
+
+            // Ensure the number of inputs and outputs match the expected number in the function.
+            ensure!(function.inputs().len() == num_inputs, "The number of transition inputs is incorrect");
+            ensure!(function.outputs().len() == num_outputs, "The number of transition outputs is incorrect");
 
             // Retrieve the parent program ID.
             // Note: The last transition in the execution does not have a parent, by definition.

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -383,7 +383,7 @@ mod tests {
         account::{Address, ViewKey},
         types::Field,
     };
-    use ledger_block::{Block, Header, Metadata, Transaction};
+    use ledger_block::{Block, Header, Metadata, Transaction, Transition};
 
     type CurrentNetwork = test_helpers::CurrentNetwork;
 
@@ -640,5 +640,74 @@ function compute:
 
         // Ensure that the program can't be deployed.
         assert!(vm.deploy_raw(&program, rng).is_err());
+    }
+
+    #[test]
+    fn test_check_mutated_execution() {
+        let rng = &mut TestRng::default();
+
+        // Initialize the VM.
+        let vm = crate::vm::test_helpers::sample_vm();
+        // Fetch the caller's private key.
+        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+        // Initialize the genesis block.
+        let genesis = crate::vm::test_helpers::sample_genesis_block(rng);
+        // Update the VM.
+        vm.add_next_block(&genesis).unwrap();
+
+        // Fetch a valid execution transaction with a public fee.
+        let valid_transaction = crate::vm::test_helpers::sample_execution_transaction_with_public_fee(rng);
+        vm.check_transaction(&valid_transaction, None, rng).unwrap();
+
+        // Mutate the execution transaction by inserting a Field::Zero as an output.
+        let execution = valid_transaction.execution().unwrap();
+
+        // Extract the first transition from the execution.
+        let transitions: Vec<_> = execution.transitions().collect();
+        assert_eq!(transitions.len(), 1);
+        let transition = transitions[0].clone();
+
+        // Mutate the transition by adding an additional `Field::zero` output. This is significant because the Varuna
+        // verifier pads the inputs with `Field::zero`s, which means that the same proof is valid for both the
+        // original and the mutated executions.
+        let added_output = Output::ExternalRecord(Field::zero());
+        let mutated_outputs = [transition.outputs(), &[added_output]].concat();
+        let mutated_transition = Transition::new(
+            *transition.program_id(),
+            *transition.function_name(),
+            transition.inputs().to_vec(),
+            mutated_outputs,
+            *transition.tpk(),
+            *transition.tcm(),
+            *transition.scm(),
+        )
+        .unwrap();
+
+        // Construct the mutated execution.
+        let mutated_execution = Execution::from(
+            [mutated_transition].into_iter(),
+            execution.global_state_root(),
+            execution.proof().cloned(),
+        )
+        .unwrap();
+
+        // Authorize the fee.
+        let authorization = vm
+            .authorize_fee_public(
+                &caller_private_key,
+                10_000_000,
+                100,
+                mutated_execution.to_execution_id().unwrap(),
+                rng,
+            )
+            .unwrap();
+        // Compute the fee.
+        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
+
+        // Construct the transaction.
+        let mutated_transaction = Transaction::from_execution(mutated_execution, Some(fee)).unwrap();
+
+        // Ensure that the mutated transaction fails verification due to an extra output.
+        assert!(vm.check_transaction(&mutated_transaction, None, rng).is_err());
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds additional safety checks to Execution verification. Previously we weren't explicitly checking the number of transition inputs/outputs; we were passing through the inputs and outputs to the Varuna proof verification as the guarantee. The problem is that the Varuna verifier pads the inputs with `Field::zero`. This means that malicious parties can craft a mutated transactions by taking an honest execution transaction, adding an extra `Output::ExternalRecord(Field::zero))` output that uses the same proof (and different fee), and crafting a new transaction with a new ID that performs the same state transition.

We fix this by adding an explicit check against the number if inputs and the number of outputs in each transition.

_TLDR:
This "attack" can **NOT** perform malicious state changes. It will be able to cause the honest transaction to be rejected, but still perform the same state changes. The risk is that this may cause a victim to be enticed/confused into re-executing their transaction._

The CI run is [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM/153/workflows/4e398cd1-0fb0-43a3-96c9-ad0aac43b672). 

## Test Plan

A test has been added to ensure that the mutated transaction fails to verify due to the newly added check against the number of outputs.

## Related Issues

Partially related to possible transaction mutations discussed here - https://github.com/AleoNet/snarkVM/issues/2451.
