### PR TITLE
Adjust `ConsensusVersion::V4` height for Canary

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -140,7 +140,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
-        (ConsensusVersion::V4, 5_590_000),
+        (ConsensusVersion::V4, 5_660_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -140,7 +140,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
-        (ConsensusVersion::V4, 5_695_000),
+        (ConsensusVersion::V4, 5_730_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -140,7 +140,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
-        (ConsensusVersion::V4, 5_660_000),
+        (ConsensusVersion::V4, 5_695_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -141,7 +141,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_800_000),
         (ConsensusVersion::V3, 4_900_000),
-        (ConsensusVersion::V4, 7_100_000),
+        (ConsensusVersion::V4, 7_060_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -140,7 +140,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_950_000),
         (ConsensusVersion::V3, 4_800_000),
-        (ConsensusVersion::V4, 6_635_000),
+        (ConsensusVersion::V4, 6_710_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adjusts the Consensus V4 activation heights, the new estimations are as follows:
| Network | Release (00:00:00 PT) | Buffer | Consensus V4 |
|---------|--------------|--------|--------------|
| Canary  | Apr 8, 2025 | 1.5 days | Apr 9, 2025 |
| Testnet | Apr 10, 2025 | 3 days | Apr 13, 2025 |
| Mainnet | Apr 22, 2025  | 14 days | May 6, 2025 |