### PR TITLE
[Feat] Feature-gated R1CS hash collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,6 +2895,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4677,6 +4678,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,6 +2887,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "serial_test",
+ "sha2",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-circuit-environment-witness",
@@ -2895,7 +2896,6 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -4678,12 +4678,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ cli = [
 aleo-cli = [ "snarkvm-synthesizer/aleo-cli" ]
 async = [ "snarkvm-ledger/async", "snarkvm-synthesizer/async" ]
 cuda = [ "snarkvm-algorithms/cuda" ]
+save_r1cs_hashes = [ "snarkvm-circuit/save_r1cs_hashes" ]
 history = [ "snarkvm-synthesizer/history" ]
 parameters_no_std_out = [ "snarkvm-parameters/no_std_out" ]
 noconfig = [ ]

--- a/circuit/Cargo.toml
+++ b/circuit/Cargo.toml
@@ -23,6 +23,9 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "Apache-2.0"
 edition = "2021"
 
+[features]
+save_r1cs_hashes = [ "snarkvm-circuit-environment/save_r1cs_hashes" ]
+
 [dependencies.snarkvm-circuit-account]
 path = "./account"
 version = "=1.3.0"

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -59,6 +59,11 @@ version = "0.2"
 [dependencies.once_cell]
 version = "1.18.0"
 
+[dependencies.xxhash-rust]
+version = "0.8"
+features = ["xxh3"]
+optional = true
+
 [dev-dependencies.snarkvm-algorithms]
 path = "../../algorithms"
 features = [ "polycommit_full", "snark", "test" ]
@@ -77,3 +82,4 @@ version = "2.0.0"
 
 [features]
 default = [ "snarkvm-curves/default" ]
+save_r1cs_hashes = [ "dep:xxhash-rust" ] # used in regression-checking

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -59,9 +59,9 @@ version = "0.2"
 [dependencies.once_cell]
 version = "1.18.0"
 
-[dependencies.xxhash-rust]
-version = "0.8"
-features = ["xxh3"]
+[dependencies.sha2]
+version = "0.10"
+default-features = false
 optional = true
 
 [dev-dependencies.snarkvm-algorithms]
@@ -82,4 +82,4 @@ version = "2.0.0"
 
 [features]
 default = [ "snarkvm-curves/default" ]
-save_r1cs_hashes = [ "dep:xxhash-rust" ] # used in regression-checking
+save_r1cs_hashes = [ "dep:sha2" ] # used in regression-checking

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -99,6 +99,9 @@ pub struct Assignment<F: PrimeField> {
 impl<F: PrimeField> From<crate::R1CS<F>> for Assignment<F> {
     /// Converts an R1CS to an assignment.
     fn from(r1cs: crate::R1CS<F>) -> Self {
+        #[cfg(feature = "save_r1cs_hashes")]
+        r1cs.save_hash();
+
         Self {
             public: FromIterator::from_iter(
                 r1cs.to_public_variables().iter().map(|variable| (variable.index(), variable.value())),

--- a/circuit/environment/src/helpers/constraint.rs
+++ b/circuit/environment/src/helpers/constraint.rs
@@ -16,7 +16,7 @@
 use crate::{prelude::*, *};
 use snarkvm_fields::PrimeField;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct Constraint<F: PrimeField>(
     pub(crate) Scope,
     pub(crate) LinearCombination<F>,

--- a/circuit/environment/src/helpers/counter.rs
+++ b/circuit/environment/src/helpers/counter.rs
@@ -18,7 +18,7 @@ use snarkvm_fields::PrimeField;
 
 use std::{mem, rc::Rc};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Hash)]
 pub(crate) struct Counter<F: PrimeField> {
     scope: Scope,
     constraints: Vec<Rc<Constraint<F>>>,

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -31,7 +31,7 @@ use core::{
 // \end{itemize}
 // The constant and variable terms directly refer to how often the R1CS variables are invoked in a row.
 // A full R1CS row is "completed" when we introduce a multiplication between three non-const linear combinations (a*b=c).
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 pub struct LinearCombination<F: PrimeField> {
     constant: F,
     /// The list of terms is kept sorted in order to speed up lookups.

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -20,10 +20,23 @@ use crate::{
 use snarkvm_fields::PrimeField;
 
 use std::rc::Rc;
+#[cfg(feature = "save_r1cs_hashes")]
+use std::{
+    hash::{Hash, Hasher},
+    sync::Mutex,
+};
 
 pub type Scope = String;
 
-#[derive(Debug)]
+/// A list of hashes of all the R1CS objects that have reached the
+/// coversion to Assignment stage. It's a vector in case there are
+/// any duplicates (which could indicate no change or redundant
+/// work) and since they need to eventually be sorted in order to
+/// have deterministic order, as they may be created in parallel.
+#[cfg(feature = "save_r1cs_hashes")]
+pub static R1CS_HASHES: Mutex<Vec<u64>> = Mutex::new(Vec::new());
+
+#[derive(Debug, Hash)]
 pub struct R1CS<F: PrimeField> {
     constants: Vec<Variable<F>>,
     public: Vec<Variable<F>>,
@@ -208,6 +221,16 @@ impl<F: PrimeField> R1CS<F> {
     /// Returns the constraints in the constraint system.
     pub fn to_constraints(&self) -> &Vec<Rc<Constraint<F>>> {
         &self.constraints
+    }
+
+    /// Register the current hash of the entire R1CS and add
+    /// it to the R1CS_HASHES collection.
+    #[cfg(feature = "save_r1cs_hashes")]
+    pub(crate) fn save_hash(&self) {
+        let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+        self.hash(&mut hasher);
+        let r1cs_hash = hasher.finish();
+        R1CS_HASHES.lock().unwrap().push(r1cs_hash);
     }
 }
 

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -19,12 +19,35 @@ use crate::{
 };
 use snarkvm_fields::PrimeField;
 
+#[cfg(feature = "save_r1cs_hashes")]
+use sha2::{Digest, Sha256};
 use std::rc::Rc;
 #[cfg(feature = "save_r1cs_hashes")]
 use std::{
     hash::{Hash, Hasher},
     sync::Mutex,
 };
+
+#[cfg(feature = "save_r1cs_hashes")]
+struct Sha256Hasher(Sha256);
+
+#[cfg(feature = "save_r1cs_hashes")]
+impl Hasher for Sha256Hasher {
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.update(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        unimplemented!("Use Digest::finalize instead to get the full SHA-256 digest");
+    }
+}
+
+#[cfg(feature = "save_r1cs_hashes")]
+fn hash_to_sha256<T: Hash>(t: &T) -> [u8; 32] {
+    let mut hasher = Sha256Hasher(Sha256::new());
+    t.hash(&mut hasher);
+    hasher.0.finalize().into()
+}
 
 pub type Scope = String;
 
@@ -34,7 +57,7 @@ pub type Scope = String;
 /// work) and since they need to eventually be sorted in order to
 /// have deterministic order, as they may be created in parallel.
 #[cfg(feature = "save_r1cs_hashes")]
-pub static R1CS_HASHES: Mutex<Vec<u64>> = Mutex::new(Vec::new());
+pub static R1CS_HASHES: Mutex<Vec<[u8; 32]>> = Mutex::new(Vec::new());
 
 #[derive(Debug, Hash)]
 pub struct R1CS<F: PrimeField> {
@@ -227,9 +250,7 @@ impl<F: PrimeField> R1CS<F> {
     /// it to the R1CS_HASHES collection.
     #[cfg(feature = "save_r1cs_hashes")]
     pub(crate) fn save_hash(&self) {
-        let mut hasher = xxhash_rust::xxh3::Xxh3::new();
-        self.hash(&mut hasher);
-        let r1cs_hash = hasher.finish();
+        let r1cs_hash = hash_to_sha256(self);
         R1CS_HASHES.lock().unwrap().push(r1cs_hash);
     }
 }


### PR DESCRIPTION
The goal of this PR is to allow snarkVM users to verify that the R1CS objects aren't affected by potentially related changes, i.e. to facilitate regression testing.

I didn't feature-gate the additional `Hash` impls, as I don't think it would be impactful (especially not to runtime performance), and there have been times when I was interested in hashing some of the underlying objects during development.