### PR TITLE
Tighten deserialization bounds

### DIFF
--- a/circuit/program/src/data/plaintext/from_bits.rs
+++ b/circuit/program/src/data/plaintext/from_bits.rs
@@ -20,6 +20,26 @@ impl<A: Aleo> FromBits for Plaintext<A> {
 
     /// Initializes a new plaintext from a list of little-endian bits *without* trailing zeros.
     fn from_bits_le(bits_le: &[Boolean<A>]) -> Self {
+        Self::from_bits_le_internal(bits_le, 0)
+    }
+
+    /// Initializes a new plaintext from a list of big-endian bits *without* trailing zeros.
+    fn from_bits_be(bits_be: &[Boolean<A>]) -> Self {
+        Self::from_bits_be_internal(bits_be, 0)
+    }
+}
+
+impl<A: Aleo> Plaintext<A> {
+    /// Initializes a new plaintext from a list of little-endian bits *without* trailing zeros, while tracking the depth of the data.
+    fn from_bits_le_internal(bits_le: &[Boolean<A>], depth: usize) -> Self {
+        // Ensure that the depth is within the maximum limit.
+        if depth > <A::Network as console::Network>::MAX_DATA_DEPTH {
+            A::halt(format!(
+                "Plaintext depth exceeds maximum limit: {}",
+                <A::Network as console::Network>::MAX_DATA_DEPTH
+            ))
+        }
+
         let bits = bits_le;
 
         // The starting index used to create subsequent subslices of the `bits` slice.
@@ -64,7 +84,7 @@ impl<A: Aleo> FromBits for Plaintext<A> {
                 let identifier = Identifier::from_bits_le(next_bits(*identifier_size as usize));
 
                 let member_size = U16::from_bits_le(next_bits(16)).eject_value();
-                let value = Plaintext::from_bits_le(next_bits(*member_size as usize));
+                let value = Plaintext::from_bits_le_internal(next_bits(*member_size as usize), depth + 1);
 
                 members.insert(identifier, value);
             }
@@ -79,7 +99,7 @@ impl<A: Aleo> FromBits for Plaintext<A> {
             let mut elements = Vec::with_capacity(*num_elements as usize);
             for _ in 0..*num_elements {
                 let element_size = U16::from_bits_le(next_bits(16)).eject_value();
-                let value = Plaintext::from_bits_le(next_bits(*element_size as usize));
+                let value = Plaintext::from_bits_le_internal(next_bits(*element_size as usize), depth + 1);
 
                 elements.push(value);
             }
@@ -93,8 +113,16 @@ impl<A: Aleo> FromBits for Plaintext<A> {
         }
     }
 
-    /// Initializes a new plaintext from a list of big-endian bits *without* trailing zeros.
-    fn from_bits_be(bits_be: &[Boolean<A>]) -> Self {
+    /// Initializes a new plaintext from a list of big-endian bits *without* trailing zeros, while tracking the depth of the data.
+    fn from_bits_be_internal(bits_be: &[Boolean<A>], depth: usize) -> Self {
+        // Ensure that the depth is within the maximum limit.
+        if depth > <A::Network as console::Network>::MAX_DATA_DEPTH {
+            A::halt(format!(
+                "Plaintext depth exceeds maximum limit: {}",
+                <A::Network as console::Network>::MAX_DATA_DEPTH
+            ))
+        }
+
         let bits = bits_be;
 
         // The starting index used to create subsequent subslices of the `bits` slice.
@@ -139,7 +167,7 @@ impl<A: Aleo> FromBits for Plaintext<A> {
                 let identifier = Identifier::from_bits_be(next_bits(*identifier_size as usize));
 
                 let member_size = U16::from_bits_be(next_bits(16)).eject_value();
-                let value = Plaintext::from_bits_be(next_bits(*member_size as usize));
+                let value = Plaintext::from_bits_be_internal(next_bits(*member_size as usize), depth + 1);
 
                 members.insert(identifier, value);
             }
@@ -154,7 +182,7 @@ impl<A: Aleo> FromBits for Plaintext<A> {
             let mut elements = Vec::with_capacity(*num_elements as usize);
             for _ in 0..*num_elements {
                 let element_size = U16::from_bits_be(next_bits(16)).eject_value();
-                let value = Plaintext::from_bits_be(next_bits(*element_size as usize));
+                let value = Plaintext::from_bits_be_internal(next_bits(*element_size as usize), depth + 1);
 
                 elements.push(value);
             }

--- a/console/program/src/data/future/argument.rs
+++ b/console/program/src/data/future/argument.rs
@@ -46,38 +46,6 @@ impl<N: Network> Equal<Self> for Argument<N> {
     }
 }
 
-impl<N: Network> FromBytes for Argument<N> {
-    fn read_le<R: Read>(mut reader: R) -> IoResult<Self>
-    where
-        Self: Sized,
-    {
-        // Read the index.
-        let index = u8::read_le(&mut reader)?;
-        // Read the argument.
-        let argument = match index {
-            0 => Self::Plaintext(Plaintext::read_le(&mut reader)?),
-            1 => Self::Future(Future::read_le(&mut reader)?),
-            2.. => return Err(error(format!("Failed to decode future argument {index}"))),
-        };
-        Ok(argument)
-    }
-}
-
-impl<N: Network> ToBytes for Argument<N> {
-    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        match self {
-            Self::Plaintext(plaintext) => {
-                0u8.write_le(&mut writer)?;
-                plaintext.write_le(&mut writer)
-            }
-            Self::Future(future) => {
-                1u8.write_le(&mut writer)?;
-                future.write_le(&mut writer)
-            }
-        }
-    }
-}
-
 impl<N: Network> ToBits for Argument<N> {
     /// Returns the argument as a list of **little-endian** bits.
     #[inline]

--- a/console/program/src/data/future/bytes.rs
+++ b/console/program/src/data/future/bytes.rs
@@ -18,6 +18,25 @@ use super::*;
 impl<N: Network> FromBytes for Future<N> {
     /// Reads in a future from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the future.
+        Self::read_le_internal(&mut reader, 0)
+    }
+}
+
+impl<N: Network> Future<N> {
+    /// Reads in a future from a buffer, while tracking the depth of the data.
+    fn read_le_internal<R: Read>(mut reader: R, depth: usize) -> IoResult<Self> {
+        // Ensure that the depth is within the maximum limit.
+        // Note: `N::MAX_DATA_DEPTH` is an upper bound on the number of nested futures.
+        //  The true maximum is defined by `Transaction::<N>::MAX_TRANSITIONS`, however, that object is not accessible in this crate.
+        //  In practice, `MAX_DATA_DEPTH` is 32, while `MAX_TRANSITIONS` is 31.
+        //  TODO: @d0cd, should we use a more precise bound?
+        if depth > N::MAX_DATA_DEPTH {
+            return Err(error(format!(
+                "Failed to deserialize plaintext: Depth exceeds maximum limit: {}",
+                N::MAX_DATA_DEPTH
+            )));
+        }
         // Read the program ID.
         let program_id = ProgramID::read_le(&mut reader)?;
         // Read the function name.
@@ -36,7 +55,7 @@ impl<N: Network> FromBytes for Future<N> {
             let mut bytes = Vec::new();
             (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
             // Recover the argument.
-            let entry = Argument::read_le(&mut bytes.as_slice())?;
+            let entry = Argument::read_le_internal(&mut bytes.as_slice(), depth)?;
             // Add the argument.
             arguments.push(entry);
         }
@@ -67,6 +86,38 @@ impl<N: Network> ToBytes for Future<N> {
             bytes.write_le(&mut writer)?;
         }
         Ok(())
+    }
+}
+
+impl<N: Network> Argument<N> {
+    fn read_le_internal<R: Read>(mut reader: R, depth: usize) -> IoResult<Self>
+    where
+        Self: Sized,
+    {
+        // Read the index.
+        let index = u8::read_le(&mut reader)?;
+        // Read the argument.
+        let argument = match index {
+            0 => Self::Plaintext(Plaintext::read_le(&mut reader)?),
+            1 => Self::Future(Future::read_le_internal(&mut reader, depth + 1)?),
+            2.. => return Err(error(format!("Failed to decode future argument {index}"))),
+        };
+        Ok(argument)
+    }
+}
+
+impl<N: Network> ToBytes for Argument<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        match self {
+            Self::Plaintext(plaintext) => {
+                0u8.write_le(&mut writer)?;
+                plaintext.write_le(&mut writer)
+            }
+            Self::Future(future) => {
+                1u8.write_le(&mut writer)?;
+                future.write_le(&mut writer)
+            }
+        }
     }
 }
 

--- a/console/program/src/data/future/parse.rs
+++ b/console/program/src/data/future/parse.rs
@@ -19,27 +19,48 @@ impl<N: Network> Parser for Future<N> {
     /// Parses a string into a future value.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        /// Parses an array of future arguments: `[arg_0, ..., arg_1]`.
-        fn parse_arguments<N: Network>(string: &str) -> ParserResult<Vec<Argument<N>>> {
-            // Parse the whitespace and comments from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the "[" from the string.
-            let (string, _) = tag("[")(string)?;
-            // Parse the whitespace from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the members.
-            let (string, arguments) = separated_list0(
-                pair(pair(Sanitizer::parse_whitespaces, tag(",")), Sanitizer::parse),
-                alt((map(Future::parse, Argument::Future), map(Plaintext::parse, Argument::Plaintext))),
-            )(string)?;
-            // Parse the whitespace and comments from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the ']' from the string.
-            let (string, _) = tag("]")(string)?;
-            // Output the plaintext.
-            Ok((string, arguments))
-        }
+        // Parse the future from the string.
+        Self::parse_internal(string, 0)
+    }
+}
 
+impl<N: Network> Future<N> {
+    /// Parses an array of future arguments: `[arg_0, ..., arg_1]`, while tracking the depth of the data.
+    fn parse_arguments(string: &str, depth: usize) -> ParserResult<Vec<Argument<N>>> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the "[" from the string.
+        let (string, _) = tag("[")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the members.
+        let (string, arguments) = separated_list0(
+            pair(pair(Sanitizer::parse_whitespaces, tag(",")), Sanitizer::parse),
+            alt((
+                map(|input| Self::parse_internal(input, depth + 1), Argument::Future),
+                map(Plaintext::parse, Argument::Plaintext),
+            )),
+        )(string)?;
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the ']' from the string.
+        let (string, _) = tag("]")(string)?;
+        // Output the plaintext.
+        Ok((string, arguments))
+    }
+
+    /// Parses a string into a future value, while tracking the depth of the data.
+    #[inline]
+    fn parse_internal(string: &str, depth: usize) -> ParserResult<Self> {
+        // Ensure that the depth is within the maximum limit.
+        // Note: `N::MAX_DATA_DEPTH` is an upper bound on the number of nested futures.
+        //  The true maximum is defined by `Transaction::<N>::MAX_TRANSITIONS`, however, that object is not accessible in this crate.
+        //  In practice, `MAX_DATA_DEPTH` is 32, while `MAX_TRANSITIONS` is 31.
+        if depth > N::MAX_DATA_DEPTH {
+            return map_res(take(0usize), |_| {
+                Err(error(format!("Found a future that exceeds maximum data depth ({})", N::MAX_DATA_DEPTH)))
+            })(string);
+        }
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the "{" from the string.
@@ -90,7 +111,7 @@ impl<N: Network> Parser for Future<N> {
         // Parse the whitespace from the string.
         let (string, _) = Sanitizer::parse_whitespaces(string)?;
         // Parse the arguments from the string.
-        let (string, arguments) = parse_arguments(string)?;
+        let (string, arguments) = Self::parse_arguments(string, depth)?;
 
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;

--- a/console/program/src/data/plaintext/bytes.rs
+++ b/console/program/src/data/plaintext/bytes.rs
@@ -18,6 +18,20 @@ use super::*;
 impl<N: Network> FromBytes for Plaintext<N> {
     /// Reads the plaintext from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        Self::read_le_internal(&mut reader, 0)
+    }
+}
+
+impl<N: Network> Plaintext<N> {
+    /// Reads the plaintext from a buffer, while tracking the depth of the data.
+    fn read_le_internal<R: Read>(mut reader: R, depth: usize) -> IoResult<Self> {
+        // Ensure that the depth is within the maximum limit.
+        if depth > N::MAX_DATA_DEPTH {
+            return Err(error(format!(
+                "Failed to deserialize plaintext: Depth exceeds maximum limit: {}",
+                N::MAX_DATA_DEPTH
+            )));
+        }
         // Read the index.
         let index = u8::read_le(&mut reader)?;
         // Read the plaintext.
@@ -37,7 +51,7 @@ impl<N: Network> FromBytes for Plaintext<N> {
                     let mut bytes = Vec::new();
                     (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
                     // Recover the plaintext value.
-                    let plaintext = Plaintext::read_le(&mut bytes.as_slice())?;
+                    let plaintext = Self::read_le_internal(&mut bytes.as_slice(), depth + 1)?;
                     // Add the member.
                     members.insert(identifier, plaintext);
                 }
@@ -59,7 +73,7 @@ impl<N: Network> FromBytes for Plaintext<N> {
                     let mut bytes = Vec::new();
                     (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
                     // Recover the plaintext value.
-                    let plaintext = Plaintext::read_le(&mut bytes.as_slice())?;
+                    let plaintext = Self::read_le_internal(&mut bytes.as_slice(), depth + 1)?;
                     // Add the element.
                     elements.push(plaintext);
                 }

--- a/console/program/src/data/plaintext/from_bits.rs
+++ b/console/program/src/data/plaintext/from_bits.rs
@@ -18,6 +18,23 @@ use super::*;
 impl<N: Network> FromBits for Plaintext<N> {
     /// Initializes a new plaintext from a list of little-endian bits *without* trailing zeros.
     fn from_bits_le(bits_le: &[bool]) -> Result<Self> {
+        Self::from_bits_le_internal(bits_le, 0)
+    }
+
+    /// Initializes a new plaintext from a list of big-endian bits *without* trailing zeros.
+    fn from_bits_be(bits_be: &[bool]) -> Result<Self> {
+        Self::from_bits_be_internal(bits_be, 0)
+    }
+}
+
+impl<N: Network> Plaintext<N> {
+    /// Initializes a new plaintext from a list of little-endian bits *without* trailing zeros, while the depth of the data.
+    fn from_bits_le_internal(bits_le: &[bool], depth: usize) -> Result<Self> {
+        // Ensure that the depth is within the maximum limit.
+        if depth > N::MAX_DATA_DEPTH {
+            bail!("Plaintext depth exceeds maximum limit: {}", N::MAX_DATA_DEPTH)
+        }
+
         let bits = bits_le;
 
         // The starting index used to create subsequent subslices of the `bits` slice.
@@ -63,7 +80,7 @@ impl<N: Network> FromBits for Plaintext<N> {
                 let identifier = Identifier::from_bits_le(next_bits(identifier_size as usize)?)?;
 
                 let member_size = u16::from_bits_le(next_bits(16)?)?;
-                let value = Plaintext::from_bits_le(next_bits(member_size as usize)?)?;
+                let value = Plaintext::from_bits_le_internal(next_bits(member_size as usize)?, depth + 1)?;
 
                 if members.insert(identifier, value).is_some() {
                     bail!("Duplicate identifier in struct.");
@@ -83,7 +100,7 @@ impl<N: Network> FromBits for Plaintext<N> {
             let mut elements = Vec::with_capacity(num_elements as usize);
             for _ in 0..num_elements {
                 let element_size = u16::from_bits_le(next_bits(16)?)?;
-                let element = Plaintext::from_bits_le(next_bits(element_size as usize)?)?;
+                let element = Plaintext::from_bits_le_internal(next_bits(element_size as usize)?, depth + 1)?;
 
                 elements.push(element);
             }
@@ -97,8 +114,13 @@ impl<N: Network> FromBits for Plaintext<N> {
         }
     }
 
-    /// Initializes a new plaintext from a list of big-endian bits *without* trailing zeros.
-    fn from_bits_be(bits_be: &[bool]) -> Result<Self> {
+    /// Initializes a new plaintext from a list of big-endian bits *without* trailing zeros, while tracking the depth of the data.
+    fn from_bits_be_internal(bits_be: &[bool], depth: usize) -> Result<Self> {
+        // Ensure that the depth is within the maximum limit.
+        if depth > N::MAX_DATA_DEPTH {
+            bail!("Plaintext depth exceeds maximum limit: {}", N::MAX_DATA_DEPTH)
+        }
+
         let bits = bits_be;
 
         // The starting index used to create subsequent subslices of the `bits` slice.
@@ -137,15 +159,12 @@ impl<N: Network> FromBits for Plaintext<N> {
             if num_members as usize > N::MAX_STRUCT_ENTRIES {
                 bail!("Struct exceeds maximum of entries.");
             }
-
             let mut members = IndexMap::with_capacity(num_members as usize);
             for _ in 0..num_members {
                 let identifier_size = u8::from_bits_be(next_bits(8)?)?;
                 let identifier = Identifier::from_bits_be(next_bits(identifier_size as usize)?)?;
-
                 let member_size = u16::from_bits_be(next_bits(16)?)?;
-                let value = Plaintext::from_bits_be(next_bits(member_size as usize)?)?;
-
+                let value = Plaintext::from_bits_be_internal(next_bits(member_size as usize)?, depth + 1)?;
                 if members.insert(identifier, value).is_some() {
                     bail!("Duplicate identifier in struct.");
                 }
@@ -164,7 +183,7 @@ impl<N: Network> FromBits for Plaintext<N> {
             let mut elements = Vec::with_capacity(num_elements as usize);
             for _ in 0..num_elements {
                 let element_size = u16::from_bits_be(next_bits(16)?)?;
-                let element = Plaintext::from_bits_be(next_bits(element_size as usize)?)?;
+                let element = Plaintext::from_bits_be_internal(next_bits(element_size as usize)?, depth + 1)?;
 
                 elements.push(element);
             }

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -19,32 +19,39 @@ impl<N: Network> Parser for Plaintext<N> {
     /// Parses a string into a plaintext value.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        /// Parses a sanitized pair: `identifier: plaintext`.
-        fn parse_pair<N: Network>(string: &str) -> ParserResult<(Identifier<N>, Plaintext<N>)> {
-            // Parse the whitespace and comments from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the identifier from the string.
-            let (string, identifier) = Identifier::parse(string)?;
-            // Parse the whitespace from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Parse the ":" from the string.
-            let (string, _) = tag(":")(string)?;
-            // Parse the plaintext from the string.
-            let (string, plaintext) = Plaintext::parse(string)?;
-            // Parse the whitespace from the string.
-            let (string, _) = Sanitizer::parse_whitespaces(string)?;
-            // Return the identifier and plaintext.
-            Ok((string, (identifier, plaintext)))
-        }
+        // Parse the string into a plaintext value.
+        Self::parse_internal(string, 0)
+    }
+}
 
-        /// Parses a plaintext as a struct: `{ identifier_0: plaintext_0, ..., identifier_n: plaintext_n }`.
-        fn parse_struct<N: Network>(string: &str) -> ParserResult<Plaintext<N>> {
-            // Parse the whitespace and comments from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the "{" from the string.
-            let (string, _) = tag("{")(string)?;
-            // Parse the members.
-            let (string, members) = map_res(separated_list1(tag(","), parse_pair), |members: Vec<_>| {
+impl<N: Network> Plaintext<N> {
+    /// Parses a sanitized pair: `identifier: plaintext`.
+    fn parse_pair(string: &str, depth: usize) -> ParserResult<(Identifier<N>, Self)> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the identifier from the string.
+        let (string, identifier) = Identifier::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the ":" from the string.
+        let (string, _) = tag(":")(string)?;
+        // Parse the plaintext from the string.
+        let (string, plaintext) = Self::parse_internal(string, depth + 1)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Return the identifier and plaintext.
+        Ok((string, (identifier, plaintext)))
+    }
+
+    /// Parses a plaintext as a struct: `{ identifier_0: plaintext_0, ..., identifier_n: plaintext_n }`.
+    fn parse_struct(string: &str, depth: usize) -> ParserResult<Self> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the "{" from the string.
+        let (string, _) = tag("{")(string)?;
+        // Parse the members.
+        let (string, members) =
+            map_res(separated_list1(tag(","), |input| Self::parse_pair(input, depth)), |members: Vec<_>| {
                 // Ensure the members has no duplicate names.
                 if has_duplicates(members.iter().map(|(name, ..)| name)) {
                     return Err(error("Duplicate member in struct"));
@@ -55,40 +62,49 @@ impl<N: Network> Parser for Plaintext<N> {
                     false => Err(error(format!("Found a plaintext that exceeds size ({})", members.len()))),
                 }
             })(string)?;
-            // Parse the whitespace and comments from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the '}' from the string.
-            let (string, _) = tag("}")(string)?;
-            // Output the plaintext.
-            Ok((string, Plaintext::Struct(IndexMap::from_iter(members), Default::default())))
-        }
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the '}' from the string.
+        let (string, _) = tag("}")(string)?;
+        // Output the plaintext.
+        Ok((string, Self::Struct(IndexMap::from_iter(members), Default::default())))
+    }
 
-        /// Parses a plaintext as an array: `[plaintext_0, ..., plaintext_n]`.
-        fn parse_array<N: Network>(string: &str) -> ParserResult<Plaintext<N>> {
-            // Parse the whitespace and comments from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the "[" from the string.
-            let (string, _) = tag("[")(string)?;
-            // Parse the members.
-            let (string, members) = separated_list1(tag(","), Plaintext::parse)(string)?;
-            // Parse the whitespace and comments from the string.
-            let (string, _) = Sanitizer::parse(string)?;
-            // Parse the ']' from the string.
-            let (string, _) = tag("]")(string)?;
-            // Output the plaintext.
-            Ok((string, Plaintext::Array(members, Default::default())))
-        }
+    /// Parses a plaintext as an array: `[plaintext_0, ..., plaintext_n]`.
+    fn parse_array(string: &str, depth: usize) -> ParserResult<Self> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the "[" from the string.
+        let (string, _) = tag("[")(string)?;
+        // Parse the members.
+        let (string, members) = separated_list1(tag(","), |input| Self::parse_internal(input, depth + 1))(string)?;
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the ']' from the string.
+        let (string, _) = tag("]")(string)?;
+        // Output the plaintext.
+        Ok((string, Self::Array(members, Default::default())))
+    }
 
-        // Parse the whitespace from the string.
-        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+    /// Parses a string into a plaintext value, while tracking the depth of the data.
+    fn parse_internal(string: &str, depth: usize) -> ParserResult<Self> {
+        // Ensure that the depth is within the maximum limit.
+        if depth > N::MAX_DATA_DEPTH {
+            return map_res(take(0usize), |_| {
+                Err(error(format!("Found a plaintext that exceeds maximum data depth ({})", N::MAX_DATA_DEPTH)))
+            })(string);
+        }
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the struct or array from the string.
         // Parse to determine the plaintext (order matters).
         alt((
             // Parse a plaintext literal.
             map(Literal::parse, |literal| Self::Literal(literal, Default::default())),
             // Parse a plaintext struct.
-            parse_struct,
+            |input| Self::parse_struct(input, depth),
             // Parse a plaintext array.
-            parse_array,
+            |input| Self::parse_array(input, depth),
         ))(string)
     }
 }

--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -27,8 +27,8 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             Private,
         }
 
-        /// Parses a sanitized pair: `identifier: entry`.
-        fn parse_pair<N: Network>(string: &str) -> ParserResult<(Identifier<N>, Plaintext<N>, Mode)> {
+        /// Parses a sanitized pair: `identifier: entry`, while tracking the depth of the data.
+        fn parse_pair<N: Network>(string: &str, depth: usize) -> ParserResult<(Identifier<N>, Plaintext<N>, Mode)> {
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the identifier from the string.
@@ -42,11 +42,11 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             // Parse the plaintext and visibility from the string.
             let (string, (plaintext, mode)) = alt((
                 // Parse a literal.
-                parse_literal,
+                |input| parse_literal(input, depth),
                 // Parse a struct.
-                parse_struct,
+                |input| parse_struct(input, depth),
                 // Parse an array.
-                parse_array,
+                |input| parse_array(input, depth),
             ))(string)?;
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
@@ -54,8 +54,14 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             Ok((string, (identifier, plaintext, mode)))
         }
 
-        /// Parses an entry as a literal: `literal.visibility`.
-        fn parse_literal<N: Network>(string: &str) -> ParserResult<(Plaintext<N>, Mode)> {
+        /// Parses an entry as a literal: `literal.visibility`, while tracking the depth of the data.
+        fn parse_literal<N: Network>(string: &str, depth: usize) -> ParserResult<(Plaintext<N>, Mode)> {
+            // Ensure that the depth is within the maximum limit.
+            if depth > N::MAX_DATA_DEPTH {
+                return map_res(take(0usize), |_| {
+                    Err(error(format!("Found an entry future that exceeds maximum data depth ({})", N::MAX_DATA_DEPTH)))
+                })(string);
+            }
             alt((
                 map(pair(Literal::parse, tag(".constant")), |(literal, _)| (Plaintext::from(literal), Mode::Constant)),
                 map(pair(Literal::parse, tag(".public")), |(literal, _)| (Plaintext::from(literal), Mode::Public)),
@@ -63,9 +69,15 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             ))(string)
         }
 
-        /// Parses an entry as a struct: `{ identifier_0: plaintext_0.visibility, ..., identifier_n: plaintext_n.visibility }`.
+        /// Parses an entry as a struct: `{ identifier_0: plaintext_0.visibility, ..., identifier_n: plaintext_n.visibility }`, while tracking the depth of the data.
         /// Observe the `visibility` is the same for all members of the plaintext value.
-        fn parse_struct<N: Network>(string: &str) -> ParserResult<(Plaintext<N>, Mode)> {
+        fn parse_struct<N: Network>(string: &str, depth: usize) -> ParserResult<(Plaintext<N>, Mode)> {
+            // Ensure that the depth is within the maximum limit.
+            if depth > N::MAX_DATA_DEPTH {
+                return map_res(take(0usize), |_| {
+                    Err(error(format!("Found an entry that exceeds maximum data depth ({})", N::MAX_DATA_DEPTH)))
+                })(string);
+            }
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the "{" from the string.
@@ -73,24 +85,25 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the members.
-            let (string, (members, mode)) = map_res(separated_list1(tag(","), parse_pair), |members: Vec<_>| {
-                // Ensure the members has no duplicate names.
-                if has_duplicates(members.iter().map(|(name, ..)| name)) {
-                    return Err(error("Duplicate member in struct"));
-                }
-                // Ensure the members all have the same visibility.
-                let mode = members.iter().map(|(_, _, mode)| mode).dedup().collect::<Vec<_>>();
-                let mode = match mode.len() == 1 {
-                    true => *mode[0],
-                    false => return Err(error("Members of struct in entry have different visibilities")),
-                };
-                // Ensure the number of structs is within the maximum limit.
-                match members.len() <= N::MAX_STRUCT_ENTRIES {
-                    // Return the members and the visibility.
-                    true => Ok((members.into_iter().map(|(i, p, _)| (i, p)).collect::<Vec<_>>(), mode)),
-                    false => Err(error(format!("Found a struct that exceeds size ({})", members.len()))),
-                }
-            })(string)?;
+            let (string, (members, mode)) =
+                map_res(separated_list1(tag(","), |input| parse_pair(input, depth + 1)), |members: Vec<_>| {
+                    // Ensure the members has no duplicate names.
+                    if has_duplicates(members.iter().map(|(name, ..)| name)) {
+                        return Err(error("Duplicate member in struct"));
+                    }
+                    // Ensure the members all have the same visibility.
+                    let mode = members.iter().map(|(_, _, mode)| mode).dedup().collect::<Vec<_>>();
+                    let mode = match mode.len() == 1 {
+                        true => *mode[0],
+                        false => return Err(error("Members of struct in entry have different visibilities")),
+                    };
+                    // Ensure the number of structs is within the maximum limit.
+                    match members.len() <= N::MAX_STRUCT_ENTRIES {
+                        // Return the members and the visibility.
+                        true => Ok((members.into_iter().map(|(i, p, _)| (i, p)).collect::<Vec<_>>(), mode)),
+                        false => Err(error(format!("Found a struct that exceeds size ({})", members.len()))),
+                    }
+                })(string)?;
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the '}' from the string.
@@ -99,9 +112,15 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             Ok((string, (Plaintext::Struct(IndexMap::from_iter(members), Default::default()), mode)))
         }
 
-        /// Parses an entry as an array: `[plaintext_0.visibility, ..., plaintext_n.visibility]`.
+        /// Parses an entry as an array: `[plaintext_0.visibility, ..., plaintext_n.visibility]`, while tracking the depth of the data.
         /// Observe the `visibility` is the same for all members of the plaintext value.
-        fn parse_array<N: Network>(string: &str) -> ParserResult<(Plaintext<N>, Mode)> {
+        fn parse_array<N: Network>(string: &str, depth: usize) -> ParserResult<(Plaintext<N>, Mode)> {
+            // Ensure that the depth is within the maximum limit.
+            if depth > N::MAX_DATA_DEPTH {
+                return map_res(take(0usize), |_| {
+                    Err(error(format!("Found an entry future that exceeds maximum data depth ({})", N::MAX_DATA_DEPTH)))
+                })(string);
+            }
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the "[" from the string.
@@ -112,7 +131,11 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
             let (string, (elements, mode)) = map_res(
                 separated_list1(
                     pair(Sanitizer::parse_whitespaces, pair(tag(","), Sanitizer::parse_whitespaces)),
-                    alt((parse_literal, parse_struct, parse_array)),
+                    alt((
+                        |input| parse_literal(input, depth + 1),
+                        |input| parse_struct(input, depth + 1),
+                        |input| parse_array(input, depth + 1),
+                    )),
                 ),
                 |members: Vec<(Plaintext<N>, Mode)>| {
                     // Ensure the members all have the same visibility.
@@ -142,11 +165,11 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
         // Parse to determine the entry (order matters).
         let (string, (plaintext, mode)) = alt((
             // Parse a literal.
-            parse_literal,
+            |input| parse_literal(input, 0),
             // Parse a struct.
-            parse_struct,
+            |input| parse_struct(input, 0),
             // Parse an array.
-            parse_array,
+            |input| parse_array(input, 0),
         ))(string)?;
 
         // Return the entry.

--- a/ledger/block/src/transaction/deployment/mod.rs
+++ b/ledger/block/src/transaction/deployment/mod.rs
@@ -80,6 +80,13 @@ impl<N: Network> Deployment<N> {
             bail!("Deployment has an incorrect number of verifying keys, according to the program.");
         }
 
+        // Ensure the number of functions does not exceed the maximum.
+        ensure!(
+            self.program.functions().len() <= N::MAX_FUNCTIONS,
+            "Deployment has too many functions (maximum is '{}')",
+            N::MAX_FUNCTIONS
+        );
+
         // Ensure the function and verifying keys correspond.
         for ((function_name, function), (name, _)) in self.program.functions().iter().zip_eq(&self.verifying_keys) {
             // Ensure the function name is correct.


### PR DESCRIPTION
## Motivation

Tightens the deserialization bounds for various structs.

## Test Plan

- [x] Existing blocks up until April 19th parsed correctly.
- Unit tests will be added in a next PR.
