### PR TITLE
Don't assume solution checksum consistency in check_subdag_transmissions

### DIFF
--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -577,15 +577,11 @@ impl<N: Network> Block<N> {
             // Process the transmission ID.
             match transmission_id {
                 TransmissionID::Ratification => {}
-                TransmissionID::Solution(solution_id, checksum) => {
+                TransmissionID::Solution(solution_id, _checksum) => {
                     match solutions.peek() {
                         // Check the next solution matches the expected solution ID.
-                        Some((_, solution))
-                            if solution.id() == *solution_id
-                                && Data::<Solution<N>>::Buffer(solution.to_bytes_le()?.into())
-                                    .to_checksum::<N>()?
-                                    == *checksum =>
-                        {
+                        // We don't check against the checksum, because check_solution_mut might mutate the solution.
+                        Some((_, solution)) if solution.id() == *solution_id => {
                             // Increment the solution iterator.
                             solutions.next();
                         }


### PR DESCRIPTION
## Motivation

This is a small improvement to https://github.com/AleoNet/snarkVM/pull/2521 . Due to the fixes introduced, honest validators may mutate a seemingly invalid solution to a valid one. As a result, there's a deviation between the checksum in the subdag and the block. If such an attack were to happen, it can be easily recovered from by implementing this PR.

The fix is to ignore the checksum. We're already guaranteed only unique solution id's enter the block.

## Test Plan

Tested by simulating malicious validator.
[CI run here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM/208/workflows/7b445769-6e16-4261-b737-a004e292d50a)