### PR TITLE
Further reduce test parameter downloads to reduce CI flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,7 +669,7 @@ jobs:
   parameters-large:
     docker:
       - image: cimg/rust:1.81.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: << pipeline.parameters.small >>
+    resource_class: << pipeline.parameters.medium >>
     steps:
       - run_serial:
           flags: --no-run --features large_params

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,6 +666,16 @@ jobs:
           workspace_member: parameters
           cache_key: v1.0.0-rust-1.81.0-snarkvm-parameters-cache
 
+  parameters_large:
+    docker:
+      - image: cimg/rust:1.81.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+    resource_class: << pipeline.parameters.small >>
+    steps:
+      - run_serial:
+          flags: --no-run --features large_params
+          workspace_member: parameters
+          cache_key: v1.0.0-rust-1.81.0-snarkvm-parameters-cache
+
   parameters-uncached:
     docker:
       - image: cimg/rust:1.81.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,7 +666,7 @@ jobs:
           workspace_member: parameters
           cache_key: v1.0.0-rust-1.81.0-snarkvm-parameters-cache
 
-  parameters_large:
+  parameters-large:
     docker:
       - image: cimg/rust:1.81.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
     resource_class: << pipeline.parameters.small >>
@@ -984,6 +984,7 @@ workflows:
       - ledger-store
       - ledger-test-helpers
       - parameters
+      - parameters-large
       - parameters-uncached
       - synthesizer
       - synthesizer-mem-heavy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,12 +669,12 @@ jobs:
   parameters-large:
     docker:
       - image: cimg/rust:1.81.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: << pipeline.parameters.medium >>
+    resource_class: << pipeline.parameters.large >>
     steps:
       - run_serial:
           flags: --no-run --features large_params
           workspace_member: parameters
-          cache_key: v1.0.0-rust-1.81.0-snarkvm-parameters-cache
+          cache_key: v1.0.0-rust-1.81.0-snarkvm-parameters-large-cache
 
   parameters-uncached:
     docker:

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -24,6 +24,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
+large_params = [ ]
 default = [ "colored", "remote" ]
 no_std_out = [ ]
 remote = [ "curl" ]

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -44,9 +44,12 @@ impl_remote!(Degree25, REMOTE_URL, "resources/", "powers-of-beta-25", "usrs");
 // this size. When a users wants to create a proof, they load the appropriate
 // powers for the circuit in `batch_circuit_setup` which calls `max_degree`
 // based on the domain size.
-// impl_remote!(Degree26, REMOTE_URL, "resources/", "powers-of-beta-26", "usrs");
-// impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
-// impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
+#[cfg(feature = "large_params")]
+impl_remote!(Degree26, REMOTE_URL, "resources/", "powers-of-beta-26", "usrs");
+#[cfg(feature = "large_params")]
+impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
+#[cfg(feature = "large_params")]
+impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
 #[cfg(not(feature = "wasm"))]
@@ -68,8 +71,10 @@ impl_remote!(ShiftedDegree24, REMOTE_URL, "resources/", "shifted-powers-of-beta-
 impl_remote!(ShiftedDegree25, REMOTE_URL, "resources/", "shifted-powers-of-beta-25", "usrs");
 // TODO (nkls): restore on CI.
 // See `Degree28` above for context.
-// impl_remote!(ShiftedDegree26, REMOTE_URL, "resources/", "shifted-powers-of-beta-26", "usrs");
-// impl_remote!(ShiftedDegree27, REMOTE_URL, "resources/", "shifted-powers-of-beta-27", "usrs");
+#[cfg(feature = "large_params")]
+impl_remote!(ShiftedDegree26, REMOTE_URL, "resources/", "shifted-powers-of-beta-26", "usrs");
+#[cfg(feature = "large_params")]
+impl_remote!(ShiftedDegree27, REMOTE_URL, "resources/", "shifted-powers-of-beta-27", "usrs");
 
 // Powers of Beta Times Gamma * G
 impl_local!(Gamma, "resources/", "powers-of-beta-gamma", "usrs");

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -39,13 +39,13 @@ impl_remote!(Degree22, REMOTE_URL, "resources/", "powers-of-beta-22", "usrs");
 impl_remote!(Degree23, REMOTE_URL, "resources/", "powers-of-beta-23", "usrs");
 impl_remote!(Degree24, REMOTE_URL, "resources/", "powers-of-beta-24", "usrs");
 impl_remote!(Degree25, REMOTE_URL, "resources/", "powers-of-beta-25", "usrs");
-impl_remote!(Degree26, REMOTE_URL, "resources/", "powers-of-beta-26", "usrs");
-impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
 // TODO (nkls): restore on CI.
 // The SRS is only used for proving and we don't currently support provers of
 // this size. When a users wants to create a proof, they load the appropriate
 // powers for the circuit in `batch_circuit_setup` which calls `max_degree`
 // based on the domain size.
+// impl_remote!(Degree26, REMOTE_URL, "resources/", "powers-of-beta-26", "usrs");
+// impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
 // impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
@@ -66,9 +66,9 @@ impl_remote!(ShiftedDegree22, REMOTE_URL, "resources/", "shifted-powers-of-beta-
 impl_remote!(ShiftedDegree23, REMOTE_URL, "resources/", "shifted-powers-of-beta-23", "usrs");
 impl_remote!(ShiftedDegree24, REMOTE_URL, "resources/", "shifted-powers-of-beta-24", "usrs");
 impl_remote!(ShiftedDegree25, REMOTE_URL, "resources/", "shifted-powers-of-beta-25", "usrs");
-impl_remote!(ShiftedDegree26, REMOTE_URL, "resources/", "shifted-powers-of-beta-26", "usrs");
 // TODO (nkls): restore on CI.
 // See `Degree28` above for context.
+// impl_remote!(ShiftedDegree26, REMOTE_URL, "resources/", "shifted-powers-of-beta-26", "usrs");
 // impl_remote!(ShiftedDegree27, REMOTE_URL, "resources/", "shifted-powers-of-beta-27", "usrs");
 
 // Powers of Beta Times Gamma * G

--- a/parameters/src/mainnet/powers.rs
+++ b/parameters/src/mainnet/powers.rs
@@ -50,10 +50,10 @@ const NUM_POWERS_25: usize = 1 << 25;
 // based on the domain size.
 // const NUM_POWERS_26: usize = 1 << 26;
 // const NUM_POWERS_27: usize = 1 << 27;
-// const NUM_POWERS_28: usize = 1 << 28;
+const NUM_POWERS_28: usize = 1 << 28;
 
 /// The maximum degree supported by the SRS.
-const MAX_NUM_POWERS: usize = NUM_POWERS_25;
+const MAX_NUM_POWERS: usize = NUM_POWERS_28;
 
 lazy_static::lazy_static! {
     static ref POWERS_OF_BETA_G_15: Vec<u8> = Degree15::load_bytes().expect("Failed to load powers of beta in universal SRS");

--- a/parameters/src/mainnet/powers.rs
+++ b/parameters/src/mainnet/powers.rs
@@ -43,12 +43,17 @@ const NUM_POWERS_22: usize = 1 << 22;
 const NUM_POWERS_23: usize = 1 << 23;
 const NUM_POWERS_24: usize = 1 << 24;
 const NUM_POWERS_25: usize = 1 << 25;
-const NUM_POWERS_26: usize = 1 << 26;
-const NUM_POWERS_27: usize = 1 << 27;
-const NUM_POWERS_28: usize = 1 << 28;
+// TODO (nkls): restore on CI.
+// The SRS is only used for proving and we don't currently support provers of
+// this size. When a users wants to create a proof, they load the appropriate
+// powers for the circuit in `batch_circuit_setup` which calls `max_degree`
+// based on the domain size.
+// const NUM_POWERS_26: usize = 1 << 26;
+// const NUM_POWERS_27: usize = 1 << 27;
+// const NUM_POWERS_28: usize = 1 << 28;
 
 /// The maximum degree supported by the SRS.
-const MAX_NUM_POWERS: usize = NUM_POWERS_28;
+const MAX_NUM_POWERS: usize = NUM_POWERS_25;
 
 lazy_static::lazy_static! {
     static ref POWERS_OF_BETA_G_15: Vec<u8> = Degree15::load_bytes().expect("Failed to load powers of beta in universal SRS");
@@ -413,9 +418,9 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
                 NUM_POWERS_23 => Degree23::load_bytes()?,
                 NUM_POWERS_24 => Degree24::load_bytes()?,
                 NUM_POWERS_25 => Degree25::load_bytes()?,
-                NUM_POWERS_26 => Degree26::load_bytes()?,
-                NUM_POWERS_27 => Degree27::load_bytes()?,
                 // TODO (nkls): restore on CI.
+                // NUM_POWERS_26 => Degree26::load_bytes()?,
+                // NUM_POWERS_27 => Degree27::load_bytes()?,
                 // NUM_POWERS_28 => Degree28::load_bytes()?,
                 _ => bail!("Cannot download an invalid degree of '{num_powers}'"),
             };
@@ -492,8 +497,8 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
                 NUM_POWERS_23 => ShiftedDegree23::load_bytes()?,
                 NUM_POWERS_24 => ShiftedDegree24::load_bytes()?,
                 NUM_POWERS_25 => ShiftedDegree25::load_bytes()?,
-                NUM_POWERS_26 => ShiftedDegree26::load_bytes()?,
                 // TODO (nkls): restore on CI.
+                // NUM_POWERS_26 => ShiftedDegree26::load_bytes()?,
                 // NUM_POWERS_27 => ShiftedDegree27::load_bytes()?,
                 _ => bail!("Cannot download an invalid degree of '{num_powers}'"),
             };

--- a/parameters/src/mainnet/powers.rs
+++ b/parameters/src/mainnet/powers.rs
@@ -48,8 +48,10 @@ const NUM_POWERS_25: usize = 1 << 25;
 // this size. When a users wants to create a proof, they load the appropriate
 // powers for the circuit in `batch_circuit_setup` which calls `max_degree`
 // based on the domain size.
-// const NUM_POWERS_26: usize = 1 << 26;
-// const NUM_POWERS_27: usize = 1 << 27;
+#[cfg(feature = "large_params")]
+const NUM_POWERS_26: usize = 1 << 26;
+#[cfg(feature = "large_params")]
+const NUM_POWERS_27: usize = 1 << 27;
 const NUM_POWERS_28: usize = 1 << 28;
 
 /// The maximum degree supported by the SRS.
@@ -419,9 +421,12 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
                 NUM_POWERS_24 => Degree24::load_bytes()?,
                 NUM_POWERS_25 => Degree25::load_bytes()?,
                 // TODO (nkls): restore on CI.
-                // NUM_POWERS_26 => Degree26::load_bytes()?,
-                // NUM_POWERS_27 => Degree27::load_bytes()?,
-                // NUM_POWERS_28 => Degree28::load_bytes()?,
+                #[cfg(feature = "large_params")]
+                NUM_POWERS_26 => Degree26::load_bytes()?,
+                #[cfg(feature = "large_params")]
+                NUM_POWERS_27 => Degree27::load_bytes()?,
+                #[cfg(feature = "large_params")]
+                NUM_POWERS_28 => Degree28::load_bytes()?,
                 _ => bail!("Cannot download an invalid degree of '{num_powers}'"),
             };
 
@@ -498,8 +503,10 @@ impl<E: PairingEngine> PowersOfBetaG<E> {
                 NUM_POWERS_24 => ShiftedDegree24::load_bytes()?,
                 NUM_POWERS_25 => ShiftedDegree25::load_bytes()?,
                 // TODO (nkls): restore on CI.
-                // NUM_POWERS_26 => ShiftedDegree26::load_bytes()?,
-                // NUM_POWERS_27 => ShiftedDegree27::load_bytes()?,
+                #[cfg(feature = "large_params")]
+                NUM_POWERS_26 => ShiftedDegree26::load_bytes()?,
+                #[cfg(feature = "large_params")]
+                NUM_POWERS_27 => ShiftedDegree27::load_bytes()?,
                 _ => bail!("Cannot download an invalid degree of '{num_powers}'"),
             };
 


### PR DESCRIPTION
## Motivation

A parameter test still failed recently: https://app.circleci.com/pipelines/github/ProvableHQ/snarkVM/13487/workflows/4c90c4b7-c758-4774-a323-6dd68c421a7f/jobs/597293?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

Further reducing the downloads, as already proposed by @raychu86 in the past

## Test Plan

Existing tests should suffice.

## Related PRs

The previous reduction in the tests was implemented in https://github.com/ProvableHQ/snarkVM/pull/2594
