### PR TITLE
[Bug] Fix cargo doc compilation

### DIFF
--- a/curves/src/edwards_bls12/fr.rs
+++ b/curves/src/edwards_bls12/fr.rs
@@ -33,6 +33,8 @@ impl Fp256Parameters for FrParameters {}
 impl FftParameters for FrParameters {
     type BigInteger = BigInteger;
 
+    // `cargo doc` will fail without this attribute
+    #[doc(hidden)]
     const POWERS_OF_ROOTS_OF_UNITY: &'static [BigInteger] = unimplemented!();
     const TWO_ADICITY: u32 = 1;
     #[rustfmt::skip]


### PR DESCRIPTION
## Motivation
`cargo doc` currently fails for snarkVM. This is because in `curves/src/edwards_bls12/fr.rs` a constant is set to `unimplemented!()`. This PR simply disables documentation for that one constant.

## Test Plan
This PR only adds an attribute to existing code and does not change any functionality. Existing tests should be sufficient to verify that it is safe to merge.

## Notes
`cargo doc` still prints some warnings, such as links being formatted incorrectly. I want to keep this PR minimal, but I can address those with a future PR.