### PR TITLE
[Feature] set heights for consensus v4

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -136,13 +136,17 @@ impl Network for CanaryV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
-        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_900_000), (ConsensusVersion::V3, 4_560_000)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 4] = [
+        (ConsensusVersion::V1, 0),
+        (ConsensusVersion::V2, 2_900_000),
+        (ConsensusVersion::V3, 4_560_000),
+        (ConsensusVersion::V4, 5_570_000),
+    ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
-        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 4] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11), (ConsensusVersion::V4, 12)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -140,7 +140,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
-        (ConsensusVersion::V4, 5_570_000),
+        (ConsensusVersion::V4, 5_590_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -76,6 +76,7 @@ pub enum ConsensusVersion {
     V1 = 1,
     V2 = 2,
     V3 = 3,
+    V4 = 4,
 }
 
 pub trait Network:
@@ -217,7 +218,7 @@ pub trait Network:
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 4];
     ///  A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     //  Note: This value must **not** decrease without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -137,13 +137,17 @@ impl Network for MainnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
-        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_800_000), (ConsensusVersion::V3, 4_900_000)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 4] = [
+        (ConsensusVersion::V1, 0),
+        (ConsensusVersion::V2, 2_800_000),
+        (ConsensusVersion::V3, 4_900_000),
+        (ConsensusVersion::V4, 7_100_000),
+    ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
-        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 4] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11), (ConsensusVersion::V4, 12)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -136,13 +136,17 @@ impl Network for TestnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
-        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 2_950_000), (ConsensusVersion::V3, 4_800_000)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 4] = [
+        (ConsensusVersion::V1, 0),
+        (ConsensusVersion::V2, 2_950_000),
+        (ConsensusVersion::V3, 4_800_000),
+        (ConsensusVersion::V4, 6_635_000),
+    ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 3] =
-        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11)];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 4] =
+        [(ConsensusVersion::V1, 0), (ConsensusVersion::V2, 10), (ConsensusVersion::V3, 11), (ConsensusVersion::V4, 12)];
     /// The network edition.
     const EDITION: u16 = 0;
     /// The genesis block coinbase target.


### PR DESCRIPTION
This PR introduces the heights for `ConsensusVersion::V4`. The following table is the approximate timeline and buffers for each network:

| Network | Release Date | Buffer | Consensus V4 |
|---------|--------------|--------|--------------|
| Canary  | Apr 1, 2025 | 3 days | Apr 4, 2025 |
| Testnet | Apr 8, 2025 | 5 days | Apr 13, 2025 |
| Mainnet | Apr 22, 2025  | 14 days | May 6, 2025 |