### PR TITLE
[ARC-0042] Adjust reward algorithms to utilize timestamps

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -133,6 +133,13 @@ impl Network for CanaryV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
+    /// The block height from which consensus V2 rules apply.
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_V2_HEIGHT: u32 = 2_500_000;
+    // TODO (raychu86): Update this value based on the desired canary height.
+    /// The block height from which consensus V2 rules apply.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_V2_HEIGHT: u32 = 0;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -135,7 +135,7 @@ impl Network for CanaryV0 {
 
     /// The block height from which consensus V2 rules apply.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V2_HEIGHT: u32 = 2_500_000;
+    const CONSENSUS_V2_HEIGHT: u32 = 2_900_000;
     // TODO (raychu86): Update this value based on the desired canary height.
     /// The block height from which consensus V2 rules apply.
     #[cfg(any(test, feature = "test"))]

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -91,6 +91,9 @@ pub trait Network:
     /// The network edition.
     const EDITION: u16;
 
+    /// The block height from which consensus V2 rules apply.
+    const CONSENSUS_V2_HEIGHT: u32;
+
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str;
 

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -134,6 +134,13 @@ impl Network for MainnetV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
+    /// The block height from which consensus V2 rules apply.
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_V2_HEIGHT: u32 = 2_000_000;
+    // TODO (raychu86): Update this value based on the desired mainnet height.
+    /// The block height from which consensus V2 rules apply.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_V2_HEIGHT: u32 = 0;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -136,7 +136,7 @@ impl Network for MainnetV0 {
 
     /// The block height from which consensus V2 rules apply.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V2_HEIGHT: u32 = 2_000_000;
+    const CONSENSUS_V2_HEIGHT: u32 = 2_800_000;
     // TODO (raychu86): Update this value based on the desired mainnet height.
     /// The block height from which consensus V2 rules apply.
     #[cfg(any(test, feature = "test"))]

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -135,7 +135,7 @@ impl Network for TestnetV0 {
 
     /// The block height from which consensus V2 rules apply.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V2_HEIGHT: u32 = 2_500_000;
+    const CONSENSUS_V2_HEIGHT: u32 = 2_950_000;
     // TODO (raychu86): Update this value based on the desired testnet height.
     /// The block height from which consensus V2 rules apply.
     #[cfg(any(test, feature = "test"))]

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -133,6 +133,13 @@ impl Network for TestnetV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
+    /// The block height from which consensus V2 rules apply.
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_V2_HEIGHT: u32 = 2_500_000;
+    // TODO (raychu86): Update this value based on the desired testnet height.
+    /// The block height from which consensus V2 rules apply.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_V2_HEIGHT: u32 = 10;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -87,6 +87,8 @@ pub fn block_reward_v2(
 }
 
 /// Calculate the puzzle reward, given the coinbase reward.
+/// The puzzle reward is 2/3 of the total coinbase reward and paid out to the provers. The other 1/3 of
+/// the coinbase reward is included in the block reward and paid out to stakers.
 pub const fn puzzle_reward(coinbase_reward: u64) -> u64 {
     // Return the coinbase reward multiplied by 2 and divided by 3.
     coinbase_reward.saturating_mul(2).saturating_div(3)
@@ -200,6 +202,8 @@ pub fn coinbase_reward_v2(
 }
 
 /// Calculates the anchor block reward for the given block height.
+/// The anchor block reward is upper bound of the coinbase reward for the given block before
+/// calculating the final pro-rata coinbase reward based on the targets.
 ///     R_anchor = max(floor((2 * S * H_A * H_R) / (H_Y10 * (H_Y10 + 1))), R_Y9).
 ///     S = Starting supply.
 ///     H_A = Anchor block height.
@@ -232,6 +236,8 @@ fn anchor_block_reward_at_height(block_height: u32, starting_supply: u64, anchor
 }
 
 /// Calculates the anchor block reward for the given block timestamp.
+/// The anchor block reward is upper bound of the coinbase reward for the given block before
+/// calculating the final pro-rata coinbase reward based on the targets.
 /// This function uses timestamp rather than block height to determine the reward in order to combat
 /// the volatility of block times and better align with human timescales.
 ///     R_anchor = max(floor((2 * S * T_A * T_R) / (T_Y10 * (T_Y10 + 1))), R_Y9).

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -76,7 +76,7 @@ pub fn block_reward_v2(
     // Compute the annual reward: (0.05 * S).
     let annual_reward = total_supply / 20;
     // Compute the seconds since last block with a maximum of `V2_MAX_BLOCK_INTERVAL` seconds and minimum of `V2_MIN_BLOCK_INTERVAL` seconds;
-    let time_since_last_block = time_since_last_block.max(V2_MIN_BLOCK_INTERVAL).min(V2_MAX_BLOCK_INTERVAL);
+    let time_since_last_block = time_since_last_block.clamp(V2_MIN_BLOCK_INTERVAL, V2_MAX_BLOCK_INTERVAL);
     // Compute the block reward: (0.05 * S) * min(max(I, MIN_BLOCK_INTERVAL), MAX_BLOCK_INTERVAL) / S_Y.
     let block_reward = annual_reward * time_since_last_block as u64 / SECONDS_IN_A_YEAR;
     // Return the sum of the block reward, coinbase reward, and transaction fees.

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -388,7 +388,7 @@ impl<N: Network> Block<N> {
         )?;
 
         // Calculate the expected coinbase reward.
-        let expected_coinbase_reward = coinbase_reward(
+        let expected_coinbase_reward = coinbase_reward_v1(
             height,
             N::STARTING_SUPPLY,
             N::ANCHOR_HEIGHT,
@@ -404,7 +404,7 @@ impl<N: Network> Block<N> {
 
         // Compute the expected block reward.
         let expected_block_reward =
-            block_reward(N::STARTING_SUPPLY, N::BLOCK_TIME, expected_coinbase_reward, expected_transaction_fees);
+            block_reward_v1(N::STARTING_SUPPLY, N::BLOCK_TIME, expected_coinbase_reward, expected_transaction_fees);
         // Compute the expected puzzle reward.
         let expected_puzzle_reward = puzzle_reward(expected_coinbase_reward);
 

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -388,9 +388,12 @@ impl<N: Network> Block<N> {
         )?;
 
         // Calculate the expected coinbase reward.
-        let expected_coinbase_reward = coinbase_reward_v1(
+        let expected_coinbase_reward = coinbase_reward::<N>(
             height,
+            timestamp,
+            N::GENESIS_TIMESTAMP,
             N::STARTING_SUPPLY,
+            N::ANCHOR_TIME,
             N::ANCHOR_HEIGHT,
             N::BLOCK_TIME,
             combined_proof_target,

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -402,9 +402,17 @@ impl<N: Network> Block<N> {
         let expected_transaction_fees =
             self.transactions.iter().map(|tx| Ok(*tx.priority_fee_amount()?)).sum::<Result<u64>>()?;
 
+        // Calculate the time since last block.
+        let time_since_last_block = timestamp.saturating_sub(previous_block.timestamp());
         // Compute the expected block reward.
-        let expected_block_reward =
-            block_reward_v1(N::STARTING_SUPPLY, N::BLOCK_TIME, expected_coinbase_reward, expected_transaction_fees);
+        let expected_block_reward = block_reward::<N>(
+            height,
+            N::STARTING_SUPPLY,
+            N::BLOCK_TIME,
+            time_since_last_block,
+            expected_coinbase_reward,
+            expected_transaction_fees,
+        );
         // Compute the expected puzzle reward.
         let expected_puzzle_reward = puzzle_reward(expected_coinbase_reward);
 

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -316,6 +316,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Speculate over the ratifications, solutions, and transactions.
         let (ratifications, transactions, aborted_transaction_ids, ratified_finalize_operations) = self.vm.speculate(
             state,
+            next_timestamp.saturating_sub(previous_block.timestamp()),
             Some(coinbase_reward),
             candidate_ratifications,
             &solutions,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -295,7 +295,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         )?;
 
         // Calculate the coinbase reward.
-        let coinbase_reward = coinbase_reward(
+        let coinbase_reward = coinbase_reward_v1(
             next_height,
             N::STARTING_SUPPLY,
             N::ANCHOR_HEIGHT,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -295,9 +295,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         )?;
 
         // Calculate the coinbase reward.
-        let coinbase_reward = coinbase_reward_v1(
+        let coinbase_reward = coinbase_reward::<N>(
             next_height,
+            next_timestamp,
+            N::GENESIS_TIMESTAMP,
             N::STARTING_SUPPLY,
+            N::ANCHOR_TIME,
             N::ANCHOR_HEIGHT,
             N::BLOCK_TIME,
             combined_proof_target,

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -70,8 +70,15 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         )?;
 
         // Ensure speculation over the unconfirmed transactions is correct and ensure each transaction is well-formed and unique.
-        let ratified_finalize_operations =
-            self.vm.check_speculate(state, block.ratifications(), block.solutions(), block.transactions(), rng)?;
+        let time_since_last_block = block.timestamp().saturating_sub(self.latest_timestamp());
+        let ratified_finalize_operations = self.vm.check_speculate(
+            state,
+            time_since_last_block,
+            block.ratifications(),
+            block.solutions(),
+            block.transactions(),
+            rng,
+        )?;
 
         // Retrieve the committee lookback.
         let committee_lookback = {

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -32,6 +32,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     ///     `Ratify::BlockReward(block_reward)` and `Ratify::PuzzleReward(puzzle_reward)`
     ///     to the front of the `ratifications` list.
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn speculate<'a, R: Rng + CryptoRng>(
         &self,
         state: FinalizeGlobalState,

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -478,7 +478,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     };
 
                     // Compute the block reward.
-                    let block_reward = ledger_block::block_reward(
+                    let block_reward = ledger_block::block_reward_v1(
                         N::STARTING_SUPPLY,
                         N::BLOCK_TIME,
                         coinbase_reward,

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -361,7 +361,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let state = FinalizeGlobalState::new_genesis::<N>()?;
         // Speculate on the ratifications, solutions, and transactions.
         let (ratifications, transactions, aborted_transaction_ids, ratified_finalize_operations) =
-            self.speculate(state, None, ratifications, &solutions, transactions.iter(), rng)?;
+            self.speculate(state, 0, None, ratifications, &solutions, transactions.iter(), rng)?;
         ensure!(
             aborted_transaction_ids.is_empty(),
             "Failed to initialize a genesis block - found aborted transaction IDs"
@@ -764,8 +764,16 @@ function compute:
         let previous_block = vm.block_store().get_block(&block_hash).unwrap().unwrap();
 
         // Construct the new block header.
-        let (ratifications, transactions, aborted_transaction_ids, ratified_finalize_operations) =
-            vm.speculate(sample_finalize_state(1), None, vec![], &None.into(), transactions.iter(), rng)?;
+        let time_since_last_block = MainnetV0::BLOCK_TIME as i64;
+        let (ratifications, transactions, aborted_transaction_ids, ratified_finalize_operations) = vm.speculate(
+            sample_finalize_state(1),
+            time_since_last_block,
+            None,
+            vec![],
+            &None.into(),
+            transactions.iter(),
+            rng,
+        )?;
 
         // Construct the metadata associated with the block.
         let metadata = Metadata::new(
@@ -778,7 +786,7 @@ function compute:
             MainnetV0::GENESIS_PROOF_TARGET,
             previous_block.last_coinbase_target(),
             previous_block.last_coinbase_timestamp(),
-            MainnetV0::GENESIS_TIMESTAMP + 1,
+            previous_block.timestamp().saturating_add(time_since_last_block),
         )?;
 
         let header = Header::from(

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -547,8 +547,17 @@ mod tests {
         let deployment_transaction = vm.deploy(&caller_private_key, &program, Some(credits), 10, None, rng).unwrap();
 
         // Construct the new block header.
+        let time_since_last_block = CurrentNetwork::BLOCK_TIME as i64;
         let (ratifications, transactions, aborted_transaction_ids, ratified_finalize_operations) = vm
-            .speculate(sample_finalize_state(1), Some(0u64), vec![], &None.into(), [deployment_transaction].iter(), rng)
+            .speculate(
+                sample_finalize_state(1),
+                time_since_last_block,
+                Some(0u64),
+                vec![],
+                &None.into(),
+                [deployment_transaction].iter(),
+                rng,
+            )
             .unwrap();
         assert!(aborted_transaction_ids.is_empty());
 
@@ -563,7 +572,7 @@ mod tests {
             CurrentNetwork::GENESIS_PROOF_TARGET,
             genesis.last_coinbase_target(),
             genesis.last_coinbase_timestamp(),
-            CurrentNetwork::GENESIS_TIMESTAMP + 1,
+            genesis.timestamp().saturating_add(time_since_last_block),
         )
         .unwrap();
 

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -466,6 +466,7 @@ fn construct_fee_records<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng
 }
 
 // A helper function to construct the next block.
+#[allow(clippy::too_many_arguments)]
 fn construct_next_block<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>(
     vm: &VM<CurrentNetwork, C>,
     time_since_last_block: i64,


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR is intended to implement and address the concerns highlighted in [ARC-0042](https://github.com/AleoNet/ARCs/discussions/76).

The gist is that the current block times are not aligned with our current algorithms and causing the following:
1. `block_reward` is emitting at a higher inflation rate than the expected 5%
2. `coinbase_reward` is reducing too quickly and not over the expected 10 year timeline.

This PR addresses the problem by using `timestamps` as the peg rather than `block_height`. Both the inflation rate and the `coinbase_reward` reduction-over-time are on human timescales; it makes sense for us to align the formulas to the human timescale with `timestamps` rather than relying on `block_heights`, which are on a network timescale.

### `block_reward`:
- Rename original to `block_reward_v1`
- Implement `block_reward_v2`
- Use `time_since_last_block` to determine how much reward to emit for that particular block in relation to how much inflation that `time_since_last_block` seconds should cause.
- This `time_since_last_block` is bound by a block interval of 60 seconds to prevent the block reward from becoming too large in the event of a long block interval such as a network outage or network upgrade.

### `coinbase_reward`:
- Rename original to `coinbase_reward_v1`
- Implement `coinbase_reward_v2`
- Use `anchor_block_reward_at_timestamp` instead of `anchor_block_reward_at_height`
- Uses the number of seconds the block is to the 10 year mark to determine the reward. The closer we are, the less reward.

Some emission analysis can be seen in the comments below - https://github.com/AleoNet/snarkVM/pull/2569#issuecomment-2456020249

## **Migration:**
- Introduce `N::CONSENSUS_V2_HEIGHT` to Network trait 
    - This is the height for each network that snarkVM will swap from the `v1` reward impls to the `v2` reward impls.
- SnarkOS will require nodes to swap to the new version before height `N::CONSENSUS_V2_HEIGHT`, otherwise there may be some issues.
    - Validators need to change to the new version or risk possible forking
    - Clients need to change to the new version or risk sync halting

The migration and reward logic change will occur at the following block heights (These heights are subject to change):

### **Canary** - Block 2,900,000 (~Nov 15, 2024 at the current 3.3s block times)
### **Testnet** - Block 2,950,000 (~Nov 22, 2024 at the current 3.3s block times)
### **Mainnet** - Block 2,800,000 (~Dec 10, 2024 at the current 3.0s block times)

These numbers were calculated by determining the planned release schedule and backing into the block height using the current block speeds and including a buffer between release and consensus change. This buffer is intended to give leeway for nodes to upgrade before the consensus change. The following table is the approximate timeline and buffers for the networks:

| Network | Release Date | Buffer | Consensus V2 |
|---------|--------------|--------|--------------|
| Canary  | Nov 12, 2024 | 3 days | Nov 15, 2024 |
| Testnet | Nov 19, 2024 | 3 days | Nov 22, 2024 |
| Mainnet | Dec 3, 2024  | 7 days | Dec 10, 2024 |


## Test Plan

Tests have been added to ensure that the V2 `block_reward` and `coinbase_reward` implementations match the expected behavior. 

CI can be found [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM?branch=feat%2Fblock_reward_v2-ci).

