### PR TITLE
[Refactor] Move committee cache from snarkOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,6 +3278,7 @@ dependencies = [
  "bincode",
  "criterion",
  "indexmap 2.7.1",
+ "lru",
  "parking_lot",
  "rand",
  "rayon",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -122,6 +122,9 @@ version = "1.0.73"
 version = "2.0"
 features = [ "serde" ]
 
+[dependencies.lru]
+version = "0.12"
+
 [dependencies.parking_lot]
 version = "0.12"
 

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -23,7 +23,30 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the committee for the given `round`.
     pub fn get_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
-        self.vm.finalize_store().committee_store().get_committee_for_round(round)
+        // Check if the committee is already in the cache.
+        if let Some(committee) = self.committee_cache.lock().get(&round) {
+            return Ok(Some(committee.clone()));
+        }
+
+        match self.vm.finalize_store().committee_store().get_committee_for_round(round)? {
+            // Return the committee if it exists.
+            Some(committee) => {
+                // Insert the committee into the cache.
+                self.committee_cache.lock().push(round, committee.clone());
+                // Return the committee.
+                Ok(Some(committee))
+            }
+            // Return the current committee if the round is equivalent.
+            None => {
+                // Retrieve the current committee.
+                let current_committee = self.latest_committee()?;
+                // Return the current committee if the round is equivalent.
+                match current_committee.starting_round() == round {
+                    true => Ok(Some(current_committee)),
+                    false => Ok(None),
+                }
+            }
+        }
     }
 
     /// Returns the committee lookback for the given round.

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -70,7 +70,8 @@ use aleo_std::{
 use anyhow::Result;
 use core::ops::Range;
 use indexmap::IndexMap;
-use parking_lot::RwLock;
+use lru::LruCache;
+use parking_lot::{Mutex, RwLock};
 use rand::{prelude::IteratorRandom, rngs::OsRng};
 use std::{borrow::Cow, sync::Arc};
 use time::OffsetDateTime;
@@ -79,6 +80,9 @@ use time::OffsetDateTime;
 use rayon::prelude::*;
 
 pub type RecordMap<N> = IndexMap<Field<N>, Record<N, Plaintext<N>>>;
+
+/// The capacity of the LRU holding the recently queried committees.
+const COMMITTEE_CACHE_SIZE: usize = 16;
 
 #[derive(Copy, Clone, Debug)]
 pub enum RecordsFilter<N: Network> {
@@ -106,6 +110,8 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
     current_committee: Arc<RwLock<Option<Committee<N>>>>,
     /// The current block.
     current_block: Arc<RwLock<Block<N>>>,
+    /// The recent committees of interest paired with their applicable rounds.
+    committee_cache: Arc<Mutex<LruCache<u64, Committee<N>>>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
@@ -160,6 +166,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Retrieve the current committee.
         let current_committee = vm.finalize_store().committee_store().current_committee().ok();
 
+        // Create a committee cache.
+        let committee_cache = Arc::new(Mutex::new(LruCache::new(COMMITTEE_CACHE_SIZE.try_into().unwrap())));
+
         // Initialize the ledger.
         let mut ledger = Self {
             vm,
@@ -167,6 +176,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             current_epoch_hash: Default::default(),
             current_committee: Arc::new(RwLock::new(current_committee)),
             current_block: Arc::new(RwLock::new(genesis_block.clone())),
+            committee_cache,
         };
 
         // If the block store is empty, initialize the genesis block.
@@ -299,6 +309,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the latest block transactions.
     pub fn latest_transactions(&self) -> Transactions<N> {
         self.current_block.read().transactions().clone()
+    }
+
+    /// Returns a reference to the committee cache.
+    pub fn committee_cache(&self) -> &Arc<Mutex<LruCache<u64, Committee<N>>>> {
+        &self.committee_cache
     }
 }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -310,11 +310,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     pub fn latest_transactions(&self) -> Transactions<N> {
         self.current_block.read().transactions().clone()
     }
-
-    /// Returns a reference to the committee cache.
-    pub fn committee_cache(&self) -> &Arc<Mutex<LruCache<u64, Committee<N>>>> {
-        &self.committee_cache
-    }
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {


### PR DESCRIPTION
As requested [here](https://github.com/ProvableHQ/snarkVM/pull/2615#discussion_r1975347420); it's a simple 1:1 move.