### PR TITLE
Feat/lazy load deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "colored",
  "criterion",
  "indexmap 2.2.6",
+ "lru",
  "once_cell",
  "parking_lot",
  "rand",
@@ -3457,6 +3458,7 @@ dependencies = [
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/ledger/puzzle/epoch/src/synthesis/program/mod.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/mod.rs
@@ -103,7 +103,7 @@ function synthesize:
         let program = Program::from_str(&program_string)?;
 
         // Initialize a new process.
-        let process = Process::<N>::load()?;
+        let process = Process::<N>::for_puzzle()?;
         // Initialize the stack with the synthesis challenge program.
         let stack = Stack::new(&process, &program)?;
 

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -32,7 +32,7 @@ aleo-cli = [ ]
 async = [ "ledger-query/async", "synthesizer-process/async" ]
 cuda = [ "algorithms/cuda" ]
 history = [ "serde" ]
-rocks = [ "ledger-store/rocks" ]
+rocks = ["ledger-store/rocks", "synthesizer-process/rocks"]
 serial = [
   "console/serial",
   "ledger-block/serial",

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -78,6 +78,9 @@ package = "snarkvm-ledger-store"
 path = "../../ledger/store"
 version = "=0.16.19"
 
+[dependencies.lru]
+version = "0.12"
+
 [dependencies.synthesizer-program]
 package = "snarkvm-synthesizer-program"
 path = "../../synthesizer/program"
@@ -93,9 +96,12 @@ package = "snarkvm-utilities"
 path = "../../utilities"
 version = "=0.16.19"
 
+[dependencies.tracing]
+version = "0.1"
+
 [dependencies.aleo-std]
 version = "0.1.24"
-default-features = false
+features = ["storage"]
 
 [dependencies.colored]
 version = "2"

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -40,7 +40,7 @@ impl<N: Network> Process<N> {
     /// Adds the newly-deployed program.
     /// This method assumes the given deployment **is valid**.
     #[inline]
-    pub fn load_deployment(&mut self, deployment: &Deployment<N>) -> Result<()> {
+    pub fn load_deployment(&self, deployment: &Deployment<N>) -> Result<()> {
         let timer = timer!("Process::load_deployment");
 
         // Compute the program stack.

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -53,7 +53,7 @@ impl<N: Network> Process<N> {
             // Retrieve the fee stack.
             let fee_stack = self.get_stack(fee.program_id())?;
             // Finalize the fee transition.
-            finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
+            finalize_operations.extend(finalize_fee_transition(state, store, &fee_stack, fee)?);
             lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
 
             /* Finalize the deployment. */
@@ -109,7 +109,7 @@ impl<N: Network> Process<N> {
             // Finalize the root transition.
             // Note that this will result in all the remaining transitions being finalized, since the number
             // of calls matches the number of transitions.
-            let mut finalize_operations = finalize_transition(state, store, stack, transition, call_graph)?;
+            let mut finalize_operations = finalize_transition(state, store, &stack, transition, call_graph)?;
 
             /* Finalize the fee. */
 
@@ -117,7 +117,7 @@ impl<N: Network> Process<N> {
                 // Retrieve the fee stack.
                 let fee_stack = self.get_stack(fee.program_id())?;
                 // Finalize the fee transition.
-                finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
+                finalize_operations.extend(finalize_fee_transition(state, store, &fee_stack, fee)?);
                 lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
             }
 
@@ -143,7 +143,7 @@ impl<N: Network> Process<N> {
             // Retrieve the stack.
             let stack = self.get_stack(fee.program_id())?;
             // Finalize the fee transition.
-            let result = finalize_fee_transition(state, store, stack, fee);
+            let result = finalize_fee_transition(state, store, &stack, fee);
             finish!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
             // Return the result.
             result
@@ -495,7 +495,7 @@ function compute:
         .unwrap();
 
         // Initialize a new process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Deploy the program.
         let deployment = process.deploy::<CurrentAleo, _>(&program, rng).unwrap();
 

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -88,7 +88,7 @@ use ledger_store::helpers::memory::ConsensusMemory;
 use ledger_store::helpers::rocksdb::ConsensusDB;
 
 #[cfg(not(any(test, feature = "test")))]
-const MAX_STACKS: usize = 50;
+const MAX_STACKS: usize = 1000;
 
 #[cfg(any(test, feature = "test"))]
 const MAX_STACKS: usize = 2;

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -87,7 +87,11 @@ use ledger_store::helpers::memory::ConsensusMemory;
 #[cfg(feature = "rocks")]
 use ledger_store::helpers::rocksdb::ConsensusDB;
 
+#[cfg(not(any(test, feature = "test")))]
 const MAX_STACKS: usize = 50;
+
+#[cfg(any(test, feature = "test"))]
+const MAX_STACKS: usize = 2;
 
 #[derive(Clone)]
 pub struct Process<N: Network> {

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -249,6 +249,21 @@ impl<N: Network> Process<N> {
         Ok(process)
     }
 
+    /// Initializes a new process without creating the 'credits.aleo' program.
+    #[inline]
+    pub fn for_puzzle() -> Result<Self> {
+        // Initialize the process.
+        let process = Self {
+            universal_srs: Arc::new(UniversalSRS::load()?),
+            credits: None,
+            stacks: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(MAX_STACKS).unwrap()))),
+            store: None,
+        };
+
+        // Return the process.
+        Ok(process)
+    }
+
     /// Initializes a new process without downloading the 'credits.aleo' circuit keys (for web contexts).
     #[inline]
     #[cfg(feature = "wasm")]

--- a/synthesizer/process/src/tests/mod.rs
+++ b/synthesizer/process/src/tests/mod.rs
@@ -14,3 +14,4 @@
 
 pub mod test_credits;
 pub mod test_execute;
+pub mod test_process;

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -2889,7 +2889,7 @@ mod sanity_checks {
         let r2 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1, r2], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1, r2], rng);
         assert_eq!(16, assignment.num_public());
         assert_eq!(50956, assignment.num_private());
         assert_eq!(51002, assignment.num_constraints());
@@ -2917,7 +2917,7 @@ mod sanity_checks {
         let r1 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1], rng);
         assert_eq!(11, assignment.num_public());
         assert_eq!(12318, assignment.num_private());
         assert_eq!(12325, assignment.num_constraints());
@@ -2945,7 +2945,7 @@ mod sanity_checks {
         let r1 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1], rng);
         assert_eq!(11, assignment.num_public());
         assert_eq!(12323, assignment.num_private());
         assert_eq!(12330, assignment.num_constraints());
@@ -2979,7 +2979,7 @@ mod sanity_checks {
         let r3 = Value::<CurrentNetwork>::from_str(&Field::<CurrentNetwork>::rand(rng).to_string()).unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1, r2, r3], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1, r2, r3], rng);
         assert_eq!(15, assignment.num_public());
         assert_eq!(38115, assignment.num_private());
         assert_eq!(38151, assignment.num_constraints());
@@ -3007,7 +3007,7 @@ mod sanity_checks {
         let r2 = Value::<CurrentNetwork>::from_str(&Field::<CurrentNetwork>::rand(rng).to_string()).unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1, r2], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1, r2], rng);
         assert_eq!(12, assignment.num_public());
         assert_eq!(12920, assignment.num_private());
         assert_eq!(12930, assignment.num_constraints());

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -2371,7 +2371,7 @@ fn test_process_deploy_credits_program() {
         universal_srs: Arc::new(UniversalSRS::<CurrentNetwork>::load().unwrap()),
         credits: None,
         stacks: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(MAX_STACKS).unwrap()))),
-        storage_mode: None,
+        store: None,
     };
 
     // Construct the process.

--- a/synthesizer/process/src/tests/test_process.rs
+++ b/synthesizer/process/src/tests/test_process.rs
@@ -1,0 +1,100 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str::FromStr;
+
+use console::{
+    network::MainnetV0,
+    program::{Parser, ProgramID},
+};
+use synthesizer_program::Program;
+
+use crate::Process;
+
+type CurrentNetwork = MainnetV0;
+
+#[test]
+pub fn test_credits() {
+    let process = Process::load().unwrap();
+    let credits_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+    assert!(process.contains_program(&credits_id));
+}
+
+#[test]
+pub fn test_cache() {
+    let (_, program1) = Program::<CurrentNetwork>::parse(
+        r"
+program testing1.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.public;
+    add r0 r1 into r2;
+    output r2 as u32.public;",
+    )
+    .unwrap();
+    // Initialize a new process.
+    let process = crate::test_helpers::sample_process(&program1);
+    assert!(process.contains_program(program1.id()));
+}
+
+#[test]
+pub fn test_cache_evict() {
+    let (_, program1) = Program::<CurrentNetwork>::parse(
+        r"
+program testing1.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.public;
+    add r0 r1 into r2;
+    output r2 as u32.public;",
+    )
+    .unwrap();
+    let (_, program2) = Program::<CurrentNetwork>::parse(
+        r"
+program testing2.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.public;
+    add r0 r1 into r2;
+    output r2 as u32.public;",
+    )
+    .unwrap();
+    let (_, program3) = Program::<CurrentNetwork>::parse(
+        r"
+program testing3.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.public;
+    add r0 r1 into r2;
+    output r2 as u32.public;",
+    )
+    .unwrap();
+
+    // Initialize a new process.
+    let mut process = crate::test_helpers::sample_process(&program1);
+    assert!(process.contains_program(program1.id()));
+    process.add_program(&program2).unwrap();
+    assert!(process.contains_program(program2.id()));
+    process.add_program(&program3).unwrap();
+    assert!(process.contains_program(program3.id()));
+    // only 2 programs are cached, so program1 should be evicted
+    assert!(!process.contains_program(program1.id()));
+    // test we still have credits.aleo
+    let credits_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+    assert!(process.contains_program(&credits_id));
+}

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -570,7 +570,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Acquire the write lock on the process.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
             // we choose to acquire the write lock for the entire duration of this atomic batch.
-            let mut process = self.process.write();
+            let process = self.process.write();
 
             // Initialize a list for the deployed stacks.
             let mut stacks = Vec::new();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -54,7 +54,6 @@ use ledger_store::{
     ConsensusStore,
     FinalizeMode,
     FinalizeStore,
-    TransactionStorage,
     TransactionStore,
     TransitionStore,
 };
@@ -96,7 +95,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     #[inline]
     pub fn from(store: ConsensusStore<N, C>) -> Result<Self> {
         // Initialize a new process.
-        let mut process = Process::load()?;
+        let process = Process::load_from_storage(Some(store.storage_mode().clone()))?;
 
         // Initialize the store for 'credits.aleo'.
         let credits = Program::<N>::credits()?;
@@ -105,83 +104,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             if !store.finalize_store().contains_mapping_confirmed(credits.id(), mapping.name())? {
                 // Initialize the mappings for 'credits.aleo'.
                 store.finalize_store().initialize_mapping(*credits.id(), *mapping.name())?;
-            }
-        }
-
-        // A helper function to retrieve all the deployments.
-        fn load_deployment_and_imports<N: Network, T: TransactionStorage<N>>(
-            process: &Process<N>,
-            transaction_store: &TransactionStore<N, T>,
-            transaction_id: N::TransactionID,
-        ) -> Result<Vec<(ProgramID<N>, Deployment<N>)>> {
-            // Retrieve the deployment from the transaction ID.
-            let deployment = match transaction_store.get_deployment(&transaction_id)? {
-                Some(deployment) => deployment,
-                None => bail!("Deployment transaction '{transaction_id}' is not found in storage."),
-            };
-
-            // Fetch the program from the deployment.
-            let program = deployment.program();
-            let program_id = program.id();
-
-            // Return early if the program is already loaded.
-            if process.contains_program(program_id) {
-                return Ok(vec![]);
-            }
-
-            // Prepare a vector for the deployments.
-            let mut deployments = vec![];
-
-            // Iterate through the program imports.
-            for import_program_id in program.imports().keys() {
-                // Add the imports to the process if does not exist yet.
-                if !process.contains_program(import_program_id) {
-                    // Fetch the deployment transaction ID.
-                    let Some(transaction_id) =
-                        transaction_store.deployment_store().find_transaction_id_from_program_id(import_program_id)?
-                    else {
-                        bail!("Transaction ID for '{program_id}' is not found in storage.");
-                    };
-
-                    // Add the deployment and its imports found recursively.
-                    deployments.extend_from_slice(&load_deployment_and_imports(
-                        process,
-                        transaction_store,
-                        transaction_id,
-                    )?);
-                }
-            }
-
-            // Once all the imports have been included, add the parent deployment.
-            deployments.push((*program_id, deployment));
-
-            Ok(deployments)
-        }
-
-        // Retrieve the transaction store.
-        let transaction_store = store.transaction_store();
-        // Retrieve the list of deployment transaction IDs.
-        let deployment_ids = transaction_store.deployment_transaction_ids().collect::<Vec<_>>();
-        // Load the deployments from the store.
-        for (i, chunk) in deployment_ids.chunks(256).enumerate() {
-            debug!(
-                "Loading deployments {}-{} (of {})...",
-                i * 256,
-                ((i + 1) * 256).min(deployment_ids.len()),
-                deployment_ids.len()
-            );
-            let deployments = cfg_iter!(chunk)
-                .map(|transaction_id| {
-                    // Load the deployment and its imports.
-                    load_deployment_and_imports(&process, transaction_store, **transaction_id)
-                })
-                .collect::<Result<Vec<_>>>()?;
-
-            for (program_id, deployment) in deployments.iter().flatten() {
-                // Load the deployment if it does not exist in the process yet.
-                if !process.contains_program(program_id) {
-                    process.load_deployment(deployment)?;
-                }
             }
         }
 

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -177,11 +177,8 @@ impl<N: Network> Package<N> {
         let process = self.get_process()?;
 
         // Retrieve the imported programs.
-        let imported_programs = program
-            .imports()
-            .keys()
-            .map(|program_id| process.get_program(program_id).cloned())
-            .collect::<Result<Vec<_>>>()?;
+        let imported_programs =
+            program.imports().keys().map(|program_id| process.get_program(program_id)).collect::<Result<Vec<_>>>()?;
 
         // Synthesize each proving and verifying key.
         for function_name in program.functions().keys() {
@@ -230,7 +227,7 @@ impl<N: Network> Package<N> {
                         CallOperator::Locator(locator) => {
                             (process.get_program(locator.program_id())?, locator.resource())
                         }
-                        CallOperator::Resource(resource) => (program, resource),
+                        CallOperator::Resource(resource) => (program.clone(), resource),
                     };
                     // If this is a function call, save its corresponding prover and verifier files.
                     if program.contains_function(resource) {

--- a/vm/package/execute.rs
+++ b/vm/package/execute.rs
@@ -60,7 +60,7 @@ impl<N: Network> Package<N> {
                 // Retrieve the program and resource.
                 let (program, resource) = match call.operator() {
                     CallOperator::Locator(locator) => (process.get_program(locator.program_id())?, locator.resource()),
-                    CallOperator::Resource(resource) => (program, resource),
+                    CallOperator::Resource(resource) => (program.clone(), resource),
                 };
                 // If this is a function call, save its corresponding prover and verifier files.
                 if program.contains_function(resource) {


### PR DESCRIPTION
## Motivation

We've seen that RSS size is correlated with deployments loaded (and staying) in memory. This PR keeps `MAX_STACKS` programs in memory (chosen arbitrarily at 1000). 

## Test Plan

Tested by running a local devnet, deploying programs and executing them. Then restarting the network and trying to execute these programs. The `Stack`s were lazily loaded from storage, execution worked. Also tested executing programs that are not deployed.
