### PR TITLE
[Perf] Remove a redundant Arc

### DIFF
--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -78,7 +78,7 @@ use colored::Colorize;
 #[derive(Clone)]
 pub struct Process<N: Network> {
     /// The universal SRS.
-    universal_srs: Arc<UniversalSRS<N>>,
+    universal_srs: UniversalSRS<N>,
     /// The mapping of program IDs to stacks.
     stacks: IndexMap<ProgramID<N>, Arc<Stack<N>>>,
 }
@@ -90,7 +90,7 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process:setup");
 
         // Initialize the process.
-        let mut process = Self { universal_srs: Arc::new(UniversalSRS::load()?), stacks: IndexMap::new() };
+        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: IndexMap::new() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -145,7 +145,7 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process::load");
 
         // Initialize the process.
-        let mut process = Self { universal_srs: Arc::new(UniversalSRS::load()?), stacks: IndexMap::new() };
+        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: IndexMap::new() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -183,7 +183,7 @@ impl<N: Network> Process<N> {
     #[cfg(feature = "wasm")]
     pub fn load_web() -> Result<Self> {
         // Initialize the process.
-        let mut process = Self { universal_srs: Arc::new(UniversalSRS::load()?), stacks: IndexMap::new() };
+        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: IndexMap::new() };
 
         // Initialize the 'credits.aleo' program.
         let program = Program::credits()?;
@@ -200,7 +200,7 @@ impl<N: Network> Process<N> {
 
     /// Returns the universal SRS.
     #[inline]
-    pub const fn universal_srs(&self) -> &Arc<UniversalSRS<N>> {
+    pub const fn universal_srs(&self) -> &UniversalSRS<N> {
         &self.universal_srs
     }
 

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -182,7 +182,7 @@ pub struct Stack<N: Network> {
     /// The mapping of finalize names to their register types.
     finalize_types: IndexMap<Identifier<N>, FinalizeTypes<N>>,
     /// The universal SRS.
-    universal_srs: Arc<UniversalSRS<N>>,
+    universal_srs: UniversalSRS<N>,
     /// The mapping of function name to proving key.
     proving_keys: Arc<RwLock<IndexMap<Identifier<N>, ProvingKey<N>>>>,
     /// The mapping of function name to verifying key.

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -2365,7 +2365,7 @@ fn test_process_deploy_credits_program() {
 
     // Initialize an empty process without the `credits` program.
     let empty_process =
-        Process { universal_srs: Arc::new(UniversalSRS::<CurrentNetwork>::load().unwrap()), stacks: IndexMap::new() };
+        Process { universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(), stacks: IndexMap::new() };
 
     // Construct the process.
     let process = Process::load().unwrap();


### PR DESCRIPTION
The `UniversalSRS` already derives `Clone` and is cheap to clone around:
```
#[derive(Clone)]
pub struct UniversalSRS<N: Network> {
    /// The universal SRS parameter.
    srs: Arc<OnceCell<varuna::UniversalSRS<N::PairingCurve>>>,
}
```
So wrapping it in an additional `Arc` serves no purpose.