### PR TITLE
docs: fixed dead link `opcodes`

### DIFF
--- a/ledger/puzzle/epoch/docs/spec.md
+++ b/ledger/puzzle/epoch/docs/spec.md
@@ -216,7 +216,7 @@ Each entry in the instruction set is a vector of at most
 `NUM_SEQUENCE_INSTRUCTIONS` is returned, each consisting of a tuple
 with:
 
--   The instruction as [defined here](https://developer.aleo.org/aleo/opcodes).
+-   The instruction as [defined here](https://developer.aleo.org/guides/aleo/opcodes/).
 
 -   The operands, which can be:
 


### PR DESCRIPTION
## Description

Hey! I fixed a broken link in the documentation (`ledger/puzzle/epoch/docs/spec.md`). The old link pointed to `/aleo/opcodes`, and it's now corrected to `/guides/aleo/opcodes/`.