### PR TITLE
[Feature] Consensus V6

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -136,22 +136,24 @@ impl Network for CanaryV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
         (ConsensusVersion::V4, 5_730_000),
         (ConsensusVersion::V5, 5_780_000),
+        (ConsensusVersion::V6, 6_225_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
         (ConsensusVersion::V4, 12),
         (ConsensusVersion::V5, 13),
+        (ConsensusVersion::V6, 14),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -134,7 +134,7 @@ impl Network for CanaryV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
+    /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
         (ConsensusVersion::V1, 0),
@@ -144,7 +144,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V5, 5_780_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
+    /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
         (ConsensusVersion::V1, 0),

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -142,7 +142,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V3, 4_560_000),
         (ConsensusVersion::V4, 5_730_000),
         (ConsensusVersion::V5, 5_780_000),
-        (ConsensusVersion::V6, 6_225_000),
+        (ConsensusVersion::V6, 6_240_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -175,12 +175,20 @@ impl Network for CanaryV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
-        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100), (ConsensusVersion::V5, 100)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+        (ConsensusVersion::V1, 100),
+        (ConsensusVersion::V3, 100),
+        (ConsensusVersion::V5, 100),
+        (ConsensusVersion::V6, 100),
+    ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
-        [(ConsensusVersion::V1, 25), (ConsensusVersion::V3, 25), (ConsensusVersion::V5, 25)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+        (ConsensusVersion::V1, 25),
+        (ConsensusVersion::V3, 25),
+        (ConsensusVersion::V5, 25),
+        (ConsensusVersion::V6, 25),
+    ];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -83,6 +83,8 @@ pub enum ConsensusVersion {
     V4 = 4,
     /// V5: Update to the number of validators and enable batch proposal spend limits.
     V5 = 5,
+    /// V6: Update to the number of validators.
+    V6 = 6,
 }
 
 pub trait Network:
@@ -222,7 +224,7 @@ pub trait Network:
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6];
     ///  A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     //  Note: This value must **not** decrease without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -230,7 +230,7 @@ pub trait Network:
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4];
 
     /// Returns the consensus version which is active at the given height.
     #[allow(non_snake_case)]

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -70,13 +70,18 @@ pub(crate) type VarunaProvingKey<N> = CircuitProvingKey<<N as Environment>::Pair
 pub(crate) type VarunaVerifyingKey<N> = CircuitVerifyingKey<<N as Environment>::PairingCurve>;
 
 /// The different consensus versions.
-/// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
+/// If you need the version active for a specific height, see: `N::CONSENSUS_VERSION`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ConsensusVersion {
+    /// V1: The initial genesis consensus version.
     V1 = 1,
+    /// V2: Update to the block reward and execution cost algorithms.
     V2 = 2,
+    /// V3: Update to the number of validators and finalize scope RNG seed.
     V3 = 3,
+    /// V4: Update to the Varuna version.
     V4 = 4,
+    /// V5: Update to the number of validators and enable batch proposal spend limits.
     V5 = 5,
 }
 
@@ -226,16 +231,6 @@ pub trait Network:
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3];
 
     /// Returns the consensus version which is active at the given height.
-    ///
-    /// V1: The initial genesis consensus version.
-    ///
-    /// V2: Update to the block reward and execution cost algorithms.
-    ///
-    /// V3: Update to the number of validators and finalize scope RNG seed.
-    ///
-    /// V4: Update to the Varuna version.
-    ///
-    /// V5: Update to the number of validators and enable batch proposal spend limits.
     #[allow(non_snake_case)]
     fn CONSENSUS_VERSION(seek_height: u32) -> anyhow::Result<ConsensusVersion> {
         match Self::CONSENSUS_VERSION_HEIGHTS.binary_search_by(|(_, height)| height.cmp(&seek_height)) {

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -143,7 +143,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V3, 4_900_000),
         (ConsensusVersion::V4, 6_135_000),
         (ConsensusVersion::V5, 7_060_000),
-        (ConsensusVersion::V6, 7_820_000),
+        (ConsensusVersion::V6, 7_870_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -135,7 +135,7 @@ impl Network for MainnetV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
+    /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
         (ConsensusVersion::V1, 0),
@@ -145,7 +145,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V5, 7_060_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
+    /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
         (ConsensusVersion::V1, 0),

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -180,12 +180,20 @@ impl Network for MainnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
-        [(ConsensusVersion::V1, 16), (ConsensusVersion::V3, 25), (ConsensusVersion::V5, 30)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+        (ConsensusVersion::V1, 16),
+        (ConsensusVersion::V3, 25),
+        (ConsensusVersion::V5, 30),
+        (ConsensusVersion::V6, 35),
+    ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
-        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100), (ConsensusVersion::V5, 100)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+        (ConsensusVersion::V1, 100),
+        (ConsensusVersion::V3, 100),
+        (ConsensusVersion::V5, 100),
+        (ConsensusVersion::V6, 100),
+    ];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -143,7 +143,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V3, 4_900_000),
         (ConsensusVersion::V4, 6_135_000),
         (ConsensusVersion::V5, 7_060_000),
-        (ConsensusVersion::V6, 7_870_000),
+        (ConsensusVersion::V6, 7_900_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -137,22 +137,24 @@ impl Network for MainnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_800_000),
         (ConsensusVersion::V3, 4_900_000),
         (ConsensusVersion::V4, 6_135_000),
         (ConsensusVersion::V5, 7_060_000),
+        (ConsensusVersion::V6, 7_820_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
         (ConsensusVersion::V4, 12),
         (ConsensusVersion::V5, 13),
+        (ConsensusVersion::V6, 14),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -142,7 +142,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V3, 4_800_000),
         (ConsensusVersion::V4, 6_625_000),
         (ConsensusVersion::V5, 6_765_000),
-        (ConsensusVersion::V6, 7_605_000),
+        (ConsensusVersion::V6, 7_600_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -175,12 +175,20 @@ impl Network for TestnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
-        [(ConsensusVersion::V1, 100), (ConsensusVersion::V3, 100), (ConsensusVersion::V5, 100)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+        (ConsensusVersion::V1, 100),
+        (ConsensusVersion::V3, 100),
+        (ConsensusVersion::V5, 100),
+        (ConsensusVersion::V6, 100),
+    ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 3] =
-        [(ConsensusVersion::V1, 25), (ConsensusVersion::V3, 25), (ConsensusVersion::V5, 25)];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+        (ConsensusVersion::V1, 25),
+        (ConsensusVersion::V3, 25),
+        (ConsensusVersion::V5, 25),
+        (ConsensusVersion::V6, 25),
+    ];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";
 

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -142,7 +142,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V3, 4_800_000),
         (ConsensusVersion::V4, 6_625_000),
         (ConsensusVersion::V5, 6_765_000),
-        (ConsensusVersion::V6, 7_625_000),
+        (ConsensusVersion::V6, 7_605_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -136,22 +136,24 @@ impl Network for TestnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_950_000),
         (ConsensusVersion::V3, 4_800_000),
         (ConsensusVersion::V4, 6_625_000),
         (ConsensusVersion::V5, 6_765_000),
+        (ConsensusVersion::V6, 7_625_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
         (ConsensusVersion::V4, 12),
         (ConsensusVersion::V5, 13),
+        (ConsensusVersion::V6, 14),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -134,7 +134,7 @@ impl Network for TestnetV0 {
     type TransmissionChecksum = u128;
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
+    /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
         (ConsensusVersion::V1, 0),
@@ -144,7 +144,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V5, 6_765_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
-    /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
+    /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
     const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 5] = [
         (ConsensusVersion::V1, 0),


### PR DESCRIPTION
This PR introduces a new consensus version (V6) and increases `MAX_CERTIFICATES` to `35` (increasing validator count) on mainnet. Approximate activation dates for each network:

| Network | Release Date | Buffer | Consensus V6 |
|---------|--------------|--------|--------------|
| Canary  | Apr 29, 2025 | 3 days | May 2, 2025 |
| Testnet | May 13, 2025 | 5 days | May 18, 2025 |
| Mainnet | May 20, 2025  | 14 days | June 3, 2025 |