### PR TITLE
fix `minimum_tree_size` for `KaryMerkleTree`

### DIFF
--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -94,11 +94,9 @@ impl<LH: LeafHash<Hash = PH::Hash>, PH: PathHash, const DEPTH: u8, const ARITY: 
         // The minimum tree size is either a single root node or the calculated number of nodes plus
         // the supplied leaves, and empty hashes that pad up to the tree's arity (making every node full).
         let arity = ARITY as usize;
-        let all_nodes_are_full = leaves.len() % arity == 0;
-        let minimum_tree_size = std::cmp::max(
-            1,
-            num_nodes + leaves.len() + if all_nodes_are_full { 0 } else { arity - leaves.len() % arity },
-        );
+        let all_nodes_are_full = leaves.len() == max_leaves;
+        let minimum_tree_size =
+            std::cmp::max(1, num_nodes + leaves.len() + if all_nodes_are_full { 0 } else { max_leaves - leaves.len() });
 
         // Initialize the Merkle tree.
         let mut tree = vec![empty_hash; minimum_tree_size];

--- a/ledger/puzzle/epoch/src/synthesis/program/to_leaves.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/to_leaves.rs
@@ -35,12 +35,12 @@ impl<N: Network> EpochProgram<N> {
             leaves.push(private_variable.value().to_bits_le());
         }
 
-        // Pad the leaves to the next power of two.
+        // Pad the leaves to the next power of ARITY.
         let Some(num_padded_leaves) = checked_next_power_of_n(leaves.len(), ARITY as usize) else {
             bail!("Integer overflow when computing the maximum number of leaves in the Merkle tree");
         };
 
-        // Pad the leaves up to the next power of two.
+        // Pad the leaves up to the next power of ARITY.
         if leaves.len() < num_padded_leaves {
             leaves.resize(num_padded_leaves, vec![false; 254]);
         }


### PR DESCRIPTION
This issue is not detected because the `leaves` parameter is now ensured to be a power of 8: [source](https://github.com/AleoNet/snarkVM/blob/5bb50a845c774f10247657947b9f1c9ec7f21d81/ledger/puzzle/epoch/src/synthesis/program/to_leaves.rs#L45) .