### PR TITLE
Add test-exports feature for accessing snarkVM/algorithms TestCircuit in external projects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ parameters = [ "snarkvm-parameters" ]
 synthesizer = [ "snarkvm-synthesizer" ]
 utilities = [ "snarkvm-utilities" ]
 wasm = [ "snarkvm-wasm" ]
-test-exports = [ "snarkvm-algorithms/test-exports" ]
+test_exports = [ "snarkvm-algorithms/test_exports" ]
 test_targets = [ "snarkvm-console/test_targets" ]
 
 [dependencies.snarkvm-algorithms]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ parameters = [ "snarkvm-parameters" ]
 synthesizer = [ "snarkvm-synthesizer" ]
 utilities = [ "snarkvm-utilities" ]
 wasm = [ "snarkvm-wasm" ]
+test-exports = [ "snarkvm-algorithms/test-exports" ]
 test_targets = [ "snarkvm-console/test_targets" ]
 
 [dependencies.snarkvm-algorithms]

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -212,4 +212,4 @@ serial = [
   "snarkvm-utilities/serial"
 ]
 snark = [ "crypto_hash", "fft", "msm", "polycommit", "r1cs" ]
-test-exports = ["test"]
+test-exports = []

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -212,3 +212,4 @@ serial = [
   "snarkvm-utilities/serial"
 ]
 snark = [ "crypto_hash", "fft", "msm", "polycommit", "r1cs" ]
+test-exports = ["test"]

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -212,4 +212,4 @@ serial = [
   "snarkvm-utilities/serial"
 ]
 snark = [ "crypto_hash", "fft", "msm", "polycommit", "r1cs" ]
-test-exports = []
+test_exports = []

--- a/algorithms/src/snark/varuna/data_structures/mod.rs
+++ b/algorithms/src/snark/varuna/data_structures/mod.rs
@@ -39,7 +39,6 @@ pub use test_circuit::*;
 #[cfg(feature = "test-exports")]
 pub mod test_exports {
     /// Test circuit for Varuna (for testing purposes only).
-    #[cfg(feature = "test")]
     pub use crate::snark::varuna::TestCircuit;
 }
 

--- a/algorithms/src/snark/varuna/data_structures/mod.rs
+++ b/algorithms/src/snark/varuna/data_structures/mod.rs
@@ -30,9 +30,9 @@ pub(super) mod proof;
 pub use proof::*;
 
 /// A test circuit.
-#[cfg(any(test, feature = "test"))]
+#[cfg(any(test, feature = "test", feature = "test-exports"))]
 pub(super) mod test_circuit;
-#[cfg(any(test, feature = "test"))]
+#[cfg(any(test, feature = "test", feature = "test-exports"))]
 pub use test_circuit::*;
 
 /// Test exports module that provides access to test utilities for external crates.

--- a/algorithms/src/snark/varuna/data_structures/mod.rs
+++ b/algorithms/src/snark/varuna/data_structures/mod.rs
@@ -30,13 +30,13 @@ pub(super) mod proof;
 pub use proof::*;
 
 /// A test circuit.
-#[cfg(any(test, feature = "test", feature = "test-exports"))]
+#[cfg(any(test, feature = "test", feature = "test_exports"))]
 pub(super) mod test_circuit;
-#[cfg(any(test, feature = "test", feature = "test-exports"))]
+#[cfg(any(test, feature = "test", feature = "test_exports"))]
 pub use test_circuit::*;
 
 /// Test exports module that provides access to test utilities for external crates.
-#[cfg(feature = "test-exports")]
+#[cfg(feature = "test_exports")]
 pub mod test_exports {
     /// Test circuit for Varuna (for testing purposes only).
     pub use crate::snark::varuna::TestCircuit;

--- a/algorithms/src/snark/varuna/data_structures/mod.rs
+++ b/algorithms/src/snark/varuna/data_structures/mod.rs
@@ -35,5 +35,13 @@ pub(super) mod test_circuit;
 #[cfg(any(test, feature = "test"))]
 pub use test_circuit::*;
 
+/// Test exports module that provides access to test utilities for external crates.
+#[cfg(feature = "test-exports")]
+pub mod test_exports {
+    /// Test circuit for Varuna (for testing purposes only).
+    #[cfg(feature = "test")]
+    pub use crate::snark::varuna::TestCircuit;
+}
+
 /// The Varuna universal SRS.
 pub type UniversalSRS<E> = crate::polycommit::sonic_pc::UniversalParams<E>;


### PR DESCRIPTION
## Motivation

Enable access to test utilities (specifically the Varuna `TestCircuit` in snarkVM/algorithms) from external crates without modifying the original visibility modifiers or core logic. This provides a clean way to use testing components in dependent projects while maintaining clear separation between test and production code.

Tested usage in an external project on execution fee estimation.