### PR TITLE
fix: deduplicate log lines

### DIFF
--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -172,7 +172,7 @@ impl<N: Network> Puzzle<N> {
                     // Ensure that the proof target matches the expected proof target.
                     ensure!(
                         solution.target() == *proof_target,
-                        "The proof target does not match the expected proof target"
+                        "The proof target does not match the cached proof target"
                     );
                     targets[i] = *proof_target
                 }
@@ -195,7 +195,7 @@ impl<N: Network> Puzzle<N> {
                     // Ensure that the proof target matches the expected proof target.
                     ensure!(
                         solution.target() == proof_target,
-                        "The proof target does not match the expected proof target"
+                        "The proof target does not match the computed proof target"
                     );
                     // Insert the proof target into the cache.
                     self.proof_target_cache.write().put(*solution_id, proof_target);


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

The log line `The proof target does not match the expected proof target` is present in 3 different places, making it hard to pinpoint where the problem lies. This PR deduplicates these log lines.
