### PR TITLE
Only keep track of recently used programs in memory.

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -202,11 +202,7 @@ pub trait Network:
 
     /// The maximum number of stacks in the process
     /// Allows for fast processing for blocks made from 4 maximally full rounds.
-    #[cfg(not(feature = "test"))]
-    const MAX_STACKS: usize = Self::MAX_TRANSMISSIONS_PER_BATCH as usize * Self::MAX_CERTIFICATES as usize * 4;
-    /// The maximum number of stacks in the process.
-    #[cfg(feature = "test")]
-    const MAX_STACKS: usize = 64;
+    const MAX_STACKS: usize = Self::MAX_PROGRAM_DEPTH * Self::MAX_IMPORTS * 10;
 
     /// The maximum number of bytes in a transaction.
     // Note: This value must **not** be decreased as it would invalidate existing transactions.

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -140,7 +140,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         }
     }
 
-    /// Returns a state path for the given `commitment`.
+    /// Returns the current block height.
     fn current_block_height(&self) -> Result<u32> {
         match self {
             Self::VM(block_store) => Ok(block_store.max_height().unwrap_or_default()),
@@ -159,7 +159,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         }
     }
 
-    /// Returns a state path for the given `commitment`.
+    /// Returns the current block height.
     #[cfg(feature = "async")]
     async fn current_block_height_async(&self) -> Result<u32> {
         match self {

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1810,6 +1810,1226 @@ fn test_abort_invalid_transaction() {
 }
 
 #[test]
+fn test_deploy_difference() {
+    println!("CONSENSUS_V2_HEIGHT: {:?}", CurrentNetwork::CONSENSUS_V2_HEIGHT);
+    let rng = &mut TestRng::default();
+
+    let prelim_program_1 = Program::<CurrentNetwork>::from_str(
+        r"
+        import credits.aleo;
+
+program staking_v1.aleo;
+
+record PrivateToken:
+    owner as address.private;
+    amount as u64.private;
+
+struct Metadata:
+    name as u128;
+    symbol as u128;
+    decimals as u8;
+
+struct State:
+    total_supply as u64;
+    total_reserve as u64;
+    total_unstaking as u64;
+    total_reward as u64;
+
+struct Settings:
+    unstake_wait as u32;
+    stake_paused as boolean;
+    global_paused as boolean;
+    max_reward_per_notify as u64;
+    protocol_fee as u16;
+    fee_account as address;
+
+struct Unstaking:
+    microcredits as u64;
+    height as u32;
+
+struct ApprovalKey:
+    approver as address;
+    spender as address;
+
+mapping account:
+    key as address.public;
+    value as u64.public;
+
+mapping approvals:
+    key as field.public;
+    value as u64.public;
+
+mapping metadata:
+    key as boolean.public;
+    value as Metadata.public;
+
+mapping state:
+    key as boolean.public;
+    value as State.public;
+
+mapping settings:
+    key as boolean.public;
+    value as Settings.public;
+
+mapping unstakings:
+    key as address.public;
+    value as Unstaking.public;
+
+mapping admins:
+    key as address.public;
+    value as boolean.public;
+
+mapping stakers:
+    key as address.public;
+    value as boolean.public;
+
+function transfer_public:
+    input r0 as address.public;
+    input r1 as u64.public;
+    async transfer_public self.caller r0 r1 into r2;
+    output r2 as staking_v1.aleo/transfer_public.future;
+finalize transfer_public:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as u64.public;
+    get account[r0] into r3;
+    sub r3 r2 into r4;
+    set r4 into account[r0];
+    get.or_use account[r1] 0u64 into r5;
+    add r5 r2 into r6;
+    set r6 into account[r1];
+
+function transfer_private:
+    input r0 as PrivateToken.record;
+    input r1 as address.private;
+    input r2 as u64.private;
+    cast r1 r2 into r3 as PrivateToken.record;
+    sub r0.amount r2 into r4;
+    cast r0.owner r4 into r5 as PrivateToken.record;
+    output r3 as PrivateToken.record;
+    output r5 as PrivateToken.record;
+
+function transfer_private_to_public:
+    input r0 as PrivateToken.record;
+    input r1 as address.public;
+    input r2 as u64.public;
+    sub r0.amount r2 into r3;
+    cast r0.owner r3 into r4 as PrivateToken.record;
+    async transfer_private_to_public r1 r2 into r5;
+    output r4 as PrivateToken.record;
+    output r5 as staking_v1.aleo/transfer_private_to_public.future;
+finalize transfer_private_to_public:
+    input r0 as address.public;
+    input r1 as u64.public;
+    get.or_use account[r0] 0u64 into r2;
+    add r2 r1 into r3;
+    set r3 into account[r0];
+
+function transfer_public_to_private:
+    input r0 as address.private;
+    input r1 as u64.public;
+    cast r0 r1 into r2 as PrivateToken.record;
+    async transfer_public_to_private self.caller r1 into r3;
+    output r2 as PrivateToken.record;
+    output r3 as staking_v1.aleo/transfer_public_to_private.future;
+finalize transfer_public_to_private:
+    input r0 as address.public;
+    input r1 as u64.public;
+    get account[r0] into r2;
+    sub r2 r1 into r3;
+    set r3 into account[r0];
+
+function join:
+    input r0 as PrivateToken.record;
+    input r1 as PrivateToken.record;
+    add r0.amount r1.amount into r2;
+    cast r0.owner r2 into r3 as PrivateToken.record;
+    output r3 as PrivateToken.record;
+
+function stake_public:
+    input r0 as u64.public;
+    input r1 as address.public;
+    assert.neq r0 0u64;
+    call credits.aleo/transfer_public_as_signer staking_v1.aleo r0 into r2;
+    async stake_public r0 r1 r2 into r3;
+    output r3 as staking_v1.aleo/stake_public.future;
+finalize stake_public:
+    input r0 as u64.public;
+    input r1 as address.public;
+    input r2 as credits.aleo/transfer_public_as_signer.future;
+    await r2;
+    get settings[true] into r3;
+    assert.eq r3.stake_paused false;
+    assert.eq r3.global_paused false;
+    get state[true] into r4;
+    is.eq r4.total_reserve 0u64 into r5;
+    cast r4.total_reserve into r6 as u128;
+    ternary r5 1u128 r6 into r7;
+    is.eq r4.total_reserve 0u64 into r8;
+    cast r0 into r9 as u128;
+    cast r4.total_supply into r10 as u128;
+    mul r9 r10 into r11;
+    div r11 r7 into r12;
+    cast r12 into r13 as u64;
+    ternary r8 r0 r13 into r14;
+    assert.neq r14 0u64;
+    add r4.total_supply r14 into r15;
+    add r4.total_reserve r0 into r16;
+    cast r15 r16 r4.total_unstaking r4.total_reward into r17 as State;
+    set r17 into state[true];
+    get.or_use account[r1] 0u64 into r18;
+    add r18 r14 into r19;
+    set r19 into account[r1];
+
+function stake_private:
+    input r0 as credits.aleo/credits.record;
+    input r1 as u64.public;
+    input r2 as address.public;
+    assert.neq r1 0u64;
+    call credits.aleo/transfer_private_to_public r0 staking_v1.aleo r1 into r3 r4;
+    async stake_private r1 r2 r4 into r5;
+    output r3 as credits.aleo/credits.record;
+    output r5 as staking_v1.aleo/stake_private.future;
+finalize stake_private:
+    input r0 as u64.public;
+    input r1 as address.public;
+    input r2 as credits.aleo/transfer_private_to_public.future;
+    await r2;
+    get settings[true] into r3;
+    assert.eq r3.stake_paused false;
+    assert.eq r3.global_paused false;
+    get state[true] into r4;
+    is.eq r4.total_reserve 0u64 into r5;
+    cast r4.total_reserve into r6 as u128;
+    ternary r5 1u128 r6 into r7;
+    is.eq r4.total_reserve 0u64 into r8;
+    cast r0 into r9 as u128;
+    cast r4.total_supply into r10 as u128;
+    mul r9 r10 into r11;
+    div r11 r7 into r12;
+    cast r12 into r13 as u64;
+    ternary r8 r0 r13 into r14;
+    assert.neq r14 0u64;
+    add r4.total_supply r14 into r15;
+    add r4.total_reserve r0 into r16;
+    cast r15 r16 r4.total_unstaking r4.total_reward into r17 as State;
+    set r17 into state[true];
+    get.or_use account[r1] 0u64 into r18;
+    add r18 r14 into r19;
+    set r19 into account[r1];
+
+function unstake_token:
+    input r0 as u64.public;
+    assert.neq r0 0u64;
+    async unstake_token self.caller r0 into r1;
+    output r1 as staking_v1.aleo/unstake_token.future;
+finalize unstake_token:
+    input r0 as address.public;
+    input r1 as u64.public;
+    get settings[true] into r2;
+    assert.eq r2.global_paused false;
+    get.or_use account[r0] 0u64 into r3;
+    sub r3 r1 into r4;
+    set r4 into account[r0];
+    get state[true] into r5;
+    cast r1 into r6 as u128;
+    cast r5.total_reserve into r7 as u128;
+    mul r6 r7 into r8;
+    cast r5.total_supply into r9 as u128;
+    div r8 r9 into r10;
+    cast r10 into r11 as u64;
+    assert.neq r11 0u64;
+    sub r5.total_supply r1 into r12;
+    sub r5.total_reserve r11 into r13;
+    add r5.total_unstaking r11 into r14;
+    cast r12 r13 r14 r5.total_reward into r15 as State;
+    set r15 into state[true];
+    cast 0u64 0u32 into r16 as Unstaking;
+    get.or_use unstakings[r0] r16 into r17;
+    add r17.microcredits r11 into r18;
+    add block.height r2.unstake_wait into r19;
+    cast r18 r19 into r20 as Unstaking;
+    set r20 into unstakings[r0];
+
+function unstake_aleo:
+    input r0 as u64.public;
+    assert.neq r0 0u64;
+    async unstake_aleo self.caller r0 into r1;
+    output r1 as staking_v1.aleo/unstake_aleo.future;
+finalize unstake_aleo:
+    input r0 as address.public;
+    input r1 as u64.public;
+    get settings[true] into r2;
+    assert.eq r2.global_paused false;
+    get state[true] into r3;
+    cast r1 into r4 as u128;
+    cast r3.total_supply into r5 as u128;
+    mul r4 r5 into r6;
+    cast r3.total_reserve into r7 as u128;
+    add r6 r7 into r8;
+    sub r8 1u128 into r9;
+    cast r3.total_reserve into r10 as u128;
+    div r9 r10 into r11;
+    cast r11 into r12 as u64;
+    assert.neq r12 0u64;
+    get.or_use account[r0] 0u64 into r13;
+    sub r13 r12 into r14;
+    set r14 into account[r0];
+    sub r3.total_supply r12 into r15;
+    sub r3.total_reserve r1 into r16;
+    add r3.total_unstaking r1 into r17;
+    cast r15 r16 r17 r3.total_reward into r18 as State;
+    set r18 into state[true];
+    cast 0u64 0u32 into r19 as Unstaking;
+    get.or_use unstakings[r0] r19 into r20;
+    add r20.microcredits r1 into r21;
+    add block.height r2.unstake_wait into r22;
+    cast r21 r22 into r23 as Unstaking;
+    set r23 into unstakings[r0];
+
+function withdraw:
+    input r0 as u64.public;
+    input r1 as address.public;
+    assert.neq r0 0u64;
+    call credits.aleo/transfer_public r1 r0 into r2;
+    async withdraw self.caller r0 r2 into r3;
+    output r3 as staking_v1.aleo/withdraw.future;
+finalize withdraw:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as credits.aleo/transfer_public.future;
+    await r2;
+    get settings[true] into r3;
+    assert.eq r3.global_paused false;
+    get unstakings[r0] into r4;
+    gte block.height r4.height into r5;
+    assert.eq r5 true;
+    sub r4.microcredits r1 into r6;
+    cast r6 r4.height into r7 as Unstaking;
+    set r7 into unstakings[r0];
+    get state[true] into r8;
+    sub r8.total_unstaking r1 into r9;
+    cast r8.total_supply r8.total_reserve r9 r8.total_reward into r10 as State;
+    set r10 into state[true];
+
+function withdraw_private:
+    input r0 as u64.public;
+    input r1 as address.private;
+    assert.neq r0 0u64;
+    call credits.aleo/transfer_public_to_private r1 r0 into r2 r3;
+    async withdraw_private self.caller r0 r3 into r4;
+    output r2 as credits.aleo/credits.record;
+    output r4 as staking_v1.aleo/withdraw_private.future;
+finalize withdraw_private:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as credits.aleo/transfer_public_to_private.future;
+    await r2;
+    get settings[true] into r3;
+    assert.eq r3.global_paused false;
+    get unstakings[r0] into r4;
+    gte block.height r4.height into r5;
+    assert.eq r5 true;
+    sub r4.microcredits r1 into r6;
+    cast r6 r4.height into r7 as Unstaking;
+    set r7 into unstakings[r0];
+    get state[true] into r8;
+    sub r8.total_unstaking r1 into r9;
+    cast r8.total_supply r8.total_reserve r9 r8.total_reward into r10 as State;
+    set r10 into state[true];
+
+function approve_public:
+    input r0 as address.public;
+    input r1 as u64.public;
+    cast self.caller r0 into r2 as ApprovalKey;
+    hash.bhp256 r2 into r3 as field;
+    async approve_public r3 r1 into r4;
+    output r4 as staking_v1.aleo/approve_public.future;
+finalize approve_public:
+    input r0 as field.public;
+    input r1 as u64.public;
+    get.or_use approvals[r0] 0u64 into r2;
+    sub 18446744073709551615u64 r2 into r3;
+    lt r1 r3 into r4;
+    add.w r2 r1 into r5;
+    ternary r4 r5 18446744073709551615u64 into r6;
+    set r6 into approvals[r0];
+
+function unapprove_public:
+    input r0 as address.public;
+    input r1 as u64.public;
+    cast self.caller r0 into r2 as ApprovalKey;
+    hash.bhp256 r2 into r3 as field;
+    async unapprove_public r3 r1 into r4;
+    output r4 as staking_v1.aleo/unapprove_public.future;
+finalize unapprove_public:
+    input r0 as field.public;
+    input r1 as u64.public;
+    get approvals[r0] into r2;
+    gt r2 r1 into r3;
+    sub.w r2 r1 into r4;
+    ternary r3 r4 0u64 into r5;
+    set r5 into approvals[r0];
+
+function transfer_from_public:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as u64.public;
+    cast r0 self.caller into r3 as ApprovalKey;
+    hash.bhp256 r3 into r4 as field;
+    async transfer_from_public r4 r0 r1 r2 into r5;
+    output r5 as staking_v1.aleo/transfer_from_public.future;
+finalize transfer_from_public:
+    input r0 as field.public;
+    input r1 as address.public;
+    input r2 as address.public;
+    input r3 as u64.public;
+    get approvals[r0] into r4;
+    sub r4 r3 into r5;
+    set r5 into approvals[r0];
+    get account[r1] into r6;
+    sub r6 r3 into r7;
+    set r7 into account[r1];
+    get.or_use account[r2] 0u64 into r8;
+    add r8 r3 into r9;
+    set r9 into account[r2];
+
+function notify_reward:
+    input r0 as u64.public;
+    assert.neq r0 0u64;
+    async notify_reward self.caller r0 into r1;
+    output r1 as staking_v1.aleo/notify_reward.future;
+finalize notify_reward:
+    input r0 as address.public;
+    input r1 as u64.public;
+    get settings[true] into r2;
+    assert.eq r2.global_paused false;
+    get stakers[r0] into r3;
+    assert.eq r3 true;
+    lte r1 r2.max_reward_per_notify into r4;
+    assert.eq r4 true;
+    get state[true] into r5;
+    cast r5.total_reserve into r6 as u128;
+    mul r6 10000u128 into r7;
+    cast r1 into r8 as u128;
+    cast r2.protocol_fee into r9 as u128;
+    sub 10000u128 r9 into r10;
+    mul r8 r10 into r11;
+    add r7 r11 into r12;
+    cast r2.protocol_fee into r13 as u128;
+    cast r1 into r14 as u128;
+    mul r13 r14 into r15;
+    cast r5.total_supply into r16 as u128;
+    mul r15 r16 into r17;
+    div r17 r12 into r18;
+    cast r18 into r19 as u64;
+    add r5.total_supply r19 into r20;
+    add r5.total_reserve r1 into r21;
+    add r5.total_reward r1 into r22;
+    cast r20 r21 r5.total_unstaking r22 into r23 as State;
+    set r23 into state[true];
+    get.or_use account[r2.fee_account] 0u64 into r24;
+    add r24 r19 into r25;
+    set r25 into account[r2.fee_account];
+
+function pull_aleo:
+    input r0 as u64.public;
+    call credits.aleo/transfer_public self.caller r0 into r1;
+    async pull_aleo self.caller r1 into r2;
+    output r2 as staking_v1.aleo/pull_aleo.future;
+finalize pull_aleo:
+    input r0 as address.public;
+    input r1 as credits.aleo/transfer_public.future;
+    await r1;
+    get settings[true] into r2;
+    assert.eq r2.global_paused false;
+    get stakers[r0] into r3;
+    assert.eq r3 true;
+
+function update_settings:
+    input r0 as Settings.public;
+    lte r0.protocol_fee 5000u16 into r1;
+    assert.eq r1 true;
+    async update_settings self.caller r0 into r2;
+    output r2 as staking_v1.aleo/update_settings.future;
+finalize update_settings:
+    input r0 as address.public;
+    input r1 as Settings.public;
+    get admins[r0] into r2;
+    assert.eq r2 true;
+    set r1 into settings[true];
+
+function set_staker:
+    input r0 as address.public;
+    input r1 as boolean.public;
+    async set_staker self.caller r0 r1 into r2;
+    output r2 as staking_v1.aleo/set_staker.future;
+finalize set_staker:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as boolean.public;
+    get admins[r0] into r3;
+    assert.eq r3 true;
+    set r2 into stakers[r1];
+
+function set_admin:
+    input r0 as address.public;
+    input r1 as boolean.public;
+    assert.neq self.caller r0;
+    async set_admin self.caller r0 r1 into r2;
+    output r2 as staking_v1.aleo/set_admin.future;
+finalize set_admin:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as boolean.public;
+    get admins[r0] into r3;
+    assert.eq r3 true;
+    set r2 into admins[r1];
+
+function init:
+    input r0 as address.public;
+    assert.eq self.caller aleo18jfrqsz4m853grpgzflrlzdkcm9art926668g80vd9ruyzv8rsqqlchzyj;
+    async init r0 into r1;
+    output r1 as staking_v1.aleo/init.future;
+finalize init:
+    input r0 as address.public;
+    contains metadata[true] into r1;
+    assert.eq r1 false;
+    cast 394103260206656316532079u128 126943148918095u128 6u8 into r2 as Metadata;
+    set r2 into metadata[true];
+    set true into admins[aleo18jfrqsz4m853grpgzflrlzdkcm9art926668g80vd9ruyzv8rsqqlchzyj];
+    cast 0u64 0u64 0u64 0u64 into r3 as State;
+    set r3 into state[true];
+    cast 360u32 false false 1000000000u64 1000u16 r0 into r4 as Settings;
+    set r4 into settings[true];
+    ",
+    )
+    .unwrap();
+
+    let prelim_program_2 = Program::<CurrentNetwork>::from_str(
+        r"
+        import credits.aleo;
+import staking_v1.aleo;
+
+program staker_v1_b.aleo;
+
+struct bond_state:
+    validator as address;
+    microcredits as u64;
+
+struct unbond_state:
+    microcredits as u64;
+    height as u32;
+
+struct Settings:
+    unstake_wait as u32;
+    stake_paused as boolean;
+    global_paused as boolean;
+    max_reward_per_notify as u64;
+    protocol_fee as u16;
+    fee_account as address;
+
+struct StakerState:
+    total_pulled as u64;
+    total_pushed as u64;
+    total_reward as u64;
+
+mapping admins:
+    key as address.public;
+    value as boolean.public;
+
+mapping operators:
+    key as address.public;
+    value as boolean.public;
+
+mapping state:
+    key as boolean.public;
+    value as StakerState.public;
+
+function notify_reward:
+    input r0 as u64.public;
+    call staking_v1.aleo/notify_reward r0 into r1;
+    async notify_reward self.caller r0 r1 into r2;
+    output r2 as staker_v1_b.aleo/notify_reward.future;
+finalize notify_reward:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as staking_v1.aleo/notify_reward.future;
+    await r2;
+    get operators[r0] into r3;
+    assert.eq r3 true;
+    get.or_use credits.aleo/account[staker_v1_b.aleo] 0u64 into r4;
+    cast aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc 0u64 into r5 as bond_state;
+    get.or_use credits.aleo/bonded[staker_v1_b.aleo] r5 into r6;
+    cast 0u64 0u32 into r7 as unbond_state;
+    get.or_use credits.aleo/unbonding[staker_v1_b.aleo] r7 into r8;
+    get state[true] into r9;
+    add r4 r6.microcredits into r10;
+    add r10 r8.microcredits into r11;
+    add r11 r9.total_pushed into r12;
+    sub r12 r9.total_pulled into r13;
+    sub r13 r9.total_reward into r14;
+    lte r1 r14 into r15;
+    assert.eq r15 true;
+    add r9.total_reward r1 into r16;
+    cast r9.total_pulled r9.total_pushed r16 into r17 as StakerState;
+    set r17 into state[true];
+
+function set_admin:
+    input r0 as address.public;
+    input r1 as boolean.public;
+    assert.neq self.caller r0;
+    async set_admin self.caller r0 r1 into r2;
+    output r2 as staker_v1_b.aleo/set_admin.future;
+finalize set_admin:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as boolean.public;
+    get admins[r0] into r3;
+    assert.eq r3 true;
+    set r2 into admins[r1];
+
+function init:
+    assert.eq self.caller aleo18jfrqsz4m853grpgzflrlzdkcm9art926668g80vd9ruyzv8rsqqlchzyj;
+    async init  into r0;
+    output r0 as staker_v1_b.aleo/init.future;
+finalize init:
+    contains admins[aleo18jfrqsz4m853grpgzflrlzdkcm9art926668g80vd9ruyzv8rsqqlchzyj] into r0;
+    assert.eq r0 false;
+    set true into admins[aleo18jfrqsz4m853grpgzflrlzdkcm9art926668g80vd9ruyzv8rsqqlchzyj];
+    set true into operators[aleo18jfrqsz4m853grpgzflrlzdkcm9art926668g80vd9ruyzv8rsqqlchzyj];
+    cast 0u64 0u64 0u64 into r1 as StakerState;
+    set r1 into state[true];
+
+function bond:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as u64.public;
+    lte r2 r1 into r3;
+    assert.eq r3 true;
+    call staking_v1.aleo/pull_aleo r2 into r4;
+    call credits.aleo/bond_public r0 staker_v1_b.aleo r1 into r5;
+    async bond self.caller r2 r4 r5 into r6;
+    output r6 as staker_v1_b.aleo/bond.future;
+finalize bond:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as staking_v1.aleo/pull_aleo.future;
+    input r3 as credits.aleo/bond_public.future;
+    await r2;
+    await r3;
+    get operators[r0] into r4;
+    assert.eq r4 true;
+    get state[true] into r5;
+    add r5.total_pulled r1 into r6;
+    cast r6 r5.total_pushed r5.total_reward into r7 as StakerState;
+    set r7 into state[true];
+
+function unbond:
+    input r0 as u64.public;
+    assert.neq r0 0u64;
+    call credits.aleo/unbond_public staker_v1_b.aleo r0 into r1;
+    async unbond self.caller r1 into r2;
+    output r2 as staker_v1_b.aleo/unbond.future;
+finalize unbond:
+    input r0 as address.public;
+    input r1 as credits.aleo/unbond_public.future;
+    await r1;
+    get operators[r0] into r2;
+    assert.eq r2 true;
+
+function claim:
+    call credits.aleo/claim_unbond_public staker_v1_b.aleo into r0;
+    async claim self.caller r0 into r1;
+    output r1 as staker_v1_b.aleo/claim.future;
+finalize claim:
+    input r0 as address.public;
+    input r1 as credits.aleo/claim_unbond_public.future;
+    await r1;
+    get operators[r0] into r2;
+    assert.eq r2 true;
+
+function push_aleo:
+    input r0 as u64.public;
+    assert.neq r0 0u64;
+    call credits.aleo/transfer_public staking_v1.aleo r0 into r1;
+    async push_aleo self.caller r0 r1 into r2;
+    output r2 as staker_v1_b.aleo/push_aleo.future;
+finalize push_aleo:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as credits.aleo/transfer_public.future;
+    await r2;
+    get operators[r0] into r3;
+    assert.eq r3 true;
+    get state[true] into r4;
+    add r4.total_pushed r1 into r5;
+    cast r4.total_pulled r5 r4.total_reward into r6 as StakerState;
+    set r6 into state[true];
+
+function claim_and_push:
+    input r0 as u64.public;
+    call credits.aleo/claim_unbond_public staker_v1_b.aleo into r1;
+    call credits.aleo/transfer_public staking_v1.aleo r0 into r2;
+    async claim_and_push self.caller r0 r1 r2 into r3;
+    output r3 as staker_v1_b.aleo/claim_and_push.future;
+finalize claim_and_push:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as credits.aleo/claim_unbond_public.future;
+    input r3 as credits.aleo/transfer_public.future;
+    await r2;
+    await r3;
+    get operators[r0] into r4;
+    assert.eq r4 true;
+    get state[true] into r5;
+    add r5.total_pushed r1 into r6;
+    cast r5.total_pulled r6 r5.total_reward into r7 as StakerState;
+    set r7 into state[true];
+
+function set_operator:
+    input r0 as address.public;
+    input r1 as boolean.public;
+    async set_operator self.caller r0 r1 into r2;
+    output r2 as staker_v1_b.aleo/set_operator.future;
+finalize set_operator:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as boolean.public;
+    get admins[r0] into r3;
+    assert.eq r3 true;
+    set r2 into operators[r1];
+        ",
+    )
+    .unwrap();
+
+    let prelim_program_3 = Program::<CurrentNetwork>::from_str(
+        r"
+program multisig_v1.aleo;
+
+struct Operation:
+    program_id as address;
+    op_type as u8;
+    params as field;
+    op_salt as u64;
+    delay as u32;
+
+struct Request:
+    operation as Operation;
+    multisig as address;
+
+struct ReqState:
+    state as u8;
+    active_block as u32;
+
+mapping admins:
+    key as address.public;
+    value as boolean.public;
+
+mapping initialized:
+    key as u8.public;
+    value as boolean.public;
+
+mapping requests:
+    key as field.public;
+    value as ReqState.public;
+
+function init:
+    input r0 as [address; 5u32].public;
+    assert.neq r0[0u32] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc;
+    assert.neq r0[1u32] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc;
+    assert.neq r0[2u32] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc;
+    assert.neq r0[3u32] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc;
+    assert.neq r0[4u32] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc;
+    assert.neq r0[0u32] r0[1u32];
+    assert.neq r0[0u32] r0[2u32];
+    assert.neq r0[0u32] r0[3u32];
+    assert.neq r0[0u32] r0[4u32];
+    assert.neq r0[1u32] r0[2u32];
+    assert.neq r0[1u32] r0[3u32];
+    assert.neq r0[1u32] r0[4u32];
+    assert.neq r0[2u32] r0[3u32];
+    assert.neq r0[2u32] r0[4u32];
+    assert.neq r0[3u32] r0[4u32];
+    async init r0 into r1;
+    output r1 as multisig_v1.aleo/init.future;
+finalize init:
+    input r0 as [address; 5u32].public;
+    contains initialized[1u8] into r1;
+    assert.eq r1 false;
+    set true into initialized[1u8];
+    set true into admins[r0[0u32]];
+    set true into admins[r0[1u32]];
+    set true into admins[r0[2u32]];
+    set true into admins[r0[3u32]];
+    set true into admins[r0[4u32]];
+
+closure verify_signatures:
+    input r0 as Request;
+    input r1 as [address; 3u32];
+    input r2 as [signature; 3u32];
+    assert.neq r1[0u32] r1[1u32];
+    assert.neq r1[0u32] r1[2u32];
+    assert.neq r1[1u32] r1[2u32];
+    hash.bhp256 r0 into r3 as field;
+    sign.verify r2[0u32] r1[0u32] r3 into r4;
+    assert.eq r4 true;
+    sign.verify r2[1u32] r1[1u32] r3 into r5;
+    assert.eq r5 true;
+    sign.verify r2[2u32] r1[2u32] r3 into r6;
+    assert.eq r6 true;
+    output r3 as field;
+
+function change_admin:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as u64.private;
+    input r3 as [address; 3u32].public;
+    input r4 as [signature; 3u32].private;
+    assert.neq r0 r1;
+    assert.neq r1 aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc;
+    cast r0 r1 into r5 as [address; 2u32];
+    hash.bhp256 r5 into r6 as field;
+    cast multisig_v1.aleo 1u8 r6 r2 0u32 into r7 as Operation;
+    cast r7 multisig_v1.aleo into r8 as Request;
+    call verify_signatures r8 r3 r4 into r9;
+    async change_admin r0 r1 r9 r3 into r10;
+    output r10 as multisig_v1.aleo/change_admin.future;
+finalize change_admin:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as field.public;
+    input r3 as [address; 3u32].public;
+    get admins[r3[0u32]] into r4;
+    assert.eq r4 true;
+    get admins[r3[1u32]] into r5;
+    assert.eq r5 true;
+    get admins[r3[2u32]] into r6;
+    assert.eq r6 true;
+    contains requests[r2] into r7;
+    assert.eq r7 false;
+    cast 1u8 block.height into r8 as ReqState;
+    set r8 into requests[r2];
+    get admins[r0] into r9;
+    assert.eq r9 true;
+    get.or_use admins[r1] false into r10;
+    assert.eq r10 false;
+    remove admins[r0];
+    set true into admins[r1];
+
+function new_request:
+    input r0 as Operation.public;
+    input r1 as boolean.public;
+    input r2 as [address; 3u32].public;
+    input r3 as [signature; 3u32].private;
+    cast r0 multisig_v1.aleo into r4 as Request;
+    call verify_signatures r4 r2 r3 into r5;
+    not r1 into r6;
+    is.eq r0.program_id self.caller into r7;
+    or r6 r7 into r8;
+    assert.eq r8 true;
+    not r1 into r9;
+    is.eq r0.delay 0u32 into r10;
+    or r9 r10 into r11;
+    assert.eq r11 true;
+    async new_request r1 r0.delay r5 r2 into r12;
+    output r12 as multisig_v1.aleo/new_request.future;
+finalize new_request:
+    input r0 as boolean.public;
+    input r1 as u32.public;
+    input r2 as field.public;
+    input r3 as [address; 3u32].public;
+    get admins[r3[0u32]] into r4;
+    assert.eq r4 true;
+    get admins[r3[1u32]] into r5;
+    assert.eq r5 true;
+    get admins[r3[2u32]] into r6;
+    assert.eq r6 true;
+    contains requests[r2] into r7;
+    assert.eq r7 false;
+    ternary r0 1u8 0u8 into r8;
+    add block.height r1 into r9;
+    cast r8 r9 into r10 as ReqState;
+    set r10 into requests[r2];
+
+function cancel_request:
+    input r0 as field.public;
+    input r1 as [address; 3u32].public;
+    input r2 as [signature; 3u32].private;
+    cast multisig_v1.aleo 2u8 r0 0u64 0u32 into r3 as Operation;
+    cast r3 multisig_v1.aleo into r4 as Request;
+    call verify_signatures r4 r1 r2 into r5;
+    async cancel_request r0 r1 into r6;
+    output r6 as multisig_v1.aleo/cancel_request.future;
+finalize cancel_request:
+    input r0 as field.public;
+    input r1 as [address; 3u32].public;
+    get admins[r1[0u32]] into r2;
+    assert.eq r2 true;
+    get admins[r1[1u32]] into r3;
+    assert.eq r3 true;
+    get admins[r1[2u32]] into r4;
+    assert.eq r4 true;
+    get requests[r0] into r5;
+    assert.eq r5.state 0u8;
+    cast 2u8 r5.active_block into r6 as ReqState;
+    set r6 into requests[r0];
+
+function execute:
+    input r0 as Operation.public;
+    assert.eq r0.program_id self.caller;
+    cast r0 multisig_v1.aleo into r1 as Request;
+    hash.bhp256 r1 into r2 as field;
+    async execute r2 into r3;
+    output r3 as multisig_v1.aleo/execute.future;
+finalize execute:
+    input r0 as field.public;
+    get requests[r0] into r1;
+    assert.eq r1.state 0u8;
+    lte r1.active_block block.height into r2;
+    assert.eq r2 true;
+    cast 1u8 r1.active_block into r3 as ReqState;
+    set r3 into requests[r0];
+    ",
+    )
+    .unwrap();
+
+    let program_1 = Program::<CurrentNetwork>::from_str(
+        r"
+        import credits.aleo;
+import staking_v1.aleo;
+import staker_v1_b.aleo;
+import multisig_v1.aleo;
+
+program staker_v1_multisig_b.aleo;
+
+struct Settings:
+    unstake_wait as u32;
+    stake_paused as boolean;
+    global_paused as boolean;
+    max_reward_per_notify as u64;
+    protocol_fee as u16;
+    fee_account as address;
+    fixed_stakers as boolean;
+
+struct Operation:
+    program_id as address;
+    op_type as u8;
+    params as field;
+    op_salt as u64;
+    delay as u32;
+
+struct Request:
+    operation as Operation;
+    multisig as address;
+
+struct SetOperatorParams:
+    operator as address;
+    flag as boolean;
+
+function dummy:
+
+function set_operator:
+    input r0 as address.public;
+    input r1 as boolean.public;
+    input r2 as u64.public;
+    input r3 as [address; 3u32].public;
+    input r4 as [signature; 3u32].private;
+    cast r0 r1 into r5 as SetOperatorParams;
+    hash.bhp256 r5 into r6 as field;
+    cast staker_v1_multisig_b.aleo 3u8 r6 r2 0u32 into r7 as Operation;
+    call multisig_v1.aleo/new_request r7 true r3 r4 into r8;
+    call staker_v1_b.aleo/set_operator r0 r1 into r9;
+    async set_operator r8 r9 into r10;
+    output r10 as staker_v1_multisig_b.aleo/set_operator.future;
+
+finalize set_operator:
+    input r0 as multisig_v1.aleo/new_request.future;
+    input r1 as staker_v1_b.aleo/set_operator.future;
+    await r0;
+    await r1;
+
+function add_admin:
+    input r0 as address.public;
+    input r1 as u64.public;
+    hash.bhp256 r0 into r2 as field;
+    cast staker_v1_multisig_b.aleo 1u8 r2 r1 1200u32 into r3 as Operation;
+    call multisig_v1.aleo/execute r3 into r4;
+    call staker_v1_b.aleo/set_admin r0 true into r5;
+    async add_admin r4 r5 into r6;
+    output r6 as staker_v1_multisig_b.aleo/add_admin.future;
+
+finalize add_admin:
+    input r0 as multisig_v1.aleo/execute.future;
+    input r1 as staker_v1_b.aleo/set_admin.future;
+    await r0;
+    await r1;
+
+function remove_admin:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as [address; 3u32].public;
+    input r3 as [signature; 3u32].private;
+    assert.neq self.caller r0 ;
+    hash.bhp256 r0 into r4 as field;
+    cast staker_v1_multisig_b.aleo 2u8 r4 r1 0u32 into r5 as Operation;
+    call multisig_v1.aleo/new_request r5 true r2 r3 into r6;
+    call staker_v1_b.aleo/set_admin r0 false into r7;
+    async remove_admin r6 r7 into r8;
+    output r8 as staker_v1_multisig_b.aleo/remove_admin.future;
+
+finalize remove_admin:
+    input r0 as multisig_v1.aleo/new_request.future;
+    input r1 as staker_v1_b.aleo/set_admin.future;
+    await r0;
+    await r1;
+        ",
+    )
+    .unwrap();
+
+    // `program_2` is the same as `program_1` but with a different name.
+    let program_2 = Program::<CurrentNetwork>::from_str(
+        r"
+        import credits.aleo;
+import staking_v1.aleo;
+import staker_v1_b.aleo;
+import multisig_v1.aleo;
+
+program staker_v2_multisig_b.aleo;
+
+struct Settings:
+    unstake_wait as u32;
+    stake_paused as boolean;
+    global_paused as boolean;
+    max_reward_per_notify as u64;
+    protocol_fee as u16;
+    fee_account as address;
+    fixed_stakers as boolean;
+
+struct Operation:
+    program_id as address;
+    op_type as u8;
+    params as field;
+    op_salt as u64;
+    delay as u32;
+
+struct Request:
+    operation as Operation;
+    multisig as address;
+
+struct SetOperatorParams:
+    operator as address;
+    flag as boolean;
+
+function dummy:
+
+function set_operator:
+    input r0 as address.public;
+    input r1 as boolean.public;
+    input r2 as u64.public;
+    input r3 as [address; 3u32].public;
+    input r4 as [signature; 3u32].private;
+    cast r0 r1 into r5 as SetOperatorParams;
+    hash.bhp256 r5 into r6 as field;
+    cast staker_v2_multisig_b.aleo 3u8 r6 r2 0u32 into r7 as Operation;
+    call multisig_v1.aleo/new_request r7 true r3 r4 into r8;
+    call staker_v1_b.aleo/set_operator r0 r1 into r9;
+    async set_operator r8 r9 into r10;
+    output r10 as staker_v2_multisig_b.aleo/set_operator.future;
+
+finalize set_operator:
+    input r0 as multisig_v1.aleo/new_request.future;
+    input r1 as staker_v1_b.aleo/set_operator.future;
+    await r0;
+    await r1;
+
+function add_admin:
+    input r0 as address.public;
+    input r1 as u64.public;
+    hash.bhp256 r0 into r2 as field;
+    cast staker_v2_multisig_b.aleo 1u8 r2 r1 1200u32 into r3 as Operation;
+    call multisig_v1.aleo/execute r3 into r4;
+    call staker_v1_b.aleo/set_admin r0 true into r5;
+    async add_admin r4 r5 into r6;
+    output r6 as staker_v2_multisig_b.aleo/add_admin.future;
+
+finalize add_admin:
+    input r0 as multisig_v1.aleo/execute.future;
+    input r1 as staker_v1_b.aleo/set_admin.future;
+    await r0;
+    await r1;
+
+function remove_admin:
+    input r0 as address.public;
+    input r1 as u64.public;
+    input r2 as [address; 3u32].public;
+    input r3 as [signature; 3u32].private;
+    assert.neq self.caller r0 ;
+    hash.bhp256 r0 into r4 as field;
+    cast staker_v2_multisig_b.aleo 2u8 r4 r1 0u32 into r5 as Operation;
+    call multisig_v1.aleo/new_request r5 true r2 r3 into r6;
+    call staker_v1_b.aleo/set_admin r0 false into r7;
+    async remove_admin r6 r7 into r8;
+    output r8 as staker_v2_multisig_b.aleo/remove_admin.future;
+
+finalize remove_admin:
+    input r0 as multisig_v1.aleo/new_request.future;
+    input r1 as staker_v1_b.aleo/set_admin.future;
+    await r0;
+    await r1;
+        ",
+    )
+    .unwrap();
+
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, private_key, .. } = crate::test_helpers::sample_test_env(rng);
+
+    //PRELIM PROGRAMS:
+
+    let prelim_1 = ledger.vm.deploy(&private_key, &prelim_program_1, None, 0, None, rng).unwrap();
+    let block = ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![prelim_1], rng).unwrap();
+    // Check that the block does not have any aborted transactions.
+    assert!(block.aborted_transaction_ids().is_empty());
+    // Check that the block does not have any rejected transactions.
+    assert_eq!(block.transactions().num_rejected(), 0);
+    ledger.check_next_block(&block, rng).unwrap();
+    ledger.advance_to_next_block(&block).unwrap();
+
+    let prelim_2 = ledger.vm.deploy(&private_key, &prelim_program_2, None, 0, None, rng).unwrap();
+    println!("Prelim 2 is {}", prelim_2.id());
+    let block = ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![prelim_2], rng).unwrap();
+    // Check that the block does not have any aborted transactions.
+    assert!(block.aborted_transaction_ids().is_empty());
+    // Check that the block does not have any rejected transactions.
+    assert_eq!(block.transactions().num_rejected(), 0);
+    ledger.check_next_block(&block, rng).unwrap();
+    ledger.advance_to_next_block(&block).unwrap();
+
+    let prelim_3 = ledger.vm.deploy(&private_key, &prelim_program_3, None, 0, None, rng).unwrap();
+    println!("Prelim 3 is {}", prelim_3.id());
+    let block = ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![prelim_3], rng).unwrap();
+    // Check that the block does not have any aborted transactions.
+    assert!(block.aborted_transaction_ids().is_empty());
+    // Check that the block does not have any rejected transactions.
+    assert_eq!(block.transactions().num_rejected(), 0);
+    ledger.check_next_block(&block, rng).unwrap();
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Deploy MAX_STACKS dummy deployments to test cache eviction.
+    for i in 0..=<CurrentNetwork as Network>::MAX_STACKS {
+        let program = Program::<CurrentNetwork>::from_str(&format!(
+            r"
+program testing{i}.aleo;
+
+function compute:"
+        ))
+        .unwrap();
+        let deployment = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment], rng).unwrap();
+        // Assert that the deployment was accepted.
+        assert!(block.aborted_transaction_ids().is_empty());
+        assert_eq!(block.transactions().num_rejected(), 0);
+        ledger.check_next_block(&block, rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+    }
+
+    // Create a deployment transaction for the first program.
+    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
+    let deployment_1_id = deployment_1.id();
+    let deployment_is_ok = ledger.check_transaction_basic(&deployment_1, None, rng).is_ok();
+    let fee_amount = deployment_1.fee_amount().unwrap();
+
+    println!("\n\n\n@@@@@@@@@@@");
+    println!("Program fee is {:?}", fee_amount);
+    println!("Program deployment is valid - {deployment_is_ok}");
+    println!("@@@@@@@@@@@\n\n\n");
+    assert!(deployment_is_ok);
+
+    // Create a block.
+    let block =
+        ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_1], rng).unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    let is_aborted = block.aborted_transaction_ids().contains(&deployment_1_id);
+    let is_accepted = block.transactions().transaction_ids().contains(&deployment_1_id);
+
+    println!("\n\n\n@@@@@@@@@@@");
+    println!("Block height is {:?}", block.height());
+    println!("Program fee is {:?}", fee_amount);
+    println!("Program deployment is valid - {deployment_is_ok}");
+    println!("Program is accepted: {is_accepted}");
+    println!("Program is aborted: {is_aborted}");
+    println!("@@@@@@@@@@@\n\n\n");
+    assert!(is_accepted);
+
+    // Add 10 dummy transactions executions, 1 each block.
+    for i in 0..10 {
+        println!("Adding dummy transaction {}", i);
+        let dummy_execution = ledger
+            .vm
+            .execute(
+                &private_key,
+                ("staker_v1_multisig_b.aleo", "dummy"),
+                Vec::<Value<CurrentNetwork>>::new().iter(),
+                None,
+                0,
+                None,
+                rng,
+            )
+            .unwrap();
+        let block = ledger
+            .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![dummy_execution], rng)
+            .unwrap();
+        // Check that the block does not have any aborted transactions.
+        assert!(block.aborted_transaction_ids().is_empty());
+        // Check that the block does not have any rejected transactions.
+        assert_eq!(block.transactions().num_rejected(), 0);
+        ledger.check_next_block(&block, rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+    }
+
+    // Create a deployment transaction for the second program.
+    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, None, 0, None, rng).unwrap();
+    let deployment_2_id = deployment_2.id();
+    let deployment_is_ok = ledger.check_transaction_basic(&deployment_2, None, rng).is_ok();
+    let fee_amount = deployment_2.fee_amount().unwrap();
+
+    println!("\n\n\n@@@@@@@@@@@");
+    println!("Program fee is {:?}", fee_amount);
+    println!("Program deployment is valid - {deployment_is_ok}");
+    println!("@@@@@@@@@@@\n\n\n");
+    assert!(deployment_is_ok);
+
+    // Create a block.
+    let block =
+        ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_2], rng).unwrap();
+
+    // Check that the next block is valid.
+    ledger.check_next_block(&block, rng).unwrap();
+
+    // Add the block to the ledger.
+    ledger.advance_to_next_block(&block).unwrap();
+
+    let is_aborted = block.aborted_transaction_ids().contains(&deployment_2_id);
+    let is_accepted = block.transactions().transaction_ids().contains(&deployment_2_id);
+
+    println!("\n\n\n@@@@@@@@@@@");
+    println!("Block height is {:?}", block.height());
+    println!("Program fee is {:?}", fee_amount);
+    println!("Program deployment is valid - {deployment_is_ok}");
+    println!("Program is accepted: {is_accepted}");
+    println!("Program is aborted: {is_aborted}");
+    println!("@@@@@@@@@@@\n\n\n");
+    assert!(is_accepted);
+}
+
+#[test]
 fn test_deployment_duplicate_program_id() {
     let rng = &mut TestRng::default();
 

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -38,11 +38,40 @@ impl<N: Network> Process<N> {
         deployment
     }
 
-    /// Adds the newly-deployed program.
+    /// Loads the stack and imported stacks for the given program ID into memory.
+    #[inline]
+    pub fn load_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<Arc<Stack<N>>> {
+        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        debug!("Lazy loading stack for {program_id}");
+        // Retrieve the stores.
+        let store = self.store.as_ref().ok_or_else(|| anyhow!("Failed to get store"))?;
+        // Retrieve the transaction store.
+        let transaction_store = store.transaction_store();
+
+        // Retrieve the deployment store.
+        let deployment_store = transaction_store.deployment_store();
+        // Retrieve the transaction ID.
+        let transaction_id = deployment_store
+            .find_transaction_id_from_program_id(&program_id)
+            .map_err(|e| anyhow!("Program ID not found in storage: {e}"))?
+            .ok_or_else(|| anyhow!("Program ID not found in storage"))?;
+
+        // Retrieve the deployment from the transaction ID.
+        let deployment = match transaction_store.get_deployment(&transaction_id)? {
+            Some(deployment) => deployment,
+            None => bail!("Deployment transaction '{transaction_id}' is not found in storage."),
+        };
+
+        // Load the deployment into memory and return it.
+        // When initializing the corresponding Stack, each import Stack will be loaded recursively.
+        self.load_deployment(deployment)
+    }
+
+    /// Constructs, loads and returns the Stack from the deployment.
     /// This method assumes the given deployment **is valid**.
     #[inline]
-    pub fn load_deployment(&self, deployment: &Deployment<N>) -> Result<()> {
-        let timer = timer!("Process::load_testing_only_deployment");
+    fn load_deployment(&self, deployment: Deployment<N>) -> Result<Arc<Stack<N>>> {
+        let timer = timer!("Process::load_deployment");
 
         // Compute the program stack.
         let stack = Stack::new(self, deployment.program())?;
@@ -54,11 +83,14 @@ impl<N: Network> Process<N> {
         }
         lap!(timer, "Insert the verifying keys");
 
+        // Wrap the stack in an Arc.
+        let stack = Arc::new(stack);
+
         // Add the stack to the process.
-        self.add_stack(stack);
+        self.add_stack(stack.clone())?;
 
         finish!(timer);
 
-        Ok(())
+        Ok(stack)
     }
 }

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -514,7 +514,7 @@ function compute:
         let (stack, _) =
             process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
         // Add the stack *manually* to the process.
-        process.add_stack(stack);
+        process.add_stack(Arc::new(stack)).unwrap();
 
         // Ensure the program exists.
         assert!(process.contains_program(program.id()));

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -50,7 +50,7 @@ use console::{
     types::{Field, U16, U64},
 };
 use ledger_block::{Deployment, Execution, Fee, Input, Transition};
-use ledger_store::{FinalizeStorage, FinalizeStore, atomic_batch_scope};
+use ledger_store::{ConsensusStore, FinalizeStorage, FinalizeStore, atomic_batch_scope};
 use synthesizer_program::{
     Branch,
     Closure,
@@ -65,16 +65,15 @@ use synthesizer_program::{
     StackProgram,
 };
 use synthesizer_snark::{ProvingKey, UniversalSRS, VerifyingKey};
-use tracing::debug;
 
 use aleo_std::{
     StorageMode,
     prelude::{finish, lap, timer},
 };
-use ledger_store::{ConsensusStore, TransactionStorage, TransactionStore};
 use lru::LruCache;
 use parking_lot::{Mutex, RwLock};
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
+use tracing::debug;
 
 #[cfg(feature = "aleo-cli")]
 use colored::Colorize;
@@ -155,17 +154,65 @@ impl<N: Network> Process<N> {
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
         if program.id() != &credits_program_id {
-            self.add_stack(Stack::new(self, program)?);
+            self.add_stack(Arc::new(Stack::new(self, program)?))?;
         }
         Ok(())
     }
 
-    /// Adds a new stack to the process.
+    /// Adds a new stack to the LRU cache in the process.
     /// If you intend to `execute` the program, use `deploy` and `finalize_deployment` instead.
     #[inline]
-    pub fn add_stack(&self, stack: Stack<N>) {
-        // Add the stack to the process.
-        self.stacks.lock().put(*stack.program_id(), Arc::new(stack));
+    pub fn add_stack(&self, stack: Arc<Stack<N>>) -> Result<()> {
+        // Collect all direct and indirect external stacks.
+        let external_stacks = stack.all_external_stacks();
+        // Obtain the lock on the stacks.
+        let mut stacks = self.stacks.lock();
+        // Determine which stacks still need to be added into the process.
+        let programs_to_add = external_stacks
+            .into_iter()
+            .unique_by(|(id, _)|*id) // indirect imports might contain duplicates.
+            .chain(std::iter::once((*stack.program_id(), stack))) // add the root stack.
+            .filter(|(program_id, _)| !stacks.contains(program_id)) // remove stacks present in the cache.
+            .collect::<Vec<_>>();
+        // Determine the required capacity.
+        let current_capacity = stacks.cap().get().saturating_sub(stacks.len());
+        let mut required_capacity = programs_to_add.len().saturating_sub(current_capacity);
+        if required_capacity > 0 {
+            debug!("Evicting {required_capacity} stacks from the cache.");
+        }
+        // If the new stacks require more capacity, attempt to remove the least recently used stacks.
+        while required_capacity > 0 {
+            // To avoid dangling stacks, we only remove stacks that do not have more than 1 reference (e.g. as external stack).
+            // For this not to loop endlessly, we assume to always quickly find stacks with just one reference, so:
+            // 1. queried stacks must be short-lived, which is essential anyway to avoid memory leaks.
+            // 2. queried stacks must expire before a querying thread queries the next stack.
+            let root_program_ids = stacks
+                .iter()
+                .rev()
+                .filter_map(|(program_id, stack)| (std::sync::Arc::<_>::strong_count(stack) == 1).then_some(program_id))
+                .take(required_capacity)
+                .cloned()
+                .collect::<Vec<_>>();
+            // Lower the required capacity.
+            required_capacity = required_capacity.saturating_sub(root_program_ids.len());
+            // Evict the old stacks from the cache.
+            for program_id in root_program_ids {
+                if stacks.pop(&program_id).is_none() {
+                    bail!("Could not find expected program id in cache.")
+                }
+            }
+        }
+        // Add a new stacks into the cache.
+        for (program_id, stack) in programs_to_add {
+            stacks.put(program_id, stack);
+        }
+        Ok(())
+    }
+
+    /// Returns the size of the cache.
+    #[inline]
+    pub fn num_stacks(&self) -> usize {
+        self.stacks.lock().len()
     }
 }
 
@@ -281,37 +328,37 @@ impl<N: Network> Process<N> {
         &self.universal_srs
     }
 
-    /// Returns `true` if the process contains the program with the given ID.
+    /// Returns `true` if the process or storage contains the program with the given ID.
     #[inline]
     pub fn contains_program(&self, program_id: &ProgramID<N>) -> bool {
+        // Check if the program is in memory.
+        if self.contains_program_in_memory(program_id) {
+            return true;
+        }
+        // Retrieve the stores.
+        if let Some(store) = self.store.as_ref() {
+            let transaction_store = store.transaction_store();
+            let deployment_store = transaction_store.deployment_store();
+            // Check if the program ID exists in the storage.
+            match deployment_store.find_transaction_id_from_program_id(program_id) {
+                Ok(Some(_)) => return true,
+                Ok(None) => debug!("Program ID not found in storage"),
+                Err(err) => debug!("Could not retrieve transaction ID for program ID: {err}"),
+            }
+        }
+
+        false
+    }
+
+    /// Returns `true` if the process contains the program with the given ID.
+    #[inline]
+    pub fn contains_program_in_memory(&self, program_id: &ProgramID<N>) -> bool {
+        // Check if the program ID is 'credits.aleo'.
         if self.credits.as_ref().map_or(false, |stack| stack.program_id() == program_id) {
             return true;
         }
+        // Check if the program ID exists in the cache.
         self.stacks.lock().contains(program_id)
-    }
-
-    /// Loads the Stack and imported Stacks for the given program ID into memory.
-    #[inline]
-    fn load_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<()> {
-        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
-        debug!("Lazy loading stack for {program_id}");
-        // Retrieve the stores.
-        let store = self.store.as_ref().ok_or_else(|| anyhow!("Failed to get store"))?;
-        let transaction_store = store.transaction_store();
-        let deployment_store = transaction_store.deployment_store();
-        // Retrieve the transaction ID.
-        let transaction_id = deployment_store
-            .find_transaction_id_from_program_id(&program_id)
-            .map_err(|e| anyhow!("Program ID not found in storage: {e}"))?
-            .ok_or_else(|| anyhow!("Program ID not found in storage"))?;
-        // Collect the deployment and imports.
-        let deployments = load_deployment_and_imports(self, transaction_store, transaction_id)?;
-        // Load the deployment into memory.
-        for deployment in deployments {
-            self.load_deployment(&deployment.1)?;
-        }
-        debug!("Loaded stack for {program_id}");
-        Ok(())
     }
 
     /// Returns the stack for the given program ID.
@@ -323,17 +370,21 @@ impl<N: Network> Process<N> {
         if program_id == ProgramID::<N>::from_str("credits.aleo")? {
             return self.credits.clone().ok_or_else(|| anyhow!("Failed to get stack for 'credits.aleo'"));
         }
-        // Maybe lazy load the stack
-        if !self.contains_program(&program_id) {
-            self.load_stack(program_id)?;
+        // Try to retrieve the stack from the LRU cache.
+        if let Some(stack) = self.stacks.lock().get(&program_id) {
+            // Ensure the program ID matches.
+            ensure!(
+                stack.program_id() == &program_id,
+                "Expected program '{}', found '{program_id}'",
+                stack.program_id()
+            );
+            // Return the stack.
+            Ok(stack.clone())
+        // Otherwise, retrieve the stack from the storage.
+        } else {
+            // Try to load and return the stack.
+            self.load_stack(program_id)
         }
-        // Retrieve the stack.
-        let mut lru_cache = self.stacks.lock();
-        let stack = lru_cache.get(&program_id).ok_or_else(|| anyhow!("Failed to load stack"))?;
-        // Ensure the program ID matches.
-        ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
-        // Return the stack.
-        Ok(stack.clone())
     }
 
     /// Returns the program for the given program ID.
@@ -402,52 +453,6 @@ impl<N: Network> Process<N> {
         // Synthesize the proving and verifying key.
         self.get_stack(program_id)?.synthesize_key::<A, R>(function_name, rng)
     }
-}
-
-// A helper function to retrieve all the deployments.
-fn load_deployment_and_imports<N: Network, T: TransactionStorage<N>>(
-    process: &Process<N>,
-    transaction_store: &TransactionStore<N, T>,
-    transaction_id: N::TransactionID,
-) -> Result<Vec<(ProgramID<N>, Deployment<N>)>> {
-    // Retrieve the deployment from the transaction ID.
-    let deployment = match transaction_store.get_deployment(&transaction_id)? {
-        Some(deployment) => deployment,
-        None => bail!("Deployment transaction '{transaction_id}' is not found in storage."),
-    };
-
-    // Fetch the program from the deployment.
-    let program = deployment.program();
-    let program_id = program.id();
-
-    // Return early if the program is already loaded.
-    if process.contains_program(program_id) {
-        return Ok(vec![]);
-    }
-
-    // Prepare a vector for the deployments.
-    let mut deployments = vec![];
-
-    // Iterate through the program imports.
-    for import_program_id in program.imports().keys() {
-        // Add the imports to the process if does not exist yet.
-        if !process.contains_program(import_program_id) {
-            // Fetch the deployment transaction ID.
-            let Some(transaction_id) =
-                transaction_store.deployment_store().find_transaction_id_from_program_id(import_program_id)?
-            else {
-                bail!("Transaction ID for '{program_id}' is not found in storage.");
-            };
-
-            // Add the deployment and its imports found recursively.
-            deployments.extend_from_slice(&load_deployment_and_imports(process, transaction_store, transaction_id)?);
-        }
-    }
-
-    // Once all the imports have been included, add the parent deployment.
-    deployments.push((*program_id, deployment));
-
-    Ok(deployments)
 }
 
 #[cfg(test)]

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -35,16 +35,18 @@ impl<N: Network> Stack<N> {
 
         // Add all the imports into the stack.
         for import in program.imports().keys() {
-            // Ensure the program imports all exist in the process already.
+            // Ensure the program imports all exist in the process or storage already.
             if !process.contains_program(import) {
                 bail!("Cannot add program '{}' because its import '{import}' must be added first", program.id())
             }
             // Retrieve the external stack for the import program ID.
             let external_stack = process.get_stack(import)?;
+            // Determine the external program depth.
+            let external_stack_program_depth = external_stack.program_depth;
             // Add the external stack to the stack.
-            stack.insert_external_stack(external_stack.clone())?;
+            stack.insert_external_stack(external_stack)?;
             // Update the program depth, checking that it does not exceed the maximum call depth.
-            stack.program_depth = std::cmp::max(stack.program_depth, external_stack.program_depth() + 1);
+            stack.program_depth = std::cmp::max(stack.program_depth, external_stack_program_depth + 1);
             ensure!(
                 stack.program_depth <= N::MAX_PROGRAM_DEPTH,
                 "Program depth exceeds the maximum allowed call depth"

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -442,6 +442,23 @@ impl<N: Network> Stack<N> {
 }
 
 impl<N: Network> Stack<N> {
+    /// Returns all direct and indirect external stacks.
+    /// Note that this may contain duplicates.
+    #[inline]
+    pub fn all_external_stacks(&self) -> Vec<(ProgramID<N>, Arc<Stack<N>>)> {
+        let mut stacks = vec![];
+        // Iterate through the program imports.
+        for (program_id, external_stack) in &self.external_stacks {
+            // Insert imports of the import.
+            stacks.extend_from_slice(&external_stack.all_external_stacks());
+            // Insert the import itself.
+            stacks.push((*program_id, external_stack.clone()));
+        }
+        stacks
+    }
+}
+
+impl<N: Network> Stack<N> {
     /// Inserts the proving key if the program ID is 'credits.aleo'.
     fn try_insert_credits_function_proving_key(&self, function_name: &Identifier<N>) -> Result<()> {
         // If the program is 'credits.aleo' and it does not exist yet, load the proving key directly.

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -1255,7 +1255,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1368,7 +1368,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1495,7 +1495,7 @@ finalize mint_public:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1624,7 +1624,7 @@ finalize mint_public:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1664,7 +1664,7 @@ finalize init:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(2), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1782,7 +1782,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2211,7 +2211,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2442,7 +2442,7 @@ function {function_name}:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(Arc::new(stack)).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();

--- a/synthesizer/process/src/tests/test_process.rs
+++ b/synthesizer/process/src/tests/test_process.rs
@@ -48,47 +48,91 @@ function compute:
     .unwrap();
     // Initialize a new process.
     let process = crate::test_helpers::sample_process(&program1);
-    assert!(process.contains_program(program1.id()));
+    // assert_eq!(process.num_stacks(), 1); // TODO: currently, storage between tests is shared, this needs to be fixed.
+    assert!(process.contains_program_in_memory(program1.id()));
 }
 
 #[test]
 pub fn test_cache_evict() {
-    let (_, program1) = Program::<CurrentNetwork>::parse(
-        r"
-program testing1.aleo;
-
-function compute:
-    input r0 as u32.private;
-    input r1 as u32.public;
-    add r0 r1 into r2;
-    output r2 as u32.public;",
-    )
-    .unwrap();
-    // Initialize a new process.
-    let mut process = crate::test_helpers::sample_process(&program1);
-    assert!(process.contains_program(program1.id()));
-
-    for i in 2..=<CurrentNetwork as Network>::MAX_STACKS + 1 {
-        let source = format!(
+    let mid_program_template = |i| {
+        format!(
             r"
-program testing{i}.aleo;
+import credits.aleo;
 
-function compute:
-    input r0 as u32.private;
-    input r1 as u32.public;
-    add r0 r1 into r2;
-    output r2 as u32.public;"
-        );
-        // Program1 should still be cached
-        assert!(process.contains_program(program1.id()));
-        let (_, program) = Program::<CurrentNetwork>::parse(&source).unwrap();
+program mid{i}.aleo;
+
+function mid{i}_transfer:
+    input r0 as credits.aleo/credits.record;
+    input r1 as address.private;
+    input r2 as u64.private;
+
+    call credits.aleo/transfer_private r0 r1 r2 into r3 r4;
+
+    output r3 as credits.aleo/credits.record;
+    output r4 as credits.aleo/credits.record;"
+        )
+    };
+
+    let root_program_template = |i| {
+        format!(
+            r"
+import credits.aleo;
+import mid1.aleo;
+import mid2.aleo;
+
+program root{i}.aleo;
+
+function root_call:
+    input r0 as credits.aleo/credits.record;
+    input r1 as address.private;
+    input r2 as u64.private;
+
+    // Call mid1's transfer function
+    call mid1.aleo/mid1_transfer r0 r1 r2 into r3 r4;
+
+    // Call mid2's transfer function
+    call mid2.aleo/mid2_transfer r4 r1 r2 into r5 r6;
+
+    output r3 as credits.aleo/credits.record;
+    output r4 as credits.aleo/credits.record;
+    output r5 as credits.aleo/credits.record;
+    output r6 as credits.aleo/credits.record;"
+        )
+    };
+
+    // Sample two programs.
+    let (_, mid1) = Program::<CurrentNetwork>::parse(&mid_program_template(1)).unwrap();
+    let (_, mid2) = Program::<CurrentNetwork>::parse(&mid_program_template(2)).unwrap();
+    // Initialize a new process.
+    let mut process = crate::test_helpers::sample_process(&mid1);
+
+    // Adding the root program should fail because an import is missing from memory and storage.
+    let (_, root1) = Program::<CurrentNetwork>::parse(&root_program_template(1)).unwrap();
+    assert!(process.add_program(&root1).is_err());
+    assert!(!process.contains_program_in_memory(root1.id()));
+
+    // Check whether mid1 is in memory.
+    assert!(process.contains_program_in_memory(mid1.id()));
+    // assert_eq!(process.num_stacks(), 1); // TODO: currently, storage between tests is shared, this needs to be fixed.
+    process.add_program(&mid2).unwrap();
+    // Check whether mid2 is in memory.
+    assert!(process.contains_program_in_memory(mid2.id()));
+    // assert_eq!(process.num_stacks(), 2); // TODO: currently, storage between tests is shared, this needs to be fixed.
+
+    for i in 3..=<CurrentNetwork as Network>::MAX_STACKS + 1 {
+        // mid1 and mid2 should still be cached.
+        assert!(process.contains_program_in_memory(mid1.id()));
+        assert!(process.contains_program_in_memory(mid2.id()));
+        let (_, program) = Program::<CurrentNetwork>::parse(&root_program_template(i)).unwrap();
         process.add_program(&program).unwrap();
-        assert!(process.contains_program(program.id()));
+        // The new program should be cached.
+        assert!(process.contains_program_in_memory(program.id()));
     }
 
-    // only MAX_STACKS programs are cached, so program1 should be evicted
-    assert!(!process.contains_program(program1.id()));
-    // test we still have credits.aleo
+    // Only MAX_STACKS programs are cached, so the oldest root should be evicted.
+    let test_id = ProgramID::<CurrentNetwork>::from_str("root3.aleo").unwrap();
+    assert!(!process.contains_program_in_memory(&test_id));
+    // Test we still have credits.aleo in memory.
     let credits_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
-    assert!(process.contains_program(&credits_id));
+    assert!(process.contains_program_in_memory(&credits_id));
 }

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -765,7 +765,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             // Commit all of the stacks to the process.
             if !stacks.is_empty() {
-                stacks.into_iter().for_each(|stack| process.add_stack(stack))
+                for stack in stacks {
+                    process.add_stack(Arc::new(stack)).map_err(|e| format!("{e}"))?;
+                }
             }
 
             finish!(timer); // <- Note: This timer does **not** include the time to write batch to DB.


### PR DESCRIPTION
## Motivation

RSS growth is correlated with deployments. By lazy loading deployments, hopefully unbounded memory growth is eliminated.

Note that programs, represented as `Stack`s, have imports. This means the cache is essentially a DAG with multiple roots. To avoid memory leaks, we only evict root stacks from the cache. In the following diagram, you can see in the call graph where the cache is (temporarily) locked and updated:

<img width="935" alt="Screenshot 2025-01-10 at 16 30 57" src="https://github.com/user-attachments/assets/63b0bddd-355b-4996-8c7d-8bd014f4e794" />

## Test Plan

- [ ] Github seems to have a bug which shows the remote is outdated and implies this PR has conflicts.
- [ ] Unit tests pass.
- [ ] Local network passes, using tx-cannon to deploy and fetch multiple sets of maximally nested deployments.
- [ ] Deployed network passes, using tx-cannon to deploy and fetch multiple sets of maximally nested deployments.
- [ ] Consider fixing how test storage works, which currently leaks states across tests.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2519
https://github.com/ProvableHQ/snarkVM/pull/2553
https://github.com/ProvableHQ/snarkVM/pull/2578
