### PR TITLE
avoid comments about (3f + 1) and (2f + 1)

### DIFF
--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -173,6 +173,7 @@ impl<N: Network> Committee<N> {
     pub fn quorum_threshold(&self) -> u64 {
         // Assuming `N = 3f + 1 + k`, where `0 <= k < 3`,
         // then `2N/3 + 1 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f`.
+        // In the line above, `/` means integer division.
         self.total_stake().saturating_mul(2).saturating_div(3).saturating_add(1)
     }
 

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -169,14 +169,14 @@ impl<N: Network> Committee<N> {
         self.total_stake().saturating_add(2).saturating_div(3)
     }
 
-    /// Returns the amount of stake required to reach a quorum threshold `(2f + 1)`.
+    /// Returns the amount of stake required to reach a quorum threshold `(N - f)`.
     pub fn quorum_threshold(&self) -> u64 {
         // Assuming `N = 3f + 1 + k`, where `0 <= k < 3`,
-        // then `(2N + 3) / 3 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f`.
+        // then `2N/3 + 1 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f`.
         self.total_stake().saturating_mul(2).saturating_div(3).saturating_add(1)
     }
 
-    /// Returns the total amount of stake in the committee `(3f + 1)`.
+    /// Returns the total amount of stake in the committee.
     pub const fn total_stake(&self) -> u64 {
         self.total_stake
     }

--- a/ledger/committee/src/prop_tests.rs
+++ b/ledger/committee/src/prop_tests.rs
@@ -186,7 +186,7 @@ fn committee_members(input: CommitteeContext) {
     }
     let quorum_threshold = committee.quorum_threshold();
     let availability_threshold = committee.availability_threshold();
-    // (2f + 1) + (f + 1) - 1 = 3f + 1 = N
+    // (N - f) + (f + 1) - 1 = N
     assert_eq!(quorum_threshold + availability_threshold - 1, total_stake);
 }
 

--- a/synthesizer/src/vm/helpers/rewards.rs
+++ b/synthesizer/src/vm/helpers/rewards.rs
@@ -36,9 +36,10 @@ const MAX_COINBASE_REWARD: u64 = ledger_block::MAX_COINBASE_REWARD; // Coinbase 
 /// of the total stake will not receive a staking reward. In addition, this method
 /// ensures delegators who have less than 10,000 credits are not eligible for a staking reward.
 ///
-/// The choice of 25% is to ensure at least 4 validators are operational at any given time,
-/// since our security model adheres to 3f+1, where f=1. As such, we tolerate Byzantine behavior
-/// up to 33% of the total stake.
+/// The choice of 25% is to ensure at least 4 validators are operational at any given time.
+/// Our security model tolerates Byzantines behavior by validators staking up to f stake,
+/// where f = max{m: integer | m < N/3}, N being the total amount staked.
+/// Therefore, 1 Byzantine validator out of 4 equal-staked validators will be tolerated.
 pub fn staking_rewards<N: Network>(
     stakers: &IndexMap<Address<N>, (Address<N>, u64)>,
     committee: &Committee<N>,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

In `snarkvm_ledger_committee`, `quorum_threshold` is correctly calculated as `N - f`.
Since `N` is not always `3f + 1` (it could be `3f + 2` or `3f + 3`),
the quorum threshold is not always `2f + 1`.

This PR changes some comments to avoid the imprecise `3f + 1` and `2f + 1`.

NOTE: no need for CI to pass since only comments were changed.