### PR TITLE
[Refactor] Global stack map.

### DIFF
--- a/synthesizer/process/benches/check_deployment.rs
+++ b/synthesizer/process/benches/check_deployment.rs
@@ -92,7 +92,7 @@ fn transfer_private(c: &mut Criterion) {
     let r2 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
     // Compute the assignment.
-    prepare_check_deployment::<_, CurrentAleo>(c, stack, &private_key, function_name, &[r0, r1, r2], rng);
+    prepare_check_deployment::<_, CurrentAleo>(c, &stack, &private_key, function_name, &[r0, r1, r2], rng);
 }
 
 fn transfer_public(c: &mut Criterion) {
@@ -115,7 +115,7 @@ fn transfer_public(c: &mut Criterion) {
     let r1 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
     // Compute the assignment.
-    prepare_check_deployment::<_, CurrentAleo>(c, stack, &private_key, function_name, &[r0, r1], rng);
+    prepare_check_deployment::<_, CurrentAleo>(c, &stack, &private_key, function_name, &[r0, r1], rng);
 }
 
 fn large_program(c: &mut Criterion) {

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -87,7 +87,7 @@ pub fn execution_cost_v1<N: Network>(process: &Process<N>, execution: &Execution
 
     // Get the finalize cost for the root transition.
     let stack = process.get_stack(transition.program_id())?;
-    let finalize_cost = cost_in_microcredits_v1(stack, transition.function_name())?;
+    let finalize_cost = cost_in_microcredits_v1(&stack, transition.function_name())?;
 
     // Compute the total cost in microcredits.
     let total_cost = storage_cost
@@ -446,7 +446,7 @@ pub fn cost_in_microcredits_v1<N: Network>(stack: &Stack<N>, function_name: &Ide
             let stack = stack.get_external_stack(future.program_id())?;
             // Accumulate the finalize cost of the future.
             future_cost = future_cost
-                .checked_add(cost_in_microcredits_v1(stack, future.resource())?)
+                .checked_add(cost_in_microcredits_v1(&stack, future.resource())?)
                 .ok_or(anyhow!("Finalize cost overflowed"))?;
         }
     }

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -55,7 +55,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Insert the verifying keys");
 
         // Add the stack to the process.
-        self.add_stack(stack)?;
+        self.add_stack(stack);
 
         finish!(timer);
 

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -55,7 +55,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Insert the verifying keys");
 
         // Add the stack to the process.
-        self.add_stack(stack);
+        self.add_stack(stack)?;
 
         finish!(timer);
 

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -230,13 +230,12 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
         states.pop()
     {
         // Get the finalize logic.
-        let finalize = match stack.get_function_ref(registers.function_name())?.finalize_logic() {
-            Some(finalize) => finalize,
-            None => bail!(
+        let Some(finalize) = stack.get_function_ref(registers.function_name())?.finalize_logic() else {
+            bail!(
                 "The function '{}/{}' does not have an associated finalize block",
                 stack.program_id(),
                 registers.function_name()
-            ),
+            )
         };
         // Evaluate the commands.
         while counter < finalize.commands().len() {
@@ -245,13 +244,8 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
             // Finalize the command.
             match &command {
                 Command::BranchEq(branch_eq) => {
-                    let result = try_vm_runtime!(|| branch_to(
-                        counter,
-                        branch_eq,
-                        finalize.positions(),
-                        stack.deref(),
-                        &registers
-                    ));
+                    let result =
+                        try_vm_runtime!(|| branch_to(counter, branch_eq, finalize.positions(), &stack, &registers));
                     match result {
                         Ok(Ok(new_counter)) => {
                             counter = new_counter;
@@ -263,13 +257,8 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     }
                 }
                 Command::BranchNeq(branch_neq) => {
-                    let result = try_vm_runtime!(|| branch_to(
-                        counter,
-                        branch_neq,
-                        finalize.positions(),
-                        stack.deref(),
-                        &registers
-                    ));
+                    let result =
+                        try_vm_runtime!(|| branch_to(counter, branch_neq, finalize.positions(), &stack, &registers));
                     match result {
                         Ok(Ok(new_counter)) => {
                             counter = new_counter;

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -558,7 +558,7 @@ function compute:
         let (stack, _) =
             process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
         // Add the stack *manually* to the process.
-        process.add_stack(stack).unwrap();
+        process.add_stack(stack);
 
         // Ensure the program exists.
         assert!(process.contains_program(program.id()));

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -404,9 +404,9 @@ fn initialize_finalize_state<N: Network>(
     nonce: u64,
 ) -> Result<FinalizeState<N>> {
     // Get the stack.
-    let stack = match stack.get_external_stack(future.program_id()) {
-        Ok(stack) => stack,
-        Err(_) => stack.clone(),
+    let stack = match stack.program_id() == future.program_id() {
+        true => stack.clone(),
+        false => stack.get_external_stack(future.program_id())?,
     };
     // Get the finalize logic and check that it exists.
     let finalize = match stack.get_function_ref(future.function_name())?.finalize_logic() {

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -54,7 +54,7 @@ impl<N: Network> Process<N> {
             // Retrieve the fee stack.
             let fee_stack = self.get_stack(fee.program_id())?;
             // Finalize the fee transition.
-            finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
+            finalize_operations.extend(finalize_fee_transition(state, store, &fee_stack, fee)?);
             lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
 
             /* Finalize the deployment. */
@@ -116,7 +116,7 @@ impl<N: Network> Process<N> {
             // Finalize the root transition.
             // Note that this will result in all the remaining transitions being finalized, since the number
             // of calls matches the number of transitions.
-            let mut finalize_operations = finalize_transition(state, store, stack, transition, call_graph)?;
+            let mut finalize_operations = finalize_transition(state, store, &stack, transition, call_graph)?;
 
             /* Finalize the fee. */
 
@@ -124,7 +124,7 @@ impl<N: Network> Process<N> {
                 // Retrieve the fee stack.
                 let fee_stack = self.get_stack(fee.program_id())?;
                 // Finalize the fee transition.
-                finalize_operations.extend(finalize_fee_transition(state, store, fee_stack, fee)?);
+                finalize_operations.extend(finalize_fee_transition(state, store, &fee_stack, fee)?);
                 lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
             }
 
@@ -150,7 +150,7 @@ impl<N: Network> Process<N> {
             // Retrieve the stack.
             let stack = self.get_stack(fee.program_id())?;
             // Finalize the fee transition.
-            let result = finalize_fee_transition(state, store, stack, fee);
+            let result = finalize_fee_transition(state, store, &stack, fee);
             finish!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
             // Return the result.
             result
@@ -162,7 +162,7 @@ impl<N: Network> Process<N> {
 fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
     state: FinalizeGlobalState,
     store: &FinalizeStore<N, P>,
-    stack: &Stack<N>,
+    stack: &Arc<Stack<N>>,
     fee: &Fee<N>,
 ) -> Result<Vec<FinalizeOperation<N>>> {
     // Construct the call graph.
@@ -187,7 +187,7 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
 fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
     state: FinalizeGlobalState,
     store: &FinalizeStore<N, P>,
-    stack: &Stack<N>,
+    stack: &Arc<Stack<N>>,
     transition: &Transition<N>,
     call_graph: HashMap<N::TransitionID, Vec<N::TransitionID>>,
 ) -> Result<Vec<FinalizeOperation<N>>> {
@@ -226,15 +226,18 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
     states.push(initialize_finalize_state(state, future, stack, *transition.id(), nonce)?);
 
     // While there are active finalize states, finalize them.
-    'outer: while let Some(FinalizeState {
-        mut counter,
-        finalize,
-        mut registers,
-        stack,
-        mut call_counter,
-        mut awaited,
-    }) = states.pop()
+    'outer: while let Some(FinalizeState { mut counter, mut registers, stack, mut call_counter, mut awaited }) =
+        states.pop()
     {
+        // Get the finalize logic.
+        let finalize = match stack.get_function_ref(registers.function_name())?.finalize_logic() {
+            Some(finalize) => finalize,
+            None => bail!(
+                "The function '{}/{}' does not have an associated finalize block",
+                stack.program_id(),
+                registers.function_name()
+            ),
+        };
         // Evaluate the commands.
         while counter < finalize.commands().len() {
             // Retrieve the command.
@@ -242,7 +245,13 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
             // Finalize the command.
             match &command {
                 Command::BranchEq(branch_eq) => {
-                    let result = try_vm_runtime!(|| branch_to(counter, branch_eq, finalize, stack, &registers));
+                    let result = try_vm_runtime!(|| branch_to(
+                        counter,
+                        branch_eq,
+                        finalize.positions(),
+                        stack.deref(),
+                        &registers
+                    ));
                     match result {
                         Ok(Ok(new_counter)) => {
                             counter = new_counter;
@@ -254,7 +263,13 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     }
                 }
                 Command::BranchNeq(branch_neq) => {
-                    let result = try_vm_runtime!(|| branch_to(counter, branch_neq, finalize, stack, &registers));
+                    let result = try_vm_runtime!(|| branch_to(
+                        counter,
+                        branch_neq,
+                        finalize.positions(),
+                        stack.deref(),
+                        &registers
+                    ));
                     match result {
                         Ok(Ok(new_counter)) => {
                             counter = new_counter;
@@ -300,14 +315,20 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     nonce += 1;
 
                     // Set up the finalize state for the await.
-                    let callee_state =
-                        match try_vm_runtime!(|| setup_await(state, await_, stack, &registers, transition_id, nonce)) {
-                            Ok(Ok(callee_state)) => callee_state,
-                            // If the evaluation fails, bail and return the error.
-                            Ok(Err(error)) => bail!("'finalize' failed to evaluate command ({command}): {error}"),
-                            // If the evaluation fails, bail and return the error.
-                            Err(_) => bail!("'finalize' failed to evaluate command ({command})"),
-                        };
+                    let callee_state = match try_vm_runtime!(|| setup_await(
+                        state,
+                        await_,
+                        &stack,
+                        &registers,
+                        transition_id,
+                        nonce
+                    )) {
+                        Ok(Ok(callee_state)) => callee_state,
+                        // If the evaluation fails, bail and return the error.
+                        Ok(Err(error)) => bail!("'finalize' failed to evaluate command ({command}): {error}"),
+                        // If the evaluation fails, bail and return the error.
+                        Err(_) => bail!("'finalize' failed to evaluate command ({command})"),
+                    };
 
                     // Increment the call counter.
                     call_counter += 1;
@@ -317,7 +338,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     awaited.insert(await_.register().clone());
 
                     // Aggregate the caller state.
-                    let caller_state = FinalizeState { counter, finalize, registers, stack, call_counter, awaited };
+                    let caller_state = FinalizeState { counter, registers, stack, call_counter, awaited };
 
                     // Push the caller state onto the stack.
                     states.push(caller_state);
@@ -327,7 +348,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     continue 'outer;
                 }
                 _ => {
-                    let result = try_vm_runtime!(|| command.finalize(stack, store, &mut registers));
+                    let result = try_vm_runtime!(|| command.finalize(stack.deref(), store, &mut registers));
                     match result {
                         // If the evaluation succeeds with an operation, add it to the list.
                         Ok(Ok(Some(finalize_operation))) => finalize_operations.push(finalize_operation),
@@ -361,15 +382,13 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
 }
 
 // A helper struct to track the execution of a finalize block.
-struct FinalizeState<'a, N: Network> {
+struct FinalizeState<N: Network> {
     // A counter for the index of the commands.
     counter: usize,
-    // The finalize logic.
-    finalize: &'a Finalize<N>,
     // The registers.
     registers: FinalizeRegisters<N>,
     // The stack.
-    stack: &'a Stack<N>,
+    stack: Arc<Stack<N>>,
     // Call counter.
     call_counter: usize,
     // Awaited futures.
@@ -377,23 +396,20 @@ struct FinalizeState<'a, N: Network> {
 }
 
 // A helper function to initialize the finalize state.
-fn initialize_finalize_state<'a, N: Network>(
+fn initialize_finalize_state<N: Network>(
     state: FinalizeGlobalState,
     future: &Future<N>,
-    stack: &'a Stack<N>,
+    stack: &Arc<Stack<N>>,
     transition_id: N::TransitionID,
     nonce: u64,
-) -> Result<FinalizeState<'a, N>> {
-    // Get the finalize logic and the stack.
-    let (finalize, stack) = match stack.program_id() == future.program_id() {
-        true => (stack.get_function_ref(future.function_name())?.finalize_logic(), stack),
-        false => {
-            let stack = stack.get_external_stack(future.program_id())?.as_ref();
-            (stack.get_function_ref(future.function_name())?.finalize_logic(), stack)
-        }
+) -> Result<FinalizeState<N>> {
+    // Get the stack.
+    let stack = match stack.get_external_stack(future.program_id()) {
+        Ok(stack) => stack,
+        Err(_) => stack.clone(),
     };
-    // Check that the finalize logic exists.
-    let finalize = match finalize {
+    // Get the finalize logic and check that it exists.
+    let finalize = match stack.get_function_ref(future.function_name())?.finalize_logic() {
         Some(finalize) => finalize,
         None => bail!(
             "The function '{}/{}' does not have an associated finalize block",
@@ -414,25 +430,25 @@ fn initialize_finalize_state<'a, N: Network>(
     finalize.inputs().iter().map(|i| i.register()).zip_eq(future.arguments().iter()).try_for_each(
         |(register, input)| {
             // Assign the input value to the register.
-            registers.store(stack, register, Value::from(input))
+            registers.store(stack.deref(), register, Value::from(input))
         },
     )?;
 
-    Ok(FinalizeState { counter: 0, finalize, registers, stack, call_counter: 0, awaited: Default::default() })
+    Ok(FinalizeState { counter: 0, registers, stack, call_counter: 0, awaited: Default::default() })
 }
 
 // A helper function that sets up the await operation.
 #[inline]
-fn setup_await<'a, N: Network>(
+fn setup_await<N: Network>(
     state: FinalizeGlobalState,
     await_: &Await<N>,
-    stack: &'a Stack<N>,
+    stack: &Arc<Stack<N>>,
     registers: &FinalizeRegisters<N>,
     transition_id: N::TransitionID,
     nonce: u64,
-) -> Result<FinalizeState<'a, N>> {
+) -> Result<FinalizeState<N>> {
     // Retrieve the input as a future.
-    let future = match registers.load(stack, &Operand::Register(await_.register().clone()))? {
+    let future = match registers.load(stack.deref(), &Operand::Register(await_.register().clone()))? {
         Value::Future(future) => future,
         _ => bail!("The input to 'await' is not a future"),
     };
@@ -445,16 +461,16 @@ fn setup_await<'a, N: Network>(
 fn branch_to<N: Network, const VARIANT: u8>(
     counter: usize,
     branch: &Branch<N, VARIANT>,
-    finalize: &Finalize<N>,
+    positions: &HashMap<Identifier<N>, usize>,
     stack: &Stack<N>,
-    registers: &FinalizeRegisters<N>,
+    registers: &impl RegistersLoad<N>,
 ) -> Result<usize> {
     // Retrieve the inputs.
     let first = registers.load(stack, branch.first())?;
     let second = registers.load(stack, branch.second())?;
 
     // A helper to get the index corresponding to a position.
-    let get_position_index = |position: &Identifier<N>| match finalize.positions().get(position) {
+    let get_position_index = |position: &Identifier<N>| match positions.get(position) {
         Some(index) if *index > counter => Ok(*index),
         Some(_) => bail!("Cannot branch to an earlier position '{position}' in the program"),
         None => bail!("The position '{position}' does not exist."),
@@ -542,7 +558,7 @@ function compute:
         let (stack, _) =
             process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
         // Add the stack *manually* to the process.
-        process.add_stack(stack);
+        process.add_stack(stack).unwrap();
 
         // Ensure the program exists.
         assert!(process.contains_program(program.id()));

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -218,14 +218,17 @@ impl<N: Network> Process<N> {
     pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<Arc<Stack<N>>> {
         // Prepare the program ID.
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
-        // Acquire the read lock.
-        let stacks = self.stacks.read();
         // Retrieve the stack.
-        let stack = stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
+        let stack = self
+            .stacks
+            .read()
+            .get(&program_id)
+            .ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?
+            .clone();
         // Ensure the program ID matches.
         ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
         // Return the stack.
-        Ok(stack.clone())
+        Ok(stack)
     }
 
     /// Returns the proving key for the given program ID and function name.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -135,10 +135,10 @@ impl<N: Network> Process<N> {
     pub fn add_stack(&mut self, stack: Stack<N>) {
         // Get the program ID.
         let program_id = *stack.program_id();
-        // Acquire the write lock.
-        let mut stacks = self.stacks.write();
+        // Arc the stack first to limit the scope of the write lock.
+        let stack = Arc::new(stack);
         // Insert the stack into the process, replacing the existing stack if it exists.
-        stacks.insert(program_id, Arc::new(stack));
+        self.stacks.write().insert(program_id, stack);
     }
 }
 

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -55,7 +55,6 @@ use synthesizer_program::{
     Branch,
     Closure,
     Command,
-    Finalize,
     FinalizeGlobalState,
     FinalizeOperation,
     Instruction,
@@ -80,7 +79,7 @@ pub struct Process<N: Network> {
     /// The universal SRS.
     universal_srs: UniversalSRS<N>,
     /// The mapping of program IDs to stacks.
-    stacks: IndexMap<ProgramID<N>, Arc<Stack<N>>>,
+    stacks: Arc<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>>,
 }
 
 impl<N: Network> Process<N> {
@@ -90,7 +89,8 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process:setup");
 
         // Initialize the process.
-        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: IndexMap::new() };
+        let mut process =
+            Self { universal_srs: UniversalSRS::load()?, stacks: Arc::new(RwLock::new(IndexMap::new())) };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -109,7 +109,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Synthesize credits program keys");
 
         // Add the 'credits.aleo' stack to the process.
-        process.add_stack(stack);
+        process.add_stack(stack)?;
 
         finish!(timer);
         // Return the process.
@@ -124,7 +124,7 @@ impl<N: Network> Process<N> {
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
         if program.id() != &credits_program_id {
-            self.add_stack(Stack::new(self, program)?);
+            self.add_stack(Stack::new(self, program)?)?;
         }
         Ok(())
     }
@@ -132,9 +132,14 @@ impl<N: Network> Process<N> {
     /// Adds a new stack to the process.
     /// If you intend to `execute` the program, use `deploy` and `finalize_deployment` instead.
     #[inline]
-    pub fn add_stack(&mut self, stack: Stack<N>) {
-        // Add the stack to the process.
-        self.stacks.insert(*stack.program_id(), Arc::new(stack));
+    pub fn add_stack(&mut self, stack: Stack<N>) -> Result<()> {
+        // Get the program ID.
+        let program_id = *stack.program_id();
+        // Acquire the write lock.
+        let mut stacks = self.stacks.write();
+        // Insert the stack into the process, replacing the existing stack if it exists.
+        stacks.insert(program_id, Arc::new(stack));
+        Ok(())
     }
 }
 
@@ -145,7 +150,8 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process::load");
 
         // Initialize the process.
-        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: IndexMap::new() };
+        let mut process =
+            Self { universal_srs: UniversalSRS::load()?, stacks: Arc::new(RwLock::new(IndexMap::new())) };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -171,7 +177,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Load circuit keys");
 
         // Add the stack to the process.
-        process.add_stack(stack);
+        process.add_stack(stack)?;
 
         finish!(timer, "Process::load");
         // Return the process.
@@ -183,7 +189,8 @@ impl<N: Network> Process<N> {
     #[cfg(feature = "wasm")]
     pub fn load_web() -> Result<Self> {
         // Initialize the process.
-        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: IndexMap::new() };
+        let mut process =
+            Self { universal_srs: UniversalSRS::load()?, stacks: Arc::new(RwLock::new(IndexMap::new())) };
 
         // Initialize the 'credits.aleo' program.
         let program = Program::credits()?;
@@ -192,7 +199,7 @@ impl<N: Network> Process<N> {
         let stack = Stack::new(&process, &program)?;
 
         // Add the stack to the process.
-        process.add_stack(stack);
+        process.add_stack(stack)?;
 
         // Return the process.
         Ok(process)
@@ -207,26 +214,22 @@ impl<N: Network> Process<N> {
     /// Returns `true` if the process contains the program with the given ID.
     #[inline]
     pub fn contains_program(&self, program_id: &ProgramID<N>) -> bool {
-        self.stacks.contains_key(program_id)
+        self.stacks.read().contains_key(program_id)
     }
 
     /// Returns the stack for the given program ID.
     #[inline]
-    pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Arc<Stack<N>>> {
+    pub fn get_stack(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<Arc<Stack<N>>> {
         // Prepare the program ID.
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        // Acquire the read lock.
+        let stacks = self.stacks.read();
         // Retrieve the stack.
-        let stack = self.stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
+        let stack = stacks.get(&program_id).ok_or_else(|| anyhow!("Program '{program_id}' does not exist"))?;
         // Ensure the program ID matches.
         ensure!(stack.program_id() == &program_id, "Expected program '{}', found '{program_id}'", stack.program_id());
         // Return the stack.
-        Ok(stack)
-    }
-
-    /// Returns the program for the given program ID.
-    #[inline]
-    pub fn get_program(&self, program_id: impl TryInto<ProgramID<N>>) -> Result<&Program<N>> {
-        Ok(self.get_stack(program_id)?.program())
+        Ok(stack.clone())
     }
 
     /// Returns the proving key for the given program ID and function name.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -90,7 +90,7 @@ impl<N: Network> Process<N> {
 
         // Initialize the process.
         let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Arc::new(RwLock::new(IndexMap::new())) };
+            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -109,7 +109,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Synthesize credits program keys");
 
         // Add the 'credits.aleo' stack to the process.
-        process.add_stack(stack)?;
+        process.add_stack(stack);
 
         finish!(timer);
         // Return the process.
@@ -124,7 +124,7 @@ impl<N: Network> Process<N> {
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
         if program.id() != &credits_program_id {
-            self.add_stack(Stack::new(self, program)?)?;
+            self.add_stack(Stack::new(self, program)?);
         }
         Ok(())
     }
@@ -132,14 +132,13 @@ impl<N: Network> Process<N> {
     /// Adds a new stack to the process.
     /// If you intend to `execute` the program, use `deploy` and `finalize_deployment` instead.
     #[inline]
-    pub fn add_stack(&mut self, stack: Stack<N>) -> Result<()> {
+    pub fn add_stack(&mut self, stack: Stack<N>) {
         // Get the program ID.
         let program_id = *stack.program_id();
         // Acquire the write lock.
         let mut stacks = self.stacks.write();
         // Insert the stack into the process, replacing the existing stack if it exists.
         stacks.insert(program_id, Arc::new(stack));
-        Ok(())
     }
 }
 
@@ -151,7 +150,7 @@ impl<N: Network> Process<N> {
 
         // Initialize the process.
         let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Arc::new(RwLock::new(IndexMap::new())) };
+            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -177,7 +176,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Load circuit keys");
 
         // Add the stack to the process.
-        process.add_stack(stack)?;
+        process.add_stack(stack);
 
         finish!(timer, "Process::load");
         // Return the process.
@@ -190,7 +189,7 @@ impl<N: Network> Process<N> {
     pub fn load_web() -> Result<Self> {
         // Initialize the process.
         let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Arc::new(RwLock::new(IndexMap::new())) };
+            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
 
         // Initialize the 'credits.aleo' program.
         let program = Program::credits()?;
@@ -199,7 +198,7 @@ impl<N: Network> Process<N> {
         let stack = Stack::new(&process, &program)?;
 
         // Add the stack to the process.
-        process.add_stack(stack)?;
+        process.add_stack(stack);
 
         // Return the process.
         Ok(process)

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -89,8 +89,7 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process:setup");
 
         // Initialize the process.
-        let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
+        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -149,8 +148,7 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process::load");
 
         // Initialize the process.
-        let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
+        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -188,8 +186,7 @@ impl<N: Network> Process<N> {
     #[cfg(feature = "wasm")]
     pub fn load_web() -> Result<Self> {
         // Initialize the process.
-        let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
+        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
 
         // Initialize the 'credits.aleo' program.
         let program = Program::credits()?;

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -71,11 +71,11 @@ impl<N: Network> CallTrait<N> for Call<N> {
         // Load the operands values.
         let inputs: Vec<_> = self.operands().iter().map(|operand| registers.load(stack, operand)).try_collect()?;
 
-        // Retrieve the substack and resource.
-        let (substack, resource) = match self.operator() {
+        // Retrieve the optional external stack and resource.
+        let (external_stack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
             CallOperator::Locator(locator) => {
-                (stack.get_external_stack(locator.program_id())?.as_ref(), locator.resource())
+                (Some(stack.get_external_stack(locator.program_id())?), locator.resource())
             }
             CallOperator::Resource(resource) => {
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
@@ -84,9 +84,13 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 if stack.program().contains_function(resource) {
                     bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
                 }
-
-                (stack, resource)
+                (None, resource)
             }
+        };
+        // Retrieve the substack.
+        let substack = match &external_stack {
+            Some(external_stack) => external_stack.as_ref(),
+            None => stack,
         };
         lap!(timer, "Retrieved the substack and resource");
 
@@ -155,8 +159,8 @@ impl<N: Network> CallTrait<N> for Call<N> {
         let inputs: Vec<_> =
             self.operands().iter().map(|operand| registers.load_circuit(stack, operand)).try_collect()?;
 
-        // Retrieve the substack and resource.
-        let (substack, resource) = match self.operator() {
+        // Retrieve the optional external stack and resource.
+        let (external_stack, resource) = match self.operator() {
             // Retrieve the call stack and resource from the locator.
             CallOperator::Locator(locator) => {
                 // Check the external call locator.
@@ -169,7 +173,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 if is_credits_program && (is_fee_private || is_fee_public) {
                     bail!("Cannot perform an external call to 'credits.aleo/fee_private' or 'credits.aleo/fee_public'.")
                 } else {
-                    (stack.get_external_stack(locator.program_id())?.as_ref(), locator.resource())
+                    (Some(stack.get_external_stack(locator.program_id())?), locator.resource())
                 }
             }
             CallOperator::Resource(resource) => {
@@ -179,9 +183,13 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 if stack.program().contains_function(resource) {
                     bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
                 }
-
-                (stack, resource)
+                (None, resource)
             }
+        };
+        // Retrieve the substack.
+        let substack = match &external_stack {
+            Some(external_stack) => external_stack.as_ref(),
+            None => stack,
         };
         lap!(timer, "Retrieve the substack and resource");
 

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -266,7 +266,8 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
                 }
                 // Retrieve the program.
-                let external = stack.get_external_program(program_id)?;
+                let external_stack = stack.get_external_stack(program_id)?;
+                let external = external_stack.program();
                 // Ensure the mapping exists in the program.
                 if !external.contains_mapping(mapping_name) {
                     bail!("Mapping '{mapping_name}' in '{program_id}' is not defined.")
@@ -328,7 +329,8 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
                 }
                 // Retrieve the program.
-                let external = stack.get_external_program(program_id)?;
+                let external_stack = stack.get_external_stack(program_id)?;
+                let external = external_stack.program();
                 // Ensure the mapping exists in the program.
                 if !external.contains_mapping(mapping_name) {
                     bail!("Mapping '{mapping_name}' in '{program_id}' is not defined.")
@@ -394,7 +396,8 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("External program '{locator}' is not imported by '{program_id}'.");
                 }
                 // Retrieve the program.
-                let external = stack.get_external_program(program_id)?;
+                let external_stack = stack.get_external_stack(program_id)?;
+                let external = external_stack.program();
                 // Ensure the mapping exists in the program.
                 if !external.contains_mapping(mapping_name) {
                     bail!("Mapping '{mapping_name}' in '{program_id}' is not defined.")

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -26,7 +26,6 @@ use console::{
         FinalizeType,
         Identifier,
         LiteralType,
-        Locator,
         PlaintextType,
         Register,
         RegisterType,
@@ -123,14 +122,6 @@ impl<N: Network> FinalizeTypes<N> {
             self.destinations.get(&register.locator()).ok_or_else(|| anyhow!("Register '{register}' does not exist"))?
         };
 
-        // A helper enum to track the type of the register.
-        enum FinalizeRefType<'a, N: Network> {
-            /// A plaintext type.
-            Plaintext(&'a PlaintextType<N>),
-            /// A finalize type.
-            Future(&'a Locator<N>),
-        }
-
         // Retrieve the path if the register is an access. Otherwise, return the type.
         let (mut finalize_type, path) = match (finalize_type, register) {
             // If the register is a locator, then output the register type.
@@ -140,10 +131,7 @@ impl<N: Network> FinalizeTypes<N> {
                 // Ensure the path is valid.
                 ensure!(!path.is_empty(), "Register '{register}' references no accesses.");
                 // Return the finalize type and path.
-                match finalize_type {
-                    FinalizeType::Plaintext(plaintext_type) => (FinalizeRefType::Plaintext(plaintext_type), path),
-                    FinalizeType::Future(locator) => (FinalizeRefType::Future(locator), path),
-                }
+                (finalize_type.clone(), path)
             }
         };
 
@@ -151,36 +139,39 @@ impl<N: Network> FinalizeTypes<N> {
         for access in path.iter() {
             match (&finalize_type, access) {
                 // Ensure the plaintext type is not a literal, as the register references an access.
-                (FinalizeRefType::Plaintext(PlaintextType::Literal(..)), _) => {
+                (FinalizeType::Plaintext(PlaintextType::Literal(..)), _) => {
                     bail!("'{register}' references a literal.")
                 }
                 // Access the member on the path to output the register type.
-                (FinalizeRefType::Plaintext(PlaintextType::Struct(struct_name)), Access::Member(identifier)) => {
+                (FinalizeType::Plaintext(PlaintextType::Struct(struct_name)), Access::Member(identifier)) => {
                     // Retrieve the member type from the struct and check that it exists.
                     match stack.program().get_struct(struct_name)?.members().get(identifier) {
                         // Retrieve the member and update `finalize_type` for the next iteration.
-                        Some(member_type) => finalize_type = FinalizeRefType::Plaintext(member_type),
+                        Some(member_type) => finalize_type = FinalizeType::Plaintext(member_type.clone()),
                         // Halts if the member does not exist.
                         None => bail!("'{identifier}' does not exist in struct '{struct_name}'"),
                     }
                 }
                 // Access the member on the path to output the register type and check that it is in bounds.
-                (FinalizeRefType::Plaintext(PlaintextType::Array(array_type)), Access::Index(index)) => {
+                (FinalizeType::Plaintext(PlaintextType::Array(array_type)), Access::Index(index)) => {
                     match index < array_type.length() {
                         // Retrieve the element type and update `finalize_type` for the next iteration.
-                        true => finalize_type = FinalizeRefType::Plaintext(array_type.next_element_type()),
+                        true => finalize_type = FinalizeType::Plaintext(array_type.next_element_type().clone()),
                         // Halts if the index is out of bounds.
                         false => bail!("Index out of bounds"),
                     }
                 }
                 // Access the input to the future to output the register type and check that it is in bounds.
-                (FinalizeRefType::Future(locator), Access::Index(index)) => {
+                (FinalizeType::Future(locator), Access::Index(index)) => {
+                    // Get the external stack, if needed.
+                    let external_stack = match locator.program_id() == stack.program_id() {
+                        true => None,
+                        false => Some(stack.get_external_stack(locator.program_id())?),
+                    };
                     // Retrieve the associated function.
-                    let function = match locator.program_id() == stack.program_id() {
-                        true => stack.get_function_ref(locator.resource())?,
-                        false => {
-                            stack.get_external_program(locator.program_id())?.get_function_ref(locator.resource())?
-                        }
+                    let function = match &external_stack {
+                        Some(external_stack) => external_stack.get_function_ref(locator.resource())?,
+                        None => stack.get_function_ref(locator.resource())?,
                     };
                     // Retrieve the finalize inputs.
                     let finalize_inputs = match function.finalize_logic() {
@@ -192,26 +183,25 @@ impl<N: Network> FinalizeTypes<N> {
                         // Retrieve the input type and update `finalize_type` for the next iteration.
                         Some(input) => {
                             finalize_type = match input.finalize_type() {
-                                FinalizeType::Plaintext(plaintext_type) => FinalizeRefType::Plaintext(plaintext_type),
-                                FinalizeType::Future(locator) => FinalizeRefType::Future(locator),
+                                FinalizeType::Plaintext(plaintext_type) => {
+                                    FinalizeType::Plaintext(plaintext_type.clone())
+                                }
+                                FinalizeType::Future(locator) => FinalizeType::Future(*locator),
                             }
                         }
                         // Halts if the index is out of bounds.
                         None => bail!("Index out of bounds"),
                     }
                 }
-                (FinalizeRefType::Plaintext(PlaintextType::Struct(..)), Access::Index(..))
-                | (FinalizeRefType::Plaintext(PlaintextType::Array(..)), Access::Member(..))
-                | (FinalizeRefType::Future(..), Access::Member(..)) => {
+                (FinalizeType::Plaintext(PlaintextType::Struct(..)), Access::Index(..))
+                | (FinalizeType::Plaintext(PlaintextType::Array(..)), Access::Member(..))
+                | (FinalizeType::Future(..), Access::Member(..)) => {
                     bail!("Invalid access `{access}`")
                 }
             }
         }
 
         // Return the output type.
-        Ok(match finalize_type {
-            FinalizeRefType::Plaintext(plaintext_type) => FinalizeType::Plaintext(plaintext_type.clone()),
-            FinalizeRefType::Future(locator) => FinalizeType::Future(*locator),
-        })
+        Ok(finalize_type)
     }
 }

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -181,14 +181,7 @@ impl<N: Network> FinalizeTypes<N> {
                     // Check that the index is in bounds.
                     match finalize_inputs.get_index(**index as usize) {
                         // Retrieve the input type and update `finalize_type` for the next iteration.
-                        Some(input) => {
-                            finalize_type = match input.finalize_type() {
-                                FinalizeType::Plaintext(plaintext_type) => {
-                                    FinalizeType::Plaintext(plaintext_type.clone())
-                                }
-                                FinalizeType::Future(locator) => FinalizeType::Future(*locator),
-                            }
-                        }
+                        Some(input) => finalize_type = input.finalize_type().clone(),
                         // Halts if the index is out of bounds.
                         None => bail!("Index out of bounds"),
                     }

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -166,6 +166,8 @@ impl<N: Network> FinalizeTypes<N> {
                     // Get the external stack, if needed.
                     let external_stack = match locator.program_id() == stack.program_id() {
                         true => None,
+                        // Attention - This method must fail here and early return if the external program is missing.
+                        // Otherwise, this method will proceed to look for the requested function in its own program.
                         false => Some(stack.get_external_stack(locator.program_id())?),
                     };
                     // Retrieve the associated function.

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -22,7 +22,7 @@ impl<N: Network> Stack<N> {
         // Construct the stack for the program.
         let mut stack = Self {
             program: program.clone(),
-            external_stacks: Default::default(),
+            stacks: Arc::downgrade(&process.stacks),
             register_types: Default::default(),
             finalize_types: Default::default(),
             universal_srs: process.universal_srs().clone(),
@@ -36,14 +36,14 @@ impl<N: Network> Stack<N> {
 
         // Add all the imports into the stack.
         for import in program.imports().keys() {
+            // Ensure that the program does not import itself.
+            ensure!(import != program.id(), "Program cannot import itself");
             // Ensure the program imports all exist in the process already.
             if !process.contains_program(import) {
                 bail!("Cannot add program '{}' because its import '{import}' must be added first", program.id())
             }
             // Retrieve the external stack for the import program ID.
             let external_stack = process.get_stack(import)?;
-            // Add the external stack to the stack.
-            stack.insert_external_stack(external_stack.clone())?;
             // Update the program depth, checking that it does not exceed the maximum call depth.
             stack.program_depth = std::cmp::max(stack.program_depth, external_stack.program_depth() + 1);
             ensure!(
@@ -104,23 +104,6 @@ impl<N: Network> Stack<N> {
 }
 
 impl<N: Network> Stack<N> {
-    /// Inserts the given external stack to the stack.
-    #[inline]
-    fn insert_external_stack(&mut self, external_stack: Arc<Stack<N>>) -> Result<()> {
-        // Retrieve the program ID.
-        let program_id = *external_stack.program_id();
-        // Ensure the external stack is not already added.
-        ensure!(!self.external_stacks.contains_key(&program_id), "Program '{program_id}' already exists");
-        // Ensure the program exists in the main program imports.
-        ensure!(self.program.contains_import(&program_id), "'{program_id}' does not exist in the main program imports");
-        // Ensure the external stack is not for the main program.
-        ensure!(self.program.id() != external_stack.program_id(), "External stack program cannot be the main program");
-        // Add the external stack to the stack.
-        self.external_stacks.insert(program_id, external_stack);
-        // Return success.
-        Ok(())
-    }
-
     /// Inserts the given closure to the stack.
     #[inline]
     fn insert_closure(&mut self, closure: &Closure<N>) -> Result<()> {

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -57,8 +57,10 @@ impl<N: Network> StackMatches<N> for Stack<N> {
         // Ensure the record name is valid.
         ensure!(!Program::is_reserved_keyword(record_name), "Record name '{record_name}' is reserved");
 
+        // Retrieve the external stack.
+        let external_stack = self.get_external_stack(locator.program_id())?;
         // Retrieve the record type from the program.
-        let Ok(record_type) = self.get_external_record(locator) else {
+        let Ok(record_type) = external_stack.program().get_record(locator.resource()) else {
             bail!("External '{locator}' is not defined in the program")
         };
 
@@ -296,10 +298,15 @@ impl<N: Network> Stack<N> {
         // Ensure that the function names match.
         ensure!(future.function_name() == locator.resource(), "Future name does not match");
 
+        // Retrieve the external stack, if needed.
+        let external_stack = match locator.program_id() == self.program_id() {
+            true => None,
+            false => Some(self.get_external_stack(locator.program_id())?),
+        };
         // Retrieve the associated function.
-        let function = match locator.program_id() == self.program_id() {
-            true => self.get_function_ref(locator.resource())?,
-            false => self.get_external_program(locator.program_id())?.get_function_ref(locator.resource())?,
+        let function = match external_stack {
+            Some(external_stack) => external_stack.get_function(locator.resource())?,
+            None => self.get_function(locator.resource())?,
         };
         // Retrieve the finalize inputs.
         let inputs = match function.finalize_logic() {

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -306,9 +306,9 @@ impl<N: Network> Stack<N> {
             false => Some(self.get_external_stack(locator.program_id())?),
         };
         // Retrieve the associated function.
-        let function = match external_stack {
-            Some(external_stack) => external_stack.get_function(locator.resource())?,
-            None => self.get_function(locator.resource())?,
+        let function = match &external_stack {
+            Some(external_stack) => external_stack.get_function_ref(locator.resource())?,
+            None => self.get_function_ref(locator.resource())?,
         };
         // Retrieve the finalize inputs.
         let inputs = match function.finalize_logic() {

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -301,6 +301,8 @@ impl<N: Network> Stack<N> {
         // Retrieve the external stack, if needed.
         let external_stack = match locator.program_id() == self.program_id() {
             true => None,
+            // Attention - This method must fail here and early return if the external program is missing.
+            // Otherwise, this method will proceed to look for the requested function in its own program.
             false => Some(self.get_external_stack(locator.program_id())?),
         };
         // Retrieve the associated function.

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -161,10 +161,15 @@ impl<N: Network> Stack<N> {
         depth: usize,
         rng: &mut R,
     ) -> Result<Future<N>> {
+        // Retrieve the external stack, if needed.
+        let external_stack = match locator.program_id() == self.program_id() {
+            true => None,
+            false => Some(self.get_external_stack(locator.program_id())?),
+        };
         // Retrieve the associated function.
-        let function = match locator.program_id() == self.program_id() {
-            true => self.get_function_ref(locator.resource())?,
-            false => self.get_external_program(locator.program_id())?.get_function_ref(locator.resource())?,
+        let function = match &external_stack {
+            Some(external_stack) => external_stack.get_function_ref(locator.resource())?,
+            None => self.get_function_ref(locator.resource())?,
         };
 
         // Retrieve the finalize inputs.

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -164,6 +164,8 @@ impl<N: Network> Stack<N> {
         // Retrieve the external stack, if needed.
         let external_stack = match locator.program_id() == self.program_id() {
             true => None,
+            // Attention - This method must fail here and early return if the external program is missing.
+            // Otherwise, this method will proceed to look for the requested function in its own program.
             false => Some(self.get_external_stack(locator.program_id())?),
         };
         // Retrieve the associated function.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -71,7 +71,7 @@ use synthesizer_snark::{Certificate, ProvingKey, UniversalSRS, VerifyingKey};
 use aleo_std::prelude::{finish, lap, timer};
 use indexmap::IndexMap;
 use parking_lot::RwLock;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -175,8 +175,8 @@ impl<N: Network> CallStack<N> {
 pub struct Stack<N: Network> {
     /// The program (record types, structs, functions).
     program: Program<N>,
-    /// The mapping of external stacks as `(program ID, stack)`.
-    external_stacks: IndexMap<ProgramID<N>, Arc<Stack<N>>>,
+    /// A reference to the global stack map.
+    stacks: Weak<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>>,
     /// The mapping of closure and function names to their register types.
     register_types: IndexMap<Identifier<N>, RegisterTypes<N>>,
     /// The mapping of finalize names to their register types.
@@ -324,42 +324,22 @@ impl<N: Network> StackProgram<N> for Stack<N> {
         &self.program_address
     }
 
-    /// Returns `true` if the stack contains the external record.
-    #[inline]
-    fn contains_external_record(&self, locator: &Locator<N>) -> bool {
-        // Retrieve the external program.
-        match self.get_external_program(locator.program_id()) {
-            // Return `true` if the external record exists.
-            Ok(external_program) => external_program.contains_record(locator.resource()),
-            // Return `false` otherwise.
-            Err(_) => false,
-        }
-    }
-
     /// Returns the external stack for the given program ID.
     #[inline]
-    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Arc<Stack<N>>> {
-        // Retrieve the external stack.
-        self.external_stacks.get(program_id).ok_or_else(|| anyhow!("External program '{program_id}' does not exist."))
-    }
-
-    /// Returns the external program for the given program ID.
-    #[inline]
-    fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>> {
-        match self.program.id() == program_id {
-            true => bail!("Attempted to get the main program '{}' as an external program", self.program.id()),
-            // Retrieve the external stack, and return the external program.
-            false => Ok(self.get_external_stack(program_id)?.program()),
-        }
-    }
-
-    /// Returns the external record if the stack contains the external record.
-    #[inline]
-    fn get_external_record(&self, locator: &Locator<N>) -> Result<&RecordType<N>> {
-        // Retrieve the external program.
-        let external_program = self.get_external_program(locator.program_id())?;
-        // Return the external record, if it exists.
-        external_program.get_record(locator.resource())
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Stack<N>>> {
+        // Check that the program ID is imported by the program.
+        ensure!(self.program.contains_import(program_id), "External program '{program_id}' is not imported.");
+        // Upgrade the weak reference to the process-level stack map and retrieve the external stack.
+        let result = self
+            .stacks
+            .upgrade()
+            .ok_or_else(|| anyhow!("Process-level stack map does not exist"))?
+            .read()
+            .get(program_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("External stack for '{program_id}' does not exist"));
+        // Return the external stack.
+        result
     }
 
     /// Returns the expected finalize cost for the given function name.
@@ -485,7 +465,6 @@ impl<N: Network> Stack<N> {
 impl<N: Network> PartialEq for Stack<N> {
     fn eq(&self, other: &Self) -> bool {
         self.program == other.program
-            && self.external_stacks == other.external_stacks
             && self.register_types == other.register_types
             && self.finalize_types == other.finalize_types
     }

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -325,6 +325,9 @@ impl<N: Network> StackProgram<N> for Stack<N> {
     }
 
     /// Returns the external stack for the given program ID.
+    ///
+    /// Attention - this function is used to check the existence of the external program.
+    /// Developers should explicitly handle the error case so as to not default to the main program.
     #[inline]
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Stack<N>>> {
         // Check that the program ID is not itself.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -330,16 +330,13 @@ impl<N: Network> StackProgram<N> for Stack<N> {
         // Check that the program ID is imported by the program.
         ensure!(self.program.contains_import(program_id), "External program '{program_id}' is not imported.");
         // Upgrade the weak reference to the process-level stack map and retrieve the external stack.
-        let result = self
-            .stacks
+        self.stacks
             .upgrade()
             .ok_or_else(|| anyhow!("Process-level stack map does not exist"))?
             .read()
             .get(program_id)
             .cloned()
-            .ok_or_else(|| anyhow!("External stack for '{program_id}' does not exist"));
-        // Return the external stack.
-        result
+            .ok_or_else(|| anyhow!("External stack for '{program_id}' does not exist"))
     }
 
     /// Returns the expected finalize cost for the given function name.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -327,6 +327,11 @@ impl<N: Network> StackProgram<N> for Stack<N> {
     /// Returns the external stack for the given program ID.
     #[inline]
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Stack<N>>> {
+        // Check that the program ID is not itself.
+        ensure!(
+            program_id != self.program.id(),
+            "Attempted to get the main program '{program_id}' as an external program."
+        );
         // Check that the program ID is imported by the program.
         ensure!(self.program.contains_import(program_id), "External program '{program_id}' is not imported.");
         // Upgrade the weak reference to the process-level stack map and retrieve the external stack.

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -275,8 +275,10 @@ impl<N: Network> RegisterTypes<N> {
                 }
             }
             RegisterType::ExternalRecord(locator) => {
+                // Get the external stack.
+                let external_stack = stack.get_external_stack(locator.program_id())?;
                 // Ensure the external record type is defined in the program.
-                if !stack.contains_external_record(locator) {
+                if !external_stack.program().contains_record(locator.resource()) {
                     bail!("External record '{locator}' in '{}' is not defined.", stack.program_id())
                 }
             }
@@ -327,8 +329,10 @@ impl<N: Network> RegisterTypes<N> {
                 }
             }
             RegisterType::ExternalRecord(locator) => {
+                // Get the external stack.
+                let external_stack = stack.get_external_stack(locator.program_id())?;
                 // Ensure the external record type is defined in the program.
-                if !stack.contains_external_record(locator) {
+                if !external_stack.program().contains_record(locator.resource()) {
                     bail!("External record '{locator}' in '{}' is not defined.", stack.program_id())
                 }
             }
@@ -336,7 +340,9 @@ impl<N: Network> RegisterTypes<N> {
                 // Ensure that the locator is defined.
                 match locator.program_id() == stack.program_id() {
                     true => stack.get_function(locator.resource())?,
-                    false => stack.get_external_program(locator.program_id())?.get_function(locator.resource())?,
+                    false => {
+                        stack.get_external_stack(locator.program_id())?.program().get_function(locator.resource())?
+                    }
                 };
             }
         };
@@ -456,7 +462,8 @@ impl<N: Network> RegisterTypes<N> {
                         }
 
                         // Retrieve the program.
-                        let external = stack.get_external_program(program_id)?;
+                        let external_stack = stack.get_external_stack(program_id)?;
+                        let external = external_stack.program();
                         // Check that function exists in the program.
                         if let Ok(child_function) = external.get_function_ref(resource) {
                             // If the child function contains a finalize block, then the parent function must also contain a finalize block.

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -176,7 +176,10 @@ impl<N: Network> RegisterTypes<N> {
                 // Get the external stack.
                 let external_stack = stack.get_external_stack(locator.program_id())?;
                 // Get the external record.
-                let external_record = external_stack.program().get_record(locator.resource())?;
+                let external_record = external_stack
+                    .program()
+                    .get_record(locator.resource())
+                    .or_else(|_| bail!("External record '{locator}' does not exist"))?;
                 // Retrieve the first access.
                 // Note: this unwrap is safe since the path is checked to be non-empty above.
                 let access = path_iter.next().unwrap();

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -133,11 +133,11 @@ impl<N: Network> RegisterTypes<N> {
         .iter();
 
         // A helper enum to track the type of the register.
-        enum RegisterRefType<'a, N: Network> {
+        enum RegisterAccessType<N: Network> {
             /// A plaintext type.
-            Plaintext(&'a PlaintextType<N>),
+            Plaintext(PlaintextType<N>),
             /// A future.
-            Future(&'a Locator<N>),
+            Future(Locator<N>),
         }
 
         // A literal address type.
@@ -147,7 +147,7 @@ impl<N: Network> RegisterTypes<N> {
         // We perform a single access, if the register type is a record.
         // This is done to minimize the number of `clone` operations and simplify the code.
         let mut register_type = match register_type {
-            RegisterType::Plaintext(plaintext_type) => RegisterRefType::Plaintext(plaintext_type),
+            RegisterType::Plaintext(plaintext_type) => RegisterAccessType::Plaintext(plaintext_type.clone()),
             RegisterType::Record(record_name) => {
                 // Ensure the record type exists.
                 ensure!(stack.program().contains_record(record_name), "Record '{record_name}' does not exist");
@@ -157,7 +157,7 @@ impl<N: Network> RegisterTypes<N> {
                 // Retrieve the member type from the record.
                 if access == &Access::Member(Identifier::from_str("owner")?) {
                     // If the member is the owner, then output the address type.
-                    RegisterRefType::Plaintext(&literal_address_type)
+                    RegisterAccessType::Plaintext(literal_address_type)
                 } else {
                     // Retrieve the path name.
                     let path_name = match access {
@@ -167,21 +167,23 @@ impl<N: Network> RegisterTypes<N> {
                     // Retrieve the entry type from the record.
                     match stack.program().get_record(record_name)?.entries().get(path_name) {
                         // Retrieve the plaintext type.
-                        Some(entry_type) => RegisterRefType::Plaintext(entry_type.plaintext_type()),
+                        Some(entry_type) => RegisterAccessType::Plaintext(entry_type.plaintext_type().clone()),
                         None => bail!("'{path_name}' does not exist in record '{record_name}'"),
                     }
                 }
             }
             RegisterType::ExternalRecord(locator) => {
-                // Ensure the external record type exists.
-                ensure!(stack.contains_external_record(locator), "External record '{locator}' does not exist");
+                // Get the external stack.
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                // Get the external record.
+                let external_record = external_stack.program().get_record(locator.resource())?;
                 // Retrieve the first access.
                 // Note: this unwrap is safe since the path is checked to be non-empty above.
                 let access = path_iter.next().unwrap();
                 // Retrieve the member type from the external record.
                 if access == &Access::Member(Identifier::from_str("owner")?) {
                     // If the member is the owner, then output the address type.
-                    RegisterRefType::Plaintext(&literal_address_type)
+                    RegisterAccessType::Plaintext(literal_address_type)
                 } else {
                     // Retrieve the path name.
                     let path_name = match access {
@@ -189,48 +191,51 @@ impl<N: Network> RegisterTypes<N> {
                         Access::Index(_) => bail!("Attempted to index into an external record"),
                     };
                     // Retrieve the entry type from the external record.
-                    match stack.get_external_record(locator)?.entries().get(path_name) {
+                    match external_record.entries().get(path_name) {
                         // Retrieve the plaintext type.
-                        Some(entry_type) => RegisterRefType::Plaintext(entry_type.plaintext_type()),
+                        Some(entry_type) => RegisterAccessType::Plaintext(entry_type.plaintext_type().clone()),
                         None => bail!("'{path_name}' does not exist in external record '{locator}'"),
                     }
                 }
             }
-            RegisterType::Future(locator) => RegisterRefType::Future(locator),
+            RegisterType::Future(locator) => RegisterAccessType::Future(*locator),
         };
 
         // Traverse the path to find the register type.
         for access in path_iter {
             // Update the plaintext type at each step.
-            match (register_type, access) {
+            match (&register_type, access) {
                 // Ensure the plaintext type is not a literal, as the register references an access.
-                (RegisterRefType::Plaintext(PlaintextType::Literal(..)), _) => {
+                (RegisterAccessType::Plaintext(PlaintextType::Literal(..)), _) => {
                     bail!("'{register}' references a literal.")
                 }
                 // Traverse the path to output the register type.
-                (RegisterRefType::Plaintext(PlaintextType::Struct(struct_name)), Access::Member(identifier)) => {
+                (RegisterAccessType::Plaintext(PlaintextType::Struct(struct_name)), Access::Member(identifier)) => {
                     // Retrieve the member type from the struct.
                     match stack.program().get_struct(struct_name)?.members().get(identifier) {
                         // Update the member type.
-                        Some(member_type) => register_type = RegisterRefType::Plaintext(member_type),
+                        Some(member_type) => register_type = RegisterAccessType::Plaintext(member_type.clone()),
                         None => bail!("'{identifier}' does not exist in struct '{struct_name}'"),
                     }
                 }
                 // Traverse the path to output the register type.
-                (RegisterRefType::Plaintext(PlaintextType::Array(array_type)), Access::Index(index)) => {
+                (RegisterAccessType::Plaintext(PlaintextType::Array(array_type)), Access::Index(index)) => {
                     match index < array_type.length() {
-                        true => register_type = RegisterRefType::Plaintext(array_type.next_element_type()),
+                        true => register_type = RegisterAccessType::Plaintext(array_type.next_element_type().clone()),
                         false => bail!("'{index}' is out of bounds for '{register}'"),
                     }
                 }
                 // Access the input to the future to output the register type and check that it is in bounds.
-                (RegisterRefType::Future(locator), Access::Index(index)) => {
+                (RegisterAccessType::Future(locator), Access::Index(index)) => {
+                    // Retrieve the external stack, if needed.
+                    let external_stack = match locator.program_id() == stack.program_id() {
+                        true => None,
+                        false => Some(stack.get_external_stack(locator.program_id())?),
+                    };
                     // Retrieve the associated function.
-                    let function = match locator.program_id() == stack.program_id() {
-                        true => stack.get_function_ref(locator.resource())?,
-                        false => {
-                            stack.get_external_program(locator.program_id())?.get_function_ref(locator.resource())?
-                        }
+                    let function = match &external_stack {
+                        Some(external_stack) => external_stack.get_function_ref(locator.resource())?,
+                        None => stack.get_function_ref(locator.resource())?,
                     };
                     // Retrieve the finalize inputs.
                     let finalize_inputs = match function.finalize_logic() {
@@ -242,17 +247,19 @@ impl<N: Network> RegisterTypes<N> {
                         // Retrieve the input type and update `finalize_type` for the next iteration.
                         Some(input) => {
                             register_type = match input.finalize_type() {
-                                FinalizeType::Plaintext(plaintext_type) => RegisterRefType::Plaintext(plaintext_type),
-                                FinalizeType::Future(locator) => RegisterRefType::Future(locator),
+                                FinalizeType::Plaintext(plaintext_type) => {
+                                    RegisterAccessType::Plaintext(plaintext_type.clone())
+                                }
+                                FinalizeType::Future(locator) => RegisterAccessType::Future(*locator),
                             }
                         }
                         // Halts if the index is out of bounds.
                         None => bail!("Index out of bounds"),
                     }
                 }
-                (RegisterRefType::Plaintext(PlaintextType::Struct(..)), Access::Index(..))
-                | (RegisterRefType::Plaintext(PlaintextType::Array(..)), Access::Member(..))
-                | (RegisterRefType::Future(..), Access::Member(..)) => {
+                (RegisterAccessType::Plaintext(PlaintextType::Struct(..)), Access::Index(..))
+                | (RegisterAccessType::Plaintext(PlaintextType::Array(..)), Access::Member(..))
+                | (RegisterAccessType::Future(..), Access::Member(..)) => {
                     bail!("Invalid access `{access}`")
                 }
             }
@@ -260,8 +267,8 @@ impl<N: Network> RegisterTypes<N> {
 
         // Output the register type.
         Ok(match register_type {
-            RegisterRefType::Plaintext(plaintext_type) => RegisterType::Plaintext(plaintext_type.clone()),
-            RegisterRefType::Future(locator) => RegisterType::Future(*locator),
+            RegisterAccessType::Plaintext(plaintext_type) => RegisterType::Plaintext(plaintext_type.clone()),
+            RegisterAccessType::Future(locator) => RegisterType::Future(locator),
         })
     }
 }

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -233,6 +233,8 @@ impl<N: Network> RegisterTypes<N> {
                     // Retrieve the external stack, if needed.
                     let external_stack = match locator.program_id() == stack.program_id() {
                         true => None,
+                        // Attention - This method must fail here and early return if the external program is missing.
+                        // Otherwise, this method will proceed to look for the requested function in its own program.
                         false => Some(stack.get_external_stack(locator.program_id())?),
                     };
                     // Retrieve the associated function.

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -2890,7 +2890,7 @@ mod sanity_checks {
         let r2 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1, r2], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1, r2], rng);
         assert_eq!(16, assignment.num_public());
         assert_eq!(50956, assignment.num_private());
         assert_eq!(51002, assignment.num_constraints());
@@ -2918,7 +2918,7 @@ mod sanity_checks {
         let r1 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1], rng);
         assert_eq!(11, assignment.num_public());
         assert_eq!(12318, assignment.num_private());
         assert_eq!(12325, assignment.num_constraints());
@@ -2946,7 +2946,7 @@ mod sanity_checks {
         let r1 = Value::<CurrentNetwork>::from_str("1_500_000_000_000_000_u64").unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1], rng);
         assert_eq!(11, assignment.num_public());
         assert_eq!(12323, assignment.num_private());
         assert_eq!(12330, assignment.num_constraints());
@@ -2980,7 +2980,7 @@ mod sanity_checks {
         let r3 = Value::<CurrentNetwork>::from_str(&Field::<CurrentNetwork>::rand(rng).to_string()).unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1, r2, r3], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1, r2, r3], rng);
         assert_eq!(15, assignment.num_public());
         assert_eq!(38115, assignment.num_private());
         assert_eq!(38151, assignment.num_constraints());
@@ -3008,7 +3008,7 @@ mod sanity_checks {
         let r2 = Value::<CurrentNetwork>::from_str(&Field::<CurrentNetwork>::rand(rng).to_string()).unwrap();
 
         // Compute the assignment.
-        let assignment = get_assignment::<_, CurrentAleo>(stack, &private_key, function_name, &[r0, r1, r2], rng);
+        let assignment = get_assignment::<_, CurrentAleo>(&stack, &private_key, function_name, &[r0, r1, r2], rng);
         assert_eq!(12, assignment.num_public());
         assert_eq!(12920, assignment.num_private());
         assert_eq!(12930, assignment.num_constraints());

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -2363,10 +2363,8 @@ fn test_process_deploy_credits_program() {
     let rng = &mut TestRng::default();
 
     // Initialize an empty process without the `credits` program.
-    let empty_process = Process {
-        universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(),
-        stacks: Default::default(),
-    };
+    let empty_process =
+        Process { universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(), stacks: Default::default() };
 
     // Construct the process.
     let process = Process::load().unwrap();

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -39,7 +39,6 @@ use ledger_store::{
 use synthesizer_program::{FinalizeGlobalState, FinalizeStoreTrait, Program, StackProgram};
 use synthesizer_snark::UniversalSRS;
 
-use indexmap::IndexMap;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -1255,7 +1254,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1368,7 +1367,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1495,7 +1494,7 @@ finalize mint_public:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1624,7 +1623,7 @@ finalize mint_public:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1664,7 +1663,7 @@ finalize init:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(2), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1782,7 +1781,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2211,7 +2210,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2366,7 +2365,7 @@ fn test_process_deploy_credits_program() {
     // Initialize an empty process without the `credits` program.
     let empty_process = Process {
         universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(),
-        stacks: Arc::new(RwLock::new(IndexMap::new())),
+        stacks: Default::default(),
     };
 
     // Construct the process.
@@ -2440,7 +2439,7 @@ function {function_name}:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack).unwrap();
+    process.add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -1255,7 +1255,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1368,7 +1368,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1495,7 +1495,7 @@ finalize mint_public:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1624,7 +1624,7 @@ finalize mint_public:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1664,7 +1664,7 @@ finalize init:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(2), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1782,7 +1782,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2211,7 +2211,7 @@ finalize compute:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2364,8 +2364,10 @@ fn test_process_deploy_credits_program() {
     let rng = &mut TestRng::default();
 
     // Initialize an empty process without the `credits` program.
-    let empty_process =
-        Process { universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(), stacks: IndexMap::new() };
+    let empty_process = Process {
+        universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(),
+        stacks: Arc::new(RwLock::new(IndexMap::new())),
+    };
 
     // Construct the process.
     let process = Process::load().unwrap();
@@ -2438,7 +2440,7 @@ function {function_name}:
     // Finalize the deployment.
     let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.add_stack(stack).unwrap();
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -189,7 +189,8 @@ impl<N: Network> Process<N> {
         };
 
         // Retrieve the adress belonging to the parent.
-        let parent_address = self.get_stack(parent)?.program_address();
+        let stack = self.get_stack(parent)?;
+        let parent_address = stack.program_address();
 
         // Compute the x- and y-coordinate of `parent`.
         let (parent_x, parent_y) = parent_address.to_xy_coordinates();

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -188,7 +188,7 @@ impl<N: Network> Process<N> {
             None => (Field::one(), *transition.program_id()),
         };
 
-        // Retrieve the adress belonging to the parent.
+        // Retrieve the address belonging to the parent.
         let stack = self.get_stack(parent)?;
         let parent_address = stack.program_address();
 

--- a/synthesizer/process/src/verify_fee.rs
+++ b/synthesizer/process/src/verify_fee.rs
@@ -125,12 +125,12 @@ impl<N: Network> Process<N> {
         // Compute the x- and y-coordinate of `tpk`.
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
-        // Retrieve the adress belonging to the program ID.
+        // Retrieve the address belonging to the program ID.
         let stack = self.get_stack(fee.program_id())?;
-        let program_adress = stack.program_address();
+        let program_address = stack.program_address();
 
         // Compute the x- and y-coordinate of `parent`.
-        let (parent_x, parent_y) = program_adress.to_xy_coordinates();
+        let (parent_x, parent_y) = program_address.to_xy_coordinates();
 
         // Construct the public inputs to verify the proof.
         let mut inputs = vec![N::Field::one(), *tpk_x, *tpk_y, **fee.tcm(), **fee.scm()];
@@ -198,12 +198,12 @@ impl<N: Network> Process<N> {
         // Compute the x- and y-coordinate of `tpk`.
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
-        // Retrieve the adress belonging to the program ID.
+        // Retrieve the address belonging to the program ID.
         let stack = self.get_stack(fee.program_id())?;
-        let program_adress = stack.program_address();
+        let program_address = stack.program_address();
 
         // Compute the x- and y-coordinate of `parent`.
-        let (parent_x, parent_y) = program_adress.to_xy_coordinates();
+        let (parent_x, parent_y) = program_address.to_xy_coordinates();
 
         // Construct the public inputs to verify the proof.
         let mut inputs = vec![N::Field::one(), *tpk_x, *tpk_y, **fee.tcm(), **fee.scm()];

--- a/synthesizer/process/src/verify_fee.rs
+++ b/synthesizer/process/src/verify_fee.rs
@@ -126,7 +126,8 @@ impl<N: Network> Process<N> {
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
         // Retrieve the adress belonging to the program ID.
-        let program_adress = self.get_stack(fee.program_id())?.program_address();
+        let stack = self.get_stack(fee.program_id())?;
+        let program_adress = stack.program_address();
 
         // Compute the x- and y-coordinate of `parent`.
         let (parent_x, parent_y) = program_adress.to_xy_coordinates();
@@ -145,7 +146,7 @@ impl<N: Network> Process<N> {
         println!("Fee public inputs ({} elements): {:#?}", inputs.len(), inputs);
 
         // Retrieve the verifying key.
-        let verifying_key = self.get_verifying_key(fee.program_id(), fee.function_name())?;
+        let verifying_key = stack.get_verifying_key(fee.function_name())?;
 
         // Ensure the fee proof is valid.
         Trace::verify_fee_proof((verifying_key, vec![inputs]), fee)?;
@@ -198,7 +199,8 @@ impl<N: Network> Process<N> {
         let (tpk_x, tpk_y) = fee.tpk().to_xy_coordinates();
 
         // Retrieve the adress belonging to the program ID.
-        let program_adress = self.get_stack(fee.program_id())?.program_address();
+        let stack = self.get_stack(fee.program_id())?;
+        let program_adress = stack.program_address();
 
         // Compute the x- and y-coordinate of `parent`.
         let (parent_x, parent_y) = program_adress.to_xy_coordinates();
@@ -217,7 +219,7 @@ impl<N: Network> Process<N> {
         println!("Fee public inputs ({} elements): {:#?}", inputs.len(), inputs);
 
         // Retrieve the verifying key.
-        let verifying_key = self.get_verifying_key(fee.program_id(), fee.function_name())?;
+        let verifying_key = stack.get_verifying_key(fee.function_name())?;
 
         // Ensure the fee proof is valid.
         Trace::verify_fee_proof((verifying_key, vec![inputs]), fee)?;

--- a/synthesizer/program/src/logic/instruction/operation/call.rs
+++ b/synthesizer/program/src/logic/instruction/operation/call.rs
@@ -154,8 +154,10 @@ impl<N: Network> Call<N> {
         match self.operator() {
             // Check if the locator is for a function.
             CallOperator::Locator(locator) => {
+                // Get the external stack.
+                let external_stack = stack.get_external_stack(locator.program_id())?;
                 // Retrieve the program.
-                let program = stack.get_external_program(locator.program_id())?;
+                let program = external_stack.program();
                 // Check if the resource is a function.
                 Ok(program.contains_function(locator.resource()))
             }
@@ -195,11 +197,10 @@ impl<N: Network> Call<N> {
         stack: &impl StackProgram<N>,
         input_types: &[RegisterType<N>],
     ) -> Result<Vec<RegisterType<N>>> {
-        // Retrieve the program and resource.
-        let (is_external, program, resource) = match &self.operator {
-            // Retrieve the program and resource from the locator.
+        // Retrieve the external stack, if needed, and the resource.
+        let (external_stack, resource) = match &self.operator {
             CallOperator::Locator(locator) => {
-                (true, stack.get_external_program(locator.program_id())?, locator.resource())
+                (Some(stack.get_external_stack(locator.program_id())?), locator.resource())
             }
             CallOperator::Resource(resource) => {
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
@@ -208,11 +209,14 @@ impl<N: Network> Call<N> {
                 if stack.program().contains_function(resource) {
                     bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
                 }
-
-                (false, stack.program(), resource)
+                (None, resource)
             }
         };
-
+        // Retrieve the program.
+        let (is_external, program) = match &external_stack {
+            Some(external_stack) => (true, external_stack.program()),
+            None => (false, stack.program()),
+        };
         // If the operator is a closure, retrieve the closure and compute the output types.
         if let Ok(closure) = program.get_closure(resource) {
             // Ensure the number of operands matches the number of input statements.

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -29,7 +29,6 @@ use console::{
         PlaintextType,
         ProgramID,
         Record,
-        RecordType,
         Register,
         RegisterType,
         Value,
@@ -99,17 +98,8 @@ pub trait StackProgram<N: Network> {
     /// Returns the program address.
     fn program_address(&self) -> &Address<N>;
 
-    /// Returns `true` if the stack contains the external record.
-    fn contains_external_record(&self, locator: &Locator<N>) -> bool;
-
     /// Returns the external stack for the given program ID.
-    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<&Arc<Self>>;
-
-    /// Returns the external program for the given program ID.
-    fn get_external_program(&self, program_id: &ProgramID<N>) -> Result<&Program<N>>;
-
-    /// Returns `true` if the stack contains the external record.
-    fn get_external_record(&self, locator: &Locator<N>) -> Result<&RecordType<N>>;
+    fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Self>>;
 
     /// Returns the expected finalize cost for the given function name.
     fn get_finalize_cost(&self, function_name: &Identifier<N>) -> Result<u64>;

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -769,13 +769,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             // Commit all of the stacks to the process.
             if !stacks.is_empty() {
-                for stack in stacks {
-                    if let Err(e) = process.add_stack(stack) {
-                        eprintln!("Critical bug in finalize: {e}");
-                        // Note: This will abort the entire atomic batch.
-                        return Err(format!("Failed to commit the stack - {e}"));
-                    }
-                }
+                stacks.into_iter().for_each(|stack| process.add_stack(stack))
             }
 
             finish!(timer); // <- Note: This timer does **not** include the time to write batch to DB.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -769,7 +769,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             // Commit all of the stacks to the process.
             if !stacks.is_empty() {
-                stacks.into_iter().for_each(|stack| process.add_stack(stack))
+                for stack in stacks {
+                    if let Err(e) = process.add_stack(stack) {
+                        eprintln!("Critical bug in finalize: {e}");
+                        // Note: This will abort the entire atomic batch.
+                        return Err(format!("Failed to commit the stack - {e}"));
+                    }
+                }
             }
 
             finish!(timer); // <- Note: This timer does **not** include the time to write batch to DB.

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -181,7 +181,7 @@ impl<N: Network> Package<N> {
         let imported_programs = program
             .imports()
             .keys()
-            .map(|program_id| process.get_program(program_id).cloned())
+            .map(|program_id| process.get_stack(program_id).map(|stack| stack.program().clone()))
             .collect::<Result<Vec<_>>>()?;
 
         // Synthesize each proving and verifying key.
@@ -220,18 +220,24 @@ impl<N: Network> Package<N> {
         // Load each function circuit.
         for function_name in program.functions().keys() {
             // Retrieve the program.
-            let program = process.get_program(program_id)?;
+            let stack = process.get_stack(program_id)?;
+            let program = stack.program();
             // Retrieve the function from the program.
             let function = program.get_function(function_name)?;
             // Save all the prover and verifier files for any function calls that are made.
             for instruction in function.instructions() {
                 if let Instruction::Call(call) = instruction {
-                    // Retrieve the program and resource.
-                    let (program, resource) = match call.operator() {
+                    // Get the external stack and resource.
+                    let (external_stack, resource) = match call.operator() {
                         CallOperator::Locator(locator) => {
-                            (process.get_program(locator.program_id())?, locator.resource())
+                            (Some(process.get_stack(locator.program_id())?), locator.resource())
                         }
-                        CallOperator::Resource(resource) => (program, resource),
+                        CallOperator::Resource(resource) => (None, resource),
+                    };
+                    // Retrieve the program.
+                    let program = match &external_stack {
+                        Some(external_stack) => external_stack.program(),
+                        None => program,
                     };
                     // If this is a function call, save its corresponding prover and verifier files.
                     if program.contains_function(resource) {

--- a/vm/package/execute.rs
+++ b/vm/package/execute.rs
@@ -52,16 +52,24 @@ impl<N: Network> Package<N> {
         let authorization = process.authorize::<A, R>(private_key, program_id, function_name, inputs.iter(), rng)?;
 
         // Retrieve the program.
-        let program = process.get_program(program_id)?;
+        let stack = process.get_stack(program_id)?;
+        let program = stack.program();
         // Retrieve the function from the program.
         let function = program.get_function(&function_name)?;
         // Save all the prover and verifier files for any function calls that are made.
         for instruction in function.instructions() {
             if let Instruction::Call(call) = instruction {
-                // Retrieve the program and resource.
-                let (program, resource) = match call.operator() {
-                    CallOperator::Locator(locator) => (process.get_program(locator.program_id())?, locator.resource()),
-                    CallOperator::Resource(resource) => (program, resource),
+                // Retrieve the external stack and resource.
+                let (external_stack, resource) = match call.operator() {
+                    CallOperator::Locator(locator) => {
+                        (Some(process.get_stack(locator.program_id())?), locator.resource())
+                    }
+                    CallOperator::Resource(resource) => (None, resource),
+                };
+                // Retrieve the program.
+                let program = match &external_stack {
+                    Some(external_stack) => external_stack.program(),
+                    None => program,
                 };
                 // If this is a function call, save its corresponding prover and verifier files.
                 if program.contains_function(resource) {

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     prelude::{Deserialize, Deserializer, Serialize, SerializeStruct, Serializer},
     synthesizer::{
         process::{Assignments, CallMetrics, CallStack, Process, StackExecute},
-        program::{CallOperator, Instruction, Program},
+        program::{CallOperator, Instruction, Program, StackProgram},
         snark::{ProvingKey, VerifyingKey},
     },
 };


### PR DESCRIPTION
**DO NOT MERGE UNTIL BASE IS UPDATED TO `staging`**

This PR removes `external_stacks` from `Stack` and references all stacks through the global stack map in `Process`.
This significantly reduces bookkeeping needed to keep `Process` consistent as stacks are modified or evicted from memory.
The changes made in this PR should be semantically equivalent to the prior design.
While the weak reference from `Stack` to `Process` may have some overhead, it should not introduce memory leaks.

## An example

Suppose we have the following programs:
- `one.aleo`
- `two.aleo`, which imports `one.aleo`
- `three.aleo`, which imports `one.aleo` and `two.aleo`
- `four.aleo`, which imports `one.aleo`, `two.aleo` and `three.aleo`

The existing `Process` and `Stack`s are organized in this way in memory:
![image](https://github.com/user-attachments/assets/86b108c3-0e30-4467-a871-79f77c448769)

The new design is organized in this way:
![image](https://github.com/user-attachments/assets/aa545906-5424-47bc-9f0a-e2271920f5f4)

_The blue arrows are `Arc`s and the red arrows are `Weak`s._

## Profiling
-  A [memory profile](https://private-user-images.githubusercontent.com/3750347/419973700-2957decd-6064-4c3c-baad-0f8a5216bd42.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDE3Mjc3MTQsIm5iZiI6MTc0MTcyNzQxNCwicGF0aCI6Ii8zNzUwMzQ3LzQxOTk3MzcwMC0yOTU3ZGVjZC02MDY0LTRjM2MtYmFhZC0wZjhhNTIxNmJkNDIucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDMxMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAzMTFUMjExMDE0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MDZiMzM1M2RmZjM3YjkwNDYzOWYxNjJjMTg1ZGY4MjBhOTg0YWE3ODQ5ODVkNzE2MjMyZDNjZTY5MDhiOTY3ZCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.3Uia6YdTLAQO5EOK7aAzg7COHgu01g5-IJSlWDPrKMo) was done to ensure that a leak does not exist

