### PR TITLE
[Perf] Simplify the R1CS > Assignment conversion

### DIFF
--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -13,85 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Index;
+use crate::{Constraint, LinearCombination, Variable};
 use snarkvm_fields::PrimeField;
 
 use indexmap::IndexMap;
 use std::sync::Arc;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum AssignmentVariable<F: PrimeField> {
-    Constant(F),
-    Public(Index),
-    Private(Index),
-}
-
-impl<F: PrimeField> From<&crate::Variable<F>> for AssignmentVariable<F> {
-    /// Converts a variable to an assignment variable.
-    fn from(variable: &crate::Variable<F>) -> Self {
-        match variable {
-            crate::Variable::Constant(value) => Self::Constant(**value),
-            crate::Variable::Public(index_value) => {
-                let (index, _value) = index_value.as_ref();
-                Self::Public(*index)
-            }
-            crate::Variable::Private(index_value) => {
-                let (index, _value) = index_value.as_ref();
-                Self::Private(*index)
-            }
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct AssignmentLC<F: PrimeField> {
-    constant: F,
-    terms: Vec<(AssignmentVariable<F>, F)>,
-}
-
-impl<F: PrimeField> From<&crate::LinearCombination<F>> for AssignmentLC<F> {
-    /// Converts a linear combination to an assignment linear combination.
-    fn from(lc: &crate::LinearCombination<F>) -> Self {
-        Self {
-            constant: lc.to_constant(),
-            terms: FromIterator::from_iter(
-                lc.to_terms().iter().map(|(variable, coefficient)| (variable.into(), *coefficient)),
-            ),
-        }
-    }
-}
-
-impl<F: PrimeField> AssignmentLC<F> {
-    /// Returns the constant term of the linear combination.
-    pub const fn constant(&self) -> F {
-        self.constant
-    }
-
-    /// Returns the terms of the linear combination.
-    pub const fn terms(&self) -> &Vec<(AssignmentVariable<F>, F)> {
-        &self.terms
-    }
-
-    /// Returns the number of nonzeros in the linear combination.
-    pub(super) fn num_nonzeros(&self) -> u64 {
-        // Increment by one if the constant is nonzero.
-        match self.constant.is_zero() {
-            true => self.terms.len() as u64,
-            false => (self.terms.len() as u64).saturating_add(1),
-        }
-    }
-}
+use super::R1CS;
 
 /// A struct that contains public variable assignments, private variable assignments,
 /// and constraint assignments.
 #[derive(Clone, Debug)]
 pub struct Assignment<F: PrimeField> {
     /// The public variables.
-    public: Arc<[(Index, F)]>,
+    public: Arc<[Variable<F>]>,
     /// The private variables.
-    private: Arc<[(Index, F)]>,
+    private: Arc<[Variable<F>]>,
     /// The constraints.
-    constraints: Arc<[(AssignmentLC<F>, AssignmentLC<F>, AssignmentLC<F>)]>,
+    constraints: Arc<[Arc<Constraint<F>>]>,
     /// The number of constants, public, and private variables in the assignment.
     num_variables: u64,
 }
@@ -99,38 +38,28 @@ pub struct Assignment<F: PrimeField> {
 impl<F: PrimeField> From<crate::R1CS<F>> for Assignment<F> {
     /// Converts an R1CS to an assignment.
     fn from(r1cs: crate::R1CS<F>) -> Self {
-        #[cfg(feature = "save_r1cs_hashes")]
+	#[cfg(feature = "save_r1cs_hashes")]
         r1cs.save_hash();
 
-        Self {
-            public: FromIterator::from_iter(
-                r1cs.to_public_variables().iter().map(|variable| (variable.index(), variable.value())),
-            ),
-            private: FromIterator::from_iter(
-                r1cs.to_private_variables().iter().map(|variable| (variable.index(), variable.value())),
-            ),
-            constraints: FromIterator::from_iter(r1cs.to_constraints().iter().map(|constraint| {
-                let (a, b, c) = constraint.to_terms();
-                (a.into(), b.into(), c.into())
-            })),
-            num_variables: r1cs.num_variables(),
-        }
+        let R1CS { public, private, constraints, num_variables, .. } = r1cs;
+
+        Self { public: public.into(), private: private.into(), constraints: constraints.into(), num_variables }
     }
 }
 
 impl<F: PrimeField> Assignment<F> {
     /// Returns the public inputs of the assignment.
-    pub const fn public_inputs(&self) -> &Arc<[(Index, F)]> {
+    pub const fn public_inputs(&self) -> &Arc<[Variable<F>]> {
         &self.public
     }
 
     /// Returns the private inputs of the assignment.
-    pub const fn private_inputs(&self) -> &Arc<[(Index, F)]> {
+    pub const fn private_inputs(&self) -> &Arc<[Variable<F>]> {
         &self.private
     }
 
     /// Returns the constraints of the assignment.
-    pub const fn constraints(&self) -> &Arc<[(AssignmentLC<F>, AssignmentLC<F>, AssignmentLC<F>)]> {
+    pub const fn constraints(&self) -> &Arc<[Arc<Constraint<F>>]> {
         &self.constraints
     }
 
@@ -158,7 +87,10 @@ impl<F: PrimeField> Assignment<F> {
     pub fn num_nonzeros(&self) -> (u64, u64, u64) {
         self.constraints
             .iter()
-            .map(|(a, b, c)| (a.num_nonzeros(), b.num_nonzeros(), c.num_nonzeros()))
+            .map(|constraint| {
+                let (a, b, c) = constraint.to_terms();
+                (a.num_nonzeros(), b.num_nonzeros(), c.num_nonzeros())
+            })
             .fold((0, 0, 0), |(a, b, c), (x, y, z)| (a.saturating_add(x), b.saturating_add(y), c.saturating_add(z)))
     }
 }
@@ -187,27 +119,29 @@ impl<F: PrimeField> snarkvm_algorithms::r1cs::ConstraintSynthesizer<F> for Assig
 
         // Allocate the public variables.
         // NOTE: we skip the first public `One` variable because we already allocated it in the `ConstraintSystem` constructor.
-        for (i, (index, value)) in self.public.iter().skip(1).enumerate() {
-            assert_eq!((i + 1) as u64, *index, "Public vars in first system must be processed in lexicographic order");
+        for (i, variable) in self.public.iter().skip(1).enumerate() {
+            let (index, value) = variable.index_value();
+            assert_eq!((i + 1) as u64, index, "Public vars in first system must be processed in lexicographic order");
 
-            let gadget = cs.alloc_input(|| format!("Public {i}"), || Ok(*value))?;
+            let gadget = cs.alloc_input(|| format!("Public {i}"), || Ok(value))?;
 
             assert_eq!(
-                snarkvm_algorithms::r1cs::Index::Public(*index as usize),
+                snarkvm_algorithms::r1cs::Index::Public(index as usize),
                 gadget.get_unchecked(),
                 "Public variables in the second system must match the first system (with an off-by-1 for the public case)"
             );
 
-            let result = converter.public.insert(*index, gadget);
+            let result = converter.public.insert(index, gadget);
 
             assert!(result.is_none(), "Overwrote an existing public variable in the converter");
         }
 
         // Allocate the private variables.
-        for (i, (index, value)) in self.private.iter().enumerate() {
-            assert_eq!(i as u64, *index, "Private variables in first system must be processed in lexicographic order");
+        for (i, variable) in self.private.iter().enumerate() {
+            let (index, value) = variable.index_value();
+            assert_eq!(i as u64, index, "Private variables in first system must be processed in lexicographic order");
 
-            let gadget = cs.alloc(|| format!("Private {i}"), || Ok(*value))?;
+            let gadget = cs.alloc(|| format!("Private {i}"), || Ok(value))?;
 
             assert_eq!(
                 snarkvm_algorithms::r1cs::Index::Private(i),
@@ -215,58 +149,64 @@ impl<F: PrimeField> snarkvm_algorithms::r1cs::ConstraintSynthesizer<F> for Assig
                 "Private variables in the second system must match the first system"
             );
 
-            let result = converter.private.insert(*index, gadget);
+            let result = converter.private.insert(index, gadget);
 
             assert!(result.is_none(), "Overwrote an existing private variable in the converter");
         }
 
         // Enforce all of the constraints.
-        for (i, (a, b, c)) in self.constraints.iter().enumerate() {
+        for (i, constraint) in self.constraints.iter().enumerate() {
+            let (a, b, c) = constraint.to_terms();
             // Converts terms from one linear combination in the first system to the second system.
-            let convert_linear_combination = |lc: &AssignmentLC<F>| -> snarkvm_algorithms::r1cs::LinearCombination<F> {
-                // Initialize a linear combination for the second system.
-                let mut linear_combination = snarkvm_algorithms::r1cs::LinearCombination::<F>::zero();
+            let convert_linear_combination =
+                |lc: &LinearCombination<F>| -> snarkvm_algorithms::r1cs::LinearCombination<F> {
+                    // Initialize a linear combination for the second system.
+                    let mut linear_combination = snarkvm_algorithms::r1cs::LinearCombination::<F>::zero();
 
-                // Process every term in the linear combination.
-                for (variable, coefficient) in lc.terms.iter() {
-                    match variable {
-                        AssignmentVariable::Constant(_) => {
-                            unreachable!(
-                                "Failed during constraint translation. The first system by definition cannot have constant variables in the terms"
-                            )
-                        }
-                        AssignmentVariable::Public(index) => {
-                            let gadget = converter.public.get(index).unwrap();
-                            assert_eq!(
-                                snarkvm_algorithms::r1cs::Index::Public(*index as usize),
-                                gadget.get_unchecked(),
-                                "Failed during constraint translation. The public variable in the second system must match the first system (with an off-by-1 for the public case)"
-                            );
-                            linear_combination += (*coefficient, *gadget);
-                        }
-                        AssignmentVariable::Private(index) => {
-                            let gadget = converter.private.get(index).unwrap();
-                            assert_eq!(
-                                snarkvm_algorithms::r1cs::Index::Private(*index as usize),
-                                gadget.get_unchecked(),
-                                "Failed during constraint translation. The private variable in the second system must match the first system"
-                            );
-                            linear_combination += (*coefficient, *gadget);
+                    // Process every term in the linear combination.
+                    for (variable, coefficient) in lc.to_terms() {
+                        match variable {
+                            Variable::Constant(_) => {
+                                unreachable!(
+                                    "Failed during constraint translation. The first system by definition cannot have constant variables in the terms"
+                                )
+                            }
+                            Variable::Public(index_value) => {
+                                let (index, _) = index_value.as_ref();
+                                let gadget = converter.public.get(index).unwrap();
+                                assert_eq!(
+                                    snarkvm_algorithms::r1cs::Index::Public(*index as usize),
+                                    gadget.get_unchecked(),
+                                    "Failed during constraint translation. The public variable in the second system must match the first system (with an off-by-1 for the public case)"
+                                );
+                                linear_combination += (*coefficient, *gadget);
+                            }
+                            Variable::Private(index_value) => {
+                                let (index, _) = index_value.as_ref();
+                                let gadget = converter.private.get(index).unwrap();
+                                assert_eq!(
+                                    snarkvm_algorithms::r1cs::Index::Private(*index as usize),
+                                    gadget.get_unchecked(),
+                                    "Failed during constraint translation. The private variable in the second system must match the first system"
+                                );
+                                linear_combination += (*coefficient, *gadget);
+                            }
                         }
                     }
-                }
 
-                // Finally, add the accumulated constant value to the linear combination.
-                if !lc.constant.is_zero() {
-                    linear_combination += (
-                        lc.constant,
-                        snarkvm_algorithms::r1cs::Variable::new_unchecked(snarkvm_algorithms::r1cs::Index::Public(0)),
-                    );
-                }
+                    // Finally, add the accumulated constant value to the linear combination.
+                    if !lc.to_constant().is_zero() {
+                        linear_combination += (
+                            lc.to_constant(),
+                            snarkvm_algorithms::r1cs::Variable::new_unchecked(snarkvm_algorithms::r1cs::Index::Public(
+                                0,
+                            )),
+                        );
+                    }
 
-                // Return the linear combination of the second system.
-                linear_combination
-            };
+                    // Return the linear combination of the second system.
+                    linear_combination
+                };
 
             cs.enforce(
                 || format!("Constraint {i}"),

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -38,7 +38,7 @@ pub struct Assignment<F: PrimeField> {
 impl<F: PrimeField> From<crate::R1CS<F>> for Assignment<F> {
     /// Converts an R1CS to an assignment.
     fn from(r1cs: crate::R1CS<F>) -> Self {
-	#[cfg(feature = "save_r1cs_hashes")]
+        #[cfg(feature = "save_r1cs_hashes")]
         r1cs.save_hash();
 
         let R1CS { public, private, constraints, num_variables, .. } = r1cs;

--- a/circuit/environment/src/helpers/counter.rs
+++ b/circuit/environment/src/helpers/counter.rs
@@ -16,17 +16,17 @@
 use crate::*;
 use snarkvm_fields::PrimeField;
 
-use std::{mem, rc::Rc};
+use std::{mem, sync::Arc};
 
 #[derive(Debug, Default, Hash)]
 pub(crate) struct Counter<F: PrimeField> {
     scope: Scope,
-    constraints: Vec<Rc<Constraint<F>>>,
+    constraints: Vec<Arc<Constraint<F>>>,
     constants: u64,
     public: u64,
     private: u64,
     nonzeros: (u64, u64, u64),
-    parents: Vec<(Scope, Vec<Rc<Constraint<F>>>, u64, u64, u64, (u64, u64, u64))>,
+    parents: Vec<(Scope, Vec<Arc<Constraint<F>>>, u64, u64, u64, (u64, u64, u64))>,
 }
 
 impl<F: PrimeField> Counter<F> {
@@ -93,7 +93,7 @@ impl<F: PrimeField> Counter<F> {
     }
 
     /// Increments the number of constraints by 1.
-    pub(crate) fn add_constraint(&mut self, constraint: Rc<Constraint<F>>) {
+    pub(crate) fn add_constraint(&mut self, constraint: Arc<Constraint<F>>) {
         let (a_nonzeros, b_nonzeros, c_nonzeros) = constraint.num_nonzeros();
         self.nonzeros.0 += a_nonzeros;
         self.nonzeros.1 += b_nonzeros;

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -490,7 +490,7 @@ mod tests {
     use super::*;
     use snarkvm_fields::{One as O, Zero as Z};
 
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn test_zero() {
@@ -546,7 +546,7 @@ mod tests {
         let two = one + one;
         let four = two + two;
 
-        let start = LinearCombination::from(Variable::Public(Rc::new((1, one))));
+        let start = LinearCombination::from(Variable::Public(Arc::new((1, one))));
         assert!(!start.is_constant());
         assert_eq!(one, start.value());
 

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -21,7 +21,7 @@ use snarkvm_fields::PrimeField;
 
 #[cfg(feature = "save_r1cs_hashes")]
 use sha2::{Digest, Sha256};
-use std::rc::Rc;
+use std::sync::Arc;
 #[cfg(feature = "save_r1cs_hashes")]
 use std::{
     hash::{Hash, Hasher},
@@ -62,11 +62,11 @@ pub static R1CS_HASHES: Mutex<Vec<[u8; 32]>> = Mutex::new(Vec::new());
 #[derive(Debug, Hash)]
 pub struct R1CS<F: PrimeField> {
     constants: Vec<Variable<F>>,
-    public: Vec<Variable<F>>,
-    private: Vec<Variable<F>>,
-    constraints: Vec<Rc<Constraint<F>>>,
+    pub(crate) public: Vec<Variable<F>>,
+    pub(crate) private: Vec<Variable<F>>,
+    pub(crate) constraints: Vec<Arc<Constraint<F>>>,
     counter: Counter<F>,
-    num_variables: u64,
+    pub(crate) num_variables: u64,
     nonzeros: (u64, u64, u64),
 }
 
@@ -75,7 +75,7 @@ impl<F: PrimeField> R1CS<F> {
     pub(crate) fn new() -> Self {
         Self {
             constants: Default::default(),
-            public: vec![Variable::Public(Rc::new((0u64, F::one())))],
+            public: vec![Variable::Public(Arc::new((0u64, F::one())))],
             private: Default::default(),
             constraints: Default::default(),
             counter: Default::default(),
@@ -96,7 +96,7 @@ impl<F: PrimeField> R1CS<F> {
 
     /// Returns a new constant with the given value and scope.
     pub(crate) fn new_constant(&mut self, value: F) -> Variable<F> {
-        let variable = Variable::Constant(Rc::new(value));
+        let variable = Variable::Constant(Arc::new(value));
         self.constants.push(variable.clone());
         self.counter.increment_constant();
         self.num_variables += 1;
@@ -105,7 +105,7 @@ impl<F: PrimeField> R1CS<F> {
 
     /// Returns a new public variable with the given value and scope.
     pub(crate) fn new_public(&mut self, value: F) -> Variable<F> {
-        let variable = Variable::Public(Rc::new((self.public.len() as u64, value)));
+        let variable = Variable::Public(Arc::new((self.public.len() as u64, value)));
         self.public.push(variable.clone());
         self.counter.increment_public();
         self.num_variables += 1;
@@ -114,7 +114,7 @@ impl<F: PrimeField> R1CS<F> {
 
     /// Returns a new private variable with the given value and scope.
     pub(crate) fn new_private(&mut self, value: F) -> Variable<F> {
-        let variable = Variable::Private(Rc::new((self.private.len() as u64, value)));
+        let variable = Variable::Private(Arc::new((self.private.len() as u64, value)));
         self.private.push(variable.clone());
         self.counter.increment_private();
         self.num_variables += 1;
@@ -128,8 +128,8 @@ impl<F: PrimeField> R1CS<F> {
         self.nonzeros.1 += b_nonzeros;
         self.nonzeros.2 += c_nonzeros;
 
-        let constraint = Rc::new(constraint);
-        self.constraints.push(Rc::clone(&constraint));
+        let constraint = Arc::new(constraint);
+        self.constraints.push(Arc::clone(&constraint));
         self.counter.add_constraint(constraint);
     }
 
@@ -242,7 +242,7 @@ impl<F: PrimeField> R1CS<F> {
     }
 
     /// Returns the constraints in the constraint system.
-    pub fn to_constraints(&self) -> &Vec<Rc<Constraint<F>>> {
+    pub fn to_constraints(&self) -> &Vec<Arc<Constraint<F>>> {
         &self.constraints
     }
 

--- a/circuit/environment/src/helpers/variable.rs
+++ b/circuit/environment/src/helpers/variable.rs
@@ -21,15 +21,15 @@ use core::{
     fmt,
     ops::{Add, Sub},
 };
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub type Index = u64;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Variable<F: PrimeField> {
-    Constant(Rc<F>),
-    Public(Rc<(Index, F)>),
-    Private(Rc<(Index, F)>),
+    Constant(Arc<F>),
+    Public(Arc<(Index, F)>),
+    Private(Arc<(Index, F)>),
 }
 
 impl<F: PrimeField> Variable<F> {
@@ -90,6 +90,19 @@ impl<F: PrimeField> Variable<F> {
             }
         }
     }
+
+    ///
+    /// Returns the relative index and value of the variable.
+    ///
+    pub fn index_value(&self) -> (Index, F) {
+        match self {
+            Self::Constant(value) => (0, **value),
+            Self::Public(index_value) | Self::Private(index_value) => {
+                let (index, value) = index_value.as_ref();
+                (*index, *value)
+            }
+        }
+    }
 }
 
 impl<F: PrimeField> PartialOrd for Variable<F> {
@@ -146,7 +159,7 @@ impl<F: PrimeField> Add<&Variable<F>> for &Variable<F> {
 
     fn add(self, other: &Variable<F>) -> Self::Output {
         match (self, other) {
-            (Variable::Constant(a), Variable::Constant(b)) => Variable::Constant(Rc::new(**a + **b)).into(),
+            (Variable::Constant(a), Variable::Constant(b)) => Variable::Constant(Arc::new(**a + **b)).into(),
             (first, second) => LinearCombination::from([first.clone(), second.clone()]),
         }
     }
@@ -219,7 +232,7 @@ impl<F: PrimeField> Sub<&Variable<F>> for &Variable<F> {
 
     fn sub(self, other: &Variable<F>) -> Self::Output {
         match (self, other) {
-            (Variable::Constant(a), Variable::Constant(b)) => Variable::Constant(Rc::new(**a - **b)).into(),
+            (Variable::Constant(a), Variable::Constant(b)) => Variable::Constant(Arc::new(**a - **b)).into(),
             (first, second) => LinearCombination::from(first) - second,
         }
     }

--- a/circuit/types/boolean/src/not.rs
+++ b/circuit/types/boolean/src/not.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use std::rc::Rc;
+use std::sync::Arc;
 
 impl<E: Environment> Not for Boolean<E> {
     type Output = Boolean<E>;
@@ -39,7 +39,7 @@ impl<E: Environment> Not for &Boolean<E> {
             // Public and private cases.
             // Note: We directly instantiate a public variable to correctly represent a boolean in a linear combination.
             // For more information, see `LinearCombination::is_boolean_type`.
-            false => Boolean(Variable::Public(Rc::new((0, E::BaseField::one()))) - &self.0),
+            false => Boolean(Variable::Public(Arc::new((0, E::BaseField::one()))) - &self.0),
         }
     }
 }


### PR DESCRIPTION
The next (after the independent https://github.com/ProvableHQ/snarkVM/pull/2620) chapter in the synthesis optimization saga.

The conversion from `R1CS` to the `Assignment` needed for `ConstraintSynthesizer::generate_constraints` is very costly due to the allocations involved. However, most of it is actually unnecessary, and despite my worries that it had been done in order to reduce memory use, skipping it actually leads to lower utilization of RAM.

The performance impact, measured with the same synthesis as in the aforementioned other PR, is as follows:
- runtime **-21%**
- total allocs **and** deallocs **-18%** each
- peak RAM **-43%**

As for the benchmark from the aforementioned other PR:
```
CheckDeployment for do  time:   [847.87 ms 848.42 ms 848.94 ms]
                        change: [-35.625% -34.795% -34.243%] (p = 0.00 < 0.05)
                        Performance has improved.
```
However, this one also has an impact on another new benchmark from that PR:
```
CheckDeployment for transfer_private
                        time:   [139.91 ms 140.01 ms 140.20 ms]
                        change: [-10.901% -9.3525% -7.7967%] (p = 0.00 < 0.05)
                        Performance has improved.
```
(there is also a new `transfer_public` benchmark, but it's not as stable on my machine, returning results ranging from -3% to +3%)