### PR TITLE
Limit parallelization of test_vm_execute_and_finalize

### DIFF
--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -48,13 +48,15 @@ fn test_vm_execute_and_finalize() {
         load_tests::<_, ProgramTest>("./tests/vm/execute_and_finalize", "./expectations/vm/execute_and_finalize");
 
     // Run each test and compare it against its corresponding expectation.
-    tests.par_iter().for_each(|test| {
-        // Run the test.
-        let output = run_test(test);
-        // Check against the expected output.
-        test.check(&output).unwrap();
-        // Save the output.
-        test.save(&output).unwrap();
+    tests.chunks(10).collect_vec().into_iter().for_each(|chunk| {
+        chunk.par_iter().for_each(|test| {
+            // Run the test.
+            let output = run_test(test);
+            // Check against the expected output.
+            test.check(&output).unwrap();
+            // Save the output.
+            test.save(&output).unwrap();
+        });
     });
 }
 


### PR DESCRIPTION
## Motivation

Aims to partially fix https://github.com/AleoNet/snarkVM/issues/2494

This test will sometimes OOM. Limiting parallellization should prevent that.
Additionally, on M2 Max the test ran almost 10% *faster* due to reduced parallelization.

If the Foundation decides to use a smaller or bigger machine, the existing `10` can easily be changed.

## Test Plan

Ran the test locally