### PR TITLE
Nit: Do not hardcode the hiding mode

### DIFF
--- a/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
@@ -142,7 +142,7 @@ impl<F: PrimeField, SM: SNARKMode> Circuit<F, SM> {
     pub fn interpolate_matrix_evals(&self) -> Result<impl Iterator<Item = LabeledPolynomial<F>>> {
         let mut iters = Vec::with_capacity(3);
         for (label, evals) in [("a", &self.a_arith), ("b", &self.b_arith), ("c", &self.c_arith)] {
-            iters.push(MatrixArithmetization::new(&self.id, label, evals)?.into_iter());
+            iters.push(MatrixArithmetization::new::<SM>(&self.id, label, evals)?.into_iter());
         }
         Ok(iters.into_iter().flatten())
     }


### PR DESCRIPTION
## Motivation

Found this while browsing through the code. We should not be hardcoding the hiding mode, but set it during a test/library invocation. This particular instance was harmless, but should be fixed to safeguard future development nonetheless.

## Test Plan

No actual logic is changed worth testing.

A unit test failed, likely for an unrelated reason (parameter fetching), please retrigger 🙏 