### PR TITLE
[Perf] Speed up the fetching of the latest block height

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -126,7 +126,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         const NUM_BLOCKS: usize = 10;
         // Retrieve the latest height.
         let latest_height = ledger.current_block.read().height();
-        debug_assert_eq!(latest_height, *ledger.vm.block_store().heights().max().unwrap(), "Mismatch in latest height");
+        debug_assert_eq!(latest_height, ledger.vm.block_store().max_height().unwrap(), "Mismatch in latest height");
         // Sample random block heights.
         let block_heights: Vec<u32> =
             (0..=latest_height).choose_multiple(&mut OsRng, (latest_height as usize).min(NUM_BLOCKS));
@@ -169,7 +169,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         };
 
         // If the block store is empty, initialize the genesis block.
-        if ledger.vm.block_store().heights().max().is_none() {
+        if ledger.vm.block_store().max_height().is_none() {
             // Add the genesis block.
             ledger.advance_to_next_block(&genesis_block)?;
         }
@@ -177,7 +177,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Retrieve the latest height.
         let latest_height =
-            *ledger.vm.block_store().heights().max().ok_or_else(|| anyhow!("Failed to load blocks from the ledger"))?;
+            ledger.vm.block_store().max_height().ok_or_else(|| anyhow!("Failed to load blocks from the ledger"))?;
         // Fetch the latest block.
         let block = ledger
             .get_block(latest_height)

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1014,16 +1014,19 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
         // Compute the block tree.
         let tree = {
-            // Prepare an iterator over the block heights.
-            let heights = storage.id_map().keys_confirmed();
+            // Find the maximum block height.
+            let max_height = storage.id_map().len_confirmed().checked_sub(1).map(u32::try_from);
             // Prepare the leaves of the block tree.
-            let hashes = match heights.max() {
-                Some(height) => cfg_into_iter!(0..=cow_to_copied!(height))
-                    .map(|height| match storage.get_block_hash(height)? {
-                        Some(hash) => Ok(hash.to_bits_le()),
-                        None => bail!("Missing block hash for block {height}"),
-                    })
-                    .collect::<Result<Vec<Vec<bool>>>>()?,
+            let hashes = match max_height {
+                Some(height) => {
+                    let height = height?;
+                    cfg_into_iter!(0..=height)
+                        .map(|height| match storage.get_block_hash(height)? {
+                            Some(hash) => Ok(hash.to_bits_le()),
+                            None => bail!("Missing block hash for block {height}"),
+                        })
+                        .collect::<Result<Vec<Vec<bool>>>>()?
+                }
                 None => vec![],
             };
             // Construct the block tree.
@@ -1075,10 +1078,8 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         let mut tree = self.tree.write();
 
         // Determine the block heights to remove.
-        let heights = match self.storage.id_map().keys_confirmed().max() {
-            Some(height) => {
-                // Determine the end block height to remove.
-                let end_height = cow_to_copied!(height);
+        let heights = match self.max_height() {
+            Some(end_height) => {
                 // Determine the start block height to remove.
                 let start_height = end_height
                     .checked_sub(n - 1)

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1362,7 +1362,7 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
     /// Returns the height of the latest block in the storage.
     pub fn max_height(&self) -> Option<u32> {
-        u32::try_from(self.storage.id_map().len_confirmed()).ok()?.checked_sub(1)
+        self.storage.id_map().len_confirmed().checked_sub(1)?.try_into().ok()
     }
 
     /// Returns an iterator over the block hashes, for all blocks in `self`.

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1360,6 +1360,11 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.id_map().keys_confirmed()
     }
 
+    /// Returns the height of the latest block in the storage.
+    pub fn max_height(&self) -> Option<u32> {
+        u32::try_from(self.storage.id_map().len_confirmed()).ok()?.checked_sub(1)
+    }
+
     /// Returns an iterator over the block hashes, for all blocks in `self`.
     pub fn hashes(&self) -> impl '_ + Iterator<Item = Cow<'_, N::BlockHash>> {
         self.storage.reverse_id_map().keys_confirmed()

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -481,7 +481,6 @@ pub(crate) mod test_helpers {
 
     use indexmap::IndexMap;
     use once_cell::sync::OnceCell;
-    use std::borrow::Borrow;
     #[cfg(feature = "rocks")]
     use std::path::Path;
     use synthesizer_snark::VerifyingKey;
@@ -763,8 +762,7 @@ function compute:
         rng: &mut R,
     ) -> Result<Block<MainnetV0>> {
         // Get the most recent block.
-        let block_hash =
-            vm.block_store().get_block_hash(*vm.block_store().heights().max().unwrap().borrow()).unwrap().unwrap();
+        let block_hash = vm.block_store().get_block_hash(vm.block_store().max_height().unwrap()).unwrap().unwrap();
         let previous_block = vm.block_store().get_block(&block_hash).unwrap().unwrap();
 
         // Construct the new block header.

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -38,7 +38,6 @@ use anyhow::Result;
 use console::account::Address;
 use indexmap::IndexMap;
 use rayon::prelude::*;
-use std::borrow::Borrow;
 use utilities::*;
 
 #[test]
@@ -457,8 +456,7 @@ fn construct_next_block<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>
     rng: &mut R,
 ) -> Result<Block<CurrentNetwork>> {
     // Get the most recent block.
-    let block_hash =
-        vm.block_store().get_block_hash(*vm.block_store().heights().max().unwrap().borrow()).unwrap().unwrap();
+    let block_hash = vm.block_store().get_block_hash(vm.block_store().max_height().unwrap()).unwrap().unwrap();
     let previous_block = vm.block_store().get_block(&block_hash).unwrap().unwrap();
 
     // Construct the metadata associated with the block.
@@ -523,7 +521,7 @@ fn construct_finalize_global_state<C: ConsensusStorage<CurrentNetwork>>(
     vm: &VM<CurrentNetwork, C>,
 ) -> FinalizeGlobalState {
     // Retrieve the latest block.
-    let block_height = *vm.block_store().heights().max().unwrap().clone();
+    let block_height = vm.block_store().max_height().unwrap();
     let latest_block_hash = vm.block_store().get_block_hash(block_height).unwrap().unwrap();
     let latest_block = vm.block_store().get_block(&latest_block_hash).unwrap().unwrap();
     // Retrieve the latest round.


### PR DESCRIPTION
Another heap-profiling find applicable to the loading of the ledger; by counting the number of heights instead of deserializing them, we can avoid a large number of allocations.

The results at height 330598 are as follows:
- total allocs **-12%**
- temp allocs: **-15%**
- ledger loading time: **-7%**