### PR TITLE
[refactor] Use explicit wrapping addition in Fp*::mul_assign

### DIFF
--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -767,7 +767,7 @@ impl<'a, P: Fp256Parameters> MulAssign<&'a Self> for Fp256<P> {
 
         r[3] = fa::mac_with_carry(r[3], (self.0).0[3], (other.0).0[0], &mut carry1);
         r[2] = fa::mac_with_carry(r[3], k, P::MODULUS.0[3], &mut carry2);
-        r[3] = carry1 + carry2;
+        r[3] = carry1.wrapping_add(carry2);
 
         // Iteration 1.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[1], &mut carry1);
@@ -781,7 +781,7 @@ impl<'a, P: Fp256Parameters> MulAssign<&'a Self> for Fp256<P> {
 
         r[3] = fa::mac_with_carry(r[3], (self.0).0[3], (other.0).0[1], &mut carry1);
         r[2] = fa::mac_with_carry(r[3], k, P::MODULUS.0[3], &mut carry2);
-        r[3] = carry1 + carry2;
+        r[3] = carry1.wrapping_add(carry2);
 
         // Iteration 2.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[2], &mut carry1);
@@ -795,7 +795,7 @@ impl<'a, P: Fp256Parameters> MulAssign<&'a Self> for Fp256<P> {
 
         r[3] = fa::mac_with_carry(r[3], (self.0).0[3], (other.0).0[2], &mut carry1);
         r[2] = fa::mac_with_carry(r[3], k, P::MODULUS.0[3], &mut carry2);
-        r[3] = carry1 + carry2;
+        r[3] = carry1.wrapping_add(carry2);
 
         // Iteration 3.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[3], &mut carry1);
@@ -809,7 +809,7 @@ impl<'a, P: Fp256Parameters> MulAssign<&'a Self> for Fp256<P> {
 
         r[3] = fa::mac_with_carry(r[3], (self.0).0[3], (other.0).0[3], &mut carry1);
         r[2] = fa::mac_with_carry(r[3], k, P::MODULUS.0[3], &mut carry2);
-        r[3] = carry1 + carry2;
+        r[3] = carry1.wrapping_add(carry2);
 
         (self.0).0 = r;
         self.reduce();

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -790,7 +790,7 @@ impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
 
         r[5] = fa::mac_with_carry(r[5], (self.0).0[5], (other.0).0[0], &mut carry1);
         r[4] = fa::mac_with_carry(r[5], k, P::MODULUS.0[5], &mut carry2);
-        r[5] = carry1 + carry2;
+        r[5] = carry1.wrapping_add(carry2);
 
         // Iteration 1.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[1], &mut carry1);
@@ -810,7 +810,7 @@ impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
 
         r[5] = fa::mac_with_carry(r[5], (self.0).0[5], (other.0).0[1], &mut carry1);
         r[4] = fa::mac_with_carry(r[5], k, P::MODULUS.0[5], &mut carry2);
-        r[5] = carry1 + carry2;
+        r[5] = carry1.wrapping_add(carry2);
 
         // Iteration 2.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[2], &mut carry1);
@@ -830,7 +830,7 @@ impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
 
         r[5] = fa::mac_with_carry(r[5], (self.0).0[5], (other.0).0[2], &mut carry1);
         r[4] = fa::mac_with_carry(r[5], k, P::MODULUS.0[5], &mut carry2);
-        r[5] = carry1 + carry2;
+        r[5] = carry1.wrapping_add(carry2);
 
         // Iteration 3.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[3], &mut carry1);
@@ -850,7 +850,7 @@ impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
 
         r[5] = fa::mac_with_carry(r[5], (self.0).0[5], (other.0).0[3], &mut carry1);
         r[4] = fa::mac_with_carry(r[5], k, P::MODULUS.0[5], &mut carry2);
-        r[5] = carry1 + carry2;
+        r[5] = carry1.wrapping_add(carry2);
 
         // Iteration 4.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[4], &mut carry1);
@@ -870,7 +870,7 @@ impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
 
         r[5] = fa::mac_with_carry(r[5], (self.0).0[5], (other.0).0[4], &mut carry1);
         r[4] = fa::mac_with_carry(r[5], k, P::MODULUS.0[5], &mut carry2);
-        r[5] = carry1 + carry2;
+        r[5] = carry1.wrapping_add(carry2);
 
         // Iteration 5.
         r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[5], &mut carry1);
@@ -890,7 +890,7 @@ impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
 
         r[5] = fa::mac_with_carry(r[5], (self.0).0[5], (other.0).0[5], &mut carry1);
         r[4] = fa::mac_with_carry(r[5], k, P::MODULUS.0[5], &mut carry2);
-        r[5] = carry1 + carry2;
+        r[5] = carry1.wrapping_add(carry2);
 
         (self.0).0 = r;
         self.reduce();


### PR DESCRIPTION
While overflowing addition will not panic in `--release` mode ([it will instead wrap around](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#integer-overflow)), it will cause a crash under `--debug`. This PR switches to explicit wrapping addition for the `mul_assign` method for `Fp256` and `Fp384`.

Found via fuzzing.