### PR TITLE
Fix Typographical Errors in Comments Across Several Files

### DIFF
--- a/circuit/program/src/data/future/find.rs
+++ b/circuit/program/src/data/future/find.rs
@@ -20,7 +20,7 @@ impl<A: Aleo> Future<A> {
         // Ensure the path is not empty.
         ensure!(!path.is_empty(), "Attempted to find an argument with an empty path.");
 
-        // A helper enum to track the the argument.
+        // A helper enum to track the argument.
         enum ArgumentRefType<'a, A: Aleo> {
             /// A plaintext type.
             Plaintext(&'a Plaintext<A>),

--- a/console/program/src/data/future/find.rs
+++ b/console/program/src/data/future/find.rs
@@ -20,7 +20,7 @@ impl<N: Network> Future<N> {
         // Ensure the path is not empty.
         ensure!(!path.is_empty(), "Attempted to find an argument with an empty path.");
 
-        // A helper enum to track the the argument.
+        // A helper enum to track the argument.
         enum ArgumentRefType<'a, N: Network> {
             /// A plaintext type.
             Plaintext(&'a Plaintext<N>),

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -322,7 +322,7 @@ mod tests {
         );
         assert_eq!(reward_at_block_1, EXPECTED_ANCHOR_BLOCK_REWARD_AT_BLOCK_1);
 
-        // A helper function to check the the reward at the first expected block of a given year.
+        // A helper function to check the reward at the first expected block of a given year.
         fn check_reward_at_year(year: u32, expected_reward: u128) {
             let reward_at_year = anchor_block_reward_at_height(
                 block_height_at_year(CurrentNetwork::BLOCK_TIME, year),

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -241,7 +241,7 @@ impl<N: Network> Block<N> {
                 "Leader certificate has an incorrect committee ID"
             );
 
-            // Check that all all certificates on each round have the same committee ID.
+            // Check that all certificates on each round have the same committee ID.
             cfg_iter!(subdag).try_for_each(|(round, certificates)| {
                 // Check that every certificate for a given round shares the same committee ID.
                 let expected_committee_id = certificates

--- a/ledger/puzzle/epoch/src/synthesis/helpers/mod.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/mod.rs
@@ -289,7 +289,7 @@ pub(crate) fn sample_instructions<N: Network>(
                     // Move to the next instruction type.
                     continue 'outer;
                 }
-                // Check the the first destination is a register.
+                // Check the first destination is a register.
                 match instruction_destinations[0] {
                     PuzzleDestination::Ephemeral(literal_type, _) | PuzzleDestination::Register(literal_type) => {
                         instruction_string.push_str(&format!(" as {literal_type}"));

--- a/synthesizer/process/src/authorize.rs
+++ b/synthesizer/process/src/authorize.rs
@@ -72,7 +72,7 @@ impl<N: Network> Process<N> {
         Ok(authorization)
     }
 
-    /// Authorizes the fee given the the fee amount (in microcredits) and the deployment or execution ID.
+    /// Authorizes the fee given the fee amount (in microcredits) and the deployment or execution ID.
     #[inline]
     pub fn authorize_fee_public<A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
         &self,

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -166,7 +166,7 @@ fn cost_in_size<'a, N: Network>(
     Ok(base_cost.saturating_add(byte_multiplier.saturating_mul(size_of_operands)))
 }
 
-/// Returns the the cost of a command in a finalize scope.
+/// Returns the cost of a command in a finalize scope.
 pub fn cost_per_command<N: Network>(stack: &Stack<N>, finalize: &Finalize<N>, command: &Command<N>) -> Result<u64> {
     match command {
         Command::Instruction(Instruction::Abs(_)) => Ok(500),

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -2556,7 +2556,7 @@ fn test_bonding_new_staker_to_closed_validator_fails() {
     );
 }
 
-// All the the above test cases use the same staker and withdraw addresses.
+// All the above test cases use the same staker and withdraw addresses.
 // The following test check the functionality of the withdraw address using a different staker and withdraw address.
 
 #[test]

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -365,7 +365,7 @@ impl<N: Network> Process<N> {
                 }
             }
         }
-        // Check that the the traversal completed correctly.
+        // Check that the traversal completed correctly.
         ensure!(traversal_stack.is_empty(), "Invalid traversal - traversal stack is not empty");
         ensure!(
             counter == execution.len(),

--- a/synthesizer/src/vm/authorize.rs
+++ b/synthesizer/src/vm/authorize.rs
@@ -84,7 +84,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         result
     }
 
-    /// Authorizes the fee given the the fee amount (in microcredits) and the deployment or execution ID.
+    /// Authorizes the fee given the fee amount (in microcredits) and the deployment or execution ID.
     #[inline]
     pub fn authorize_fee_public<R: Rng + CryptoRng>(
         &self,

--- a/synthesizer/tests/README.md
+++ b/synthesizer/tests/README.md
@@ -1,6 +1,6 @@
 # Using the Test Framework
 
-This directory contains a set of utilities and integration tests for various components of `synthesizer` crate. The test framework is based loosely off ideas from [Characterization Testing](https://en.wikipedia.org/wiki/Characterization_test) (you have have heard these referred to as "golden tests"). At a high level, the framework runs a set of integration tests and compares their output to their corresponding expected output. If the output does not match, the framework returns an error.
+This directory contains a set of utilities and integration tests for various components of `synthesizer` crate. The test framework is based loosely off ideas from [Characterization Testing](https://en.wikipedia.org/wiki/Characterization_test) (you have heard these referred to as "golden tests"). At a high level, the framework runs a set of integration tests and compares their output to their corresponding expected output. If the output does not match, the framework returns an error.
 
 
 Some important files/folders are:


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR resolves a number of minor typo's in comments, scattered through a lot of the codebase. The changes are just rectifying duplicated words like "the the" and other small mistakes so the comments read more clearly.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

As this touches only comments, no functionality of the code has been affected. No further testing needed.

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM and https://github.com/AleoHQ/protocol-docs,
    and link to your PR here.
-->

No related PRs.