### PR TITLE
[Perf] Use heuristics to avoid allocations in Sanitizer::str_till_eol

### DIFF
--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -117,12 +117,33 @@ impl Sanitizer {
     ///
     /// Discard any leading newline.
     fn str_till_eol(string: &str) -> ParserResult<&str> {
-        map(
-            recognize(Self::till(alt((value((), tag("\\\n")), value((), Sanitizer::parse_safe_char))), Self::eol)),
-            |i| {
-                if i.as_bytes().last() == Some(&b'\n') { &i[0..i.len() - 1] } else { i }
-            },
-        )(string)
+        // A heuristic approach is applied here in order to avoid
+        // costly parsing operations in the most common scenarios.
+        if let Some((before, after)) = string.split_once('\n') {
+            let is_multiline = before.ends_with('\\');
+
+            if !is_multiline {
+                let contains_unsafe_chars = !before.chars().all(is_char_supported);
+
+                if !contains_unsafe_chars {
+                    Ok((after, before))
+                } else {
+                    recognize(Self::till(value((), Sanitizer::parse_safe_char), Self::eol))(before)
+                }
+            } else {
+                map(
+                    recognize(Self::till(
+                        alt((value((), tag("\\\n")), value((), Sanitizer::parse_safe_char))),
+                        Self::eol,
+                    )),
+                    |i| {
+                        if i.as_bytes().last() == Some(&b'\n') { &i[0..i.len() - 1] } else { i }
+                    },
+                )(string)
+            }
+        } else {
+            Ok((string, ""))
+        }
     }
 
     /// Parse a string until `*/` is encountered.

--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -280,6 +280,23 @@ mod tests {
             ("hello world", "// hel\u{4141}lo\n"),
             Sanitizer::parse_comments("// hel\u{4141}lo\nhello world").unwrap()
         );
+        assert_eq!(
+            ("hello world", "/* multi\n   line comment\n*/\n"),
+            Sanitizer::parse_comments("/* multi\n   line comment\n*/\nhello world").unwrap()
+        );
+        assert_eq!(
+            ("hello world", "// multiple\n// line\n// comments\n"),
+            Sanitizer::parse_comments("// multiple\n// line\n// comments\nhello world").unwrap()
+        );
+        assert_eq!(
+            ("hello world", "/* multi\n   line comment\n*/\n/* and\n   another\n   one\n*/\n"),
+            Sanitizer::parse_comments("/* multi\n   line comment\n*/\n/* and\n   another\n   one\n*/\nhello world")
+                .unwrap()
+        );
+        assert_eq!(
+            ("hello world", "/* multi\n   line comment\n*/\n// two single\n// line comments\n/* and\n   another\n   multi-liner\n*/\n"),
+            Sanitizer::parse_comments("/* multi\n   line comment\n*/\n// two single\n// line comments\n/* and\n   another\n   multi-liner\n*/\nhello world").unwrap()
+        );
         assert!(Sanitizer::parse_comments("// hel\x08lo\nhello world").is_err());
         assert!(Sanitizer::parse_comments("// hel\u{2066}lo\nhello world").is_err());
         assert!(Sanitizer::parse_comments("/* hel\x7flo */\nhello world").is_err());

--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -129,6 +129,8 @@ impl Sanitizer {
                 if !contains_unsafe_chars {
                     Ok((after, before))
                 } else {
+                    // `eoi` is used here instead of `eol`, since the earlier call to `split_once`
+                    // already removed the newline
                     recognize(Self::till(value((), Sanitizer::parse_safe_char), Self::eoi))(before)
                 }
             } else {

--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -129,7 +129,7 @@ impl Sanitizer {
                 if !contains_unsafe_chars {
                     Ok((after, before))
                 } else {
-                    recognize(Self::till(value((), Sanitizer::parse_safe_char), Self::eol))(before)
+                    recognize(Self::till(value((), Sanitizer::parse_safe_char), Self::eoi))(before)
                 }
             } else {
                 map(

--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -117,8 +117,9 @@ impl Sanitizer {
     ///
     /// Discard any leading newline.
     fn str_till_eol(string: &str) -> ParserResult<&str> {
-        // A heuristic approach is applied here in order to avoid
-        // costly parsing operations in the most common scenarios.
+        // A heuristic approach is applied here in order to avoid costly parsing operations in the
+        // most common scenarios: non-parsing methods are used to verify if the string has multiple
+        // lines and if there are any unsafe characters.
         if let Some((before, after)) = string.split_once('\n') {
             let is_multiline = before.ends_with('\\');
 


### PR DESCRIPTION
(transferred from https://github.com/ProvableHQ/snarkVM/pull/6, and asking @d0cd for a review as suggested there)

The `Sanitizer` is used very prominently in our parsing functions, and it is also a source of many allocations, most of which are temporary and avoidable.

The potential perf improvements are quite large, and I've measured them both with a 15-minute run of a `--dev` node and using `hyperfine` on a small binary that parsed all the valid `.aleo` programs currently present in the snarkVM codebase.

dev node:
- all allocs are down ~**15%**, of which almost all are temporary
- in `Program::from_str` specifically, allocs are reduced by ~**64%**, of which temp allocs ~**88%**

parsing all `.aleo` programs using `Program::from_str`:
- allocs are reduced by ~**41%**
- growth reallocs are down ~**70%**
- runtime is reduced by ~**31%**