### PR TITLE
[Perf] Use SmallVec in LinearCombination

### DIFF
--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -64,6 +64,9 @@ version = "0.10"
 default-features = false
 optional = true
 
+[dependencies.singlevec]
+version = "1.7"
+
 [dev-dependencies.snarkvm-algorithms]
 path = "../../algorithms"
 features = [ "polycommit_full", "snark", "test" ]

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -64,8 +64,8 @@ version = "0.10"
 default-features = false
 optional = true
 
-[dependencies.singlevec]
-version = "1.7"
+[dependencies.smallvec]
+version = "1.14"
 
 [dev-dependencies.snarkvm-algorithms]
 path = "../../algorithms"

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -20,6 +20,7 @@ use core::{
     fmt,
     ops::{Add, AddAssign, Mul, Neg, Sub},
 };
+use singlevec::SingleVec;
 
 // Before high level program operations are converted into constraints, they are first tracked as linear combinations.
 // Each linear combination corresponds to a portion or all of a single row of an R1CS matrix, and consists of:
@@ -35,7 +36,7 @@ use core::{
 pub struct LinearCombination<F: PrimeField> {
     constant: F,
     /// The list of terms is kept sorted in order to speed up lookups.
-    terms: Vec<(Variable<F>, F)>,
+    terms: SingleVec<(Variable<F>, F)>,
     /// The value of this linear combination, defined as the sum of the `terms` and `constant`.
     value: F,
 }

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -20,7 +20,7 @@ use core::{
     fmt,
     ops::{Add, AddAssign, Mul, Neg, Sub},
 };
-use singlevec::SingleVec;
+use smallvec::SmallVec;
 
 // Before high level program operations are converted into constraints, they are first tracked as linear combinations.
 // Each linear combination corresponds to a portion or all of a single row of an R1CS matrix, and consists of:
@@ -36,7 +36,7 @@ use singlevec::SingleVec;
 pub struct LinearCombination<F: PrimeField> {
     constant: F,
     /// The list of terms is kept sorted in order to speed up lookups.
-    terms: SingleVec<(Variable<F>, F)>,
+    terms: SmallVec<[(Variable<F>, F); 1]>,
     /// The value of this linear combination, defined as the sum of the `terms` and `constant`.
     value: F,
 }

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -50,6 +50,11 @@ name = "stack_operations"
 path = "benches/stack_operations.rs"
 harness = false
 
+[[bench]]
+name = "check_deployment"
+path = "benches/check_deployment.rs"
+harness = false
+
 [dependencies.console]
 package = "snarkvm-console"
 path = "../../console"

--- a/synthesizer/process/benches/check_deployment.rs
+++ b/synthesizer/process/benches/check_deployment.rs
@@ -1,0 +1,156 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate criterion;
+
+use snarkvm_synthesizer_process::{Assignments, CallStack, Process, Stack, StackExecute};
+use synthesizer_program::{Program, StackProgram};
+
+use circuit::AleoV0;
+use console::{
+    account::{Address, PrivateKey},
+    network::{MainnetV0, prelude::*},
+    program::{Identifier, ProgramID, Request, Value},
+};
+use criterion::Criterion;
+use std::{str::FromStr, time::Duration};
+use utilities::TestRng;
+
+type CurrentNetwork = MainnetV0;
+type CurrentAleo = AleoV0;
+
+fn prepare_check_deployment<N: Network, A: circuit::Aleo<Network = N>>(
+    c: &mut Criterion,
+    stack: &Stack<N>,
+    private_key: &PrivateKey<N>,
+    function_name: Identifier<N>,
+    inputs: &[Value<N>],
+    rng: &mut TestRng,
+) {
+    // Retrieve the program.
+    let program = stack.program();
+    // Get the program ID.
+    let program_id = *program.id();
+    // Retrieve the input types.
+    let input_types = program.get_function(&function_name).unwrap().input_types();
+    // Sample 'root_tvk'.
+    let root_tvk = None;
+    // Sample 'is_root'.
+    let is_root = true;
+    // Compute the request.
+    let request =
+        Request::sign(private_key, program_id, function_name, inputs.iter(), &input_types, root_tvk, is_root, rng)
+            .unwrap();
+    // Initialize the assignments.
+    let assignments = Assignments::<N>::default();
+    // Initialize the call stack.
+    let call_stack = CallStack::CheckDeployment(vec![request], *private_key, assignments.clone(), None, None);
+
+    // Benchmark synthesis of the circuit.
+    c.bench_function(&format!("CheckDeployment for {function_name}"), |b| {
+        b.iter(|| {
+            let _response = stack.execute_function::<A, _>(call_stack.clone(), None, None, rng).unwrap();
+        })
+    });
+}
+
+fn transfer_private(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller account.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let caller = Address::try_from(&private_key).unwrap();
+
+    // Construct a new process.
+    let process = Process::load().unwrap();
+    // Retrieve the stack.
+    let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+
+    // Declare the function name.
+    let function_name = Identifier::from_str("transfer_private").unwrap();
+
+    // Declare the inputs.
+    let r0 = Value::from_str(&format!(
+        "{{ owner: {caller}.private, microcredits: 1_500_000_000_000_000_u64.private, _nonce: {}.public }}",
+        console::types::Group::<CurrentNetwork>::zero()
+    ))
+    .unwrap();
+    let r1 = Value::<CurrentNetwork>::from_str(&format!("{caller}")).unwrap();
+    let r2 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
+
+    // Compute the assignment.
+    prepare_check_deployment::<_, CurrentAleo>(c, stack, &private_key, function_name, &[r0, r1, r2], rng);
+}
+
+fn transfer_public(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller account.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let caller = Address::try_from(&private_key).unwrap();
+
+    // Construct a new process.
+    let process = Process::load().unwrap();
+    // Retrieve the stack.
+    let stack = process.get_stack(ProgramID::from_str("credits.aleo").unwrap()).unwrap();
+
+    // Declare the function name.
+    let function_name = Identifier::from_str("transfer_public").unwrap();
+
+    // Declare the inputs.
+    let r0 = Value::<CurrentNetwork>::from_str(&format!("{caller}")).unwrap();
+    let r1 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
+
+    // Compute the assignment.
+    prepare_check_deployment::<_, CurrentAleo>(c, stack, &private_key, function_name, &[r0, r1], rng);
+}
+
+fn large_program(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+
+    // Construct a new process.
+    let process = Process::load().unwrap();
+    // Create the program.
+    let program = Program::from_str(
+        r"
+program synthesis_overload.aleo;
+function do:
+    input r0 as [[u128; 32u32]; 2u32].private;
+    hash.sha3_256 r0 into r1 as field;
+    output r1 as field.public;",
+    )
+    .unwrap();
+    // Create the stack.
+    let stack = Stack::new(&process, &program).unwrap();
+
+    // Declare the function name.
+    let function_name = Identifier::from_str("do").unwrap();
+
+    // Declare the inputs.
+    let r0 = Value::<CurrentNetwork>::from_str("[[1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128], [1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128, 1u128]]").unwrap();
+
+    // Compute the assignment.
+    prepare_check_deployment::<_, CurrentAleo>(c, &stack, &private_key, function_name, &[r0], rng);
+}
+
+criterion_group! {
+    name = check_deployment;
+    config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(10));
+    targets = large_program, transfer_private, transfer_public
+}
+criterion_main!(check_deployment);


### PR DESCRIPTION
I think this PR, third in the series (https://github.com/ProvableHQ/snarkVM/pull/2620, https://github.com/ProvableHQ/snarkVM/pull/2621), concludes the heap-related optimizations that can be applied to synthesis, at least based on the new `large_program` benchmark. It is also the simplest - it only substitutes one `Vec` with a `SingleVec`, which is optimized for the scenario that is most common/impactful - `LinearCombination`s consisting of a single term. I've also run profiling using a `SmallVec<[T; N]>` with `N` ranging from `1` to `8`, and it performed favorably to all of them.

This change has the following impact:
- total allocs & deallocs **-47%**
- max RAM **-2%**
```
CheckDeployment for do  time:   [867.22 ms 869.05 ms 871.85 ms]
                        change: [-32.516% -31.569% -30.881%] (p = 0.00 < 0.05)
                        Performance has improved.
```