### PR TITLE
Correct snarkVM dependency version

### DIFF
--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -60,7 +60,7 @@ features = [ "preserve_order" ]
 [dependencies.synthesizer-snark]
 package = "snarkvm-synthesizer-snark"
 path = "../snark"
-version = "=1.2.1"
+version = "=1.3.0"
 
 [dev-dependencies.bincode]
 version = "1"


### PR DESCRIPTION
## Motivation

Reminder to myself and anyone reading this: make sure CI works after `merge origin into PR`.
