### PR TITLE
[Fix] Cache parameter downloads and limit test parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,16 +66,16 @@ commands:
       - run:
           name: Prepare environment and install dependencies
           command: |
-            export SCCACHE_CACHE_SIZE=200M
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="200M"' >> $BASH_ENV
             export WORK_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"
             export SCCACHE_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"
             mkdir -p "$CIRCLE_WORKING_DIRECTORY/.bin"
             wget https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
             tar -C "$CIRCLE_WORKING_DIRECTORY/.bin" -xvf sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
-            mv $CIRCLE_WORKING_DIRECTORY/.bin/sccache-v0.3.0-x86_64-unknown-linux-musl/sccache $CIRCLE_WORKING_DIRECTORY/.bin/sccache
-            export PATH="$PATH:$CIRCLE_WORKING_DIRECTORY/.bin"
-            export RUSTC_WRAPPER="sccache"
-            rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
+            chmod +x $CIRCLE_WORKING_DIRECTORY/.bin/sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
+            mv $CIRCLE_WORKING_DIRECTORY/.bin/sccache-v0.3.0-x86_64-unknown-linux-musl/sccache /home/circleci/bin/sccache
+            rm -rf "/home/circleci/.cargo/registry"
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get dist-upgrade -y -o DPkg::Options::=--force-confold
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
@@ -90,13 +90,15 @@ commands:
         type: string
         default: snarkvm-stable-cache
     steps:
-      - run: (sccache -s||true)
+      - run: (sccache -s || true)
       - run: set +e
       - save_cache:
           key: << parameters.cache_key >>
           paths:
-            - .cache/sccache
-            - .cargo
+            - /home/circleci/.cache/sccache
+            - /home/circleci/.cargo
+            - /home/circleci/.aleo/resources
+
   run_serial:
     description: "Build and run tests"
     parameters:
@@ -167,7 +169,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: algorithms
-          cache_key: snarkvm-algorithms-cache
+          cache_key: v1-snarkvm-algorithms-cache
 
   algorithms-profiler:
     docker:
@@ -176,7 +178,7 @@ jobs:
     steps:
       - run_serial: # This runs a single test with profiler enabled
           workspace_member: algorithms
-          cache_key: snarkvm-algorithms-cache
+          cache_key: v1-snarkvm-algorithms-cache
           flags: varuna::prove_and_verify_with_square_matrix --features profiler
 
   circuit:
@@ -186,7 +188,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit
-          cache_key: snarkvm-circuit-cache
+          cache_key: v1-snarkvm-circuit-cache
 
   circuit-account:
     docker:
@@ -195,7 +197,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/account
-          cache_key: snarkvm-circuit-account-cache
+          cache_key: v1-snarkvm-circuit-account-cache
 
   # This checks that no `console` structs are used in core circuit logic.
   circuit-account-noconsole:
@@ -206,7 +208,7 @@ jobs:
       - run_serial:
           workspace_member: circuit/account
           flags: --no-default-features
-          cache_key: snarkvm-circuit-account-noconsole-cache
+          cache_key: v1-snarkvm-circuit-account-noconsole-cache
 
   circuit-algorithms:
     docker:
@@ -215,7 +217,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/algorithms
-          cache_key: snarkvm-circuit-algorithms-cache
+          cache_key: v1-snarkvm-circuit-algorithms-cache
 
   circuit-collections:
     docker:
@@ -224,7 +226,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/collections
-          cache_key: snarkvm-circuit-collections-cache
+          cache_key: v1-snarkvm-circuit-collections-cache
 
   # This checks that no `console` structs are used in core circuit logic.
   circuit-collections-noconsole:
@@ -235,7 +237,7 @@ jobs:
       - run_serial:
           workspace_member: circuit/collections
           flags: --no-default-features
-          cache_key: snarkvm-circuit-collections-noconsole-cache
+          cache_key: v1-snarkvm-circuit-collections-noconsole-cache
 
   circuit-environment:
     docker:
@@ -244,7 +246,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/environment
-          cache_key: snarkvm-circuit-environment-cache
+          cache_key: v1-snarkvm-circuit-environment-cache
 
   circuit-network:
     docker:
@@ -253,7 +255,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/network
-          cache_key: snarkvm-circuit-network-cache
+          cache_key: v1-snarkvm-circuit-network-cache
 
   circuit-program:
     docker:
@@ -262,7 +264,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/program
-          cache_key: snarkvm-circuit-program-cache
+          cache_key: v1-snarkvm-circuit-program-cache
 
   circuit-types:
     docker:
@@ -271,7 +273,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types
-          cache_key: snarkvm-circuit-types-cache
+          cache_key: v1-snarkvm-circuit-types-cache
 
   circuit-types-address:
     docker:
@@ -280,7 +282,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types/address
-          cache_key: snarkvm-circuit-types-address-cache
+          cache_key: v1-snarkvm-circuit-types-address-cache
 
   circuit-types-boolean:
     docker:
@@ -289,7 +291,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types/boolean
-          cache_key: snarkvm-circuit-types-boolean-cache
+          cache_key: v1-snarkvm-circuit-types-boolean-cache
 
   circuit-types-field:
     docker:
@@ -298,7 +300,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types/field
-          cache_key: snarkvm-circuit-types-field-cache
+          cache_key: v1-snarkvm-circuit-types-field-cache
 
   circuit-types-group:
     docker:
@@ -307,7 +309,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types/group
-          cache_key: snarkvm-circuit-types-group-cache
+          cache_key: v1-snarkvm-circuit-types-group-cache
 
   circuit-types-integers:
     docker:
@@ -316,7 +318,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types/integers
-          cache_key: snarkvm-circuit-types-integers-cache
+          cache_key: v1-snarkvm-circuit-types-integers-cache
           flags: -- --ignored
 
   circuit-types-scalar:
@@ -326,7 +328,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types/scalar
-          cache_key: snarkvm-circuit-types-scalar-cache
+          cache_key: v1-snarkvm-circuit-types-scalar-cache
 
   circuit-types-string:
     docker:
@@ -335,7 +337,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: circuit/types/string
-          cache_key: snarkvm-circuit-types-string-cache
+          cache_key: v1-snarkvm-circuit-types-string-cache
   console:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
@@ -343,7 +345,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console
-          cache_key: snarkvm-console-cache
+          cache_key: v1-snarkvm-console-cache
 
   console-account:
     docker:
@@ -352,7 +354,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/account
-          cache_key: snarkvm-console-account-cache
+          cache_key: v1-snarkvm-console-account-cache
 
   console-algorithms:
     docker:
@@ -361,7 +363,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/algorithms
-          cache_key: snarkvm-console-algorithms-cache
+          cache_key: v1-snarkvm-console-algorithms-cache
 
   console-collections:
     docker:
@@ -370,7 +372,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/collections
-          cache_key: snarkvm-console-collections-cache
+          cache_key: v1-snarkvm-console-collections-cache
 
   console-network:
     docker:
@@ -379,7 +381,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/network
-          cache_key: snarkvm-console-network-cache
+          cache_key: v1-snarkvm-console-network-cache
 
   console-network-environment:
     docker:
@@ -388,7 +390,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/network/environment
-          cache_key: snarkvm-console-network-environment-cache
+          cache_key: v1-snarkvm-console-network-environment-cache
 
   console-program:
     docker:
@@ -397,7 +399,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/program
-          cache_key: snarkvm-console-program-cache
+          cache_key: v1-snarkvm-console-program-cache
 
   console-types:
     docker:
@@ -406,7 +408,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types
-          cache_key: snarkvm-console-types-cache
+          cache_key: v1-snarkvm-console-types-cache
 
   console-types-address:
     docker:
@@ -415,7 +417,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types/address
-          cache_key: snarkvm-console-types-address-cache
+          cache_key: v1-snarkvm-console-types-address-cache
 
   console-types-boolean:
     docker:
@@ -424,7 +426,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types/boolean
-          cache_key: snarkvm-console-types-boolean-cache
+          cache_key: v1-snarkvm-console-types-boolean-cache
 
   console-types-field:
     docker:
@@ -433,7 +435,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types/field
-          cache_key: snarkvm-console-types-field-cache
+          cache_key: v1-snarkvm-console-types-field-cache
 
   console-types-group:
     docker:
@@ -442,7 +444,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types/group
-          cache_key: snarkvm-console-types-group-cache
+          cache_key: v1-snarkvm-console-types-group-cache
 
   console-types-integers:
     docker:
@@ -451,7 +453,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types/integers
-          cache_key: snarkvm-console-types-integers-cache
+          cache_key: v1-snarkvm-console-types-integers-cache
 
   console-types-scalar:
     docker:
@@ -460,7 +462,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types/scalar
-          cache_key: snarkvm-console-types-scalar-cache
+          cache_key: v1-snarkvm-console-types-scalar-cache
 
   console-types-string:
     docker:
@@ -469,7 +471,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: console/types/string
-          cache_key: snarkvm-console-types-string-cache
+          cache_key: v1-snarkvm-console-types-string-cache
 
   curves:
     docker:
@@ -478,7 +480,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: curves
-          cache_key: snarkvm-curves-cache
+          cache_key: v1-snarkvm-curves-cache
 
   fields:
     docker:
@@ -487,7 +489,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: fields
-          cache_key: snarkvm-fields-cache
+          cache_key: v1-snarkvm-fields-cache
 
   ledger:
     docker:
@@ -496,7 +498,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger
-          cache_key: snarkvm-ledger-cache
+          cache_key: v1-snarkvm-ledger-cache
 
   ledger-with-rocksdb:
     docker:
@@ -506,7 +508,7 @@ jobs:
       - run_serial:
           flags: --features=rocks
           workspace_member: ledger
-          cache_key: snarkvm-ledger-with-rocksdb-cache
+          cache_key: v1-snarkvm-ledger-with-rocksdb-cache
 
   ledger-with-valid-solutions:
     docker:
@@ -516,7 +518,7 @@ jobs:
       - run_serial:
           flags: valid_solutions --features=test
           workspace_member: ledger
-          cache_key: snarkvm-ledger-with-valid-solutions-cache
+          cache_key: v1-snarkvm-ledger-with-valid-solutions-cache
 
   ledger-authority:
     docker:
@@ -525,7 +527,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/authority
-          cache_key: snarkvm-ledger-authority-cache
+          cache_key: v1-snarkvm-ledger-authority-cache
 
   ledger-block:
     docker:
@@ -534,7 +536,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/block
-          cache_key: snarkvm-ledger-block-cache
+          cache_key: v1-snarkvm-ledger-block-cache
 
   ledger-committee:
     docker:
@@ -543,7 +545,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/committee
-          cache_key: snarkvm-ledger-committee-cache
+          cache_key: v1-snarkvm-ledger-committee-cache
 
   ledger-narwhal:
     docker:
@@ -552,7 +554,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/narwhal
-          cache_key: snarkvm-ledger-narwhal-cache
+          cache_key: v1-snarkvm-ledger-narwhal-cache
 
   ledger-narwhal-batch-certificate:
     docker:
@@ -561,7 +563,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/batch-certificate
-          cache_key: snarkvm-ledger-narwhal-batch-certificate-cache
+          cache_key: v1-snarkvm-ledger-narwhal-batch-certificate-cache
 
   ledger-narwhal-batch-header:
     docker:
@@ -570,7 +572,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/batch-header
-          cache_key: snarkvm-ledger-narwhal-batch-header-cache
+          cache_key: v1-snarkvm-ledger-narwhal-batch-header-cache
 
   ledger-narwhal-data:
     docker:
@@ -579,7 +581,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/data
-          cache_key: snarkvm-ledger-narwhal-data-cache
+          cache_key: v1-snarkvm-ledger-narwhal-data-cache
 
   ledger-narwhal-subdag:
     docker:
@@ -588,7 +590,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/subdag
-          cache_key: snarkvm-ledger-narwhal-subdag-cache
+          cache_key: v1-snarkvm-ledger-narwhal-subdag-cache
 
   ledger-narwhal-transmission:
     docker:
@@ -597,7 +599,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/transmission
-          cache_key: snarkvm-ledger-narwhal-transmission-cache
+          cache_key: v1-snarkvm-ledger-narwhal-transmission-cache
 
   ledger-narwhal-transmission-id:
     docker:
@@ -606,7 +608,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/transmission-id
-          cache_key: snarkvm-ledger-narwhal-transmission-id-cache
+          cache_key: v1-snarkvm-ledger-narwhal-transmission-id-cache
 
   ledger-puzzle:
     docker:
@@ -615,7 +617,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/puzzle
-          cache_key: snarkvm-ledger-puzzle-cache
+          cache_key: v1-snarkvm-ledger-puzzle-cache
 
   ledger-puzzle-epoch:
     docker:
@@ -624,7 +626,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/puzzle/epoch
-          cache_key: snarkvm-ledger-puzzle-epoch-cache
+          cache_key: v1-snarkvm-ledger-puzzle-epoch-cache
 
   ledger-query:
     docker:
@@ -633,7 +635,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/query
-          cache_key: snarkvm-ledger-query-cache
+          cache_key: v1-snarkvm-ledger-query-cache
 
   ledger-store:
     docker:
@@ -643,7 +645,7 @@ jobs:
       - run_serial:
           flags: --features=rocks
           workspace_member: ledger/store
-          cache_key: snarkvm-ledger-store-cache
+          cache_key: v1-snarkvm-ledger-store-cache
 
   ledger-test-helpers:
     docker:
@@ -652,7 +654,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: ledger/test-helpers
-          cache_key: snarkvm-ledger-test-helpers-cache
+          cache_key: v1-snarkvm-ledger-test-helpers-cache
 
   parameters:
     docker:
@@ -660,8 +662,9 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
+          flags: -- --test-threads=2
           workspace_member: parameters
-          cache_key: snarkvm-parameters-cache
+          cache_key: v1-snarkvm-parameters-cache
 
   synthesizer:
     docker:
@@ -669,9 +672,9 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
-          flags: --lib --bins
+          flags: --lib --bins -- --test-threads=2
           workspace_member: synthesizer
-          cache_key: snarkvm-synthesizer-cache
+          cache_key: v1-snarkvm-synthesizer-cache
 
   synthesizer-integration:
     docker:
@@ -679,18 +682,19 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
-          flags: --test '*'
+          flags: --test '*' -- --test-threads=8
           workspace_member: synthesizer
-          cache_key: snarkvm-synthesizer-integration-cache
+          cache_key: v1-snarkvm-synthesizer-integration-cache
 
   synthesizer-process:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: << pipeline.parameters.large >>
+    resource_class: << pipeline.parameters.xlarge >>
     steps:
       - run_serial:
+          flags: -- --test-threads=8
           workspace_member: synthesizer/process
-          cache_key: snarkvm-synthesizer-process-cache
+          cache_key: v1-snarkvm-synthesizer-process-cache
 
   synthesizer-process-with-rocksdb:
     docker:
@@ -700,7 +704,7 @@ jobs:
       - run_serial:
           flags: --features=rocks
           workspace_member: synthesizer/process
-          cache_key: snarkvm-synthesizer-process-cache
+          cache_key: v1-snarkvm-synthesizer-process-cache
 
   synthesizer-program:
     docker:
@@ -710,7 +714,7 @@ jobs:
       - run_serial:
           flags: --lib --bins
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-cache
 
   synthesizer-program-integration:
     docker:
@@ -720,7 +724,7 @@ jobs:
       - run_serial:
           flags: --test '*' -- --skip keccak --skip psd --skip sha --skip instruction::is --skip instruction::equal --skip instruction::commit
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-integration-cache
 
   synthesizer-program-integration-keccak:
     docker:
@@ -730,7 +734,7 @@ jobs:
       - run_serial:
           flags: keccak --test '*'
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-keccak-cache
 
   synthesizer-program-integration-psd:
     docker:
@@ -740,7 +744,7 @@ jobs:
       - run_serial:
           flags: psd --test '*'
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-psd-cache
 
   synthesizer-program-integration-sha:
     docker:
@@ -750,7 +754,7 @@ jobs:
       - run_serial:
           flags: sha --test '*'
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-sha-cache
 
   synthesizer-program-integration-instruction-is:
     docker:
@@ -760,7 +764,7 @@ jobs:
       - run_serial:
           flags: instruction::is --test '*'
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-is-cache
 
   synthesizer-program-integration-instruction-equal:
     docker:
@@ -770,7 +774,7 @@ jobs:
       - run_serial:
           flags: instruction::equal --test '*'
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-equal-cache
 
   synthesizer-program-integration-instruction-commit:
     docker:
@@ -780,7 +784,7 @@ jobs:
       - run_serial:
           flags: instruction::commit --test '*'
           workspace_member: synthesizer/program
-          cache_key: snarkvm-synthesizer-program-cache
+          cache_key: v1-snarkvm-synthesizer-program-commit-cache
 
   synthesizer-snark:
     docker:
@@ -789,7 +793,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: synthesizer/snark
-          cache_key: snarkvm-synthesizer-snark-cache
+          cache_key: v1-snarkvm-synthesizer-snark-cache
 
   utilities:
     docker:
@@ -798,7 +802,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: utilities
-          cache_key: snarkvm-utilities-cache
+          cache_key: v1-snarkvm-utilities-cache
 
   utilities-derives:
     docker:
@@ -807,7 +811,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: utilities/derives
-          cache_key: snarkvm-utilities-derives-cache
+          cache_key: v1-snarkvm-utilities-derives-cache
 
   wasm:
     docker:
@@ -816,16 +820,16 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: snarkvm-wasm-cache
+          cache_key: v1-snarkvm-wasm-cache
       - run:
           no_output_timeout: 30m
           command: |
             sudo apt-get install nodejs
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            (cargo install wasm-pack || true)
             cd wasm && wasm-pack test --node
             # cargo test --target wasm32-unknown-unknown
       - clear_environment:
-          cache_key: snarkvm-wasm-cache
+          cache_key: v1-snarkvm-wasm-cache
 
   check-fmt:
     docker:
@@ -835,13 +839,13 @@ jobs:
       - checkout
       - install_rust_nightly
       - setup_environment:
-          cache_key: snarkvm-fmt-cache
+          cache_key: v1-snarkvm-fmt-cache
       - run:
           name: Check style
           no_output_timeout: 35m
           command: cargo +nightly fmt --all -- --check
       - clear_environment:
-          cache_key: snarkvm-fmt-cache
+          cache_key: v1-snarkvm-fmt-cache
 
   check-clippy:
     docker:
@@ -850,7 +854,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: snarkvm-clippy-cache
+          cache_key: v1-snarkvm-clippy-cache
       - run:
           name: Check Clippy
           no_output_timeout: 35m
@@ -858,7 +862,7 @@ jobs:
             cargo clippy --workspace --all-targets -- -D warnings
             cargo clippy --workspace --all-targets --all-features -- -D warnings
       - clear_environment:
-          cache_key: snarkvm-clippy-cache
+          cache_key: v1-snarkvm-clippy-cache
 
   check-all-targets:
     docker:
@@ -867,13 +871,13 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: snarkvm-all-targets-cache
+          cache_key: v1-snarkvm-all-targets-cache
       - run:
           name: Check all targets
           no_output_timeout: 35m
           command: cargo check --release --workspace --all-targets
       - clear_environment:
-          cache_key: snarkvm-all-targets-cache
+          cache_key: v1-snarkvm-all-targets-cache
 
   verify-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,7 +669,7 @@ jobs:
   parameters-uncached:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: << pipeline.parameters.medium >>
+    resource_class: << pipeline.parameters.large >>
     steps:
       - run_serial:
           flags: -- --test-threads=2 --ignored test_load_bytes_mini

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,6 +666,16 @@ jobs:
           workspace_member: parameters
           cache_key: v1-snarkvm-parameters-cache
 
+  parameters-uncached:
+    docker:
+      - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+    resource_class: << pipeline.parameters.small >>
+    steps:
+      - run_serial:
+          flags: -- --test-threads=2 --ignored test_load_bytes_mini
+          workspace_member: parameters
+          cache_key: v-{{ epoch }}-snarkvm-parameters-cache
+
   synthesizer:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
@@ -954,6 +964,7 @@ workflows:
       - ledger-store
       - ledger-test-helpers
       - parameters
+      - parameters-uncached
       - synthesizer
       - synthesizer-integration
       - synthesizer-process

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,7 +669,7 @@ jobs:
   parameters-uncached:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: << pipeline.parameters.small >>
+    resource_class: << pipeline.parameters.medium >>
     steps:
       - run_serial:
           flags: -- --test-threads=2 --ignored test_load_bytes_mini

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -171,6 +171,17 @@ mod tests {
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
 
+    #[ignore]
+    #[test]
+    fn test_load_bytes_mini() {
+        Degree16::load_bytes().expect("Failed to load degree 16");
+        BondPublicVerifier::load_bytes().expect("Failed to load bond_public verifier");
+        FeePublicProver::load_bytes().expect("Failed to load fee_public prover");
+        FeePublicVerifier::load_bytes().expect("Failed to load fee_public verifier");
+        InclusionProver::load_bytes().expect("Failed to load inclusion prover");
+        InclusionVerifier::load_bytes().expect("Failed to load inclusion verifier");
+    }
+
     #[wasm_bindgen_test]
     fn test_load_bytes() {
         Degree16::load_bytes().expect("Failed to load degree 16");


### PR DESCRIPTION
## Motivation

Closes https://github.com/AleoNet/snarkVM/issues/2494 by:
- caching parameter downloads so we don't get rate limited by AWS.
- limiting parallelization of tests using `-- --test-threads`. The other option would be to use `cargo nextest`, but that would add a new dependency.

Also fixes caching, which previously wasn't actually used. By recommendation from [CircleCI](https://circleci.com/docs/configuration-reference/): "Given the immutability of caches, it might be helpful to start all your cache keys with a version prefix v1-.... That way you will be able to regenerate all your caches just by incrementing the version in this prefix."

Total runtime is now 30 minutes.

Future optimization ideas:
- Do not try to download the largest parameters in a test, which is several GiB and costs 16 min.
- Get more fine-grained data on how much memory each test uses. `nextext` allows configuring of granular test profiles depending on their load. My current tests showed most tests just use 60 MiB, but that must have been wrong since we see OOM with as little as `--test-threads=4` sometimes.

## Test Plan

- [Succesful CI run](https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM/240/workflows/48ffb50d-097d-4171-a209-0ba3a9d94605)
- Additionally ran CI multiple times in parallel to see if the issues are resolved.
