### PR TITLE
perf: Change link-time optimization in dev and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ debug-assertions = false
 
 [profile.dev]
 opt-level = 3
-lto = "thin"
+lto = "off"
 incremental = true
 
 [profile.test]


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This change improves the development cycle in both dev and test, when running the same command multiple times in a row.

On my machine I can see improvements from minutes to seconds. For example when running `cargo run` and `cargo test`.

## Test Plan

Compare running a commands 3 times in a row with or without this patch.

## Related PRs

None