### PR TITLE
[Perf] Downgrade a write guard on Process to read

### DIFF
--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -263,10 +263,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             /* Perform the atomic finalize over the transactions. */
 
-            // Acquire the write lock on the process.
+            // Acquire the read lock on the process.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
-            // we choose to acquire the write lock for the entire duration of this atomic batch.
-            let process = self.process.write();
+            // we choose to acquire the read lock for the entire duration of this atomic batch.
+            let process = self.process.read();
 
             // Initialize a list of the confirmed transactions.
             let mut confirmed = Vec::with_capacity(num_transactions);


### PR DESCRIPTION
Moved from https://github.com/ProvableHQ/snarkVM/pull/19.

The reasoning is that there is no benefit to holding a write guard here, as in addition to keeping the object frozen, it prohibits any potential readers from accessing it during finalization; a read guard in its place still won't allow the `process` to be modified for the entire duration of the atomic batch, but it _will_ allow other potential concurrent readers in the meantime. Unless the state of the `process` (or any of its contents) during finalization should not be visible to anyone else or should be considered outright invalid until it concludes, a read guard is the more performant choice.

I haven't been able to measure the impact of this change locally, but I'm confident it would make a difference in networks involving more traffic.