### PR TITLE
Fix outdated comment.

### DIFF
--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -37,7 +37,7 @@ use rayon::prelude::*;
 #[derive(Clone, PartialEq, Eq)]
 pub struct BatchHeader<N: Network> {
     /// The batch ID, defined as the hash of the author, round number, timestamp, transmission IDs,
-    /// committee ID, previous batch certificate IDs, and last election certificate IDs.
+    /// committee ID, and previous batch certificate IDs.
     batch_id: Field<N>,
     /// The author of the batch.
     author: Address<N>,


### PR DESCRIPTION
Batch headers no longer include last election certificate ID.
