### PR TITLE
[Refactor] Update deployment storage to handle future nonzero editions.

### DIFF
--- a/ledger/store/src/helpers/memory/transaction.rs
+++ b/ledger/store/src/helpers/memory/transaction.rs
@@ -90,8 +90,10 @@ impl<N: Network> TransactionStorage<N> for TransactionMemory<N> {
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub struct DeploymentMemory<N: Network> {
-    /// The ID map.
-    id_map: MemoryMap<N::TransactionID, ProgramID<N>>,
+    /// The V1 ID map.
+    id_map_v1: MemoryMap<N::TransactionID, ProgramID<N>>,
+    /// The V2 ID map.
+    id_map_v2: MemoryMap<N::TransactionID, (ProgramID<N>, u16)>,
     /// The edition map.
     edition_map: MemoryMap<ProgramID<N>, u16>,
     /// The reverse ID map.
@@ -110,7 +112,8 @@ pub struct DeploymentMemory<N: Network> {
 
 #[rustfmt::skip]
 impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
-    type IDMap = MemoryMap<N::TransactionID, ProgramID<N>>;
+    type IDMapV1 = MemoryMap<N::TransactionID, ProgramID<N>>;
+    type IDMapV2 = MemoryMap<N::TransactionID, (ProgramID<N>, u16)>;
     type EditionMap = MemoryMap<ProgramID<N>, u16>;
     type ReverseIDMap = MemoryMap<(ProgramID<N>, u16), N::TransactionID>;
     type OwnerMap = MemoryMap<(ProgramID<N>, u16), ProgramOwner<N>>;
@@ -122,7 +125,8 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
     /// Initializes the deployment storage.
     fn open(fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self> {
         Ok(Self {
-            id_map: MemoryMap::default(),
+            id_map_v1: MemoryMap::default(),
+            id_map_v2: MemoryMap::default(),
             edition_map: MemoryMap::default(),
             reverse_id_map: MemoryMap::default(),
             owner_map: MemoryMap::default(),
@@ -133,9 +137,14 @@ impl<N: Network> DeploymentStorage<N> for DeploymentMemory<N> {
         })
     }
 
-    /// Returns the ID map.
-    fn id_map(&self) -> &Self::IDMap {
-        &self.id_map
+    /// Returns the V1 ID map.
+    fn id_map_v1(&self) -> &Self::IDMapV1 {
+        &self.id_map_v1
+    }
+
+    /// Returns the V2 ID map.
+    fn id_map_v2(&self) -> &Self::IDMapV2 {
+        &self.id_map_v2
     }
 
     /// Returns the edition map.

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -105,7 +105,8 @@ pub enum CommitteeMap {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(u16)]
 pub enum DeploymentMap {
-    ID = DataID::DeploymentIDMap as u16,
+    IDV1 = DataID::DeploymentIDV1Map as u16,
+    IDV2 = DataID::DeploymentIDV2Map as u16,
     Edition = DataID::DeploymentEditionMap as u16,
     ReverseID = DataID::DeploymentReverseIDMap as u16,
     Owner = DataID::DeploymentOwnerMap as u16,
@@ -248,7 +249,7 @@ enum DataID {
     RoundToHeightMap,
     CommitteeMap,
     // Deployment
-    DeploymentIDMap,
+    DeploymentIDV1Map,
     DeploymentEditionMap,
     DeploymentReverseIDMap,
     DeploymentOwnerMap,
@@ -305,4 +306,7 @@ enum DataID {
     Test4,
     #[cfg(test)]
     Test5,
+
+    // Additional
+    DeploymentIDV2Map,
 }

--- a/ledger/store/src/helpers/rocksdb/transaction.rs
+++ b/ledger/store/src/helpers/rocksdb/transaction.rs
@@ -100,8 +100,10 @@ impl<N: Network> TransactionStorage<N> for TransactionDB<N> {
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub struct DeploymentDB<N: Network> {
-    /// The ID map.
-    id_map: DataMap<N::TransactionID, ProgramID<N>>,
+    /// The V1 ID map.
+    id_map_v1: DataMap<N::TransactionID, ProgramID<N>>,
+    /// The V2 ID map.
+    id_map_v2: DataMap<N::TransactionID, (ProgramID<N>, u16)>,
     /// The edition map.
     edition_map: DataMap<ProgramID<N>, u16>,
     /// The reverse ID map.
@@ -120,7 +122,8 @@ pub struct DeploymentDB<N: Network> {
 
 #[rustfmt::skip]
 impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
-    type IDMap = DataMap<N::TransactionID, ProgramID<N>>;
+    type IDMapV1 = DataMap<N::TransactionID, ProgramID<N>>;
+    type IDMapV2 = DataMap<N::TransactionID, (ProgramID<N>, u16)>;
     type EditionMap = DataMap<ProgramID<N>, u16>;
     type ReverseIDMap = DataMap<(ProgramID<N>, u16), N::TransactionID>;
     type OwnerMap = DataMap<(ProgramID<N>, u16), ProgramOwner<N>>;
@@ -134,7 +137,8 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
         // Retrieve the storage mode.
         let storage_mode = fee_store.storage_mode();
         Ok(Self {
-            id_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::ID))?,
+            id_map_v1: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::IDV1))?,
+            id_map_v2: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::IDV2))?,
             edition_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::Edition))?,
             reverse_id_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::ReverseID))?,
             owner_map: rocksdb::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::Deployment(DeploymentMap::Owner))?,
@@ -145,10 +149,15 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
         })
     }
 
-    /// Returns the ID map.
-    fn id_map(&self) -> &Self::IDMap {
-        &self.id_map
+    /// Returns the V1 ID map.
+    fn id_map_v1(&self) -> &Self::IDMapV1 {
+        &self.id_map_v1
     }
+
+    /// Returns the V2 ID map.
+    fn id_map_v2(&self) -> &Self::IDMapV2 {
+        &self.id_map_v2
+    }       
 
     /// Returns the edition map.
     fn edition_map(&self) -> &Self::EditionMap {

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -37,7 +37,9 @@ use std::borrow::Cow;
 /// A trait for deployment storage.
 pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
     /// The mapping of `transaction ID` to `program ID`.
-    type IDMap: for<'a> Map<'a, N::TransactionID, ProgramID<N>>;
+    type IDMapV1: for<'a> Map<'a, N::TransactionID, ProgramID<N>>;
+    /// The mapping of `transaction ID` to `(program ID, edition)`.
+    type IDMapV2: for<'a> Map<'a, N::TransactionID, (ProgramID<N>, u16)>;
     /// The mapping of `program ID` to `edition`.
     type EditionMap: for<'a> Map<'a, ProgramID<N>, u16>;
     /// The mapping of `(program ID, edition)` to `transaction ID`.
@@ -57,7 +59,9 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
     fn open(fee_store: FeeStore<N, Self::FeeStorage>) -> Result<Self>;
 
     /// Returns the ID map.
-    fn id_map(&self) -> &Self::IDMap;
+    fn id_map_v1(&self) -> &Self::IDMapV1;
+    /// Returns the V2 ID map.
+    fn id_map_v2(&self) -> &Self::IDMapV2;
     /// Returns the edition map.
     fn edition_map(&self) -> &Self::EditionMap;
     /// Returns the reverse ID map.
@@ -80,7 +84,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Starts an atomic batch write operation.
     fn start_atomic(&self) {
-        self.id_map().start_atomic();
+        self.id_map_v1().start_atomic();
+        self.id_map_v2().start_atomic();
         self.edition_map().start_atomic();
         self.reverse_id_map().start_atomic();
         self.owner_map().start_atomic();
@@ -92,7 +97,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Checks if an atomic batch is in progress.
     fn is_atomic_in_progress(&self) -> bool {
-        self.id_map().is_atomic_in_progress()
+        self.id_map_v1().is_atomic_in_progress()
+            || self.id_map_v2().is_atomic_in_progress()
             || self.edition_map().is_atomic_in_progress()
             || self.reverse_id_map().is_atomic_in_progress()
             || self.owner_map().is_atomic_in_progress()
@@ -104,7 +110,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Checkpoints the atomic batch.
     fn atomic_checkpoint(&self) {
-        self.id_map().atomic_checkpoint();
+        self.id_map_v1().atomic_checkpoint();
+        self.id_map_v2().atomic_checkpoint();
         self.edition_map().atomic_checkpoint();
         self.reverse_id_map().atomic_checkpoint();
         self.owner_map().atomic_checkpoint();
@@ -116,7 +123,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Clears the latest atomic batch checkpoint.
     fn clear_latest_checkpoint(&self) {
-        self.id_map().clear_latest_checkpoint();
+        self.id_map_v1().clear_latest_checkpoint();
+        self.id_map_v2().clear_latest_checkpoint();
         self.edition_map().clear_latest_checkpoint();
         self.reverse_id_map().clear_latest_checkpoint();
         self.owner_map().clear_latest_checkpoint();
@@ -128,7 +136,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Rewinds the atomic batch to the previous checkpoint.
     fn atomic_rewind(&self) {
-        self.id_map().atomic_rewind();
+        self.id_map_v1().atomic_rewind();
+        self.id_map_v2().atomic_rewind();
         self.edition_map().atomic_rewind();
         self.reverse_id_map().atomic_rewind();
         self.owner_map().atomic_rewind();
@@ -140,7 +149,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Aborts an atomic batch write operation.
     fn abort_atomic(&self) {
-        self.id_map().abort_atomic();
+        self.id_map_v1().abort_atomic();
+        self.id_map_v2().abort_atomic();
         self.edition_map().abort_atomic();
         self.reverse_id_map().abort_atomic();
         self.owner_map().abort_atomic();
@@ -152,7 +162,8 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Finishes an atomic batch write operation.
     fn finish_atomic(&self) -> Result<()> {
-        self.id_map().finish_atomic()?;
+        self.id_map_v1().finish_atomic()?;
+        self.id_map_v2().finish_atomic()?;
         self.edition_map().finish_atomic()?;
         self.reverse_id_map().finish_atomic()?;
         self.owner_map().finish_atomic()?;
@@ -184,9 +195,10 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         let program_id = *program.id();
 
         atomic_batch_scope!(self, {
-            // Store the program ID.
-            self.id_map().insert(*transaction_id, program_id)?;
-            // Store the edition.
+            // Store the program ID and edition.
+            // Note that the `id_map_v1` is intentionally excluded.
+            self.id_map_v2().insert(*transaction_id, (program_id, edition))?;
+            // Store the latest edition.
             self.edition_map().insert(program_id, edition)?;
 
             // Store the reverse program ID.
@@ -211,15 +223,16 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         })
     }
 
+    /// TODO (@d0cd) After the migration only the V2 map is used, so do we need to handle the old map?
     /// Removes the deployment transaction for the given `transaction ID`.
     fn remove(&self, transaction_id: &N::TransactionID) -> Result<()> {
-        // Retrieve the program ID.
-        let program_id = match self.get_program_id(transaction_id)? {
-            Some(edition) => edition,
+        // Retrieve the program ID and edition from the ID map.
+        let (program_id, edition) = match self.get_program_id_and_edition(transaction_id)? {
+            Some((program_id, edition)) => (program_id, edition),
             None => bail!("Failed to get the program ID for transaction '{transaction_id}'"),
         };
-        // Retrieve the edition.
-        let edition = match self.get_edition(&program_id)? {
+        // Get the latest edition of the program.
+        let latest_edition = match self.get_edition(&program_id)? {
             Some(edition) => edition,
             None => bail!("Failed to locate the edition for program '{program_id}'"),
         };
@@ -228,12 +241,27 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
             Some(program) => cow_to_cloned!(program),
             None => bail!("Failed to locate program '{program_id}' for transaction '{transaction_id}'"),
         };
+        // Check if the program and edition are in the old ID map.
+        let in_v1_id_map = self.id_map_v1().contains_key_confirmed(transaction_id)?;
 
         atomic_batch_scope!(self, {
             // Remove the program ID.
-            self.id_map().remove(transaction_id)?;
-            // Remove the edition.
-            self.edition_map().remove(&program_id)?;
+            if in_v1_id_map {
+                self.id_map_v1().remove(transaction_id)?;
+            } else {
+                self.id_map_v2().remove(transaction_id)?;
+            }
+            // Update the latest edition.
+            match (edition, latest_edition) {
+                // If the removed edition is 0, remove the program ID from the edition map.
+                (0, _) => self.edition_map().remove(&program_id)?,
+                // If the removed edition is the latest one, update the edition map.
+                (edition, latest_edition) if edition == latest_edition => {
+                    self.edition_map().insert(program_id, edition.saturating_sub(1))?
+                }
+                // Otherwise, do nothing.
+                _ => {}
+            }
 
             // Remove the reverse program ID.
             self.reverse_id_map().remove(&(program_id, edition))?;
@@ -257,7 +285,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         })
     }
 
-    /// Returns the transaction ID that contains the given `program ID`.
+    /// Returns the latest transaction ID that contains the given `program ID`.
     fn find_transaction_id_from_program_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
         // Check if the program ID is for 'credits.aleo'.
         // This case is handled separately, as it is a default program of the VM.
@@ -265,7 +293,6 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         if program_id == &ProgramID::from_str("credits.aleo")? {
             return Ok(None);
         }
-
         // Retrieve the edition.
         let edition = match self.get_edition(program_id)? {
             Some(edition) => edition,
@@ -278,6 +305,25 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         }
     }
 
+    /// Returns the transaction ID that contains the given `program ID` and `edition`.
+    fn find_transaction_id_from_program_id_and_edition(
+        &self,
+        program_id: &ProgramID<N>,
+        edition: u16,
+    ) -> Result<Option<N::TransactionID>> {
+        // Check if the pogram ID is for `credits.aleo`.
+        // This case is handled separately, as it is a default program of the VM.
+        // TODO: Note on removal in `find_transaction_id_from_program_id`.
+        if program_id == &ProgramID::from_str("credits.aleo")? {
+            return Ok(None);
+        }
+        // Retrieve the transaction ID.
+        match self.reverse_id_map().get_confirmed(&(*program_id, edition))? {
+            Some(transaction_id) => Ok(Some(cow_to_copied!(transaction_id))),
+            None => Ok(None),
+        }
+    }
+
     /// Returns the transaction ID that contains the given `transition ID`.
     fn find_transaction_id_from_transition_id(
         &self,
@@ -286,16 +332,28 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         self.fee_store().find_transaction_id_from_transition_id(transition_id)
     }
 
-    /// Returns the program ID for the given `transaction ID`.
-    fn get_program_id(&self, transaction_id: &N::TransactionID) -> Result<Option<ProgramID<N>>> {
-        // Retrieve the program ID.
-        match self.id_map().get_confirmed(transaction_id)? {
-            Some(program_id) => Ok(Some(cow_to_copied!(program_id))),
-            None => Ok(None),
+    /// Returns the program ID and edition for the given `transaction ID`.
+    /// Default to the V1 ID map if it does not exist in the V2 ID map.
+    fn get_program_id_and_edition(&self, transaction_id: &N::TransactionID) -> Result<Option<(ProgramID<N>, u16)>> {
+        match self.id_map_v2().get_confirmed(transaction_id)? {
+            Some(result) => Ok(Some(cow_to_copied!(result))),
+            None => {
+                let Some(program_id) = self.id_map_v1().get_confirmed(transaction_id)? else {
+                    return Ok(None);
+                };
+                let Some(edition) = self.get_edition(&program_id)? else { return Ok(None) };
+                Ok(Some((cow_to_copied!(program_id), edition)))
+            }
         }
     }
 
-    /// Returns the edition for the given `program ID`.
+    /// Returns the program ID for the given `transaction ID`.
+    fn get_program_id(&self, transaction_id: &N::TransactionID) -> Result<Option<ProgramID<N>>> {
+        // Retrieve the program ID.
+        Ok(self.get_program_id_and_edition(transaction_id)?.map(|(program_id, _)| program_id))
+    }
+
+    /// Returns the latest edition for the given `program ID`.
     fn get_edition(&self, program_id: &ProgramID<N>) -> Result<Option<u16>> {
         // Check if the program ID is for 'credits.aleo'.
         // This case is handled separately, as it is a default program of the VM.
@@ -310,7 +368,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         }
     }
 
-    /// Returns the program for the given `program ID`.
+    /// Returns the latest program for the given `program ID`.
     fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
         // Check if the program ID is for 'credits.aleo'.
         // This case is handled separately, as it is a default program of the VM.
@@ -318,7 +376,6 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         if program_id == &ProgramID::from_str("credits.aleo")? {
             return Ok(Some(Program::credits()?));
         }
-
         // Retrieve the edition.
         let edition = match self.get_edition(program_id)? {
             Some(edition) => edition,
@@ -331,7 +388,22 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         }
     }
 
-    /// Returns the verifying key for the given `program ID` and `function name`.
+    /// Returns the latest program for the given `program ID` and `edition`.
+    fn get_program_with_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<Option<Program<N>>> {
+        // Check if the program ID is for 'credits.aleo'.
+        // This case is handled separately, as it is a default program of the VM.
+        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
+        if program_id == &ProgramID::from_str("credits.aleo")? {
+            return Ok(Some(Program::credits()?));
+        }
+        // Retrieve the program.
+        match self.program_map().get_confirmed(&(*program_id, edition))? {
+            Some(program) => Ok(Some(cow_to_cloned!(program))),
+            None => bail!("Failed to get program '{program_id}' (edition {edition})"),
+        }
+    }
+
+    /// Returns the latest verifying key for the given `program ID` and `function name`.
     fn get_verifying_key(
         &self,
         program_id: &ProgramID<N>,
@@ -356,6 +428,33 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
             Some(edition) => edition,
             None => return Ok(None),
         };
+        // Retrieve the verifying key.
+        match self.verifying_key_map().get_confirmed(&(*program_id, *function_name, edition))? {
+            Some(verifying_key) => Ok(Some(cow_to_cloned!(verifying_key))),
+            None => bail!("Failed to get the verifying key for '{program_id}/{function_name}' (edition {edition})"),
+        }
+    }
+
+    /// Returns the verifying key for the given `program ID`, `function name` and `edition`.
+    fn get_verifying_key_with_edition(
+        &self,
+        program_id: &ProgramID<N>,
+        function_name: &Identifier<N>,
+        edition: u16,
+    ) -> Result<Option<VerifyingKey<N>>> {
+        // Check if the program ID is for 'credits.aleo'.
+        // This case is handled separately, as it is a default program of the VM.
+        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
+        if program_id == &ProgramID::from_str("credits.aleo")? {
+            // Load the verifying key.
+            let verifying_key = N::get_credits_verifying_key(function_name.to_string())?;
+            // Retrieve the number of public and private variables.
+            // Note: This number does *NOT* include the number of constants. This is safe because
+            // this program is never deployed, as it is a first-class citizen of the protocol.
+            let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
+            // Return the verifying key.
+            return Ok(Some(VerifyingKey::new(verifying_key.clone(), num_variables)));
+        }
         // Retrieve the verifying key.
         match self.verifying_key_map().get_confirmed(&(*program_id, *function_name, edition))? {
             Some(verifying_key) => Ok(Some(cow_to_cloned!(verifying_key))),
@@ -388,17 +487,32 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         }
     }
 
+    /// Returns the certificate for the given `program ID`, `function name`, and `edition`.
+    fn get_certificate_with_edition(
+        &self,
+        program_id: &ProgramID<N>,
+        function_name: &Identifier<N>,
+        edition: u16,
+    ) -> Result<Option<Certificate<N>>> {
+        // Check if the program ID is for 'credits.aleo'.
+        // This case is handled separately, as it is a default program of the VM.
+        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
+        if program_id == &ProgramID::from_str("credits.aleo")? {
+            return Ok(None);
+        }
+        // Retrieve the certificate.
+        match self.certificate_map().get_confirmed(&(*program_id, *function_name, edition))? {
+            Some(certificate) => Ok(Some(cow_to_cloned!(certificate))),
+            None => bail!("Failed to get the certificate for '{program_id}/{function_name}' (edition {edition})"),
+        }
+    }
+
     /// Returns the deployment for the given `transaction ID`.
     fn get_deployment(&self, transaction_id: &N::TransactionID) -> Result<Option<Deployment<N>>> {
-        // Retrieve the program ID.
-        let program_id = match self.get_program_id(transaction_id)? {
-            Some(edition) => edition,
+        // Retrieve the program ID and edition.
+        let (program_id, edition) = match self.get_program_id_and_edition(transaction_id)? {
+            Some((program_id, edition)) => (program_id, edition),
             None => return Ok(None),
-        };
-        // Retrieve the edition.
-        let edition = match self.get_edition(&program_id)? {
-            Some(edition) => edition,
-            None => bail!("Failed to get the edition for program '{program_id}'"),
         };
         // Retrieve the program.
         let program = match self.program_map().get_confirmed(&(program_id, edition))? {
@@ -434,7 +548,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         self.fee_store().get_fee(transaction_id)
     }
 
-    /// Returns the owner for the given `program ID`.
+    /// Returns the latest owner for the given `program ID`.
     fn get_owner(&self, program_id: &ProgramID<N>) -> Result<Option<ProgramOwner<N>>> {
         // Check if the program ID is for 'credits.aleo'.
         // This case is handled separately, as it is a default program of the VM.
@@ -457,6 +571,21 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         }
     }
 
+    /// Returns the owner for the given `program ID` and `edition`.
+    fn get_owner_with_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<Option<ProgramOwner<N>>> {
+        // Check if the program ID is for 'credits.aleo'.
+        // This case is handled separately, as it is a default program of the VM.
+        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
+        if program_id == &ProgramID::from_str("credits.aleo")? {
+            return Ok(None);
+        }
+        // Retrieve the owner.
+        match self.owner_map().get_confirmed(&(*program_id, edition))? {
+            Some(owner) => Ok(Some(cow_to_copied!(owner))),
+            None => bail!("Failed to find the Owner for program '{program_id}' (edition {edition})"),
+        }
+    }
+
     /// Returns the transaction for the given `transaction ID`.
     fn get_transaction(&self, transaction_id: &N::TransactionID) -> Result<Option<Transaction<N>>> {
         // Retrieve the deployment.
@@ -471,7 +600,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         };
 
         // Retrieve the owner.
-        let owner = match self.get_owner(deployment.program_id())? {
+        let owner = match self.get_owner_with_edition(deployment.program_id(), deployment.edition())? {
             Some(owner) => owner,
             None => bail!("Failed to get the owner for transaction '{transaction_id}'"),
         };
@@ -571,9 +700,19 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
         self.storage.get_deployment(transaction_id)
     }
 
-    /// Returns the edition for the given `program ID`.
+    /// Returns the latest edition for the given `program ID`.
     pub fn get_edition(&self, program_id: &ProgramID<N>) -> Result<Option<u16>> {
         self.storage.get_edition(program_id)
+    }
+
+    /// Returns the latest owner for the given `program ID`.
+    pub fn get_owner(&self, program_id: &ProgramID<N>) -> Result<Option<ProgramOwner<N>>> {
+        self.storage.get_owner(program_id)
+    }
+
+    /// Returns the owner for the given `program ID` and `edition`.
+    pub fn get_owner_with_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<Option<ProgramOwner<N>>> {
+        self.storage.get_owner_with_edition(program_id, edition)
     }
 
     /// Returns the program ID for the given `transaction ID`.
@@ -581,18 +720,38 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
         self.storage.get_program_id(transaction_id)
     }
 
-    /// Returns the program for the given `program ID`.
+    /// Returns the program ID and edition for the given `transaction ID`.
+    pub fn get_program_id_and_edition(&self, transaction_id: &N::TransactionID) -> Result<Option<(ProgramID<N>, u16)>> {
+        self.storage.get_program_id_and_edition(transaction_id)
+    }
+
+    /// Returns the latest program for the given `program ID`.
     pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
         self.storage.get_program(program_id)
     }
 
-    /// Returns the verifying key for the given `(program ID, function name)`.
+    /// Returns the program for the given `program ID` and `edition`.
+    pub fn get_program_with_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<Option<Program<N>>> {
+        self.storage.get_program_with_edition(program_id, edition)
+    }
+
+    /// Returns the latest verifying key for the given `(program ID, function name)`.
     pub fn get_verifying_key(
         &self,
         program_id: &ProgramID<N>,
         function_name: &Identifier<N>,
     ) -> Result<Option<VerifyingKey<N>>> {
         self.storage.get_verifying_key(program_id, function_name)
+    }
+
+    /// Returns the verifying key for the given `program ID`, `function name`, and `edition`.
+    pub fn get_verifying_key_with_edition(
+        &self,
+        program_id: &ProgramID<N>,
+        function_name: &Identifier<N>,
+        edition: u16,
+    ) -> Result<Option<VerifyingKey<N>>> {
+        self.storage.get_verifying_key_with_edition(program_id, function_name, edition)
     }
 
     /// Returns the certificate for the given `(program ID, function name)`.
@@ -602,6 +761,16 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
         function_name: &Identifier<N>,
     ) -> Result<Option<Certificate<N>>> {
         self.storage.get_certificate(program_id, function_name)
+    }
+
+    /// Returns the certificate for the given `program ID`, `function name`, and `edition`.
+    pub fn get_certificate_with_edition(
+        &self,
+        program_id: &ProgramID<N>,
+        function_name: &Identifier<N>,
+        edition: u16,
+    ) -> Result<Option<Certificate<N>>> {
+        self.storage.get_certificate_with_edition(program_id, function_name, edition)
     }
 
     /// Returns the fee for the given `transaction ID`.
@@ -614,6 +783,15 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     /// Returns the transaction ID that deployed the given `program ID`.
     pub fn find_transaction_id_from_program_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
         self.storage.find_transaction_id_from_program_id(program_id)
+    }
+
+    /// Returns the transaction ID that deployed the given `program ID` and `edition`.
+    pub fn find_transaction_id_from_program_id_and_edition(
+        &self,
+        program_id: &ProgramID<N>,
+        edition: u16,
+    ) -> Result<Option<N::TransactionID>> {
+        self.storage.find_transaction_id_from_program_id_and_edition(program_id, edition)
     }
 
     /// Returns the transaction ID that deployed the given `transition ID`.
@@ -630,6 +808,11 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     pub fn contains_program_id(&self, program_id: &ProgramID<N>) -> Result<bool> {
         self.storage.edition_map().contains_key_confirmed(program_id)
     }
+
+    /// Returns `true` if the given program ID and edition exists.
+    pub fn contains_program_id_and_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<bool> {
+        self.storage.reverse_id_map().contains_key_confirmed(&(*program_id, edition))
+    }
 }
 
 type ProgramTriplet<N> = (ProgramID<N>, Identifier<N>, u16);
@@ -637,22 +820,54 @@ type ProgramTriplet<N> = (ProgramID<N>, Identifier<N>, u16);
 impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     /// Returns an iterator over the deployment transaction IDs, for all deployments.
     pub fn deployment_transaction_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, N::TransactionID>> {
-        self.storage.id_map().keys_confirmed()
+        self.storage.id_map_v1().keys_confirmed().chain(self.storage.id_map_v2().keys_confirmed())
     }
 
     /// Returns an iterator over the program IDs, for all deployments.
+    /// Note that this can have duplicates.
     pub fn program_ids(&self) -> impl '_ + Iterator<Item = Cow<'_, ProgramID<N>>> {
-        self.storage.id_map().values_confirmed().map(|id| match id {
-            Cow::Borrowed(id) => Cow::Borrowed(id),
-            Cow::Owned(id) => Cow::Owned(id),
-        })
+        self.storage
+            .id_map_v1()
+            .values_confirmed()
+            .map(|id| match id {
+                Cow::Borrowed(id) => Cow::Borrowed(id),
+                Cow::Owned(id) => Cow::Owned(id),
+            })
+            .chain(self.storage.id_map_v2().values_confirmed().map(|id| match id {
+                Cow::Borrowed(id) => Cow::Borrowed(&id.0),
+                Cow::Owned(id) => Cow::Owned(id.0),
+            }))
+    }
+
+    /// Returns an iterators over the program IDs and editions, for all deployments.
+    pub fn program_ids_and_editions(&self) -> impl '_ + Iterator<Item = (Cow<'_, ProgramID<N>>, u16)> {
+        self.storage
+            .id_map_v1()
+            .values_confirmed()
+            .map(|id| match id {
+                Cow::Borrowed(id) => (Cow::Borrowed(id), N::EDITION),
+                Cow::Owned(id) => (Cow::Owned(id), N::EDITION),
+            })
+            .chain(self.storage.id_map_v2().values_confirmed().map(|id| match id {
+                Cow::Borrowed(id) => (Cow::Borrowed(&id.0), id.1),
+                Cow::Owned(id) => (Cow::Owned(id.0), id.1),
+            }))
     }
 
     /// Returns an iterator over the programs, for all deployments.
+    /// Note that this may contain multiple versions of the same program.
     pub fn programs(&self) -> impl '_ + Iterator<Item = Cow<'_, Program<N>>> {
         self.storage.program_map().values_confirmed().map(|program| match program {
             Cow::Borrowed(program) => Cow::Borrowed(program),
             Cow::Owned(program) => Cow::Owned(program),
+        })
+    }
+
+    /// Returns an iterator over the programs and their respective editions, for all deployments.
+    pub fn programs_and_editions(&self) -> impl '_ + Iterator<Item = (Cow<'_, Program<N>>, u16)> {
+        self.storage.program_map().iter_confirmed().map(|(key, value)| match value {
+            Cow::Borrowed(program) => (Cow::Borrowed(program), key.1),
+            Cow::Owned(program) => (Cow::Owned(program), key.1),
         })
     }
 

--- a/ledger/store/src/transaction/mod.rs
+++ b/ledger/store/src/transaction/mod.rs
@@ -366,12 +366,10 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
         // Retrieve the edition.
         match transaction_type {
             TransactionType::Deploy => {
-                // Retrieve the program ID.
-                let program_id = self.storage.deployment_store().get_program_id(transaction_id)?;
                 // Return the edition.
-                match program_id {
-                    Some(program_id) => self.storage.deployment_store().get_edition(&program_id),
-                    None => bail!("Failed to get the program ID for deployment transaction '{transaction_id}'"),
+                match self.storage.deployment_store().get_program_id_and_edition(transaction_id)? {
+                    Some((_, edition)) => Ok(Some(edition)),
+                    None => bail!("Failed to get the edition for deployment transaction '{transaction_id}'"),
                 }
             }
             // Return 'None'.


### PR DESCRIPTION
This PR introduces `IDMapV2` which stores the edition along with the program ID. 
The current design assumes that editions are fixed, which may not be true in the future.
The intention is to be backwards compatible with the existing design.

### Migration
This PR will need a migration height, after which `IDMapV2` will be used instead of `IDMapV1`. 
Old deployments will still live in `IDMapV1`, all which will have a zero edition.
New deployments will live in `IDMapV2`, which start with the zero edition, incrementing on each upgrade.

**TODO. Having stared at this PR in isolation, I have some ideas on how to better test. Will follow up with more commits.**