### PR TITLE
Additional deprecated endpoint references

### DIFF
--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -68,13 +68,13 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
             Self::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
-                    Ok(Self::get_request(&format!("{url}/mainnet/latest/stateRoot"))?.into_json()?)
+                    Ok(Self::get_request(&format!("{url}/mainnet/stateRoot/latest"))?.into_json()?)
                 }
                 console::network::TestnetV0::ID => {
-                    Ok(Self::get_request(&format!("{url}/testnet/latest/stateRoot"))?.into_json()?)
+                    Ok(Self::get_request(&format!("{url}/testnet/stateRoot/latest"))?.into_json()?)
                 }
                 console::network::CanaryV0::ID => {
-                    Ok(Self::get_request(&format!("{url}/canary/latest/stateRoot"))?.into_json()?)
+                    Ok(Self::get_request(&format!("{url}/canary/stateRoot/latest"))?.into_json()?)
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
@@ -88,13 +88,13 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
             Self::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
-                    Ok(Self::get_request_async(&format!("{url}/mainnet/latest/stateRoot")).await?.json().await?)
+                    Ok(Self::get_request_async(&format!("{url}/mainnet/stateRoot/latest")).await?.json().await?)
                 }
                 console::network::TestnetV0::ID => {
-                    Ok(Self::get_request_async(&format!("{url}/testnet/latest/stateRoot")).await?.json().await?)
+                    Ok(Self::get_request_async(&format!("{url}/testnet/stateRoot/latest")).await?.json().await?)
                 }
                 console::network::CanaryV0::ID => {
-                    Ok(Self::get_request_async(&format!("{url}/canary/latest/stateRoot")).await?.json().await?)
+                    Ok(Self::get_request_async(&format!("{url}/canary/stateRoot/latest")).await?.json().await?)
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This change will fix the issue reported: https://github.com/AleoNet/snarkVM/issues/2566
The "/latest/stateRoot" endpoint has been removed by https://github.com/AleoNet/snarkOS/pull/3347

