### PR TITLE
[Perf] Only use raw iterators with RocksDB and speed up ledger load

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -276,17 +276,21 @@ impl<
 
         // Count the number of keys belonging to the map.
         let mut len = 0usize;
-        while let Some(key) = iter.key() {
-            // Only compare the map ID - the network ID is guaranteed to
-            // remain the same as long as there is more than a single map.
-            if key[2..][..2] != self.context[2..][..2] {
-                // If the map ID is different, it's the end of iteration.
+        while iter.valid() {
+            if let Some(key) = iter.key() {
+                // Only compare the map ID - the network ID is guaranteed to
+                // remain the same as long as there is more than a single map.
+                if key[2..][..2] != self.context[2..][..2] {
+                    // If the map ID is different, it's the end of iteration.
+                    break;
+                }
+
+                // Increment the length and go to the next record.
+                len += 1;
+                iter.next();
+            } else {
                 break;
             }
-
-            // Increment the length and go to the next record.
-            len += 1;
-            iter.next();
         }
 
         len

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -400,7 +400,7 @@ pub struct Iter<
     K: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned,
     V: 'a + PartialEq + Eq + Serialize + DeserializeOwned,
 > {
-    db_iter: rocksdb::DBIterator<'a>,
+    db_iter: rocksdb::DBRawIterator<'a>,
     _phantom: PhantomData<(K, V)>,
 }
 
@@ -411,7 +411,7 @@ impl<
 > Iter<'a, K, V>
 {
     pub(super) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
-        Self { db_iter, _phantom: PhantomData }
+        Self { db_iter: db_iter.into(), _phantom: PhantomData }
     }
 }
 
@@ -424,13 +424,11 @@ impl<
     type Item = (Cow<'a, K>, Cow<'a, V>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, value) = self
-            .db_iter
-            .next()?
-            .map_err(|e| {
-                error!("RocksDB Iter iterator error: {e}");
-            })
-            .ok()?;
+        if !self.db_iter.valid() {
+            return None;
+        }
+
+        let (key, value) = self.db_iter.item()?;
 
         // Deserialize the key and value.
         let key = bincode::deserialize(&key[PREFIX_LEN..])
@@ -438,11 +436,13 @@ impl<
                 error!("RocksDB Iter deserialize(key) error: {e}");
             })
             .ok()?;
-        let value = bincode::deserialize(&value)
+        let value = bincode::deserialize(value)
             .map_err(|e| {
                 error!("RocksDB Iter deserialize(value) error: {e}");
             })
             .ok()?;
+
+        self.db_iter.next();
 
         Some((Cow::Owned(key), Cow::Owned(value)))
     }
@@ -450,13 +450,13 @@ impl<
 
 /// An iterator over the keys of a prefix.
 pub struct Keys<'a, K: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned> {
-    db_iter: rocksdb::DBIterator<'a>,
+    db_iter: rocksdb::DBRawIterator<'a>,
     _phantom: PhantomData<K>,
 }
 
 impl<'a, K: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned> Keys<'a, K> {
     pub(crate) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
-        Self { db_iter, _phantom: PhantomData }
+        Self { db_iter: db_iter.into(), _phantom: PhantomData }
     }
 }
 
@@ -464,20 +464,18 @@ impl<'a, K: 'a + Clone + Debug + PartialEq + Eq + Hash + Serialize + Deserialize
     type Item = Cow<'a, K>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (key, _) = self
-            .db_iter
-            .next()?
-            .map_err(|e| {
-                error!("RocksDB Keys iterator error: {e}");
-            })
-            .ok()?;
+        if !self.db_iter.valid() {
+            return None;
+        }
 
         // Deserialize the key.
-        let key = bincode::deserialize(&key[PREFIX_LEN..])
+        let key = bincode::deserialize(&self.db_iter.key()?[PREFIX_LEN..])
             .map_err(|e| {
                 error!("RocksDB Keys deserialize(key) error: {e}");
             })
             .ok()?;
+
+        self.db_iter.next();
 
         Some(Cow::Owned(key))
     }
@@ -485,13 +483,13 @@ impl<'a, K: 'a + Clone + Debug + PartialEq + Eq + Hash + Serialize + Deserialize
 
 /// An iterator over the values of a prefix.
 pub struct Values<'a, V: 'a + PartialEq + Eq + Serialize + DeserializeOwned> {
-    db_iter: rocksdb::DBIterator<'a>,
+    db_iter: rocksdb::DBRawIterator<'a>,
     _phantom: PhantomData<V>,
 }
 
 impl<'a, V: 'a + PartialEq + Eq + Serialize + DeserializeOwned> Values<'a, V> {
     pub(crate) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
-        Self { db_iter, _phantom: PhantomData }
+        Self { db_iter: db_iter.into(), _phantom: PhantomData }
     }
 }
 
@@ -499,20 +497,18 @@ impl<'a, V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned> Iterator
     type Item = Cow<'a, V>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (_, value) = self
-            .db_iter
-            .next()?
-            .map_err(|e| {
-                error!("RocksDB Values iterator error: {e}");
-            })
-            .ok()?;
+        if !self.db_iter.valid() {
+            return None;
+        }
 
         // Deserialize the value.
-        let value = bincode::deserialize(&value)
+        let value = bincode::deserialize(self.db_iter.value()?)
             .map_err(|e| {
                 error!("RocksDB Values deserialize(value) error: {e}");
             })
             .ok()?;
+
+        self.db_iter.next();
 
         Some(Cow::Owned(value))
     }

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -371,18 +371,22 @@ impl<
 
         // Count the number of keys belonging to the nested map.
         let mut len = 0usize;
-        while let Some(key) = iter.key() {
-            // Only compare the nested map - the network ID and the outer map
-            // ID are guaranteed to remain the same as long as there is more
-            // than a single map in the database.
-            if !key[PREFIX_LEN + 4..].starts_with(serialized_map) {
-                // If the nested map ID is different, it's the end of iteration.
+        while iter.valid() {
+            if let Some(key) = iter.key() {
+                // Only compare the nested map - the network ID and the outer map
+                // ID are guaranteed to remain the same as long as there is more
+                // than a single map in the database.
+                if !key[PREFIX_LEN + 4..].starts_with(serialized_map) {
+                    // If the nested map ID is different, it's the end of iteration.
+                    break;
+                }
+
+                // Increment the length and go to the next record.
+                len += 1;
+                iter.next();
+            } else {
                 break;
             }
-
-            // Increment the length and go to the next record.
-            len += 1;
-            iter.next();
         }
 
         Ok(len)


### PR DESCRIPTION
The signatures of iteration-related methods (with the `rocksdb` feature) have been haunting my heap profiles for a long time now, and while I initially believed this was something we could fine-tune with some configuration, all such attempts were unsatisfactory. It turns out that the "default" (higher-level) RocksDB iterators are just inherently inefficient, and only the `DBRawIterator` is able to avoid a massive number of allocations, some of which may remain lingering in the RSS and contribute to its inflation over time. The raw iterator is somewhat trickier to use correctly, but since it's what the regular iterator is built upon, there is nothing particularly novel about it, and we're already using it to count records.

With these changes I ran profiling with both an instrumented OS allocator and `jemalloc` and - contrary to the usual results - it was the latter that experienced larger relative differences when loading the ledger:
- total allocs and temp allocs were both reduced by **98%**
- ledger load time was down **14%**
- max RSS was reduced by **13%**

In addition, `heaptrack` ran **73%** faster and produced a **99%** smaller profile, which is very practical for future profiling needs.

Alongside these changes I realized that the current `len_confirmed` method - while working correctly and passing all tests - can be made more solid by including iterator validity checks; the only situation where this would truly be needed is if it was called on the very last map in the database and if the map was empty, but [this commit](https://github.com/AleoNet/snarkVM/commit/f8fc68ca22ce9369f3e82107c48f3738bf00af50) guards against that edge case.

The [final commit](https://github.com/AleoNet/snarkVM/commit/1dbf87418379118a74c2f53fd9f45b444c6c2d6b) is a further improvement on one of the changes from https://github.com/AleoNet/snarkVM/pull/2515 (and made possible with the switch to raw iterators).

[CI run link](https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM?branch=perf%2Fraw_rocks_iter-ci)