### PR TITLE
Implement execute_authorization_with_response.

### DIFF
--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -41,7 +41,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Determine if a priority fee is declared.
         let is_priority_fee_declared = priority_fee_in_microcredits > 0;
         // Compute the execution.
-        let execution = self.execute_authorization_raw(authorization, query.clone(), rng)?;
+        let (execution, _) = self.execute_authorization_raw(authorization, query.clone(), rng)?;
         // Compute the fee.
         let fee = match is_fee_required || is_priority_fee_declared {
             true => {
@@ -83,6 +83,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     }
 
     /// Returns a new execute transaction for the given authorization.
+    ///
+    /// This is identical to `execute_authorization_with_response` except that it
+    /// discards the `Response`.
     pub fn execute_authorization<R: Rng + CryptoRng>(
         &self,
         execute_authorization: Authorization<N>,
@@ -90,15 +93,29 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         query: Option<Query<N, C::BlockStorage>>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
+        let (execution, _) =
+            self.execute_authorization_with_response(execute_authorization, fee_authorization, query, rng)?;
+        Ok(execution)
+    }
+
+    /// Returns a new execute transaction and response for the given authorization.
+    pub fn execute_authorization_with_response<R: Rng + CryptoRng>(
+        &self,
+        execute_authorization: Authorization<N>,
+        fee_authorization: Option<Authorization<N>>,
+        query: Option<Query<N, C::BlockStorage>>,
+        rng: &mut R,
+    ) -> Result<(Transaction<N>, Response<N>)> {
         // Compute the execution.
-        let execution = self.execute_authorization_raw(execute_authorization, query.clone(), rng)?;
+        let (execution, response) = self.execute_authorization_raw(execute_authorization, query.clone(), rng)?;
         // Compute the fee.
         let fee = match fee_authorization {
             Some(authorization) => Some(self.execute_fee_authorization_raw(authorization, query, rng)?),
             None => None,
         };
-        // Return the execute transaction.
-        Transaction::from_execution(execution, fee)
+        // Return the execute transaction and response.
+        let transaction = Transaction::from_execution(execution, fee)?;
+        Ok((transaction, response))
     }
 
     /// Returns a new fee for the given authorization.
@@ -122,7 +139,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         authorization: Authorization<N>,
         query: Option<Query<N, C::BlockStorage>>,
         rng: &mut R,
-    ) -> Result<Execution<N>> {
+    ) -> Result<(Execution<N>, Response<N>)> {
         let timer = timer!("VM::execute_authorization_raw");
 
         // Construct the locator of the main function.
@@ -142,7 +159,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Prepare the authorization.
                 let authorization = cast_ref!(authorization as Authorization<$network>);
                 // Execute the call.
-                let (_, mut trace) = $process.execute::<$aleo, _>(authorization.clone(), rng)?;
+                let (response, mut trace) = $process.execute::<$aleo, _>(authorization.clone(), rng)?;
                 lap!(timer, "Execute the call");
 
                 // Prepare the assignments.
@@ -154,7 +171,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Compute the proof");
 
                 // Return the execution.
-                Ok(cast_ref!(execution as Execution<N>).clone())
+                Ok((cast_ref!(execution as Execution<N>).clone(), cast_ref!(response as Response<N>).clone()))
             }};
         }
 
@@ -354,7 +371,7 @@ mod tests {
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let execution = vm.execute_authorization_raw(authorization, None, rng).unwrap();
+        let (execution, _) = vm.execute_authorization_raw(authorization, None, rng).unwrap();
         let (cost, _) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
         let (old_cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
 
@@ -490,7 +507,7 @@ finalize test:
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let execution = vm.execute_authorization_raw(authorization, None, rng).unwrap();
+        let (execution, _) = vm.execute_authorization_raw(authorization, None, rng).unwrap();
         let (cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
         println!("Cost: {}", cost);
     }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -26,7 +26,7 @@ use crate::{Restrictions, cast_mut_ref, cast_ref, convert, process};
 use console::{
     account::{Address, PrivateKey},
     network::prelude::*,
-    program::{Argument, Identifier, Literal, Locator, Plaintext, ProgramID, ProgramOwner, Record, Value},
+    program::{Argument, Identifier, Literal, Locator, Plaintext, ProgramID, ProgramOwner, Record, Response, Value},
     types::{Field, Group, U64},
 };
 use ledger_block::{


### PR DESCRIPTION
This way callers can access the `Response` and, in particular, the `Output`s.