### PR TITLE
[Perf] Cache program address in Stack

### DIFF
--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -31,6 +31,7 @@ impl<N: Network> Stack<N> {
             number_of_calls: Default::default(),
             finalize_costs: Default::default(),
             program_depth: 0,
+            program_address: program.id().to_address()?,
         };
 
         // Add all the imports into the stack.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -193,6 +193,8 @@ pub struct Stack<N: Network> {
     finalize_costs: IndexMap<Identifier<N>, u64>,
     /// The program depth.
     program_depth: usize,
+    /// The program address.
+    program_address: Address<N>,
 }
 
 impl<N: Network> Stack<N> {
@@ -238,6 +240,12 @@ impl<N: Network> StackProgram<N> for Stack<N> {
     #[inline]
     fn program_depth(&self) -> usize {
         self.program_depth
+    }
+
+    /// Returns the program address.
+    #[inline]
+    fn program_address(&self) -> &Address<N> {
+        &self.program_address
     }
 
     /// Returns `true` if the stack contains the external record.

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -179,8 +179,12 @@ impl<N: Network> Process<N> {
             // If there is no parent, then `is_root` is `1` and `parent` is the root program ID.
             None => (Field::one(), *transition.program_id()),
         };
+
+        // Retrieve the adress belonging to the parent.
+        let parent_address = self.get_stack(parent)?.program_address();
+
         // Compute the x- and y-coordinate of `parent`.
-        let (parent_x, parent_y) = parent.to_address()?.to_xy_coordinates();
+        let (parent_x, parent_y) = parent_address.to_xy_coordinates();
 
         // [Inputs] Construct the verifier inputs to verify the proof.
         let mut inputs = vec![N::Field::one(), *tpk_x, *tpk_y, **transition.tcm(), **transition.scm()];

--- a/synthesizer/process/src/verify_fee.rs
+++ b/synthesizer/process/src/verify_fee.rs
@@ -116,8 +116,11 @@ impl<N: Network> Process<N> {
         // Compute the x- and y-coordinate of `tpk`.
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
+        // Retrieve the adress belonging to the program ID.
+        let program_adress = self.get_stack(fee.program_id())?.program_address();
+
         // Compute the x- and y-coordinate of `parent`.
-        let (parent_x, parent_y) = fee.program_id().to_address()?.to_xy_coordinates();
+        let (parent_x, parent_y) = program_adress.to_xy_coordinates();
 
         // Construct the public inputs to verify the proof.
         let mut inputs = vec![N::Field::one(), *tpk_x, *tpk_y, **fee.tcm(), **fee.scm()];
@@ -185,8 +188,11 @@ impl<N: Network> Process<N> {
         // Compute the x- and y-coordinate of `tpk`.
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
+        // Retrieve the adress belonging to the program ID.
+        let program_adress = self.get_stack(fee.program_id())?.program_address();
+
         // Compute the x- and y-coordinate of `parent`.
-        let (parent_x, parent_y) = fee.program_id().to_address()?.to_xy_coordinates();
+        let (parent_x, parent_y) = program_adress.to_xy_coordinates();
 
         // Construct the public inputs to verify the proof.
         let mut inputs = vec![N::Field::one(), *tpk_x, *tpk_y, **fee.tcm(), **fee.scm()];

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -69,6 +69,9 @@ pub trait StackProgram<N: Network> {
     /// Returns the program depth.
     fn program_depth(&self) -> usize;
 
+    /// Returns the program address.
+    fn program_address(&self) -> &Address<N>;
+
     /// Returns `true` if the stack contains the external record.
     fn contains_external_record(&self, locator: &Locator<N>) -> bool;
 


### PR DESCRIPTION
## Motivation

Currently, program address derivation accounts for about 5% of total transaction verification compute. By caching the program address during Stack generation, this cost is as good as gone.

## Test Plan

Existing unit tests should suffice.