### PR TITLE
[Feature] Introduce a console literal for raw bytes

### DIFF
--- a/circuit/program/src/data/literal/cast/mod.rs
+++ b/circuit/program/src/data/literal/cast/mod.rs
@@ -115,6 +115,9 @@ macro_rules! impl_cast_body {
             LiteralType::String => {
                 bail!(concat!("Cannot cast a ", stringify!($type_name), " literal to a string type."))
             }
+            LiteralType::Bytes => {
+                bail!(concat!("Cannot cast a ", stringify!($type_name), " literal to a bytes type."))
+            }
         }
     };
 }

--- a/circuit/program/src/data/literal/cast_lossy/mod.rs
+++ b/circuit/program/src/data/literal/cast_lossy/mod.rs
@@ -118,6 +118,9 @@ macro_rules! impl_cast_body {
             LiteralType::String => {
                 bail!(concat!("Cannot cast (lossy) a ", stringify!($type_name), " literal to a string type."))
             }
+            LiteralType::Bytes => {
+                bail!(concat!("Cannot cast (lossy) a ", stringify!($type_name), " literal to a bytes type."))
+            }
         }
     };
 }

--- a/circuit/program/src/data/literal/mod.rs
+++ b/circuit/program/src/data/literal/mod.rs
@@ -96,6 +96,7 @@ impl<A: Aleo> Inject for Literal<A> {
             Self::Primitive::Scalar(scalar) => Self::Scalar(Scalar::new(mode, scalar)),
             Self::Primitive::Signature(signature) => Self::Signature(Box::new(Signature::new(mode, *signature))),
             Self::Primitive::String(string) => Self::String(StringType::new(mode, string)),
+            Self::Primitive::Bytes(_) => unimplemented!(),
         }
     }
 }

--- a/console/network/environment/src/environment.rs
+++ b/console/network/environment/src/environment.rs
@@ -57,6 +57,11 @@ pub trait Environment:
     /// The maximum number of bytes allowed in a string.
     const MAX_STRING_BYTES: u32 = u8::MAX as u32;
 
+    /// The maximum number of bytes allowed in a hex-encoded string of bytes.
+    const MAX_ENCODED_BYTES: u32 = u16::MAX as u32 - 1; // must be even
+    /// The maximum number of bytes allowed in a hex-encoded string of bytes when decoded.
+    const MAX_DECODED_BYTES: u32 = Self::MAX_ENCODED_BYTES / 2;
+
     /// Halts the program from further synthesis, evaluation, and execution in the current environment.
     fn halt<S: Into<String>, T>(message: S) -> T {
         panic!("{}", message.into())

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -37,6 +37,7 @@ pub mod prelude {
             from_bits::*,
             from_field::*,
             parse::*,
+            parse_encoded_bytes::*,
             parse_string::*,
             to_bits_le,
             to_field::*,
@@ -128,7 +129,7 @@ pub mod prelude {
         bytes::{complete::tag, streaming::take},
         character::complete::{alpha1, alphanumeric1, char, one_of},
         combinator::{complete, fail, map, map_res, opt, recognize},
-        error::{ErrorKind, make_error},
+        error::{ErrorKind, VerboseError, VerboseErrorKind, make_error},
         multi::{count, many0, many0_count, many1, separated_list0, separated_list1},
         sequence::{pair, terminated},
     };

--- a/console/network/environment/src/traits/mod.rs
+++ b/console/network/environment/src/traits/mod.rs
@@ -33,6 +33,9 @@ pub use from_field::*;
 pub mod parse;
 pub use parse::*;
 
+pub mod parse_encoded_bytes;
+pub use parse_encoded_bytes::hex_parser;
+
 pub mod parse_string;
 pub use parse_string::string_parser;
 

--- a/console/network/environment/src/traits/parse_encoded_bytes.rs
+++ b/console/network/environment/src/traits/parse_encoded_bytes.rs
@@ -1,0 +1,25 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod hex_parser {
+    use nom::{IResult, character::complete::hex_digit1, error::ParseError};
+
+    pub fn parse_hex_encoded_bytes<'a, E>(input: &'a str) -> IResult<&'a str, &'a str, E>
+    where
+        E: ParseError<&'a str>,
+    {
+        hex_digit1(input)
+    }
+}

--- a/console/network/environment/src/traits/types.rs
+++ b/console/network/environment/src/traits/types.rs
@@ -210,6 +210,12 @@ pub trait StringTrait:
 {
 }
 
+/// Representation of bytes.
+pub trait BytesTrait:
+    Clone + Debug + Display + Eq + Equal + FromBytes + Parser + Send + Sync + ToBytes + TypeName + Uniform
+{
+}
+
 /// Representation of an integer.
 pub trait IntegerTrait<I: integer_type::IntegerType, U8: IntegerCore<u8>, U16: IntegerCore<u16>, U32: IntegerCore<u32>>:
     IntegerCore<I>

--- a/console/program/src/data/literal/bytes.rs
+++ b/console/program/src/data/literal/bytes.rs
@@ -37,7 +37,8 @@ impl<N: Network> FromBytes for Literal<N> {
             14 => Self::Scalar(Scalar::read_le(&mut reader)?),
             15 => Self::Signature(Box::new(Signature::read_le(&mut reader)?)),
             16 => Self::String(StringType::read_le(&mut reader)?),
-            17.. => return Err(error(format!("Failed to decode literal variant {index}"))),
+            17 => Self::Bytes(BytesType::read_le(&mut reader)?),
+            18.. => return Err(error(format!("Failed to decode literal variant {index}"))),
         };
         Ok(literal)
     }
@@ -116,6 +117,10 @@ impl<N: Network> ToBytes for Literal<N> {
                 (16 as Size).write_le(&mut writer)?;
                 primitive.write_le(&mut writer)
             }
+            Self::Bytes(primitive) => {
+                (17 as Size).write_le(&mut writer)?;
+                primitive.write_le(&mut writer)
+            }
         }
     }
 }
@@ -177,6 +182,8 @@ mod tests {
             check_bytes(Literal::sample(LiteralType::Signature, rng))?;
             // String
             check_bytes(Literal::<CurrentNetwork>::String(StringType::rand(rng)))?;
+            // Bytes
+            check_bytes(Literal::<CurrentNetwork>::Bytes(BytesType::rand(rng)))?;
         }
         Ok(())
     }

--- a/console/program/src/data/literal/cast/mod.rs
+++ b/console/program/src/data/literal/cast/mod.rs
@@ -62,6 +62,7 @@ impl<N: Network> Literal<N> {
             Self::Scalar(scalar) => cast_scalar_to_type(scalar, to_type),
             Self::Signature(..) => bail!("Cannot cast a signature literal to another type."),
             Self::String(..) => bail!("Cannot cast a string literal to another type."),
+            Self::Bytes(..) => bail!("Cannot cast a bytes literal to another type."),
         }
     }
 }
@@ -90,6 +91,9 @@ macro_rules! impl_cast_body {
             }
             LiteralType::String => {
                 bail!(concat!("Cannot cast a ", stringify!($type_name), " literal to a string type."))
+            }
+            LiteralType::Bytes => {
+                bail!(concat!("Cannot cast a ", stringify!($type_name), " literal to a bytes type."))
             }
         }
     };

--- a/console/program/src/data/literal/cast_lossy/mod.rs
+++ b/console/program/src/data/literal/cast_lossy/mod.rs
@@ -63,6 +63,7 @@ impl<N: Network> Literal<N> {
             Self::Scalar(scalar) => cast_lossy_scalar_to_type(scalar, to_type),
             Self::Signature(..) => bail!("Cannot cast a signature literal to another type."),
             Self::String(..) => bail!("Cannot cast a string literal to another type."),
+            Self::Bytes(..) => bail!("Cannot cast a bytes literal to another type."),
         }
     }
 }
@@ -91,6 +92,9 @@ macro_rules! impl_cast_lossy_body {
             }
             LiteralType::String => {
                 bail!(concat!("Cannot cast (lossy) a ", stringify!($type_name), " literal to a string type."))
+            }
+            LiteralType::Bytes => {
+                bail!(concat!("Cannot cast (lossy) a ", stringify!($type_name), " literal to a bytes type."))
             }
         }
     };

--- a/console/program/src/data/literal/equal.rs
+++ b/console/program/src/data/literal/equal.rs
@@ -44,6 +44,7 @@ impl<N: Network> core::hash::Hash for Literal<N> {
             Self::Scalar(a) => a.hash(state),
             Self::Signature(a) => a.hash(state),
             Self::String(a) => a.hash(state),
+            Self::Bytes(a) => a.hash(state),
         }
     }
 }
@@ -71,6 +72,7 @@ impl<N: Network> Equal for Literal<N> {
             (Self::Scalar(a), Self::Scalar(b)) => a.is_equal(b),
             (Self::Signature(a), Self::Signature(b)) => a.is_equal(b),
             (Self::String(a), Self::String(b)) => a.is_equal(b),
+            (Self::Bytes(a), Self::Bytes(b)) => a.is_equal(b),
             _ => Boolean::new(false),
         }
     }
@@ -95,6 +97,7 @@ impl<N: Network> Equal for Literal<N> {
             (Self::Scalar(a), Self::Scalar(b)) => a.is_not_equal(b),
             (Self::Signature(a), Self::Signature(b)) => a.is_not_equal(b),
             (Self::String(a), Self::String(b)) => a.is_not_equal(b),
+            (Self::Bytes(a), Self::Bytes(b)) => a.is_not_equal(b),
             _ => Boolean::new(true),
         }
     }

--- a/console/program/src/data/literal/mod.rs
+++ b/console/program/src/data/literal/mod.rs
@@ -72,4 +72,6 @@ pub enum Literal<N: Network> {
     Signature(Box<Signature<N>>),
     /// The string type.
     String(StringType<N>),
+    /// The binary type.
+    Bytes(BytesType<N>),
 }

--- a/console/program/src/data/literal/parse.rs
+++ b/console/program/src/data/literal/parse.rs
@@ -87,6 +87,7 @@ impl<N: Network> Display for Literal<N> {
             Self::Scalar(literal) => Display::fmt(literal, f),
             Self::Signature(literal) => Display::fmt(literal, f),
             Self::String(literal) => Display::fmt(literal, f),
+            Self::Bytes(literal) => Display::fmt(literal, f),
         }
     }
 }

--- a/console/program/src/data/literal/sample.rs
+++ b/console/program/src/data/literal/sample.rs
@@ -41,6 +41,7 @@ impl<N: Network> Literal<N> {
                     .expect("ComputeKey::try_from failed."),
             )))),
             LiteralType::String => Literal::String(StringType::rand(rng)),
+            LiteralType::Bytes => Literal::Bytes(BytesType::rand(rng)),
         }
     }
 }

--- a/console/program/src/data/literal/size_in_bits.rs
+++ b/console/program/src/data/literal/size_in_bits.rs
@@ -39,6 +39,10 @@ impl<N: Network> Literal<N> {
                 Some(size) => size,
                 None => N::halt("String exceeds usize::MAX bits."),
             },
+            Self::Bytes(bytes) => match bytes.len().checked_mul(8) {
+                Some(size) => size,
+                None => N::halt("Bytes exceed usize::MAX bits."),
+            },
         };
         u16::try_from(size).or_halt_with::<N>("Literal exceeds u16::MAX bits.")
     }

--- a/console/program/src/data/literal/to_bits.rs
+++ b/console/program/src/data/literal/to_bits.rs
@@ -48,6 +48,7 @@ impl<N: Network> ToBits for &Literal<N> {
             Literal::Scalar(literal) => literal.write_bits_le(vec),
             Literal::Signature(literal) => literal.write_bits_le(vec),
             Literal::String(literal) => literal.as_bytes().write_bits_le(vec),
+            Literal::Bytes(literal) => literal.deref().write_bits_le(vec),
         }
     }
 
@@ -71,6 +72,7 @@ impl<N: Network> ToBits for &Literal<N> {
             Literal::Scalar(literal) => literal.write_bits_be(vec),
             Literal::Signature(literal) => literal.write_bits_be(vec),
             Literal::String(literal) => literal.as_bytes().write_bits_be(vec),
+            Literal::Bytes(literal) => literal.deref().write_bits_be(vec),
         }
     }
 }

--- a/console/program/src/data/literal/to_type.rs
+++ b/console/program/src/data/literal/to_type.rs
@@ -36,6 +36,7 @@ impl<N: Network> Literal<N> {
             Self::Scalar(..) => LiteralType::Scalar,
             Self::Signature(..) => LiteralType::Signature,
             Self::String(..) => LiteralType::String,
+            Self::Bytes(..) => LiteralType::Bytes,
         }
     }
 }

--- a/console/program/src/data/literal/variant.rs
+++ b/console/program/src/data/literal/variant.rs
@@ -36,6 +36,7 @@ impl<N: Network> Literal<N> {
             Self::Scalar(..) => 14,
             Self::Signature(..) => 15,
             Self::String(..) => 16,
+            Self::Bytes(..) => 17,
         }
     }
 }

--- a/console/program/src/data_types/literal_type/mod.rs
+++ b/console/program/src/data_types/literal_type/mod.rs
@@ -64,6 +64,8 @@ pub enum LiteralType {
     Signature,
     /// The string type.
     String,
+    /// The bytes type.
+    Bytes,
 }
 
 impl LiteralType {
@@ -87,6 +89,7 @@ impl LiteralType {
             Self::Scalar => "scalar",
             Self::Signature => "signature",
             Self::String => "string",
+            Self::Bytes => "bytes",
         }
     }
 

--- a/console/program/src/data_types/literal_type/parse.rs
+++ b/console/program/src/data_types/literal_type/parse.rs
@@ -38,6 +38,7 @@ impl Parser for LiteralType {
             map(tag(Self::Scalar.type_name()), |_| Self::Scalar),
             map(tag(Self::Signature.type_name()), |_| Self::Signature),
             map(tag(Self::String.type_name()), |_| Self::String),
+            map(tag(Self::Bytes.type_name()), |_| Self::Bytes),
         ))(string)
     }
 }

--- a/console/program/src/data_types/literal_type/size_in_bits.rs
+++ b/console/program/src/data_types/literal_type/size_in_bits.rs
@@ -38,6 +38,7 @@ impl LiteralType {
             Self::Scalar => Scalar::<N>::size_in_bits(),
             Self::Signature => Signature::<N>::size_in_bits(),
             Self::String => N::MAX_STRING_BYTES.saturating_mul(8) as usize,
+            Self::Bytes => N::MAX_DECODED_BYTES.saturating_mul(8) as usize,
         };
         u16::try_from(size).or_halt_with::<N>("Literal exceeds u16::MAX bits.")
     }

--- a/console/types/Cargo.toml
+++ b/console/types/Cargo.toml
@@ -52,6 +52,11 @@ path = "./string"
 version = "=1.0.0"
 optional = true
 
+[dependencies.snarkvm-console-types-bytes]
+path = "./bytes"
+version = "=1.0.0"
+optional = true
+
 [dev-dependencies.criterion]
 version = "0.5.1"
 
@@ -66,7 +71,8 @@ default = [
   "group",
   "integers",
   "scalar",
-  "string"
+  "string",
+  "bytes"
 ]
 address = [
   "snarkvm-console-types-address",
@@ -90,3 +96,4 @@ string = [
   "snarkvm-console-types-field",
   "snarkvm-console-types-integers"
 ]
+bytes = [ "snarkvm-console-types-bytes" ]

--- a/console/types/bytes/Cargo.toml
+++ b/console/types/bytes/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "snarkvm-console-types-bytes"
+version = "1.0.0"
+authors = [ "The Aleo Team <hello@aleo.org>" ]
+description = "Type operations for a decentralized virtual machine"
+homepage = "https://aleo.org"
+repository = "https://github.com/AleoNet/snarkVM"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies.snarkvm-console-network-environment]
+path = "../../network/environment"
+version = "=1.0.0"
+
+[dependencies.snarkvm-console-types-boolean]
+path = "../boolean"
+version = "=1.0.0"
+
+[dependencies.hex]
+version = "0.4"
+
+[dev-dependencies.bincode]
+version = "1.3"
+
+[dev-dependencies.rand]
+version = "0.8"
+
+[dev-dependencies.serde_json]
+version = "1.0"
+features = [ "preserve_order" ]

--- a/console/types/bytes/LICENSE.md
+++ b/console/types/bytes/LICENSE.md
@@ -1,0 +1,194 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/console/types/bytes/README.md
+++ b/console/types/bytes/README.md
@@ -1,0 +1,5 @@
+# snarkvm-console-types-bytes
+
+[![Crates.io](https://img.shields.io/crates/v/snarkvm-console-types-bytes.svg?color=neon)](https://crates.io/crates/snarkvm-console-types-string)
+[![Authors](https://img.shields.io/badge/authors-Aleo-orange.svg)](https://aleo.org)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE.md)

--- a/console/types/bytes/src/bitwise.rs
+++ b/console/types/bytes/src/bitwise.rs
@@ -1,0 +1,43 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> Equal for BytesType<E> {
+    type Output = Boolean<E>;
+
+    /// Returns `true` if `self` and `other` are equal.
+    fn is_equal(&self, other: &Self) -> Self::Output {
+        Boolean::new(self == other)
+    }
+
+    /// Returns `true` if `self` and `other` are *not* equal.
+    fn is_not_equal(&self, other: &Self) -> Self::Output {
+        Boolean::new(self != other)
+    }
+}
+
+impl<E: Environment> Ternary for BytesType<E> {
+    type Boolean = Boolean<E>;
+    type Output = Self;
+
+    /// Returns `first` if `condition` is `true`, otherwise returns `second`.
+    fn ternary(condition: &Self::Boolean, first: &Self, second: &Self) -> Self::Output {
+        match **condition {
+            true => first.clone(),
+            false => second.clone(),
+        }
+    }
+}

--- a/console/types/bytes/src/bytes.rs
+++ b/console/types/bytes/src/bytes.rs
@@ -1,0 +1,79 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> FromBytes for BytesType<E> {
+    /// Reads the bytes from a buffer.
+    #[inline]
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the number of bytes.
+        let num_bytes = u32::read_le(&mut reader)?;
+        // Ensure the number of bytes is within the allowed bounds.
+        if num_bytes > E::MAX_DECODED_BYTES {
+            return Err(error(format!(
+                "The supplied byte literal exceeds maximum length of {} bytes.",
+                E::MAX_DECODED_BYTES
+            )));
+        }
+        // Read the bytes.
+        let mut bytes = vec![0u8; num_bytes as usize];
+        reader.read_exact(&mut bytes)?;
+        // Return the bytes.
+        Ok(Self::new(bytes))
+    }
+}
+
+impl<E: Environment> ToBytes for BytesType<E> {
+    /// Writes the bytes to a buffer.
+    #[inline]
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Ensure the number of bytes is within the allowed bounds.
+        if self.bytes.len() > E::MAX_DECODED_BYTES as usize {
+            return Err(error(format!("Byte literal exceeds maximum length of {} bytes.", E::MAX_DECODED_BYTES)));
+        }
+        // Write the number of bytes.
+        u32::try_from(self.bytes.len())
+            .or_halt_with::<E>(&format!("A byte literal exceed the maximum of {}", E::MAX_DECODED_BYTES))
+            .write_le(&mut writer)?;
+        // Write the bytes.
+        self.bytes.write_le(&mut writer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network_environment::Console;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: u64 = 10_000;
+
+    #[test]
+    fn test_bytes() -> Result<()> {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            // Sample new bytes.
+            let expected = BytesType::<CurrentEnvironment>::rand(&mut rng);
+
+            // Check the byte representation.
+            let expected_bytes = expected.to_bytes_le()?;
+            assert_eq!(expected, BytesType::read_le(&expected_bytes[..])?);
+        }
+        Ok(())
+    }
+}

--- a/console/types/bytes/src/lib.rs
+++ b/console/types/bytes/src/lib.rs
@@ -1,0 +1,67 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(test, allow(clippy::assertions_on_result_states))]
+#![warn(clippy::cast_possible_truncation)]
+
+mod bitwise;
+mod bytes;
+mod parse;
+mod random;
+mod serialize;
+
+pub use snarkvm_console_network_environment::prelude::*;
+pub use snarkvm_console_types_boolean::Boolean;
+
+use core::marker::PhantomData;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct BytesType<E: Environment> {
+    /// The underlying bytes.
+    bytes: Vec<u8>,
+    /// PhantomData
+    _phantom: PhantomData<E>,
+}
+
+impl<E: Environment> BytesTrait for BytesType<E> {}
+
+impl<E: Environment> BytesType<E> {
+    /// Initializes a new instance.
+    pub fn new(bytes: Vec<u8>) -> Self {
+        // Ensure the bytes are within the allowed capacity.
+        let num_bytes = bytes.len();
+        match num_bytes <= E::MAX_DECODED_BYTES as usize {
+            true => Self { bytes: bytes.to_owned(), _phantom: PhantomData },
+            false => E::halt(format!("Attempted to allocate bytes of size {num_bytes}")),
+        }
+    }
+}
+
+impl<E: Environment> TypeName for BytesType<E> {
+    /// Returns the type name as a string.
+    #[inline]
+    fn type_name() -> &'static str {
+        "bytes"
+    }
+}
+
+impl<E: Environment> Deref for BytesType<E> {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.bytes.as_slice()
+    }
+}

--- a/console/types/bytes/src/parse.rs
+++ b/console/types/bytes/src/parse.rs
@@ -1,0 +1,102 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> Parser for BytesType<E> {
+    /// Parses hex-encoded bytes into a bytes type.
+    #[inline]
+    fn parse(s: &str) -> ParserResult<Self> {
+        let (rest, value) = hex_parser::parse_hex_encoded_bytes(s)?;
+        // Hex-encoded bytes are always even in length.
+        if value.len() % 2 != 0 {
+            return Err(Err::Error(VerboseError { errors: vec![(s, VerboseErrorKind::Nom(ErrorKind::LengthValue))] }));
+        }
+        // At this point we know that we're dealing with valid hex characters.
+        let bytes = hex::decode(&value).unwrap();
+
+        Ok((rest, Self::new(bytes)))
+    }
+}
+
+impl<E: Environment> FromStr for BytesType<E> {
+    type Err = Error;
+
+    /// Parses a string into a bytes type.
+    #[inline]
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(
+                    remainder.is_empty(),
+                    "Failed to parse hex-encoded bytes. Found invalid character in: \"{remainder}\""
+                );
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse hex-encoded bytes. {error}"),
+        }
+    }
+}
+
+impl<E: Environment> Debug for BytesType<E> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<E: Environment> Display for BytesType<E> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::Fill;
+    use snarkvm_console_network_environment::Console;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: u32 = 100;
+
+    #[test]
+    fn test_display() -> Result<()> {
+        // Ensure type and empty value fails.
+        assert!(BytesType::<CurrentEnvironment>::parse(BytesType::<CurrentEnvironment>::type_name()).is_err());
+        assert!(BytesType::<CurrentEnvironment>::parse("").is_err());
+
+        let rng = &mut TestRng::default();
+        let mut buffer = vec![0u8; CurrentEnvironment::MAX_DECODED_BYTES as usize];
+
+        for _ in 0..ITERATIONS {
+            // Sample random bytes.
+            buffer.try_fill(rng).unwrap();
+            // Hex-encode them.
+            let encoded = hex::encode(&buffer);
+            assert_eq!(encoded.len(), CurrentEnvironment::MAX_ENCODED_BYTES as usize);
+
+            let candidate = BytesType::<CurrentEnvironment>::new(buffer.clone());
+            assert_eq!(candidate.len(), CurrentEnvironment::MAX_DECODED_BYTES as usize);
+            assert_eq!(candidate.to_string(), encoded);
+
+            let candidate_recovered = BytesType::<CurrentEnvironment>::from_str(&encoded).unwrap();
+            assert_eq!(candidate, candidate_recovered);
+        }
+        Ok(())
+    }
+}

--- a/console/types/bytes/src/random.rs
+++ b/console/types/bytes/src/random.rs
@@ -1,0 +1,25 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> Distribution<BytesType<E>> for Standard {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BytesType<E> {
+        let num_bytes = rng.gen_range(1..(E::MAX_DECODED_BYTES) as usize);
+        // Sample random bytes.
+        BytesType::new(rng.sample_iter(&Standard).take(num_bytes).collect())
+    }
+}

--- a/console/types/bytes/src/serialize.rs
+++ b/console/types/bytes/src/serialize.rs
@@ -1,0 +1,83 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<E: Environment> Serialize for BytesType<E> {
+    /// Serializes the string into bytes if the format is not human-readable.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => serializer.collect_str(&self.to_string()),
+            false => ToBytesSerializer::serialize(self, serializer),
+        }
+    }
+}
+
+impl<'de, E: Environment> Deserialize<'de> for BytesType<E> {
+    /// Deserializes the string from bytes, if it is not human-readable.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
+            false => FromBytesDeserializer::<Self>::deserialize_with_u32(deserializer, "bytes"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm_console_network_environment::Console;
+
+    type CurrentEnvironment = Console;
+
+    const ITERATIONS: u64 = 1000;
+
+    #[test]
+    fn test_serde_json() {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            // Sample new bytes.
+            let expected = BytesType::<CurrentEnvironment>::rand(&mut rng);
+
+            // Serialize
+            let expected_string = &expected.to_string();
+            let candidate_string = serde_json::to_string(&expected).unwrap();
+            assert_eq!(expected_string, serde_json::Value::from_str(&candidate_string).unwrap().as_str().unwrap());
+
+            // Deserialize
+            assert_eq!(expected, BytesType::from_str(expected_string).unwrap());
+            assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            // Sample new bytes.
+            let expected = BytesType::<CurrentEnvironment>::rand(&mut rng);
+
+            // Serialize
+            let expected_bytes = expected.to_bytes_le().unwrap();
+            assert_eq!(&expected_bytes[..], &bincode::serialize(&expected).unwrap()[..]);
+
+            // Deserialize
+            assert_eq!(expected, BytesType::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(expected, bincode::deserialize(&expected_bytes[..]).unwrap());
+        }
+    }
+}

--- a/console/types/src/lib.rs
+++ b/console/types/src/lib.rs
@@ -61,4 +61,9 @@ pub mod modules {
     pub use snarkvm_console_types_string as string;
     #[cfg(feature = "string")]
     pub use snarkvm_console_types_string::StringType;
+
+    #[cfg(feature = "bytes")]
+    pub use snarkvm_console_types_bytes as bytes;
+    #[cfg(feature = "bytes")]
+    pub use snarkvm_console_types_bytes::BytesType;
 }

--- a/ledger/puzzle/epoch/src/synthesis/program/construct_inputs.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/construct_inputs.rs
@@ -55,7 +55,8 @@ impl<N: Network> EpochProgram<N> {
                 | LiteralType::U128
                 | LiteralType::Scalar
                 | LiteralType::Signature
-                | LiteralType::String => {
+                | LiteralType::String
+                | LiteralType::Bytes => {
                     unreachable!("Invalid input literal type, malformed program");
                 }
             };

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -130,6 +130,7 @@ impl<N: Network> RandChaCha<N> {
             LiteralType::Scalar => Literal::Scalar(Scalar::rand(&mut rng)),
             LiteralType::Signature => bail!("Cannot 'rand.chacha' into a 'signature'"),
             LiteralType::String => bail!("Cannot 'rand.chacha' into a 'string'"),
+            LiteralType::Bytes => bail!("Cannot 'rand.chacha' into a 'bytes'"),
         };
 
         // Assign the value to the destination register.

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -123,6 +123,11 @@ impl<'de, T: FromBytes> FromBytesDeserializer<T> {
         deserializer.deserialize_tuple(1usize << 16usize, FromBytesWithU16Visitor::<T>::new(name))
     }
 
+    /// Deserializes a static-sized byte array, with a u16 length encoding at the start.
+    pub fn deserialize_with_u32<D: Deserializer<'de>>(deserializer: D, name: &str) -> Result<T, D::Error> {
+        deserializer.deserialize_tuple(1usize << 32usize, FromBytesWithU32Visitor::<T>::new(name))
+    }
+
     /// Deserializes a dynamically-sized byte array.
     pub fn deserialize_with_size_encoding<D: Deserializer<'de>>(deserializer: D, name: &str) -> Result<T, D::Error> {
         let mut buffer = Vec::with_capacity(32);
@@ -258,6 +263,40 @@ impl<'de, T: FromBytes> Visitor<'de> for FromBytesWithU16Visitor<T> {
         for i in 0..length {
             // Push the next byte into the vector.
             bytes.push(seq.next_element()?.ok_or_else(|| Error::invalid_length((i as usize) + 2, &self))?);
+        }
+        // Deserialize the vector.
+        FromBytes::read_le(&*bytes).map_err(de::Error::custom)
+    }
+}
+
+struct FromBytesWithU32Visitor<T: FromBytes>(String, PhantomData<T>);
+
+impl<T: FromBytes> FromBytesWithU32Visitor<T> {
+    /// Initializes a new `FromBytesWithU32Visitor` with the given `name`.
+    pub fn new(name: &str) -> Self {
+        Self(name.to_string(), PhantomData)
+    }
+}
+
+impl<'de, T: FromBytes> Visitor<'de> for FromBytesWithU32Visitor<T> {
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(&format!("a valid {} ", self.0))
+    }
+
+    fn visit_seq<V: SeqAccess<'de>>(self, mut seq: V) -> Result<Self::Value, V::Error> {
+        // Read the size of the object.
+        let length: u32 = seq.next_element()?.ok_or_else(|| Error::invalid_length(0, &self))?;
+
+        // Initialize the vector with the correct length.
+        let mut bytes: Vec<u8> = Vec::with_capacity((length as usize) + 4);
+        // Push the length into the vector.
+        bytes.extend(length.to_le_bytes());
+        // Read the bytes.
+        for i in 0..length {
+            // Push the next byte into the vector.
+            bytes.push(seq.next_element()?.ok_or_else(|| Error::invalid_length((i as usize) + 4, &self))?);
         }
         // Deserialize the vector.
         FromBytes::read_le(&*bytes).map_err(de::Error::custom)


### PR DESCRIPTION
This PR is a draft/RFC proposal for a new console literal containing raw bytes, which would allow us to e.g. handle hashes ([example use case](https://github.com/AleoNet/ARCs/discussions/81)) and proofs in Aleo programs.

ARC link: https://github.com/ProvableHQ/ARCs/discussions/83

Open points:
- the encoding to be used in programs
  - it is currently a hex encoding for simplicity, but that incurs a 100% penalty in size when encoded
  - e.g. `base64` would reduce that penalty to ~33%
- the [length limit(s)](https://github.com/AleoNet/snarkVM/compare/staging...ljedrz:feat/console_literal_bytes?expand=1#diff-c71ebd9fc8799045828435c4a5636c18ad9555ea752491c9f555faedc73f0b6cR60-R63)
  - is `u16::MAX` enough/too much?
  - should the length prefix be an order of magnitude greater for potential future compatibility? this is the reason for the additional implementation in `snarkvm-utilities`
- a call to `unimplemented!()` in [`circuit::Literal::new`](https://github.com/AleoNet/snarkVM/compare/staging...ljedrz:feat/console_literal_bytes?expand=1#diff-2e86ff26ab0d9dfe8c50f1a57f846af5dd70e193c776030b2512941b66b447bbR99)
  - it is safe to make it `unimplemented!` as long as `Inject::new` is not intended to be used externally
  - this new feature could be extended with a `circuit` counterpart, removing the need for it