### PR TITLE
[Fix] Add checksum to `TransmissionID`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: xlarge
   twoxlarge:
     type: string
-    default: aleonet/2xlarge
+    default: 2xlarge
 
 orbs:
   windows: circleci/windows@5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: xlarge
   twoxlarge:
     type: string
-    default: 2xlarge
+    default: aleonet/2xlarge
 
 orbs:
   windows: circleci/windows@5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,6 +3416,7 @@ dependencies = [
  "snarkvm-ledger-block",
  "snarkvm-ledger-committee",
  "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-data",
  "snarkvm-ledger-puzzle",
  "snarkvm-ledger-puzzle-epoch",
  "snarkvm-ledger-query",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,6 +3132,7 @@ dependencies = [
  "snarkvm-ledger-authority",
  "snarkvm-ledger-committee",
  "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-data",
  "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-transmission-id",
  "snarkvm-ledger-puzzle",

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -130,7 +130,7 @@ impl Network for CanaryV0 {
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
     /// The transmission checksum type.
-    type TransmissionChecksum = [u8; 32];
+    type TransmissionChecksum = u128;
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -130,7 +130,7 @@ impl Network for CanaryV0 {
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
     /// The transmission checksum type.
-    type TransmissionChecksum = AleoID<Field<Self>, { hrp2!("ch") }>;
+    type TransmissionChecksum = [u8; 32];
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -129,6 +129,8 @@ impl Network for CanaryV0 {
     type TransactionID = AleoID<Field<Self>, { hrp2!(TRANSACTION_PREFIX) }>;
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
+    /// The transmission checksum type.
+    type TransmissionChecksum = AleoID<Field<Self>, { hrp2!("ch") }>;
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -216,7 +216,7 @@ pub trait Network:
     /// The transition ID type.
     type TransitionID: Bech32ID<Field<Self>>;
     /// The transmission checksum type.
-    type TransmissionChecksum: Bech32ID<Field<Self>>;
+    type TransmissionChecksum;
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -216,7 +216,7 @@ pub trait Network:
     /// The transition ID type.
     type TransitionID: Bech32ID<Field<Self>>;
     /// The transmission checksum type.
-    type TransmissionChecksum;
+    type TransmissionChecksum: IntegerType;
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -215,6 +215,8 @@ pub trait Network:
     type TransactionID: Bech32ID<Field<Self>>;
     /// The transition ID type.
     type TransitionID: Bech32ID<Field<Self>>;
+    /// The transmission checksum type.
+    type TransmissionChecksum: Bech32ID<Field<Self>>;
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -131,7 +131,7 @@ impl Network for MainnetV0 {
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
     /// The transmission checksum type.
-    type TransmissionChecksum = [u8; 32];
+    type TransmissionChecksum = u128;
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -130,6 +130,8 @@ impl Network for MainnetV0 {
     type TransactionID = AleoID<Field<Self>, { hrp2!(TRANSACTION_PREFIX) }>;
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
+    /// The transmission checksum type.
+    type TransmissionChecksum = AleoID<Field<Self>, { hrp2!("ch") }>;
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -131,7 +131,7 @@ impl Network for MainnetV0 {
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
     /// The transmission checksum type.
-    type TransmissionChecksum = AleoID<Field<Self>, { hrp2!("ch") }>;
+    type TransmissionChecksum = [u8; 32];
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -130,7 +130,7 @@ impl Network for TestnetV0 {
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
     /// The transmission checksum type.
-    type TransmissionChecksum = AleoID<Field<Self>, { hrp2!("ch") }>;
+    type TransmissionChecksum = [u8; 32];
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -129,6 +129,8 @@ impl Network for TestnetV0 {
     type TransactionID = AleoID<Field<Self>, { hrp2!(TRANSACTION_PREFIX) }>;
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
+    /// The transmission checksum type.
+    type TransmissionChecksum = AleoID<Field<Self>, { hrp2!("ch") }>;
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -130,7 +130,7 @@ impl Network for TestnetV0 {
     /// The transition ID type.
     type TransitionID = AleoID<Field<Self>, { hrp2!("au") }>;
     /// The transmission checksum type.
-    type TransmissionChecksum = [u8; 32];
+    type TransmissionChecksum = u128;
 
     /// The network edition.
     const EDITION: u16 = 0;

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -56,6 +56,11 @@ package = "snarkvm-ledger-narwhal-batch-header"
 path = "../narwhal/batch-header"
 version = "=0.16.19"
 
+[dependencies.ledger-narwhal-data]
+package = "snarkvm-ledger-narwhal-data"
+path = "../narwhal/data"
+version = "=0.16.19"
+
 [dependencies.ledger-narwhal-subdag]
 package = "snarkvm-ledger-narwhal-subdag"
 path = "../narwhal/subdag"

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -55,6 +55,7 @@ use console::{
 };
 use ledger_authority::Authority;
 use ledger_committee::Committee;
+use ledger_narwhal_data::Data;
 use ledger_narwhal_subdag::Subdag;
 use ledger_narwhal_transmission_id::TransmissionID;
 use ledger_puzzle::{PuzzleSolutions, Solution, SolutionID};

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -563,7 +563,7 @@ impl<N: Network> Block<N> {
             // Process the transmission ID.
             match transmission_id {
                 TransmissionID::Ratification => {}
-                TransmissionID::Solution(solution_id) => {
+                TransmissionID::Solution(solution_id, _) => {
                     match solutions.peek() {
                         // Check the next solution matches the expected solution ID.
                         Some((_, solution)) if solution.id() == *solution_id => {
@@ -578,7 +578,7 @@ impl<N: Network> Block<N> {
                         }
                     }
                 }
-                TransmissionID::Transaction(transaction_id) => {
+                TransmissionID::Transaction(transaction_id, _) => {
                     match unconfirmed_transaction_ids.peek() {
                         // Check the next transaction matches the expected transaction.
                         Some(expected_id) if transaction_id == *expected_id => {

--- a/ledger/narwhal/data/src/lib.rs
+++ b/ledger/narwhal/data/src/lib.rs
@@ -35,12 +35,14 @@ pub enum Data<T: FromBytes + ToBytes + Send + 'static> {
 }
 
 impl<T: FromBytes + ToBytes + Send + 'static> Data<T> {
-    pub fn to_checksum<N: Network>(&self) -> Result<Vec<bool>> {
+    pub fn to_checksum<N: Network>(&self) -> N::TransmissionChecksum {
+        // Convert to bits.
         let bits = match self {
             Self::Object(object) => object.to_bytes_le().unwrap().to_bits_le(),
             Self::Buffer(bytes) => bytes.deref().to_bits_le(),
         };
-        N::hash_sha3_256(&bits)
+        // Hash the bits.
+        N::hash_sha3_256(&bits).unwrap().to_bytes_le().unwrap().try_into().unwrap() // TODO: cleanly catch and convert the errors.
     }
 
     pub fn into<T2: From<Data<T>> + From<T> + FromBytes + ToBytes + Send + 'static>(self) -> Data<T2> {

--- a/ledger/narwhal/data/src/lib.rs
+++ b/ledger/narwhal/data/src/lib.rs
@@ -35,6 +35,14 @@ pub enum Data<T: FromBytes + ToBytes + Send + 'static> {
 }
 
 impl<T: FromBytes + ToBytes + Send + 'static> Data<T> {
+    pub fn to_checksum<N: Network>(&self) -> Result<Vec<bool>> {
+        let bits = match self {
+            Self::Object(object) => object.to_bytes_le().unwrap().to_bits_le(),
+            Self::Buffer(bytes) => bytes.deref().to_bits_le(),
+        };
+        N::hash_sha3_256(&bits)
+    }
+
     pub fn into<T2: From<Data<T>> + From<T> + FromBytes + ToBytes + Send + 'static>(self) -> Data<T2> {
         match self {
             Self::Object(x) => Data::Object(x.into()),

--- a/ledger/narwhal/transmission-id/src/bytes.rs
+++ b/ledger/narwhal/transmission-id/src/bytes.rs
@@ -42,8 +42,8 @@ impl<N: Network> ToBytes for TransmissionID<N> {
             }
             Self::Transaction(id, checksum) => {
                 2u8.write_le(&mut writer)?;
-                checksum.write_le(&mut writer)?;
-                id.write_le(&mut writer)
+                id.write_le(&mut writer)?;
+                checksum.write_le(&mut writer)
             }
         }
     }

--- a/ledger/narwhal/transmission-id/src/bytes.rs
+++ b/ledger/narwhal/transmission-id/src/bytes.rs
@@ -22,8 +22,8 @@ impl<N: Network> FromBytes for TransmissionID<N> {
         // Match the variant.
         match variant {
             0 => Ok(Self::Ratification),
-            1 => Ok(Self::Solution(FromBytes::read_le(&mut reader)?)),
-            2 => Ok(Self::Transaction(FromBytes::read_le(&mut reader)?)),
+            1 => Ok(Self::Solution(FromBytes::read_le(&mut reader)?, FromBytes::read_le(&mut reader)?)),
+            2 => Ok(Self::Transaction(FromBytes::read_le(&mut reader)?, FromBytes::read_le(&mut reader)?)),
             3.. => Err(error("Invalid worker transmission ID variant")),
         }
     }
@@ -35,12 +35,14 @@ impl<N: Network> ToBytes for TransmissionID<N> {
         // Write the transmission.
         match self {
             Self::Ratification => 0u8.write_le(&mut writer),
-            Self::Solution(id) => {
+            Self::Solution(id, checksum) => {
                 1u8.write_le(&mut writer)?;
-                id.write_le(&mut writer)
+                id.write_le(&mut writer)?;
+                checksum.write_le(&mut writer)
             }
-            Self::Transaction(id) => {
+            Self::Transaction(id, checksum) => {
                 2u8.write_le(&mut writer)?;
+                checksum.write_le(&mut writer)?;
                 id.write_le(&mut writer)
             }
         }

--- a/ledger/narwhal/transmission-id/src/lib.rs
+++ b/ledger/narwhal/transmission-id/src/lib.rs
@@ -83,14 +83,14 @@ pub mod test_helpers {
         for _ in 0..5 {
             sample.push(TransmissionID::Solution(
                 SolutionID::from(rng.gen::<u64>()),
-                <CurrentNetwork as Network>::TransmissionChecksum::from(Field::rand(rng)),
+                <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<[u8; 32]>()),
             ));
         }
         // Append sample transaction IDs.
         for _ in 0..5 {
             let id = TransmissionID::Transaction(
                 <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
-                <CurrentNetwork as Network>::TransmissionChecksum::from(Field::rand(rng)),
+                <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<[u8; 32]>()),
             );
             sample.push(id);
         }

--- a/ledger/narwhal/transmission-id/src/lib.rs
+++ b/ledger/narwhal/transmission-id/src/lib.rs
@@ -27,22 +27,22 @@ pub enum TransmissionID<N: Network> {
     /// A ratification.
     Ratification,
     /// A solution.
-    Solution(SolutionID<N>),
+    Solution(SolutionID<N>, N::TransmissionChecksum),
     /// A transaction.
-    Transaction(N::TransactionID),
+    Transaction(N::TransactionID, N::TransmissionChecksum),
 }
 
-impl<N: Network> From<SolutionID<N>> for TransmissionID<N> {
+impl<N: Network> From<(SolutionID<N>, N::TransmissionChecksum)> for TransmissionID<N> {
     /// Converts the solution ID into a transmission ID.
-    fn from(solution_id: SolutionID<N>) -> Self {
-        Self::Solution(solution_id)
+    fn from((solution_id, checksum): (SolutionID<N>, N::TransmissionChecksum)) -> Self {
+        Self::Solution(solution_id, checksum)
     }
 }
 
-impl<N: Network> From<&N::TransactionID> for TransmissionID<N> {
+impl<N: Network> From<(&N::TransactionID, &N::TransmissionChecksum)> for TransmissionID<N> {
     /// Converts the transaction ID into a transmission ID.
-    fn from(transaction_id: &N::TransactionID) -> Self {
-        Self::Transaction(*transaction_id)
+    fn from((transaction_id, checksum): (&N::TransactionID, &N::TransmissionChecksum)) -> Self {
+        Self::Transaction(*transaction_id, *checksum)
     }
 }
 
@@ -50,7 +50,7 @@ impl<N: Network> TransmissionID<N> {
     /// Returns the solution ID if the transmission is a solution.
     pub fn solution(&self) -> Option<SolutionID<N>> {
         match self {
-            Self::Solution(solution_id) => Some(*solution_id),
+            Self::Solution(solution_id, _) => Some(*solution_id),
             _ => None,
         }
     }
@@ -58,7 +58,7 @@ impl<N: Network> TransmissionID<N> {
     /// Returns the transaction ID if the transmission is a transaction.
     pub fn transaction(&self) -> Option<N::TransactionID> {
         match self {
-            Self::Transaction(transaction_id) => Some(*transaction_id),
+            Self::Transaction(transaction_id, _) => Some(*transaction_id),
             _ => None,
         }
     }
@@ -81,11 +81,17 @@ pub mod test_helpers {
         let mut sample = Vec::with_capacity(10);
         // Append sample solution IDs.
         for _ in 0..5 {
-            sample.push(TransmissionID::Solution(SolutionID::from(rng.gen::<u64>())));
+            sample.push(TransmissionID::Solution(
+                SolutionID::from(rng.gen::<u64>()),
+                <CurrentNetwork as Network>::TransmissionChecksum::from(Field::rand(rng)),
+            ));
         }
         // Append sample transaction IDs.
         for _ in 0..5 {
-            let id = TransmissionID::Transaction(<CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)));
+            let id = TransmissionID::Transaction(
+                <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+                <CurrentNetwork as Network>::TransmissionChecksum::from(Field::rand(rng)),
+            );
             sample.push(id);
         }
         // Return the sample vector.

--- a/ledger/narwhal/transmission-id/src/lib.rs
+++ b/ledger/narwhal/transmission-id/src/lib.rs
@@ -62,6 +62,15 @@ impl<N: Network> TransmissionID<N> {
             _ => None,
         }
     }
+
+    /// Returns the checksum of the transmission.
+    pub fn checksum(&self) -> Option<N::TransmissionChecksum> {
+        match self {
+            Self::Ratification => None,
+            Self::Solution(_, checksum) => Some(*checksum),
+            Self::Transaction(_, checksum) => Some(*checksum),
+        }
+    }
 }
 
 #[cfg(any(test, feature = "test-helpers"))]
@@ -83,14 +92,14 @@ pub mod test_helpers {
         for _ in 0..5 {
             sample.push(TransmissionID::Solution(
                 SolutionID::from(rng.gen::<u64>()),
-                <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<[u8; 32]>()),
+                <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
             ));
         }
         // Append sample transaction IDs.
         for _ in 0..5 {
             let id = TransmissionID::Transaction(
                 <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
-                <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<[u8; 32]>()),
+                <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
             );
             sample.push(id);
         }

--- a/ledger/narwhal/transmission-id/src/lib.rs
+++ b/ledger/narwhal/transmission-id/src/lib.rs
@@ -33,14 +33,14 @@ pub enum TransmissionID<N: Network> {
 }
 
 impl<N: Network> From<(SolutionID<N>, N::TransmissionChecksum)> for TransmissionID<N> {
-    /// Converts the solution ID into a transmission ID.
+    /// Converts the solution ID and checksum into a transmission ID.
     fn from((solution_id, checksum): (SolutionID<N>, N::TransmissionChecksum)) -> Self {
         Self::Solution(solution_id, checksum)
     }
 }
 
 impl<N: Network> From<(&N::TransactionID, &N::TransmissionChecksum)> for TransmissionID<N> {
-    /// Converts the transaction ID into a transmission ID.
+    /// Converts the transaction ID and checksum into a transmission ID.
     fn from((transaction_id, checksum): (&N::TransactionID, &N::TransmissionChecksum)) -> Self {
         Self::Transaction(*transaction_id, *checksum)
     }
@@ -63,7 +63,7 @@ impl<N: Network> TransmissionID<N> {
         }
     }
 
-    /// Returns the checksum of the transmission.
+    /// Returns the checksum if the transmission is a solution or a transaction.
     pub fn checksum(&self) -> Option<N::TransmissionChecksum> {
         match self {
             Self::Ratification => None,

--- a/ledger/narwhal/transmission/src/lib.rs
+++ b/ledger/narwhal/transmission/src/lib.rs
@@ -64,6 +64,17 @@ impl<N: Network> From<Data<Transaction<N>>> for Transmission<N> {
     }
 }
 
+impl<N: Network> Transmission<N> {
+    /// Returns the checksum of the transmission.
+    pub fn checksum(&self) -> Result<Option<N::TransmissionChecksum>> {
+        match self {
+            Self::Ratification => Ok(None),
+            Self::Solution(solution) => solution.to_checksum::<N>().map(Some),
+            Self::Transaction(transaction) => transaction.to_checksum::<N>().map(Some),
+        }
+    }
+}
+
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers {
     use super::*;

--- a/ledger/narwhal/transmission/src/lib.rs
+++ b/ledger/narwhal/transmission/src/lib.rs
@@ -66,7 +66,7 @@ impl<N: Network> From<Data<Transaction<N>>> for Transmission<N> {
 
 impl<N: Network> Transmission<N> {
     /// Returns the checksum of the transmission.
-    pub fn checksum(&self) -> Result<Option<N::TransmissionChecksum>> {
+    pub fn to_checksum(&self) -> Result<Option<N::TransmissionChecksum>> {
         match self {
             Self::Ratification => Ok(None),
             Self::Solution(solution) => solution.to_checksum::<N>().map(Some),

--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -266,6 +266,34 @@ impl<N: Network> Puzzle<N> {
         Ok(())
     }
 
+    /// ATTENTION: This function will update the target if the solution target is different from the calculated one.
+    /// Returns `Ok(())` if the solution is valid.
+    pub fn check_solution_mut(
+        &self,
+        solution: &mut Solution<N>,
+        expected_epoch_hash: N::BlockHash,
+        expected_proof_target: u64,
+    ) -> Result<()> {
+        // Ensure the epoch hash matches.
+        if solution.epoch_hash() != expected_epoch_hash {
+            bail!(
+                "Solution does not match the expected epoch hash (found '{}', expected '{expected_epoch_hash}')",
+                solution.epoch_hash()
+            )
+        }
+        // Calculate the proof target of the solution.
+        let proof_target = self.get_proof_target_unchecked(solution)?;
+
+        // Set the target with the newly calculated proof target value.
+        solution.target = proof_target;
+
+        // Ensure the solution is greater than or equal to the expected proof target.
+        if proof_target < expected_proof_target {
+            bail!("Solution does not meet the proof target requirement ({proof_target} < {expected_proof_target})")
+        }
+        Ok(())
+    }
+
     /// Returns `Ok(())` if the solutions are valid.
     pub fn check_solutions(
         &self,

--- a/ledger/puzzle/src/solution/mod.rs
+++ b/ledger/puzzle/src/solution/mod.rs
@@ -25,7 +25,7 @@ pub struct Solution<N: Network> {
     /// The partial solution.
     partial_solution: PartialSolution<N>,
     /// The solution target.
-    target: u64,
+    pub(super) target: u64,
 }
 
 impl<N: Network> Solution<N> {

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -154,14 +154,10 @@ where
         };
 
         // Verify the solutions in the chunk.
-        let verification_results: Vec<_> = candidates_chunk
-            .iter_mut()
-            .rev()
-            .map(|solution| {
-                let verified = verification_fn(solution);
-                (solution, verified)
-            })
-            .collect();
+        let verification_results = candidates_chunk.iter_mut().rev().map(|solution| {
+            let verified = verification_fn(solution);
+            (solution, verified)
+        });
 
         // Process the results of the verification.
         for (solution, is_valid) in verification_results.into_iter() {

--- a/ledger/src/contains.rs
+++ b/ledger/src/contains.rs
@@ -44,8 +44,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     pub fn contains_transmission(&self, transmission_id: &TransmissionID<N>) -> Result<bool> {
         match transmission_id {
             TransmissionID::Ratification => Ok(false),
-            TransmissionID::Solution(solution_id) => self.contains_solution_id(solution_id),
-            TransmissionID::Transaction(transaction_id) => self.contains_transaction_id(transaction_id),
+            TransmissionID::Solution(solution_id, _) => self.contains_solution_id(solution_id),
+            TransmissionID::Transaction(transaction_id, _) => self.contains_transaction_id(transaction_id),
         }
     }
 

--- a/ledger/src/helpers/bft.rs
+++ b/ledger/src/helpers/bft.rs
@@ -46,7 +46,7 @@ pub fn decouple_transmissions<N: Network>(
         // Deserialize and store the transmission.
         match (transmission_id, transmission) {
             (TransmissionID::Ratification, Transmission::Ratification) => (),
-            (TransmissionID::Solution(commitment), Transmission::Solution(solution)) => {
+            (TransmissionID::Solution(commitment, _), Transmission::Solution(solution)) => {
                 // Deserialize the solution.
                 let solution = solution.deserialize_blocking()?;
                 // Ensure the transmission ID corresponds to the solution.
@@ -54,7 +54,7 @@ pub fn decouple_transmissions<N: Network>(
                 // Insert the solution into the list.
                 solutions.push(solution);
             }
-            (TransmissionID::Transaction(transaction_id), Transmission::Transaction(transaction)) => {
+            (TransmissionID::Transaction(transaction_id, _), Transmission::Transaction(transaction)) => {
                 // Deserialize the transaction.
                 let transaction = transaction.deserialize_blocking()?;
                 // Ensure the transmission ID corresponds to the transaction.

--- a/ledger/src/helpers/bft.rs
+++ b/ledger/src/helpers/bft.rs
@@ -46,7 +46,9 @@ pub fn decouple_transmissions<N: Network>(
         // Deserialize and store the transmission.
         match (transmission_id, transmission) {
             (TransmissionID::Ratification, Transmission::Ratification) => (),
-            (TransmissionID::Solution(commitment, _), Transmission::Solution(solution)) => {
+            (TransmissionID::Solution(commitment, checksum), Transmission::Solution(solution)) => {
+                // Ensure the transmission checksum corresponds to the solution.
+                ensure!(checksum == solution.to_checksum::<N>()?, "Mismatching transmission checksum (solution)");
                 // Deserialize the solution.
                 let solution = solution.deserialize_blocking()?;
                 // Ensure the transmission ID corresponds to the solution.
@@ -54,7 +56,9 @@ pub fn decouple_transmissions<N: Network>(
                 // Insert the solution into the list.
                 solutions.push(solution);
             }
-            (TransmissionID::Transaction(transaction_id, _), Transmission::Transaction(transaction)) => {
+            (TransmissionID::Transaction(transaction_id, checksum), Transmission::Transaction(transaction)) => {
+                // Ensure the transmission checksum corresponds to the transaction.
+                ensure!(checksum == transaction.to_checksum::<N>()?, "Mismatching transmission checksum (transaction)");
                 // Deserialize the transaction.
                 let transaction = transaction.deserialize_blocking()?;
                 // Ensure the transmission ID corresponds to the transaction.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2704,7 +2704,7 @@ mod valid_solutions {
             malicious_solution.id(),
             "The malicious solution should have the same ID as the valid solution"
         );
-        assert_eq!(
+        assert_ne!(
             valid_solution.target(),
             malicious_solution.target(),
             "The malicious solution should have a different target than the valid solution"

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2351,6 +2351,7 @@ finalize is_id:
 #[cfg(feature = "test")]
 mod valid_solutions {
     use super::*;
+    use ledger_puzzle::Solution;
     use rand::prelude::SliceRandom;
     use std::collections::HashSet;
 
@@ -2667,5 +2668,142 @@ mod valid_solutions {
         let expected_aborted_solutions =
             candidate_solutions.iter().skip(CurrentNetwork::MAX_SOLUTIONS).map(|s| s.id()).collect::<HashSet<_>>();
         assert_eq!(block_aborted_solution_ids, expected_aborted_solutions, "Aborted solutions do not match");
+    }
+
+    #[test]
+    fn test_malicious_solution() {
+        // Initialize an RNG.
+        let rng = &mut TestRng::default();
+
+        // Initialize the test environment.
+        let crate::test_helpers::TestEnv { ledger, private_key, address, .. } =
+            crate::test_helpers::sample_test_env(rng);
+
+        // Retrieve the puzzle parameters.
+        let puzzle = ledger.puzzle();
+        let latest_epoch_hash = ledger.latest_epoch_hash().unwrap();
+        let minimum_proof_target = ledger.latest_proof_target();
+
+        // Initialize a valid solution object.
+        let mut valid_solution = None;
+        while valid_solution.is_none() {
+            let solution = puzzle.prove(latest_epoch_hash, address, rng.gen(), None).unwrap();
+            if puzzle.get_proof_target(&solution).unwrap() >= minimum_proof_target {
+                valid_solution = Some(solution);
+            }
+        }
+        // Unwrap the valid solution.
+        let valid_solution = valid_solution.unwrap();
+
+        // Construct a malicious solution with a different target.
+        let malicious_solution =
+            Solution::new(*valid_solution.partial_solution(), valid_solution.target().saturating_add(1));
+
+        assert_eq!(
+            valid_solution.id(),
+            malicious_solution.id(),
+            "The malicious solution should have the same ID as the valid solution"
+        );
+
+        // Create a valid transaction for the block.
+        let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
+        let transfer_transaction = ledger
+            .vm
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .unwrap();
+
+        // Check that the block creation fixes the malformed solution.
+        let expected_solution_id = valid_solution.id();
+        let expected_solution = valid_solution;
+        let mut check_block = |candidate_solutions: Vec<Solution<CurrentNetwork>>| {
+            // Create a block.
+            let block = ledger
+                .prepare_advance_to_next_beacon_block(
+                    &private_key,
+                    vec![],
+                    candidate_solutions.clone(),
+                    vec![transfer_transaction.clone()],
+                    rng,
+                )
+                .unwrap();
+
+            // Check that the next block is valid.
+            ledger.check_next_block(&block, rng).unwrap();
+
+            // Check that the block's solutions are well-formed.
+            assert_eq!(block.solutions().len(), 1);
+            assert_eq!(block.aborted_solution_ids().len(), 0);
+
+            // Fetch the solution from the block.
+            let (solution_id, solution) = block.solutions().as_ref().unwrap().first().unwrap();
+            assert_eq!(*solution_id, expected_solution_id, "Check that the block has the correct solution ID");
+            assert_eq!(*solution, expected_solution, "Check that the block has the correct solution");
+        };
+
+        // Case 1: The valid solution is included in the block.
+        let candidate_solutions = vec![valid_solution];
+        check_block(candidate_solutions);
+
+        // Case 2: The malicious solution is included in the block.
+        let candidate_solutions = vec![malicious_solution];
+        check_block(candidate_solutions);
+    }
+
+    #[test]
+    fn test_solution_with_insufficient_target() {
+        // Initialize an RNG.
+        let rng = &mut TestRng::default();
+
+        // Initialize the test environment.
+        let crate::test_helpers::TestEnv { ledger, private_key, address, .. } =
+            crate::test_helpers::sample_test_env(rng);
+
+        // Retrieve the puzzle parameters.
+        let puzzle = ledger.puzzle();
+        let latest_epoch_hash = ledger.latest_epoch_hash().unwrap();
+        let minimum_proof_target = ledger.latest_proof_target();
+
+        // Initialize a valid solution object.
+        let mut invalid_solution = None;
+        while invalid_solution.is_none() {
+            let solution = puzzle.prove(latest_epoch_hash, address, rng.gen(), None).unwrap();
+            if puzzle.get_proof_target(&solution).unwrap() < minimum_proof_target {
+                invalid_solution = Some(solution);
+            }
+        }
+        // Unwrap the invalid solution.
+        let invalid_solution = invalid_solution.unwrap();
+
+        // Create a valid transaction for the block.
+        let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
+        let transfer_transaction = ledger
+            .vm
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .unwrap();
+
+        // Create a block.
+        let block = ledger
+            .prepare_advance_to_next_beacon_block(
+                &private_key,
+                vec![],
+                vec![invalid_solution],
+                vec![transfer_transaction],
+                rng,
+            )
+            .unwrap();
+
+        // Check that the next block is valid.
+        ledger.check_next_block(&block, rng).unwrap();
+
+        // Add the deployment block to the ledger.
+        ledger.advance_to_next_block(&block).unwrap();
+
+        // Check that the block's solutions are well-formed.
+        assert_eq!(block.solutions().len(), 0);
+        assert_eq!(block.aborted_solution_ids().len(), 1);
+
+        // Check that the aborted solution is correct.
+        let block_aborted_solution_id = block.aborted_solution_ids().first().unwrap();
+        assert_eq!(*block_aborted_solution_id, invalid_solution.id(), "Aborted solutions do not match");
     }
 }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2696,13 +2696,18 @@ mod valid_solutions {
         let valid_solution = valid_solution.unwrap();
 
         // Construct a malicious solution with a different target.
-        let malicious_solution =
-            Solution::new(*valid_solution.partial_solution(), valid_solution.target().saturating_add(1));
+        let different_target = valid_solution.target().wrapping_sub(1);
+        let malicious_solution = Solution::new(*valid_solution.partial_solution(), different_target);
 
         assert_eq!(
             valid_solution.id(),
             malicious_solution.id(),
             "The malicious solution should have the same ID as the valid solution"
+        );
+        assert_eq!(
+            valid_solution.target(),
+            malicious_solution.target(),
+            "The malicious solution should have a different target than the valid solution"
         );
 
         // Create a valid transaction for the block.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2745,12 +2745,12 @@ mod valid_solutions {
             assert_eq!(*solution, expected_solution, "Check that the block has the correct solution");
         };
 
-        // Case 1: The valid solution is included in the block.
-        let candidate_solutions = vec![valid_solution];
+        // Case 1: The malicious solution is included in the block construction.
+        let candidate_solutions = vec![malicious_solution];
         check_block(candidate_solutions);
 
-        // Case 2: The malicious solution is included in the block.
-        let candidate_solutions = vec![malicious_solution];
+        // Case 2: The valid solution is included in the block construction.
+        let candidate_solutions = vec![valid_solution];
         check_block(candidate_solutions);
     }
 

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1774,7 +1774,7 @@ fn test_split_candidate_solutions() {
         let candidate_solutions: Vec<u8> = rng.sample_iter(Standard).take(num_candidates).collect();
 
         let (_accepted, _aborted) =
-            split_candidate_solutions(candidate_solutions, max_solutions, |candidate| candidate % 2 == 0);
+            split_candidate_solutions(candidate_solutions, max_solutions, |candidate| *candidate % 2 == 0);
     }
 }
 

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -91,6 +91,11 @@ package = "snarkvm-ledger-committee"
 path = "../ledger/committee"
 version = "=0.16.19"
 
+[dependencies.ledger-narwhal-data]
+package = "snarkvm-ledger-narwhal-data"
+path = "../ledger/narwhal/data"
+version = "=0.16.19"
+
 [dependencies.ledger-puzzle]
 package = "snarkvm-ledger-puzzle"
 path = "../ledger/puzzle"

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -81,7 +81,7 @@ pub struct VM<N: Network, C: ConsensusStorage<N>> {
     /// The VM store.
     store: ConsensusStore<N, C>,
     /// A cache containing the list of recent partially-verified transactions.
-    partially_verified_transactions: Arc<RwLock<LruCache<N::TransactionID, ()>>>,
+    partially_verified_transactions: Arc<RwLock<LruCache<N::TransactionID, ()>>>, // TODO: we should also store the checksum
     /// The restrictions list.
     restrictions: Restrictions<N>,
     /// The lock to guarantee atomicity over calls to speculate and finalize.
@@ -219,6 +219,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Returns the partially-verified transactions.
     #[inline]
     pub fn partially_verified_transactions(&self) -> Arc<RwLock<LruCache<N::TransactionID, ()>>> {
+        // N::TransmissionChecksum
         self.partially_verified_transactions.clone()
     }
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -44,6 +44,7 @@ use ledger_block::{
     Transactions,
 };
 use ledger_committee::Committee;
+use ledger_narwhal_data::Data;
 use ledger_puzzle::Puzzle;
 use ledger_query::Query;
 use ledger_store::{
@@ -81,7 +82,7 @@ pub struct VM<N: Network, C: ConsensusStorage<N>> {
     /// The VM store.
     store: ConsensusStore<N, C>,
     /// A cache containing the list of recent partially-verified transactions.
-    partially_verified_transactions: Arc<RwLock<LruCache<N::TransactionID, ()>>>, // TODO: we should also store the checksum
+    partially_verified_transactions: Arc<RwLock<LruCache<N::TransactionID, N::TransmissionChecksum>>>,
     /// The restrictions list.
     restrictions: Restrictions<N>,
     /// The lock to guarantee atomicity over calls to speculate and finalize.
@@ -218,8 +219,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
     /// Returns the partially-verified transactions.
     #[inline]
-    pub fn partially_verified_transactions(&self) -> Arc<RwLock<LruCache<N::TransactionID, ()>>> {
-        // N::TransmissionChecksum
+    pub fn partially_verified_transactions(&self) -> Arc<RwLock<LruCache<N::TransactionID, N::TransmissionChecksum>>> {
         self.partially_verified_transactions.clone()
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR introduces the concept of a `TransmissionChecksum`. This checksum is a `Sha3_256` hash on the underlying `Transmission` object that is truncated to fit a `u128`. The intention is to prevent malicious validators from tampering with solutions or transactions and broadcasting these malformed objects to other validators. The addition of these checksums, alongside additional snarkOS level checks will allow honest validators to detect and disregard the attack from the malicious validators.


This PR also unifies the changes from https://github.com/AleoNet/snarkVM/pull/2520, as it aims to solve the same attack. The change there updates block production to correctly address malicious solutions. This additional fix overwrites the solution target with value calculated during solution verification. So even if a malicious solution is injected by a malicious validator, honest validators will always process them and safely convert them to honest solutions.

The CI is run [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM?branch=fix%2Ftransmission-checksum-ci).

**NOTE**: This updates the block serialization, so it is not backwards compatible with the networks (Testnet Beta and Canary) being run. These will require a reset.

#### Benchmarks
The benchmarks indicate that the added runtime overhead is quite miniscule. `Data::to_checksum` benchmarks (on a 64 GB M1 MAX):
- Solution: 10μs
- `transfer_public` transaction: 82μs
- Largest possible transaction (128 kb): 5.5ms 

## Related PRs

The sister PR is https://github.com/AleoNet/snarkOS/pull/3367.