### PR TITLE
Improve consensus versioning clarity and guarantees

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
-          flags: --lib --bins --features test
+          flags: --lib --bins
           workspace_member: synthesizer
           cache_key: v1.0.0-rust-1.81.0-snarkvm-synthesizer-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ jobs:
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
-          flags: --lib --bins
+          flags: --lib --bins --features test
           workspace_member: synthesizer
           cache_key: v1.0.0-rust-1.81.0-snarkvm-synthesizer-cache
 

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -122,6 +122,10 @@ impl Environment for CanaryV0 {
 impl Network for CanaryV0 {
     /// The block hash type.
     type BlockHash = AleoID<Field<Self>, { hrp2!("ab") }>;
+    /// The consensus block height.
+    type ConsensusHeight = u32;
+    /// The consensus block height.
+    type ConsensusVersion = u16;
     /// The ratification ID type.
     type RatificationID = AleoID<Field<Self>, { hrp2!("ar") }>;
     /// The state root type.
@@ -146,6 +150,9 @@ impl Network for CanaryV0 {
     /// The block height from which consensus V3 rules apply.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_V3_HEIGHT: u32 = 11;
+    /// The block heights at which consensus versions are updated.
+    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2] = [(0, 0), (100, 1)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -168,6 +175,9 @@ impl Network for CanaryV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// The maximum number of certificates in a batch before consensus V3 rules apply.
     const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
+    // The maximum number of certificates per round for each consensus version.
+    // This effectively limits the number of validators per round as well.
+    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2] = [(0, 16), (1, 25)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -136,13 +136,13 @@ impl Network for CanaryV0 {
     /// The block heights at which consensus versions are updated.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
-        [(0, ConsensusVersion::V1), (2_900_000, ConsensusVersion::V2), (4_560_000, ConsensusVersion::V3)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_900_000), (ConsensusVersion::V3, 4_560_000)];
     /// The block heights at which consensus versions are updated.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
-        [(0, ConsensusVersion::V1), (10, ConsensusVersion::V2), (11, ConsensusVersion::V3)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -169,16 +169,16 @@ impl Network for CanaryV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// The maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
-    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 16), (4_560_000, 25)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// The maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
-    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 100), (4_560_000, 100)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 
     /// Returns the height at which a specified consensus version becomes active.
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSIONS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.0)
+        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.1)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -161,44 +161,14 @@ impl Network for CanaryV0 {
     const ID: u16 = 2;
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
-    /// The maximum number of certificates in a batch.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: u16 = 25;
-    /// The maximum number of certificates in a batch.
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
+    /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: u16 = 100;
-    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(any(test, feature = "test"))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
-        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
-    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(not(any(test, feature = "test")))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
-        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
-
-    /// Returns the consensus version which is active at the given height.
-    fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
-        match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {
-            // If a consensus version was found at this height, return it.
-            Ok(index) => Ok(Self::CONSENSUS_VERSION_HEIGHTS[index].0),
-            // If the specified height was not found, determine whether to return an appropriate version.
-            Err(index) => {
-                if index == 0 {
-                    Err(anyhow!("Expected consensus version 1 to exist at height 0."))
-                } else {
-                    // Return the appropriate version belonging to the height *lower* than the sought height.
-                    Ok(Self::CONSENSUS_VERSION_HEIGHTS[index - 1].0)
-                }
-            }
-        }
-    }
-
-    /// Returns the height at which a specified consensus version becomes active.
-    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize - 1).ok_or(anyhow!("Invalid consensus version"))?.1)
-    }
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -134,13 +134,15 @@ impl Network for CanaryV0 {
     type TransmissionChecksum = u128;
 
     /// The block heights at which consensus versions are updated.
-    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_900_000, 2), (4_560_000, 3)];
+    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
+        [(0, ConsensusVersion::V1), (2_900_000, ConsensusVersion::V2), (4_560_000, ConsensusVersion::V3)];
     /// The block heights at which consensus versions are updated.
-    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
+    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
+        [(0, ConsensusVersion::V1), (10, ConsensusVersion::V2), (11, ConsensusVersion::V3)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -173,6 +175,11 @@ impl Network for CanaryV0 {
     const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 100), (4_560_000, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
+
+    /// Returns the height at which a specified consensus version becomes active.
+    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
+        Ok(Self::CONSENSUS_VERSIONS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.0)
+    }
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {
@@ -505,11 +512,6 @@ impl Network for CanaryV0 {
         leaf: &Vec<Field<Self>>,
     ) -> bool {
         path.verify(&*CANARY_POSEIDON_4, &*CANARY_POSEIDON_2, root, leaf)
-    }
-
-    /// Returns the height at which a specified consensus version becomes active.
-    fn HEIGHT_V(version: usize) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
     }
 }
 

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -169,10 +169,12 @@ impl Network for CanaryV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
+        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
+        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -134,12 +134,12 @@ impl Network for CanaryV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_900_000), (ConsensusVersion::V3, 4_560_000)];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -134,12 +134,12 @@ impl Network for CanaryV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
+    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_900_000), (ConsensusVersion::V3, 4_560_000)];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
+    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
@@ -178,9 +178,26 @@ impl Network for CanaryV0 {
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 
+    /// Returns the consensus version which is active at the given height.
+    fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
+        match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {
+            // If a consensus version was found at this height, return it.
+            Ok(index) => Ok(Self::CONSENSUS_VERSION_HEIGHTS[index].0),
+            // If the specified height was not found, determine whether to return an appropriate version.
+            Err(index) => {
+                if index == 0 {
+                    Err(anyhow!("Expected consensus version 1 to exist at height 0."))
+                } else {
+                    // Return the appropriate version belonging to the height *lower* than the sought height.
+                    Ok(Self::CONSENSUS_VERSION_HEIGHTS[index - 1].0)
+                }
+            }
+        }
+    }
+
     /// Returns the height at which a specified consensus version becomes active.
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.1)
+        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize - 1).ok_or(anyhow!("Invalid consensus version"))?.1)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -133,12 +133,12 @@ impl Network for CanaryV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
-    /// The block heights at which consensus versions are updated.
+    /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_900_000), (ConsensusVersion::V3, 4_560_000)];
-    /// The block heights at which consensus versions are updated.
+    /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
@@ -167,10 +167,10 @@ impl Network for CanaryV0 {
     /// The maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_CERTIFICATES: u16 = 100;
-    /// The maximum number of validators in a committee.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
-    /// The maximum number of validators in a committee.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -122,10 +122,6 @@ impl Environment for CanaryV0 {
 impl Network for CanaryV0 {
     /// The block hash type.
     type BlockHash = AleoID<Field<Self>, { hrp2!("ab") }>;
-    /// The consensus block height.
-    type ConsensusHeight = u32;
-    /// The consensus block height.
-    type ConsensusVersion = u16;
     /// The ratification ID type.
     type RatificationID = AleoID<Field<Self>, { hrp2!("ar") }>;
     /// The state root type.
@@ -137,22 +133,14 @@ impl Network for CanaryV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
-    /// The block height from which consensus V2 rules apply.
-    #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V2_HEIGHT: u32 = 2_900_000;
-    /// The block height from which consensus V2 rules apply.
-    #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V2_HEIGHT: u32 = 10;
-    // TODO: (raychu86): Update this value based on the desired mainnet height.
-    // The block height from which consensus V3 rules apply.
-    #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V3_HEIGHT: u32 = 4_560_000;
-    /// The block height from which consensus V3 rules apply.
-    #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V3_HEIGHT: u32 = 11;
     /// The block heights at which consensus versions are updated.
-    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
-    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2] = [(0, 0), (100, 1)];
+    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_900_000, 2), (4_560_000, 3)];
+    /// The block heights at which consensus versions are updated.
+    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -172,12 +160,17 @@ impl Network for CanaryV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
+    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_CERTIFICATES: u16 = 25;
+    /// The maximum number of certificates in a batch.
+    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_CERTIFICATES: u16 = 100;
-    /// The maximum number of certificates in a batch before consensus V3 rules apply.
-    const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
-    // The maximum number of certificates per round for each consensus version.
-    // This effectively limits the number of validators per round as well.
-    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2] = [(0, 16), (1, 25)];
+    /// The maximum number of validators in a committee.
+    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 16), (4_560_000, 25)];
+    /// The maximum number of validators in a committee.
+    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 100), (4_560_000, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 
@@ -512,6 +505,11 @@ impl Network for CanaryV0 {
         leaf: &Vec<Field<Self>>,
     ) -> bool {
         path.verify(&*CANARY_POSEIDON_4, &*CANARY_POSEIDON_2, root, leaf)
+    }
+
+    /// Returns the height at which a specified consensus version becomes active.
+    fn HEIGHT_V(version: usize) -> Result<u32> {
+        Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
     }
 }
 

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -162,16 +162,16 @@ impl Network for CanaryV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: u16 = 25;
     /// The maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: u16 = 100;
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(any(test, feature = "test"))]
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -162,10 +162,10 @@ impl Network for CanaryV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) type VarunaProvingKey<N> = CircuitProvingKey<<N as Environment>::Pair
 pub(crate) type VarunaVerifyingKey<N> = CircuitVerifyingKey<<N as Environment>::PairingCurve>;
 
 /// The different consensus versions.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ConsensusVersion {
     V1 = 0,
     V2 = 1,
@@ -216,7 +216,7 @@ pub trait Network:
 
     /// The consensus versions.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
-    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3];
     /// The maximum number of certificates in a batch.
     //  Note: This value must **not** be changed without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit
@@ -228,7 +228,7 @@ pub trait Network:
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_COMMITTEE_SIZE: [(u32, u16); 2];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2];
 
     /// Returns the height at which a specified consensus version becomes active.
     ///
@@ -435,22 +435,34 @@ pub trait Network:
 /// Returns the consensus configuration value for the specified height.
 ///
 /// Arguments:
+/// - `$network`: The network to use the constant of.
 /// - `$constant`: The constant to search a value of.
 /// - `$seek_height`: The block height to search the value for.
 #[macro_export]
 macro_rules! consensus_config_value {
-    ($constant:expr, $seek_height:expr) => {
-        match $constant.binary_search_by(|(height, _)| height.cmp(&$seek_height)) {
-            // If the specified height was found, return the appropriate config value.
-            Ok(index) => Some($constant[index].1),
-            // If the specified height was not found, determine whether to return an appropriate value.
+    ($network:ident, $constant:ident, $seek_height:expr) => {
+        // Search the consensus version enacted at the specified height.
+        match $network::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&$seek_height)) {
+            // If a consensus version was found, return the corresponding consensus value.
+            Ok(index) => {
+                let consensus_version = $network::CONSENSUS_VERSION_HEIGHTS[index].0;
+                match $network::$constant.binary_search_by(|(version, _)| version.cmp(&consensus_version)) {
+                    Ok(index) => Some($network::$constant[index].1),
+                    Err(_) => None,
+                }
+            }
+            // If the specified height was not found, determine whether to return an appropriate version.
             Err(index) => {
                 // This constant is not yet in effect at this height.
                 if index == 0 {
                     None
-                // Return the appropriate value belonging to the height lower than the sought height.
+                // Return the appropriate value belonging to the height *lower* than the sought height.
                 } else {
-                    Some($constant[index - 1].1)
+                    let consensus_version = $network::CONSENSUS_VERSION_HEIGHTS[index - 1].0;
+                    match $network::$constant.binary_search_by(|(version, _)| version.cmp(&consensus_version)) {
+                        Ok(index) => Some($network::$constant[index].1),
+                        Err(_) => None,
+                    }
                 }
             }
         }
@@ -464,52 +476,58 @@ mod tests {
     /// Ensure that the consensus constants are defined and correct at genesis.
     /// It is possible this invariant no longer holds in the future, e.g. due to pruning or novel types of constants.
     fn consensus_constants_at_genesis<N: Network>() {
-        let height = N::CONSENSUS_VERSIONS.first().unwrap().0;
+        let height = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().1;
         assert_eq!(height, 0);
-        let height = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
-        assert_eq!(height, 0);
+        let consensus_version = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().0;
+        assert_eq!(consensus_version as usize, 0);
+        let consensus_version = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
+        assert_eq!(consensus_version as usize, 0);
     }
 
-    /// Ensure that the consensus versions are unique, incrementing by 1 and start with 0.
+    /// Ensure that the consensus *versions* are unique, incrementing and start with 0.
     fn consensus_versions<N: Network>() {
-        let mut previous_version = N::CONSENSUS_VERSIONS.first().unwrap().1;
+        let mut previous_version = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().0;
         // Ensure that the consensus versions start with 0.
         assert_eq!(previous_version as usize, 0);
         // Ensure that the consensus versions are unique and incrementing by 1.
-        for (height, version) in N::CONSENSUS_VERSIONS.iter().skip(1) {
+        for (version, _) in N::CONSENSUS_VERSION_HEIGHTS.iter().skip(1) {
             assert_eq!(*version as usize, previous_version as usize + 1);
             previous_version = *version;
+        }
+        // Ensure that the consensus versions are unique and incrementing.
+        let mut previous_version = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
+        for (version, _) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
+            assert!(*version > previous_version);
+            previous_version = *version;
+        }
+    }
+
+    /// Ensure that consensus *heights* are unique and incrementing.
+    fn consensus_constants_increasing_heights<N: Network>() {
+        let mut previous_height = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().1;
+        for (version, height) in N::CONSENSUS_VERSION_HEIGHTS.iter().skip(1) {
+            assert!(*height > previous_height);
+            previous_height = *height;
             // Ensure that N::CONSENSUS_HEIGHT returns the expected value.
             assert_eq!(N::CONSENSUS_HEIGHT(*version).unwrap(), *height);
         }
     }
 
-    /// Ensure that keys of all consensus-relevant constants are unique and incrementing.
-    fn consensus_constants_increasing_heights<N: Network>() {
-        let mut previous_height = N::CONSENSUS_VERSIONS.first().unwrap().0;
-        for (height, _) in N::CONSENSUS_VERSIONS.iter().skip(1) {
-            assert!(*height > previous_height);
-            previous_height = *height;
-        }
-        let mut previous_height = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
-        for (height, _) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
-            assert!(*height > previous_height);
-            previous_height = *height;
-        }
-    }
-
-    /// Ensure that keys of all consensus-relevant constants are present in the consensus version heights.
+    /// Ensure that version of all consensus-relevant constants are present in the consensus version heights.
     fn consensus_constants_valid_heights<N: Network>() {
-        for (height, value) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
-            // Ensure that the height at which an update occurs are present in CONSENSUS_VERSIONS.
-            assert!(consensus_config_value!(N::CONSENSUS_VERSIONS, *height).is_some());
-            // Double-check that the value is as expected.
-            assert_eq!(consensus_config_value!(N::MAX_COMMITTEE_SIZE, *height).unwrap(), *value);
+        for (consensus_version, value) in N::MAX_COMMITTEE_SIZE.iter() {
+            println!("Checking version {:?} value {}", *consensus_version, value);
+            // Ensure that the height at which an update occurs are present in CONSENSUS_VERSION_HEIGHTS.
+            let height =
+                N::CONSENSUS_VERSION_HEIGHTS.iter().find(|(version, _)| *version == *consensus_version).unwrap().1;
+            println!("Found height {}", height);
+            // Double-check that consensus_config_value returns the correct value.
+            assert_eq!(consensus_config_value!(N, MAX_COMMITTEE_SIZE, height).unwrap(), *value);
         }
     }
 
     /// Ensure that `MAX_COMMITTEE_SIZE` strictly increases and is correctly defined.
-    /// If this
+    /// See the constant declaration for an explanation why.
     fn max_certificates_increasing<N: Network>() {
         let mut previous_value = N::MAX_COMMITTEE_SIZE.first().unwrap().1;
         for (_, value) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
@@ -517,13 +535,14 @@ mod tests {
             previous_value = *value;
         }
         // Ensure that the last value is equal to `MAX_CERTIFICATES`.
+        // See the constant declaration for an explanation why.
         assert_eq!(N::MAX_CERTIFICATES, previous_value);
     }
 
     /// Ensure that the number of constant definitions is the same across networks.
     fn constants_equal_length<N1: Network, N2: Network, N3: Network>() {
         // If we can construct an array, that means the underlying types must be the same.
-        let _ = [N1::CONSENSUS_VERSIONS, N2::CONSENSUS_VERSIONS, N3::CONSENSUS_VERSIONS];
+        let _ = [N1::CONSENSUS_VERSION_HEIGHTS, N2::CONSENSUS_VERSION_HEIGHTS, N3::CONSENSUS_VERSION_HEIGHTS];
         let _ = [N1::MAX_COMMITTEE_SIZE, N2::MAX_COMMITTEE_SIZE, N3::MAX_COMMITTEE_SIZE];
     }
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -72,8 +72,11 @@ pub(crate) type VarunaVerifyingKey<N> = CircuitVerifyingKey<<N as Environment>::
 /// The different consensus versions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ConsensusVersion {
+    /// V1: The initial genesis consensus version.
     V1 = 0,
+    /// V2: Update to the block reward and execution cost algorithms.
     V2 = 1,
+    /// V3: Update to the number of validators and finalize scope RNG seed.
     V3 = 2,
 }
 
@@ -215,7 +218,7 @@ pub trait Network:
     type TransmissionChecksum: IntegerType;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3];
     /// The maximum number of certificates in a batch.
     //  Note: This value must **not** be changed without considering the impact on serialization.
@@ -231,13 +234,6 @@ pub trait Network:
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2];
 
     /// Returns the height at which a specified consensus version becomes active.
-    ///
-    /// V1: The initial genesis consensus version.
-    ///
-    /// V2: Update to the block reward and execution cost algorithms.
-    ///
-    /// V3: Update to the number of validators and finalize scope RNG seed.
-    ///
     #[allow(non_snake_case)]
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> anyhow::Result<u32>;
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -36,7 +36,7 @@ mod testnet_v0;
 pub use testnet_v0::*;
 
 pub mod prelude {
-    pub use crate::{Network, environment::prelude::*};
+    pub use crate::{Network, consensus_config_value, environment::prelude::*};
 }
 
 use crate::environment::prelude::*;
@@ -219,6 +219,18 @@ pub trait Network:
     type TransitionID: Bech32ID<Field<Self>>;
     /// The transmission checksum type.
     type TransmissionChecksum: IntegerType;
+    /// The consensus block height.
+    type ConsensusHeight: IntegerType;
+    /// The consensus version.
+    type ConsensusVersion: IntegerType;
+
+    /// The consensus versions.
+    /// V0: The initial genesis consensus version.
+    /// V1: Update to the block reward and execution cost algorithms.
+    /// V2: Update to the number of validators and finalize scope RNG seed.
+    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2];
+    /// A test config.
+    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2];
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];
@@ -409,4 +421,110 @@ pub trait Network:
         root: &Field<Self>,
         leaf: &Vec<Field<Self>>,
     ) -> bool;
+}
+
+/// Returns the consensus configuration value for the specified height.
+#[macro_export]
+macro_rules! consensus_config_value {
+    ($constant:expr, $seek_height:expr) => {
+        match $constant.binary_search_by(|(height, _)| height.cmp(&$seek_height)) {
+            // If the specified height was found, return the appropriate config value.
+            Ok(index) => Some($constant[index].1),
+            // If the specified height was not found, determine whether to return an appropriate value.
+            Err(index) => {
+                // This constant is not yet in effect at this height.
+                if index == 0 {
+                    None
+                // Return the appropriate value belonging to the height lower than the sought height.
+                } else {
+                    Some($constant[index - 1].1)
+                }
+            }
+        }
+    };
+}
+
+/// Returns the height at which a specified consensus version becomes active.
+pub fn height_consensus_v<N: Network>(version: usize) -> Option<N::ConsensusHeight> {
+    Some(N::CONSENSUS_VERSIONS.get(version)?.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure that the consensus constants are defined and correct at genesis.
+    /// It is possible this invariant no longer holds in the future, e.g. due to pruning or novel types of constants.
+    fn consensus_constants_at_genesis<N: Network<ConsensusHeight = u32>>() {
+        let height = N::CONSENSUS_VERSIONS.first().unwrap().0;
+        assert_eq!(height, 0);
+        let height = N::MAX_CERTIFICATES_PER_ROUND.first().unwrap().0;
+        assert_eq!(height, 0);
+    }
+
+    /// Ensure that the consensus versions are unique, incrementing by 1 and start with 0.
+    fn consensus_versions<N: Network<ConsensusVersion = u16>>() {
+        let mut previous_version = N::CONSENSUS_VERSIONS.first().unwrap().1;
+        // Ensure that the consensus versions start with 0.
+        assert_eq!(previous_version, 0);
+        // Ensure that the consensus versions are unique and incrementing by 1.
+        for (height, version) in N::CONSENSUS_VERSIONS.iter().skip(1) {
+            assert_eq!(*version, previous_version + 1);
+            previous_version = *version;
+            // Ensure that height_consensus_v returns the expected value.
+            assert_eq!(height_consensus_v::<N>(*version as usize).unwrap(), *height);
+        }
+    }
+
+    /// Ensure that keys of all consensus-relevant constants are unique and incrementing.
+    fn consensus_constants_increasing_heights<N: Network<ConsensusVersion = u16>>() {
+        // Collect all constants that are relevant for consensus.
+        let constants = [N::CONSENSUS_VERSIONS, N::MAX_CERTIFICATES_PER_ROUND];
+        // Ensure that the heights are unique and incrementing.
+        for constant in constants {
+            let mut previous_height = constant.first().unwrap().0;
+            for (height, _) in constant.iter().skip(1) {
+                assert!(*height > previous_height);
+                previous_height = *height;
+            }
+        }
+    }
+
+    /// Ensure that keys of all consensus-relevant constants are present in the consensus version heights.
+    fn consensus_constants_valid_heights<N: Network>() {
+        // Collect all constants that are relevant for consensus, except for CONSENSUS_VERSIONS.
+        let constants = [N::MAX_CERTIFICATES_PER_ROUND];
+        for constant in constants {
+            for (height, value) in constant.iter().skip(1) {
+                // Ensure that the height at which an update occurs are present in CONSENSUS_VERSIONS.
+                assert!(consensus_config_value!(N::CONSENSUS_VERSIONS, *height).is_some());
+                // Double-check that the value is as expected.
+                assert_eq!(consensus_config_value!(constant, *height).unwrap(), *value);
+            }
+        }
+    }
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn test_consensus_constants() {
+        consensus_constants_at_genesis::<MainnetV0>();
+        consensus_constants_at_genesis::<TestnetV0>();
+        consensus_constants_at_genesis::<CanaryV0>();
+
+        consensus_versions::<MainnetV0>();
+        consensus_versions::<TestnetV0>();
+        consensus_versions::<CanaryV0>();
+
+        consensus_constants_increasing_heights::<MainnetV0>();
+        consensus_constants_increasing_heights::<TestnetV0>();
+        consensus_constants_increasing_heights::<CanaryV0>();
+
+        consensus_constants_valid_heights::<MainnetV0>();
+        consensus_constants_valid_heights::<TestnetV0>();
+        consensus_constants_valid_heights::<CanaryV0>();
+
+        // Test that the number of CONSENSUS_VERSIONS is the same across networks.
+        assert_eq!(MainnetV0::CONSENSUS_VERSIONS.len(), TestnetV0::CONSENSUS_VERSIONS.len());
+        assert_eq!(MainnetV0::CONSENSUS_VERSIONS.len(), CanaryV0::CONSENSUS_VERSIONS.len());
+    }
 }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -515,12 +515,9 @@ mod tests {
 
     /// Ensure that version of all consensus-relevant constants are present in the consensus version heights.
     fn consensus_constants_valid_heights<N: Network>() {
-        for (consensus_version, value) in N::MAX_COMMITTEE_SIZE.iter() {
-            println!("Checking version {:?} value {}", *consensus_version, value);
+        for (version, value) in N::MAX_COMMITTEE_SIZE.iter() {
             // Ensure that the height at which an update occurs are present in CONSENSUS_VERSION_HEIGHTS.
-            let height =
-                N::CONSENSUS_VERSION_HEIGHTS.iter().find(|(version, _)| *version == *consensus_version).unwrap().1;
-            println!("Found height {}", height);
+            let height = N::CONSENSUS_VERSION_HEIGHTS.iter().find(|(c_version, _)| *c_version == *version).unwrap().1;
             // Double-check that consensus_config_value returns the correct value.
             assert_eq!(consensus_config_value!(N, MAX_COMMITTEE_SIZE, height).unwrap(), *value);
         }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -494,10 +494,10 @@ mod tests {
         assert_eq!(consensus_version as usize, 1);
     }
 
-    /// Ensure that the consensus *versions* are unique, incrementing and start with 0.
+    /// Ensure that the consensus *versions* are unique, incrementing and start with 1.
     fn consensus_versions<N: Network>() {
         let mut previous_version = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().0;
-        // Ensure that the consensus versions start with 0.
+        // Ensure that the consensus versions start with 1.
         assert_eq!(previous_version as usize, 1);
         // Ensure that the consensus versions are unique and incrementing by 1.
         for (version, _) in N::CONSENSUS_VERSION_HEIGHTS.iter().skip(1) {

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -218,18 +218,12 @@ pub trait Network:
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3];
-    /// The maximum number of certificates in a batch.
-    //  Note: This value must **not** be changed without considering the impact on serialization.
+    ///  A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
+    //  Note: This value must **not** decrease without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_CERTIFICATES: u16;
-    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    //  Note: If value must **not** decrease without considering the impact on serialization.
-    //  Decreasing this value will break backwards compatibility of serialization without explicit
-    //  declaration of migration based on round number rather than block height.
-    //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2];
 
     /// Returns the consensus version which is active at the given height.
     ///
@@ -239,10 +233,31 @@ pub trait Network:
     ///
     /// V3: Update to the number of validators and finalize scope RNG seed.
     #[allow(non_snake_case)]
-    fn CONSENSUS_VERSION(height: u32) -> anyhow::Result<ConsensusVersion>;
+    fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
+        match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {
+            // If a consensus version was found at this height, return it.
+            Ok(index) => Ok(Self::CONSENSUS_VERSION_HEIGHTS[index].0),
+            // If the specified height was not found, determine whether to return an appropriate version.
+            Err(index) => {
+                if index == 0 {
+                    Err(anyhow!("Expected consensus version 1 to exist at height 0."))
+                } else {
+                    // Return the appropriate version belonging to the height *lower* than the sought height.
+                    Ok(Self::CONSENSUS_VERSION_HEIGHTS[index - 1].0)
+                }
+            }
+        }
+    }
     /// Returns the height at which a specified consensus version becomes active.
     #[allow(non_snake_case)]
-    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32>;
+    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
+        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize - 1).ok_or(anyhow!("Invalid consensus version"))?.1)
+    }
+    /// Returns the last `MAX_CERTIFICATES` value.
+    #[allow(non_snake_case)]
+    fn LAST_MAX_CERTIFICATES() -> Result<u16> {
+        Self::MAX_CERTIFICATES.last().map_or(Err(anyhow!("No MAX_CERTIFICATES defined.")), |(_, value)| Ok(*value))
+    }
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];
@@ -477,9 +492,6 @@ mod tests {
         let consensus_version = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().0;
         assert_eq!(consensus_version, ConsensusVersion::V1);
         assert_eq!(consensus_version as usize, 1);
-        let consensus_version = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
-        assert_eq!(consensus_version, ConsensusVersion::V1);
-        assert_eq!(consensus_version as usize, 1);
     }
 
     /// Ensure that the consensus *versions* are unique, incrementing and start with 0.
@@ -493,8 +505,8 @@ mod tests {
             previous_version = *version;
         }
         // Ensure that the consensus versions are unique and incrementing.
-        let mut previous_version = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
-        for (version, _) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
+        let mut previous_version = N::MAX_CERTIFICATES.first().unwrap().0;
+        for (version, _) in N::MAX_CERTIFICATES.iter().skip(1) {
             assert!(*version > previous_version);
             previous_version = *version;
         }
@@ -515,32 +527,29 @@ mod tests {
 
     /// Ensure that version of all consensus-relevant constants are present in the consensus version heights.
     fn consensus_constants_valid_heights<N: Network>() {
-        for (version, value) in N::MAX_COMMITTEE_SIZE.iter() {
+        for (version, value) in N::MAX_CERTIFICATES.iter() {
             // Ensure that the height at which an update occurs are present in CONSENSUS_VERSION_HEIGHTS.
             let height = N::CONSENSUS_VERSION_HEIGHTS.iter().find(|(c_version, _)| *c_version == *version).unwrap().1;
             // Double-check that consensus_config_value returns the correct value.
-            assert_eq!(consensus_config_value!(N, MAX_COMMITTEE_SIZE, height).unwrap(), *value);
+            assert_eq!(consensus_config_value!(N, MAX_CERTIFICATES, height).unwrap(), *value);
         }
     }
 
-    /// Ensure that `MAX_COMMITTEE_SIZE` strictly increases and is correctly defined.
+    /// Ensure that `MAX_CERTIFICATES` strictly increases and is correctly defined.
     /// See the constant declaration for an explanation why.
     fn max_certificates_increasing<N: Network>() {
-        let mut previous_value = N::MAX_COMMITTEE_SIZE.first().unwrap().1;
-        for (_, value) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
+        let mut previous_value = N::MAX_CERTIFICATES.first().unwrap().1;
+        for (_, value) in N::MAX_CERTIFICATES.iter().skip(1) {
             assert!(*value > previous_value);
             previous_value = *value;
         }
-        // Ensure that the last value is equal to `MAX_CERTIFICATES`.
-        // See the constant declaration for an explanation why.
-        assert_eq!(N::MAX_CERTIFICATES, previous_value);
     }
 
     /// Ensure that the number of constant definitions is the same across networks.
     fn constants_equal_length<N1: Network, N2: Network, N3: Network>() {
         // If we can construct an array, that means the underlying types must be the same.
         let _ = [N1::CONSENSUS_VERSION_HEIGHTS, N2::CONSENSUS_VERSION_HEIGHTS, N3::CONSENSUS_VERSION_HEIGHTS];
-        let _ = [N1::MAX_COMMITTEE_SIZE, N2::MAX_COMMITTEE_SIZE, N3::MAX_COMMITTEE_SIZE];
+        let _ = [N1::MAX_CERTIFICATES, N2::MAX_CERTIFICATES, N3::MAX_CERTIFICATES];
     }
 
     #[test]

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -91,11 +91,6 @@ pub trait Network:
     /// The network edition.
     const EDITION: u16;
 
-    /// The block height from which consensus V2 rules apply.
-    const CONSENSUS_V2_HEIGHT: u32;
-    /// The block height from which consensus V3 rules apply.
-    const CONSENSUS_V3_HEIGHT: u32;
-
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str;
 
@@ -194,15 +189,6 @@ pub trait Network:
     /// The maximum number of imports.
     const MAX_IMPORTS: usize = 64;
 
-    /// The maximum number of certificates in a batch before consensus V3 rules apply.
-    const MAX_CERTIFICATES_BEFORE_V3: u16;
-    /// The maximum number of certificates in a batch.
-    // Note: This value must **not** be changed without considering the impact on serialization.
-    //  Decreasing this value will break backwards compatibility of serialization without explicit
-    //  declaration of migration based on round number rather than block height.
-    //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_CERTIFICATES: u16;
-
     /// The maximum number of bytes in a transaction.
     // Note: This value must **not** be decreased as it would invalidate existing transactions.
     const MAX_TRANSACTION_SIZE: usize = 128_000; // 128 kB
@@ -219,18 +205,22 @@ pub trait Network:
     type TransitionID: Bech32ID<Field<Self>>;
     /// The transmission checksum type.
     type TransmissionChecksum: IntegerType;
-    /// The consensus block height.
-    type ConsensusHeight: IntegerType;
-    /// The consensus version.
-    type ConsensusVersion: IntegerType;
 
     /// The consensus versions.
-    /// V0: The initial genesis consensus version.
-    /// V1: Update to the block reward and execution cost algorithms.
-    /// V2: Update to the number of validators and finalize scope RNG seed.
-    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2];
-    /// A test config.
-    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2];
+    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    const CONSENSUS_VERSIONS: [(u32, u16); 3];
+    /// The maximum number of certificates in a batch.
+    //  Note: This value must **not** be changed without considering the impact on serialization.
+    //  Decreasing this value will break backwards compatibility of serialization without explicit
+    //  declaration of migration based on round number rather than block height.
+    //  Increasing this value will require a migration to prevent forking during network upgrades.
+    const MAX_CERTIFICATES: u16;
+    /// The maximum number of validators in a committee.
+    //  Note: If value must **not** decrease without considering the impact on serialization.
+    //  Decreasing this value will break backwards compatibility of serialization without explicit
+    //  declaration of migration based on round number rather than block height.
+    //  Increasing this value will require a migration to prevent forking during network upgrades.
+    const MAX_COMMITTEE_SIZE: [(u32, u16); 2];
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];
@@ -421,9 +411,24 @@ pub trait Network:
         root: &Field<Self>,
         leaf: &Vec<Field<Self>>,
     ) -> bool;
+
+    /// Returns the height at which a specified consensus version becomes active.
+    ///
+    /// V1: The initial genesis consensus version.
+    ///
+    /// V2: Update to the block reward and execution cost algorithms.
+    ///
+    /// V3: Update to the number of validators and finalize scope RNG seed.
+    ///
+    #[allow(non_snake_case)]
+    fn HEIGHT_V(version: usize) -> anyhow::Result<u32>;
 }
 
 /// Returns the consensus configuration value for the specified height.
+///
+/// Arguments:
+/// - `$constant`: The constant to search a value of.
+/// - `$seek_height`: The block height to search the value for.
 #[macro_export]
 macro_rules! consensus_config_value {
     ($constant:expr, $seek_height:expr) => {
@@ -444,64 +449,74 @@ macro_rules! consensus_config_value {
     };
 }
 
-/// Returns the height at which a specified consensus version becomes active.
-pub fn height_consensus_v<N: Network>(version: usize) -> Option<N::ConsensusHeight> {
-    Some(N::CONSENSUS_VERSIONS.get(version)?.0)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     /// Ensure that the consensus constants are defined and correct at genesis.
     /// It is possible this invariant no longer holds in the future, e.g. due to pruning or novel types of constants.
-    fn consensus_constants_at_genesis<N: Network<ConsensusHeight = u32>>() {
+    fn consensus_constants_at_genesis<N: Network>() {
         let height = N::CONSENSUS_VERSIONS.first().unwrap().0;
         assert_eq!(height, 0);
-        let height = N::MAX_CERTIFICATES_PER_ROUND.first().unwrap().0;
+        let height = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
         assert_eq!(height, 0);
     }
 
     /// Ensure that the consensus versions are unique, incrementing by 1 and start with 0.
-    fn consensus_versions<N: Network<ConsensusVersion = u16>>() {
+    fn consensus_versions<N: Network>() {
         let mut previous_version = N::CONSENSUS_VERSIONS.first().unwrap().1;
-        // Ensure that the consensus versions start with 0.
-        assert_eq!(previous_version, 0);
+        // Ensure that the consensus versions start with 1.
+        assert_eq!(previous_version, 1);
         // Ensure that the consensus versions are unique and incrementing by 1.
         for (height, version) in N::CONSENSUS_VERSIONS.iter().skip(1) {
             assert_eq!(*version, previous_version + 1);
             previous_version = *version;
-            // Ensure that height_consensus_v returns the expected value.
-            assert_eq!(height_consensus_v::<N>(*version as usize).unwrap(), *height);
+            // Ensure that N::HEIGHT_V returns the expected value.
+            assert_eq!(N::HEIGHT_V(*version as usize).unwrap(), *height);
         }
     }
 
     /// Ensure that keys of all consensus-relevant constants are unique and incrementing.
-    fn consensus_constants_increasing_heights<N: Network<ConsensusVersion = u16>>() {
-        // Collect all constants that are relevant for consensus.
-        let constants = [N::CONSENSUS_VERSIONS, N::MAX_CERTIFICATES_PER_ROUND];
-        // Ensure that the heights are unique and incrementing.
-        for constant in constants {
-            let mut previous_height = constant.first().unwrap().0;
-            for (height, _) in constant.iter().skip(1) {
-                assert!(*height > previous_height);
-                previous_height = *height;
-            }
+    fn consensus_constants_increasing_heights<N: Network>() {
+        let mut previous_height = N::CONSENSUS_VERSIONS.first().unwrap().0;
+        for (height, _) in N::CONSENSUS_VERSIONS.iter().skip(1) {
+            assert!(*height > previous_height);
+            previous_height = *height;
+        }
+        let mut previous_height = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
+        for (height, _) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
+            assert!(*height > previous_height);
+            previous_height = *height;
         }
     }
 
     /// Ensure that keys of all consensus-relevant constants are present in the consensus version heights.
     fn consensus_constants_valid_heights<N: Network>() {
-        // Collect all constants that are relevant for consensus, except for CONSENSUS_VERSIONS.
-        let constants = [N::MAX_CERTIFICATES_PER_ROUND];
-        for constant in constants {
-            for (height, value) in constant.iter().skip(1) {
-                // Ensure that the height at which an update occurs are present in CONSENSUS_VERSIONS.
-                assert!(consensus_config_value!(N::CONSENSUS_VERSIONS, *height).is_some());
-                // Double-check that the value is as expected.
-                assert_eq!(consensus_config_value!(constant, *height).unwrap(), *value);
-            }
+        for (height, value) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
+            // Ensure that the height at which an update occurs are present in CONSENSUS_VERSIONS.
+            assert!(consensus_config_value!(N::CONSENSUS_VERSIONS, *height).is_some());
+            // Double-check that the value is as expected.
+            assert_eq!(consensus_config_value!(N::MAX_COMMITTEE_SIZE, *height).unwrap(), *value);
         }
+    }
+
+    /// Ensure that `MAX_COMMITTEE_SIZE` strictly increases and is correctly defined.
+    /// If this
+    fn max_certificates_increasing<N: Network>() {
+        let mut previous_value = N::MAX_COMMITTEE_SIZE.first().unwrap().1;
+        for (_, value) in N::MAX_COMMITTEE_SIZE.iter().skip(1) {
+            assert!(*value > previous_value);
+            previous_value = *value;
+        }
+        // Ensure that the last value is equal to `MAX_CERTIFICATES`.
+        assert_eq!(N::MAX_CERTIFICATES, previous_value);
+    }
+
+    /// Ensure that the number of constant definitions is the same across networks.
+    fn constants_equal_length<N1: Network, N2: Network, N3: Network>() {
+        // If we can construct an array, that means the underlying types must be the same.
+        let _ = [N1::CONSENSUS_VERSIONS, N2::CONSENSUS_VERSIONS, N3::CONSENSUS_VERSIONS];
+        let _ = [N1::MAX_COMMITTEE_SIZE, N2::MAX_COMMITTEE_SIZE, N3::MAX_COMMITTEE_SIZE];
     }
 
     #[test]
@@ -523,8 +538,10 @@ mod tests {
         consensus_constants_valid_heights::<TestnetV0>();
         consensus_constants_valid_heights::<CanaryV0>();
 
-        // Test that the number of CONSENSUS_VERSIONS is the same across networks.
-        assert_eq!(MainnetV0::CONSENSUS_VERSIONS.len(), TestnetV0::CONSENSUS_VERSIONS.len());
-        assert_eq!(MainnetV0::CONSENSUS_VERSIONS.len(), CanaryV0::CONSENSUS_VERSIONS.len());
+        max_certificates_increasing::<MainnetV0>();
+        max_certificates_increasing::<TestnetV0>();
+        max_certificates_increasing::<CanaryV0>();
+
+        constants_equal_length::<MainnetV0, TestnetV0, CanaryV0>();
     }
 }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -70,14 +70,12 @@ pub(crate) type VarunaProvingKey<N> = CircuitProvingKey<<N as Environment>::Pair
 pub(crate) type VarunaVerifyingKey<N> = CircuitVerifyingKey<<N as Environment>::PairingCurve>;
 
 /// The different consensus versions.
+/// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ConsensusVersion {
-    /// V1: The initial genesis consensus version.
-    V1 = 0,
-    /// V2: Update to the block reward and execution cost algorithms.
-    V2 = 1,
-    /// V3: Update to the number of validators and finalize scope RNG seed.
-    V3 = 2,
+    V1 = 1,
+    V2 = 2,
+    V3 = 3,
 }
 
 pub trait Network:
@@ -218,7 +216,7 @@ pub trait Network:
     type TransmissionChecksum: IntegerType;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
+    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3];
     /// The maximum number of certificates in a batch.
     //  Note: This value must **not** be changed without considering the impact on serialization.
@@ -233,9 +231,18 @@ pub trait Network:
     //  Increasing this value will require a migration to prevent forking during network upgrades.
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2];
 
+    /// Returns the consensus version which is active at the given height.
+    ///
+    /// V1: The initial genesis consensus version.
+    ///
+    /// V2: Update to the block reward and execution cost algorithms.
+    ///
+    /// V3: Update to the number of validators and finalize scope RNG seed.
+    #[allow(non_snake_case)]
+    fn CONSENSUS_VERSION(height: u32) -> anyhow::Result<ConsensusVersion>;
     /// Returns the height at which a specified consensus version becomes active.
     #[allow(non_snake_case)]
-    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> anyhow::Result<u32>;
+    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32>;
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];
@@ -438,30 +445,23 @@ pub trait Network:
 macro_rules! consensus_config_value {
     ($network:ident, $constant:ident, $seek_height:expr) => {
         // Search the consensus version enacted at the specified height.
-        match $network::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&$seek_height)) {
-            // If a consensus version was found, return the corresponding consensus value.
-            Ok(index) => {
-                let consensus_version = $network::CONSENSUS_VERSION_HEIGHTS[index].0;
-                match $network::$constant.binary_search_by(|(version, _)| version.cmp(&consensus_version)) {
-                    Ok(index) => Some($network::$constant[index].1),
-                    Err(_) => None,
-                }
-            }
-            // If the specified height was not found, determine whether to return an appropriate version.
-            Err(index) => {
-                // This constant is not yet in effect at this height.
-                if index == 0 {
-                    None
-                // Return the appropriate value belonging to the height *lower* than the sought height.
-                } else {
-                    let consensus_version = $network::CONSENSUS_VERSION_HEIGHTS[index - 1].0;
-                    match $network::$constant.binary_search_by(|(version, _)| version.cmp(&consensus_version)) {
-                        Ok(index) => Some($network::$constant[index].1),
-                        Err(_) => None,
+        $network::CONSENSUS_VERSION($seek_height).map_or(None, |seek_version| {
+            // Search the consensus value for the specified version.
+            match $network::$constant.binary_search_by(|(version, _)| version.cmp(&seek_version)) {
+                // If a value was found for this consensus version, return it.
+                Ok(index) => Some($network::$constant[index].1),
+                // If the specified version was not found exactly, determine whether to return an appropriate value anyway.
+                Err(index) => {
+                    // This constant is not yet in effect at this consensus version.
+                    if index == 0 {
+                        None
+                    // Return the appropriate value belonging to the consensus version *lower* than the sought version.
+                    } else {
+                        Some($network::$constant[index - 1].1)
                     }
                 }
             }
-        }
+        })
     };
 }
 
@@ -475,16 +475,18 @@ mod tests {
         let height = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().1;
         assert_eq!(height, 0);
         let consensus_version = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().0;
-        assert_eq!(consensus_version as usize, 0);
+        assert_eq!(consensus_version, ConsensusVersion::V1);
+        assert_eq!(consensus_version as usize, 1);
         let consensus_version = N::MAX_COMMITTEE_SIZE.first().unwrap().0;
-        assert_eq!(consensus_version as usize, 0);
+        assert_eq!(consensus_version, ConsensusVersion::V1);
+        assert_eq!(consensus_version as usize, 1);
     }
 
     /// Ensure that the consensus *versions* are unique, incrementing and start with 0.
     fn consensus_versions<N: Network>() {
         let mut previous_version = N::CONSENSUS_VERSION_HEIGHTS.first().unwrap().0;
         // Ensure that the consensus versions start with 0.
-        assert_eq!(previous_version as usize, 0);
+        assert_eq!(previous_version as usize, 1);
         // Ensure that the consensus versions are unique and incrementing by 1.
         for (version, _) in N::CONSENSUS_VERSION_HEIGHTS.iter().skip(1) {
             assert_eq!(*version as usize, previous_version as usize + 1);
@@ -504,6 +506,8 @@ mod tests {
         for (version, height) in N::CONSENSUS_VERSION_HEIGHTS.iter().skip(1) {
             assert!(*height > previous_height);
             previous_height = *height;
+            // Ensure that N::CONSENSUS_VERSION returns the expected value.
+            assert_eq!(N::CONSENSUS_VERSION(*height).unwrap(), *version);
             // Ensure that N::CONSENSUS_HEIGHT returns the expected value.
             assert_eq!(N::CONSENSUS_HEIGHT(*version).unwrap(), *height);
         }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -214,7 +214,7 @@ pub trait Network:
     /// The transmission checksum type.
     type TransmissionChecksum: IntegerType;
 
-    /// The consensus versions.
+    /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3];
     /// The maximum number of certificates in a batch.
@@ -223,7 +223,7 @@ pub trait Network:
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
     const MAX_CERTIFICATES: u16;
-    /// The maximum number of validators in a committee.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     //  Note: If value must **not** decrease without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -535,12 +535,12 @@ mod tests {
         }
     }
 
-    /// Ensure that `MAX_CERTIFICATES` strictly increases and is correctly defined.
+    /// Ensure that `MAX_CERTIFICATES` increases and is correctly defined.
     /// See the constant declaration for an explanation why.
     fn max_certificates_increasing<N: Network>() {
         let mut previous_value = N::MAX_CERTIFICATES.first().unwrap().1;
         for (_, value) in N::MAX_CERTIFICATES.iter().skip(1) {
-            assert!(*value > previous_value);
+            assert!(*value >= previous_value);
             previous_value = *value;
         }
     }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -36,7 +36,7 @@ mod testnet_v0;
 pub use testnet_v0::*;
 
 pub mod prelude {
-    pub use crate::{Network, consensus_config_value, environment::prelude::*};
+    pub use crate::{ConsensusVersion, Network, consensus_config_value, environment::prelude::*};
 }
 
 use crate::environment::prelude::*;
@@ -68,6 +68,14 @@ pub type FiatShamirParameters<N> = <FiatShamir<N> as AlgebraicSponge<Fq<N>, 2>>:
 /// Helper types for the Varuna proving and verifying key.
 pub(crate) type VarunaProvingKey<N> = CircuitProvingKey<<N as Environment>::PairingCurve, VarunaHidingMode>;
 pub(crate) type VarunaVerifyingKey<N> = CircuitVerifyingKey<<N as Environment>::PairingCurve>;
+
+/// The different consensus versions.
+#[derive(Debug, Copy, Clone)]
+pub enum ConsensusVersion {
+    V1 = 0,
+    V2 = 1,
+    V3 = 2,
+}
 
 pub trait Network:
     'static
@@ -207,8 +215,8 @@ pub trait Network:
     type TransmissionChecksum: IntegerType;
 
     /// The consensus versions.
-    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
-    const CONSENSUS_VERSIONS: [(u32, u16); 3];
+    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3];
     /// The maximum number of certificates in a batch.
     //  Note: This value must **not** be changed without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit
@@ -221,6 +229,17 @@ pub trait Network:
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
     const MAX_COMMITTEE_SIZE: [(u32, u16); 2];
+
+    /// Returns the height at which a specified consensus version becomes active.
+    ///
+    /// V1: The initial genesis consensus version.
+    ///
+    /// V2: Update to the block reward and execution cost algorithms.
+    ///
+    /// V3: Update to the number of validators and finalize scope RNG seed.
+    ///
+    #[allow(non_snake_case)]
+    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> anyhow::Result<u32>;
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8];
@@ -411,17 +430,6 @@ pub trait Network:
         root: &Field<Self>,
         leaf: &Vec<Field<Self>>,
     ) -> bool;
-
-    /// Returns the height at which a specified consensus version becomes active.
-    ///
-    /// V1: The initial genesis consensus version.
-    ///
-    /// V2: Update to the block reward and execution cost algorithms.
-    ///
-    /// V3: Update to the number of validators and finalize scope RNG seed.
-    ///
-    #[allow(non_snake_case)]
-    fn HEIGHT_V(version: usize) -> anyhow::Result<u32>;
 }
 
 /// Returns the consensus configuration value for the specified height.
@@ -465,14 +473,14 @@ mod tests {
     /// Ensure that the consensus versions are unique, incrementing by 1 and start with 0.
     fn consensus_versions<N: Network>() {
         let mut previous_version = N::CONSENSUS_VERSIONS.first().unwrap().1;
-        // Ensure that the consensus versions start with 1.
-        assert_eq!(previous_version, 1);
+        // Ensure that the consensus versions start with 0.
+        assert_eq!(previous_version as usize, 0);
         // Ensure that the consensus versions are unique and incrementing by 1.
         for (height, version) in N::CONSENSUS_VERSIONS.iter().skip(1) {
-            assert_eq!(*version, previous_version + 1);
+            assert_eq!(*version as usize, previous_version as usize + 1);
             previous_version = *version;
-            // Ensure that N::HEIGHT_V returns the expected value.
-            assert_eq!(N::HEIGHT_V(*version as usize).unwrap(), *height);
+            // Ensure that N::CONSENSUS_HEIGHT returns the expected value.
+            assert_eq!(N::CONSENSUS_HEIGHT(*version).unwrap(), *height);
         }
     }
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -255,7 +255,7 @@ pub trait Network:
     }
     /// Returns the last `MAX_CERTIFICATES` value.
     #[allow(non_snake_case)]
-    fn LAST_MAX_CERTIFICATES() -> Result<u16> {
+    fn LATEST_MAX_CERTIFICATES() -> Result<u16> {
         Self::MAX_CERTIFICATES.last().map_or(Err(anyhow!("No MAX_CERTIFICATES defined.")), |(_, value)| Ok(*value))
     }
 

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -166,44 +166,14 @@ impl Network for MainnetV0 {
     const ID: u16 = 0;
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
-    /// The maximum number of certificates in a batch.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: u16 = 25;
-    /// The maximum number of certificates in a batch.
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
+    /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: u16 = 100;
-    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(any(test, feature = "test"))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
-        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
-    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(not(any(test, feature = "test")))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
-        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
-
-    /// Returns the consensus version which is active at the given height.
-    fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
-        match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {
-            // If a consensus version was found at this height, return it.
-            Ok(index) => Ok(Self::CONSENSUS_VERSION_HEIGHTS[index].0),
-            // If the specified height was not found, determine whether to return an appropriate version.
-            Err(index) => {
-                if index == 0 {
-                    Err(anyhow!("Expected consensus version 1 to exist at height 0."))
-                } else {
-                    // Return the appropriate version belonging to the height *lower* than the sought height.
-                    Ok(Self::CONSENSUS_VERSION_HEIGHTS[index - 1].0)
-                }
-            }
-        }
-    }
-
-    /// Returns the height at which a specified consensus version becomes active.
-    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize - 1).ok_or(anyhow!("Invalid consensus version"))?.1)
-    }
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -137,13 +137,13 @@ impl Network for MainnetV0 {
     /// The block heights at which consensus versions are updated.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
-        [(0, ConsensusVersion::V1), (2_800_000, ConsensusVersion::V2), (4_900_000, ConsensusVersion::V3)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_800_000), (ConsensusVersion::V3, 4_900_000)];
     /// The block heights at which consensus versions are updated.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
-        [(0, ConsensusVersion::V1), (10, ConsensusVersion::V2), (11, ConsensusVersion::V3)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -174,19 +174,15 @@ impl Network for MainnetV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// The maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
-    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 16), (4_900_000, 25)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// The maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
-    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 100), (4_900_000, 100)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 
-    /// Returns the height at which a specified consensus version becomes active.
-    // fn CONSENSUS_HEIGHT(version: usize) -> Result<u32> {
-    //     Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
-    // }
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSIONS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.0)
+        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.1)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -135,11 +135,11 @@ impl Network for MainnetV0 {
     type TransmissionChecksum = u128;
 
     /// The block heights at which consensus versions are updated.
-    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_800_000, 2), (4_900_000, 3)];
     /// The block heights at which consensus versions are updated.
-    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
     /// The network edition.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -135,13 +135,15 @@ impl Network for MainnetV0 {
     type TransmissionChecksum = u128;
 
     /// The block heights at which consensus versions are updated.
-    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_800_000, 2), (4_900_000, 3)];
+    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
+        [(0, ConsensusVersion::V1), (2_800_000, ConsensusVersion::V2), (4_900_000, ConsensusVersion::V3)];
     /// The block heights at which consensus versions are updated.
-    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
+    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
+        [(0, ConsensusVersion::V1), (10, ConsensusVersion::V2), (11, ConsensusVersion::V3)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -180,8 +182,11 @@ impl Network for MainnetV0 {
     const NAME: &'static str = "Aleo Mainnet (v0)";
 
     /// Returns the height at which a specified consensus version becomes active.
-    fn HEIGHT_V(version: usize) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
+    // fn CONSENSUS_HEIGHT(version: usize) -> Result<u32> {
+    //     Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
+    // }
+    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
+        Ok(Self::CONSENSUS_VERSIONS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.0)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -167,10 +167,10 @@ impl Network for MainnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -135,12 +135,12 @@ impl Network for MainnetV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_800_000), (ConsensusVersion::V3, 4_900_000)];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
@@ -181,6 +181,7 @@ impl Network for MainnetV0 {
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 
+    /// Returns the height at which a specified consensus version becomes active.
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
         Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.1)
     }

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -167,16 +167,16 @@ impl Network for MainnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: u16 = 25;
     /// The maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: u16 = 100;
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(any(test, feature = "test"))]
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -135,12 +135,12 @@ impl Network for MainnetV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
+    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_800_000), (ConsensusVersion::V3, 4_900_000)];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
+    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
@@ -183,9 +183,26 @@ impl Network for MainnetV0 {
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 
+    /// Returns the consensus version which is active at the given height.
+    fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
+        match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {
+            // If a consensus version was found at this height, return it.
+            Ok(index) => Ok(Self::CONSENSUS_VERSION_HEIGHTS[index].0),
+            // If the specified height was not found, determine whether to return an appropriate version.
+            Err(index) => {
+                if index == 0 {
+                    Err(anyhow!("Expected consensus version 1 to exist at height 0."))
+                } else {
+                    // Return the appropriate version belonging to the height *lower* than the sought height.
+                    Ok(Self::CONSENSUS_VERSION_HEIGHTS[index - 1].0)
+                }
+            }
+        }
+    }
+
     /// Returns the height at which a specified consensus version becomes active.
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.1)
+        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize - 1).ok_or(anyhow!("Invalid consensus version"))?.1)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -123,10 +123,6 @@ impl Environment for MainnetV0 {
 impl Network for MainnetV0 {
     /// The block hash type.
     type BlockHash = AleoID<Field<Self>, { hrp2!("ab") }>;
-    /// The consensus block height.
-    type ConsensusHeight = u32;
-    /// The consensus block height.
-    type ConsensusVersion = u16;
     /// The ratification ID type.
     type RatificationID = AleoID<Field<Self>, { hrp2!("ar") }>;
     /// The state root type.
@@ -138,22 +134,14 @@ impl Network for MainnetV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
-    /// The block height from which consensus V2 rules apply.
-    #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V2_HEIGHT: u32 = 2_800_000;
-    /// The block height from which consensus V2 rules apply.
-    #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V2_HEIGHT: u32 = 10;
-    // TODO: (raychu86): Update this value based on the desired canary height.
-    // The block height from which consensus V3 rules apply.
-    #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V3_HEIGHT: u32 = 4_900_000;
-    /// The block height from which consensus V3 rules apply.
-    #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V3_HEIGHT: u32 = 11;
     /// The block heights at which consensus versions are updated.
     /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
-    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2] = [(0, 0), (100, 1)];
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_800_000, 2), (4_900_000, 3)];
+    /// The block heights at which consensus versions are updated.
+    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -177,14 +165,24 @@ impl Network for MainnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
+    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_CERTIFICATES: u16 = 25;
-    /// The maximum number of certificates in a batch before consensus V3 rules apply.
-    const MAX_CERTIFICATES_BEFORE_V3: u16 = 16;
-    // The maximum number of certificates per round for each consensus version.
-    // This effectively limits the number of validators per round as well.
-    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2] = [(0, 16), (100, 25)];
+    /// The maximum number of certificates in a batch.
+    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_CERTIFICATES: u16 = 100;
+    /// The maximum number of validators in a committee.
+    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 16), (4_900_000, 25)];
+    /// The maximum number of validators in a committee.
+    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 100), (4_900_000, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
+
+    /// Returns the height at which a specified consensus version becomes active.
+    fn HEIGHT_V(version: usize) -> Result<u32> {
+        Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
+    }
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -123,6 +123,10 @@ impl Environment for MainnetV0 {
 impl Network for MainnetV0 {
     /// The block hash type.
     type BlockHash = AleoID<Field<Self>, { hrp2!("ab") }>;
+    /// The consensus block height.
+    type ConsensusHeight = u32;
+    /// The consensus block height.
+    type ConsensusVersion = u16;
     /// The ratification ID type.
     type RatificationID = AleoID<Field<Self>, { hrp2!("ar") }>;
     /// The state root type.
@@ -147,6 +151,9 @@ impl Network for MainnetV0 {
     /// The block height from which consensus V3 rules apply.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_V3_HEIGHT: u32 = 11;
+    /// The block heights at which consensus versions are updated.
+    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2] = [(0, 0), (100, 1)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -173,6 +180,9 @@ impl Network for MainnetV0 {
     const MAX_CERTIFICATES: u16 = 25;
     /// The maximum number of certificates in a batch before consensus V3 rules apply.
     const MAX_CERTIFICATES_BEFORE_V3: u16 = 16;
+    // The maximum number of certificates per round for each consensus version.
+    // This effectively limits the number of validators per round as well.
+    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2] = [(0, 16), (100, 25)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -174,10 +174,12 @@ impl Network for MainnetV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
+        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
+        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -134,12 +134,12 @@ impl Network for MainnetV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
-    /// The block heights at which consensus versions are updated.
+    /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_800_000), (ConsensusVersion::V3, 4_900_000)];
-    /// The block heights at which consensus versions are updated.
+    /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
@@ -172,10 +172,10 @@ impl Network for MainnetV0 {
     /// The maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_CERTIFICATES: u16 = 100;
-    /// The maximum number of validators in a committee.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
-    /// The maximum number of validators in a committee.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -134,13 +134,15 @@ impl Network for TestnetV0 {
     type TransmissionChecksum = u128;
 
     /// The block heights at which consensus versions are updated.
-    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_950_000, 2), (4_800_000, 3)];
+    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
+        [(0, ConsensusVersion::V1), (2_950_000, ConsensusVersion::V2), (4_800_000, ConsensusVersion::V3)];
     /// The block heights at which consensus versions are updated.
-    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
+    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
+    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
+        [(0, ConsensusVersion::V1), (10, ConsensusVersion::V2), (11, ConsensusVersion::V3)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -175,8 +177,8 @@ impl Network for TestnetV0 {
     const NAME: &'static str = "Aleo Testnet (v0)";
 
     /// Returns the height at which a specified consensus version becomes active.
-    fn HEIGHT_V(version: usize) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
+    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
+        Ok(Self::CONSENSUS_VERSIONS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.0)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -162,16 +162,16 @@ impl Network for TestnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: u16 = 25;
     /// The maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: u16 = 100;
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(any(test, feature = "test"))]
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -169,10 +169,12 @@ impl Network for TestnetV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
+        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
+        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
 

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -134,11 +134,11 @@ impl Network for TestnetV0 {
     type TransmissionChecksum = u128;
 
     /// The block heights at which consensus versions are updated.
-    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_950_000, 2), (4_800_000, 3)];
     /// The block heights at which consensus versions are updated.
-    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    /// Documentation for what is changed at each version can be found in `Network::HEIGHT_V`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
     /// The network edition.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -161,44 +161,14 @@ impl Network for TestnetV0 {
     const ID: u16 = 1;
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
-    /// The maximum number of certificates in a batch.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: u16 = 25;
-    /// The maximum number of certificates in a batch.
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
+    /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: u16 = 100;
-    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(any(test, feature = "test"))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
-        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
-    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
-    #[cfg(not(any(test, feature = "test")))]
-    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] =
-        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, Self::MAX_CERTIFICATES)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
-
-    /// Returns the consensus version which is active at the given height.
-    fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
-        match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {
-            // If a consensus version was found at this height, return it.
-            Ok(index) => Ok(Self::CONSENSUS_VERSION_HEIGHTS[index].0),
-            // If the specified height was not found, determine whether to return an appropriate version.
-            Err(index) => {
-                if index == 0 {
-                    Err(anyhow!("Expected consensus version 1 to exist at height 0."))
-                } else {
-                    // Return the appropriate version belonging to the height *lower* than the sought height.
-                    Ok(Self::CONSENSUS_VERSION_HEIGHTS[index - 1].0)
-                }
-            }
-        }
-    }
-
-    /// Returns the height at which a specified consensus version becomes active.
-    fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize - 1).ok_or(anyhow!("Invalid consensus version"))?.1)
-    }
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -134,12 +134,12 @@ impl Network for TestnetV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_950_000), (ConsensusVersion::V3, 4_800_000)];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
+    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -122,10 +122,6 @@ impl Environment for TestnetV0 {
 impl Network for TestnetV0 {
     /// The block hash type.
     type BlockHash = AleoID<Field<Self>, { hrp2!("ab") }>;
-    /// The consensus block height.
-    type ConsensusHeight = u32;
-    /// The consensus block height.
-    type ConsensusVersion = u16;
     /// The ratification ID type.
     type RatificationID = AleoID<Field<Self>, { hrp2!("ar") }>;
     /// The state root type.
@@ -137,22 +133,14 @@ impl Network for TestnetV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
-    /// The block height from which consensus V2 rules apply.
-    #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V2_HEIGHT: u32 = 2_950_000;
-    /// The block height from which consensus V2 rules apply.
-    #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V2_HEIGHT: u32 = 10;
-    // TODO: (raychu86): Update this value based on the desired testnet height.
-    // The block height from which consensus V3 rules apply.
-    #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_V3_HEIGHT: u32 = 4_800_000;
-    /// The block height from which consensus V3 rules apply.
-    #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_V3_HEIGHT: u32 = 11;
     /// The block heights at which consensus versions are updated.
     /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
-    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2] = [(0, 0), (100, 1)];
+    #[cfg(not(any(test, feature = "test")))]
+    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (2_950_000, 2), (4_800_000, 3)];
+    /// The block heights at which consensus versions are updated.
+    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    #[cfg(any(test, feature = "test"))]
+    const CONSENSUS_VERSIONS: [(u32, u16); 3] = [(0, 1), (10, 2), (11, 3)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -172,14 +160,24 @@ impl Network for TestnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
+    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_CERTIFICATES: u16 = 25;
+    /// The maximum number of certificates in a batch.
+    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_CERTIFICATES: u16 = 100;
-    /// The maximum number of certificates in a batch before consensus V3 rules apply.
-    const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
-    // The maximum number of certificates per round for each consensus version.
-    // This effectively limits the number of validators per round as well.
-    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2] = [(0, 16), (1, 25)];
+    /// The maximum number of validators in a committee.
+    #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 16), (4_800_000, 25)];
+    /// The maximum number of validators in a committee.
+    #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
+    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 100), (4_800_000, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
+
+    /// Returns the height at which a specified consensus version becomes active.
+    fn HEIGHT_V(version: usize) -> Result<u32> {
+        Ok(Self::CONSENSUS_VERSIONS.get(version).ok_or(anyhow!("Invalid consensus version"))?.0)
+    }
 
     /// Returns the genesis block bytes.
     fn genesis_bytes() -> &'static [u8] {

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -136,13 +136,13 @@ impl Network for TestnetV0 {
     /// The block heights at which consensus versions are updated.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
-        [(0, ConsensusVersion::V1), (2_950_000, ConsensusVersion::V2), (4_800_000, ConsensusVersion::V3)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_950_000), (ConsensusVersion::V3, 4_800_000)];
     /// The block heights at which consensus versions are updated.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSIONS: [(u32, ConsensusVersion); 3] =
-        [(0, ConsensusVersion::V1), (10, ConsensusVersion::V2), (11, ConsensusVersion::V3)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -169,16 +169,16 @@ impl Network for TestnetV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// The maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
-    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 16), (4_800_000, 25)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// The maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
-    const MAX_COMMITTEE_SIZE: [(u32, u16); 2] = [(0, 100), (4_800_000, 100)];
+    const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
 
     /// Returns the height at which a specified consensus version becomes active.
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSIONS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.0)
+        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.1)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -134,12 +134,12 @@ impl Network for TestnetV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
+    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_950_000), (ConsensusVersion::V3, 4_800_000)];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `enum ConsensusVersion`.
+    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
@@ -178,9 +178,26 @@ impl Network for TestnetV0 {
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
 
+    /// Returns the consensus version which is active at the given height.
+    fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
+        match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {
+            // If a consensus version was found at this height, return it.
+            Ok(index) => Ok(Self::CONSENSUS_VERSION_HEIGHTS[index].0),
+            // If the specified height was not found, determine whether to return an appropriate version.
+            Err(index) => {
+                if index == 0 {
+                    Err(anyhow!("Expected consensus version 1 to exist at height 0."))
+                } else {
+                    // Return the appropriate version belonging to the height *lower* than the sought height.
+                    Ok(Self::CONSENSUS_VERSION_HEIGHTS[index - 1].0)
+                }
+            }
+        }
+    }
+
     /// Returns the height at which a specified consensus version becomes active.
     fn CONSENSUS_HEIGHT(version: ConsensusVersion) -> Result<u32> {
-        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize).ok_or(anyhow!("Invalid consensus version"))?.1)
+        Ok(Self::CONSENSUS_VERSION_HEIGHTS.get(version as usize - 1).ok_or(anyhow!("Invalid consensus version"))?.1)
     }
 
     /// Returns the genesis block bytes.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -133,12 +133,12 @@ impl Network for TestnetV0 {
     /// The transmission checksum type.
     type TransmissionChecksum = u128;
 
-    /// The block heights at which consensus versions are updated.
+    /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
         [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_950_000), (ConsensusVersion::V3, 4_800_000)];
-    /// The block heights at which consensus versions are updated.
+    /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `Network::CONSENSUS_HEIGHT`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
@@ -167,10 +167,10 @@ impl Network for TestnetV0 {
     /// The maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_CERTIFICATES: u16 = 100;
-    /// The maximum number of validators in a committee.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(any(test, feature = "test"))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
-    /// The maximum number of validators in a committee.
+    /// A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     #[cfg(not(any(test, feature = "test")))] // TODO: or should we use the 'test-helpers' feature?
     const MAX_COMMITTEE_SIZE: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -162,10 +162,10 @@ impl Network for TestnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -122,6 +122,10 @@ impl Environment for TestnetV0 {
 impl Network for TestnetV0 {
     /// The block hash type.
     type BlockHash = AleoID<Field<Self>, { hrp2!("ab") }>;
+    /// The consensus block height.
+    type ConsensusHeight = u32;
+    /// The consensus block height.
+    type ConsensusVersion = u16;
     /// The ratification ID type.
     type RatificationID = AleoID<Field<Self>, { hrp2!("ar") }>;
     /// The state root type.
@@ -146,6 +150,9 @@ impl Network for TestnetV0 {
     /// The block height from which consensus V3 rules apply.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_V3_HEIGHT: u32 = 11;
+    /// The block heights at which consensus versions are updated.
+    /// For a description of each upgrade, see the declaration of `CONSENSUS_VERSIONS` in the trait.
+    const CONSENSUS_VERSIONS: [(Self::ConsensusHeight, Self::ConsensusVersion); 2] = [(0, 0), (100, 1)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.
@@ -168,6 +175,9 @@ impl Network for TestnetV0 {
     const MAX_CERTIFICATES: u16 = 100;
     /// The maximum number of certificates in a batch before consensus V3 rules apply.
     const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
+    // The maximum number of certificates per round for each consensus version.
+    // This effectively limits the number of validators per round as well.
+    const MAX_CERTIFICATES_PER_ROUND: [(Self::ConsensusHeight, u16); 2] = [(0, 16), (1, 25)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
 

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -45,7 +45,7 @@ impl<N: Network> FromBytes for Block<N> {
         // Read the number of aborted solution IDs.
         let num_aborted_solutions = u32::read_le(&mut reader)?;
         // Ensure the number of aborted solutions IDs is within bounds (this is an early safety check).
-        if num_aborted_solutions as usize > Solutions::<N>::MAX_ABORTED_SOLUTIONS {
+        if num_aborted_solutions as usize > Solutions::<N>::max_aborted_solutions().map_err(error)? {
             return Err(error("Invalid number of aborted solutions IDs in the block"));
         }
         // Read the aborted solution IDs.
@@ -60,7 +60,7 @@ impl<N: Network> FromBytes for Block<N> {
         // Read the number of aborted transaction IDs.
         let num_aborted_transactions = u32::read_le(&mut reader)?;
         // Ensure the number of aborted transaction IDs is within bounds (this is an early safety check).
-        if num_aborted_transactions as usize > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
+        if num_aborted_transactions as usize > Transactions::<N>::max_aborted_transactions().map_err(error)? {
             return Err(error("Invalid number of aborted transaction IDs in the block"));
         }
         // Read the aborted transaction IDs.

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use console::prelude::{Network, Result, ensure};
+use console::prelude::{ConsensusVersion, Network, Result, ensure};
 
 /// A safety bound (sanity-check) for the coinbase reward.
 pub const MAX_COINBASE_REWARD: u64 = 190_258_739; // Coinbase reward at block 1.
@@ -38,10 +38,12 @@ pub fn block_reward<N: Network>(
     transaction_fees: u64,
 ) -> Result<u64> {
     // Determine which block reward version to use.
-    Ok(match N::CONSENSUS_VERSION(block_height)? as usize {
-        1 => block_reward_v1(total_supply, block_time, coinbase_reward, transaction_fees),
-        _ => block_reward_v2(total_supply, time_since_last_block, coinbase_reward, transaction_fees),
-    })
+    let consensus_version = N::CONSENSUS_VERSION(block_height)?;
+    if consensus_version == ConsensusVersion::V1 {
+        Ok(block_reward_v1(total_supply, block_time, coinbase_reward, transaction_fees))
+    } else {
+        Ok(block_reward_v2(total_supply, time_since_last_block, coinbase_reward, transaction_fees))
+    }
 }
 
 /// Calculate the V1 block reward, given the total supply, block time, coinbase reward, and transaction fees.
@@ -108,8 +110,9 @@ pub fn coinbase_reward<N: Network>(
     coinbase_target: u64,
 ) -> Result<u64> {
     // Determine which coinbase reward version to use.
-    match N::CONSENSUS_VERSION(block_height)? as usize {
-        1 => coinbase_reward_v1(
+    let consensus_version = N::CONSENSUS_VERSION(block_height)?;
+    if consensus_version == ConsensusVersion::V1 {
+        coinbase_reward_v1(
             block_height,
             starting_supply,
             anchor_height,
@@ -117,8 +120,9 @@ pub fn coinbase_reward<N: Network>(
             combined_proof_target,
             cumulative_proof_target,
             coinbase_target,
-        ),
-        _ => coinbase_reward_v2(
+        )
+    } else {
+        coinbase_reward_v2(
             block_timestamp,
             genesis_timestamp,
             starting_supply,
@@ -126,7 +130,7 @@ pub fn coinbase_reward<N: Network>(
             combined_proof_target,
             cumulative_proof_target,
             coinbase_target,
-        ),
+        )
     }
 }
 

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use console::prelude::{ConsensusVersion, Network, Result, ensure};
+use console::prelude::{Network, Result, ensure};
 
 /// A safety bound (sanity-check) for the coinbase reward.
 pub const MAX_COINBASE_REWARD: u64 = 190_258_739; // Coinbase reward at block 1.
@@ -38,10 +38,8 @@ pub fn block_reward<N: Network>(
     transaction_fees: u64,
 ) -> Result<u64> {
     // Determine which block reward version to use.
-    Ok(match block_height {
-        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => {
-            block_reward_v1(total_supply, block_time, coinbase_reward, transaction_fees)
-        }
+    Ok(match N::CONSENSUS_VERSION(block_height)? as usize {
+        1 => block_reward_v1(total_supply, block_time, coinbase_reward, transaction_fees),
         _ => block_reward_v2(total_supply, time_since_last_block, coinbase_reward, transaction_fees),
     })
 }
@@ -110,8 +108,8 @@ pub fn coinbase_reward<N: Network>(
     coinbase_target: u64,
 ) -> Result<u64> {
     // Determine which coinbase reward version to use.
-    match block_height {
-        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => coinbase_reward_v1(
+    match N::CONSENSUS_VERSION(block_height)? as usize {
+        1 => coinbase_reward_v1(
             block_height,
             starting_supply,
             anchor_height,

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use console::prelude::{Network, Result, ensure};
+use console::prelude::{ConsensusVersion, Network, Result, ensure};
 
 /// A safety bound (sanity-check) for the coinbase reward.
 pub const MAX_COINBASE_REWARD: u64 = 190_258_739; // Coinbase reward at block 1.
@@ -39,7 +39,7 @@ pub fn block_reward<N: Network>(
 ) -> Result<u64> {
     // Determine which block reward version to use.
     Ok(match block_height {
-        height if height < N::HEIGHT_V(2)? => {
+        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => {
             block_reward_v1(total_supply, block_time, coinbase_reward, transaction_fees)
         }
         _ => block_reward_v2(total_supply, time_since_last_block, coinbase_reward, transaction_fees),
@@ -111,7 +111,7 @@ pub fn coinbase_reward<N: Network>(
 ) -> Result<u64> {
     // Determine which coinbase reward version to use.
     match block_height {
-        height if height < N::HEIGHT_V(2)? => coinbase_reward_v1(
+        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => coinbase_reward_v1(
             block_height,
             starting_supply,
             anchor_height,
@@ -764,10 +764,10 @@ mod tests {
     fn test_block_reward() {
         let mut rng = TestRng::default();
 
-        // Ensure that a block height of `TestnetV0::HEIGHT_V(2).unwrap()` uses block reward V2.
+        // Ensure that a block height of `TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap()` uses block reward V2.
         let time_since_last_block = rng.gen_range(1..=V2_MAX_BLOCK_INTERVAL);
         let reward = block_reward::<TestnetV0>(
-            TestnetV0::HEIGHT_V(2).unwrap(),
+            TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap(),
             TestnetV0::STARTING_SUPPLY,
             TestnetV0::BLOCK_TIME,
             time_since_last_block,
@@ -780,7 +780,7 @@ mod tests {
 
         for _ in 0..100 {
             // Check that the block reward is correct for the first consensus version.
-            let consensus_v1_height = rng.gen_range(0..TestnetV0::HEIGHT_V(2).unwrap());
+            let consensus_v1_height = rng.gen_range(0..TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap());
             let consensus_v1_reward = block_reward::<TestnetV0>(
                 consensus_v1_height,
                 TestnetV0::STARTING_SUPPLY,
@@ -794,7 +794,8 @@ mod tests {
             assert_eq!(consensus_v1_reward, expected_reward);
 
             // Check that the block reward is correct for the second consensus version.
-            let consensus_v2_height = rng.gen_range(TestnetV0::HEIGHT_V(2).unwrap()..u32::MAX);
+            let consensus_v2_height =
+                rng.gen_range(TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap()..u32::MAX);
             let time_since_last_block = rng.gen_range(1..=V2_MAX_BLOCK_INTERVAL);
             let consensus_v2_reward = block_reward::<TestnetV0>(
                 consensus_v2_height,
@@ -905,11 +906,13 @@ mod tests {
     fn test_coinbase_reward() {
         let mut rng = TestRng::default();
 
-        // Ensure that a block height of `TestnetV0::HEIGHT_V(2).unwrap()` uses coinbase reward V2.
-        let block_timestamp = TestnetV0::GENESIS_TIMESTAMP
-            .saturating_add(TestnetV0::HEIGHT_V(2).unwrap().saturating_mul(TestnetV0::BLOCK_TIME as u32) as i64);
+        // Ensure that a block height of `TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap()` uses coinbase reward V2.
+        let block_timestamp = TestnetV0::GENESIS_TIMESTAMP.saturating_add(
+            TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap().saturating_mul(TestnetV0::BLOCK_TIME as u32)
+                as i64,
+        );
         let reward = coinbase_reward::<TestnetV0>(
-            TestnetV0::HEIGHT_V(2).unwrap(),
+            TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap(),
             block_timestamp,
             TestnetV0::GENESIS_TIMESTAMP,
             TestnetV0::STARTING_SUPPLY,
@@ -935,7 +938,7 @@ mod tests {
 
         for _ in 0..100 {
             // Check that the block reward is correct for the first consensus version.
-            let consensus_v1_height = rng.gen_range(0..TestnetV0::HEIGHT_V(2).unwrap());
+            let consensus_v1_height = rng.gen_range(0..TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap());
             let block_timestamp = TestnetV0::GENESIS_TIMESTAMP
                 .saturating_add(consensus_v1_height.saturating_mul(TestnetV0::BLOCK_TIME as u32) as i64);
             let consensus_v1_reward = coinbase_reward::<TestnetV0>(
@@ -964,7 +967,8 @@ mod tests {
             assert_eq!(consensus_v1_reward, expected_reward);
 
             // Check that the block reward is correct for the second consensus version.
-            let consensus_v2_height = rng.gen_range(TestnetV0::HEIGHT_V(2).unwrap()..u32::MAX);
+            let consensus_v2_height =
+                rng.gen_range(TestnetV0::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap()..u32::MAX);
             let block_timestamp = TestnetV0::GENESIS_TIMESTAMP
                 .saturating_add(consensus_v2_height.saturating_mul(TestnetV0::BLOCK_TIME as u32) as i64);
             let consensus_v2_reward = coinbase_reward::<TestnetV0>(

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -36,12 +36,14 @@ pub fn block_reward<N: Network>(
     time_since_last_block: i64,
     coinbase_reward: u64,
     transaction_fees: u64,
-) -> u64 {
+) -> Result<u64> {
     // Determine which block reward version to use.
-    match block_height < N::CONSENSUS_V2_HEIGHT {
-        true => block_reward_v1(total_supply, block_time, coinbase_reward, transaction_fees),
-        false => block_reward_v2(total_supply, time_since_last_block, coinbase_reward, transaction_fees),
-    }
+    Ok(match block_height {
+        height if height < N::HEIGHT_V(2)? => {
+            block_reward_v1(total_supply, block_time, coinbase_reward, transaction_fees)
+        }
+        _ => block_reward_v2(total_supply, time_since_last_block, coinbase_reward, transaction_fees),
+    })
 }
 
 /// Calculate the V1 block reward, given the total supply, block time, coinbase reward, and transaction fees.
@@ -108,8 +110,8 @@ pub fn coinbase_reward<N: Network>(
     coinbase_target: u64,
 ) -> Result<u64> {
     // Determine which coinbase reward version to use.
-    match block_height < N::CONSENSUS_V2_HEIGHT {
-        true => coinbase_reward_v1(
+    match block_height {
+        height if height < N::HEIGHT_V(2)? => coinbase_reward_v1(
             block_height,
             starting_supply,
             anchor_height,
@@ -118,7 +120,7 @@ pub fn coinbase_reward<N: Network>(
             cumulative_proof_target,
             coinbase_target,
         ),
-        false => coinbase_reward_v2(
+        _ => coinbase_reward_v2(
             block_timestamp,
             genesis_timestamp,
             starting_supply,
@@ -762,22 +764,23 @@ mod tests {
     fn test_block_reward() {
         let mut rng = TestRng::default();
 
-        // Ensure that a block height of `TestnetV0::CONSENSUS_V2_HEIGHT` uses block reward V2.
+        // Ensure that a block height of `TestnetV0::HEIGHT_V(2).unwrap()` uses block reward V2.
         let time_since_last_block = rng.gen_range(1..=V2_MAX_BLOCK_INTERVAL);
         let reward = block_reward::<TestnetV0>(
-            TestnetV0::CONSENSUS_V2_HEIGHT,
+            TestnetV0::HEIGHT_V(2).unwrap(),
             TestnetV0::STARTING_SUPPLY,
             TestnetV0::BLOCK_TIME,
             time_since_last_block,
             0,
             0,
-        );
+        )
+        .unwrap();
         let expected_reward = block_reward_v2(TestnetV0::STARTING_SUPPLY, time_since_last_block, 0, 0);
         assert_eq!(reward, expected_reward);
 
         for _ in 0..100 {
             // Check that the block reward is correct for the first consensus version.
-            let consensus_v1_height = rng.gen_range(0..TestnetV0::CONSENSUS_V2_HEIGHT);
+            let consensus_v1_height = rng.gen_range(0..TestnetV0::HEIGHT_V(2).unwrap());
             let consensus_v1_reward = block_reward::<TestnetV0>(
                 consensus_v1_height,
                 TestnetV0::STARTING_SUPPLY,
@@ -785,12 +788,13 @@ mod tests {
                 0,
                 0,
                 0,
-            );
+            )
+            .unwrap();
             let expected_reward = block_reward_v1(TestnetV0::STARTING_SUPPLY, TestnetV0::BLOCK_TIME, 0, 0);
             assert_eq!(consensus_v1_reward, expected_reward);
 
             // Check that the block reward is correct for the second consensus version.
-            let consensus_v2_height = rng.gen_range(TestnetV0::CONSENSUS_V2_HEIGHT..u32::MAX);
+            let consensus_v2_height = rng.gen_range(TestnetV0::HEIGHT_V(2).unwrap()..u32::MAX);
             let time_since_last_block = rng.gen_range(1..=V2_MAX_BLOCK_INTERVAL);
             let consensus_v2_reward = block_reward::<TestnetV0>(
                 consensus_v2_height,
@@ -799,7 +803,8 @@ mod tests {
                 time_since_last_block,
                 0,
                 0,
-            );
+            )
+            .unwrap();
             let expected_reward = block_reward_v2(TestnetV0::STARTING_SUPPLY, time_since_last_block, 0, 0);
             assert_eq!(consensus_v2_reward, expected_reward);
         }
@@ -900,11 +905,11 @@ mod tests {
     fn test_coinbase_reward() {
         let mut rng = TestRng::default();
 
-        // Ensure that a block height of `TestnetV0::CONSENSUS_V2_HEIGHT` uses coinbase reward V2.
+        // Ensure that a block height of `TestnetV0::HEIGHT_V(2).unwrap()` uses coinbase reward V2.
         let block_timestamp = TestnetV0::GENESIS_TIMESTAMP
-            .saturating_add(TestnetV0::CONSENSUS_V2_HEIGHT.saturating_mul(TestnetV0::BLOCK_TIME as u32) as i64);
+            .saturating_add(TestnetV0::HEIGHT_V(2).unwrap().saturating_mul(TestnetV0::BLOCK_TIME as u32) as i64);
         let reward = coinbase_reward::<TestnetV0>(
-            TestnetV0::CONSENSUS_V2_HEIGHT,
+            TestnetV0::HEIGHT_V(2).unwrap(),
             block_timestamp,
             TestnetV0::GENESIS_TIMESTAMP,
             TestnetV0::STARTING_SUPPLY,
@@ -930,7 +935,7 @@ mod tests {
 
         for _ in 0..100 {
             // Check that the block reward is correct for the first consensus version.
-            let consensus_v1_height = rng.gen_range(0..TestnetV0::CONSENSUS_V2_HEIGHT);
+            let consensus_v1_height = rng.gen_range(0..TestnetV0::HEIGHT_V(2).unwrap());
             let block_timestamp = TestnetV0::GENESIS_TIMESTAMP
                 .saturating_add(consensus_v1_height.saturating_mul(TestnetV0::BLOCK_TIME as u32) as i64);
             let consensus_v1_reward = coinbase_reward::<TestnetV0>(
@@ -959,7 +964,7 @@ mod tests {
             assert_eq!(consensus_v1_reward, expected_reward);
 
             // Check that the block reward is correct for the second consensus version.
-            let consensus_v2_height = rng.gen_range(TestnetV0::CONSENSUS_V2_HEIGHT..u32::MAX);
+            let consensus_v2_height = rng.gen_range(TestnetV0::HEIGHT_V(2).unwrap()..u32::MAX);
             let block_timestamp = TestnetV0::GENESIS_TIMESTAMP
                 .saturating_add(consensus_v2_height.saturating_mul(TestnetV0::BLOCK_TIME as u32) as i64);
             let consensus_v2_reward = coinbase_reward::<TestnetV0>(

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -154,11 +154,8 @@ impl<N: Network> Block<N> {
         aborted_transaction_ids: Vec<N::TransactionID>,
     ) -> Result<Self> {
         // Ensure the number of aborted solutions IDs is within the allowed range.
-        if aborted_solution_ids.len() > Solutions::<N>::MAX_ABORTED_SOLUTIONS {
-            bail!(
-                "Cannot initialize a block with more than {} aborted solutions IDs",
-                Solutions::<N>::MAX_ABORTED_SOLUTIONS
-            );
+        if aborted_solution_ids.len() > Solutions::<N>::max_aborted_solutions()? {
+            bail!("Cannot initialize a block with {} aborted solutions IDs", aborted_solution_ids.len());
         }
 
         // Ensure the number of transactions is within the allowed range.
@@ -170,10 +167,10 @@ impl<N: Network> Block<N> {
         }
 
         // Ensure the number of aborted transaction IDs is within the allowed range.
-        if aborted_transaction_ids.len() > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
+        if aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
             bail!(
                 "Cannot initialize a block with more than {} aborted transaction IDs",
-                Transactions::<N>::MAX_ABORTED_TRANSACTIONS
+                Transactions::<N>::max_aborted_transactions()?
             );
         }
 

--- a/ledger/block/src/solutions/mod.rs
+++ b/ledger/block/src/solutions/mod.rs
@@ -31,9 +31,11 @@ pub struct Solutions<N: Network> {
 
 impl<N: Network> Solutions<N> {
     /// The maximum number of aborted solutions allowed in a block.
-    pub const MAX_ABORTED_SOLUTIONS: usize = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH
-        * BatchHeader::<N>::MAX_GC_ROUNDS
-        * Committee::<N>::MAX_COMMITTEE_SIZE as usize;
+    pub fn max_aborted_solutions() -> Result<usize> {
+        Ok(BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH
+            * BatchHeader::<N>::MAX_GC_ROUNDS
+            * Committee::<N>::max_committee_size()? as usize)
+    }
 }
 
 impl<N: Network> From<Option<PuzzleSolutions<N>>> for Solutions<N> {

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -170,12 +170,15 @@ impl<N: Network> Transactions<N> {
 }
 
 impl<N: Network> Transactions<N> {
-    /// The maximum number of aborted transactions allowed in a block.
-    pub const MAX_ABORTED_TRANSACTIONS: usize = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH
-        * BatchHeader::<N>::MAX_GC_ROUNDS
-        * Committee::<N>::MAX_COMMITTEE_SIZE as usize;
     /// The maximum number of transactions allowed in a block.
     pub const MAX_TRANSACTIONS: usize = usize::pow(2, TRANSACTIONS_DEPTH as u32).saturating_sub(1);
+
+    /// The maximum number of aborted transactions allowed in a block.
+    pub fn max_aborted_transactions() -> Result<usize> {
+        Ok(BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH
+            * BatchHeader::<N>::MAX_GC_ROUNDS
+            * Committee::<N>::max_committee_size()? as usize)
+    }
 
     /// Returns an iterator over all transactions, for all transactions in `self`.
     pub fn iter(&self) -> impl '_ + ExactSizeIterator<Item = &ConfirmedTransaction<N>> {
@@ -360,7 +363,7 @@ mod tests {
         // Determine the maximum number of transmissions in a block.
         let max_transmissions_per_block = BatchHeader::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_BATCH
             * BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS
-            * BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES as usize;
+            * CurrentNetwork::LAST_MAX_CERTIFICATES().unwrap() as usize;
 
         // Note: The maximum number of *transmissions* in a block cannot exceed the maximum number of *transactions* in a block.
         // If you intended to change the number of 'MAX_TRANSACTIONS', note that this will break the inclusion proof,

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -363,7 +363,7 @@ mod tests {
         // Determine the maximum number of transmissions in a block.
         let max_transmissions_per_block = BatchHeader::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_BATCH
             * BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS
-            * CurrentNetwork::LAST_MAX_CERTIFICATES().unwrap() as usize;
+            * CurrentNetwork::LATEST_MAX_CERTIFICATES().unwrap() as usize;
 
         // Note: The maximum number of *transmissions* in a block cannot exceed the maximum number of *transactions* in a block.
         // If you intended to change the number of 'MAX_TRANSACTIONS', note that this will break the inclusion proof,

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -415,7 +415,7 @@ impl<N: Network> Block<N> {
             time_since_last_block,
             expected_coinbase_reward,
             expected_transaction_fees,
-        );
+        )?;
         // Compute the expected puzzle reward.
         let expected_puzzle_reward = puzzle_reward(expected_coinbase_reward);
 

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -329,10 +329,9 @@ impl<N: Network> Block<N> {
         );
         // Ensure the number of aborted solution IDs is within the allowed range.
         ensure!(
-            self.aborted_solution_ids.len() <= Solutions::<N>::MAX_ABORTED_SOLUTIONS,
-            "Block {height} contains too many aborted solution IDs (found '{}', expected '{}')",
+            self.aborted_solution_ids.len() <= Solutions::<N>::max_aborted_solutions()?,
+            "Block {height} contains too many aborted solution IDs (found '{}')",
             self.aborted_solution_ids.len(),
-            Solutions::<N>::MAX_ABORTED_SOLUTIONS
         );
 
         // Ensure there are no duplicate solution IDs.
@@ -444,10 +443,10 @@ impl<N: Network> Block<N> {
         }
 
         // Ensure the number of aborted transaction IDs is within the allowed range.
-        if self.aborted_transaction_ids.len() > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
+        if self.aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
             bail!(
                 "Cannot validate a block with more than {} aborted transaction IDs",
-                Transactions::<N>::MAX_ABORTED_TRANSACTIONS
+                Transactions::<N>::max_aborted_transactions()?
             );
         }
 

--- a/ledger/committee/src/bytes.rs
+++ b/ledger/committee/src/bytes.rs
@@ -32,10 +32,10 @@ impl<N: Network> FromBytes for Committee<N> {
         // Read the number of members.
         let num_members = u16::read_le(&mut reader)?;
         // Ensure the number of members is within the allowed limit.
-        if num_members > Self::MAX_COMMITTEE_SIZE {
+        if num_members > Self::max_committee_size().map_err(error)? {
             return Err(error(format!(
                 "Committee cannot exceed {} members, found {num_members}",
-                Self::MAX_COMMITTEE_SIZE,
+                Self::max_committee_size().map_err(error)?,
             )));
         }
 

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -61,8 +61,11 @@ pub struct Committee<N: Network> {
 impl<N: Network> Committee<N> {
     /// The committee lookback range.
     pub const COMMITTEE_LOOKBACK_RANGE: u64 = BatchHeader::<N>::MAX_GC_ROUNDS as u64;
+
     /// The maximum number of members that may be in a committee.
-    pub const MAX_COMMITTEE_SIZE: u16 = BatchHeader::<N>::MAX_CERTIFICATES;
+    pub fn max_committee_size() -> Result<u16> {
+        N::LAST_MAX_CERTIFICATES()
+    }
 
     /// Initializes a new `Committee` instance.
     pub fn new_genesis(members: IndexMap<Address<N>, (u64, bool, u8)>) -> Result<Self> {
@@ -76,9 +79,9 @@ impl<N: Network> Committee<N> {
         ensure!(members.len() >= 3, "Committee must have at least 3 members");
         // Ensure there are no more than the maximum number of members.
         ensure!(
-            members.len() <= Self::MAX_COMMITTEE_SIZE as usize,
+            members.len() <= Self::max_committee_size()? as usize,
             "Committee must have no more than {} members",
-            Self::MAX_COMMITTEE_SIZE
+            Self::max_committee_size()?
         );
         // Ensure all members have the minimum required stake.
         ensure!(
@@ -436,7 +439,7 @@ mod tests {
         // Set the number of rounds.
         const NUM_ROUNDS: u64 = 256 * 2_000;
         // Sample the number of members.
-        let num_members = rng.gen_range(3..=Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE);
+        let num_members = rng.gen_range(3..=Committee::<CurrentNetwork>::max_committee_size().unwrap());
         // Sample a committee.
         let committee = crate::test_helpers::sample_committee_custom(num_members, rng);
         // Check the leader distribution.
@@ -448,8 +451,10 @@ mod tests {
         // Initialize the RNG.
         let rng = &mut TestRng::default();
         // Sample a committee.
-        let committee =
-            crate::test_helpers::sample_committee_custom(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE, rng);
+        let committee = crate::test_helpers::sample_committee_custom(
+            Committee::<CurrentNetwork>::max_committee_size().unwrap(),
+            rng,
+        );
 
         // Start a timer.
         let timer = std::time::Instant::now();
@@ -462,11 +467,5 @@ mod tests {
             let (address2, (_, _, _)) = sorted_members[i + 1];
             assert!(address1.to_x_coordinate() > address2.to_x_coordinate());
         }
-    }
-
-    #[test]
-    #[allow(clippy::assertions_on_constants)]
-    fn test_maximum_committee_size() {
-        assert_eq!(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE, BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES);
     }
 }

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -64,7 +64,7 @@ impl<N: Network> Committee<N> {
 
     /// The maximum number of members that may be in a committee.
     pub fn max_committee_size() -> Result<u16> {
-        N::LAST_MAX_CERTIFICATES()
+        N::LATEST_MAX_CERTIFICATES()
     }
 
     /// Initializes a new `Committee` instance.

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -63,8 +63,6 @@ impl<N: Network> Committee<N> {
     pub const COMMITTEE_LOOKBACK_RANGE: u64 = BatchHeader::<N>::MAX_GC_ROUNDS as u64;
     /// The maximum number of members that may be in a committee.
     pub const MAX_COMMITTEE_SIZE: u16 = BatchHeader::<N>::MAX_CERTIFICATES;
-    /// The maximum number of members that may be in a committee before consensus V3 rules apply.
-    pub const MAX_COMMITTEE_SIZE_BEFORE_V3: u16 = BatchHeader::<N>::MAX_CERTIFICATES_BEFORE_V3;
 
     /// Initializes a new `Committee` instance.
     pub fn new_genesis(members: IndexMap<Address<N>, (u64, bool, u8)>) -> Result<Self> {
@@ -469,16 +467,6 @@ mod tests {
     #[test]
     #[allow(clippy::assertions_on_constants)]
     fn test_maximum_committee_size() {
-        assert_eq!(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3,
-            BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES_BEFORE_V3
-        );
         assert_eq!(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE, BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES);
-        // Adding explicit check that updates to the maximum committee size are strictly increasing. A decreasing maximum will
-        // require additional migration logic based on a `round` number.
-        assert!(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3
-                <= Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE
-        );
     }
 }

--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -30,10 +30,10 @@ impl<N: Network> FromBytes for BatchCertificate<N> {
         // Read the number of signatures.
         let num_signatures = u16::read_le(&mut reader)?;
         // Ensure the number of signatures is within bounds.
-        if num_signatures > Self::MAX_SIGNATURES {
+        if num_signatures > Self::max_signatures().map_err(error)? {
             return Err(error(format!(
                 "Number of signatures ({num_signatures}) exceeds the maximum ({})",
-                Self::MAX_SIGNATURES
+                Self::max_signatures().map_err(error)?
             )));
         }
         // Read the signature bytes.

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -45,14 +45,16 @@ pub struct BatchCertificate<N: Network> {
 
 impl<N: Network> BatchCertificate<N> {
     /// The maximum number of signatures in a batch certificate.
-    pub const MAX_SIGNATURES: u16 = BatchHeader::<N>::MAX_CERTIFICATES;
+    pub fn max_signatures() -> Result<u16> {
+        N::LAST_MAX_CERTIFICATES()
+    }
 }
 
 impl<N: Network> BatchCertificate<N> {
     /// Initializes a new batch certificate.
     pub fn from(batch_header: BatchHeader<N>, signatures: IndexSet<Signature<N>>) -> Result<Self> {
         // Ensure that the number of signatures is within bounds.
-        ensure!(signatures.len() <= Self::MAX_SIGNATURES as usize, "Invalid number of signatures");
+        ensure!(signatures.len() <= N::LAST_MAX_CERTIFICATES()? as usize, "Invalid number of signatures");
 
         // Ensure that the signature is from a unique signer and not from the author.
         let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<HashSet<_>>();
@@ -235,17 +237,5 @@ pub mod test_helpers {
         );
 
         (certificate, previous_certificates)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    type CurrentNetwork = console::network::MainnetV0;
-
-    #[test]
-    fn test_maximum_signatures() {
-        assert_eq!(BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES, BatchCertificate::<CurrentNetwork>::MAX_SIGNATURES);
     }
 }

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -46,7 +46,7 @@ pub struct BatchCertificate<N: Network> {
 impl<N: Network> BatchCertificate<N> {
     /// The maximum number of signatures in a batch certificate.
     pub fn max_signatures() -> Result<u16> {
-        N::LAST_MAX_CERTIFICATES()
+        N::LATEST_MAX_CERTIFICATES()
     }
 }
 
@@ -54,7 +54,7 @@ impl<N: Network> BatchCertificate<N> {
     /// Initializes a new batch certificate.
     pub fn from(batch_header: BatchHeader<N>, signatures: IndexSet<Signature<N>>) -> Result<Self> {
         // Ensure that the number of signatures is within bounds.
-        ensure!(signatures.len() <= N::LAST_MAX_CERTIFICATES()? as usize, "Invalid number of signatures");
+        ensure!(signatures.len() <= N::LATEST_MAX_CERTIFICATES()? as usize, "Invalid number of signatures");
 
         // Ensure that the signature is from a unique signer and not from the author.
         let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<HashSet<_>>();

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -54,7 +54,7 @@ impl<N: Network> BatchCertificate<N> {
     /// Initializes a new batch certificate.
     pub fn from(batch_header: BatchHeader<N>, signatures: IndexSet<Signature<N>>) -> Result<Self> {
         // Ensure that the number of signatures is within bounds.
-        ensure!(signatures.len() <= N::LATEST_MAX_CERTIFICATES()? as usize, "Invalid number of signatures");
+        ensure!(signatures.len() <= Self::max_signatures()? as usize, "Invalid number of signatures");
 
         // Ensure that the signature is from a unique signer and not from the author.
         let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<HashSet<_>>();

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -55,10 +55,9 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u16::read_le(&mut reader)?;
         // Ensure the number of previous certificate IDs is within bounds.
-        if num_previous_certificate_ids > Self::MAX_CERTIFICATES {
+        if num_previous_certificate_ids > N::LAST_MAX_CERTIFICATES().map_err(error)? {
             return Err(error(format!(
-                "Number of previous certificate IDs ({num_previous_certificate_ids}) exceeds the maximum ({})",
-                Self::MAX_CERTIFICATES
+                "Number of previous certificate IDs ({num_previous_certificate_ids}) exceeds the maximum.",
             )));
         }
 

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -55,7 +55,7 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u16::read_le(&mut reader)?;
         // Ensure the number of previous certificate IDs is within bounds.
-        if num_previous_certificate_ids > N::LAST_MAX_CERTIFICATES().map_err(error)? {
+        if num_previous_certificate_ids > N::LATEST_MAX_CERTIFICATES().map_err(error)? {
             return Err(error(format!(
                 "Number of previous certificate IDs ({num_previous_certificate_ids}) exceeds the maximum.",
             )));

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -57,19 +57,7 @@ pub struct BatchHeader<N: Network> {
 
 impl<N: Network> BatchHeader<N> {
     /// The maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test-helpers")))]
     pub const MAX_CERTIFICATES: u16 = N::MAX_CERTIFICATES;
-    /// The maximum number of certificates in a batch.
-    /// This is deliberately set to a high value (100) for testing purposes only.
-    #[cfg(any(test, feature = "test-helpers"))]
-    pub const MAX_CERTIFICATES: u16 = 100;
-    /// The maximum number of certificates in a batch before consensus V3 rules apply.
-    #[cfg(not(any(test, feature = "test-helpers")))]
-    pub const MAX_CERTIFICATES_BEFORE_V3: u16 = N::MAX_CERTIFICATES_BEFORE_V3;
-    /// The maximum number of certificates in a batch before consensus V3 rules apply.
-    /// This is deliberately set to a high value (100) for testing purposes only.
-    #[cfg(any(test, feature = "test-helpers"))]
-    pub const MAX_CERTIFICATES_BEFORE_V3: u16 = 100;
     /// The maximum number of rounds to store before garbage collecting.
     pub const MAX_GC_ROUNDS: usize = 100;
     /// The maximum number of transmissions in a batch.

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -56,8 +56,6 @@ pub struct BatchHeader<N: Network> {
 }
 
 impl<N: Network> BatchHeader<N> {
-    /// The maximum number of certificates in a batch.
-    pub const MAX_CERTIFICATES: u16 = N::MAX_CERTIFICATES;
     /// The maximum number of rounds to store before garbage collecting.
     pub const MAX_GC_ROUNDS: usize = 100;
     /// The maximum number of transmissions in a batch.
@@ -95,7 +93,7 @@ impl<N: Network> BatchHeader<N> {
         );
         // Ensure that the number of previous certificate IDs is within bounds.
         ensure!(
-            previous_certificate_ids.len() <= Self::MAX_CERTIFICATES as usize,
+            previous_certificate_ids.len() <= N::LAST_MAX_CERTIFICATES()? as usize,
             "Invalid number of previous certificate IDs ({})",
             previous_certificate_ids.len()
         );
@@ -153,7 +151,7 @@ impl<N: Network> BatchHeader<N> {
         );
         // Ensure that the number of previous certificate IDs is within bounds.
         ensure!(
-            previous_certificate_ids.len() <= Self::MAX_CERTIFICATES as usize,
+            previous_certificate_ids.len() <= N::LAST_MAX_CERTIFICATES()? as usize,
             "Invalid number of previous certificate IDs ({})",
             previous_certificate_ids.len()
         );

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -93,7 +93,7 @@ impl<N: Network> BatchHeader<N> {
         );
         // Ensure that the number of previous certificate IDs is within bounds.
         ensure!(
-            previous_certificate_ids.len() <= N::LAST_MAX_CERTIFICATES()? as usize,
+            previous_certificate_ids.len() <= N::LATEST_MAX_CERTIFICATES()? as usize,
             "Invalid number of previous certificate IDs ({})",
             previous_certificate_ids.len()
         );
@@ -151,7 +151,7 @@ impl<N: Network> BatchHeader<N> {
         );
         // Ensure that the number of previous certificate IDs is within bounds.
         ensure!(
-            previous_certificate_ids.len() <= N::LAST_MAX_CERTIFICATES()? as usize,
+            previous_certificate_ids.len() <= N::LATEST_MAX_CERTIFICATES()? as usize,
             "Invalid number of previous certificate IDs ({})",
             previous_certificate_ids.len()
         );

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -39,11 +39,8 @@ impl<N: Network> FromBytes for Subdag<N> {
             // Read the number of certificates.
             let num_certificates = u16::read_le(&mut reader)?;
             // Ensure the number of certificates is within bounds.
-            if num_certificates > BatchHeader::<N>::MAX_CERTIFICATES {
-                return Err(error(format!(
-                    "Number of certificates ({num_certificates}) exceeds the maximum ({})",
-                    BatchHeader::<N>::MAX_CERTIFICATES
-                )));
+            if num_certificates > N::LAST_MAX_CERTIFICATES().map_err(error)? {
+                return Err(error(format!("Number of certificates ({num_certificates}) exceeds the maximum.",)));
             }
             // Read the certificates.
             let mut certificates = IndexSet::new();

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -39,7 +39,7 @@ impl<N: Network> FromBytes for Subdag<N> {
             // Read the number of certificates.
             let num_certificates = u16::read_le(&mut reader)?;
             // Ensure the number of certificates is within bounds.
-            if num_certificates > N::LAST_MAX_CERTIFICATES().map_err(error)? {
+            if num_certificates > N::LATEST_MAX_CERTIFICATES().map_err(error)? {
                 return Err(error(format!("Number of certificates ({num_certificates}) exceeds the maximum.",)));
             }
             // Read the certificates.

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -311,7 +311,7 @@ mod tests {
     fn test_max_certificates() {
         // Determine the maximum number of certificates in a block.
         let max_certificates_per_block =
-            BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS * CurrentNetwork::LAST_MAX_CERTIFICATES().unwrap() as usize;
+            BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS * CurrentNetwork::LATEST_MAX_CERTIFICATES().unwrap() as usize;
 
         // Note: The maximum number of certificates in a block must be able to be Merklized.
         assert!(

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -311,7 +311,7 @@ mod tests {
     fn test_max_certificates() {
         // Determine the maximum number of certificates in a block.
         let max_certificates_per_block =
-            BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS * BatchHeader::<CurrentNetwork>::MAX_CERTIFICATES as usize;
+            BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS * CurrentNetwork::LAST_MAX_CERTIFICATES().unwrap() as usize;
 
         // Note: The maximum number of certificates in a block must be able to be Merklized.
         assert!(

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1924,7 +1924,8 @@ fn test_max_committee_limit_with_bonds() {
     let vm = sample_vm();
 
     // Construct the validators, one less than the maximum committee size.
-    let validators = (0..Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 - 1)
+    let max_committee_size = consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap();
+    let validators = (0..max_committee_size - 1)
         .map(|_| {
             let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
             let amount = MIN_VALIDATOR_STAKE;

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1924,7 +1924,7 @@ fn test_max_committee_limit_with_bonds() {
     let vm = sample_vm();
 
     // Construct the validators, one less than the maximum committee size.
-    let max_committee_size = consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap();
+    let max_committee_size = consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap();
     let validators = (0..max_committee_size - 1)
         .map(|_| {
             let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1924,7 +1924,7 @@ fn test_max_committee_limit_with_bonds() {
     let vm = sample_vm();
 
     // Construct the validators, one less than the maximum committee size.
-    let max_committee_size = consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap();
+    let max_committee_size = consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap();
     let validators = (0..max_committee_size - 1)
         .map(|_| {
             let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -104,9 +104,9 @@ impl<N: Network> Process<N> {
         lap!(timer, "Verify the number of transitions");
 
         // Construct the call graph.
-        // If the height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then provide an empty call graph, as it is no longer used during finalization.
-        let call_graph = match state.block_height() {
-            height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => self.construct_call_graph(execution)?,
+        // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
+        let call_graph = match N::CONSENSUS_VERSION(state.block_height())? as usize {
+            1..3 => self.construct_call_graph(execution)?,
             _ => HashMap::new(),
         };
 
@@ -164,11 +164,9 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
     fee: &Fee<N>,
 ) -> Result<Vec<FinalizeOperation<N>>> {
     // Construct the call graph.
-    // If the height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then provide an empty call graph, as it is no longer used during finalization.
-    let call_graph = match state.block_height() {
-        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => {
-            HashMap::from([(*fee.transition_id(), Vec::new())])
-        }
+    // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
+    let call_graph = match N::CONSENSUS_VERSION(state.block_height())? as usize {
+        1..3 => HashMap::from([(*fee.transition_id(), Vec::new())]),
         _ => HashMap::new(),
     };
 
@@ -276,10 +274,10 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     );
 
                     // Get the transition ID used to initialize the finalize registers.
-                    // If the block height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then use the top-level transition ID.
+                    // If the block height is greater than or equal to `ConsensusVersion::V3`, then use the top-level transition ID.
                     // Otherwise, query the call graph for the child transition ID corresponding to the future that is being awaited.
-                    let transition_id = match state.block_height() {
-                        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => {
+                    let transition_id = match N::CONSENSUS_VERSION(state.block_height())? as usize {
+                        1..3 => {
                             // Get the current transition ID.
                             let transition_id = registers.transition_id();
                             // Get the child transition ID.

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -106,7 +106,7 @@ impl<N: Network> Process<N> {
         // Construct the call graph.
         // If the height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then provide an empty call graph, as it is no longer used during finalization.
         let call_graph = match state.block_height() {
-            height if height < N::HEIGHT_V(3)? => self.construct_call_graph(execution)?,
+            height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => self.construct_call_graph(execution)?,
             _ => HashMap::new(),
         };
 
@@ -166,7 +166,9 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
     // Construct the call graph.
     // If the height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then provide an empty call graph, as it is no longer used during finalization.
     let call_graph = match state.block_height() {
-        height if height < N::HEIGHT_V(3)? => HashMap::from([(*fee.transition_id(), Vec::new())]),
+        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => {
+            HashMap::from([(*fee.transition_id(), Vec::new())])
+        }
         _ => HashMap::new(),
     };
 
@@ -277,7 +279,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     // If the block height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then use the top-level transition ID.
                     // Otherwise, query the call graph for the child transition ID corresponding to the future that is being awaited.
                     let transition_id = match state.block_height() {
-                        height if height < N::HEIGHT_V(3)? => {
+                        height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => {
                             // Get the current transition ID.
                             let transition_id = registers.transition_id();
                             // Get the child transition ID.

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -106,7 +106,7 @@ impl<N: Network> Process<N> {
         // Construct the call graph.
         // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
         let call_graph = match N::CONSENSUS_VERSION(state.block_height())? as usize {
-            1..3 => self.construct_call_graph(execution)?,
+            1..=2 => self.construct_call_graph(execution)?,
             _ => HashMap::new(),
         };
 
@@ -166,7 +166,7 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
     // Construct the call graph.
     // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
     let call_graph = match N::CONSENSUS_VERSION(state.block_height())? as usize {
-        1..3 => HashMap::from([(*fee.transition_id(), Vec::new())]),
+        1..=2 => HashMap::from([(*fee.transition_id(), Vec::new())]),
         _ => HashMap::new(),
     };
 
@@ -277,7 +277,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     // If the block height is greater than or equal to `ConsensusVersion::V3`, then use the top-level transition ID.
                     // Otherwise, query the call graph for the child transition ID corresponding to the future that is being awaited.
                     let transition_id = match N::CONSENSUS_VERSION(state.block_height())? as usize {
-                        1..3 => {
+                        1..=2 => {
                             // Get the current transition ID.
                             let transition_id = registers.transition_id();
                             // Get the child transition ID.

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -105,9 +105,9 @@ impl<N: Network> Process<N> {
 
         // Construct the call graph.
         // If the height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then provide an empty call graph, as it is no longer used during finalization.
-        let call_graph = match state.block_height() < N::CONSENSUS_V3_HEIGHT {
-            true => self.construct_call_graph(execution)?,
-            false => HashMap::new(),
+        let call_graph = match state.block_height() {
+            height if height < N::HEIGHT_V(3)? => self.construct_call_graph(execution)?,
+            _ => HashMap::new(),
         };
 
         atomic_batch_scope!(store, {
@@ -165,9 +165,9 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
 ) -> Result<Vec<FinalizeOperation<N>>> {
     // Construct the call graph.
     // If the height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then provide an empty call graph, as it is no longer used during finalization.
-    let call_graph = match state.block_height() < N::CONSENSUS_V3_HEIGHT {
-        true => HashMap::from([(*fee.transition_id(), Vec::new())]),
-        false => HashMap::new(),
+    let call_graph = match state.block_height() {
+        height if height < N::HEIGHT_V(3)? => HashMap::from([(*fee.transition_id(), Vec::new())]),
+        _ => HashMap::new(),
     };
 
     // Finalize the transition.
@@ -276,8 +276,8 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     // Get the transition ID used to initialize the finalize registers.
                     // If the block height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then use the top-level transition ID.
                     // Otherwise, query the call graph for the child transition ID corresponding to the future that is being awaited.
-                    let transition_id = match state.block_height() < N::CONSENSUS_V3_HEIGHT {
-                        true => {
+                    let transition_id = match state.block_height() {
+                        height if height < N::HEIGHT_V(3)? => {
                             // Get the current transition ID.
                             let transition_id = registers.transition_id();
                             // Get the child transition ID.
@@ -289,7 +289,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                                 None => bail!("Transition ID '{transition_id}' not found in call graph"),
                             }
                         }
-                        false => *transition.id(),
+                        _ => *transition.id(),
                     };
 
                     // Increment the nonce.

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -104,10 +104,12 @@ impl<N: Network> Process<N> {
         lap!(timer, "Verify the number of transitions");
 
         // Construct the call graph.
+        let consensus_version = N::CONSENSUS_VERSION(state.block_height())?;
+        let call_graph = if (ConsensusVersion::V1..=ConsensusVersion::V2).contains(&consensus_version) {
+            self.construct_call_graph(execution)?
         // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
-        let call_graph = match N::CONSENSUS_VERSION(state.block_height())? as usize {
-            1..=2 => self.construct_call_graph(execution)?,
-            _ => HashMap::new(),
+        } else {
+            HashMap::new()
         };
 
         atomic_batch_scope!(store, {
@@ -164,10 +166,12 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
     fee: &Fee<N>,
 ) -> Result<Vec<FinalizeOperation<N>>> {
     // Construct the call graph.
-    // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
-    let call_graph = match N::CONSENSUS_VERSION(state.block_height())? as usize {
-        1..=2 => HashMap::from([(*fee.transition_id(), Vec::new())]),
-        _ => HashMap::new(),
+    let consensus_version = N::CONSENSUS_VERSION(state.block_height())?;
+    let call_graph = if (ConsensusVersion::V1..=ConsensusVersion::V2).contains(&consensus_version) {
+        HashMap::from([(*fee.transition_id(), Vec::new())])
+    } else {
+        // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
+        HashMap::new()
     };
 
     // Finalize the transition.
@@ -276,20 +280,20 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     // Get the transition ID used to initialize the finalize registers.
                     // If the block height is greater than or equal to `ConsensusVersion::V3`, then use the top-level transition ID.
                     // Otherwise, query the call graph for the child transition ID corresponding to the future that is being awaited.
-                    let transition_id = match N::CONSENSUS_VERSION(state.block_height())? as usize {
-                        1..=2 => {
-                            // Get the current transition ID.
-                            let transition_id = registers.transition_id();
-                            // Get the child transition ID.
-                            match call_graph.get(transition_id) {
-                                Some(transitions) => match transitions.get(call_counter) {
-                                    Some(transition_id) => *transition_id,
-                                    None => bail!("Child transition ID not found."),
-                                },
-                                None => bail!("Transition ID '{transition_id}' not found in call graph"),
-                            }
+                    let consensus_version = N::CONSENSUS_VERSION(state.block_height())?;
+                    let transition_id = if (ConsensusVersion::V1..=ConsensusVersion::V2).contains(&consensus_version) {
+                        // Get the current transition ID.
+                        let transition_id = registers.transition_id();
+                        // Get the child transition ID.
+                        match call_graph.get(transition_id) {
+                            Some(transitions) => match transitions.get(call_counter) {
+                                Some(transition_id) => *transition_id,
+                                None => bail!("Child transition ID not found."),
+                            },
+                            None => bail!("Transition ID '{transition_id}' not found in call graph"),
                         }
-                        _ => *transition.id(),
+                    } else {
+                        *transition.id()
                     };
 
                     // Increment the nonce.

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -91,8 +91,9 @@ impl<N: Network> RandChaCha<N> {
         // Construct the random seed.
         // If the height is greater than or equal to consensus V3, then use the new preimage definition.
         // The difference is that a nonce is also included in the new definition.
-        let preimage = match N::CONSENSUS_VERSION(registers.state().block_height())? as usize {
-            1..=2 => to_bits_le![
+        let consensus_version = N::CONSENSUS_VERSION(registers.state().block_height())?;
+        let preimage = if (ConsensusVersion::V1..=ConsensusVersion::V2).contains(&consensus_version) {
+            to_bits_le![
                 registers.state().random_seed(),
                 **registers.transition_id(),
                 stack.program_id(),
@@ -100,8 +101,9 @@ impl<N: Network> RandChaCha<N> {
                 self.destination.locator(),
                 self.destination_type.type_id(),
                 seeds
-            ],
-            _ => to_bits_le![
+            ]
+        } else {
+            to_bits_le![
                 registers.state().random_seed(),
                 **registers.transition_id(),
                 stack.program_id(),
@@ -110,7 +112,7 @@ impl<N: Network> RandChaCha<N> {
                 self.destination.locator(),
                 self.destination_type.type_id(),
                 seeds
-            ],
+            ]
         };
 
         // Hash the preimage.

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -91,8 +91,8 @@ impl<N: Network> RandChaCha<N> {
         // Construct the random seed.
         // If the height is greater than or equal to consensus V3, then use the new preimage definition.
         // The difference is that a nonce is also included in the new definition.
-        let preimage = match registers.state().block_height() {
-            height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => to_bits_le![
+        let preimage = match N::CONSENSUS_VERSION(registers.state().block_height())? as usize {
+            1..3 => to_bits_le![
                 registers.state().random_seed(),
                 **registers.transition_id(),
                 stack.program_id(),

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -92,7 +92,7 @@ impl<N: Network> RandChaCha<N> {
         // If the height is greater than or equal to consensus V3, then use the new preimage definition.
         // The difference is that a nonce is also included in the new definition.
         let preimage = match registers.state().block_height() {
-            height if height < N::HEIGHT_V(3)? => to_bits_le![
+            height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V3)? => to_bits_le![
                 registers.state().random_seed(),
                 **registers.transition_id(),
                 stack.program_id(),

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -89,10 +89,10 @@ impl<N: Network> RandChaCha<N> {
         let seeds: Vec<_> = self.operands.iter().map(|operand| registers.load(stack, operand)).try_collect()?;
 
         // Construct the random seed.
-        // If the height is greater than or equal to `CONSENSUS_V3_HEIGHT`, then use the new preimage definition.
+        // If the height is greater than or equal to consensus V3, then use the new preimage definition.
         // The difference is that a nonce is also included in the new definition.
-        let preimage = match registers.state().block_height() < N::CONSENSUS_V3_HEIGHT {
-            true => to_bits_le![
+        let preimage = match registers.state().block_height() {
+            height if height < N::HEIGHT_V(3)? => to_bits_le![
                 registers.state().random_seed(),
                 **registers.transition_id(),
                 stack.program_id(),
@@ -101,7 +101,7 @@ impl<N: Network> RandChaCha<N> {
                 self.destination_type.type_id(),
                 seeds
             ],
-            false => to_bits_le![
+            _ => to_bits_le![
                 registers.state().random_seed(),
                 **registers.transition_id(),
                 stack.program_id(),

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -92,7 +92,7 @@ impl<N: Network> RandChaCha<N> {
         // If the height is greater than or equal to consensus V3, then use the new preimage definition.
         // The difference is that a nonce is also included in the new definition.
         let preimage = match N::CONSENSUS_VERSION(registers.state().block_height())? as usize {
-            1..3 => to_bits_le![
+            1..=2 => to_bits_le![
                 registers.state().random_seed(),
                 **registers.transition_id(),
                 stack.program_id(),

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -48,9 +48,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Compute the minimum execution cost.
                 let query = query.clone().unwrap_or(Query::VM(self.block_store().clone()));
                 let block_height = query.current_block_height()?;
-                let (minimum_execution_cost, (_, _)) = match block_height < N::CONSENSUS_V2_HEIGHT {
-                    true => execution_cost_v1(&self.process().read(), &execution)?,
-                    false => execution_cost_v2(&self.process().read(), &execution)?,
+                let (minimum_execution_cost, (_, _)) = match block_height {
+                    height if height < N::HEIGHT_V(2)? => execution_cost_v1(&self.process().read(), &execution)?,
+                    _ => execution_cost_v2(&self.process().read(), &execution)?,
                 };
                 // Compute the execution ID.
                 let execution_id = execution.to_execution_id()?;
@@ -367,9 +367,6 @@ mod tests {
     #[cfg(feature = "test")]
     #[test]
     fn test_fee_migration_occurs_at_correct_block_height() {
-        // This test will fail if the consensus v2 height is 0
-        assert_ne!(0, CurrentNetwork::CONSENSUS_V2_HEIGHT);
-
         let rng = &mut TestRng::default();
 
         // Initialize a new caller.
@@ -393,7 +390,7 @@ mod tests {
         assert_eq!(51_060, *transaction.base_fee_amount().unwrap());
 
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        for _ in 0..CurrentNetwork::CONSENSUS_V2_HEIGHT {
+        for _ in 0..CurrentNetwork::HEIGHT_V(2).unwrap() {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();
@@ -408,9 +405,6 @@ mod tests {
     #[cfg(feature = "test")]
     #[test]
     fn test_fee_migration_correctly_calculates_nested() {
-        // This test will fail if the consensus v2 height is 0
-        assert_ne!(0, CurrentNetwork::CONSENSUS_V2_HEIGHT);
-
         let rng = &mut TestRng::default();
 
         // Initialize a new caller.
@@ -459,7 +453,7 @@ finalize test:
         assert_eq!(62_776, *transaction.base_fee_amount().unwrap());
 
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        for _ in 1..CurrentNetwork::CONSENSUS_V2_HEIGHT {
+        for _ in 1..CurrentNetwork::HEIGHT_V(2).unwrap() {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -48,10 +48,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Compute the minimum execution cost.
                 let query = query.clone().unwrap_or(Query::VM(self.block_store().clone()));
                 let block_height = query.current_block_height()?;
-                let (minimum_execution_cost, (_, _)) = match block_height {
-                    height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => {
-                        execution_cost_v1(&self.process().read(), &execution)?
-                    }
+                let (minimum_execution_cost, (_, _)) = match N::CONSENSUS_VERSION(block_height)? as usize {
+                    1 => execution_cost_v1(&self.process().read(), &execution)?,
                     _ => execution_cost_v2(&self.process().read(), &execution)?,
                 };
                 // Compute the execution ID.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -47,10 +47,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             true => {
                 // Compute the minimum execution cost.
                 let query = query.clone().unwrap_or(Query::VM(self.block_store().clone()));
-                let block_height = query.current_block_height()?;
-                let (minimum_execution_cost, (_, _)) = match N::CONSENSUS_VERSION(block_height)? as usize {
-                    1 => execution_cost_v1(&self.process().read(), &execution)?,
-                    _ => execution_cost_v2(&self.process().read(), &execution)?,
+                let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
+                let (minimum_execution_cost, (_, _)) = if consensus_version == ConsensusVersion::V1 {
+                    execution_cost_v1(&self.process().read(), &execution)?
+                } else {
+                    execution_cost_v2(&self.process().read(), &execution)?
                 };
                 // Compute the execution ID.
                 let execution_id = execution.to_execution_id()?;

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -49,7 +49,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 let query = query.clone().unwrap_or(Query::VM(self.block_store().clone()));
                 let block_height = query.current_block_height()?;
                 let (minimum_execution_cost, (_, _)) = match block_height {
-                    height if height < N::HEIGHT_V(2)? => execution_cost_v1(&self.process().read(), &execution)?,
+                    height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => {
+                        execution_cost_v1(&self.process().read(), &execution)?
+                    }
                     _ => execution_cost_v2(&self.process().read(), &execution)?,
                 };
                 // Compute the execution ID.
@@ -390,7 +392,7 @@ mod tests {
         assert_eq!(51_060, *transaction.base_fee_amount().unwrap());
 
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        for _ in 0..CurrentNetwork::HEIGHT_V(2).unwrap() {
+        for _ in 0..CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap() {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();
@@ -453,7 +455,7 @@ finalize test:
         assert_eq!(62_776, *transaction.base_fee_amount().unwrap());
 
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        for _ in 1..CurrentNetwork::HEIGHT_V(2).unwrap() {
+        for _ in 1..CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap() {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1916,54 +1916,20 @@ finalize transfer_public:
         // Initialize an RNG.
         let rng = &mut TestRng::default();
 
-        // Initialize the VM.
-        let vm = sample_vm();
-
         // Initialize the validators with the maximum number of validators before consensus v3.
         let validators = sample_validators::<CurrentNetwork>(
             consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap() as usize + 1,
             rng,
         );
 
-        // Initialize a new address.
-        let new_validator_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
-        let new_validator_address = Address::try_from(&new_validator_private_key).unwrap();
-
         // Construct the committee.
         // Track the allocated amount.
-        let (committee_map, allocated_amount) =
+        let (committee_map, _allocated_amount) =
             sample_committee_map_and_allocated_amount(&validators, &IndexMap::new());
 
-        // Collect all of the addresses in a single place
-        let validator_addresses =
-            validators.keys().map(|private_key| Address::try_from(private_key).unwrap()).collect::<Vec<_>>();
-
-        // Construct the public balances, allocating the remaining supply.
-        let new_validator_balance = MIN_VALIDATOR_STAKE + 100_000_000;
-        let mut public_balances = sample_public_balances(
-            &validator_addresses,
-            <CurrentNetwork as Network>::STARTING_SUPPLY - allocated_amount - new_validator_balance,
-        );
-        // Set the public balance of the new validator to the minimum validator stake.
-        public_balances.insert(new_validator_address, new_validator_balance);
-
-        // Construct the bonded balances.
-        let bonded_balances = sample_bonded_balances(&validators, &IndexMap::new());
-
-        // Ensure that the block with too many validators fails to be created.
-        assert!(
-            vm.genesis_quorum(
-                validators.keys().next().unwrap(),
-                Committee::new_genesis(committee_map).unwrap(),
-                public_balances,
-                bonded_balances,
-                rng,
-            )
-            .is_err()
-        );
+        assert!(Committee::new_genesis(committee_map).is_err());
     }
 
-    #[cfg(feature = "test")]
     #[test]
     #[allow(clippy::assertions_on_constants)]
     fn test_migration_v3_maximum_validator_increase() {
@@ -2062,24 +2028,6 @@ finalize transfer_public:
         assert_eq!(
             confirmed_transactions[0],
             reject(0, &bond_validator_transaction, confirmed_transactions[0].finalize_operations())
-        );
-
-        // Update the VM to the migration block height
-        let private_key = test_helpers::sample_genesis_private_key(rng);
-        let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap()
-        {
-            // Call the function
-            let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
-            vm.add_next_block(&next_block).unwrap();
-        }
-
-        // Test that attempting to bond a new validator above the maximum number of validators after the migration block height succeeds.
-
-        // Check that the new committee size is greater than the maximum committee size before the migration.
-        assert!(
-            consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap()
-                < Committee::<CurrentNetwork>::max_committee_size().unwrap()
         );
 
         // Speculate on the transactions.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -500,7 +500,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         time_since_last_block,
                         coinbase_reward,
                         transaction_fees,
-                    );
+                    )
+                    .map_err(|e| format!("Failed to compute the block reward - {e}"))?;
                     // Compute the puzzle reward.
                     let puzzle_reward = ledger_block::puzzle_reward(coinbase_reward);
 
@@ -1000,10 +1001,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Compute the next committee size.
                 let next_committee_size = committee_members.len().saturating_add(num_new_validators);
                 // Determine the maximum committee size to use.
-                let max_committee_size = match state.block_height() < N::CONSENSUS_V3_HEIGHT {
-                    true => Committee::<N>::MAX_COMMITTEE_SIZE_BEFORE_V3,
-                    false => Committee::<N>::MAX_COMMITTEE_SIZE,
-                };
+                let max_committee_size = consensus_config_value!(N::MAX_COMMITTEE_SIZE, state.block_height())
+                    .ok_or(anyhow!("Failed to retrieve the maximum committee size"))?;
                 // Check that the number of new validators being bonded does not exceed the maximum number of validators.
                 match next_committee_size > max_committee_size as usize {
                     true => Err(anyhow!("Call to 'credits.aleo/bond_public' exceeds the committee size")),
@@ -1054,17 +1053,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         "Ratify::Genesis(..) expected a genesis committee round of 0"
                     );
                     // Ensure that the number of members in the committee does not exceed the maximum.
+                    let max_committee_size = consensus_config_value!(N::MAX_COMMITTEE_SIZE, state.block_height())
+                        .ok_or(anyhow!("Ratify::Genesis(..) failed to retrieve the maximum committee size"))?;
                     ensure!(
-                        committee.members().len() <= Committee::<N>::MAX_COMMITTEE_SIZE as usize,
+                        committee.members().len() <= max_committee_size as usize,
                         "Ratify::Genesis(..) exceeds the maximum number of committee members"
                     );
-                    // Ensure that the number of members in the committee does not exceed the maximum before consensus V3 rules apply.
-                    if state.block_height() < N::CONSENSUS_V3_HEIGHT {
-                        ensure!(
-                            committee.members().len() <= Committee::<N>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize,
-                            "Ratify::Genesis(..) exceeds the maximum number of committee members before V3"
-                        );
-                    }
                     // Ensure that the number of delegators does not exceed the maximum.
                     ensure!(
                         bonded_balances.len().saturating_sub(committee.members().len()) <= MAX_DELEGATORS as usize,
@@ -1826,7 +1820,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators.
         let validators = sample_validators::<CurrentNetwork>(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize,
+            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
             rng,
         );
 
@@ -1917,7 +1911,7 @@ finalize transfer_public:
     #[test]
     fn test_genesis_num_validators_does_not_exceed_maximum_before_v3() {
         // This test will fail if the consensus v3 height is 0
-        assert_ne!(0, CurrentNetwork::CONSENSUS_V3_HEIGHT);
+        assert_ne!(0, CurrentNetwork::HEIGHT_V(3).unwrap());
 
         // Initialize an RNG.
         let rng = &mut TestRng::default();
@@ -1927,7 +1921,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators before consensus v3.
         let validators = sample_validators::<CurrentNetwork>(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize + 1,
+            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize + 1,
             rng,
         );
 
@@ -1974,7 +1968,7 @@ finalize transfer_public:
     #[allow(clippy::assertions_on_constants)]
     fn test_migration_v3_maximum_validator_increase() {
         // This test will fail if the consensus v3 height is 0
-        assert_ne!(0, CurrentNetwork::CONSENSUS_V3_HEIGHT);
+        assert_ne!(0, CurrentNetwork::HEIGHT_V(3).unwrap());
 
         // Initialize an RNG.
         let rng = &mut TestRng::default();
@@ -1984,7 +1978,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators before consensus v3.
         let validators = sample_validators::<CurrentNetwork>(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize,
+            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
             rng,
         );
 
@@ -2073,7 +2067,7 @@ finalize transfer_public:
         // Update the VM to the migration block height
         let private_key = test_helpers::sample_genesis_private_key(rng);
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_V3_HEIGHT {
+        while vm.block_store().current_block_height() < CurrentNetwork::HEIGHT_V(3).unwrap() {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();
@@ -2083,14 +2077,15 @@ finalize transfer_public:
 
         // Check that the new committee size is greater than the maximum committee size before the migration.
         assert!(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 < Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE
+            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap()
+                < Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE
         );
 
         // Speculate on the transactions.
         let transactions = [bond_validator_transaction.clone()];
         let (_, confirmed_transactions, aborted_transaction_ids, _) = vm
             .atomic_speculate(
-                sample_finalize_state(CurrentNetwork::CONSENSUS_V3_HEIGHT),
+                sample_finalize_state(CurrentNetwork::HEIGHT_V(3).unwrap()),
                 CurrentNetwork::BLOCK_TIME as i64,
                 None,
                 vec![],
@@ -2650,7 +2645,7 @@ finalize compute:
         // Reset the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators = sample_validators::<CurrentNetwork>(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize,
+            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
             rng,
         );
 
@@ -2695,7 +2690,7 @@ finalize compute:
         // Construct the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators = sample_validators::<CurrentNetwork>(
-            Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE_BEFORE_V3 as usize / 4,
+            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize / 4,
             rng,
         );
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1001,7 +1001,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Compute the next committee size.
                 let next_committee_size = committee_members.len().saturating_add(num_new_validators);
                 // Determine the maximum committee size to use.
-                let max_committee_size = consensus_config_value!(N::MAX_COMMITTEE_SIZE, state.block_height())
+                let max_committee_size = consensus_config_value!(N, MAX_COMMITTEE_SIZE, state.block_height())
                     .ok_or(anyhow!("Failed to retrieve the maximum committee size"))?;
                 // Check that the number of new validators being bonded does not exceed the maximum number of validators.
                 match next_committee_size > max_committee_size as usize {
@@ -1053,7 +1053,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         "Ratify::Genesis(..) expected a genesis committee round of 0"
                     );
                     // Ensure that the number of members in the committee does not exceed the maximum.
-                    let max_committee_size = consensus_config_value!(N::MAX_COMMITTEE_SIZE, state.block_height())
+                    let max_committee_size = consensus_config_value!(N, MAX_COMMITTEE_SIZE, state.block_height())
                         .ok_or(anyhow!("Ratify::Genesis(..) failed to retrieve the maximum committee size"))?;
                     ensure!(
                         committee.members().len() <= max_committee_size as usize,
@@ -1820,7 +1820,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
+            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
             rng,
         );
 
@@ -1921,7 +1921,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators before consensus v3.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize + 1,
+            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize + 1,
             rng,
         );
 
@@ -1978,7 +1978,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators before consensus v3.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
+            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
             rng,
         );
 
@@ -2078,7 +2078,7 @@ finalize transfer_public:
 
         // Check that the new committee size is greater than the maximum committee size before the migration.
         assert!(
-            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap()
+            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap()
                 < Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE
         );
 
@@ -2646,7 +2646,7 @@ finalize compute:
         // Reset the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
+            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
             rng,
         );
 
@@ -2691,7 +2691,7 @@ finalize compute:
         // Construct the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork::MAX_COMMITTEE_SIZE, 0).unwrap() as usize / 4,
+            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize / 4,
             rng,
         );
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1911,7 +1911,7 @@ finalize transfer_public:
     #[test]
     fn test_genesis_num_validators_does_not_exceed_maximum_before_v3() {
         // This test will fail if the consensus v3 height is 0
-        assert_ne!(0, CurrentNetwork::HEIGHT_V(3).unwrap());
+        assert_ne!(0, CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap());
 
         // Initialize an RNG.
         let rng = &mut TestRng::default();
@@ -1968,7 +1968,7 @@ finalize transfer_public:
     #[allow(clippy::assertions_on_constants)]
     fn test_migration_v3_maximum_validator_increase() {
         // This test will fail if the consensus v3 height is 0
-        assert_ne!(0, CurrentNetwork::HEIGHT_V(3).unwrap());
+        assert_ne!(0, CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap());
 
         // Initialize an RNG.
         let rng = &mut TestRng::default();
@@ -2067,7 +2067,8 @@ finalize transfer_public:
         // Update the VM to the migration block height
         let private_key = test_helpers::sample_genesis_private_key(rng);
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        while vm.block_store().current_block_height() < CurrentNetwork::HEIGHT_V(3).unwrap() {
+        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap()
+        {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();
@@ -2085,7 +2086,7 @@ finalize transfer_public:
         let transactions = [bond_validator_transaction.clone()];
         let (_, confirmed_transactions, aborted_transaction_ids, _) = vm
             .atomic_speculate(
-                sample_finalize_state(CurrentNetwork::HEIGHT_V(3).unwrap()),
+                sample_finalize_state(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap()),
                 CurrentNetwork::BLOCK_TIME as i64,
                 None,
                 vec![],

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -226,24 +226,24 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let num_solutions = solutions.len();
         // Retrieve the number of transactions.
         let num_transactions = transactions.len();
+        // Determine the maximum number of aborted solutions allowed in a block.
+        let max_aborted_solutions = Solutions::<N>::max_aborted_solutions()?;
+        // Determine the maximum number of aborted transactions allowed in a block.
+        let max_aborted_transactions = Transactions::<N>::max_aborted_transactions()?;
 
         // Perform the finalize operation on the preset finalize mode.
         atomic_finalize!(self.finalize_store(), FinalizeMode::DryRun, {
             // Ensure the number of solutions does not exceed the maximum.
-            if num_solutions > Solutions::<N>::MAX_ABORTED_SOLUTIONS {
+            if num_solutions > max_aborted_solutions {
                 // Note: This will abort the entire atomic batch.
-                return Err(format!(
-                    "Too many solutions in the block - {num_solutions} (max: {})",
-                    Solutions::<N>::MAX_ABORTED_SOLUTIONS
-                ));
+                return Err(format!("Too many solutions in the block - {num_solutions}",));
             }
 
             // Ensure the number of transactions does not exceed the maximum.
-            if num_transactions > Transactions::<N>::MAX_ABORTED_TRANSACTIONS {
+            if num_transactions > max_aborted_transactions {
                 // Note: This will abort the entire atomic batch.
                 return Err(format!(
-                    "Too many transactions in the block - {num_transactions} (max: {})",
-                    Transactions::<N>::MAX_ABORTED_TRANSACTIONS
+                    "Too many transactions in the block - {num_transactions} (max: {max_aborted_transactions})",
                 ));
             }
 
@@ -1001,7 +1001,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Compute the next committee size.
                 let next_committee_size = committee_members.len().saturating_add(num_new_validators);
                 // Determine the maximum committee size to use.
-                let max_committee_size = consensus_config_value!(N, MAX_COMMITTEE_SIZE, state.block_height())
+                let max_committee_size = consensus_config_value!(N, MAX_CERTIFICATES, state.block_height())
                     .ok_or(anyhow!("Failed to retrieve the maximum committee size"))?;
                 // Check that the number of new validators being bonded does not exceed the maximum number of validators.
                 match next_committee_size > max_committee_size as usize {
@@ -1053,7 +1053,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         "Ratify::Genesis(..) expected a genesis committee round of 0"
                     );
                     // Ensure that the number of members in the committee does not exceed the maximum.
-                    let max_committee_size = consensus_config_value!(N, MAX_COMMITTEE_SIZE, state.block_height())
+                    let max_committee_size = consensus_config_value!(N, MAX_CERTIFICATES, state.block_height())
                         .ok_or(anyhow!("Ratify::Genesis(..) failed to retrieve the maximum committee size"))?;
                     ensure!(
                         committee.members().len() <= max_committee_size as usize,
@@ -1820,7 +1820,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
+            consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap() as usize,
             rng,
         );
 
@@ -1921,7 +1921,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators before consensus v3.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize + 1,
+            consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap() as usize + 1,
             rng,
         );
 
@@ -1978,7 +1978,7 @@ finalize transfer_public:
 
         // Initialize the validators with the maximum number of validators before consensus v3.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
+            consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap() as usize,
             rng,
         );
 
@@ -2078,8 +2078,8 @@ finalize transfer_public:
 
         // Check that the new committee size is greater than the maximum committee size before the migration.
         assert!(
-            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap()
-                < Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE
+            consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap()
+                < Committee::<CurrentNetwork>::max_committee_size().unwrap()
         );
 
         // Speculate on the transactions.
@@ -2629,8 +2629,10 @@ finalize compute:
         let vm = sample_vm();
 
         // Construct the validators, greater than the maximum committee size.
-        let validators =
-            sample_validators::<CurrentNetwork>(Committee::<CurrentNetwork>::MAX_COMMITTEE_SIZE as usize + 1, rng);
+        let validators = sample_validators::<CurrentNetwork>(
+            Committee::<CurrentNetwork>::max_committee_size().unwrap() as usize + 1,
+            rng,
+        );
 
         // Construct the committee.
         let mut committee_map = IndexMap::new();
@@ -2646,7 +2648,7 @@ finalize compute:
         // Reset the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize,
+            consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap() as usize,
             rng,
         );
 
@@ -2691,7 +2693,7 @@ finalize compute:
         // Construct the validators.
         // Note: We use a smaller committee size to ensure that there is enough supply to allocate to the validators and genesis block transactions.
         let validators = sample_validators::<CurrentNetwork>(
-            consensus_config_value!(CurrentNetwork, MAX_COMMITTEE_SIZE, 0).unwrap() as usize / 4,
+            consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, 0).unwrap() as usize / 4,
             rng,
         );
 

--- a/synthesizer/src/vm/helpers/committee.rs
+++ b/synthesizer/src/vm/helpers/committee.rs
@@ -466,7 +466,7 @@ mod tests {
         let rng = &mut TestRng::default();
 
         // Sample a committee.
-        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 100, rng);
+        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 25, rng);
 
         // Initialize the committee map.
         let committee_map = to_committee_map(committee.members());
@@ -489,7 +489,7 @@ mod tests {
         let rng = &mut TestRng::default();
 
         // Sample a committee.
-        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 100, rng);
+        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 25, rng);
         // Convert the committee into stakers.
         let expected_stakers = crate::committee::test_helpers::to_stakers(committee.members(), rng);
         // Initialize the bonded map.
@@ -509,7 +509,7 @@ mod tests {
         let rng = &mut TestRng::default();
 
         // Sample a committee.
-        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 100, rng);
+        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 25, rng);
         // Convert the committee into stakers.
         let stakers = crate::committee::test_helpers::to_stakers(committee.members(), rng);
 
@@ -526,7 +526,7 @@ mod tests {
         let rng = &mut TestRng::default();
 
         // Sample a committee.
-        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 100, rng);
+        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 25, rng);
         // Convert the committee into stakers.
         let _stakers = crate::committee::test_helpers::to_stakers(committee.members(), rng);
         // Convert the committee into delegations.

--- a/synthesizer/src/vm/helpers/rewards.rs
+++ b/synthesizer/src/vm/helpers/rewards.rs
@@ -340,7 +340,7 @@ mod tests {
         // Sample a random block reward.
         let block_reward = rng.gen_range(0..MAX_COINBASE_REWARD);
         // Sample a committee.
-        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 100, rng);
+        let committee = ledger_committee::test_helpers::sample_committee_for_round_and_size(1, 25, rng);
         // Convert the committee into stakers.
         let stakers = crate::committee::test_helpers::to_stakers(committee.members(), rng);
 

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -243,10 +243,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             .block_store()
                             .find_block_height_from_state_root(execution.global_state_root())?
                             .unwrap_or_default();
-                        let (cost, (_, _)) = match block_height {
-                            height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => {
-                                execution_cost_v1(&self.process().read(), execution)?
-                            }
+                        let (cost, (_, _)) = match N::CONSENSUS_VERSION(block_height)? as usize {
+                            1 => execution_cost_v1(&self.process().read(), execution)?,
                             _ => execution_cost_v2(&self.process().read(), execution)?,
                         };
                         // Ensure the fee is sufficient to cover the cost.

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -244,7 +244,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             .find_block_height_from_state_root(execution.global_state_root())?
                             .unwrap_or_default();
                         let (cost, (_, _)) = match block_height {
-                            height if height < N::HEIGHT_V(2)? => execution_cost_v1(&self.process().read(), execution)?,
+                            height if height < N::CONSENSUS_HEIGHT(ConsensusVersion::V2)? => {
+                                execution_cost_v1(&self.process().read(), execution)?
+                            }
                             _ => execution_cost_v2(&self.process().read(), execution)?,
                         };
                         // Ensure the fee is sufficient to cover the cost.
@@ -823,7 +825,7 @@ function compute:
         // Update the VM to the migration block height
         let private_key = test_helpers::sample_genesis_private_key(rng);
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        for _ in 0..CurrentNetwork::HEIGHT_V(2).unwrap() {
+        for _ in 0..CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap() {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -243,9 +243,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             .block_store()
                             .find_block_height_from_state_root(execution.global_state_root())?
                             .unwrap_or_default();
-                        let (cost, (_, _)) = match block_height < N::CONSENSUS_V2_HEIGHT {
-                            true => execution_cost_v1(&self.process().read(), execution)?,
-                            false => execution_cost_v2(&self.process().read(), execution)?,
+                        let (cost, (_, _)) = match block_height {
+                            height if height < N::HEIGHT_V(2)? => execution_cost_v1(&self.process().read(), execution)?,
+                            _ => execution_cost_v2(&self.process().read(), execution)?,
                         };
                         // Ensure the fee is sufficient to cover the cost.
                         if *fee.base_amount()? < cost {
@@ -785,9 +785,6 @@ function compute:
     #[cfg(feature = "test")]
     #[test]
     fn test_fee_migration() {
-        // This test will fail if the consensus v2 height is 0
-        assert_ne!(0, CurrentNetwork::CONSENSUS_V2_HEIGHT);
-
         let minimum_credits_transfer_public_fee = 34_060;
         let old_minimum_credits_transfer_public_fee = 51_060;
 
@@ -826,7 +823,7 @@ function compute:
         // Update the VM to the migration block height
         let private_key = test_helpers::sample_genesis_private_key(rng);
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        for _ in 0..CurrentNetwork::CONSENSUS_V2_HEIGHT {
+        for _ in 0..CurrentNetwork::HEIGHT_V(2).unwrap() {
             // Call the function
             let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
             vm.add_next_block(&next_block).unwrap();

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -243,9 +243,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             .block_store()
                             .find_block_height_from_state_root(execution.global_state_root())?
                             .unwrap_or_default();
-                        let (cost, (_, _)) = match N::CONSENSUS_VERSION(block_height)? as usize {
-                            1 => execution_cost_v1(&self.process().read(), execution)?,
-                            _ => execution_cost_v2(&self.process().read(), execution)?,
+                        let consensus_version = N::CONSENSUS_VERSION(block_height)?;
+                        let (cost, (_, _)) = if consensus_version == ConsensusVersion::V1 {
+                            execution_cost_v1(&self.process().read(), execution)?
+                        } else {
+                            execution_cost_v2(&self.process().read(), execution)?
                         };
                         // Ensure the fee is sufficient to cover the cost.
                         if *fee.base_amount()? < cost {


### PR DESCRIPTION
## Motivation

At the time of writing, consensus-relevant constants for different networks at different block heights are defined in the Environment trait: https://github.com/ProvableHQ/snarkVM/blob/mainnet/console/network/src/

Upgrades to the values of consensus-relevant constants are specified as e.g.:
- CONSENSUS_V2_HEIGHT and CONSENSUS_V3_HEIGHT
- MAX_CERTIFICATES and MAX_CERTIFICATES_BEFORE_V3

However, ideally we have a system which satisfies the following design criteria:
- A developer should be able to see what are the consensus values at a given height, and which changes were introduced at which heights, in order to audit and validate the logic changes.
- When introducing a change to a particular value at a given height, code changes should be minimal. Meaning a developer should only have to specify a {height, value} pair, should be able to retrieve it using something like `CONSTANT.get(height)`, or should only have to adjust a `match` arm.
- When introducing a new consensus version, a developer should only have to add values to constants which are actually changing.
- We don’t have to necessarily express *all* config values in a new format, just the ones which depend on height.
- Constants may only start to be defined from a certain height onwards.

## Why we can't have nice things
- Rust does not allow matching directly on runtime variables or generics, which is why this PR uses `height if height < CONSENSUS_HEIGHT(X)? => { }`.
- Many parts of the code are currently checking that certain values don't surpass `MAX_CERTIFICATES` or `MAX_COMMITTEE_SIZE`, which is not semantically correct, because those values change over time. To limit the scope of this PR, those constants have been left **unchanged**, and a new `N::MAX_COMMITTEE_SIZE` array is introduced along with a test that its largest value matches `MAX_CERTIFICATES`.

## Test Plan

- Added a bunch of unit tests with documentation of what they achieve for the new constants.