### PR TITLE
[Feat] Increase `MAX_CERTIFICATES` on `MainnetV0`

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -136,10 +136,16 @@ impl Network for CanaryV0 {
     /// The block height from which consensus V2 rules apply.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_V2_HEIGHT: u32 = 2_900_000;
-    // TODO (raychu86): Update this value based on the desired canary height.
     /// The block height from which consensus V2 rules apply.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V2_HEIGHT: u32 = 0;
+    const CONSENSUS_V2_HEIGHT: u32 = 10;
+    // TODO: (raychu86): Update this value based on the desired mainnet height.
+    // The block height from which consensus V3 rules apply.
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_V3_HEIGHT: u32 = 4_560_000;
+    /// The block height from which consensus V3 rules apply.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_V3_HEIGHT: u32 = 20;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -145,7 +145,7 @@ impl Network for CanaryV0 {
     const CONSENSUS_V3_HEIGHT: u32 = 4_560_000;
     /// The block height from which consensus V3 rules apply.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V3_HEIGHT: u32 = 20;
+    const CONSENSUS_V3_HEIGHT: u32 = 11;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -166,6 +166,8 @@ impl Network for CanaryV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
     const MAX_CERTIFICATES: u16 = 100;
+    /// The maximum number of certificates in a batch before consensus V3 rules apply.
+    const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -200,6 +200,7 @@ pub trait Network:
     // Note: This value must **not** be changed without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
+    //  Increasing this value will require a migration to prevent forking during network upgrades.
     const MAX_CERTIFICATES: u16;
 
     /// The maximum number of bytes in a transaction.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -194,7 +194,12 @@ pub trait Network:
     /// The maximum number of imports.
     const MAX_IMPORTS: usize = 64;
 
+    /// The maximum number of certificates in a batch before consensus V3 rules apply.
+    const MAX_CERTIFICATES_BEFORE_V3: u16;
     /// The maximum number of certificates in a batch.
+    // Note: This value must **not** be changed without considering the impact on serialization.
+    //  Decreasing this value will break backwards compatibility of serialization without explicit
+    //  declaration of migration based on round number rather than block height.
     const MAX_CERTIFICATES: u16;
 
     /// The maximum number of bytes in a transaction.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -93,6 +93,8 @@ pub trait Network:
 
     /// The block height from which consensus V2 rules apply.
     const CONSENSUS_V2_HEIGHT: u32;
+    /// The block height from which consensus V3 rules apply.
+    const CONSENSUS_V3_HEIGHT: u32;
 
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str;

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -140,7 +140,7 @@ impl Network for MainnetV0 {
     /// The block height from which consensus V2 rules apply.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_V2_HEIGHT: u32 = 10;
-    // TODO: (raychu86): Update this value based on the desired mainnet height.
+    // TODO: (raychu86): Update this value based on the desired canary height.
     // The block height from which consensus V3 rules apply.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_V3_HEIGHT: u32 = 4_900_000;

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -146,7 +146,7 @@ impl Network for MainnetV0 {
     const CONSENSUS_V3_HEIGHT: u32 = 4_900_000;
     /// The block height from which consensus V3 rules apply.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V3_HEIGHT: u32 = 20;
+    const CONSENSUS_V3_HEIGHT: u32 = 11;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -137,10 +137,16 @@ impl Network for MainnetV0 {
     /// The block height from which consensus V2 rules apply.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_V2_HEIGHT: u32 = 2_800_000;
-    // TODO (raychu86): Update this value based on the desired mainnet height.
     /// The block height from which consensus V2 rules apply.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_V2_HEIGHT: u32 = 10;
+    // TODO: (raychu86): Update this value based on the desired mainnet height.
+    // The block height from which consensus V3 rules apply.
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_V3_HEIGHT: u32 = 4_900_000;
+    /// The block height from which consensus V3 rules apply.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_V3_HEIGHT: u32 = 20;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -170,7 +170,9 @@ impl Network for MainnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
-    const MAX_CERTIFICATES: u16 = 16;
+    const MAX_CERTIFICATES: u16 = 25;
+    /// The maximum number of certificates in a batch before consensus V3 rules apply.
+    const MAX_CERTIFICATES_BEFORE_V3: u16 = 16;
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -145,7 +145,7 @@ impl Network for TestnetV0 {
     const CONSENSUS_V3_HEIGHT: u32 = 4_800_000;
     /// The block height from which consensus V3 rules apply.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V3_HEIGHT: u32 = 20;
+    const CONSENSUS_V3_HEIGHT: u32 = 11;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -136,10 +136,16 @@ impl Network for TestnetV0 {
     /// The block height from which consensus V2 rules apply.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_V2_HEIGHT: u32 = 2_950_000;
-    // TODO (raychu86): Update this value based on the desired testnet height.
     /// The block height from which consensus V2 rules apply.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_V2_HEIGHT: u32 = 10;
+    // TODO: (raychu86): Update this value based on the desired testnet height.
+    // The block height from which consensus V3 rules apply.
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_V3_HEIGHT: u32 = 4_800_000;
+    /// The block height from which consensus V3 rules apply.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_V3_HEIGHT: u32 = 20;
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -166,6 +166,8 @@ impl Network for TestnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
     const MAX_CERTIFICATES: u16 = 100;
+    /// The maximum number of certificates in a batch before consensus V3 rules apply.
+    const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
 

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -63,6 +63,8 @@ impl<N: Network> Committee<N> {
     pub const COMMITTEE_LOOKBACK_RANGE: u64 = BatchHeader::<N>::MAX_GC_ROUNDS as u64;
     /// The maximum number of members that may be in a committee.
     pub const MAX_COMMITTEE_SIZE: u16 = BatchHeader::<N>::MAX_CERTIFICATES;
+    /// The maximum number of members that may be in a committee before consensus V3 rules apply.
+    pub const MAX_COMMITTEE_SIZE_BEFORE_V3: u16 = BatchHeader::<N>::MAX_CERTIFICATES_BEFORE_V3;
 
     /// Initializes a new `Committee` instance.
     pub fn new_genesis(members: IndexMap<Address<N>, (u64, bool, u8)>) -> Result<Self> {
@@ -465,7 +467,18 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)]
     fn test_maximum_committee_size() {
+        assert_eq!(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3,
+            BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES_BEFORE_V3
+        );
         assert_eq!(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE, BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES);
+        // Adding explicit check that updates to the maximum committee size are strictly increasing. A decreasing maximum will
+        // require additional migration logic based on a `round` number.
+        assert!(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3
+                <= Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE
+        );
     }
 }

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -64,7 +64,12 @@ impl<N: Network> BatchHeader<N> {
     #[cfg(any(test, feature = "test-helpers"))]
     pub const MAX_CERTIFICATES: u16 = 100;
     /// The maximum number of certificates in a batch before consensus V3 rules apply.
+    #[cfg(not(any(test, feature = "test-helpers")))]
     pub const MAX_CERTIFICATES_BEFORE_V3: u16 = N::MAX_CERTIFICATES_BEFORE_V3;
+    /// The maximum number of certificates in a batch before consensus V3 rules apply.
+    /// This is deliberately set to a high value (100) for testing purposes only.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
     /// The maximum number of rounds to store before garbage collecting.
     pub const MAX_GC_ROUNDS: usize = 100;
     /// The maximum number of transmissions in a batch.

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -63,6 +63,8 @@ impl<N: Network> BatchHeader<N> {
     /// This is deliberately set to a high value (100) for testing purposes only.
     #[cfg(any(test, feature = "test-helpers"))]
     pub const MAX_CERTIFICATES: u16 = 100;
+    /// The maximum number of certificates in a batch before consensus V3 rules apply.
+    pub const MAX_CERTIFICATES_BEFORE_V3: u16 = N::MAX_CERTIFICATES_BEFORE_V3;
     /// The maximum number of rounds to store before garbage collecting.
     pub const MAX_GC_ROUNDS: usize = 100;
     /// The maximum number of transmissions in a batch.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1924,7 +1924,7 @@ fn test_max_committee_limit_with_bonds() {
     let vm = sample_vm();
 
     // Construct the validators, one less than the maximum committee size.
-    let validators = (0..Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE - 1)
+    let validators = (0..Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 - 1)
         .map(|_| {
             let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
             let amount = MIN_VALIDATOR_STAKE;

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -393,7 +393,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     // and update the respective leaves of the finalize tree.
                     Transaction::Execute(_, execution, fee) => {
                         // Determine if the transaction is safe for execution, and proceed to execute it.
-                        match Self::prepare_for_execution(store, execution)
+                        match Self::prepare_for_execution(state, store, execution)
                             .and_then(|_| process.finalize_execution(state, store, execution, fee.as_ref()))
                         {
                             // Construct the accepted execute transaction.
@@ -953,7 +953,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// - If the transaction contains a `credits.aleo/bond_public` transition,
     ///   then the outcome should not exceed the maximum committee size.
     #[inline]
-    fn prepare_for_execution(store: &FinalizeStore<N, C::FinalizeStorage>, execution: &Execution<N>) -> Result<()> {
+    fn prepare_for_execution(
+        state: FinalizeGlobalState,
+        store: &FinalizeStore<N, C::FinalizeStorage>,
+        execution: &Execution<N>,
+    ) -> Result<()> {
         // Construct the program ID.
         let program_id = ProgramID::from_str("credits.aleo")?;
         // Construct the committee mapping name.
@@ -995,8 +999,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     bond_validator_addresses.into_iter().filter(|address| !committee_members.contains(address)).count();
                 // Compute the next committee size.
                 let next_committee_size = committee_members.len().saturating_add(num_new_validators);
+                // Determine the maximum committee size to use.
+                let max_committee_size = match state.block_height() < N::CONSENSUS_V3_HEIGHT {
+                    true => Committee::<N>::MAX_COMMITTEE_SIZE_BEFORE_V3,
+                    false => Committee::<N>::MAX_COMMITTEE_SIZE,
+                };
                 // Check that the number of new validators being bonded does not exceed the maximum number of validators.
-                match next_committee_size > Committee::<N>::MAX_COMMITTEE_SIZE as usize {
+                match next_committee_size > max_committee_size as usize {
                     true => Err(anyhow!("Call to 'credits.aleo/bond_public' exceeds the committee size")),
                     false => Ok(()),
                 }
@@ -1893,6 +1902,144 @@ finalize transfer_public:
             confirmed_transactions[0],
             reject(0, &bond_validator_transaction, confirmed_transactions[0].finalize_operations())
         );
+    }
+
+    #[cfg(feature = "test")]
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn test_migration_v3_maximum_validator_increase() {
+        // This test will fail if the consensus v3 height is 0
+        assert_ne!(0, CurrentNetwork::CONSENSUS_V3_HEIGHT);
+
+        // Initialize an RNG.
+        let rng = &mut TestRng::default();
+
+        // Initialize the VM.
+        let vm = sample_vm();
+
+        // Initialize the validators with the maximum number of validators before consensus v3.
+        let validators = sample_validators::<CurrentNetwork>(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize,
+            rng,
+        );
+
+        // Initialize a new address.
+        let new_validator_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        let new_validator_address = Address::try_from(&new_validator_private_key).unwrap();
+
+        // Construct the committee.
+        // Track the allocated amount.
+        let (committee_map, allocated_amount) =
+            sample_committee_map_and_allocated_amount(&validators, &IndexMap::new());
+
+        // Collect all of the addresses in a single place
+        let validator_addresses =
+            validators.keys().map(|private_key| Address::try_from(private_key).unwrap()).collect::<Vec<_>>();
+
+        // Construct the public balances, allocating the remaining supply.
+        let new_validator_balance = MIN_VALIDATOR_STAKE + 100_000_000;
+        let mut public_balances = sample_public_balances(
+            &validator_addresses,
+            <CurrentNetwork as Network>::STARTING_SUPPLY - allocated_amount - new_validator_balance,
+        );
+        // Set the public balance of the new validator to the minimum validator stake.
+        public_balances.insert(new_validator_address, new_validator_balance);
+
+        // Construct the bonded balances.
+        let bonded_balances = sample_bonded_balances(&validators, &IndexMap::new());
+
+        // Construct the genesis block, which should pass.
+        let block = vm
+            .genesis_quorum(
+                validators.keys().next().unwrap(),
+                Committee::new_genesis(committee_map).unwrap(),
+                public_balances,
+                bonded_balances,
+                rng,
+            )
+            .unwrap();
+
+        // Add the block.
+        vm.add_next_block(&block).unwrap();
+
+        // Attempt to bond a new validator above the maximum number of validators.
+        let inputs = vec![
+            Value::<CurrentNetwork>::from_str(&validator_addresses.first().unwrap().to_string()).unwrap(), // Withdrawal address
+            Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),              // Amount
+            Value::<CurrentNetwork>::from_str("42u8").unwrap(),                                            // Commission
+        ];
+
+        // Execute.
+        let bond_validator_transaction = vm
+            .execute(
+                &new_validator_private_key,
+                ("credits.aleo", "bond_validator"),
+                inputs.clone().into_iter(),
+                None,
+                1,
+                None,
+                rng,
+            )
+            .unwrap();
+
+        // Verify.
+        vm.check_transaction(&bond_validator_transaction, None, rng).unwrap();
+
+        // Speculate on the transactions.
+        let transactions = [bond_validator_transaction.clone()];
+        let (_, confirmed_transactions, _, _) = vm
+            .atomic_speculate(
+                sample_finalize_state(1),
+                CurrentNetwork::BLOCK_TIME as i64,
+                None,
+                vec![],
+                &None.into(),
+                transactions.iter(),
+            )
+            .unwrap();
+
+        // Assert that the transaction is rejected.
+        assert_eq!(confirmed_transactions.len(), 1);
+        assert_eq!(
+            confirmed_transactions[0],
+            reject(0, &bond_validator_transaction, confirmed_transactions[0].finalize_operations())
+        );
+
+        // Update the VM to the migration block height
+        let private_key = test_helpers::sample_genesis_private_key(rng);
+        let transactions: [Transaction<CurrentNetwork>; 0] = [];
+        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_V3_HEIGHT {
+            // Call the function
+            let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
+            vm.add_next_block(&next_block).unwrap();
+        }
+
+        // Test that attempting to bond a new validator above the maximum number of validators after the migration block height succeeds.
+
+        // Check that the new committee size is greater than the maximum committee size before the migration.
+        assert!(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 < Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE
+        );
+
+        // Speculate on the transactions.
+        let transactions = [bond_validator_transaction.clone()];
+        let (_, confirmed_transactions, aborted_transaction_ids, _) = vm
+            .atomic_speculate(
+                sample_finalize_state(CurrentNetwork::CONSENSUS_V3_HEIGHT),
+                CurrentNetwork::BLOCK_TIME as i64,
+                None,
+                vec![],
+                &None.into(),
+                transactions.iter(),
+            )
+            .unwrap();
+
+        // Assert that the transaction is accepted.
+        assert_eq!(confirmed_transactions.len(), 1);
+        assert!(confirmed_transactions[0].is_accepted());
+        assert!(aborted_transaction_ids.is_empty());
+
+        assert_eq!(confirmed_transactions[0].transaction(), &bond_validator_transaction);
     }
 
     #[test]

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1825,8 +1825,10 @@ finalize transfer_public:
         let vm = sample_vm();
 
         // Initialize the validators with the maximum number of validators.
-        let validators =
-            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize, rng);
+        let validators = sample_validators::<CurrentNetwork>(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize,
+            rng,
+        );
 
         // Initialize a new address.
         let new_validator_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2647,8 +2649,10 @@ finalize compute:
 
         // Reset the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
-        let validators =
-            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize, rng);
+        let validators = sample_validators::<CurrentNetwork>(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize,
+            rng,
+        );
 
         // Construct the committee.
         // Track the allocated amount.
@@ -2690,8 +2694,10 @@ finalize compute:
 
         // Construct the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
-        let validators =
-            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize / 4, rng);
+        let validators = sample_validators::<CurrentNetwork>(
+            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize / 4,
+            rng,
+        );
 
         // Construct the delegators, greater than the maximum delegator size.
         let delegators = (0..MAX_DELEGATORS + 1)


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR plans to increase the number `N::MAX_CERTIFICATES` value for `MainnetV0`. The main result of this change is that the maximum number of validators in a committee is also increased. Since Mainnet was launched, the codebase has undergone some extensive upgrades and optimizations and based on internal/external testing, we believe the number of validators can be expanded safely. The original maximum is 16 and this change increases that value to 25 (subject to change). 

Increasing the number of validators creates a more robust and more decentralized network. This increase also has a number of other effects (increasing TPS, increasing network overhead, and increasing block size to name a few), so we must be vigilant when deciding to expand this number. As we further improve the network, we can iteratively increase the maximum number of validators in order to ensure network stability, even if it feels conservative.

## **Migration:**
- Introduce `N::CONSENSUS_V3_HEIGHT` to Network trait 
    - This is the height for each network that snarkVM will swap from the `v2` consensus to `v3` consensus.
- SnarkOS will require nodes to swap to the new version before height `N::CONSENSUS_V3_HEIGHT`, otherwise there may be some issues.
    - Validators need to change to the new version or risk possible forking
    - Clients need to change to the new version or risk sync halting

The migration and reward logic change will occur at the following block heights (These heights are subject to change):

### **Canary** - Block 4,560,000 (~Jan 24, 2025 at the current 3.7s block times)
### **Testnet** - Block 4,800,000 (~Jan 31, 2025 at the current 3.4s block times)
### **Mainnet** - Block 4,900,000 (~Feb 18, 2025 at the current 3.0s block times)

These numbers were calculated by determining the planned release schedule and backing into the block height using the current block speeds and including a buffer between release and consensus change. This buffer is intended to give leeway for nodes to upgrade before the consensus change. The following table is the approximate timeline and buffers for the networks:

| Network | Release Date | Buffer | Consensus V3 |
|---------|--------------|--------|--------------|
| Canary  | Jan 21, 2025 | 3 days | Jan 24, 2025 |
| Testnet | Jan 28, 2025 | 3 days | Jan 31, 2025 |
| Mainnet | Feb 11, 2025  | 7 days | Feb 18, 2025 |


## Test Plan

Tests have been added to ensure that the migration properly transitions the old `MAX_CERTIFICATES_BEFORE_V3` value to the new `MAX_CERTIFICATES` value.

CI can be found [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM?branch=feat%2Fincrease_validators-ci).

## Related PRs

This PR replaces https://github.com/ProvableHQ/snarkVM/pull/2586 due to branching issues.

Migration will coincide with https://github.com/AleoNet/snarkVM/pull/2575.

