### PR TITLE
[Feat] Consensus-restricted keywords.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,6 +696,16 @@ jobs:
           workspace_member: synthesizer
           cache_key: v1.3.0-rust-1.83.0-snarkvm-synthesizer-cache
 
+  synthesizer-test:
+    docker:
+      - image: cimg/rust:1.83.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+    resource_class: << pipeline.parameters.twoxlarge >>
+    steps:
+      - run_serial:
+          flags: --lib --bins --features test
+          workspace_member: synthesizer
+          cache_key: v1.3.0-rust-1.83.0-snarkvm-synthesizer-test-cache
+
   synthesizer-mem-heavy:
     docker:
       - image: cimg/rust:1.83.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
@@ -994,6 +1004,7 @@ workflows:
       - parameters-large
       - parameters-uncached
       - synthesizer
+      - synthesizer-test
       - synthesizer-mem-heavy
       - synthesizer-integration
       - synthesizer-process

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -574,7 +574,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
     // New keywords should be enforced through `RESTRICTED_KEYWORDS` instead, if possible.
     // Adding keywords to this list will require a backwards-compatible versioning for programs.
     #[rustfmt::skip]
-    const KEYWORDS: &'static [&'static str] = &[
+    pub const KEYWORDS: &'static [&'static str] = &[
         // Mode
         "const",
         "constant",
@@ -653,7 +653,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
     /// If the current consensus version is greater than or equal to the specified version,
     /// the keywords in the list should be restricted.
     #[rustfmt::skip]
-    const RESTRICTED_KEYWORDS: &'static [(ConsensusVersion, &'static [&'static str])] = &[
+    pub const RESTRICTED_KEYWORDS: &'static [(ConsensusVersion, &'static [&'static str])] = &[
         (ConsensusVersion::V6, &["constructor"])
     ];
 

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -48,44 +48,47 @@ mod parse;
 mod serialize;
 
 use console::{
-    network::prelude::{
-        Debug,
-        Deserialize,
-        Deserializer,
-        Display,
-        Err,
-        Error,
-        ErrorKind,
-        Formatter,
-        FromBytes,
-        FromBytesDeserializer,
-        FromStr,
-        IoResult,
-        Network,
-        Parser,
-        ParserResult,
-        Read,
-        Result,
-        Sanitizer,
-        Serialize,
-        Serializer,
-        ToBytes,
-        ToBytesSerializer,
-        TypeName,
-        Write,
-        anyhow,
-        bail,
-        de,
-        ensure,
-        error,
-        fmt,
-        make_error,
-        many0,
-        many1,
-        map,
-        map_res,
-        tag,
-        take,
+    network::{
+        ConsensusVersion,
+        prelude::{
+            Debug,
+            Deserialize,
+            Deserializer,
+            Display,
+            Err,
+            Error,
+            ErrorKind,
+            Formatter,
+            FromBytes,
+            FromBytesDeserializer,
+            FromStr,
+            IoResult,
+            Network,
+            Parser,
+            ParserResult,
+            Read,
+            Result,
+            Sanitizer,
+            Serialize,
+            Serializer,
+            ToBytes,
+            ToBytesSerializer,
+            TypeName,
+            Write,
+            anyhow,
+            bail,
+            de,
+            ensure,
+            error,
+            fmt,
+            make_error,
+            many0,
+            many1,
+            map,
+            map_res,
+            tag,
+            take,
+        },
     },
     program::{Identifier, PlaintextType, ProgramID, RecordType, StructType},
 };
@@ -93,7 +96,7 @@ use console::{
 use indexmap::IndexMap;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-enum ProgramDefinition {
+pub enum ProgramDefinition {
     /// A program mapping.
     Mapping,
     /// A program struct.
@@ -154,6 +157,11 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
     /// Returns the ID of the program.
     pub const fn id(&self) -> &ProgramID<N> {
         &self.id
+    }
+
+    /// Returns the identifiers in the program.
+    pub fn identifiers(&self) -> &IndexMap<Identifier<N>, ProgramDefinition> {
+        &self.identifiers
     }
 
     /// Returns the imports in the program.
@@ -642,6 +650,15 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         "type",
         "future",
     ];
+    /// A list of restricted keywords for Aleo programs.
+    /// These restrictions are used to enforce program hygiene.
+    /// Each entry is a tuple of the consensus version and a list of keywords.
+    /// If the current consensus version is greater than or equal to the specified version,
+    /// the keywords in the list should be restricted.
+    #[rustfmt::skip]
+    const RESTRICTED_KEYWORDS: &'static [(ConsensusVersion, &'static [&'static str])] = &[
+        (ConsensusVersion::V6, &["constructor"])
+    ];
 
     /// Returns `true` if the given name does not already exist in the program.
     fn is_unique_name(&self, name: &Identifier<N>) -> bool {
@@ -659,6 +676,17 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         let name = name.to_string();
         // Check if the name is a keyword.
         Self::KEYWORDS.iter().any(|keyword| *keyword == name)
+    }
+
+    /// Returns an iterator over the restricted keywords for the consensus version.
+    pub fn restricted_keywords_for_consensus_version(
+        current_version: ConsensusVersion,
+    ) -> impl Iterator<Item = &'static str> {
+        Self::RESTRICTED_KEYWORDS
+            .iter()
+            .filter(move |(version, _)| *version <= current_version)
+            .flat_map(|(_, keywords)| *keywords)
+            .copied()
     }
 }
 

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -93,7 +93,7 @@ use console::{
     program::{Identifier, PlaintextType, ProgramID, RecordType, StructType},
 };
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 enum ProgramDefinition {
@@ -677,44 +677,60 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
 
     /// Returns an iterator over the restricted keywords for the given consensus version.
     pub fn restricted_keywords_for_consensus_version(
-        current_version: ConsensusVersion,
+        consensus_version: ConsensusVersion,
     ) -> impl Iterator<Item = &'static str> {
         Self::RESTRICTED_KEYWORDS
             .iter()
-            .filter(move |(version, _)| *version <= current_version)
+            .filter(move |(version, _)| *version <= consensus_version)
             .flat_map(|(_, keywords)| *keywords)
             .copied()
     }
 
     /// Checks a program for restricted keywords for the given consensus version.
     /// Returns an error if any restricted keywords are found.
+    /// Note: Restrictions are not enforced on the import names in case they were deployed before the restrictions were added.
     pub fn check_restricted_keywords_for_consensus_version(&self, consensus_version: ConsensusVersion) -> Result<()> {
         // Get all keywords that are restricted for the consensus version.
-        let keywords = Program::<N>::restricted_keywords_for_consensus_version(consensus_version).collect::<Vec<_>>();
+        let keywords =
+            Program::<N>::restricted_keywords_for_consensus_version(consensus_version).collect::<IndexSet<_>>();
         // Check if the program name is a restricted keywords.
         let program_name = self.id().name().to_string();
-        if keywords.iter().any(|keyword| program_name == *keyword) {
-            bail!("Program name '{}' is a restricted keyword for the current consensus version", program_name)
+        if keywords.contains(&program_name.as_str()) {
+            bail!("Program name '{program_name}' is a restricted keyword for the current consensus version")
         }
         // Check that all top-level program components are not restricted keywords.
         for identifier in self.identifiers.keys() {
-            if keywords.iter().any(|keyword| identifier.to_string() == *keyword) {
-                bail!("Program component '{}' is a restricted keyword for the current consensus version", identifier)
+            if keywords.contains(identifier.to_string().as_str()) {
+                bail!("Program component '{identifier}' is a restricted keyword for the current consensus version")
             }
         }
         // Check that all record entry names are not restricted keywords.
         for record_type in self.records().values() {
-            for member_name in record_type.entries().keys() {
-                if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
-                    bail!("Record entry '{}' is a restricted keyword for the current consensus version", member_name)
+            for entry_name in record_type.entries().keys() {
+                if keywords.contains(entry_name.to_string().as_str()) {
+                    bail!("Record entry '{entry_name}' is a restricted keyword for the current consensus version")
                 }
             }
         }
         // Check that all struct member names are not restricted keywords.
         for struct_type in self.structs().values() {
             for member_name in struct_type.members().keys() {
-                if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
-                    bail!("Struct member '{}' is a restricted keyword for the current consensus version", member_name)
+                if keywords.contains(member_name.to_string().as_str()) {
+                    bail!("Struct member '{member_name}' is a restricted keyword for the current consensus version")
+                }
+            }
+        }
+        // Check that all `finalize` positions.
+        // Note: It is sufficient to only check the positions in `FinalizeCore` since `FinalizeTypes::initialize` checks that every
+        // `Branch` instruction targets a valid position.
+        for function in self.functions().values() {
+            if let Some(finalize_logic) = function.finalize_logic() {
+                for position in finalize_logic.positions().keys() {
+                    if keywords.contains(position.to_string().as_str()) {
+                        bail!(
+                            "Finalize position '{position}' is a restricted keyword for the current consensus version"
+                        )
+                    }
                 }
             }
         }

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -96,7 +96,7 @@ use console::{
 use indexmap::IndexMap;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub enum ProgramDefinition {
+enum ProgramDefinition {
     /// A program mapping.
     Mapping,
     /// A program struct.
@@ -157,11 +157,6 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
     /// Returns the ID of the program.
     pub const fn id(&self) -> &ProgramID<N> {
         &self.id
-    }
-
-    /// Returns the identifiers in the program.
-    pub fn identifiers(&self) -> &IndexMap<Identifier<N>, ProgramDefinition> {
-        &self.identifiers
     }
 
     /// Returns the imports in the program.
@@ -575,6 +570,9 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
 }
 
 impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> ProgramCore<N, Instruction, Command> {
+    /// A list of reserved keywords for Aleo programs, enforced at the parser level.
+    // New keywords should be enforced through `RESTRICTED_KEYWORDS` instead, if possible.
+    // Adding keywords to this list will require a backwards-compatible versioning for programs.
     #[rustfmt::skip]
     const KEYWORDS: &'static [&'static str] = &[
         // Mode
@@ -650,8 +648,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         "type",
         "future",
     ];
-    /// A list of restricted keywords for Aleo programs.
-    /// These restrictions are used to enforce program hygiene.
+    /// A list of restricted keywords for Aleo programs, enforced at the VM-level for program hygiene.
     /// Each entry is a tuple of the consensus version and a list of keywords.
     /// If the current consensus version is greater than or equal to the specified version,
     /// the keywords in the list should be restricted.
@@ -678,7 +675,7 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
         Self::KEYWORDS.iter().any(|keyword| *keyword == name)
     }
 
-    /// Returns an iterator over the restricted keywords for the consensus version.
+    /// Returns an iterator over the restricted keywords for the given consensus version.
     pub fn restricted_keywords_for_consensus_version(
         current_version: ConsensusVersion,
     ) -> impl Iterator<Item = &'static str> {
@@ -687,6 +684,41 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
             .filter(move |(version, _)| *version <= current_version)
             .flat_map(|(_, keywords)| *keywords)
             .copied()
+    }
+
+    /// Checks a program for restricted keywords for the given consensus version.
+    /// Returns an error if any restricted keywords are found.
+    pub fn check_restricted_keywords_for_consensus_version(&self, consensus_version: ConsensusVersion) -> Result<()> {
+        // Get all keywords that are restricted for the consensus version.
+        let keywords = Program::<N>::restricted_keywords_for_consensus_version(consensus_version).collect::<Vec<_>>();
+        // Check if the program name is a restricted keywords.
+        let program_name = self.id().name().to_string();
+        if keywords.iter().any(|keyword| program_name == *keyword) {
+            bail!("Program name '{}' is a restricted keyword for the current consensus version", program_name)
+        }
+        // Check that all top-level program components are not restricted keywords.
+        for identifier in self.identifiers.keys() {
+            if keywords.iter().any(|keyword| identifier.to_string() == *keyword) {
+                bail!("Program component '{}' is a restricted keyword for the current consensus version", identifier)
+            }
+        }
+        // Check that all record entry names are not restricted keywords.
+        for record_type in self.records().values() {
+            for member_name in record_type.entries().keys() {
+                if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
+                    bail!("Record entry '{}' is a restricted keyword for the current consensus version", member_name)
+                }
+            }
+        }
+        // Check that all struct member names are not restricted keywords.
+        for struct_type in self.structs().values() {
+            for member_name in struct_type.members().keys() {
+                if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
+                    bail!("Struct member '{}' is a restricted keyword for the current consensus version", member_name)
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1933,6 +1933,7 @@ finalize transfer_public:
         assert!(Committee::new_genesis(committee_map).is_err());
     }
 
+    #[cfg(not(feature = "test"))]
     #[test]
     #[allow(clippy::assertions_on_constants)]
     fn test_migration_v3_maximum_validator_increase() {

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -474,6 +474,7 @@ pub(crate) mod test_helpers {
         VM::from(ConsensusStore::open(StorageMode::new_test(None)).unwrap()).unwrap()
     }
 
+    #[cfg(feature = "test")]
     pub(crate) fn sample_vm_at_height(height: u32, rng: &mut TestRng) -> VM<CurrentNetwork, LedgerType> {
         // Initialize the VM with a genesis block.
         let vm = sample_vm_with_genesis_block(rng);

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -3052,8 +3052,8 @@ function adder:
         assert!(vm.process().read().contains_program(&ProgramID::from_str("child_program.aleo").unwrap()));
     }
 
-    #[test]
     #[cfg(feature = "test")]
+    #[test]
     fn test_versioned_keyword_restrictions() {
         let rng = &mut TestRng::default();
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -3052,7 +3052,7 @@ function adder:
     }
 
     #[test]
-    #[feature = "test"]
+    #[cfg(feature = "test")]
     fn test_versioned_keyword_restrictions() {
         let rng = &mut TestRng::default();
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -474,6 +474,20 @@ pub(crate) mod test_helpers {
         VM::from(ConsensusStore::open(StorageMode::new_test(None)).unwrap()).unwrap()
     }
 
+    pub(crate) fn sample_vm_at_height(height: u32, rng: &mut TestRng) -> VM<CurrentNetwork, LedgerType> {
+        // Initialize the VM with a genesis block.
+        let vm = sample_vm_with_genesis_block(rng);
+        // Get the genesis private key.
+        let genesis_private_key = sample_genesis_private_key(rng);
+        // Advance the VM to the given height.
+        for _ in 0..height {
+            let block = sample_next_block(&vm, &genesis_private_key, &[], rng).unwrap();
+            vm.add_next_block(&block).unwrap();
+        }
+        // Return the VM.
+        vm
+    }
+
     pub(crate) fn sample_genesis_private_key(rng: &mut TestRng) -> PrivateKey<CurrentNetwork> {
         static INSTANCE: OnceCell<PrivateKey<CurrentNetwork>> = OnceCell::new();
         *INSTANCE.get_or_init(|| {
@@ -3035,5 +3049,60 @@ function adder:
 
         // Check that only `child_program.aleo` is in the VM.
         assert!(vm.process().read().contains_program(&ProgramID::from_str("child_program.aleo").unwrap()));
+    }
+
+    #[test]
+    fn test_versioned_keyword_restrictions() {
+        let rng = &mut TestRng::default();
+
+        // Initialize a new caller.
+        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+        // Initialize the VM at a specific height.
+        // We subtract by 7 to deploy the 7 invalid programs.
+        let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V6).unwrap() - 7, rng);
+
+        // Define the invalid program bodies.
+        let invalid_program_bodies = vec![
+            "function constructor:",
+            "function dummy:\nclosure constructor: input r0 as u8; assert.eq r0 0u8;",
+            "function dummy:\nmapping constructor: key as boolean.public; value as boolean.public;",
+            "function dummy:\nrecord constructor: owner as address.private;",
+            "function dummy:\nrecord foo: owner as address.public; constructor as address.public;",
+            "function dummy:\nstruct constructor: foo as address;",
+            "function dummy:\nstruct foo:\nconstructor as address;",
+        ];
+
+        println!("Current height: {}", vm.block_store().current_block_height());
+
+        // Deploy a test program for each of the invalid program bodies.
+        // They should all be accepted by the VM, because the restriction is not yet in place.
+        for (i, body) in invalid_program_bodies.iter().enumerate() {
+            println!("Deploying 'valid' test program {}: {}", i, body);
+            let program = Program::from_str(&format!("program test_valid_{}.aleo;\n{}", i, body)).unwrap();
+            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+            let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+            assert_eq!(block.transactions().num_accepted(), 1);
+            assert_eq!(block.transactions().num_rejected(), 0);
+            assert_eq!(block.aborted_transaction_ids().len(), 0);
+            vm.add_next_block(&block).unwrap();
+        }
+
+        println!("Current height: {}", vm.block_store().current_block_height());
+
+        // Deploy a test program for each of the invalid program bodies.
+        // Verify that `check_transaction` fails for each of them.
+        for (i, body) in invalid_program_bodies.iter().enumerate() {
+            println!("Deploying 'invalid' test program {}: {}", i, body);
+            let program = Program::from_str(&format!("program test_invalid_{}.aleo;\n{}", i, body)).unwrap();
+            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+            assert!(vm.check_transaction(&deployment, None, rng).is_err());
+        }
+
+        // Attempt to deploy a program with the name `constructor`.
+        // Verify that `check_transaction` fails.
+        let program = Program::from_str(r"program constructor.aleo; function dummy:").unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        assert!(vm.check_transaction(&deployment, None, rng).is_err());
     }
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -3097,13 +3097,21 @@ function adder:
             println!("Deploying 'invalid' test program {}: {}", i, body);
             let program = Program::from_str(&format!("program test_invalid_{}.aleo;\n{}", i, body)).unwrap();
             let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
-            assert!(vm.check_transaction(&deployment, None, rng).is_err());
+            if let Err(e) = vm.check_transaction(&deployment, None, rng) {
+                println!("Error: {}", e);
+            } else {
+                panic!("Expected an error, but the deployment was accepted.")
+            }
         }
 
         // Attempt to deploy a program with the name `constructor`.
         // Verify that `check_transaction` fails.
         let program = Program::from_str(r"program constructor.aleo; function dummy:").unwrap();
         let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
-        assert!(vm.check_transaction(&deployment, None, rng).is_err());
+        if let Err(e) = vm.check_transaction(&deployment, None, rng) {
+            println!("Error: {}", e);
+        } else {
+            panic!("Expected an error, but the deployment was accepted.")
+        }
     }
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -3052,6 +3052,7 @@ function adder:
     }
 
     #[test]
+    #[feature = "test"]
     fn test_versioned_keyword_restrictions() {
         let rng = &mut TestRng::default();
 
@@ -3063,14 +3064,14 @@ function adder:
         let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V6).unwrap() - 7, rng);
 
         // Define the invalid program bodies.
-        let invalid_program_bodies = vec![
+        let invalid_program_bodies = [
             "function constructor:",
             "function dummy:\nclosure constructor: input r0 as u8; assert.eq r0 0u8;",
             "function dummy:\nmapping constructor: key as boolean.public; value as boolean.public;",
             "function dummy:\nrecord constructor: owner as address.private;",
             "function dummy:\nrecord foo: owner as address.public; constructor as address.public;",
             "function dummy:\nstruct constructor: foo as address;",
-            "function dummy:\nstruct foo:\nconstructor as address;",
+            "function dummy:\nstruct foo: constructor as address;",
         ];
 
         println!("Current height: {}", vm.block_store().current_block_height());

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -161,6 +161,53 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 if self.contains_program(deployment.program_id()) {
                     bail!("Program ID '{}' already exists", deployment.program_id());
                 }
+                // If the `ConsensusVersion` is V6 or greater, enforce the syntax restrictions.
+                let current_block_height = self.block_store().current_block_height();
+                let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
+                if consensus_version >= ConsensusVersion::V6 {
+                    // Get all keywords that are restricted for the current version.
+                    let keywords =
+                        Program::<N>::restricted_keywords_for_consensus_version(consensus_version).collect::<Vec<_>>();
+                    // Check if the program name is a restricted keywords.
+                    let program_name = deployment.program().id().name().to_string();
+                    if keywords.iter().any(|keyword| program_name == *keyword) {
+                        bail!(
+                            "Program name '{}' is a restricted keyword for the current consensus version",
+                            program_name
+                        )
+                    }
+                    // Check that all top-level program components are not restricted keywords.
+                    for identifier in deployment.program().identifiers().keys() {
+                        if keywords.iter().any(|keyword| identifier.to_string() == *keyword) {
+                            bail!(
+                                "Program component '{}' is a restricted keyword for the current consensus version",
+                                identifier
+                            )
+                        }
+                    }
+                    // Check that all record entry names are not restricted keywords.
+                    for record_type in deployment.program().records().values() {
+                        for member_name in record_type.entries().keys() {
+                            if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
+                                bail!(
+                                    "Record entry '{}' is a restricted keyword for the current consensus version",
+                                    member_name
+                                )
+                            }
+                        }
+                    }
+                    // Check that all struct member names are not restricted keywords.
+                    for struct_type in deployment.program().structs().values() {
+                        for member_name in struct_type.members().keys() {
+                            if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
+                                bail!(
+                                    "Struct member '{}' is a restricted keyword for the current consensus version",
+                                    member_name
+                                )
+                            }
+                        }
+                    }
+                }
                 // Verify the deployment if it has not been verified before.
                 if !is_partially_verified {
                     // Verify the deployment.

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -161,50 +161,46 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 if self.contains_program(deployment.program_id()) {
                     bail!("Program ID '{}' already exists", deployment.program_id());
                 }
-                // If the `ConsensusVersion` is V6 or greater, enforce the syntax restrictions.
+                // Enforce the syntax restrictions on the programs based on the current consensus version.
+                // Note: We intentionally do not enforce restrictions on the import names in case they were deployed before the restrictions were added.
                 let current_block_height = self.block_store().current_block_height();
                 let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
-                if consensus_version >= ConsensusVersion::V6 {
-                    // Get all keywords that are restricted for the current version.
-                    let keywords =
-                        Program::<N>::restricted_keywords_for_consensus_version(consensus_version).collect::<Vec<_>>();
-                    // Check if the program name is a restricted keywords.
-                    let program_name = deployment.program().id().name().to_string();
-                    if keywords.iter().any(|keyword| program_name == *keyword) {
+                // Get all keywords that are restricted for the current version.
+                let keywords =
+                    Program::<N>::restricted_keywords_for_consensus_version(consensus_version).collect::<Vec<_>>();
+                // Check if the program name is a restricted keywords.
+                let program_name = deployment.program().id().name().to_string();
+                if keywords.iter().any(|keyword| program_name == *keyword) {
+                    bail!("Program name '{}' is a restricted keyword for the current consensus version", program_name)
+                }
+                // Check that all top-level program components are not restricted keywords.
+                for identifier in deployment.program().identifiers().keys() {
+                    if keywords.iter().any(|keyword| identifier.to_string() == *keyword) {
                         bail!(
-                            "Program name '{}' is a restricted keyword for the current consensus version",
-                            program_name
+                            "Program component '{}' is a restricted keyword for the current consensus version",
+                            identifier
                         )
                     }
-                    // Check that all top-level program components are not restricted keywords.
-                    for identifier in deployment.program().identifiers().keys() {
-                        if keywords.iter().any(|keyword| identifier.to_string() == *keyword) {
+                }
+                // Check that all record entry names are not restricted keywords.
+                for record_type in deployment.program().records().values() {
+                    for member_name in record_type.entries().keys() {
+                        if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
                             bail!(
-                                "Program component '{}' is a restricted keyword for the current consensus version",
-                                identifier
+                                "Record entry '{}' is a restricted keyword for the current consensus version",
+                                member_name
                             )
                         }
                     }
-                    // Check that all record entry names are not restricted keywords.
-                    for record_type in deployment.program().records().values() {
-                        for member_name in record_type.entries().keys() {
-                            if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
-                                bail!(
-                                    "Record entry '{}' is a restricted keyword for the current consensus version",
-                                    member_name
-                                )
-                            }
-                        }
-                    }
-                    // Check that all struct member names are not restricted keywords.
-                    for struct_type in deployment.program().structs().values() {
-                        for member_name in struct_type.members().keys() {
-                            if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
-                                bail!(
-                                    "Struct member '{}' is a restricted keyword for the current consensus version",
-                                    member_name
-                                )
-                            }
+                }
+                // Check that all struct member names are not restricted keywords.
+                for struct_type in deployment.program().structs().values() {
+                    for member_name in struct_type.members().keys() {
+                        if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
+                            bail!(
+                                "Struct member '{}' is a restricted keyword for the current consensus version",
+                                member_name
+                            )
                         }
                     }
                 }

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -162,7 +162,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     bail!("Program ID '{}' already exists", deployment.program_id());
                 }
                 // Enforce the syntax restrictions on the programs based on the current consensus version.
-                // Note: We intentionally do not enforce restrictions on the import names in case they were deployed before the restrictions were added.
                 let current_block_height = self.block_store().current_block_height();
                 let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
                 deployment.program().check_restricted_keywords_for_consensus_version(consensus_version)?;

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -165,45 +165,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Note: We intentionally do not enforce restrictions on the import names in case they were deployed before the restrictions were added.
                 let current_block_height = self.block_store().current_block_height();
                 let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
-                // Get all keywords that are restricted for the current version.
-                let keywords =
-                    Program::<N>::restricted_keywords_for_consensus_version(consensus_version).collect::<Vec<_>>();
-                // Check if the program name is a restricted keywords.
-                let program_name = deployment.program().id().name().to_string();
-                if keywords.iter().any(|keyword| program_name == *keyword) {
-                    bail!("Program name '{}' is a restricted keyword for the current consensus version", program_name)
-                }
-                // Check that all top-level program components are not restricted keywords.
-                for identifier in deployment.program().identifiers().keys() {
-                    if keywords.iter().any(|keyword| identifier.to_string() == *keyword) {
-                        bail!(
-                            "Program component '{}' is a restricted keyword for the current consensus version",
-                            identifier
-                        )
-                    }
-                }
-                // Check that all record entry names are not restricted keywords.
-                for record_type in deployment.program().records().values() {
-                    for member_name in record_type.entries().keys() {
-                        if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
-                            bail!(
-                                "Record entry '{}' is a restricted keyword for the current consensus version",
-                                member_name
-                            )
-                        }
-                    }
-                }
-                // Check that all struct member names are not restricted keywords.
-                for struct_type in deployment.program().structs().values() {
-                    for member_name in struct_type.members().keys() {
-                        if keywords.iter().any(|keyword| member_name.to_string() == *keyword) {
-                            bail!(
-                                "Struct member '{}' is a restricted keyword for the current consensus version",
-                                member_name
-                            )
-                        }
-                    }
-                }
+                deployment.program().check_restricted_keywords_for_consensus_version(consensus_version)?;
                 // Verify the deployment if it has not been verified before.
                 if !is_partially_verified {
                     // Verify the deployment.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

As programming standards evolve on Aleo, it would be useful to be able to enforce syntactic restrictions at the consensus layer. This PR:
- adds a mechanism for describing versioned syntax restrictions and enforces them in `check_transactions`.
- adds a CI runner with the `test` feature enabled for the `synthesizer` crate.

## Test Plan

A test was added verifying that syntax restrictions are not enforced before a given version height and that they are enforced after.
