### PR TITLE
[Perf] Reserve the exact capacity in ToBits for BigIntegers

### DIFF
--- a/utilities/src/biginteger/bigint_256.rs
+++ b/utilities/src/biginteger/bigint_256.rs
@@ -229,12 +229,16 @@ impl crate::biginteger::BigInteger for BigInteger256 {
 impl ToBits for BigInteger256 {
     #[doc = " Returns `self` as a boolean array in little-endian order, with trailing zeros."]
     fn write_bits_le(&self, vec: &mut Vec<bool>) {
-        vec.extend(BitIteratorLE::new(self));
+        let iter = BitIteratorLE::new(self);
+        vec.reserve(iter.len());
+        vec.extend(iter);
     }
 
     #[doc = " Returns `self` as a boolean array in big-endian order, with leading zeros."]
     fn write_bits_be(&self, vec: &mut Vec<bool>) {
-        vec.extend(BitIteratorBE::new(self));
+        let iter = BitIteratorBE::new(self);
+        vec.reserve(iter.len());
+        vec.extend(iter);
     }
 }
 


### PR DESCRIPTION
While heap-profiling the loading of the Canary ledger, I was surprised by the number of temporary allocations pointing to the `ToBits` impl for `BigInteger256`; it appears that the `Extend` impl that's used there is not able to take advantage of the `ExactSizeIterator` impl for `BitIteratorLE`, and we need to be more explicit in order to avoid them.

The results at height 330598 are as follows:
- total allocs **-14%**
- temp allocs: **-28%**
- ledger loading time: **-9%**