### PR TITLE
Store unconfirmed id in rejected transaction

### DIFF
--- a/ledger/block/src/transactions/confirmed/mod.rs
+++ b/ledger/block/src/transactions/confirmed/mod.rs
@@ -564,6 +564,7 @@ mod test {
         // Ensure that the unconfirmed transaction of a rejected deployment is not equivalent to its confirmed transaction.
         let deployment_transaction = crate::transaction::test_helpers::sample_deployment_transaction(true, rng);
         let rejected = Rejected::new_deployment(
+            None,
             *deployment_transaction.owner().unwrap(),
             deployment_transaction.deployment().unwrap().clone(),
         );
@@ -573,6 +574,7 @@ mod test {
         assert_eq!(rejected_deploy.to_unconfirmed_transaction().unwrap(), deployment_transaction);
         let deployment_transaction = crate::transaction::test_helpers::sample_deployment_transaction(false, rng);
         let rejected = Rejected::new_deployment(
+            None,
             *deployment_transaction.owner().unwrap(),
             deployment_transaction.deployment().unwrap().clone(),
         );
@@ -583,18 +585,19 @@ mod test {
 
         // Ensure that the unconfirmed transaction of a rejected execute is not equivalent to its confirmed transaction.
         let execution_transaction = crate::transaction::test_helpers::sample_execution_transaction_with_fee(true, rng);
-        let rejected = Rejected::new_execution(execution_transaction.execution().unwrap().clone());
+        let rejected = Rejected::new_execution(None, execution_transaction.execution().unwrap().clone());
         let fee = Transaction::from_fee(execution_transaction.fee_transition().unwrap()).unwrap();
         let rejected_execute =
             ConfirmedTransaction::rejected_execute(Uniform::rand(rng), fee, rejected, vec![]).unwrap();
         assert_eq!(rejected_execute.to_unconfirmed_transaction_id().unwrap(), execution_transaction.id());
         assert_eq!(rejected_execute.to_unconfirmed_transaction().unwrap(), execution_transaction);
         let execution_transaction = crate::transaction::test_helpers::sample_execution_transaction_with_fee(false, rng);
-        let rejected = Rejected::new_execution(execution_transaction.execution().unwrap().clone());
+        let rejected = Rejected::new_execution(None, execution_transaction.execution().unwrap().clone());
         let fee = Transaction::from_fee(execution_transaction.fee_transition().unwrap()).unwrap();
         let rejected_execute =
             ConfirmedTransaction::rejected_execute(Uniform::rand(rng), fee, rejected, vec![]).unwrap();
         assert_eq!(rejected_execute.to_unconfirmed_transaction_id().unwrap(), execution_transaction.id());
         assert_eq!(rejected_execute.to_unconfirmed_transaction().unwrap(), execution_transaction);
+        // TODO: consider adding tests passing Some(unconfirmed_id)
     }
 }

--- a/ledger/block/src/transactions/confirmed/mod.rs
+++ b/ledger/block/src/transactions/confirmed/mod.rs
@@ -390,7 +390,7 @@ pub mod test_helpers {
         };
 
         // Extract the rejected deployment.
-        let rejected = crate::rejected::test_helpers::sample_rejected_deployment(is_fee_private, rng);
+        let rejected = crate::rejected::test_helpers::sample_rejected_deployment(is_fee_private, true, rng);
 
         // Return the confirmed transaction.
         ConfirmedTransaction::rejected_deploy(index, fee_transaction, rejected, vec![]).unwrap()
@@ -409,7 +409,7 @@ pub mod test_helpers {
         };
 
         // Extract the rejected execution.
-        let rejected = crate::rejected::test_helpers::sample_rejected_execution(is_fee_private, rng);
+        let rejected = crate::rejected::test_helpers::sample_rejected_execution(is_fee_private, true, rng);
 
         // Return the confirmed transaction.
         ConfirmedTransaction::rejected_execute(index, fee_transaction, rejected, vec![]).unwrap()

--- a/ledger/block/src/transactions/rejected/bytes.rs
+++ b/ledger/block/src/transactions/rejected/bytes.rs
@@ -26,15 +26,33 @@ impl<N: Network> FromBytes for Rejected<N> {
                 // Read the deployment.
                 let deployment = Deployment::read_le(&mut reader)?;
                 // Return the rejected deployment.
-                Ok(Self::new_deployment(program_owner, deployment))
+                Ok(Self::new_deployment(None, program_owner, deployment))
             }
             1 => {
                 // Read the execution.
                 let execution = Execution::read_le(&mut reader)?;
                 // Return the rejected execution.
-                Ok(Self::new_execution(execution))
+                Ok(Self::new_execution(None, execution))
             }
-            2.. => Err(error(format!("Failed to decode rejected transaction variant {variant}"))),
+            2 => {
+                // Read the unconfirmed ID.
+                let unconfirmed_id = N::TransactionID::read_le(&mut reader)?;
+                // Read the program owner.
+                let program_owner = ProgramOwner::read_le(&mut reader)?;
+                // Read the deployment.
+                let deployment = Deployment::read_le(&mut reader)?;
+                // Return the rejected deployment.
+                Ok(Self::new_deployment(Some(unconfirmed_id), program_owner, deployment))
+            }
+            3 => {
+                // Read the unconfirmed ID.
+                let unconfirmed_id = N::TransactionID::read_le(&mut reader)?;
+                // Read the execution.
+                let execution = Execution::read_le(&mut reader)?;
+                // Return the rejected execution.
+                Ok(Self::new_execution(Some(unconfirmed_id), execution))
+            }
+            4.. => Err(error(format!("Failed to decode rejected transaction variant {variant}"))),
         }
     }
 }
@@ -43,17 +61,37 @@ impl<N: Network> ToBytes for Rejected<N> {
     /// Writes the rejected transaction to a buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         match self {
-            Self::Deployment(program_owner, deployment) => {
-                // Write the variant.
-                0u8.write_le(&mut writer)?;
+            Self::Deployment(unconfirmed_id, program_owner, deployment) => {
+                match unconfirmed_id {
+                    None => {
+                        // Write the variant.
+                        0u8.write_le(&mut writer)?;
+                    }
+                    Some(unconfirmed_id) => {
+                        // Write the variant.
+                        2u8.write_le(&mut writer)?;
+                        // Write the unconfirmed ID.
+                        unconfirmed_id.write_le(&mut writer)?;
+                    }
+                }
                 // Write the program owner.
                 program_owner.write_le(&mut writer)?;
                 // Write the deployment.
                 deployment.write_le(&mut writer)
             }
-            Self::Execution(execution) => {
-                // Write the variant.
-                1u8.write_le(&mut writer)?;
+            Self::Execution(unconfirmed_id, execution) => {
+                match unconfirmed_id {
+                    None => {
+                        // Write the variant.
+                        1u8.write_le(&mut writer)?;
+                    }
+                    Some(unconfirmed_id) => {
+                        // Write the variant.
+                        3u8.write_le(&mut writer)?;
+                        // Write the unconfirmed ID.
+                        unconfirmed_id.write_le(&mut writer)?;
+                    }
+                }
                 // Write the execution.
                 execution.write_le(&mut writer)
             }
@@ -68,6 +106,7 @@ mod tests {
     #[test]
     fn test_bytes() {
         for expected in crate::transactions::rejected::test_helpers::sample_rejected_transactions() {
+            // TODO: sample the old and new version.
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Rejected::read_le(&expected_bytes[..]).unwrap());

--- a/ledger/block/src/transactions/rejected/bytes.rs
+++ b/ledger/block/src/transactions/rejected/bytes.rs
@@ -106,7 +106,6 @@ mod tests {
     #[test]
     fn test_bytes() {
         for expected in crate::transactions::rejected::test_helpers::sample_rejected_transactions() {
-            // TODO: sample the old and new version.
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Rejected::read_le(&expected_bytes[..]).unwrap());

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -115,33 +115,48 @@ pub mod test_helpers {
     type CurrentNetwork = MainnetV0;
 
     /// Samples a rejected deployment.
-    pub(crate) fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    pub(crate) fn sample_rejected_deployment(
+        is_fee_private: bool,
+        store_unconfirmed_id: bool,
+        rng: &mut TestRng,
+    ) -> Rejected<CurrentNetwork> {
         // Sample a deploy transaction.
-        let deployment = match crate::transaction::test_helpers::sample_deployment_transaction(is_fee_private, rng) {
-            Transaction::Deploy(_, _, _, deployment, _) => (*deployment).clone(),
-            _ => unreachable!(),
-        };
+        let (unconfirmed_id, deployment) =
+            match crate::transaction::test_helpers::sample_deployment_transaction(is_fee_private, rng) {
+                Transaction::Deploy(id, _, _, deployment, _) => (id, *deployment).clone(),
+                _ => unreachable!(),
+            };
 
         // Sample a new program owner.
         let private_key = PrivateKey::new(rng).unwrap();
         let deployment_id = deployment.to_deployment_id().unwrap();
         let program_owner = ProgramOwner::new(&private_key, deployment_id, rng).unwrap();
 
+        // Get the unconfirmed transaction id.
+        let unconfirmed_id = store_unconfirmed_id.then_some(unconfirmed_id);
+
         // Return the rejected deployment.
-        Rejected::new_deployment(None, program_owner, deployment)
+        Rejected::new_deployment(unconfirmed_id, program_owner, deployment)
     }
 
     /// Samples a rejected execution.
-    pub(crate) fn sample_rejected_execution(is_fee_private: bool, rng: &mut TestRng) -> Rejected<CurrentNetwork> {
+    pub(crate) fn sample_rejected_execution(
+        is_fee_private: bool,
+        store_unconfirmed_id: bool,
+        rng: &mut TestRng,
+    ) -> Rejected<CurrentNetwork> {
         // Sample an execute transaction.
-        let execution =
+        let (unconfirmed_id, execution) =
             match crate::transaction::test_helpers::sample_execution_transaction_with_fee(is_fee_private, rng) {
-                Transaction::Execute(_, _, execution, _) => execution,
+                Transaction::Execute(id, _, execution, _) => (id, execution),
                 _ => unreachable!(),
             };
 
+        // Get the unconfirmed transaction id.
+        let unconfirmed_id = store_unconfirmed_id.then_some(unconfirmed_id);
+
         // Return the rejected execution.
-        Rejected::new_execution(None, *execution)
+        Rejected::new_execution(unconfirmed_id, *execution)
     }
 
     /// Sample a list of randomly rejected transactions.
@@ -149,10 +164,14 @@ pub mod test_helpers {
         let rng = &mut TestRng::default();
 
         vec![
-            sample_rejected_deployment(true, rng),
-            sample_rejected_deployment(false, rng),
-            sample_rejected_execution(true, rng),
-            sample_rejected_execution(false, rng),
+            sample_rejected_deployment(true, false, rng),
+            sample_rejected_deployment(false, false, rng),
+            sample_rejected_execution(true, false, rng),
+            sample_rejected_execution(false, false, rng),
+            sample_rejected_deployment(true, true, rng),
+            sample_rejected_deployment(false, true, rng),
+            sample_rejected_execution(true, true, rng),
+            sample_rejected_execution(false, true, rng),
         ]
     }
 }

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -24,19 +24,23 @@ use crate::{Deployment, Execution, Fee};
 /// A wrapper around the rejected deployment or execution.
 #[derive(Clone, PartialEq, Eq)]
 pub enum Rejected<N: Network> {
-    Deployment(ProgramOwner<N>, Box<Deployment<N>>),
-    Execution(Box<Execution<N>>),
+    Deployment(Option<N::TransactionID>, ProgramOwner<N>, Box<Deployment<N>>),
+    Execution(Option<N::TransactionID>, Box<Execution<N>>),
 }
 
 impl<N: Network> Rejected<N> {
     /// Initializes a rejected deployment.
-    pub fn new_deployment(program_owner: ProgramOwner<N>, deployment: Deployment<N>) -> Self {
-        Self::Deployment(program_owner, Box::new(deployment))
+    pub fn new_deployment(
+        unconfirmed_id: Option<N::TransactionID>,
+        program_owner: ProgramOwner<N>,
+        deployment: Deployment<N>,
+    ) -> Self {
+        Self::Deployment(unconfirmed_id, program_owner, Box::new(deployment))
     }
 
     /// Initializes a rejected execution.
-    pub fn new_execution(execution: Execution<N>) -> Self {
-        Self::Execution(Box::new(execution))
+    pub fn new_execution(unconfirmed_id: Option<N::TransactionID>, execution: Execution<N>) -> Self {
+        Self::Execution(unconfirmed_id, Box::new(execution))
     }
 
     /// Returns true if the rejected transaction is a deployment.
@@ -52,32 +56,32 @@ impl<N: Network> Rejected<N> {
     /// Returns the program owner of the rejected deployment.
     pub fn program_owner(&self) -> Option<&ProgramOwner<N>> {
         match self {
-            Self::Deployment(program_owner, _) => Some(program_owner),
-            Self::Execution(_) => None,
+            Self::Deployment(_, program_owner, _) => Some(program_owner),
+            Self::Execution(_, _) => None,
         }
     }
 
     /// Returns the rejected deployment.
     pub fn deployment(&self) -> Option<&Deployment<N>> {
         match self {
-            Self::Deployment(_, deployment) => Some(deployment),
-            Self::Execution(_) => None,
+            Self::Deployment(_, _, deployment) => Some(deployment),
+            Self::Execution(_, _) => None,
         }
     }
 
     /// Returns the rejected execution.
     pub fn execution(&self) -> Option<&Execution<N>> {
         match self {
-            Self::Deployment(_, _) => None,
-            Self::Execution(execution) => Some(execution),
+            Self::Deployment(_, _, _) => None,
+            Self::Execution(_, execution) => Some(execution),
         }
     }
 
     /// Returns the rejected ID.
     pub fn to_id(&self) -> Result<Field<N>> {
         match self {
-            Self::Deployment(_, deployment) => deployment.to_deployment_id(),
-            Self::Execution(execution) => execution.to_execution_id(),
+            Self::Deployment(_, _, deployment) => deployment.to_deployment_id(),
+            Self::Execution(_, execution) => execution.to_execution_id(),
         }
     }
 
@@ -86,8 +90,14 @@ impl<N: Network> Rejected<N> {
     /// changing the original transaction ID.
     pub fn to_unconfirmed_id(&self, fee: &Option<Fee<N>>) -> Result<Field<N>> {
         let (tree, fee_index) = match self {
-            Self::Deployment(_, deployment) => (Transaction::deployment_tree(deployment)?, deployment.len()),
-            Self::Execution(execution) => (Transaction::execution_tree(execution)?, execution.len()),
+            Self::Deployment(Some(unconfirmed_id), _, _) => {
+                return Ok(**unconfirmed_id);
+            }
+            Self::Deployment(None, _, deployment) => (Transaction::deployment_tree(deployment)?, deployment.len()),
+            Self::Execution(Some(unconfirmed_id), _) => {
+                return Ok(**unconfirmed_id);
+            }
+            Self::Execution(None, execution) => (Transaction::execution_tree(execution)?, execution.len()),
         };
         if let Some(fee) = fee {
             Ok(*Transaction::transaction_tree(tree, fee_index, fee)?.root())
@@ -118,7 +128,7 @@ pub mod test_helpers {
         let program_owner = ProgramOwner::new(&private_key, deployment_id, rng).unwrap();
 
         // Return the rejected deployment.
-        Rejected::new_deployment(program_owner, deployment)
+        Rejected::new_deployment(None, program_owner, deployment)
     }
 
     /// Samples a rejected execution.
@@ -131,7 +141,7 @@ pub mod test_helpers {
             };
 
         // Return the rejected execution.
-        Rejected::new_execution(*execution)
+        Rejected::new_execution(None, *execution)
     }
 
     /// Sample a list of randomly rejected transactions.

--- a/ledger/block/src/transactions/rejected/serialize.rs
+++ b/ledger/block/src/transactions/rejected/serialize.rs
@@ -20,14 +20,29 @@ impl<N: Network> Serialize for Rejected<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => match self {
-                Self::Deployment(program_owner, deployment) => {
+                Self::Deployment(Some(unconfirmed_id), program_owner, deployment) => {
+                    let mut object = serializer.serialize_struct("Rejected", 4)?;
+                    object.serialize_field("type", "deployment")?;
+                    object.serialize_field("unconfirmed_id", &unconfirmed_id)?;
+                    object.serialize_field("program_owner", program_owner)?;
+                    object.serialize_field("deployment", deployment)?;
+                    object.end()
+                }
+                Self::Deployment(None, program_owner, deployment) => {
                     let mut object = serializer.serialize_struct("Rejected", 3)?;
                     object.serialize_field("type", "deployment")?;
                     object.serialize_field("program_owner", program_owner)?;
                     object.serialize_field("deployment", deployment)?;
                     object.end()
                 }
-                Self::Execution(execution) => {
+                Self::Execution(Some(unconfirmed_id), execution) => {
+                    let mut object = serializer.serialize_struct("Rejected", 3)?;
+                    object.serialize_field("type", "execution")?;
+                    object.serialize_field("unconfirmed_id", &unconfirmed_id)?;
+                    object.serialize_field("execution", execution)?;
+                    object.end()
+                }
+                Self::Execution(None, execution) => {
                     let mut object = serializer.serialize_struct("Rejected", 2)?;
                     object.serialize_field("type", "execution")?;
                     object.serialize_field("execution", execution)?;
@@ -47,6 +62,12 @@ impl<'de, N: Network> Deserialize<'de> for Rejected<N> {
                 // Parse the rejected transaction from a string into a value.
                 let mut object = serde_json::Value::deserialize(deserializer)?;
 
+                // Try to parse the unconfirmed ID.
+                let contains_unconfirmed_id = object.get("unconfirmed_id").is_some();
+                let unconfirmed_id: Option<N::TransactionID> = contains_unconfirmed_id
+                    .then(|| DeserializeExt::take_from_value::<D>(&mut object, "unconfirmed_id"))
+                    .transpose()?;
+
                 // Parse the type.
                 let type_ = object.get("type").and_then(|t| t.as_str());
 
@@ -60,13 +81,13 @@ impl<'de, N: Network> Deserialize<'de> for Rejected<N> {
                         let deployment: Deployment<N> =
                             DeserializeExt::take_from_value::<D>(&mut object, "deployment")?;
                         // Return the rejected deployment.
-                        Ok(Self::new_deployment(program_owner, deployment))
+                        Ok(Self::new_deployment(unconfirmed_id, program_owner, deployment))
                     }
                     Some("execution") => {
                         // Parse the execution.
                         let execution: Execution<N> = DeserializeExt::take_from_value::<D>(&mut object, "execution")?;
                         // Return the rejected execution.
-                        Ok(Self::new_execution(execution))
+                        Ok(Self::new_execution(unconfirmed_id, execution))
                     }
                     _ => Err(de::Error::custom("Invalid rejected transaction type")),
                 }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -704,10 +704,14 @@ finalize failed_assert:
     assert_eq!(next_block.transactions().len(), 1);
     let confirmed_transaction = next_block.transactions().iter().next().unwrap();
     assert!(confirmed_transaction.is_rejected());
-    if let Transaction::Execute(_, _, execution, fee) = failed_assert_transaction {
+    if let Transaction::Execute(unconfirmed_id, _, execution, fee) = failed_assert_transaction {
         let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
-        let expected_confirmed_transaction =
-            ConfirmedTransaction::RejectedExecute(0, fee_transaction, Rejected::new_execution(*execution), vec![]);
+        let expected_confirmed_transaction = ConfirmedTransaction::RejectedExecute(
+            0,
+            fee_transaction,
+            Rejected::new_execution(Some(unconfirmed_id), *execution),
+            vec![],
+        );
 
         assert_eq!(confirmed_transaction, &expected_confirmed_transaction);
     }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -704,12 +704,12 @@ finalize failed_assert:
     assert_eq!(next_block.transactions().len(), 1);
     let confirmed_transaction = next_block.transactions().iter().next().unwrap();
     assert!(confirmed_transaction.is_rejected());
-    if let Transaction::Execute(unconfirmed_id, _, execution, fee) = failed_assert_transaction {
+    if let Transaction::Execute(_, _, execution, fee) = failed_assert_transaction {
         let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
         let expected_confirmed_transaction = ConfirmedTransaction::RejectedExecute(
             0,
             fee_transaction,
-            Rejected::new_execution(Some(unconfirmed_id), *execution),
+            Rejected::new_execution(None, *execution),
             vec![],
         );
 

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -176,7 +176,7 @@ pub fn sample_rejected_deployment(is_fee_private: bool, rng: &mut TestRng) -> Re
     let program_owner = ProgramOwner::new(&private_key, deployment_id, rng).unwrap();
 
     // Return the rejected deployment.
-    Rejected::new_deployment(program_owner, deployment)
+    Rejected::new_deployment(None, program_owner, deployment)
 }
 
 /******************************************* Execution ********************************************/
@@ -200,7 +200,7 @@ pub fn sample_rejected_execution(is_fee_private: bool, rng: &mut TestRng) -> Rej
     };
 
     // Return the rejected execution.
-    Rejected::new_execution(*execution)
+    Rejected::new_execution(None, *execution)
 }
 
 /********************************************** Fee ***********************************************/

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1664,10 +1664,10 @@ finalize transfer_public:
         finalize: &[FinalizeOperation<CurrentNetwork>],
     ) -> ConfirmedTransaction<CurrentNetwork> {
         match transaction {
-            Transaction::Execute(unconfirmed_id, _, execution, fee) => ConfirmedTransaction::RejectedExecute(
+            Transaction::Execute(_, _, execution, fee) => ConfirmedTransaction::RejectedExecute(
                 index,
                 Transaction::from_fee(fee.clone().unwrap()).unwrap(),
-                Rejected::new_execution(Some(*unconfirmed_id), *execution.clone()),
+                Rejected::new_execution(None, *execution.clone()),
                 finalize.to_vec(),
             ),
             _ => panic!("only reject execution transactions"),
@@ -2364,12 +2364,12 @@ function ped_hash:
             // Ensure that the transaction is rejected.
             assert_eq!(confirmed_transactions.len(), 1);
             assert!(transaction.is_execute());
-            if let Transaction::Execute(unconfirmed_id, _, execution, fee) = transaction {
+            if let Transaction::Execute(_, _, execution, fee) = transaction {
                 let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
                 let expected_confirmed_transaction = ConfirmedTransaction::RejectedExecute(
                     0,
                     fee_transaction,
-                    Rejected::new_execution(Some(unconfirmed_id), *execution),
+                    Rejected::new_execution(None, *execution),
                     vec![],
                 );
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -331,7 +331,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 let outcome = match transaction {
                     // The finalize operation here involves appending the 'stack',
                     // and adding the program to the finalize tree.
-                    Transaction::Deploy(_, _, program_owner, deployment, fee) => {
+                    Transaction::Deploy(unconfirmed_id, _, program_owner, deployment, fee) => {
                         // Define the closure for processing a rejected deployment.
                         let process_rejected_deployment =
                             |fee: &Fee<N>,
@@ -343,7 +343,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         Transaction::from_fee(fee.clone()).map(|fee_tx| (fee_tx, finalize))
                                     })
                                     .map(|(fee_tx, finalize)| {
-                                        let rejected = Rejected::new_deployment(*program_owner, deployment);
+                                        let rejected =
+                                            Rejected::new_deployment(Some(*unconfirmed_id), *program_owner, deployment);
                                         ConfirmedTransaction::rejected_deploy(counter, fee_tx, rejected, finalize)
                                             .map_err(|e| e.to_string())
                                     })
@@ -391,7 +392,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     }
                     // The finalize operation here involves calling 'update_key_value',
                     // and update the respective leaves of the finalize tree.
-                    Transaction::Execute(_, _, execution, fee) => {
+                    Transaction::Execute(unconfirmed_id, _, execution, fee) => {
                         // Determine if the transaction is safe for execution, and proceed to execute it.
                         match Self::prepare_for_execution(state, store, execution)
                             .and_then(|_| process.finalize_execution(state, store, execution, fee.as_ref()))
@@ -410,7 +411,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                     }) {
                                         Ok((fee_tx, finalize)) => {
                                             // Construct the rejected execution.
-                                            let rejected = Rejected::new_execution(*execution.clone());
+                                            let rejected =
+                                                Rejected::new_execution(Some(*unconfirmed_id), *execution.clone());
                                             // Construct the rejected execute transaction.
                                             ConfirmedTransaction::rejected_execute(counter, fee_tx, rejected, finalize)
                                                 .map_err(|e| e.to_string())
@@ -1657,10 +1659,10 @@ finalize transfer_public:
         finalize: &[FinalizeOperation<CurrentNetwork>],
     ) -> ConfirmedTransaction<CurrentNetwork> {
         match transaction {
-            Transaction::Execute(_, _, execution, fee) => ConfirmedTransaction::RejectedExecute(
+            Transaction::Execute(unconfirmed_id, _, execution, fee) => ConfirmedTransaction::RejectedExecute(
                 index,
                 Transaction::from_fee(fee.clone().unwrap()).unwrap(),
-                Rejected::new_execution(*execution.clone()),
+                Rejected::new_execution(Some(*unconfirmed_id), *execution.clone()),
                 finalize.to_vec(),
             ),
             _ => panic!("only reject execution transactions"),
@@ -2357,12 +2359,12 @@ function ped_hash:
             // Ensure that the transaction is rejected.
             assert_eq!(confirmed_transactions.len(), 1);
             assert!(transaction.is_execute());
-            if let Transaction::Execute(_, _, execution, fee) = transaction {
+            if let Transaction::Execute(unconfirmed_id, _, execution, fee) = transaction {
                 let fee_transaction = Transaction::from_fee(fee.unwrap()).unwrap();
                 let expected_confirmed_transaction = ConfirmedTransaction::RejectedExecute(
                     0,
                     fee_transaction,
-                    Rejected::new_execution(*execution),
+                    Rejected::new_execution(Some(unconfirmed_id), *execution),
                     vec![],
                 );
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -299,6 +299,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Initialize the list of deployment payers.
             let mut deployment_payers: IndexSet<Address<N>> = IndexSet::new();
 
+            // Determine whether to include the unconfirmed ID in rejected transactions.
+            let consensus_version = N::CONSENSUS_VERSION(state.block_height()).map_err(|e| e.to_string())?;
+            let store_unconfirmed_id = !(ConsensusVersion::V1..=ConsensusVersion::V5).contains(&consensus_version);
+
             // Finalize the transactions.
             'outer: for transaction in transactions {
                 // Ensure the number of confirmed transactions does not exceed the maximum.
@@ -343,8 +347,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         Transaction::from_fee(fee.clone()).map(|fee_tx| (fee_tx, finalize))
                                     })
                                     .map(|(fee_tx, finalize)| {
+                                        let unconfirmed_id = store_unconfirmed_id.then_some(*unconfirmed_id);
                                         let rejected =
-                                            Rejected::new_deployment(Some(*unconfirmed_id), *program_owner, deployment);
+                                            Rejected::new_deployment(unconfirmed_id, *program_owner, deployment);
                                         ConfirmedTransaction::rejected_deploy(counter, fee_tx, rejected, finalize)
                                             .map_err(|e| e.to_string())
                                     })
@@ -410,9 +415,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         Transaction::from_fee(fee.clone()).map(|fee_tx| (fee_tx, finalize))
                                     }) {
                                         Ok((fee_tx, finalize)) => {
+                                            let unconfirmed_id = store_unconfirmed_id.then_some(*unconfirmed_id);
                                             // Construct the rejected execution.
-                                            let rejected =
-                                                Rejected::new_execution(Some(*unconfirmed_id), *execution.clone());
+                                            let rejected = Rejected::new_execution(unconfirmed_id, *execution.clone());
                                             // Construct the rejected execute transaction.
                                             ConfirmedTransaction::rejected_execute(counter, fee_tx, rejected, finalize)
                                                 .map_err(|e| e.to_string())


### PR DESCRIPTION
## Motivation

Currently, in order to know whether a transaction was rejected, one has to track and store its fee transition id, and match that to the rejected transaction's fee transition id. This requires exchanges, explorers and other users to track extra information. At least one exchange, one explorer and multiple developers have complained about this, and they continue to do so, showing its a real issue.

This PR suggests to store the `unconfirmed_id` in rejected transactions  from `ConsensusVersion::V6` onwards.

Closes https://github.com/ProvableHQ/snarkVM/issues/2683

## Test Plan

- [ ] [devnet] Run a validator and client with and without this PR in the same network before the migration height
- [ ] [devnet] Run a set of validators and clients with this PR as they surpass the migration height (without this PR they would halt)
- [ ] Gather early feedback from every major explorer that they can handle such a change.