### PR TITLE
[Fix] CI for memory-intensive synthesizer tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
-          flags: --lib --bins -- --test-threads=2
+          flags: --lib --bins -- --test-threads=1
           workspace_member: synthesizer
           cache_key: v1.0.0-rust-1.81.0-snarkvm-synthesizer-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: xlarge
   twoxlarge:
     type: string
-    default: aleonet/2xlarge
+    default: 2xlarge
 
 orbs:
   windows: circleci/windows@5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -692,7 +692,7 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
-          flags: -- --test-threads=1 --ignored test_deployment_synthesis_overload test_deep_nested_execution_cost
+          flags: -- --ignored test_deployment_synthesis_overload test_deep_nested_execution_cost
           workspace_member: synthesizer
           cache_key: v1.0.0-rust-1.81.0-snarkvm-synthesizer-mem-heavy-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,16 @@ jobs:
           workspace_member: synthesizer
           cache_key: v1.0.0-rust-1.81.0-snarkvm-synthesizer-cache
 
+  synthesizer-mem-heavy:
+    docker:
+      - image: cimg/rust:1.81.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+    resource_class: << pipeline.parameters.twoxlarge >>
+    steps:
+      - run_serial:
+          flags: -- --test-threads=1 --ignored test_deployment_synthesis_overload test_deep_nested_execution_cost
+          workspace_member: synthesizer
+          cache_key: v1.0.0-rust-1.81.0-snarkvm-synthesizer-mem-heavy-cache
+
   synthesizer-integration:
     docker:
       - image: cimg/rust:1.81.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
@@ -966,6 +976,7 @@ workflows:
       - parameters
       - parameters-uncached
       - synthesizer
+      - synthesizer-mem-heavy
       - synthesizer-integration
       - synthesizer-process
       - synthesizer-process-with-rocksdb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
-          flags: --lib --bins -- --test-threads=1
+          flags: --lib --bins
           workspace_member: synthesizer
           cache_key: v1.0.0-rust-1.81.0-snarkvm-synthesizer-cache
 

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -42,6 +42,10 @@ impl_remote!(Degree25, REMOTE_URL, "resources/", "powers-of-beta-25", "usrs");
 impl_remote!(Degree26, REMOTE_URL, "resources/", "powers-of-beta-26", "usrs");
 impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
 // TODO (nkls): restore on CI.
+// The SRS is only used for proving and we don't currently support provers of
+// this size. When a users wants to create a proof, they load the appropriate
+// powers for the circuit in `batch_circuit_setup` which calls `max_degree`
+// based on the domain size.
 // impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
@@ -64,6 +68,7 @@ impl_remote!(ShiftedDegree24, REMOTE_URL, "resources/", "shifted-powers-of-beta-
 impl_remote!(ShiftedDegree25, REMOTE_URL, "resources/", "shifted-powers-of-beta-25", "usrs");
 impl_remote!(ShiftedDegree26, REMOTE_URL, "resources/", "shifted-powers-of-beta-26", "usrs");
 // TODO (nkls): restore on CI.
+// See `Degree28` above for context.
 // impl_remote!(ShiftedDegree27, REMOTE_URL, "resources/", "shifted-powers-of-beta-27", "usrs");
 
 // Powers of Beta Times Gamma * G

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -41,7 +41,8 @@ impl_remote!(Degree24, REMOTE_URL, "resources/", "powers-of-beta-24", "usrs");
 impl_remote!(Degree25, REMOTE_URL, "resources/", "powers-of-beta-25", "usrs");
 impl_remote!(Degree26, REMOTE_URL, "resources/", "powers-of-beta-26", "usrs");
 impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
-impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
+// TODO (nkls): restore on CI.
+// impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
 #[cfg(not(feature = "wasm"))]
@@ -62,7 +63,8 @@ impl_remote!(ShiftedDegree23, REMOTE_URL, "resources/", "shifted-powers-of-beta-
 impl_remote!(ShiftedDegree24, REMOTE_URL, "resources/", "shifted-powers-of-beta-24", "usrs");
 impl_remote!(ShiftedDegree25, REMOTE_URL, "resources/", "shifted-powers-of-beta-25", "usrs");
 impl_remote!(ShiftedDegree26, REMOTE_URL, "resources/", "shifted-powers-of-beta-26", "usrs");
-impl_remote!(ShiftedDegree27, REMOTE_URL, "resources/", "shifted-powers-of-beta-27", "usrs");
+// TODO (nkls): restore on CI.
+// impl_remote!(ShiftedDegree27, REMOTE_URL, "resources/", "shifted-powers-of-beta-27", "usrs");
 
 // Powers of Beta Times Gamma * G
 impl_local!(Gamma, "resources/", "powers-of-beta-gamma", "usrs");

--- a/parameters/src/mainnet/powers.rs
+++ b/parameters/src/mainnet/powers.rs
@@ -415,7 +415,8 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
                 NUM_POWERS_25 => Degree25::load_bytes()?,
                 NUM_POWERS_26 => Degree26::load_bytes()?,
                 NUM_POWERS_27 => Degree27::load_bytes()?,
-                NUM_POWERS_28 => Degree28::load_bytes()?,
+                // TODO (nkls): restore on CI.
+                // NUM_POWERS_28 => Degree28::load_bytes()?,
                 _ => bail!("Cannot download an invalid degree of '{num_powers}'"),
             };
 
@@ -492,7 +493,8 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
                 NUM_POWERS_24 => ShiftedDegree24::load_bytes()?,
                 NUM_POWERS_25 => ShiftedDegree25::load_bytes()?,
                 NUM_POWERS_26 => ShiftedDegree26::load_bytes()?,
-                NUM_POWERS_27 => ShiftedDegree27::load_bytes()?,
+                // TODO (nkls): restore on CI.
+                // NUM_POWERS_27 => ShiftedDegree27::load_bytes()?,
                 _ => bail!("Cannot download an invalid degree of '{num_powers}'"),
             };
 

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -915,6 +915,7 @@ finalize test:
     }
 
     #[test]
+    #[ignore = "memory-intensive"]
     fn test_deep_nested_execution_cost() {
         // Initialize an RNG.
         let rng = &mut TestRng::default();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1356,6 +1356,7 @@ function call_fee_private:
     }
 
     #[test]
+    #[ignore = "memory-intensive"]
     fn test_deployment_synthesis_overload() {
         let rng = &mut TestRng::default();
 


### PR DESCRIPTION
Builds on #2593 and achieves sub 20 minute CI times for synthesiser tests on `2xlarge` instances. Memory-intensive tests are moved to a dedicated multi-threaded job (`synthesizer-mem-heavy`) and the other synthesizer tests can now be run in parallel without OOM'ing. 

I have also commented out the highest power test cases as the parameter download fails for them at the moment. We don't use these in production but it might be possible to restore their testing on CI by:
1. ssh'ing into the machine while the main job sleeps (don't `pkill sleep` or the job will fail)
2. running the tests manually to download the parameters (retries should eventually succeed)
4. making sure the `resources` directory gets cached
