### PR TITLE
[Fix] Update permissions on Continuous Benchmarks CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'staging'
-      - 'testnet'
-      - 'mainnet'
 
 jobs:
   # Run benchmarks and stores the output to a file

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,6 +3,8 @@ name: Run snarkVM Benchmarks
 on:
   push:
     branches:
+      - 'staging'
+      - 'testnet'
       - 'mainnet'
 
 jobs:
@@ -10,9 +12,11 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -21,7 +25,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -94,13 +98,13 @@ jobs:
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark
 
       - name: Store benchmark result
-        uses: rhysd/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@v1
         with:
           name: snarkVM Benchmarks
           tool: 'cargo'


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

After the Repo ownership change, the Continuous Benchmarks github action has not been completed due to permissions differences. This fixes the permissions and allows benchmarks to be run whenever PRs are merged into `staging`, `testnet`, or `mainnet`. 

This allows us to accurately track the performance history.

Benchmarks can be found here - https://provablehq.github.io/snarkVM/dev/bench/

Note: I believe the previous benchmarks were also lost with the repo migration