### PR TITLE
[Fix] Missing license header change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,6 +2888,7 @@ dependencies = [
  "once_cell",
  "serial_test",
  "sha2",
+ "smallvec",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-circuit-environment-witness",

--- a/synthesizer/process/benches/check_deployment.rs
+++ b/synthesizer/process/benches/check_deployment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Aleo Network Foundation
+// Copyright 2024-2025 Aleo Network Foundation
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This was missed, as the new benchmark file was added before the licenses were adjusted across the repo. Also, this PR contains a tiny missing adjustment to the lockfile.