### PR TITLE
Allow 30 validators

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -167,10 +167,12 @@ impl Network for CanaryV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
+        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100), (ConsensusVersion::V4, 100)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 25), (ConsensusVersion::V3, 25)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
+        [(ConsensusVersion::V1, 25), (ConsensusVersion::V3, 25), (ConsensusVersion::V4, 25)];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -224,7 +224,7 @@ pub trait Network:
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3];
 
     /// Returns the consensus version which is active at the given height.
     ///

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -172,10 +172,12 @@ impl Network for MainnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
+        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25), (ConsensusVersion::V4, 30)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
+        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100), (ConsensusVersion::V4, 100)];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -167,10 +167,12 @@ impl Network for TestnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
+        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100), (ConsensusVersion::V4, 100)];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 2] = [(ConsensusVersion::V1, 25), (ConsensusVersion::V3, 25)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
+        [(ConsensusVersion::V1, 25), (ConsensusVersion::V3, 25), (ConsensusVersion::V4, 25)];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
 


### PR DESCRIPTION
## Motivation

More validators enable a more decentralized and performant Aleo network.
With the recent snarkOS and snarkVM performance improvements (see below), we can safely increase the number of mainnet validators to 30 on mainnet, testnet and canary.

Should be merged after #2601.

## Test Plan

Tested the `fn test_consensus_constants` on this branch.
Generally, stress tests with more than 30 validators were ran.

## Related PRs

snarkOS and snarkVM performance improvements:
* https://github.com/ProvableHQ/snarkOS/pull/3451
* https://github.com/ProvableHQ/snarkVM/pull/2577
* https://github.com/ProvableHQ/snarkVM/pull/2580

Base branch on batch proposal spend limits:
* https://github.com/ProvableHQ/snarkVM/pull/2601