### PR TITLE
[Fix] Add deserialization check on max solutions.

### DIFF
--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -36,7 +36,7 @@ impl<N: Network> FromBytes for Block<N> {
         // Read the authority.
         let authority = FromBytes::read_le(&mut reader)?;
 
-        // Read the number of ratifications.
+        // Read the ratifications.
         let ratifications = Ratifications::read_le(&mut reader)?;
 
         // Read the solutions.

--- a/ledger/puzzle/src/solutions/bytes.rs
+++ b/ledger/puzzle/src/solutions/bytes.rs
@@ -20,6 +20,10 @@ impl<N: Network> FromBytes for PuzzleSolutions<N> {
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the number of solutions.
         let num_solutions: u8 = FromBytes::read_le(&mut reader)?;
+        // Ensure the number of solutions is within bounds.
+        if num_solutions as usize > N::MAX_SOLUTIONS {
+            return Err(error("Failed to read solutions: too many solutions"));
+        }
         // Read the solutions.
         let mut solutions = Vec::with_capacity(num_solutions as usize);
         for _ in 0..num_solutions {


### PR DESCRIPTION
During deserialization, it is important to check that the number of next items to deserialize is within bounds. For block deserialization, this is done for transactions, aborted transaction IDs, and and aborted solution IDs, but the check for solutions was missing. This commit adds it.

Also fix a comment in some deserialization code.
