### PR TITLE
Removes `PartialEq` and `Eq` on Map `V` traits

### DIFF
--- a/ledger/store/src/helpers/memory/internal/map.rs
+++ b/ledger/store/src/helpers/memory/internal/map.rs
@@ -33,7 +33,7 @@ use std::{
 #[derive(Clone)]
 pub struct MemoryMap<
     K: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > {
     // The reason for using BTreeMap with binary keys is for the order of items to be the same as
     // the one in the RocksDB-backed DataMap; if not for that, it could be any map
@@ -46,7 +46,7 @@ pub struct MemoryMap<
 
 impl<
     K: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > Default for MemoryMap<K, V>
 {
     fn default() -> Self {
@@ -61,7 +61,7 @@ impl<
 
 impl<
     K: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > FromIterator<(K, V)> for MemoryMap<K, V>
 {
     /// Initializes a new `MemoryMap` from the given iterator.
@@ -82,7 +82,7 @@ impl<
 impl<
     'a,
     K: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: 'a + Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > Map<'a, K, V> for MemoryMap<K, V>
 {
     ///
@@ -253,7 +253,7 @@ impl<
 impl<
     'a,
     K: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: 'a + Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > MapRead<'a, K, V> for MemoryMap<K, V>
 {
     type Iterator = core::iter::Map<btree_map::IntoIter<Vec<u8>, V>, fn((Vec<u8>, V)) -> (Cow<'a, K>, Cow<'a, V>)>;
@@ -371,7 +371,7 @@ impl<
 
 impl<
     K: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > Deref for MemoryMap<K, V>
 {
     type Target = Arc<RwLock<BTreeMap<Vec<u8>, V>>>;

--- a/ledger/store/src/helpers/memory/internal/nested_map.rs
+++ b/ledger/store/src/helpers/memory/internal/nested_map.rs
@@ -33,7 +33,7 @@ use std::{
 pub struct NestedMemoryMap<
     M: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
     K: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > {
     // The reason for using BTreeMap with binary keys is for the order of items to be the same as
     // the one in the RocksDB-backed DataMap; if not for that, it could be any map
@@ -48,7 +48,7 @@ pub struct NestedMemoryMap<
 impl<
     M: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
     K: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > Default for NestedMemoryMap<M, K, V>
 {
     fn default() -> Self {
@@ -65,7 +65,7 @@ impl<
 impl<
     M: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
     K: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > FromIterator<(M, K, V)> for NestedMemoryMap<M, K, V>
 {
     /// Initializes a new `NestedMemoryMap` from the given iterator.
@@ -94,7 +94,7 @@ impl<
     'a,
     M: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
     K: 'a + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: 'a + Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > NestedMap<'a, M, K, V> for NestedMemoryMap<M, K, V>
 {
     ///
@@ -239,7 +239,7 @@ impl<
     'a,
     M: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
     K: 'a + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: 'a + Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 > NestedMapRead<'a, M, K, V> for NestedMemoryMap<M, K, V>
 {
     // type Iterator = core::iter::FlatMap<
@@ -507,7 +507,7 @@ impl<
 fn insert<
     M: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
     K: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 >(
     map: &mut BTreeMap<Vec<u8>, BTreeSet<Vec<u8>>>,
     map_inner: &mut BTreeMap<Vec<u8>, V>,
@@ -531,7 +531,7 @@ fn insert<
 /// Removes the given map-key pair.
 fn remove_map<
     M: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 >(
     map: &mut BTreeMap<Vec<u8>, BTreeSet<Vec<u8>>>,
     map_inner: &mut BTreeMap<Vec<u8>, V>,
@@ -557,7 +557,7 @@ fn remove_map<
 fn remove_key<
     M: Copy + Clone + PartialEq + Eq + Hash + Serialize + for<'de> Deserialize<'de> + Send + Sync,
     K: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
-    V: Clone + PartialEq + Eq + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync,
 >(
     map: &mut BTreeMap<Vec<u8>, BTreeSet<Vec<u8>>>,
     map_inner: &mut BTreeMap<Vec<u8>, V>,

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -51,7 +51,7 @@ pub struct InnerDataMap<K: Serialize + DeserializeOwned, V: Serialize + Deserial
 impl<
     'a,
     K: 'a + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync,
+    V: 'a + Clone + Serialize + DeserializeOwned + Send + Sync,
 > Map<'a, K, V> for DataMap<K, V>
 {
     ///
@@ -258,7 +258,7 @@ impl<
 impl<
     'a,
     K: 'a + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync,
+    V: 'a + Clone + Serialize + DeserializeOwned + Send + Sync,
 > MapRead<'a, K, V> for DataMap<K, V>
 {
     type Iterator = Iter<'a, K, V>;
@@ -404,17 +404,14 @@ impl<
 pub struct Iter<
     'a,
     K: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned,
-    V: 'a + PartialEq + Eq + Serialize + DeserializeOwned,
+    V: 'a + Serialize + DeserializeOwned,
 > {
     db_iter: rocksdb::DBRawIterator<'a>,
     _phantom: PhantomData<(K, V)>,
 }
 
-impl<
-    'a,
-    K: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned,
-    V: 'a + PartialEq + Eq + Serialize + DeserializeOwned,
-> Iter<'a, K, V>
+impl<'a, K: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned, V: 'a + Serialize + DeserializeOwned>
+    Iter<'a, K, V>
 {
     pub(super) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
         Self { db_iter: db_iter.into(), _phantom: PhantomData }
@@ -424,7 +421,7 @@ impl<
 impl<
     'a,
     K: 'a + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned,
-    V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned,
+    V: 'a + Clone + Serialize + DeserializeOwned,
 > Iterator for Iter<'a, K, V>
 {
     type Item = (Cow<'a, K>, Cow<'a, V>);
@@ -488,18 +485,18 @@ impl<'a, K: 'a + Clone + Debug + PartialEq + Eq + Hash + Serialize + Deserialize
 }
 
 /// An iterator over the values of a prefix.
-pub struct Values<'a, V: 'a + PartialEq + Eq + Serialize + DeserializeOwned> {
+pub struct Values<'a, V: 'a + Serialize + DeserializeOwned> {
     db_iter: rocksdb::DBRawIterator<'a>,
     _phantom: PhantomData<V>,
 }
 
-impl<'a, V: 'a + PartialEq + Eq + Serialize + DeserializeOwned> Values<'a, V> {
+impl<'a, V: 'a + Serialize + DeserializeOwned> Values<'a, V> {
     pub(crate) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
         Self { db_iter: db_iter.into(), _phantom: PhantomData }
     }
 }
 
-impl<'a, V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned> Iterator for Values<'a, V> {
+impl<'a, V: 'a + Clone + Serialize + DeserializeOwned> Iterator for Values<'a, V> {
     type Item = Cow<'a, V>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -105,7 +105,7 @@ impl<
     'a,
     M: 'a + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync,
     K: 'a + Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync,
+    V: 'a + Clone + Serialize + DeserializeOwned + Send + Sync,
 > NestedMap<'a, M, K, V> for NestedDataMap<M, K, V>
 {
     ///
@@ -346,7 +346,7 @@ impl<
     'a,
     M: 'a + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync,
     K: 'a + Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned + Send + Sync,
+    V: 'a + Clone + Serialize + DeserializeOwned + Send + Sync,
 > NestedMapRead<'a, M, K, V> for NestedDataMap<M, K, V>
 {
     type Iterator = NestedIter<'a, M, K, V>;
@@ -597,7 +597,7 @@ pub struct NestedIter<
     'a,
     M: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned,
     K: 'a + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-    V: 'a + PartialEq + Eq + Serialize + DeserializeOwned,
+    V: 'a + Serialize + DeserializeOwned,
 > {
     db_iter: rocksdb::DBRawIterator<'a>,
     _phantom: PhantomData<(M, K, V)>,
@@ -607,7 +607,7 @@ impl<
     'a,
     M: 'a + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned,
     K: 'a + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-    V: 'a + PartialEq + Eq + Serialize + DeserializeOwned,
+    V: 'a + Serialize + DeserializeOwned,
 > NestedIter<'a, M, K, V>
 {
     pub(super) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
@@ -619,7 +619,7 @@ impl<
     'a,
     M: 'a + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned,
     K: 'a + Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned,
-    V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned,
+    V: 'a + Clone + Serialize + DeserializeOwned,
 > Iterator for NestedIter<'a, M, K, V>
 {
     type Item = (Cow<'a, M>, Cow<'a, K>, Cow<'a, V>);
@@ -724,18 +724,18 @@ impl<
 }
 
 /// An iterator over the values of a prefix.
-pub struct NestedValues<'a, V: 'a + PartialEq + Eq + Serialize + DeserializeOwned> {
+pub struct NestedValues<'a, V: 'a + Serialize + DeserializeOwned> {
     db_iter: rocksdb::DBRawIterator<'a>,
     _phantom: PhantomData<V>,
 }
 
-impl<'a, V: 'a + PartialEq + Eq + Serialize + DeserializeOwned> NestedValues<'a, V> {
+impl<'a, V: 'a + Serialize + DeserializeOwned> NestedValues<'a, V> {
     pub(crate) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
         Self { db_iter: db_iter.into(), _phantom: PhantomData }
     }
 }
 
-impl<'a, V: 'a + Clone + PartialEq + Eq + Serialize + DeserializeOwned> Iterator for NestedValues<'a, V> {
+impl<'a, V: 'a + Clone + Serialize + DeserializeOwned> Iterator for NestedValues<'a, V> {
     type Item = Cow<'a, V>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/ledger/store/src/helpers/traits/map.rs
+++ b/ledger/store/src/helpers/traits/map.rs
@@ -22,7 +22,7 @@ use std::borrow::Cow;
 pub trait Map<
     'a,
     K: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + Deserialize<'a> + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Send + Sync,
+    V: 'a + Clone + Serialize + Deserialize<'a> + Send + Sync,
 >: Clone + MapRead<'a, K, V> + Send + Sync
 {
     ///
@@ -93,7 +93,7 @@ pub trait Map<
 pub trait MapRead<
     'a,
     K: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + Deserialize<'a> + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Sync,
+    V: 'a + Clone + Serialize + Deserialize<'a> + Sync,
 >
 {
     type PendingIterator: Iterator<Item = (Cow<'a, K>, Option<Cow<'a, V>>)>;

--- a/ledger/store/src/helpers/traits/nested_map.rs
+++ b/ledger/store/src/helpers/traits/nested_map.rs
@@ -23,7 +23,7 @@ pub trait NestedMap<
     'a,
     M: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + Deserialize<'a> + Send + Sync,
     K: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Send + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Send + Sync,
+    V: 'a + Clone + Serialize + Deserialize<'a> + Send + Sync,
 >: Clone + NestedMapRead<'a, M, K, V> + Send + Sync
 {
     ///
@@ -87,7 +87,7 @@ pub trait NestedMapRead<
     'a,
     M: 'a + Copy + Clone + PartialEq + Eq + Hash + Serialize + Deserialize<'a> + Sync,
     K: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Sync,
-    V: 'a + Clone + PartialEq + Eq + Serialize + Deserialize<'a> + Sync,
+    V: 'a + Clone + Serialize + Deserialize<'a> + Sync,
 >
 {
     type PendingIterator: Iterator<Item = (Cow<'a, M>, Option<Cow<'a, K>>, Option<Cow<'a, V>>)>;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR removes `PartialEq` and `Eq` on Map `V` traits.

These properties are not needed, and reduces the dependencies required for an object to be supported by our maps.
