### PR TITLE
[Feature] Introduce the `metadata.get` command.

### DIFF
--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -399,6 +399,7 @@ pub fn cost_per_command<N: Network>(
         Command::GetOrUse(command) => {
             cost_in_size(stack, finalize, [command.key()], MAPPING_PER_BYTE_COST, mapping_base_cost)
         }
+        Command::MetadataGet(_) => Ok(500),
         Command::RandChaCha(_) => Ok(25_000),
         Command::Remove(_) => Ok(SET_BASE_COST),
         Command::Set(command) => {

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -492,10 +492,8 @@ impl<N: Network> FinalizeTypes<N> {
         metadata_get: &MetadataGet<N>,
     ) -> Result<()> {
         // Ensure that the program is defined.
-        // Note that we do not check that the metadata name is valid, as that can change in future updates.
-        if let CallOperator::Locator(locator) = metadata_get.name() {
-            // Ensure the program ID is defined.
-            let program_id = locator.program_id();
+        // Note that we do not check that the metadata name is valid, as that can change by an update to the program.
+        if let Some(program_id) = metadata_get.program() {
             // Ensure the program ID is imported by the current program.
             if !stack.program().imports().keys().contains(program_id) {
                 bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -201,6 +201,7 @@ impl<N: Network> FinalizeTypes<N> {
             Command::Contains(contains) => self.check_contains(stack, contains)?,
             Command::Get(get) => self.check_get(stack, get)?,
             Command::GetOrUse(get_or_use) => self.check_get_or_use(stack, get_or_use)?,
+            Command::MetadataGet(metadata_get) => self.check_metadata_get(stack, metadata_get)?,
             Command::RandChaCha(rand_chacha) => self.check_rand_chacha(stack, rand_chacha)?,
             Command::Remove(remove) => self.check_remove(stack, remove)?,
             Command::Set(set) => self.check_set(stack, set)?,
@@ -480,6 +481,37 @@ impl<N: Network> FinalizeTypes<N> {
         ensure!(matches!(destination, Register::Locator(..)), "Destination '{destination}' must be a locator.");
         // Insert the destination register.
         self.add_destination(destination, FinalizeType::Plaintext(default_value_type))?;
+        Ok(())
+    }
+
+    /// Ensures the given `metadata.get` command is well-formed.
+    #[inline]
+    fn check_metadata_get(
+        &mut self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        metadata_get: &MetadataGet<N>,
+    ) -> Result<()> {
+        // Ensure that the program is defined.
+        // Note that we do not check that the metadata name is valid, as that can change in future updates.
+        if let CallOperator::Locator(locator) = metadata_get.name() {
+            // Ensure the program ID is defined.
+            let program_id = locator.program_id();
+            // Ensure the program ID is imported by the current program.
+            if !stack.program().imports().keys().contains(program_id) {
+                bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
+            }
+            // Check that the process contains the external program.
+            stack.get_external_stack(program_id)?;
+        }
+        // Get the destination register.
+        let destination = metadata_get.destination().clone();
+        // Ensure the destination register is a locator (and does not reference an access).
+        ensure!(matches!(destination, Register::Locator(..)), "Destination '{destination}' must be a locator.");
+        // Insert the destination register.
+        self.add_destination(
+            destination,
+            FinalizeType::Plaintext(PlaintextType::Literal(metadata_get.destination_type().clone())),
+        )?;
         Ok(())
     }
 

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -510,7 +510,7 @@ impl<N: Network> FinalizeTypes<N> {
         // Insert the destination register.
         self.add_destination(
             destination,
-            FinalizeType::Plaintext(PlaintextType::Literal(metadata_get.destination_type().clone())),
+            FinalizeType::Plaintext(PlaintextType::Literal(*metadata_get.destination_type())),
         )?;
         Ok(())
     }

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -46,6 +46,7 @@ use synthesizer_program::{
     Instruction,
     InstructionTrait,
     MAX_ADDITIONAL_SEEDS,
+    MetadataGet,
     Opcode,
     Operand,
     Program,

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -30,6 +30,7 @@ impl<N: Network> Stack<N> {
             proving_keys: Default::default(),
             verifying_keys: Default::default(),
             program_address: program.id().to_address()?,
+            program_checksum: program.checksum()?,
         };
 
         // Add all the imports into the stack.
@@ -41,6 +42,7 @@ impl<N: Network> Stack<N> {
                 bail!("Cannot add program '{}' because its import '{import}' must be added first", program.id())
             }
         }
+
         // Add the program closures to the stack.
         for closure in program.closures().values() {
             // Add the closure to the stack.
@@ -54,7 +56,6 @@ impl<N: Network> Stack<N> {
             // Determine the number of calls for the function.
             // This includes a safety check for the maximum number of calls.
             stack.get_number_of_calls(function.name())?;
-
             // Get the finalize cost.
             let finalize_cost = cost_in_microcredits_v2(&stack, function.name())?;
             // Check that the finalize cost does not exceed the maximum.
@@ -63,7 +64,7 @@ impl<N: Network> Stack<N> {
                 "Finalize block '{}' has a cost '{finalize_cost}' which exceeds the transaction spend limit '{}'",
                 function.name(),
                 N::TRANSACTION_SPEND_LIMIT
-            );
+            )
         }
 
         // Add the constructor to the stack if it exists.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -62,7 +62,7 @@ use console::{
         Value,
         ValueType,
     },
-    types::{Field, Group},
+    types::{Field, Group, U128},
 };
 use ledger_block::{Deployment, Transaction, Transition};
 use synthesizer_program::{CallOperator, Closure, Constructor, Function, Instruction, Operand, Program, traits::*};
@@ -200,6 +200,8 @@ pub struct Stack<N: Network> {
     verifying_keys: Arc<RwLock<IndexMap<Identifier<N>, VerifyingKey<N>>>>,
     /// The program address.
     program_address: Address<N>,
+    /// The program checksum.
+    program_checksum: U128<N>,
 }
 
 impl<N: Network> Stack<N> {
@@ -321,6 +323,12 @@ impl<N: Network> StackProgram<N> for Stack<N> {
     #[inline]
     fn program_address(&self) -> &Address<N> {
         &self.program_address
+    }
+
+    /// Returns the program checksum.
+    #[inline]
+    fn program_checksum(&self) -> &U128<N> {
+        &self.program_checksum
     }
 
     /// Returns the external stack for the given program ID.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -527,6 +527,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         "type",
         "future",
         "_init",
+        "_checksum"
     ];
 
     /// Returns `true` if the given name is a reserved opcode.

--- a/synthesizer/program/src/logic/command/metadata_get.rs
+++ b/synthesizer/program/src/logic/command/metadata_get.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Aleo Network Foundation
+// Copyright 2024-2025 Aleo Network Foundation
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/metadata_get.rs
+++ b/synthesizer/program/src/logic/command/metadata_get.rs
@@ -99,10 +99,8 @@ impl<N: Network> MetadataGet<N> {
                 None => *stack.program_checksum(),
             }),
             MetadataName::Identifier(identifier) => match &self.program {
-                Some(program) => {
-                    stack.get_external_stack(program)?.program().get_metadata(&identifier)?.value().clone()
-                }
-                None => stack.program().get_metadata(&identifier)?.value().clone(),
+                Some(program) => stack.get_external_stack(program)?.program().get_metadata(identifier)?.value().clone(),
+                None => stack.program().get_metadata(identifier)?.value().clone(),
             },
         };
         let plaintext = Plaintext::from(literal);
@@ -190,7 +188,7 @@ impl<N: Network> Display for MetadataGet<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Format the program.
         let program = match &self.program {
-            Some(program) => format!("{}/", program.to_string()),
+            Some(program) => format!("{program}/"),
             None => String::new(),
         };
         // Format the name.

--- a/synthesizer/program/src/logic/command/metadata_get.rs
+++ b/synthesizer/program/src/logic/command/metadata_get.rs
@@ -14,27 +14,37 @@
 // limitations under the License.
 
 use crate::{
-    CallOperator,
     Opcode,
     traits::{FinalizeStoreTrait, RegistersLoad, RegistersStore, StackMatches, StackProgram},
 };
 use console::{
     network::prelude::*,
-    program::{Literal, LiteralType, Plaintext, PlaintextType, Register, Value},
+    program::{Identifier, Literal, LiteralType, Plaintext, PlaintextType, ProgramID, Register, Value},
 };
+
+/// The name of the metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MetadataName<N: Network> {
+    /// The program checksum.
+    Checksum,
+    /// A declared metadata identifier.
+    Identifier(Identifier<N>),
+}
 
 /// A command to get metadata about a program, e.g. `metadata.get program_owner into r1 as address;`.
 /// Gets the value with the `name` from the program and stores it in the `destination` register.
 /// The value is checked to be of the `destination_type`.
 ///
-/// `metadata.get checksum into r1 as u128;` is a special case where the metadata is not retrieved from the program.
+/// `metadata.get _checksum into r1 as u128;` is a special case where the metadata is not retrieved from the program.
 /// Instead, the checksum of the program is calculated and stored in the destination register.
 ///
 /// Note that other than the `checksum`, metadata can only be retrieved for V2 programs.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MetadataGet<N: Network> {
-    /// The global ID.
-    name: CallOperator<N>,
+    /// The optional program name.
+    program: Option<ProgramID<N>>,
+    /// The name of the metadata.
+    name: MetadataName<N>,
     /// The destination register.
     destination: Register<N>,
     /// The destination type.
@@ -48,9 +58,15 @@ impl<N: Network> MetadataGet<N> {
         Opcode::Command("metadata.get")
     }
 
+    /// Returns the program.
+    #[inline]
+    pub const fn program(&self) -> Option<&ProgramID<N>> {
+        self.program.as_ref()
+    }
+
     /// Returns the name.
     #[inline]
-    pub const fn name(&self) -> &CallOperator<N> {
+    pub const fn name(&self) -> &MetadataName<N> {
         &self.name
     }
 
@@ -76,19 +92,20 @@ impl<N: Network> MetadataGet<N> {
         _store: &impl FinalizeStoreTrait<N>,
         registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
     ) -> Result<()> {
-        // Determine the program ID and name.
-        let (external_stack, name) = match self.name {
-            CallOperator::Locator(locator) => {
-                (Some(stack.get_external_stack(locator.program_id())?), *locator.resource())
-            }
-            CallOperator::Resource(name) => (None, name),
+        // Get the metadata literal.
+        let literal = match &self.name {
+            MetadataName::Checksum => Literal::U128(match &self.program {
+                Some(program) => *stack.get_external_stack(program)?.program_checksum(),
+                None => *stack.program_checksum(),
+            }),
+            MetadataName::Identifier(identifier) => match &self.program {
+                Some(program) => {
+                    stack.get_external_stack(program)?.program().get_metadata(&identifier)?.value().clone()
+                }
+                None => stack.program().get_metadata(&identifier)?.value().clone(),
+            },
         };
-        let plaintext = Plaintext::from(match (external_stack, name.to_string().as_str()) {
-            (Some(external_stack), "checksum") => Literal::U128(*external_stack.program_checksum()),
-            (None, "checksum") => Literal::U128(*stack.program_checksum()),
-            (Some(external_stack), _) => external_stack.program().get_metadata(&name)?.value().clone(),
-            (None, _) => stack.program().get_metadata(&name)?.value().clone(),
-        });
+        let plaintext = Plaintext::from(literal);
         // Check that retrieved metadata is of the correct type.
         stack.matches_plaintext(&plaintext, &PlaintextType::Literal(*self.destination_type()))?;
         // Assign the value to the destination register.
@@ -109,8 +126,13 @@ impl<N: Network> Parser for MetadataGet<N> {
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
 
-        // Parse the name from the string.
-        let (string, name) = CallOperator::parse(string)?;
+        // Optionally parse the program and the "/" separator from the string.
+        let (string, (program, _)) = pair(opt(ProgramID::parse), opt(tag("/")))(string)?;
+        // Parse the metadata name from the string.
+        let (string, name) = alt((
+            map(tag("_checksum"), |_| MetadataName::Checksum),
+            map(Identifier::parse, MetadataName::Identifier),
+        ))(string)?;
 
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
@@ -134,7 +156,7 @@ impl<N: Network> Parser for MetadataGet<N> {
         // Parse the ";" from the string.
         let (string, _) = tag(";")(string)?;
 
-        Ok((string, Self { name, destination, destination_type }))
+        Ok((string, Self { program, name, destination, destination_type }))
     }
 }
 
@@ -166,34 +188,72 @@ impl<N: Network> Debug for MetadataGet<N> {
 impl<N: Network> Display for MetadataGet<N> {
     /// Prints the command to a string.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Format the program.
+        let program = match &self.program {
+            Some(program) => format!("{}/", program.to_string()),
+            None => String::new(),
+        };
+        // Format the name.
+        let name = match &self.name {
+            MetadataName::Checksum => "_checksum".to_string(),
+            MetadataName::Identifier(identifier) => identifier.to_string(),
+        };
         // Print the command.
-        write!(f, "{} {} into {} as {};", Self::opcode(), self.name, self.destination, self.destination_type)
+        write!(f, "{} {program}{name} into {} as {};", Self::opcode(), self.destination, self.destination_type)
     }
 }
 
 impl<N: Network> FromBytes for MetadataGet<N> {
     /// Reads the command from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the program.
+        let option = u8::read_le(&mut reader)?;
+        let program = match option {
+            0 => None,
+            1 => Some(ProgramID::read_le(&mut reader)?),
+            _ => return Err(error("Failed to read program ID. Invalid option.")),
+        };
         // Read the name.
-        let name = CallOperator::read_le(&mut reader)?;
+        let variant = u8::read_le(&mut reader)?;
+        let name = match variant {
+            0 => MetadataName::Checksum,
+            1 => MetadataName::Identifier(Identifier::read_le(&mut reader)?),
+            _ => return Err(error("Failed to read metadata name. Invalid variant: {variant}")),
+        };
         // Read the destination register.
         let destination = Register::read_le(&mut reader)?;
         // Read the destination type.
         let destination_type = LiteralType::read_le(&mut reader)?;
         // Return the command.
-        Ok(Self { name, destination, destination_type })
+        Ok(Self { program, name, destination, destination_type })
     }
 }
 
 impl<N: Network> ToBytes for MetadataGet<N> {
     /// Writes the command to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the program.
+        match &self.program {
+            None => 0u8.write_le(&mut writer)?,
+            Some(program) => {
+                1u8.write_le(&mut writer)?;
+                program.write_le(&mut writer)?;
+            }
+        }
         // Write the name.
-        self.name.write_le(&mut writer)?;
+        match &self.name {
+            MetadataName::Checksum => 0u8.write_le(&mut writer)?,
+            MetadataName::Identifier(identifier) => {
+                1u8.write_le(&mut writer)?;
+                identifier.write_le(&mut writer)?;
+            }
+        }
         // Write the destination register.
         self.destination.write_le(&mut writer)?;
         // Write the destination type.
-        self.destination_type.write_le(&mut writer)
+        self.destination_type.write_le(&mut writer)?;
+        // Return success.
+        Ok(())
     }
 }
 
@@ -212,16 +272,26 @@ mod tests {
         let (string, metadata_get) =
             MetadataGet::<CurrentNetwork>::parse("metadata.get edition into r1 as u16;").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(metadata_get.name(), &CallOperator::from_str("edition").unwrap());
+        assert_eq!(metadata_get.program(), None);
+        assert_eq!(metadata_get.name(), &MetadataName::Identifier(Identifier::from_str("edition").unwrap()));
         assert_eq!(metadata_get.destination, Register::Locator(1), "The destination is incorrect");
         assert_eq!(metadata_get.destination_type, LiteralType::U16, "The destination type is incorrect");
 
         let (string, metadata_get) =
             MetadataGet::<CurrentNetwork>::parse("metadata.get token.aleo/bar into r1 as u16;").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
-        assert_eq!(metadata_get.name(), &CallOperator::from_str("token.aleo/bar").unwrap());
+        assert_eq!(metadata_get.program(), Some(&ProgramID::from_str("token.aleo").unwrap()));
+        assert_eq!(metadata_get.name(), &MetadataName::Identifier(Identifier::from_str("bar").unwrap()));
         assert_eq!(metadata_get.destination, Register::Locator(1), "The destination is incorrect");
         assert_eq!(metadata_get.destination_type, LiteralType::U16, "The destination type is incorrect");
+
+        let (string, metadata_get) =
+            MetadataGet::<CurrentNetwork>::parse("metadata.get _checksum into r1 as u128;").unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+        assert_eq!(metadata_get.program(), None);
+        assert_eq!(metadata_get.name(), &MetadataName::Checksum);
+        assert_eq!(metadata_get.destination, Register::Locator(1), "The destination is incorrect");
+        assert_eq!(metadata_get.destination_type, LiteralType::U128, "The destination type is incorrect");
     }
 
     #[test]

--- a/synthesizer/program/src/logic/command/metadata_get.rs
+++ b/synthesizer/program/src/logic/command/metadata_get.rs
@@ -1,0 +1,243 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    CallOperator,
+    Opcode,
+    traits::{FinalizeStoreTrait, RegistersLoad, RegistersStore, StackMatches, StackProgram},
+};
+use console::{
+    network::prelude::*,
+    program::{Literal, LiteralType, Plaintext, PlaintextType, Register, Value},
+};
+
+/// A command to get metadata about a program, e.g. `metadata.get program_owner into r1 as address;`.
+/// Gets the value with the `name` from the program and stores it in the `destination` register.
+/// The value is checked to be of the `destination_type`.
+///
+/// `metadata.get checksum into r1 as u128;` is a special case where the metadata is not retrieved from the program.
+/// Instead, the checksum of the program is calculated and stored in the destination register.
+///
+/// Note that other than the `checksum`, metadata can only be retrieved for V2 programs.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct MetadataGet<N: Network> {
+    /// The global ID.
+    name: CallOperator<N>,
+    /// The destination register.
+    destination: Register<N>,
+    /// The destination type.
+    destination_type: LiteralType,
+}
+
+impl<N: Network> MetadataGet<N> {
+    /// Returns the opcode.
+    #[inline]
+    pub const fn opcode() -> Opcode {
+        Opcode::Command("metadata.get")
+    }
+
+    /// Returns the name.
+    #[inline]
+    pub const fn name(&self) -> &CallOperator<N> {
+        &self.name
+    }
+
+    /// Returns the destination register.
+    #[inline]
+    pub const fn destination(&self) -> &Register<N> {
+        &self.destination
+    }
+
+    /// Returns the destination type.
+    #[inline]
+    pub const fn destination_type(&self) -> &LiteralType {
+        &self.destination_type
+    }
+}
+
+impl<N: Network> MetadataGet<N> {
+    /// Finalizes the command.
+    #[inline]
+    pub fn finalize(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        _store: &impl FinalizeStoreTrait<N>,
+        registers: &mut (impl RegistersLoad<N> + RegistersStore<N>),
+    ) -> Result<()> {
+        // Determine the program ID and name.
+        let (external_stack, name) = match self.name {
+            CallOperator::Locator(locator) => {
+                (Some(stack.get_external_stack(locator.program_id())?), *locator.resource())
+            }
+            CallOperator::Resource(name) => (None, name),
+        };
+        let plaintext = Plaintext::from(match (external_stack, name.to_string().as_str()) {
+            (Some(external_stack), "checksum") => Literal::U128(*external_stack.program_checksum()),
+            (None, "checksum") => Literal::U128(*stack.program_checksum()),
+            (Some(external_stack), _) => external_stack.program().get_metadata(&name)?.value().clone(),
+            (None, _) => stack.program().get_metadata(&name)?.value().clone(),
+        });
+        // Check that retrieved metadata is of the correct type.
+        stack.matches_plaintext(&plaintext, &PlaintextType::Literal(*self.destination_type()))?;
+        // Assign the value to the destination register.
+        registers.store(stack, &self.destination, Value::Plaintext(plaintext))?;
+
+        Ok(())
+    }
+}
+
+impl<N: Network> Parser for MetadataGet<N> {
+    /// Parses a string into the command.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the opcode from the string.
+        let (string, _) = tag(*Self::opcode())(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+
+        // Parse the name from the string.
+        let (string, name) = CallOperator::parse(string)?;
+
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "into" keyword from the string.
+        let (string, _) = tag("into")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the destination register from the string.
+        let (string, destination) = Register::parse(string)?;
+
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "as" keyword from the string.
+        let (string, _) = tag("as")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the destination type from the string.
+        let (string, destination_type) = LiteralType::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the ";" from the string.
+        let (string, _) = tag(";")(string)?;
+
+        Ok((string, Self { name, destination, destination_type }))
+    }
+}
+
+impl<N: Network> FromStr for MetadataGet<N> {
+    type Err = Error;
+
+    /// Parses a string into the command.
+    #[inline]
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for MetadataGet<N> {
+    /// Prints the command as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for MetadataGet<N> {
+    /// Prints the command to a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Print the command.
+        write!(f, "{} {} into {} as {};", Self::opcode(), self.name, self.destination, self.destination_type)
+    }
+}
+
+impl<N: Network> FromBytes for MetadataGet<N> {
+    /// Reads the command from a buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the name.
+        let name = CallOperator::read_le(&mut reader)?;
+        // Read the destination register.
+        let destination = Register::read_le(&mut reader)?;
+        // Read the destination type.
+        let destination_type = LiteralType::read_le(&mut reader)?;
+        // Return the command.
+        Ok(Self { name, destination, destination_type })
+    }
+}
+
+impl<N: Network> ToBytes for MetadataGet<N> {
+    /// Writes the command to a buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the name.
+        self.name.write_le(&mut writer)?;
+        // Write the destination register.
+        self.destination.write_le(&mut writer)?;
+        // Write the destination type.
+        self.destination_type.write_le(&mut writer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::{
+        network::MainnetV0,
+        program::{LiteralType, Register},
+    };
+
+    type CurrentNetwork = MainnetV0;
+
+    #[test]
+    fn test_parse() {
+        let (string, metadata_get) =
+            MetadataGet::<CurrentNetwork>::parse("metadata.get edition into r1 as u16;").unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+        assert_eq!(metadata_get.name(), &CallOperator::from_str("edition").unwrap());
+        assert_eq!(metadata_get.destination, Register::Locator(1), "The destination is incorrect");
+        assert_eq!(
+            metadata_get.destination_type,
+            LiteralType::U16,
+            "The destination type is incorrect"
+        );
+
+        let (string, metadata_get) =
+            MetadataGet::<CurrentNetwork>::parse("metadata.get token.aleo/bar into r1 as u16;").unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+        assert_eq!(metadata_get.name(), &CallOperator::from_str("token.aleo/bar").unwrap());
+        assert_eq!(metadata_get.destination, Register::Locator(1), "The destination is incorrect");
+        assert_eq!(
+            metadata_get.destination_type,
+            LiteralType::U16,
+            "The destination type is incorrect"
+        );
+    }
+
+    #[test]
+    fn test_from_bytes() {
+        let (string, get) = MetadataGet::<CurrentNetwork>::parse("metadata.get foo into r1 as u16;").unwrap();
+        assert!(string.is_empty());
+        let bytes_le = get.to_bytes_le().unwrap();
+        let result = MetadataGet::<CurrentNetwork>::from_bytes_le(&bytes_le[..]);
+        assert!(result.is_ok())
+    }
+}

--- a/synthesizer/program/src/logic/command/metadata_get.rs
+++ b/synthesizer/program/src/logic/command/metadata_get.rs
@@ -214,22 +214,14 @@ mod tests {
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(metadata_get.name(), &CallOperator::from_str("edition").unwrap());
         assert_eq!(metadata_get.destination, Register::Locator(1), "The destination is incorrect");
-        assert_eq!(
-            metadata_get.destination_type,
-            LiteralType::U16,
-            "The destination type is incorrect"
-        );
+        assert_eq!(metadata_get.destination_type, LiteralType::U16, "The destination type is incorrect");
 
         let (string, metadata_get) =
             MetadataGet::<CurrentNetwork>::parse("metadata.get token.aleo/bar into r1 as u16;").unwrap();
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
         assert_eq!(metadata_get.name(), &CallOperator::from_str("token.aleo/bar").unwrap());
         assert_eq!(metadata_get.destination, Register::Locator(1), "The destination is incorrect");
-        assert_eq!(
-            metadata_get.destination_type,
-            LiteralType::U16,
-            "The destination type is incorrect"
-        );
+        assert_eq!(metadata_get.destination_type, LiteralType::U16, "The destination type is incorrect");
     }
 
     #[test]

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -28,6 +28,9 @@ pub use get::*;
 mod get_or_use;
 pub use get_or_use::*;
 
+mod metadata_get;
+pub use metadata_get::*;
+
 mod rand_chacha;
 pub use crate::command::rand_chacha::*;
 
@@ -73,6 +76,8 @@ pub enum Command<N: Network> {
     /// Gets the value stored at the `key` operand in `mapping` and stores the result into `destination`.
     /// If the key is not present, `default` is stored `destination`.
     GetOrUse(GetOrUse<N>),
+    /// Gets the value stored at `global` and stores the result into `destination`.
+    MetadataGet(MetadataGet<N>),
     /// Generates a random value using the `rand.chacha` command and stores the result into `destination`.
     RandChaCha(RandChaCha<N>),
     /// Removes the (`key`, `value`) entry from the `mapping`.
@@ -96,6 +101,7 @@ impl<N: Network> CommandTrait<N> for Command<N> {
             Command::Contains(contains) => vec![contains.destination().clone()],
             Command::Get(get) => vec![get.destination().clone()],
             Command::GetOrUse(get_or_use) => vec![get_or_use.destination().clone()],
+            Command::MetadataGet(metadata_get) => vec![metadata_get.destination().clone()],
             Command::RandChaCha(rand_chacha) => vec![rand_chacha.destination().clone()],
             Command::Await(_)
             | Command::BranchEq(_)
@@ -171,6 +177,8 @@ impl<N: Network> Command<N> {
             Command::Get(get) => get.finalize(stack, store, registers).map(|_| None),
             // Finalize the 'get.or_use' command, and return no finalize operation.
             Command::GetOrUse(get_or_use) => get_or_use.finalize(stack, store, registers).map(|_| None),
+            // Finalize the 'metadata.get' command, and return no finalize operation.
+            Command::MetadataGet(metadata_get) => metadata_get.finalize(stack, store, registers).map(|_| None),
             // Finalize the `rand.chacha` command, and return no finalize operation.
             Command::RandChaCha(rand_chacha) => rand_chacha.finalize(stack, registers).map(|_| None),
             // Finalize the 'remove' command, and return the finalize operation.
@@ -215,8 +223,10 @@ impl<N: Network> FromBytes for Command<N> {
             9 => Ok(Self::BranchNeq(BranchNeq::read_le(&mut reader)?)),
             // Read the `position` command.
             10 => Ok(Self::Position(Position::read_le(&mut reader)?)),
+            // Read the `metadata.get` command.
+            11 => Ok(Self::MetadataGet(MetadataGet::read_le(&mut reader)?)),
             // Invalid variant.
-            11.. => Err(error(format!("Invalid command variant: {variant}"))),
+            12.. => Err(error(format!("Invalid command variant: {variant}"))),
         }
     }
 }
@@ -291,6 +301,12 @@ impl<N: Network> ToBytes for Command<N> {
                 // Write the position command.
                 position.write_le(&mut writer)
             }
+            Self::MetadataGet(metadata_get) => {
+                // Write the variant.
+                11u8.write_le(&mut writer)?;
+                // Write the `metadata.get` command.
+                metadata_get.write_le(&mut writer)
+            }
         }
     }
 }
@@ -306,6 +322,7 @@ impl<N: Network> Parser for Command<N> {
             map(Contains::parse, |contains| Self::Contains(contains)),
             map(GetOrUse::parse, |get_or_use| Self::GetOrUse(get_or_use)),
             map(Get::parse, |get| Self::Get(get)),
+            map(MetadataGet::parse, |metadata_get| Self::MetadataGet(metadata_get)),
             map(RandChaCha::parse, |rand_chacha| Self::RandChaCha(rand_chacha)),
             map(Remove::parse, |remove| Self::Remove(remove)),
             map(Set::parse, |set| Self::Set(set)),
@@ -351,6 +368,7 @@ impl<N: Network> Display for Command<N> {
             Self::Contains(contains) => Display::fmt(contains, f),
             Self::Get(get) => Display::fmt(get, f),
             Self::GetOrUse(get_or_use) => Display::fmt(get_or_use, f),
+            Self::MetadataGet(metadata_get) => Display::fmt(metadata_get, f),
             Self::RandChaCha(rand_chacha) => Display::fmt(rand_chacha, f),
             Self::Remove(remove) => Display::fmt(remove, f),
             Self::Set(set) => Display::fmt(set, f),
@@ -404,6 +422,12 @@ mod tests {
 
         // GetOr
         let expected = "get.or_use object[r0] r1 into r2;";
+        let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
+        let bytes = command.to_bytes_le().unwrap();
+        assert_eq!(command, Command::from_bytes_le(&bytes).unwrap());
+
+        // MetadataGet
+        let expected = "metadata.get edition into r0 as u16;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
         let bytes = command.to_bytes_le().unwrap();
         assert_eq!(command, Command::from_bytes_le(&bytes).unwrap());
@@ -483,6 +507,12 @@ mod tests {
         let expected = "get.or_use object[r0] r1 into r2;";
         let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
         assert_eq!(Command::GetOrUse(GetOrUse::from_str(expected).unwrap()), command);
+        assert_eq!(expected, command.to_string());
+
+        // MetadataGet
+        let expected = "metadata.get edition into r0 as u16;";
+        let command = Command::<CurrentNetwork>::parse(expected).unwrap().1;
+        assert_eq!(Command::MetadataGet(MetadataGet::from_str(expected).unwrap()), command);
         assert_eq!(expected, command.to_string());
 
         // RandChaCha

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -34,7 +34,7 @@ use console::{
         Value,
         ValueType,
     },
-    types::{Address, Field},
+    types::{Address, Field, U128},
 };
 use rand::{CryptoRng, Rng};
 use synthesizer_snark::{ProvingKey, VerifyingKey};
@@ -94,6 +94,9 @@ pub trait StackProgram<N: Network> {
 
     /// Returns the program address.
     fn program_address(&self) -> &Address<N>;
+
+    /// Returns the program checksum.
+    fn program_checksum(&self) -> &U128<N>;
 
     /// Returns the external stack for the given program ID.
     fn get_external_stack(&self, program_id: &ProgramID<N>) -> Result<Arc<Self>>;

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/metadata_get_v1.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/metadata_get_v1.out
@@ -1,0 +1,36 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    check_metadata_v1.aleo/test_checksum:
+      outputs:
+      - '{"type":"future","id":"1942986884224057660836892540982579789376753278170115639219825830812951807719field","value":"{\n  program_id: check_metadata_v1.aleo,\n  function_name: test_checksum,\n  arguments: []\n}"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- verified: true
+  execute:
+    check_metadata_v1.aleo/test_checksum_invalid:
+      outputs:
+      - '{"type":"future","id":"2099969932477975167199589480291573112946889522738085542175794817660517581192field","value":"{\n  program_id: check_metadata_v1.aleo,\n  function_name: test_checksum_invalid,\n  arguments: []\n}"}'
+  speculate: the execution was rejected
+  add_next_block: succeeded.
+- verified: true
+  execute:
+    check_metadata_v1.aleo/test_metadata_does_not_exist:
+      outputs:
+      - '{"type":"future","id":"1028342846796861707856911399525063996224302600495504888866637929312698682285field","value":"{\n  program_id: check_metadata_v1.aleo,\n  function_name: test_metadata_does_not_exist,\n  arguments: []\n}"}'
+  speculate: the execution was rejected
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"2681681182947927914827189098374851266973897041646544830684575468637736931309field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo10lhsyx8sf7mcxaj5qxv6z28dums30x0g0f24kfs90qzplgvcvqpss3kvzg,\n    2232u64\n  ]\n}"}'
+- child_outputs:
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"3039352655640560307505744753384261236065475548961473988441346016471874726189field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo10lhsyx8sf7mcxaj5qxv6z28dums30x0g0f24kfs90qzplgvcvqpss3kvzg,\n    1748u64\n  ]\n}"}'
+- child_outputs:
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"4938245309536825183360950500748921311149037680955338030510513016533335414648field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo10lhsyx8sf7mcxaj5qxv6z28dums30x0g0f24kfs90qzplgvcvqpss3kvzg,\n    1762u64\n  ]\n}"}'

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/metadata_get_v2.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/metadata_get_v2.out
@@ -1,0 +1,47 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    check_metadata_v2.aleo/test_checksum:
+      outputs:
+      - '{"type":"future","id":"3448242660880055378059357845410054207495341007634789775869357466673497694026field","value":"{\n  program_id: check_metadata_v2.aleo,\n  function_name: test_checksum,\n  arguments: []\n}"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- verified: true
+  execute:
+    check_metadata_v2.aleo/test_metadata:
+      outputs:
+      - '{"type":"future","id":"7040377961178264697037568505097752497263411784397392356646264774052314254205field","value":"{\n  program_id: check_metadata_v2.aleo,\n  function_name: test_metadata,\n  arguments: []\n}"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- verified: true
+  execute:
+    check_metadata_v2.aleo/test_checksum_invalid:
+      outputs:
+      - '{"type":"future","id":"7683580035611736062455457541222816481527732596436715046989422521949883054222field","value":"{\n  program_id: check_metadata_v2.aleo,\n  function_name: test_checksum_invalid,\n  arguments: []\n}"}'
+  speculate: the execution was rejected
+  add_next_block: succeeded.
+- verified: true
+  execute:
+    check_metadata_v2.aleo/test_metadata_does_not_exist:
+      outputs:
+      - '{"type":"future","id":"6002232368572516474489140138360602819466895942338407493845621055840252068419field","value":"{\n  program_id: check_metadata_v2.aleo,\n  function_name: test_metadata_does_not_exist,\n  arguments: []\n}"}'
+  speculate: the execution was rejected
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"1874003891957116548493958748267788725705038845223782347213684961846662285450field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1s8ynfrjjlge4exyn4ulznyww6ug6nj37pxscpcj9jgjzw43uucrsgxsxxm,\n    2732u64\n  ]\n}"}'
+- child_outputs:
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"1509833671818497701588244430600020324904600341865745241528529091424112255359field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1s8ynfrjjlge4exyn4ulznyww6ug6nj37pxscpcj9jgjzw43uucrsgxsxxm,\n    5732u64\n  ]\n}"}'
+- child_outputs:
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"4748698605574321994146916454780754715095785112742722886727593832348662024865field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1s8ynfrjjlge4exyn4ulznyww6ug6nj37pxscpcj9jgjzw43uucrsgxsxxm,\n    1748u64\n  ]\n}"}'
+- child_outputs:
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"7450046554206775139410162586564438874695416418798365419589797207134000546155field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1s8ynfrjjlge4exyn4ulznyww6ug6nj37pxscpcj9jgjzw43uucrsgxsxxm,\n    1762u64\n  ]\n}"}'

--- a/synthesizer/tests/tests/vm/execute_and_finalize/metadata_get_v1.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/metadata_get_v1.aleo
@@ -1,0 +1,41 @@
+/*
+randomness: 3457689
+cases:
+  - program: check_metadata_v1.aleo
+    function: test_checksum
+    inputs: []
+  - program: check_metadata_v1.aleo
+    function: test_checksum_invalid
+    inputs: []
+  - program: check_metadata_v1.aleo
+    function: test_metadata_does_not_exist
+    inputs: []
+*/
+
+import credits.aleo;
+
+program check_metadata_v1.aleo;
+
+function test_checksum:
+    async test_checksum into r0;
+    output r0 as check_metadata_v1.aleo/test_checksum.future;
+
+finalize test_checksum:
+    metadata.get _checksum into r0 as u128;
+    metadata.get credits.aleo/_checksum into r1 as u128;
+
+function test_checksum_invalid:
+    async test_checksum_invalid into r0;
+    output r0 as check_metadata_v1.aleo/test_checksum_invalid.future;
+
+finalize test_checksum_invalid:
+    metadata.get _checksum into r0 as i128;
+
+function test_metadata_does_not_exist:
+    async test_metadata_does_not_exist into r0;
+    output r0 as check_metadata_v1.aleo/test_metadata_does_not_exist.future;
+
+finalize test_metadata_does_not_exist:
+    metadata.get foo into r0 as i128;
+
+

--- a/synthesizer/tests/tests/vm/execute_and_finalize/metadata_get_v2.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/metadata_get_v2.aleo
@@ -1,0 +1,75 @@
+/*
+randomness: 489234981
+cases:
+  - program: check_metadata_v2.aleo
+    function: test_checksum
+    inputs: []
+  - program: check_metadata_v2.aleo
+    function: test_metadata
+    inputs: []
+  - program: check_metadata_v2.aleo
+    function: test_checksum_invalid
+    inputs: []
+  - program: check_metadata_v2.aleo
+    function: test_metadata_does_not_exist
+    inputs: []
+*/
+
+
+program$2 child.aleo;
+
+function foo:
+
+$metadata program_owner: aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+$metadata edition: 0u16;
+$metadata upgradable: true;
+
+/////////////////////////////////////////////////
+
+import credits.aleo;
+import child.aleo;
+
+program$2 check_metadata_v2.aleo;
+
+function test_checksum:
+    async test_checksum into r0;
+    output r0 as check_metadata_v2.aleo/test_checksum.future;
+
+finalize test_checksum:
+    metadata.get _checksum into r0 as u128;
+    metadata.get credits.aleo/_checksum into r1 as u128;
+    metadata.get child.aleo/_checksum into r2 as u128;
+
+function test_metadata:
+    async test_metadata into r0;
+    output r0 as check_metadata_v2.aleo/test_metadata.future;
+
+finalize test_metadata:
+    metadata.get program_owner into r0 as address;
+    metadata.get edition into r1 as u16;
+    metadata.get upgradable into r2 as boolean;
+    metadata.get child.aleo/program_owner into r3 as address;
+    metadata.get child.aleo/edition into r4 as u16;
+    metadata.get child.aleo/upgradable into r5 as boolean;
+    assert.eq r0 r3;
+    assert.eq r1 r4;
+    assert.eq r2 r5;
+
+function test_checksum_invalid:
+    async test_checksum_invalid into r0;
+    output r0 as check_metadata_v2.aleo/test_checksum_invalid.future;
+
+finalize test_checksum_invalid:
+    metadata.get _checksum into r0 as i128;
+
+function test_metadata_does_not_exist:
+    async test_metadata_does_not_exist into r0;
+    output r0 as check_metadata_v2.aleo/test_metadata_does_not_exist.future;
+
+finalize test_metadata_does_not_exist:
+    metadata.get foo into r0 as i128;
+
+$metadata program_owner: aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+$metadata edition: 0u16;
+$metadata upgradable: true;
+


### PR DESCRIPTION
**DO NOT MERGE UNTIL BASE IS UPDATED TO `staging`**

This PR introduces the `metadata.get` command to both V1 and V2 programs, allowing them to request their own metadata or metadata of other programs. Note that V1 programs only have `_checksum` metadata, while V2 programs can also use metadata declarations.