### PR TITLE
[Perf] Skip costly validation for stored data

### DIFF
--- a/console/account/src/compute_key/bytes.rs
+++ b/console/account/src/compute_key/bytes.rs
@@ -27,6 +27,18 @@ impl<N: Network> FromBytes for ComputeKey<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for ComputeKey<N> {
+    /// Reads an account compute key from a buffer.
+    #[inline]
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        let pk_sig = Group::from_x_coordinate_unchecked(Field::new(N::Field::read_le(&mut reader)?))
+            .map_err(|e| error(format!("{e}")))?;
+        let pr_sig = Group::from_x_coordinate_unchecked(Field::new(N::Field::read_le(&mut reader)?))
+            .map_err(|e| error(format!("{e}")))?;
+        Self::try_from((pk_sig, pr_sig)).map_err(|e| error(format!("{e}")))
+    }
+}
+
 impl<N: Network> ToBytes for ComputeKey<N> {
     /// Writes an account compute key to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
@@ -56,7 +68,9 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, ComputeKey::read_le(&expected_bytes[..])?);
+            assert_eq!(expected, ComputeKey::read_le_unchecked(&expected_bytes[..])?);
             assert!(ComputeKey::<CurrentNetwork>::read_le(&expected_bytes[1..]).is_err());
+            assert!(ComputeKey::<CurrentNetwork>::read_le_unchecked(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/account/src/signature/bytes.rs
+++ b/console/account/src/signature/bytes.rs
@@ -26,6 +26,17 @@ impl<N: Network> FromBytes for Signature<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for Signature<N> {
+    /// Reads an account signature from a buffer.
+    #[inline]
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        let challenge = Scalar::new(FromBytes::read_le(&mut reader)?);
+        let response = Scalar::new(FromBytes::read_le(&mut reader)?);
+        let compute_key = ComputeKey::read_le_unchecked(&mut reader)?;
+        Ok(Self { challenge, response, compute_key })
+    }
+}
+
 impl<N: Network> ToBytes for Signature<N> {
     /// Writes an account signature to a buffer.
     #[inline]
@@ -56,7 +67,9 @@ mod tests {
             // Check the byte representation.
             let signature_bytes = signature.to_bytes_le()?;
             assert_eq!(signature, Signature::read_le(&signature_bytes[..])?);
+            assert_eq!(signature, Signature::read_le_unchecked(&signature_bytes[..])?);
             assert!(Signature::<CurrentNetwork>::read_le(&signature_bytes[1..]).is_err());
+            assert!(Signature::<CurrentNetwork>::read_le_unchecked(&signature_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -65,6 +65,8 @@ pub mod prelude {
         FromBits as _,
         FromBytes,
         FromBytesDeserializer,
+        FromBytesUnchecked,
+        FromBytesUncheckedDeserializer,
         LimitedWriter,
         TestRng,
         ToBits as _,

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -73,6 +73,7 @@ pub mod prelude {
         ToBytes,
         ToBytesSerializer,
         Uniform,
+        Verified,
         cfg_chunks,
         cfg_find,
         cfg_find_map,

--- a/console/types/address/src/bytes.rs
+++ b/console/types/address/src/bytes.rs
@@ -23,6 +23,14 @@ impl<E: Environment> FromBytes for Address<E> {
     }
 }
 
+impl<E: Environment> FromBytesUnchecked for Address<E> {
+    /// Reads in an account address from a buffer.
+    #[inline]
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        Ok(Address::new(FromBytesUnchecked::read_le_unchecked(&mut reader)?))
+    }
+}
+
 impl<E: Environment> ToBytes for Address<E> {
     /// Writes an account address to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
@@ -50,7 +58,9 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Address::read_le(&expected_bytes[..])?);
+            assert_eq!(expected, Address::read_le_unchecked(&expected_bytes[..])?);
             assert!(Address::<CurrentEnvironment>::read_le(&expected_bytes[1..]).is_err());
+            assert!(Address::<CurrentEnvironment>::read_le_unchecked(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/types/group/src/bytes.rs
+++ b/console/types/group/src/bytes.rs
@@ -23,6 +23,14 @@ impl<E: Environment> FromBytes for Group<E> {
     }
 }
 
+impl<E: Environment> FromBytesUnchecked for Group<E> {
+    /// Reads the group from a buffer.
+    #[inline]
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        Self::from_x_coordinate_unchecked(FromBytes::read_le(&mut reader)?).map_err(|e| error(e.to_string()))
+    }
+}
+
 impl<E: Environment> ToBytes for Group<E> {
     /// Writes the group to a buffer.
     #[inline]
@@ -51,7 +59,9 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Group::read_le(&expected_bytes[..])?);
+            assert_eq!(expected, Group::read_le_unchecked(&expected_bytes[..])?);
             assert!(Group::<CurrentEnvironment>::read_le(&expected_bytes[1..]).is_err());
+            assert!(Group::<CurrentEnvironment>::read_le_unchecked(&expected_bytes[1..]).is_err());
         }
         Ok(())
     }

--- a/console/types/group/src/from_x_coordinate.rs
+++ b/console/types/group/src/from_x_coordinate.rs
@@ -28,4 +28,12 @@ impl<E: Environment> Group<E> {
         }
         bail!("Failed to recover an affine group from an x-coordinate of {x_coordinate}")
     }
+
+    /// Attempts to recover an affine group element from a given x-coordinate field element.
+    pub fn from_x_coordinate_unchecked(x_coordinate: Field<E>) -> Result<Self> {
+        if let Some((p1, _p2)) = E::Affine::pair_from_x_coordinate(*x_coordinate) {
+            return Ok(Self::new(p1));
+        }
+        bail!("Failed to recover an affine group from an x-coordinate of {x_coordinate}")
+    }
 }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -27,6 +27,12 @@ path = "benches/bonded_mapping.rs"
 harness = false
 
 [[bench]]
+name = "dag"
+path = "benches/dag.rs"
+harness = false
+required-features = ["test-helpers"]
+
+[[bench]]
 name = "transaction"
 path = "benches/transaction.rs"
 harness = false

--- a/ledger/authority/src/bytes.rs
+++ b/ledger/authority/src/bytes.rs
@@ -29,6 +29,20 @@ impl<N: Network> FromBytes for Authority<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for Authority<N> {
+    /// Reads the authority from the buffer.
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the variant.
+        let variant = u8::read_le(&mut reader)?;
+        // Match the variant.
+        match variant {
+            0 => Ok(Self::Beacon(FromBytes::read_le(&mut reader)?)),
+            1 => Ok(Self::Quorum(FromBytesUnchecked::read_le_unchecked(&mut reader)?)),
+            2.. => Err(error("Invalid authority variant")),
+        }
+    }
+}
+
 impl<N: Network> ToBytes for Authority<N> {
     /// Writes the authority to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
@@ -63,6 +77,7 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Authority::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(expected, Authority::read_le_unchecked(&expected_bytes[..]).unwrap());
         }
     }
 }

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -33,6 +33,7 @@ use console::{
         Formatter,
         FromBytes,
         FromBytesDeserializer,
+        FromBytesUnchecked,
         FromStr,
         IoResult,
         Read,

--- a/ledger/benches/dag.rs
+++ b/ledger/benches/dag.rs
@@ -1,0 +1,98 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate criterion;
+
+use console::{network::MainnetV0, prelude::*};
+use snarkvm_ledger::narwhal::subdag::test_helpers::sample_subdag;
+
+use criterion::Criterion;
+
+/// Helper method to benchmark serialization.
+fn bench_serialization<T: Serialize + DeserializeOwned + ToBytes + FromBytes + FromBytesUnchecked + Clone>(
+    c: &mut Criterion,
+    name: &str,
+    object: T,
+) {
+    ///////////////
+    // Serialize //
+    ///////////////
+
+    // snarkvm_utilities::ToBytes
+    {
+        let object = object.clone();
+        c.bench_function(&format!("{name}::to_bytes_le"), move |b| b.iter(|| object.to_bytes_le().unwrap()));
+    }
+    // bincode::serialize
+    {
+        let object = object.clone();
+        c.bench_function(&format!("{name}::serialize (bincode)"), move |b| {
+            b.iter(|| bincode::serialize(&object).unwrap())
+        });
+    }
+    // serde_json::to_string
+    {
+        let object = object.clone();
+        c.bench_function(&format!("{name}::to_string (serde_json)"), move |b| {
+            b.iter(|| serde_json::to_string(&object).unwrap())
+        });
+    }
+
+    /////////////////
+    // Deserialize //
+    /////////////////
+
+    // snarkvm_utilities::FromBytes
+    {
+        let buffer = object.to_bytes_le().unwrap();
+        c.bench_function(&format!("{name}::from_bytes_le"), move |b| b.iter(|| T::from_bytes_le(&buffer).unwrap()));
+    }
+    // snarkvm_utilities::FromBytesUnchecked
+    {
+        let buffer = object.to_bytes_le().unwrap();
+        c.bench_function(&format!("{name}::from_bytes_le_unchecked"), move |b| {
+            b.iter(|| T::from_bytes_le_unchecked(&buffer).unwrap())
+        });
+    }
+    // bincode::deserialize
+    {
+        let buffer = bincode::serialize(&object).unwrap();
+        c.bench_function(&format!("{name}::deserialize (bincode)"), move |b| {
+            b.iter(|| bincode::deserialize::<T>(&buffer).unwrap())
+        });
+    }
+    // serde_json::from_str
+    {
+        let object = serde_json::to_string(&object).unwrap();
+        c.bench_function(&format!("{name}::from_str (serde_json)"), move |b| {
+            b.iter(|| serde_json::from_str::<T>(&object).unwrap())
+        });
+    }
+}
+
+fn subdag_serialization(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+    let subdag = sample_subdag(rng);
+    bench_serialization(c, "Subdag", subdag);
+}
+
+criterion_group! {
+    name = subdag;
+    config = Criterion::default().sample_size(10);
+    targets = subdag_serialization
+}
+
+criterion_main!(subdag);

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -90,6 +90,76 @@ impl<N: Network> FromBytes for Block<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for Block<N> {
+    /// Reads the block from the buffer without performing expensive input validation.
+    #[inline]
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid block version"));
+        }
+
+        // Read the block hash.
+        let block_hash: N::BlockHash = FromBytes::read_le(&mut reader)?;
+        // Read the previous block hash.
+        let previous_hash = FromBytes::read_le(&mut reader)?;
+        // Read the header.
+        let header = FromBytes::read_le(&mut reader)?;
+
+        // Write the authority.
+        let authority = FromBytesUnchecked::read_le_unchecked(&mut reader)?;
+
+        // Read the number of ratifications.
+        let ratifications = Ratifications::read_le(&mut reader)?;
+
+        // Read the solutions.
+        let solutions: Solutions<N> = FromBytes::read_le(&mut reader)?;
+
+        // Read the number of aborted solution IDs.
+        let num_aborted_solutions = u32::read_le(&mut reader)?;
+        // Ensure the number of aborted solutions IDs is within bounds (this is an early safety check).
+        if num_aborted_solutions as usize > Solutions::<N>::MAX_ABORTED_SOLUTIONS {
+            return Err(error("Invalid number of aborted solutions IDs in the block"));
+        }
+        // Read the aborted solution IDs.
+        let mut aborted_solution_ids = Vec::with_capacity(num_aborted_solutions as usize);
+        for _ in 0..num_aborted_solutions {
+            aborted_solution_ids.push(FromBytes::read_le(&mut reader)?);
+        }
+
+        // Read the transactions.
+        let transactions = FromBytes::read_le(&mut reader)?;
+
+        // Read the number of aborted transaction IDs.
+        let num_aborted_transactions = u32::read_le(&mut reader)?;
+        // Ensure the number of aborted transaction IDs is within bounds (this is an early safety check).
+        if num_aborted_transactions as usize > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
+            return Err(error("Invalid number of aborted transaction IDs in the block"));
+        }
+        // Read the aborted transaction IDs.
+        let mut aborted_transaction_ids = Vec::with_capacity(num_aborted_transactions as usize);
+        for _ in 0..num_aborted_transactions {
+            aborted_transaction_ids.push(FromBytes::read_le(&mut reader)?);
+        }
+
+        // Construct the block.
+        Self::from_unchecked(
+            block_hash,
+            previous_hash,
+            header,
+            authority,
+            ratifications,
+            solutions,
+            aborted_solution_ids,
+            transactions,
+            aborted_transaction_ids,
+        )
+        .map_err(error)
+    }
+}
+
 impl<N: Network> ToBytes for Block<N> {
     /// Writes the block to the buffer.
     #[inline]
@@ -141,6 +211,7 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Block::read_le(&expected_bytes[..])?);
+            assert_eq!(expected, Block::read_le_unchecked(&expected_bytes[..])?);
         }
         Ok(())
     }
@@ -153,6 +224,7 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = genesis_block.to_bytes_le()?;
         assert_eq!(genesis_block, Block::read_le(&expected_bytes[..])?);
+        assert_eq!(genesis_block, Block::read_le_unchecked(&expected_bytes[..])?);
 
         Ok(())
     }

--- a/ledger/block/src/serialize.rs
+++ b/ledger/block/src/serialize.rs
@@ -64,7 +64,7 @@ impl<'de, N: Network> Deserialize<'de> for Block<N> {
                     false => Err(de::Error::custom(error("Mismatching block hash, possible data corruption"))),
                 }
             }
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "block"),
+            false => FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "block"),
         }
     }
 }

--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -66,6 +66,39 @@ impl<N: Network> ToBytes for BatchCertificate<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for BatchCertificate<N> {
+    /// Reads the batch certificate from the buffer.
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid batch certificate version"));
+        }
+
+        // Read the batch header.
+        let batch_header = BatchHeader::read_le_unchecked(&mut reader)?;
+        // Read the number of signatures.
+        let num_signatures = u16::read_le(&mut reader)?;
+        // Ensure the number of signatures is within bounds.
+        if num_signatures > Self::MAX_SIGNATURES {
+            return Err(error(format!(
+                "Number of signatures ({num_signatures}) exceeds the maximum ({})",
+                Self::MAX_SIGNATURES
+            )));
+        }
+        // Read the signature bytes.
+        let mut signature_bytes = vec![0u8; num_signatures as usize * Signature::<N>::size_in_bytes()];
+        reader.read_exact(&mut signature_bytes)?;
+        // Read the signatures.
+        let signatures = cfg_chunks!(signature_bytes, Signature::<N>::size_in_bytes())
+            .map(Signature::read_le_unchecked)
+            .collect::<Result<IndexSet<_>, _>>()?;
+        // Return the batch certificate.
+        Self::from_unchecked(batch_header, signatures).map_err(error)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,6 +111,7 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, BatchCertificate::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(expected, BatchCertificate::read_le_unchecked(&expected_bytes[..]).unwrap());
         }
     }
 }

--- a/ledger/narwhal/batch-certificate/src/serialize.rs
+++ b/ledger/narwhal/batch-certificate/src/serialize.rs
@@ -42,7 +42,10 @@ impl<'de, N: Network> Deserialize<'de> for BatchCertificate<N> {
                 )
                 .map_err(de::Error::custom)
             }
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "batch certificate"),
+            false => FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(
+                deserializer,
+                "batch certificate",
+            ),
         }
     }
 }

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -87,6 +87,79 @@ impl<N: Network> FromBytes for BatchHeader<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for BatchHeader<N> {
+    /// Reads the batch header from the buffer.
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid batch header version"));
+        }
+
+        // Read the batch ID.
+        let batch_id = Field::read_le(&mut reader)?;
+        // Read the author.
+        let author = Address::read_le(&mut reader)?;
+        // Read the round number.
+        let round = u64::read_le(&mut reader)?;
+        // Read the timestamp.
+        let timestamp = i64::read_le(&mut reader)?;
+        // Read the committee ID.
+        let committee_id = Field::read_le(&mut reader)?;
+
+        // Read the number of transmission IDs.
+        let num_transmission_ids = u32::read_le(&mut reader)?;
+        // Ensure the number of transmission IDs is within bounds.
+        if num_transmission_ids as usize > Self::MAX_TRANSMISSIONS_PER_BATCH {
+            return Err(error(format!(
+                "Number of transmission IDs ({num_transmission_ids}) exceeds the maximum ({})",
+                Self::MAX_TRANSMISSIONS_PER_BATCH,
+            )));
+        }
+        // Read the transmission IDs.
+        let mut transmission_ids = IndexSet::new();
+        for _ in 0..num_transmission_ids {
+            // Insert the transmission ID.
+            transmission_ids.insert(TransmissionID::read_le(&mut reader)?);
+        }
+
+        // Read the number of previous certificate IDs.
+        let num_previous_certificate_ids = u16::read_le(&mut reader)?;
+        // Ensure the number of previous certificate IDs is within bounds.
+        if num_previous_certificate_ids > Self::MAX_CERTIFICATES {
+            return Err(error(format!(
+                "Number of previous certificate IDs ({num_previous_certificate_ids}) exceeds the maximum ({})",
+                Self::MAX_CERTIFICATES
+            )));
+        }
+
+        // Read the previous certificate ID bytes.
+        let mut previous_certificate_id_bytes =
+            vec![0u8; num_previous_certificate_ids as usize * Field::<N>::size_in_bytes()];
+        reader.read_exact(&mut previous_certificate_id_bytes)?;
+        // Read the previous certificate IDs.
+        let previous_certificate_ids = cfg_chunks!(previous_certificate_id_bytes, Field::<N>::size_in_bytes())
+            .map(Field::read_le)
+            .collect::<Result<IndexSet<_>, _>>()?;
+
+        // Read the signature.
+        let signature = Signature::read_le_unchecked(&mut reader)?;
+
+        // Construct the batch.
+        Ok(Self::from_unchecked(
+            author,
+            batch_id,
+            round,
+            timestamp,
+            committee_id,
+            transmission_ids,
+            previous_certificate_ids,
+            signature,
+        ))
+    }
+}
+
 impl<N: Network> ToBytes for BatchHeader<N> {
     /// Writes the batch header to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
@@ -133,6 +206,7 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, BatchHeader::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(expected, BatchHeader::read_le_unchecked(&expected_bytes[..]).unwrap());
         }
     }
 }

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -174,7 +174,7 @@ impl<N: Network> BatchHeader<N> {
             bail!("Invalid signature for the batch header");
         }
         // Return the batch header.
-        Ok(Self {
+        Ok(Self::from_unchecked(
             author,
             batch_id,
             round,
@@ -183,7 +183,22 @@ impl<N: Network> BatchHeader<N> {
             transmission_ids,
             previous_certificate_ids,
             signature,
-        })
+        ))
+    }
+
+    /// Initializes a new batch header.
+    pub fn from_unchecked(
+        author: Address<N>,
+        batch_id: Field<N>,
+        round: u64,
+        timestamp: i64,
+        committee_id: Field<N>,
+        transmission_ids: IndexSet<TransmissionID<N>>,
+        previous_certificate_ids: IndexSet<Field<N>>,
+        signature: Signature<N>,
+    ) -> Self {
+        // Return the batch header.
+        Self { author, batch_id, round, timestamp, committee_id, transmission_ids, previous_certificate_ids, signature }
     }
 }
 

--- a/ledger/narwhal/batch-header/src/serialize.rs
+++ b/ledger/narwhal/batch-header/src/serialize.rs
@@ -65,7 +65,9 @@ impl<'de, N: Network> Deserialize<'de> for BatchHeader<N> {
                     )))),
                 }
             }
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "batch header"),
+            false => {
+                FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "batch header")
+            }
         }
     }
 }

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -60,6 +60,51 @@ impl<N: Network> FromBytes for Subdag<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for Subdag<N> {
+    /// Reads the subdag from the buffer.
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error(format!("Invalid subdag version ({version})")));
+        }
+
+        // Read the number of rounds.
+        let num_rounds = u32::read_le(&mut reader)?;
+        // Ensure the number of rounds is within bounds.
+        if num_rounds as u64 > Self::MAX_ROUNDS {
+            return Err(error(format!("Number of rounds ({num_rounds}) exceeds the maximum ({})", Self::MAX_ROUNDS)));
+        }
+        // Read the round certificates.
+        let mut subdag = BTreeMap::new();
+        for _ in 0..num_rounds {
+            // Read the round.
+            let round = u64::read_le(&mut reader)?;
+            // Read the number of certificates.
+            let num_certificates = u16::read_le(&mut reader)?;
+            // Ensure the number of certificates is within bounds.
+            if num_certificates > BatchHeader::<N>::MAX_CERTIFICATES {
+                return Err(error(format!(
+                    "Number of certificates ({num_certificates}) exceeds the maximum ({})",
+                    BatchHeader::<N>::MAX_CERTIFICATES
+                )));
+            }
+            // Read the certificates.
+            let mut certificates = IndexSet::new();
+            for _ in 0..num_certificates {
+                // Read the certificate.
+                certificates.insert(BatchCertificate::read_le_unchecked(&mut reader)?);
+            }
+            // Insert the round and certificates.
+            subdag.insert(round, certificates);
+        }
+
+        // Return the subdag.
+        Ok(Self::from_unchecked(subdag))
+    }
+}
+
 impl<N: Network> ToBytes for Subdag<N> {
     /// Writes the subdag to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
@@ -95,6 +140,7 @@ mod tests {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Subdag::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(expected, Subdag::read_le_unchecked(&expected_bytes[..]).unwrap());
         }
     }
 }

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -146,6 +146,11 @@ impl<N: Network> Subdag<N> {
         // Ensure the leader certificate is an even round.
         Ok(Self { subdag })
     }
+
+    /// Initializes a new subdag.
+    pub fn from_unchecked(subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>) -> Self {
+        Self { subdag }
+    }
 }
 
 impl<N: Network> Subdag<N> {

--- a/ledger/narwhal/subdag/src/serialize.rs
+++ b/ledger/narwhal/subdag/src/serialize.rs
@@ -39,7 +39,7 @@ impl<'de, N: Network> Deserialize<'de> for Subdag<N> {
                 Ok(Self::from(DeserializeExt::take_from_value::<D>(&mut value, "subdag")?)
                     .map_err(de::Error::custom)?)
             }
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "subdag"),
+            false => FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "subdag"),
         }
     }
 }

--- a/ledger/narwhal/transmission/src/bytes.rs
+++ b/ledger/narwhal/transmission/src/bytes.rs
@@ -37,6 +37,28 @@ impl<N: Network> FromBytes for Transmission<N> {
     }
 }
 
+impl<N: Network> FromBytesUnchecked for Transmission<N> {
+    /// Reads the transmission from the buffer.
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid transmission version"));
+        }
+
+        // Read the variant.
+        let variant = u8::read_le(&mut reader)?;
+        // Match the variant.
+        match variant {
+            0 => Ok(Self::Ratification),
+            1 => Ok(Self::Solution(Data::read_le(&mut reader)?)),
+            2 => Ok(Self::Transaction(Data::read_le(&mut reader)?)),
+            3.. => Err(error("Invalid transmission variant")),
+        }
+    }
+}
+
 impl<N: Network> ToBytes for Transmission<N> {
     /// Writes the transmission to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -87,7 +87,7 @@ pub fn execution_cost_v1<N: Network>(process: &Process<N>, execution: &Execution
 
     // Get the finalize cost for the root transition.
     let stack = process.get_stack(transition.program_id())?;
-    let finalize_cost = cost_in_microcredits_v1(stack, transition.function_name())?;
+    let finalize_cost = cost_in_microcredits_v1(&stack, transition.function_name())?;
 
     // Compute the total cost in microcredits.
     let total_cost = storage_cost

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -21,7 +21,9 @@ use crate::{
     marker::PhantomData,
 };
 use serde::{
+    Deserialize,
     Deserializer,
+    Serialize,
     Serializer,
     de::{self, Error, SeqAccess, Visitor},
     ser::{self, SerializeTuple},
@@ -97,6 +99,25 @@ pub trait FromBytesUnchecked {
     }
 }
 
+/// Transparant wrapper struct to indicate that a value has been verified and does not require expensive input validation on deserialization.
+/// TODO: consider bounding database read operations by Verified and consider automatically dereferencing to the inner type.
+/// TODO: add a serialize/deserialize test for Verified wrapped data.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct Verified<T: FromBytesUnchecked + ToBytes>(pub T);
+
+impl<T: FromBytesUnchecked + ToBytes> FromBytes for Verified<T> {
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        T::read_le_unchecked(reader).map(Verified)
+    }
+}
+
+impl<T: FromBytesUnchecked + ToBytes> ToBytes for Verified<T> {
+    fn write_le<W: Write>(&self, writer: W) -> IoResult<()> {
+        self.0.write_le(writer)
+    }
+}
+
+/// Helper struct to serialize an object.
 pub struct ToBytesSerializer<T: ToBytes>(PhantomData<T>);
 
 impl<T: ToBytes> ToBytesSerializer<T> {
@@ -117,6 +138,7 @@ impl<T: ToBytes> ToBytesSerializer<T> {
     }
 }
 
+/// Helper struct to deserialize an object.
 pub struct FromBytesDeserializer<T: FromBytes>(PhantomData<T>);
 
 impl<'de, T: FromBytes> FromBytesDeserializer<T> {

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -81,6 +81,22 @@ pub trait FromBytes {
     }
 }
 
+pub trait FromBytesUnchecked {
+    /// Reads `Self` from `reader` as little-endian bytes.
+    /// Does not perform input validation.
+    fn read_le_unchecked<R: Read>(reader: R) -> IoResult<Self>
+    where
+        Self: Sized;
+
+    /// Returns `Self` from a byte array in little-endian order.
+    fn from_bytes_le_unchecked(bytes: &[u8]) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self::read_le_unchecked(bytes)?)
+    }
+}
+
 pub struct ToBytesSerializer<T: ToBytes>(PhantomData<T>);
 
 impl<T: ToBytes> ToBytesSerializer<T> {
@@ -164,6 +180,17 @@ impl<'de, T: FromBytes> FromBytesDeserializer<T> {
                 false => Err(error),
             },
         }
+    }
+}
+
+pub struct FromBytesUncheckedDeserializer<T: FromBytesUnchecked>(PhantomData<T>);
+
+impl<'de, T: FromBytesUnchecked> FromBytesUncheckedDeserializer<T> {
+    /// Deserializes a dynamically-sized byte array.
+    pub fn deserialize_with_size_encoding<D: Deserializer<'de>>(deserializer: D, name: &str) -> Result<T, D::Error> {
+        let mut buffer = Vec::with_capacity(32);
+        deserializer.deserialize_bytes(FromBytesVisitor::new(&mut buffer, name))?;
+        FromBytesUnchecked::read_le_unchecked(&*buffer).map_err(de::Error::custom)
     }
 }
 


### PR DESCRIPTION
## Motivation

Currently, every time an object is deserialized, input validation is performed. Ideally, we only perform input validation on data received from the network, not from disk.

This PR takes an initial stab at skipping the most expensive input validation with the smallest possible code diff. Deserialization of a `Subdag` and its contents is now about 10x faster, see the new `dag.rs` benchmark (half of which is due to skipping `is_in_correct_subgroup_assuming_on_curve`).

Whenever we (de)serialize from disk, we use `bincode` (which in its current use just prepends some bytes to `to_bytes_le`). Bincode calls into `Deserialize::deserialize`, which now calls into `FromBytesUncheckedDeserializer`, which now calls into `from_bytes_le_unchecked`.

## Test Plan

- [ ] CI passes
- [ ] Run a local network, with traffic and restarts

## Open TODOs
- [ ] Ensure that `Deserialize::deserialize` is only used when getting data from disk, consider enforcing types are `Verified` in the `DataMap` interface.
- [ ] Profile which objects we're actually reading from disk in practice, given that we have so many caches.
- [ ] Look into correctness of `from_x_coordinate_unchecked`
- [ ] New functions and types are all defined consistently, in the same order, with clear comments
- [ ] Update Cargo.lock
- [ ] Review if the recently added [transmissions cache](https://github.com/AleoNet/snarkOS/pull/3395) is still warranted
