### PR TITLE
Doc fixes and additions for block verification/construction.

### DIFF
--- a/ledger/block/src/header/mod.rs
+++ b/ledger/block/src/header/mod.rs
@@ -44,7 +44,7 @@ pub struct Header<N: Network> {
     ratifications_root: Field<N>,
     /// The solutions root of the puzzle.
     solutions_root: Field<N>,
-    /// The subdag root of the authority.
+    /// The subdag Merkle root of the authority.
     subdag_root: Field<N>,
     /// The metadata of the block.
     metadata: Metadata<N>,

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -141,8 +141,8 @@ impl<N: Network> Block<N> {
         )
     }
 
-    /// Initializes a new block from the given previous block hash, block header,
-    /// authority, ratifications, solutions, transactions, and aborted transaction IDs.
+    /// Initializes a new block from the given previous block hash, block header, authority,
+    /// ratifications, solutions, aborted solution IDs, transactions, and aborted transaction IDs.
     pub fn from(
         previous_hash: N::BlockHash,
         header: Header<N>,
@@ -155,21 +155,31 @@ impl<N: Network> Block<N> {
     ) -> Result<Self> {
         // Ensure the number of aborted solutions IDs is within the allowed range.
         if aborted_solution_ids.len() > Solutions::<N>::max_aborted_solutions()? {
-            bail!("Cannot initialize a block with {} aborted solutions IDs", aborted_solution_ids.len());
+            bail!(
+                "Cannot initialize a block with {} aborted solutions IDs which exceed the maximum {}",
+                aborted_solution_ids.len(),
+                Solutions::<N>::max_aborted_solutions()?
+            );
         }
 
         // Ensure the number of transactions is within the allowed range.
         if transactions.len() > Transactions::<N>::MAX_TRANSACTIONS {
             bail!(
-                "Cannot initialize a block with more than {} confirmed transactions",
+                "Cannot initialize a block with {} confirmed transactions which exceed the maximum {}",
+                transactions.len(),
                 Transactions::<N>::MAX_TRANSACTIONS
             );
         }
 
+        // Here we do not check that the number of solutions is within the allowed range,
+        // because that was already done when constructing [`Solutions`] values,
+        // specifically in [`PuzzleSolutions::new()`].
+
         // Ensure the number of aborted transaction IDs is within the allowed range.
         if aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
             bail!(
-                "Cannot initialize a block with more than {} aborted transaction IDs",
+                "Cannot initialize a block with {} aborted transaction IDs which exceed the maximum {}",
+                aborted_transaction_ids.len(),
                 Transactions::<N>::max_aborted_transactions()?
             );
         }
@@ -227,7 +237,8 @@ impl<N: Network> Block<N> {
 
     /// Initializes a new block from the given block hash, previous block hash, block header,
     /// authority, ratifications, solutions, transactions, and aborted transaction IDs.
-    pub fn from_unchecked(
+    /// This is only called by [`Block::from`], which validates the block components.
+    fn from_unchecked(
         block_hash: N::BlockHash,
         previous_hash: N::BlockHash,
         header: Header<N>,
@@ -459,7 +470,7 @@ impl<N: Network> Block<N> {
 }
 
 impl<N: Network> Block<N> {
-    /// Returns the solution IDs in this block.
+    /// Returns an iterator over the solution IDs in this block.
     pub fn solution_ids(&self) -> Option<impl '_ + Iterator<Item = &SolutionID<N>>> {
         self.solutions.as_ref().map(|solution| solution.solution_ids())
     }

--- a/ledger/block/src/transaction/mod.rs
+++ b/ledger/block/src/transaction/mod.rs
@@ -85,7 +85,7 @@ impl<N: Network> Transaction<N> {
         // Compute the transaction ID
         let transaction_id = match &fee {
             Some(fee) => {
-                // Compute the root of the transacton tree.
+                // Compute the root of the transaction tree.
                 *Self::transaction_tree(execution_tree, execution.len(), fee)?.root()
             }
             None => execution_id,

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -320,6 +320,23 @@ impl<N: Network> Block<N> {
         let height = self.height();
         let timestamp = self.timestamp();
 
+        // Ensure the number of solutions is within the allowed range.
+        // This check is redundant if the block has been created via `Block::from()`.
+        ensure!(
+            self.solutions.len() <= N::MAX_SOLUTIONS,
+            "Block {height} contains too many prover solutions (found '{}', expected '{}')",
+            self.solutions.len(),
+            N::MAX_SOLUTIONS
+        );
+
+        // Ensure the number of aborted solution IDs is within the allowed range.
+        // This check is redundant if the block has been created via `Block::from()`.
+        ensure!(
+            self.aborted_solution_ids.len() <= Solutions::<N>::max_aborted_solutions()?,
+            "Block {height} contains too many aborted solution IDs (found '{}')",
+            self.aborted_solution_ids.len(),
+        );
+
         // Ensure there are no duplicate solution IDs.
         if has_duplicates(
             self.solutions
@@ -419,6 +436,24 @@ impl<N: Network> Block<N> {
     /// Ensures the block transactions are correct.
     fn verify_transactions(&self) -> Result<()> {
         let height = self.height();
+
+        // Ensure the number of transactions is within the allowed range.
+        // This check is redundant if the block has been created via `Block::from()`.
+        if self.transactions.len() > Transactions::<N>::MAX_TRANSACTIONS {
+            bail!(
+                "Cannot validate a block with more than {} confirmed transactions",
+                Transactions::<N>::MAX_TRANSACTIONS
+            );
+        }
+
+        // Ensure the number of aborted transaction IDs is within the allowed range.
+        // This check is redundant if the block has been created via `Block::from()`.
+        if self.aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
+            bail!(
+                "Cannot validate a block with more than {} aborted transaction IDs",
+                Transactions::<N>::max_aborted_transactions()?
+            );
+        }
 
         // Ensure there are no duplicate transaction IDs.
         if has_duplicates(self.transaction_ids().chain(self.aborted_transaction_ids.iter())) {

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -225,6 +225,9 @@ impl<N: Network> Block<N> {
                     subdag.leader_address()
                 );
                 // Ensure the transmission IDs from the subdag correspond to the block.
+                // This is redundant if the block has been created via `Block::from()`;
+                // however, we need to obtain the solution and transaction IDs here,
+                // so may want to remove the redundant check in `Block::from()` and leave it here.
                 Self::check_subdag_transmissions(
                     subdag,
                     &self.solutions,

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -320,20 +320,6 @@ impl<N: Network> Block<N> {
         let height = self.height();
         let timestamp = self.timestamp();
 
-        // Ensure the number of solutions is within the allowed range.
-        ensure!(
-            self.solutions.len() <= N::MAX_SOLUTIONS,
-            "Block {height} contains too many prover solutions (found '{}', expected '{}')",
-            self.solutions.len(),
-            N::MAX_SOLUTIONS
-        );
-        // Ensure the number of aborted solution IDs is within the allowed range.
-        ensure!(
-            self.aborted_solution_ids.len() <= Solutions::<N>::max_aborted_solutions()?,
-            "Block {height} contains too many aborted solution IDs (found '{}')",
-            self.aborted_solution_ids.len(),
-        );
-
         // Ensure there are no duplicate solution IDs.
         if has_duplicates(
             self.solutions
@@ -433,22 +419,6 @@ impl<N: Network> Block<N> {
     /// Ensures the block transactions are correct.
     fn verify_transactions(&self) -> Result<()> {
         let height = self.height();
-
-        // Ensure the number of transactions is within the allowed range.
-        if self.transactions.len() > Transactions::<N>::MAX_TRANSACTIONS {
-            bail!(
-                "Cannot validate a block with more than {} confirmed transactions",
-                Transactions::<N>::MAX_TRANSACTIONS
-            );
-        }
-
-        // Ensure the number of aborted transaction IDs is within the allowed range.
-        if self.aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
-            bail!(
-                "Cannot validate a block with more than {} aborted transaction IDs",
-                Transactions::<N>::max_aborted_transactions()?
-            );
-        }
 
         // Ensure there are no duplicate transaction IDs.
         if has_duplicates(self.transaction_ids().chain(self.aborted_transaction_ids.iter())) {

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -251,7 +251,7 @@ impl<N: Network> Block<N> {
                 "Leader certificate has an incorrect committee ID"
             );
 
-            // Check that all all certificates on each round have the same committee ID.
+            // Check that all certificates on each round have the same committee ID.
             cfg_iter!(subdag).try_for_each(|(round, certificates)| {
                 // Check that every certificate for a given round shares the same committee ID.
                 let expected_committee_id = certificates
@@ -637,9 +637,9 @@ impl<N: Network> Block<N> {
         }
 
         // Ensure there are no more solutions in the block.
-        ensure!(solutions.next().is_none(), "There exists more solutions than expected.");
+        ensure!(solutions.next().is_none(), "There exist more solutions than expected.");
         // Ensure there are no more transactions in the block.
-        ensure!(unconfirmed_transactions.next().is_none(), "There exists more transactions than expected.");
+        ensure!(unconfirmed_transactions.next().is_none(), "There exist more transactions than expected.");
 
         // Ensure the aborted solution IDs match.
         for aborted_solution_id in aborted_solution_ids {

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -118,7 +118,6 @@ pub struct Subdag<N: Network> {
 
 impl<N: Network> PartialEq for Subdag<N> {
     fn eq(&self, other: &Self) -> bool {
-        // Note: We do not check equality on `election_certificate_ids` as it would cause `Block::eq` to trigger false-positives.
         self.subdag == other.subdag
     }
 }


### PR DESCRIPTION
Fix some doc comments.

Make two similar error messages consistent.

Clarify that a naturally expected check is done elsewhere.

Make some doc comments more precise (were confusing).

Make internal "unchecked" constructor non-public.

Document some redundant block checks. These are already performed during block construction, so there is no need to repeat them during block verification. I didn't see ways in which block verification is called without having called block construction first.
