### PR TITLE
Set max open rocksdb files to 8192

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -141,6 +141,7 @@ impl Database for RocksDB {
                     options.increase_parallelism(2);
                     options.set_max_background_jobs(4);
                     options.create_if_missing(true);
+                    options.set_max_open_files(8192);
 
                     Arc::new(rocksdb::DB::open(&options, primary)?)
                 };


### PR DESCRIPTION
## Motivation

rocksdb is creating and leaving open hundreds of files. While at the moment this is harmless, if it keeps growing in the future it could cause nodes to halt.
It is unknown what will happen once the max system-wide limit is hit.
To prevent that from happening, this PR sets a conservative limit.

## Test Plan

Has been tested on a mainnet client. `lsof` outputs imply the node stayed below the limits anyway:
- Initial values: 120k total snarkos file descriptors, 1047 unique
- After a restart: 110k total snarkos file descriptors, 1049 unique 
- After a restart with this PR: 20k total snarkos file descriptors, 159 unique
- After a resync with this PR: 80k total snarkos file descriptors, 781 unique