### PR TITLE
[Hotfix] Optimize deployment loading on initialization

### DIFF
--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -97,7 +97,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     #[inline]
     pub fn from(store: ConsensusStore<N, C>) -> Result<Self> {
         // Initialize a new process.
-        let process = Arc::new(RwLock::new(Process::load()?));
+        let mut process = Process::load()?;
 
         // Initialize the store for 'credits.aleo'.
         let credits = Program::<N>::credits()?;
@@ -111,9 +111,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // A helper function to retrieve all the deployments.
         fn load_deployment_and_imports<N: Network, T: TransactionStorage<N>>(
-            process: Arc<RwLock<Process<N>>>,
+            process: &Process<N>,
             transaction_store: &TransactionStore<N, T>,
             transaction_id: N::TransactionID,
+            deployments: Arc<RwLock<IndexMap<ProgramID<N>, Deployment<N>>>>,
         ) -> Result<()> {
             // Retrieve the deployment from the transaction ID.
             let deployment = match transaction_store.get_deployment(&transaction_id)? {
@@ -126,14 +127,14 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             let program_id = program.id();
 
             // Return early if the program is already loaded.
-            if process.read().contains_program(program_id) {
+            if process.contains_program(program_id) || deployments.read().contains_key(program_id) {
                 return Ok(());
             }
 
             // Iterate through the program imports.
             for import_program_id in program.imports().keys() {
                 // Add the imports to the process if does not exist yet.
-                if !process.read().contains_program(import_program_id) {
+                if !process.contains_program(import_program_id) && !deployments.read().contains_key(program_id) {
                     // Fetch the deployment transaction ID.
                     let Some(transaction_id) =
                         transaction_store.deployment_store().find_transaction_id_from_program_id(import_program_id)?
@@ -142,12 +143,15 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     };
 
                     // Add the deployment and its imports found recursively.
-                    load_deployment_and_imports(process.clone(), transaction_store, transaction_id)?;
+                    load_deployment_and_imports(process, transaction_store, transaction_id, deployments.clone())?;
                 }
             }
 
-            if !process.read().contains_program(program_id) {
-                process.write().load_deployment(&deployment)?;
+            // Once all the imports have been included, add the parent deployment.
+            if !deployments.read().contains_key(program_id) {
+                // Note: There may be re-insertions due to parallelism, but it is safe to
+                //  reinsert into the IndexMap because it should be the same object.
+                deployments.write().insert(*program_id, deployment);
             }
 
             Ok(())
@@ -157,6 +161,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let transaction_store = store.transaction_store();
         // Retrieve the list of deployment transaction IDs.
         let deployment_ids = transaction_store.deployment_transaction_ids().collect::<Vec<_>>();
+        // TODO (raychu86): Load them in order of block height to limit recursion.
         // Load the deployments from the store.
         for (i, chunk) in deployment_ids.chunks(256).enumerate() {
             debug!(
@@ -165,17 +170,26 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 ((i + 1) * 256).min(deployment_ids.len()),
                 deployment_ids.len()
             );
+            // Prepare a tracker for the deployments.
+            let deployments = Arc::new(RwLock::new(IndexMap::new()));
             cfg_iter!(chunk)
                 .map(|transaction_id| {
                     // Load the deployment and its imports.
-                    load_deployment_and_imports(process.clone(), transaction_store, **transaction_id)
+                    load_deployment_and_imports(&process, transaction_store, **transaction_id, deployments.clone())
                 })
-                .collect::<Result<()>>()?
+                .collect::<Result<()>>()?;
+
+            for (program_id, deployment) in deployments.read().iter() {
+                // Load the deployment if it does not exist in the process yet.
+                if !process.contains_program(program_id) {
+                    process.load_deployment(deployment)?;
+                }
+            }
         }
 
         // Return the new VM.
         Ok(Self {
-            process,
+            process: Arc::new(RwLock::new(process)),
             puzzle: Self::new_puzzle()?,
             store,
             partially_verified_transactions: Arc::new(RwLock::new(LruCache::new(

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -151,7 +151,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             if !deployments.read().contains_key(program_id) {
                 // Note: There may be re-insertions due to parallelism, but it is safe to
                 //  reinsert into the IndexMap because it should be the same object.
-                deployments.write().insert(*program_id, deployment);
+                deployments.write().entry(*program_id).or_insert(deployment);
             }
 
             Ok(())

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -161,7 +161,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let transaction_store = store.transaction_store();
         // Retrieve the list of deployment transaction IDs.
         let deployment_ids = transaction_store.deployment_transaction_ids().collect::<Vec<_>>();
-        // TODO (raychu86): Load them in order of block height to limit recursion.
+        // TODO (raychu86): Investigate loading them in order to limit recursion.
         // Load the deployments from the store.
         for (i, chunk) in deployment_ids.chunks(256).enumerate() {
             debug!(

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -97,7 +97,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     #[inline]
     pub fn from(store: ConsensusStore<N, C>) -> Result<Self> {
         // Initialize a new process.
-        let mut process = Process::load()?;
+        let process = Arc::new(RwLock::new(Process::load()?));
 
         // Initialize the store for 'credits.aleo'.
         let credits = Program::<N>::credits()?;
@@ -111,10 +111,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // A helper function to retrieve all the deployments.
         fn load_deployment_and_imports<N: Network, T: TransactionStorage<N>>(
-            process: &Process<N>,
+            process: Arc<RwLock<Process<N>>>,
             transaction_store: &TransactionStore<N, T>,
             transaction_id: N::TransactionID,
-        ) -> Result<Vec<(ProgramID<N>, Deployment<N>)>> {
+        ) -> Result<()> {
             // Retrieve the deployment from the transaction ID.
             let deployment = match transaction_store.get_deployment(&transaction_id)? {
                 Some(deployment) => deployment,
@@ -126,17 +126,14 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             let program_id = program.id();
 
             // Return early if the program is already loaded.
-            if process.contains_program(program_id) {
-                return Ok(vec![]);
+            if process.read().contains_program(program_id) {
+                return Ok(());
             }
-
-            // Prepare a vector for the deployments.
-            let mut deployments = vec![];
 
             // Iterate through the program imports.
             for import_program_id in program.imports().keys() {
                 // Add the imports to the process if does not exist yet.
-                if !process.contains_program(import_program_id) {
+                if !process.read().contains_program(import_program_id) {
                     // Fetch the deployment transaction ID.
                     let Some(transaction_id) =
                         transaction_store.deployment_store().find_transaction_id_from_program_id(import_program_id)?
@@ -145,18 +142,15 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     };
 
                     // Add the deployment and its imports found recursively.
-                    deployments.extend_from_slice(&load_deployment_and_imports(
-                        process,
-                        transaction_store,
-                        transaction_id,
-                    )?);
+                    load_deployment_and_imports(process.clone(), transaction_store, transaction_id)?;
                 }
             }
 
-            // Once all the imports have been included, add the parent deployment.
-            deployments.push((*program_id, deployment));
+            if !process.read().contains_program(program_id) {
+                process.write().load_deployment(&deployment)?;
+            }
 
-            Ok(deployments)
+            Ok(())
         }
 
         // Retrieve the transaction store.
@@ -171,24 +165,17 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 ((i + 1) * 256).min(deployment_ids.len()),
                 deployment_ids.len()
             );
-            let deployments = cfg_iter!(chunk)
+            cfg_iter!(chunk)
                 .map(|transaction_id| {
                     // Load the deployment and its imports.
-                    load_deployment_and_imports(&process, transaction_store, **transaction_id)
+                    load_deployment_and_imports(process.clone(), transaction_store, **transaction_id)
                 })
-                .collect::<Result<Vec<_>>>()?;
-
-            for (program_id, deployment) in deployments.iter().flatten() {
-                // Load the deployment if it does not exist in the process yet.
-                if !process.contains_program(program_id) {
-                    process.load_deployment(deployment)?;
-                }
-            }
+                .collect::<Result<()>>()?
         }
 
         // Return the new VM.
         Ok(Self {
-            process: Arc::new(RwLock::new(process)),
+            process,
             puzzle: Self::new_puzzle()?,
             store,
             partially_verified_transactions: Arc::new(RwLock::new(LruCache::new(


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR implements optimizations to `load_deployment_and_imports` when a VM is initialized. The previous logic was quite naive in that each individual parallel thread would potentially perform a deep recursion of imports. The fix was the introduce shared state between the threads to ensure that wasted work is limited. 