### PR TITLE
Update license headers

### DIFF
--- a/.license_header
+++ b/.license_header
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/benches/crypto_hash/poseidon.rs
+++ b/algorithms/benches/crypto_hash/poseidon.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/benches/fft/fft.rs
+++ b/algorithms/benches/fft/fft.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/benches/msm/variable_base.rs
+++ b/algorithms/benches/msm/variable_base.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/benches/snark/varuna.rs
+++ b/algorithms/benches/snark/varuna.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/cuda/build.rs
+++ b/algorithms/cuda/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/cuda/cuda/polynomial.cuh
+++ b/algorithms/cuda/cuda/polynomial.cuh
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/cuda/cuda/snarkvm.cu
+++ b/algorithms/cuda/cuda/snarkvm.cu
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/cuda/cuda/snarkvm_api.cu
+++ b/algorithms/cuda/cuda/snarkvm_api.cu
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/cuda/src/lib.c
+++ b/algorithms/cuda/src/lib.c
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/cuda/src/lib.rs
+++ b/algorithms/cuda/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/examples/msm.rs
+++ b/algorithms/examples/msm.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/crypto_hash/mod.rs
+++ b/algorithms/src/crypto_hash/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/crypto_hash/sha256.rs
+++ b/algorithms/src/crypto_hash/sha256.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/crypto_hash/tests.rs
+++ b/algorithms/src/crypto_hash/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/errors.rs
+++ b/algorithms/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/mod.rs
+++ b/algorithms/src/fft/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/polynomial/multiplier.rs
+++ b/algorithms/src/fft/polynomial/multiplier.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/polynomial/sparse.rs
+++ b/algorithms/src/fft/polynomial/sparse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/fft/tests.rs
+++ b/algorithms/src/fft/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/lib.rs
+++ b/algorithms/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/msm/fixed_base.rs
+++ b/algorithms/src/msm/fixed_base.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/msm/mod.rs
+++ b/algorithms/src/msm/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/msm/tests.rs
+++ b/algorithms/src/msm/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/msm/variable_base/prefetch.rs
+++ b/algorithms/src/msm/variable_base/prefetch.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/error.rs
+++ b/algorithms/src/polycommit/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/kzg10/data_structures.rs
+++ b/algorithms/src/polycommit/kzg10/data_structures.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/mod.rs
+++ b/algorithms/src/polycommit/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/optional_rng.rs
+++ b/algorithms/src/polycommit/optional_rng.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/sonic_pc/polynomial.rs
+++ b/algorithms/src/polycommit/sonic_pc/polynomial.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/polycommit/test_templates.rs
+++ b/algorithms/src/polycommit/test_templates.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/assignment.rs
+++ b/algorithms/src/r1cs/assignment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/constraint_counter.rs
+++ b/algorithms/src/r1cs/constraint_counter.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/constraint_system.rs
+++ b/algorithms/src/r1cs/constraint_system.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/errors.rs
+++ b/algorithms/src/r1cs/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/linear_combination.rs
+++ b/algorithms/src/r1cs/linear_combination.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/mod.rs
+++ b/algorithms/src/r1cs/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/namespace.rs
+++ b/algorithms/src/r1cs/namespace.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/optional_vec.rs
+++ b/algorithms/src/r1cs/optional_vec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/test_constraint_checker.rs
+++ b/algorithms/src/r1cs/test_constraint_checker.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/r1cs/test_constraint_system.rs
+++ b/algorithms/src/r1cs/test_constraint_system.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/mod.rs
+++ b/algorithms/src/snark/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/errors.rs
+++ b/algorithms/src/snark/varuna/ahp/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/circuit_info.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/indexer/constraint_system.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/constraint_system.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/indexer/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/constraint_system.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/message.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/message.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/oracles.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/oracles.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fifth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fifth.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/first.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/prover/state.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/selectors.rs
+++ b/algorithms/src/snark/varuna/ahp/selectors.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/verifier/messages.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/messages.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/verifier/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/verifier/state.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/ahp/verifier/verifier.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/verifier.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/data_structures/certificate.rs
+++ b/algorithms/src/snark/varuna/data_structures/certificate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/data_structures/circuit_proving_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_proving_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/data_structures/mod.rs
+++ b/algorithms/src/snark/varuna/data_structures/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/data_structures/test_circuit.rs
+++ b/algorithms/src/snark/varuna/data_structures/test_circuit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/mod.rs
+++ b/algorithms/src/snark/varuna/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/mode.rs
+++ b/algorithms/src/snark/varuna/mode.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/tests.rs
+++ b/algorithms/src/snark/varuna/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/srs/mod.rs
+++ b/algorithms/src/srs/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/srs/universal_prover.rs
+++ b/algorithms/src/srs/universal_prover.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/srs/universal_verifier.rs
+++ b/algorithms/src/srs/universal_verifier.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/traits/algebraic_sponge.rs
+++ b/algorithms/src/traits/algebraic_sponge.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/traits/mod.rs
+++ b/algorithms/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/algorithms/src/traits/snark.rs
+++ b/algorithms/src/traits/snark.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/build.rs
+++ b/circuit/account/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/equal.rs
+++ b/circuit/account/src/compute_key/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/from.rs
+++ b/circuit/account/src/compute_key/from.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/from_private_key.rs
+++ b/circuit/account/src/compute_key/from_private_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/helpers/from_bits.rs
+++ b/circuit/account/src/compute_key/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/helpers/mod.rs
+++ b/circuit/account/src/compute_key/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/helpers/to_bits.rs
+++ b/circuit/account/src/compute_key/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/helpers/to_fields.rs
+++ b/circuit/account/src/compute_key/helpers/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/mod.rs
+++ b/circuit/account/src/compute_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/ternary.rs
+++ b/circuit/account/src/compute_key/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/compute_key/to_address.rs
+++ b/circuit/account/src/compute_key/to_address.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/graph_key/mod.rs
+++ b/circuit/account/src/graph_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/lib.rs
+++ b/circuit/account/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/private_key/mod.rs
+++ b/circuit/account/src/private_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/private_key/to_compute_key.rs
+++ b/circuit/account/src/private_key/to_compute_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/private_key/to_view_key.rs
+++ b/circuit/account/src/private_key/to_view_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/equal.rs
+++ b/circuit/account/src/signature/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/helpers/from_bits.rs
+++ b/circuit/account/src/signature/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/helpers/mod.rs
+++ b/circuit/account/src/signature/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/helpers/to_bits.rs
+++ b/circuit/account/src/signature/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/helpers/to_fields.rs
+++ b/circuit/account/src/signature/helpers/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/mod.rs
+++ b/circuit/account/src/signature/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/ternary.rs
+++ b/circuit/account/src/signature/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/signature/verify.rs
+++ b/circuit/account/src/signature/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/view_key/from_private_key.rs
+++ b/circuit/account/src/view_key/from_private_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/view_key/mod.rs
+++ b/circuit/account/src/view_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/account/src/view_key/to_address.rs
+++ b/circuit/account/src/view_key/to_address.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/build.rs
+++ b/circuit/algorithms/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/bhp/commit.rs
+++ b/circuit/algorithms/src/bhp/commit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/bhp/commit_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/commit_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/bhp/hash.rs
+++ b/circuit/algorithms/src/bhp/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/bhp/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hash_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/bhp/hasher/mod.rs
+++ b/circuit/algorithms/src/bhp/hasher/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/bhp/mod.rs
+++ b/circuit/algorithms/src/bhp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/elligator2/encode.rs
+++ b/circuit/algorithms/src/elligator2/encode.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/elligator2/mod.rs
+++ b/circuit/algorithms/src/elligator2/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/keccak/hash.rs
+++ b/circuit/algorithms/src/keccak/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/keccak/mod.rs
+++ b/circuit/algorithms/src/keccak/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/lib.rs
+++ b/circuit/algorithms/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/pedersen/commit.rs
+++ b/circuit/algorithms/src/pedersen/commit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/pedersen/commit_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/commit_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/pedersen/hash.rs
+++ b/circuit/algorithms/src/pedersen/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/pedersen/hash_uncompressed.rs
+++ b/circuit/algorithms/src/pedersen/hash_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/pedersen/mod.rs
+++ b/circuit/algorithms/src/pedersen/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/poseidon/hash.rs
+++ b/circuit/algorithms/src/poseidon/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/poseidon/hash_to_group.rs
+++ b/circuit/algorithms/src/poseidon/hash_to_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/circuit/algorithms/src/poseidon/hash_to_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/poseidon/mod.rs
+++ b/circuit/algorithms/src/poseidon/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/poseidon/prf.rs
+++ b/circuit/algorithms/src/poseidon/prf.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/algorithms/src/traits.rs
+++ b/circuit/algorithms/src/traits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/build.rs
+++ b/circuit/collections/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
+++ b/circuit/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/kary_merkle_tree/helpers/mod.rs
+++ b/circuit/collections/src/kary_merkle_tree/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/circuit/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/kary_merkle_tree/mod.rs
+++ b/circuit/collections/src/kary_merkle_tree/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/kary_merkle_tree/verify.rs
+++ b/circuit/collections/src/kary_merkle_tree/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/lib.rs
+++ b/circuit/collections/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/merkle_tree/helpers/leaf_hash.rs
+++ b/circuit/collections/src/merkle_tree/helpers/leaf_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/merkle_tree/helpers/mod.rs
+++ b/circuit/collections/src/merkle_tree/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/circuit/collections/src/merkle_tree/helpers/path_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/merkle_tree/mod.rs
+++ b/circuit/collections/src/merkle_tree/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/collections/src/merkle_tree/verify.rs
+++ b/circuit/collections/src/merkle_tree/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/benches/linear_combination.rs
+++ b/circuit/environment/benches/linear_combination.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/canary_circuit.rs
+++ b/circuit/environment/src/canary_circuit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/circuit_type.rs
+++ b/circuit/environment/src/helpers/circuit_type.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/constraint.rs
+++ b/circuit/environment/src/helpers/constraint.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/converter.rs
+++ b/circuit/environment/src/helpers/converter.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/count.rs
+++ b/circuit/environment/src/helpers/count.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/counter.rs
+++ b/circuit/environment/src/helpers/counter.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/mod.rs
+++ b/circuit/environment/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/mode.rs
+++ b/circuit/environment/src/helpers/mode.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/updatable_count.rs
+++ b/circuit/environment/src/helpers/updatable_count.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/helpers/variable.rs
+++ b/circuit/environment/src/helpers/variable.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/lib.rs
+++ b/circuit/environment/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/macros/metrics.rs
+++ b/circuit/environment/src/macros/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/macros/mod.rs
+++ b/circuit/environment/src/macros/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/macros/scope.rs
+++ b/circuit/environment/src/macros/scope.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/macros/witness.rs
+++ b/circuit/environment/src/macros/witness.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/eject.rs
+++ b/circuit/environment/src/traits/eject.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/from.rs
+++ b/circuit/environment/src/traits/from.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/inject.rs
+++ b/circuit/environment/src/traits/inject.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/metrics.rs
+++ b/circuit/environment/src/traits/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/mod.rs
+++ b/circuit/environment/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/operators.rs
+++ b/circuit/environment/src/traits/operators.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/to.rs
+++ b/circuit/environment/src/traits/to.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/to_bits.rs
+++ b/circuit/environment/src/traits/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/address.rs
+++ b/circuit/environment/src/traits/types/address.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/boolean.rs
+++ b/circuit/environment/src/traits/types/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/field.rs
+++ b/circuit/environment/src/traits/types/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/group.rs
+++ b/circuit/environment/src/traits/types/group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/integers.rs
+++ b/circuit/environment/src/traits/types/integers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/mod.rs
+++ b/circuit/environment/src/traits/types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/scalar.rs
+++ b/circuit/environment/src/traits/types/scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/src/traits/types/string.rs
+++ b/circuit/environment/src/traits/types/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/environment/witness/src/lib.rs
+++ b/circuit/environment/witness/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/network/build.rs
+++ b/circuit/network/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/network/src/canary_v0.rs
+++ b/circuit/network/src/canary_v0.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/network/src/lib.rs
+++ b/circuit/network/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/network/src/testnet_v0.rs
+++ b/circuit/network/src/testnet_v0.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/build.rs
+++ b/circuit/program/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/access/mod.rs
+++ b/circuit/program/src/data/access/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/decrypt.rs
+++ b/circuit/program/src/data/ciphertext/decrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/equal.rs
+++ b/circuit/program/src/data/ciphertext/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/from_bits.rs
+++ b/circuit/program/src/data/ciphertext/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/from_fields.rs
+++ b/circuit/program/src/data/ciphertext/from_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/mod.rs
+++ b/circuit/program/src/data/ciphertext/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/num_randomizers.rs
+++ b/circuit/program/src/data/ciphertext/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/size_in_fields.rs
+++ b/circuit/program/src/data/ciphertext/size_in_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/to_bits.rs
+++ b/circuit/program/src/data/ciphertext/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/ciphertext/to_fields.rs
+++ b/circuit/program/src/data/ciphertext/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/future/argument.rs
+++ b/circuit/program/src/data/future/argument.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/future/equal.rs
+++ b/circuit/program/src/data/future/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/future/find.rs
+++ b/circuit/program/src/data/future/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/future/mod.rs
+++ b/circuit/program/src/data/future/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/future/to_bits.rs
+++ b/circuit/program/src/data/future/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/future/to_fields.rs
+++ b/circuit/program/src/data/future/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/identifier/equal.rs
+++ b/circuit/program/src/data/identifier/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/identifier/from_bits.rs
+++ b/circuit/program/src/data/identifier/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/identifier/from_field.rs
+++ b/circuit/program/src/data/identifier/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/identifier/mod.rs
+++ b/circuit/program/src/data/identifier/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/identifier/size_in_bits.rs
+++ b/circuit/program/src/data/identifier/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/identifier/to_bits.rs
+++ b/circuit/program/src/data/identifier/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/identifier/to_field.rs
+++ b/circuit/program/src/data/identifier/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast/boolean.rs
+++ b/circuit/program/src/data/literal/cast/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast/field.rs
+++ b/circuit/program/src/data/literal/cast/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast/integer.rs
+++ b/circuit/program/src/data/literal/cast/integer.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast/mod.rs
+++ b/circuit/program/src/data/literal/cast/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast/scalar.rs
+++ b/circuit/program/src/data/literal/cast/scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast_lossy/boolean.rs
+++ b/circuit/program/src/data/literal/cast_lossy/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast_lossy/field.rs
+++ b/circuit/program/src/data/literal/cast_lossy/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast_lossy/integer.rs
+++ b/circuit/program/src/data/literal/cast_lossy/integer.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast_lossy/mod.rs
+++ b/circuit/program/src/data/literal/cast_lossy/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/cast_lossy/scalar.rs
+++ b/circuit/program/src/data/literal/cast_lossy/scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/equal.rs
+++ b/circuit/program/src/data/literal/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/from_bits.rs
+++ b/circuit/program/src/data/literal/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/mod.rs
+++ b/circuit/program/src/data/literal/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/size_in_bits.rs
+++ b/circuit/program/src/data/literal/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/to_bits.rs
+++ b/circuit/program/src/data/literal/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/to_fields.rs
+++ b/circuit/program/src/data/literal/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/to_type.rs
+++ b/circuit/program/src/data/literal/to_type.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/literal/variant.rs
+++ b/circuit/program/src/data/literal/variant.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/mod.rs
+++ b/circuit/program/src/data/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/encrypt.rs
+++ b/circuit/program/src/data/plaintext/encrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/equal.rs
+++ b/circuit/program/src/data/plaintext/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/find.rs
+++ b/circuit/program/src/data/plaintext/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/from_bits.rs
+++ b/circuit/program/src/data/plaintext/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/from_fields.rs
+++ b/circuit/program/src/data/plaintext/from_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/mod.rs
+++ b/circuit/program/src/data/plaintext/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/num_randomizers.rs
+++ b/circuit/program/src/data/plaintext/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/size_in_fields.rs
+++ b/circuit/program/src/data/plaintext/size_in_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/to_bits.rs
+++ b/circuit/program/src/data/plaintext/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/plaintext/to_fields.rs
+++ b/circuit/program/src/data/plaintext/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/decrypt.rs
+++ b/circuit/program/src/data/record/decrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/encrypt.rs
+++ b/circuit/program/src/data/record/encrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/entry/equal.rs
+++ b/circuit/program/src/data/record/entry/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/entry/find.rs
+++ b/circuit/program/src/data/record/entry/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/entry/mod.rs
+++ b/circuit/program/src/data/record/entry/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/entry/num_randomizers.rs
+++ b/circuit/program/src/data/record/entry/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/entry/to_bits.rs
+++ b/circuit/program/src/data/record/entry/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/equal.rs
+++ b/circuit/program/src/data/record/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/find.rs
+++ b/circuit/program/src/data/record/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/helpers/mod.rs
+++ b/circuit/program/src/data/record/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/helpers/owner.rs
+++ b/circuit/program/src/data/record/helpers/owner.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/mod.rs
+++ b/circuit/program/src/data/record/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/num_randomizers.rs
+++ b/circuit/program/src/data/record/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/serial_number.rs
+++ b/circuit/program/src/data/record/serial_number.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/tag.rs
+++ b/circuit/program/src/data/record/tag.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/to_bits.rs
+++ b/circuit/program/src/data/record/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/to_commitment.rs
+++ b/circuit/program/src/data/record/to_commitment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/record/to_fields.rs
+++ b/circuit/program/src/data/record/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/value/equal.rs
+++ b/circuit/program/src/data/value/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/value/find.rs
+++ b/circuit/program/src/data/value/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/value/mod.rs
+++ b/circuit/program/src/data/value/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/value/to_bits.rs
+++ b/circuit/program/src/data/value/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/data/value/to_fields.rs
+++ b/circuit/program/src/data/value/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/function_id/mod.rs
+++ b/circuit/program/src/function_id/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/id/mod.rs
+++ b/circuit/program/src/id/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/id/to_address.rs
+++ b/circuit/program/src/id/to_address.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/id/to_bits.rs
+++ b/circuit/program/src/id/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/id/to_fields.rs
+++ b/circuit/program/src/id/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/lib.rs
+++ b/circuit/program/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/request/mod.rs
+++ b/circuit/program/src/request/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/request/to_tpk.rs
+++ b/circuit/program/src/request/to_tpk.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/request/verify.rs
+++ b/circuit/program/src/request/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/response/from_outputs.rs
+++ b/circuit/program/src/response/from_outputs.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/response/mod.rs
+++ b/circuit/program/src/response/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/response/process_outputs_from_callback.rs
+++ b/circuit/program/src/response/process_outputs_from_callback.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/state_path/helpers/header_leaf.rs
+++ b/circuit/program/src/state_path/helpers/header_leaf.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/state_path/helpers/mod.rs
+++ b/circuit/program/src/state_path/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/state_path/helpers/transaction_leaf.rs
+++ b/circuit/program/src/state_path/helpers/transaction_leaf.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/state_path/helpers/transition_leaf.rs
+++ b/circuit/program/src/state_path/helpers/transition_leaf.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/state_path/mod.rs
+++ b/circuit/program/src/state_path/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/program/src/state_path/verify.rs
+++ b/circuit/program/src/state_path/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/build.rs
+++ b/circuit/types/address/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/compare.rs
+++ b/circuit/types/address/src/compare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/equal.rs
+++ b/circuit/types/address/src/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/helpers/from_bits.rs
+++ b/circuit/types/address/src/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/helpers/from_field.rs
+++ b/circuit/types/address/src/helpers/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/helpers/from_group.rs
+++ b/circuit/types/address/src/helpers/from_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/helpers/mod.rs
+++ b/circuit/types/address/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/helpers/to_bits.rs
+++ b/circuit/types/address/src/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/helpers/to_field.rs
+++ b/circuit/types/address/src/helpers/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/helpers/to_group.rs
+++ b/circuit/types/address/src/helpers/to_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/lib.rs
+++ b/circuit/types/address/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/address/src/ternary.rs
+++ b/circuit/types/address/src/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/benches/and.rs
+++ b/circuit/types/boolean/benches/and.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/build.rs
+++ b/circuit/types/boolean/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/and.rs
+++ b/circuit/types/boolean/src/and.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/equal.rs
+++ b/circuit/types/boolean/src/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/helpers/adder.rs
+++ b/circuit/types/boolean/src/helpers/adder.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/helpers/bits_are_zero.rs
+++ b/circuit/types/boolean/src/helpers/bits_are_zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/helpers/comparator.rs
+++ b/circuit/types/boolean/src/helpers/comparator.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/helpers/from_bits.rs
+++ b/circuit/types/boolean/src/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/helpers/mod.rs
+++ b/circuit/types/boolean/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/helpers/subtractor.rs
+++ b/circuit/types/boolean/src/helpers/subtractor.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/helpers/to_bits.rs
+++ b/circuit/types/boolean/src/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/lib.rs
+++ b/circuit/types/boolean/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/nand.rs
+++ b/circuit/types/boolean/src/nand.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/nor.rs
+++ b/circuit/types/boolean/src/nor.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/not.rs
+++ b/circuit/types/boolean/src/not.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/or.rs
+++ b/circuit/types/boolean/src/or.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/ternary.rs
+++ b/circuit/types/boolean/src/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/boolean/src/xor.rs
+++ b/circuit/types/boolean/src/xor.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/build.rs
+++ b/circuit/types/field/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/add.rs
+++ b/circuit/types/field/src/add.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/compare.rs
+++ b/circuit/types/field/src/compare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/div.rs
+++ b/circuit/types/field/src/div.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/div_unchecked.rs
+++ b/circuit/types/field/src/div_unchecked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/double.rs
+++ b/circuit/types/field/src/double.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/equal.rs
+++ b/circuit/types/field/src/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/from_bits.rs
+++ b/circuit/types/field/src/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/from_boolean.rs
+++ b/circuit/types/field/src/helpers/from_boolean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/mod.rs
+++ b/circuit/types/field/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/one.rs
+++ b/circuit/types/field/src/helpers/one.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/to_bits.rs
+++ b/circuit/types/field/src/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/to_lower_bits.rs
+++ b/circuit/types/field/src/helpers/to_lower_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/to_upper_bits.rs
+++ b/circuit/types/field/src/helpers/to_upper_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/helpers/zero.rs
+++ b/circuit/types/field/src/helpers/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/inverse.rs
+++ b/circuit/types/field/src/inverse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/lib.rs
+++ b/circuit/types/field/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/mul.rs
+++ b/circuit/types/field/src/mul.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/neg.rs
+++ b/circuit/types/field/src/neg.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/pow.rs
+++ b/circuit/types/field/src/pow.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/square.rs
+++ b/circuit/types/field/src/square.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/square_root.rs
+++ b/circuit/types/field/src/square_root.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/sub.rs
+++ b/circuit/types/field/src/sub.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/field/src/ternary.rs
+++ b/circuit/types/field/src/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/build.rs
+++ b/circuit/types/group/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/add.rs
+++ b/circuit/types/group/src/add.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/double.rs
+++ b/circuit/types/group/src/double.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/equal.rs
+++ b/circuit/types/group/src/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/from_bits.rs
+++ b/circuit/types/group/src/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/from_x_coordinate.rs
+++ b/circuit/types/group/src/helpers/from_x_coordinate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/from_xy_coordinates.rs
+++ b/circuit/types/group/src/helpers/from_xy_coordinates.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/mod.rs
+++ b/circuit/types/group/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/mul_by_cofactor.rs
+++ b/circuit/types/group/src/helpers/mul_by_cofactor.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/to_bits.rs
+++ b/circuit/types/group/src/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/to_field.rs
+++ b/circuit/types/group/src/helpers/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/to_x_coordinate.rs
+++ b/circuit/types/group/src/helpers/to_x_coordinate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/to_y_coordinate.rs
+++ b/circuit/types/group/src/helpers/to_y_coordinate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/helpers/zero.rs
+++ b/circuit/types/group/src/helpers/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/lib.rs
+++ b/circuit/types/group/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/mul.rs
+++ b/circuit/types/group/src/mul.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/neg.rs
+++ b/circuit/types/group/src/neg.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/sub.rs
+++ b/circuit/types/group/src/sub.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/group/src/ternary.rs
+++ b/circuit/types/group/src/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/build.rs
+++ b/circuit/types/integers/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/abs_checked.rs
+++ b/circuit/types/integers/src/abs_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/abs_wrapped.rs
+++ b/circuit/types/integers/src/abs_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/add_checked.rs
+++ b/circuit/types/integers/src/add_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/add_wrapped.rs
+++ b/circuit/types/integers/src/add_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/and.rs
+++ b/circuit/types/integers/src/and.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/compare.rs
+++ b/circuit/types/integers/src/compare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/div_checked.rs
+++ b/circuit/types/integers/src/div_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/equal.rs
+++ b/circuit/types/integers/src/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/from_bits.rs
+++ b/circuit/types/integers/src/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/from_field.rs
+++ b/circuit/types/integers/src/helpers/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/from_field_lossy.rs
+++ b/circuit/types/integers/src/helpers/from_field_lossy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/mod.rs
+++ b/circuit/types/integers/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/msb.rs
+++ b/circuit/types/integers/src/helpers/msb.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/one.rs
+++ b/circuit/types/integers/src/helpers/one.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/to_bits.rs
+++ b/circuit/types/integers/src/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/to_field.rs
+++ b/circuit/types/integers/src/helpers/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/to_fields.rs
+++ b/circuit/types/integers/src/helpers/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/to_scalar.rs
+++ b/circuit/types/integers/src/helpers/to_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/helpers/zero.rs
+++ b/circuit/types/integers/src/helpers/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/lib.rs
+++ b/circuit/types/integers/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/modulo.rs
+++ b/circuit/types/integers/src/modulo.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/mul_checked.rs
+++ b/circuit/types/integers/src/mul_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/mul_wrapped.rs
+++ b/circuit/types/integers/src/mul_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/neg.rs
+++ b/circuit/types/integers/src/neg.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/not.rs
+++ b/circuit/types/integers/src/not.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/or.rs
+++ b/circuit/types/integers/src/or.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/pow_checked.rs
+++ b/circuit/types/integers/src/pow_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/pow_wrapped.rs
+++ b/circuit/types/integers/src/pow_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/rem_checked.rs
+++ b/circuit/types/integers/src/rem_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/rem_wrapped.rs
+++ b/circuit/types/integers/src/rem_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/shl_checked.rs
+++ b/circuit/types/integers/src/shl_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/shl_wrapped.rs
+++ b/circuit/types/integers/src/shl_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/shr_checked.rs
+++ b/circuit/types/integers/src/shr_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/shr_wrapped.rs
+++ b/circuit/types/integers/src/shr_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/sub_checked.rs
+++ b/circuit/types/integers/src/sub_checked.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/sub_wrapped.rs
+++ b/circuit/types/integers/src/sub_wrapped.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/ternary.rs
+++ b/circuit/types/integers/src/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/integers/src/xor.rs
+++ b/circuit/types/integers/src/xor.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/build.rs
+++ b/circuit/types/scalar/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/add.rs
+++ b/circuit/types/scalar/src/add.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/compare.rs
+++ b/circuit/types/scalar/src/compare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/equal.rs
+++ b/circuit/types/scalar/src/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/from_bits.rs
+++ b/circuit/types/scalar/src/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/from_field.rs
+++ b/circuit/types/scalar/src/helpers/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/from_field_lossy.rs
+++ b/circuit/types/scalar/src/helpers/from_field_lossy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/mod.rs
+++ b/circuit/types/scalar/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/one.rs
+++ b/circuit/types/scalar/src/helpers/one.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/to_bits.rs
+++ b/circuit/types/scalar/src/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/to_field.rs
+++ b/circuit/types/scalar/src/helpers/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/to_fields.rs
+++ b/circuit/types/scalar/src/helpers/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/helpers/zero.rs
+++ b/circuit/types/scalar/src/helpers/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/lib.rs
+++ b/circuit/types/scalar/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/scalar/src/ternary.rs
+++ b/circuit/types/scalar/src/ternary.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/src/lib.rs
+++ b/circuit/types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/string/build.rs
+++ b/circuit/types/string/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/string/src/equal.rs
+++ b/circuit/types/string/src/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/string/src/helpers/from_bits.rs
+++ b/circuit/types/string/src/helpers/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/string/src/helpers/mod.rs
+++ b/circuit/types/string/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/string/src/helpers/to_bits.rs
+++ b/circuit/types/string/src/helpers/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/string/src/helpers/to_fields.rs
+++ b/circuit/types/string/src/helpers/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/circuit/types/string/src/lib.rs
+++ b/circuit/types/string/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/benches/account.rs
+++ b/console/account/benches/account.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/address/mod.rs
+++ b/console/account/src/address/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/address/try_from.rs
+++ b/console/account/src/address/try_from.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/bitwise.rs
+++ b/console/account/src/compute_key/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/bytes.rs
+++ b/console/account/src/compute_key/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/from_bits.rs
+++ b/console/account/src/compute_key/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/mod.rs
+++ b/console/account/src/compute_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/serialize.rs
+++ b/console/account/src/compute_key/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/size_in_bits.rs
+++ b/console/account/src/compute_key/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/size_in_bytes.rs
+++ b/console/account/src/compute_key/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/to_address.rs
+++ b/console/account/src/compute_key/to_address.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/to_bits.rs
+++ b/console/account/src/compute_key/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/to_fields.rs
+++ b/console/account/src/compute_key/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/compute_key/try_from.rs
+++ b/console/account/src/compute_key/try_from.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/graph_key/bytes.rs
+++ b/console/account/src/graph_key/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/graph_key/mod.rs
+++ b/console/account/src/graph_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/graph_key/serialize.rs
+++ b/console/account/src/graph_key/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/graph_key/string.rs
+++ b/console/account/src/graph_key/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/graph_key/try_from.rs
+++ b/console/account/src/graph_key/try_from.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/lib.rs
+++ b/console/account/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/private_key/bytes.rs
+++ b/console/account/src/private_key/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/private_key/mod.rs
+++ b/console/account/src/private_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/private_key/serialize.rs
+++ b/console/account/src/private_key/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/private_key/sign.rs
+++ b/console/account/src/private_key/sign.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/private_key/string.rs
+++ b/console/account/src/private_key/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/private_key/try_from.rs
+++ b/console/account/src/private_key/try_from.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/bitwise.rs
+++ b/console/account/src/signature/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/bytes.rs
+++ b/console/account/src/signature/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/from_bits.rs
+++ b/console/account/src/signature/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/mod.rs
+++ b/console/account/src/signature/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/parse.rs
+++ b/console/account/src/signature/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/serialize.rs
+++ b/console/account/src/signature/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/sign.rs
+++ b/console/account/src/signature/sign.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/size_in_bits.rs
+++ b/console/account/src/signature/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/size_in_bytes.rs
+++ b/console/account/src/signature/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/to_bits.rs
+++ b/console/account/src/signature/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/to_fields.rs
+++ b/console/account/src/signature/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/signature/verify.rs
+++ b/console/account/src/signature/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/view_key/bytes.rs
+++ b/console/account/src/view_key/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/view_key/mod.rs
+++ b/console/account/src/view_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/view_key/serialize.rs
+++ b/console/account/src/view_key/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/view_key/string.rs
+++ b/console/account/src/view_key/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/view_key/to_address.rs
+++ b/console/account/src/view_key/to_address.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/account/src/view_key/try_from.rs
+++ b/console/account/src/view_key/try_from.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/benches/bhp.rs
+++ b/console/algorithms/benches/bhp.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/benches/elligator2.rs
+++ b/console/algorithms/benches/elligator2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/benches/poseidon.rs
+++ b/console/algorithms/benches/poseidon.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/bhp/commit.rs
+++ b/console/algorithms/src/bhp/commit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/bhp/commit_uncompressed.rs
+++ b/console/algorithms/src/bhp/commit_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/bhp/hash.rs
+++ b/console/algorithms/src/bhp/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/bhp/hash_uncompressed.rs
+++ b/console/algorithms/src/bhp/hash_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/bhp/hasher/mod.rs
+++ b/console/algorithms/src/bhp/hasher/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/bhp/mod.rs
+++ b/console/algorithms/src/bhp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/blake2xs/hash_to_curve.rs
+++ b/console/algorithms/src/blake2xs/hash_to_curve.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/blake2xs/mod.rs
+++ b/console/algorithms/src/blake2xs/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/elligator2/decode.rs
+++ b/console/algorithms/src/elligator2/decode.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/elligator2/encode.rs
+++ b/console/algorithms/src/elligator2/encode.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/elligator2/mod.rs
+++ b/console/algorithms/src/elligator2/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/keccak/hash.rs
+++ b/console/algorithms/src/keccak/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/keccak/mod.rs
+++ b/console/algorithms/src/keccak/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/lib.rs
+++ b/console/algorithms/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/pedersen/commit.rs
+++ b/console/algorithms/src/pedersen/commit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/pedersen/commit_uncompressed.rs
+++ b/console/algorithms/src/pedersen/commit_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/pedersen/hash.rs
+++ b/console/algorithms/src/pedersen/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/pedersen/hash_uncompressed.rs
+++ b/console/algorithms/src/pedersen/hash_uncompressed.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/pedersen/mod.rs
+++ b/console/algorithms/src/pedersen/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/hash.rs
+++ b/console/algorithms/src/poseidon/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/hash_many.rs
+++ b/console/algorithms/src/poseidon/hash_many.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/hash_to_group.rs
+++ b/console/algorithms/src/poseidon/hash_to_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/hash_to_scalar.rs
+++ b/console/algorithms/src/poseidon/hash_to_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/helpers/mod.rs
+++ b/console/algorithms/src/poseidon/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/helpers/state.rs
+++ b/console/algorithms/src/poseidon/helpers/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/mod.rs
+++ b/console/algorithms/src/poseidon/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/algorithms/src/poseidon/prf.rs
+++ b/console/algorithms/src/poseidon/prf.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/benches/kary_merkle_tree.rs
+++ b/console/collections/benches/kary_merkle_tree.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/benches/merkle_tree.rs
+++ b/console/collections/benches/merkle_tree.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/leaf_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/kary_merkle_tree/helpers/mod.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/kary_merkle_tree/helpers/path_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/kary_merkle_tree/mod.rs
+++ b/console/collections/src/kary_merkle_tree/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/kary_merkle_tree/path/mod.rs
+++ b/console/collections/src/kary_merkle_tree/path/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/kary_merkle_tree/tests/mod.rs
+++ b/console/collections/src/kary_merkle_tree/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/lib.rs
+++ b/console/collections/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/helpers/leaf_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/leaf_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/helpers/mod.rs
+++ b/console/collections/src/merkle_tree/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/helpers/path_hash.rs
+++ b/console/collections/src/merkle_tree/helpers/path_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/mod.rs
+++ b/console/collections/src/merkle_tree/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/path/mod.rs
+++ b/console/collections/src/merkle_tree/path/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/tests/append.rs
+++ b/console/collections/src/merkle_tree/tests/append.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/tests/mod.rs
+++ b/console/collections/src/merkle_tree/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/tests/remove.rs
+++ b/console/collections/src/merkle_tree/tests/remove.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/tests/update.rs
+++ b/console/collections/src/merkle_tree/tests/update.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/collections/src/merkle_tree/tests/update_many.rs
+++ b/console/collections/src/merkle_tree/tests/update_many.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/environment.rs
+++ b/console/network/environment/src/environment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/helpers/mod.rs
+++ b/console/network/environment/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/helpers/or_halt.rs
+++ b/console/network/environment/src/helpers/or_halt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/helpers/variable_length.rs
+++ b/console/network/environment/src/helpers/variable_length.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/algorithms.rs
+++ b/console/network/environment/src/traits/algorithms.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/arithmetic.rs
+++ b/console/network/environment/src/traits/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/bitwise.rs
+++ b/console/network/environment/src/traits/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/from_bits.rs
+++ b/console/network/environment/src/traits/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/from_field.rs
+++ b/console/network/environment/src/traits/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/mod.rs
+++ b/console/network/environment/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/parse.rs
+++ b/console/network/environment/src/traits/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/parse_string.rs
+++ b/console/network/environment/src/traits/parse_string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/to_field.rs
+++ b/console/network/environment/src/traits/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/type_name.rs
+++ b/console/network/environment/src/traits/type_name.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/types.rs
+++ b/console/network/environment/src/traits/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/environment/src/traits/visibility.rs
+++ b/console/network/environment/src/traits/visibility.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/src/helpers/id.rs
+++ b/console/network/src/helpers/id.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/src/helpers/mod.rs
+++ b/console/network/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/src/helpers/object.rs
+++ b/console/network/src/helpers/object.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/access/bytes.rs
+++ b/console/program/src/data/access/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/access/mod.rs
+++ b/console/program/src/data/access/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/access/parse.rs
+++ b/console/program/src/data/access/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/access/serialize.rs
+++ b/console/program/src/data/access/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/bytes.rs
+++ b/console/program/src/data/ciphertext/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/decrypt.rs
+++ b/console/program/src/data/ciphertext/decrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/equal.rs
+++ b/console/program/src/data/ciphertext/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/from_bits.rs
+++ b/console/program/src/data/ciphertext/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/from_fields.rs
+++ b/console/program/src/data/ciphertext/from_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/mod.rs
+++ b/console/program/src/data/ciphertext/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/num_randomizers.rs
+++ b/console/program/src/data/ciphertext/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/parse.rs
+++ b/console/program/src/data/ciphertext/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/serialize.rs
+++ b/console/program/src/data/ciphertext/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/size_in_fields.rs
+++ b/console/program/src/data/ciphertext/size_in_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/to_bits.rs
+++ b/console/program/src/data/ciphertext/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/ciphertext/to_fields.rs
+++ b/console/program/src/data/ciphertext/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/argument.rs
+++ b/console/program/src/data/future/argument.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/bytes.rs
+++ b/console/program/src/data/future/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/equal.rs
+++ b/console/program/src/data/future/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/find.rs
+++ b/console/program/src/data/future/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/mod.rs
+++ b/console/program/src/data/future/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/parse.rs
+++ b/console/program/src/data/future/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/serialize.rs
+++ b/console/program/src/data/future/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/to_bits.rs
+++ b/console/program/src/data/future/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/future/to_fields.rs
+++ b/console/program/src/data/future/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/bytes.rs
+++ b/console/program/src/data/identifier/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/equal.rs
+++ b/console/program/src/data/identifier/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/from_bits.rs
+++ b/console/program/src/data/identifier/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/from_field.rs
+++ b/console/program/src/data/identifier/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/mod.rs
+++ b/console/program/src/data/identifier/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/parse.rs
+++ b/console/program/src/data/identifier/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/serialize.rs
+++ b/console/program/src/data/identifier/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/size_in_bits.rs
+++ b/console/program/src/data/identifier/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/to_bits.rs
+++ b/console/program/src/data/identifier/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/identifier/to_field.rs
+++ b/console/program/src/data/identifier/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/bytes.rs
+++ b/console/program/src/data/literal/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast/boolean.rs
+++ b/console/program/src/data/literal/cast/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast/field.rs
+++ b/console/program/src/data/literal/cast/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast/integer.rs
+++ b/console/program/src/data/literal/cast/integer.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast/mod.rs
+++ b/console/program/src/data/literal/cast/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast/scalar.rs
+++ b/console/program/src/data/literal/cast/scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast_lossy/boolean.rs
+++ b/console/program/src/data/literal/cast_lossy/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast_lossy/field.rs
+++ b/console/program/src/data/literal/cast_lossy/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast_lossy/integer.rs
+++ b/console/program/src/data/literal/cast_lossy/integer.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast_lossy/mod.rs
+++ b/console/program/src/data/literal/cast_lossy/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/cast_lossy/scalar.rs
+++ b/console/program/src/data/literal/cast_lossy/scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/equal.rs
+++ b/console/program/src/data/literal/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/from_bits.rs
+++ b/console/program/src/data/literal/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/mod.rs
+++ b/console/program/src/data/literal/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/parse.rs
+++ b/console/program/src/data/literal/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/sample.rs
+++ b/console/program/src/data/literal/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/serialize.rs
+++ b/console/program/src/data/literal/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/size_in_bits.rs
+++ b/console/program/src/data/literal/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/size_in_bytes.rs
+++ b/console/program/src/data/literal/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/to_bits.rs
+++ b/console/program/src/data/literal/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/to_type.rs
+++ b/console/program/src/data/literal/to_type.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/literal/variant.rs
+++ b/console/program/src/data/literal/variant.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/mod.rs
+++ b/console/program/src/data/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/bytes.rs
+++ b/console/program/src/data/plaintext/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/encrypt.rs
+++ b/console/program/src/data/plaintext/encrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/equal.rs
+++ b/console/program/src/data/plaintext/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/find.rs
+++ b/console/program/src/data/plaintext/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/from_bits.rs
+++ b/console/program/src/data/plaintext/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/from_fields.rs
+++ b/console/program/src/data/plaintext/from_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/mod.rs
+++ b/console/program/src/data/plaintext/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/num_randomizers.rs
+++ b/console/program/src/data/plaintext/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/serialize.rs
+++ b/console/program/src/data/plaintext/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/size_in_fields.rs
+++ b/console/program/src/data/plaintext/size_in_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/to_bits.rs
+++ b/console/program/src/data/plaintext/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/plaintext/to_fields.rs
+++ b/console/program/src/data/plaintext/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/bytes.rs
+++ b/console/program/src/data/record/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/decrypt.rs
+++ b/console/program/src/data/record/decrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/encrypt.rs
+++ b/console/program/src/data/record/encrypt.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/entry/bytes.rs
+++ b/console/program/src/data/record/entry/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/entry/equal.rs
+++ b/console/program/src/data/record/entry/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/entry/find.rs
+++ b/console/program/src/data/record/entry/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/entry/mod.rs
+++ b/console/program/src/data/record/entry/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/entry/num_randomizers.rs
+++ b/console/program/src/data/record/entry/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/entry/to_bits.rs
+++ b/console/program/src/data/record/entry/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/equal.rs
+++ b/console/program/src/data/record/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/find.rs
+++ b/console/program/src/data/record/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/helpers/mod.rs
+++ b/console/program/src/data/record/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/helpers/owner.rs
+++ b/console/program/src/data/record/helpers/owner.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/is_owner.rs
+++ b/console/program/src/data/record/is_owner.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/mod.rs
+++ b/console/program/src/data/record/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/num_randomizers.rs
+++ b/console/program/src/data/record/num_randomizers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/parse_ciphertext.rs
+++ b/console/program/src/data/record/parse_ciphertext.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/serial_number.rs
+++ b/console/program/src/data/record/serial_number.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/serialize.rs
+++ b/console/program/src/data/record/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/tag.rs
+++ b/console/program/src/data/record/tag.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/to_bits.rs
+++ b/console/program/src/data/record/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/to_commitment.rs
+++ b/console/program/src/data/record/to_commitment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/record/to_fields.rs
+++ b/console/program/src/data/record/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/register/bytes.rs
+++ b/console/program/src/data/register/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/register/mod.rs
+++ b/console/program/src/data/register/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/register/parse.rs
+++ b/console/program/src/data/register/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/register/serialize.rs
+++ b/console/program/src/data/register/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/bytes.rs
+++ b/console/program/src/data/value/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/equal.rs
+++ b/console/program/src/data/value/equal.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/find.rs
+++ b/console/program/src/data/value/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/mod.rs
+++ b/console/program/src/data/value/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/parse.rs
+++ b/console/program/src/data/value/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/serialize.rs
+++ b/console/program/src/data/value/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/to_bits.rs
+++ b/console/program/src/data/value/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data/value/to_fields.rs
+++ b/console/program/src/data/value/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/array_type/bytes.rs
+++ b/console/program/src/data_types/array_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/array_type/mod.rs
+++ b/console/program/src/data_types/array_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/array_type/parse.rs
+++ b/console/program/src/data_types/array_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/array_type/serialize.rs
+++ b/console/program/src/data_types/array_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/finalize_type/bytes.rs
+++ b/console/program/src/data_types/finalize_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/finalize_type/mod.rs
+++ b/console/program/src/data_types/finalize_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/finalize_type/parse.rs
+++ b/console/program/src/data_types/finalize_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/finalize_type/serialize.rs
+++ b/console/program/src/data_types/finalize_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/literal_type/bytes.rs
+++ b/console/program/src/data_types/literal_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/literal_type/mod.rs
+++ b/console/program/src/data_types/literal_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/literal_type/parse.rs
+++ b/console/program/src/data_types/literal_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/literal_type/serialize.rs
+++ b/console/program/src/data_types/literal_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/literal_type/size_in_bits.rs
+++ b/console/program/src/data_types/literal_type/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/literal_type/size_in_bytes.rs
+++ b/console/program/src/data_types/literal_type/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/mod.rs
+++ b/console/program/src/data_types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/plaintext_type/bytes.rs
+++ b/console/program/src/data_types/plaintext_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/plaintext_type/mod.rs
+++ b/console/program/src/data_types/plaintext_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/plaintext_type/parse.rs
+++ b/console/program/src/data_types/plaintext_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/plaintext_type/serialize.rs
+++ b/console/program/src/data_types/plaintext_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/bytes.rs
+++ b/console/program/src/data_types/record_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/entry_type/bytes.rs
+++ b/console/program/src/data_types/record_type/entry_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/entry_type/mod.rs
+++ b/console/program/src/data_types/record_type/entry_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/entry_type/parse.rs
+++ b/console/program/src/data_types/record_type/entry_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/entry_type/serialize.rs
+++ b/console/program/src/data_types/record_type/entry_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/helpers/mod.rs
+++ b/console/program/src/data_types/record_type/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/mod.rs
+++ b/console/program/src/data_types/record_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/parse.rs
+++ b/console/program/src/data_types/record_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/record_type/serialize.rs
+++ b/console/program/src/data_types/record_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/register_type/bytes.rs
+++ b/console/program/src/data_types/register_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/register_type/mod.rs
+++ b/console/program/src/data_types/register_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/register_type/parse.rs
+++ b/console/program/src/data_types/register_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/register_type/serialize.rs
+++ b/console/program/src/data_types/register_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/struct_type/bytes.rs
+++ b/console/program/src/data_types/struct_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/struct_type/mod.rs
+++ b/console/program/src/data_types/struct_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/struct_type/parse.rs
+++ b/console/program/src/data_types/struct_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/struct_type/serialize.rs
+++ b/console/program/src/data_types/struct_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/value_type/bytes.rs
+++ b/console/program/src/data_types/value_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/value_type/mod.rs
+++ b/console/program/src/data_types/value_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/value_type/parse.rs
+++ b/console/program/src/data_types/value_type/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/data_types/value_type/serialize.rs
+++ b/console/program/src/data_types/value_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/function_id/mod.rs
+++ b/console/program/src/function_id/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/id/bytes.rs
+++ b/console/program/src/id/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/id/mod.rs
+++ b/console/program/src/id/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/id/parse.rs
+++ b/console/program/src/id/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/id/serialize.rs
+++ b/console/program/src/id/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/id/to_address.rs
+++ b/console/program/src/id/to_address.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/id/to_bits.rs
+++ b/console/program/src/id/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/id/to_fields.rs
+++ b/console/program/src/id/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/lib.rs
+++ b/console/program/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/locator/bytes.rs
+++ b/console/program/src/locator/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/locator/mod.rs
+++ b/console/program/src/locator/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/locator/parse.rs
+++ b/console/program/src/locator/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/locator/serialize.rs
+++ b/console/program/src/locator/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/locator/to_fields.rs
+++ b/console/program/src/locator/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/owner/bytes.rs
+++ b/console/program/src/owner/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/owner/mod.rs
+++ b/console/program/src/owner/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/owner/serialize.rs
+++ b/console/program/src/owner/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/owner/string.rs
+++ b/console/program/src/owner/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/bytes.rs
+++ b/console/program/src/request/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/input_id/bytes.rs
+++ b/console/program/src/request/input_id/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/input_id/mod.rs
+++ b/console/program/src/request/input_id/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/input_id/serialize.rs
+++ b/console/program/src/request/input_id/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/input_id/string.rs
+++ b/console/program/src/request/input_id/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/mod.rs
+++ b/console/program/src/request/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/serialize.rs
+++ b/console/program/src/request/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/string.rs
+++ b/console/program/src/request/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/request/verify.rs
+++ b/console/program/src/request/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/response/mod.rs
+++ b/console/program/src/response/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/bytes.rs
+++ b/console/program/src/state_path/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/configuration/mod.rs
+++ b/console/program/src/state_path/configuration/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/header_leaf/bytes.rs
+++ b/console/program/src/state_path/header_leaf/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/header_leaf/mod.rs
+++ b/console/program/src/state_path/header_leaf/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/header_leaf/serialize.rs
+++ b/console/program/src/state_path/header_leaf/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/header_leaf/string.rs
+++ b/console/program/src/state_path/header_leaf/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/header_leaf/to_bits.rs
+++ b/console/program/src/state_path/header_leaf/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/mod.rs
+++ b/console/program/src/state_path/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/parse.rs
+++ b/console/program/src/state_path/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/serialize.rs
+++ b/console/program/src/state_path/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transaction_leaf/bytes.rs
+++ b/console/program/src/state_path/transaction_leaf/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transaction_leaf/mod.rs
+++ b/console/program/src/state_path/transaction_leaf/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transaction_leaf/serialize.rs
+++ b/console/program/src/state_path/transaction_leaf/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transaction_leaf/string.rs
+++ b/console/program/src/state_path/transaction_leaf/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transaction_leaf/to_bits.rs
+++ b/console/program/src/state_path/transaction_leaf/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transition_leaf/bytes.rs
+++ b/console/program/src/state_path/transition_leaf/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transition_leaf/mod.rs
+++ b/console/program/src/state_path/transition_leaf/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transition_leaf/serialize.rs
+++ b/console/program/src/state_path/transition_leaf/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transition_leaf/string.rs
+++ b/console/program/src/state_path/transition_leaf/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/transition_leaf/to_bits.rs
+++ b/console/program/src/state_path/transition_leaf/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/program/src/state_path/verify.rs
+++ b/console/program/src/state_path/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/bitwise.rs
+++ b/console/types/address/src/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/bytes.rs
+++ b/console/types/address/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/from_bits.rs
+++ b/console/types/address/src/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/from_field.rs
+++ b/console/types/address/src/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/from_fields.rs
+++ b/console/types/address/src/from_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/lib.rs
+++ b/console/types/address/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/parse.rs
+++ b/console/types/address/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/random.rs
+++ b/console/types/address/src/random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/serialize.rs
+++ b/console/types/address/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/size_in_bits.rs
+++ b/console/types/address/src/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/size_in_bytes.rs
+++ b/console/types/address/src/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/to_bits.rs
+++ b/console/types/address/src/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/to_field.rs
+++ b/console/types/address/src/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/to_fields.rs
+++ b/console/types/address/src/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/address/src/to_group.rs
+++ b/console/types/address/src/to_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/benches/group.rs
+++ b/console/types/benches/group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/bitwise.rs
+++ b/console/types/boolean/src/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/bytes.rs
+++ b/console/types/boolean/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/from_bits.rs
+++ b/console/types/boolean/src/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/lib.rs
+++ b/console/types/boolean/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/parse.rs
+++ b/console/types/boolean/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/random.rs
+++ b/console/types/boolean/src/random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/serialize.rs
+++ b/console/types/boolean/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/size_in_bits.rs
+++ b/console/types/boolean/src/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/size_in_bytes.rs
+++ b/console/types/boolean/src/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/boolean/src/to_bits.rs
+++ b/console/types/boolean/src/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/arithmetic.rs
+++ b/console/types/field/src/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/bitwise.rs
+++ b/console/types/field/src/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/bytes.rs
+++ b/console/types/field/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/compare.rs
+++ b/console/types/field/src/compare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/from_bits.rs
+++ b/console/types/field/src/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/lib.rs
+++ b/console/types/field/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/one.rs
+++ b/console/types/field/src/one.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/parse.rs
+++ b/console/types/field/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/random.rs
+++ b/console/types/field/src/random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/serialize.rs
+++ b/console/types/field/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/size_in_bits.rs
+++ b/console/types/field/src/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/size_in_bytes.rs
+++ b/console/types/field/src/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/to_bits.rs
+++ b/console/types/field/src/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/field/src/zero.rs
+++ b/console/types/field/src/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/arithmetic.rs
+++ b/console/types/group/src/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/bitwise.rs
+++ b/console/types/group/src/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/bytes.rs
+++ b/console/types/group/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/from_bits.rs
+++ b/console/types/group/src/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/from_field.rs
+++ b/console/types/group/src/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/from_fields.rs
+++ b/console/types/group/src/from_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/from_x_coordinate.rs
+++ b/console/types/group/src/from_x_coordinate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/from_xy_coordinates.rs
+++ b/console/types/group/src/from_xy_coordinates.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/lib.rs
+++ b/console/types/group/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/parse.rs
+++ b/console/types/group/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/random.rs
+++ b/console/types/group/src/random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/serialize.rs
+++ b/console/types/group/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/size_in_bits.rs
+++ b/console/types/group/src/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/size_in_bytes.rs
+++ b/console/types/group/src/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/to_bits.rs
+++ b/console/types/group/src/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/to_field.rs
+++ b/console/types/group/src/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/to_fields.rs
+++ b/console/types/group/src/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/to_x_coordinate.rs
+++ b/console/types/group/src/to_x_coordinate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/to_xy_coordinates.rs
+++ b/console/types/group/src/to_xy_coordinates.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/to_y_coordinate.rs
+++ b/console/types/group/src/to_y_coordinate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/group/src/zero.rs
+++ b/console/types/group/src/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/arithmetic.rs
+++ b/console/types/integers/src/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/bitwise.rs
+++ b/console/types/integers/src/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/bytes.rs
+++ b/console/types/integers/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/compare.rs
+++ b/console/types/integers/src/compare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/from_bits.rs
+++ b/console/types/integers/src/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/from_field.rs
+++ b/console/types/integers/src/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/from_field_lossy.rs
+++ b/console/types/integers/src/from_field_lossy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/from_fields.rs
+++ b/console/types/integers/src/from_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/lib.rs
+++ b/console/types/integers/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/one.rs
+++ b/console/types/integers/src/one.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/parse.rs
+++ b/console/types/integers/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/random.rs
+++ b/console/types/integers/src/random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/serialize.rs
+++ b/console/types/integers/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/size_in_bits.rs
+++ b/console/types/integers/src/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/size_in_bytes.rs
+++ b/console/types/integers/src/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/to_bits.rs
+++ b/console/types/integers/src/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/to_field.rs
+++ b/console/types/integers/src/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/to_fields.rs
+++ b/console/types/integers/src/to_fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/to_scalar.rs
+++ b/console/types/integers/src/to_scalar.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/integers/src/zero.rs
+++ b/console/types/integers/src/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/arithmetic.rs
+++ b/console/types/scalar/src/arithmetic.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/bitwise.rs
+++ b/console/types/scalar/src/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/bytes.rs
+++ b/console/types/scalar/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/compare.rs
+++ b/console/types/scalar/src/compare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/from_bits.rs
+++ b/console/types/scalar/src/from_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/from_field.rs
+++ b/console/types/scalar/src/from_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/from_field_lossy.rs
+++ b/console/types/scalar/src/from_field_lossy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/lib.rs
+++ b/console/types/scalar/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/one.rs
+++ b/console/types/scalar/src/one.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/parse.rs
+++ b/console/types/scalar/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/random.rs
+++ b/console/types/scalar/src/random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/serialize.rs
+++ b/console/types/scalar/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/size_in_bits.rs
+++ b/console/types/scalar/src/size_in_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/size_in_bytes.rs
+++ b/console/types/scalar/src/size_in_bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/to_bits.rs
+++ b/console/types/scalar/src/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/to_field.rs
+++ b/console/types/scalar/src/to_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/scalar/src/zero.rs
+++ b/console/types/scalar/src/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/src/lib.rs
+++ b/console/types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/string/src/bitwise.rs
+++ b/console/types/string/src/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/string/src/bytes.rs
+++ b/console/types/string/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/string/src/lib.rs
+++ b/console/types/string/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/string/src/parse.rs
+++ b/console/types/string/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/string/src/random.rs
+++ b/console/types/string/src/random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/types/string/src/serialize.rs
+++ b/console/types/string/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/bls12_377/ec.rs
+++ b/curves/benches/bls12_377/ec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/bls12_377/fq.rs
+++ b/curves/benches/bls12_377/fq.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/bls12_377/fq12.rs
+++ b/curves/benches/bls12_377/fq12.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/bls12_377/fq2.rs
+++ b/curves/benches/bls12_377/fq2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/bls12_377/fr.rs
+++ b/curves/benches/bls12_377/fr.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/bls12_377/mod.rs
+++ b/curves/benches/bls12_377/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/bls12_377/pairing.rs
+++ b/curves/benches/bls12_377/pairing.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/benches/curves.rs
+++ b/curves/benches/curves.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/build.rs
+++ b/curves/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/fq.rs
+++ b/curves/src/bls12_377/fq.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/fq12.rs
+++ b/curves/src/bls12_377/fq12.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/fq2.rs
+++ b/curves/src/bls12_377/fq2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/fq6.rs
+++ b/curves/src/bls12_377/fq6.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/fr.rs
+++ b/curves/src/bls12_377/fr.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/g1.rs
+++ b/curves/src/bls12_377/g1.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/g2.rs
+++ b/curves/src/bls12_377/g2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/mod.rs
+++ b/curves/src/bls12_377/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/parameters.rs
+++ b/curves/src/bls12_377/parameters.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/edwards_bls12/fq.rs
+++ b/curves/src/edwards_bls12/fq.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/edwards_bls12/fr.rs
+++ b/curves/src/edwards_bls12/fr.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/edwards_bls12/mod.rs
+++ b/curves/src/edwards_bls12/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/edwards_bls12/parameters.rs
+++ b/curves/src/edwards_bls12/parameters.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/edwards_bls12/tests.rs
+++ b/curves/src/edwards_bls12/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/errors.rs
+++ b/curves/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/lib.rs
+++ b/curves/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/bls12/bls12.rs
+++ b/curves/src/templates/bls12/bls12.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/bls12/g1.rs
+++ b/curves/src/templates/bls12/g1.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/bls12/mod.rs
+++ b/curves/src/templates/bls12/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/macros.rs
+++ b/curves/src/templates/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/mod.rs
+++ b/curves/src/templates/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/short_weierstrass_jacobian/mod.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/short_weierstrass_jacobian/tests.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/to_field_vec.rs
+++ b/curves/src/templates/to_field_vec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/twisted_edwards_extended/mod.rs
+++ b/curves/src/templates/twisted_edwards_extended/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/twisted_edwards_extended/projective.rs
+++ b/curves/src/templates/twisted_edwards_extended/projective.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/templates/twisted_edwards_extended/tests.rs
+++ b/curves/src/templates/twisted_edwards_extended/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/traits/group.rs
+++ b/curves/src/traits/group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/traits/mod.rs
+++ b/curves/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/traits/pairing_engine.rs
+++ b/curves/src/traits/pairing_engine.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/traits/tests_field.rs
+++ b/curves/src/traits/tests_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/traits/tests_group.rs
+++ b/curves/src/traits/tests_group.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/curves/src/traits/tests_projective.rs
+++ b/curves/src/traits/tests_projective.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/benches/fields.rs
+++ b/fields/benches/fields.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/errors/constraint_field.rs
+++ b/fields/src/errors/constraint_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/errors/field.rs
+++ b/fields/src/errors/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/errors/mod.rs
+++ b/fields/src/errors/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/fp12_2over3over2.rs
+++ b/fields/src/fp12_2over3over2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/fp6_3over2.rs
+++ b/fields/src/fp6_3over2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/legendre.rs
+++ b/fields/src/legendre.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/lib.rs
+++ b/fields/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/macros.rs
+++ b/fields/src/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/to_field_vec.rs
+++ b/fields/src/to_field_vec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/fft_field.rs
+++ b/fields/src/traits/fft_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/fft_parameters.rs
+++ b/fields/src/traits/fft_parameters.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/field.rs
+++ b/fields/src/traits/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/field_parameters.rs
+++ b/fields/src/traits/field_parameters.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/mod.rs
+++ b/fields/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/poseidon_default.rs
+++ b/fields/src/traits/poseidon_default.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/poseidon_grain_lfsr.rs
+++ b/fields/src/traits/poseidon_grain_lfsr.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/prime_field.rs
+++ b/fields/src/traits/prime_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/square_root_field.rs
+++ b/fields/src/traits/square_root_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/to_constraint_field.rs
+++ b/fields/src/traits/to_constraint_field.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/fields/src/traits/zero.rs
+++ b/fields/src/traits/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/authority/src/bytes.rs
+++ b/ledger/authority/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/authority/src/serialize.rs
+++ b/ledger/authority/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/authority/src/string.rs
+++ b/ledger/authority/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/benches/block.rs
+++ b/ledger/benches/block.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/benches/bonded_mapping.rs
+++ b/ledger/benches/bonded_mapping.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/genesis.rs
+++ b/ledger/block/src/genesis.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/bytes.rs
+++ b/ledger/block/src/header/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/genesis.rs
+++ b/ledger/block/src/header/genesis.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/merkle.rs
+++ b/ledger/block/src/header/merkle.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/bytes.rs
+++ b/ledger/block/src/header/metadata/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/genesis.rs
+++ b/ledger/block/src/header/metadata/genesis.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/mod.rs
+++ b/ledger/block/src/header/metadata/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/serialize.rs
+++ b/ledger/block/src/header/metadata/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/string.rs
+++ b/ledger/block/src/header/metadata/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/to_bits.rs
+++ b/ledger/block/src/header/metadata/to_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/to_hash.rs
+++ b/ledger/block/src/header/metadata/to_hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/metadata/verify.rs
+++ b/ledger/block/src/header/metadata/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/mod.rs
+++ b/ledger/block/src/header/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/serialize.rs
+++ b/ledger/block/src/header/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/string.rs
+++ b/ledger/block/src/header/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/header/verify.rs
+++ b/ledger/block/src/header/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/helpers/mod.rs
+++ b/ledger/block/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratifications/bytes.rs
+++ b/ledger/block/src/ratifications/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratifications/merkle.rs
+++ b/ledger/block/src/ratifications/merkle.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratifications/mod.rs
+++ b/ledger/block/src/ratifications/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratifications/serialize.rs
+++ b/ledger/block/src/ratifications/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratifications/string.rs
+++ b/ledger/block/src/ratifications/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratify/bytes.rs
+++ b/ledger/block/src/ratify/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratify/mod.rs
+++ b/ledger/block/src/ratify/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratify/serialize.rs
+++ b/ledger/block/src/ratify/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/ratify/string.rs
+++ b/ledger/block/src/ratify/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/serialize.rs
+++ b/ledger/block/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/solutions/bytes.rs
+++ b/ledger/block/src/solutions/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/solutions/merkle.rs
+++ b/ledger/block/src/solutions/merkle.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/solutions/mod.rs
+++ b/ledger/block/src/solutions/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/solutions/serialize.rs
+++ b/ledger/block/src/solutions/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/solutions/string.rs
+++ b/ledger/block/src/solutions/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/string.rs
+++ b/ledger/block/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/bytes.rs
+++ b/ledger/block/src/transaction/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/deployment/bytes.rs
+++ b/ledger/block/src/transaction/deployment/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/deployment/mod.rs
+++ b/ledger/block/src/transaction/deployment/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/deployment/serialize.rs
+++ b/ledger/block/src/transaction/deployment/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/deployment/string.rs
+++ b/ledger/block/src/transaction/deployment/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/execution/bytes.rs
+++ b/ledger/block/src/transaction/execution/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/execution/mod.rs
+++ b/ledger/block/src/transaction/execution/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/execution/serialize.rs
+++ b/ledger/block/src/transaction/execution/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/execution/string.rs
+++ b/ledger/block/src/transaction/execution/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/fee/bytes.rs
+++ b/ledger/block/src/transaction/fee/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/fee/mod.rs
+++ b/ledger/block/src/transaction/fee/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/fee/serialize.rs
+++ b/ledger/block/src/transaction/fee/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/fee/string.rs
+++ b/ledger/block/src/transaction/fee/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/merkle.rs
+++ b/ledger/block/src/transaction/merkle.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/mod.rs
+++ b/ledger/block/src/transaction/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/serialize.rs
+++ b/ledger/block/src/transaction/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transaction/string.rs
+++ b/ledger/block/src/transaction/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/bytes.rs
+++ b/ledger/block/src/transactions/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/confirmed/bytes.rs
+++ b/ledger/block/src/transactions/confirmed/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/confirmed/mod.rs
+++ b/ledger/block/src/transactions/confirmed/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/confirmed/serialize.rs
+++ b/ledger/block/src/transactions/confirmed/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/confirmed/string.rs
+++ b/ledger/block/src/transactions/confirmed/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/merkle.rs
+++ b/ledger/block/src/transactions/merkle.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/rejected/bytes.rs
+++ b/ledger/block/src/transactions/rejected/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/rejected/mod.rs
+++ b/ledger/block/src/transactions/rejected/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/rejected/serialize.rs
+++ b/ledger/block/src/transactions/rejected/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/rejected/string.rs
+++ b/ledger/block/src/transactions/rejected/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/serialize.rs
+++ b/ledger/block/src/transactions/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transactions/string.rs
+++ b/ledger/block/src/transactions/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/bytes.rs
+++ b/ledger/block/src/transition/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/input/bytes.rs
+++ b/ledger/block/src/transition/input/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/input/mod.rs
+++ b/ledger/block/src/transition/input/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/input/serialize.rs
+++ b/ledger/block/src/transition/input/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/input/string.rs
+++ b/ledger/block/src/transition/input/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/merkle.rs
+++ b/ledger/block/src/transition/merkle.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/mod.rs
+++ b/ledger/block/src/transition/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/output/bytes.rs
+++ b/ledger/block/src/transition/output/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/output/mod.rs
+++ b/ledger/block/src/transition/output/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/output/serialize.rs
+++ b/ledger/block/src/transition/output/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/output/string.rs
+++ b/ledger/block/src/transition/output/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/serialize.rs
+++ b/ledger/block/src/transition/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/transition/string.rs
+++ b/ledger/block/src/transition/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/committee/src/bytes.rs
+++ b/ledger/committee/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/committee/src/lib.rs
+++ b/ledger/committee/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/committee/src/prop_tests.rs
+++ b/ledger/committee/src/prop_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/committee/src/serialize.rs
+++ b/ledger/committee/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/committee/src/string.rs
+++ b/ledger/committee/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/committee/src/to_id.rs
+++ b/ledger/committee/src/to_id.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-certificate/src/serialize.rs
+++ b/ledger/narwhal/batch-certificate/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-certificate/src/string.rs
+++ b/ledger/narwhal/batch-certificate/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-header/src/serialize.rs
+++ b/ledger/narwhal/batch-header/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-header/src/string.rs
+++ b/ledger/narwhal/batch-header/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/batch-header/src/to_id.rs
+++ b/ledger/narwhal/batch-header/src/to_id.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/data/src/lib.rs
+++ b/ledger/narwhal/data/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/src/lib.rs
+++ b/ledger/narwhal/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/subdag/src/serialize.rs
+++ b/ledger/narwhal/subdag/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/subdag/src/string.rs
+++ b/ledger/narwhal/subdag/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission-id/src/bytes.rs
+++ b/ledger/narwhal/transmission-id/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission-id/src/lib.rs
+++ b/ledger/narwhal/transmission-id/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission-id/src/serialize.rs
+++ b/ledger/narwhal/transmission-id/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission-id/src/string.rs
+++ b/ledger/narwhal/transmission-id/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission/src/bytes.rs
+++ b/ledger/narwhal/transmission/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission/src/lib.rs
+++ b/ledger/narwhal/transmission/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission/src/serialize.rs
+++ b/ledger/narwhal/transmission/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/narwhal/transmission/src/string.rs
+++ b/ledger/narwhal/transmission/src/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/benches/puzzle.rs
+++ b/ledger/puzzle/benches/puzzle.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/lib.rs
+++ b/ledger/puzzle/epoch/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/merkle/mod.rs
+++ b/ledger/puzzle/epoch/src/merkle/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/helpers/destination.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/destination.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/helpers/instruction_set.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/instruction_set.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/helpers/instruction_type.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/instruction_type.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/helpers/mod.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/helpers/operand.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/operand.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/helpers/register.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/register.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/helpers/register_table.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/register_table.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/mod.rs
+++ b/ledger/puzzle/epoch/src/synthesis/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/program/construct_inputs.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/construct_inputs.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/program/mod.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/program/to_leaves.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/to_leaves.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/epoch/src/synthesis/program/to_r1cs.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/to_r1cs.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/partial_solution/bytes.rs
+++ b/ledger/puzzle/src/partial_solution/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/partial_solution/mod.rs
+++ b/ledger/puzzle/src/partial_solution/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/partial_solution/serialize.rs
+++ b/ledger/puzzle/src/partial_solution/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/partial_solution/string.rs
+++ b/ledger/puzzle/src/partial_solution/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution/bytes.rs
+++ b/ledger/puzzle/src/solution/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution/mod.rs
+++ b/ledger/puzzle/src/solution/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution/serialize.rs
+++ b/ledger/puzzle/src/solution/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution/string.rs
+++ b/ledger/puzzle/src/solution/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution_id/bytes.rs
+++ b/ledger/puzzle/src/solution_id/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution_id/mod.rs
+++ b/ledger/puzzle/src/solution_id/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution_id/serialize.rs
+++ b/ledger/puzzle/src/solution_id/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solution_id/string.rs
+++ b/ledger/puzzle/src/solution_id/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solutions/bytes.rs
+++ b/ledger/puzzle/src/solutions/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solutions/mod.rs
+++ b/ledger/puzzle/src/solutions/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solutions/serialize.rs
+++ b/ledger/puzzle/src/solutions/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/puzzle/src/solutions/string.rs
+++ b/ledger/puzzle/src/solutions/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/query/src/lib.rs
+++ b/ledger/query/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/query/src/traits.rs
+++ b/ledger/query/src/traits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/check_transaction_basic.rs
+++ b/ledger/src/check_transaction_basic.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/contains.rs
+++ b/ledger/src/contains.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/find.rs
+++ b/ledger/src/find.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/helpers/bft.rs
+++ b/ledger/src/helpers/bft.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/helpers/mod.rs
+++ b/ledger/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/helpers/supply.rs
+++ b/ledger/src/helpers/supply.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/iterators.rs
+++ b/ledger/src/iterators.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/block/confirmed_tx_type/bytes.rs
+++ b/ledger/store/src/block/confirmed_tx_type/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/block/confirmed_tx_type/mod.rs
+++ b/ledger/store/src/block/confirmed_tx_type/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/block/confirmed_tx_type/serialize.rs
+++ b/ledger/store/src/block/confirmed_tx_type/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/block/confirmed_tx_type/string.rs
+++ b/ledger/store/src/block/confirmed_tx_type/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/consensus/mod.rs
+++ b/ledger/store/src/consensus/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/block.rs
+++ b/ledger/store/src/helpers/memory/block.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/consensus.rs
+++ b/ledger/store/src/helpers/memory/consensus.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/internal/map.rs
+++ b/ledger/store/src/helpers/memory/internal/map.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/internal/mod.rs
+++ b/ledger/store/src/helpers/memory/internal/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/internal/nested_map.rs
+++ b/ledger/store/src/helpers/memory/internal/nested_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/mod.rs
+++ b/ledger/store/src/helpers/memory/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/program.rs
+++ b/ledger/store/src/helpers/memory/program.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/transaction.rs
+++ b/ledger/store/src/helpers/memory/transaction.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/memory/transition.rs
+++ b/ledger/store/src/helpers/memory/transition.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/mod.rs
+++ b/ledger/store/src/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/block.rs
+++ b/ledger/store/src/helpers/rocksdb/block.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/consensus.rs
+++ b/ledger/store/src/helpers/rocksdb/consensus.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/internal/tests.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/program.rs
+++ b/ledger/store/src/helpers/rocksdb/program.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/transaction.rs
+++ b/ledger/store/src/helpers/rocksdb/transaction.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/rocksdb/transition.rs
+++ b/ledger/store/src/helpers/rocksdb/transition.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/map/check_atomic_writes_are_batched.rs
+++ b/ledger/store/src/helpers/test_helpers/map/check_atomic_writes_are_batched.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/map/check_atomic_writes_can_be_aborted.rs
+++ b/ledger/store/src/helpers/test_helpers/map/check_atomic_writes_can_be_aborted.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/map/check_contains_key.rs
+++ b/ledger/store/src/helpers/test_helpers/map/check_contains_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/map/check_insert_and_get_speculative.rs
+++ b/ledger/store/src/helpers/test_helpers/map/check_insert_and_get_speculative.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/map/check_iterators_match.rs
+++ b/ledger/store/src/helpers/test_helpers/map/check_iterators_match.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/map/check_remove_and_get_speculative.rs
+++ b/ledger/store/src/helpers/test_helpers/map/check_remove_and_get_speculative.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/map/mod.rs
+++ b/ledger/store/src/helpers/test_helpers/map/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/mod.rs
+++ b/ledger/store/src/helpers/test_helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_atomic_writes_are_batched.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_atomic_writes_are_batched.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_atomic_writes_can_be_aborted.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_atomic_writes_can_be_aborted.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_contains_key.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_contains_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_get_map.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_get_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_insert_and_get_value_speculative.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_insert_and_get_value_speculative.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_iterators_match.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_iterators_match.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/check_remove_and_get_value_speculative.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/check_remove_and_get_value_speculative.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/test_helpers/nested_map/mod.rs
+++ b/ledger/store/src/helpers/test_helpers/nested_map/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/traits/map.rs
+++ b/ledger/store/src/helpers/traits/map.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/traits/mod.rs
+++ b/ledger/store/src/helpers/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/helpers/traits/nested_map.rs
+++ b/ledger/store/src/helpers/traits/nested_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/lib.rs
+++ b/ledger/store/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/program/committee.rs
+++ b/ledger/store/src/program/committee.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/program/mod.rs
+++ b/ledger/store/src/program/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/transaction/execution.rs
+++ b/ledger/store/src/transaction/execution.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/transaction/fee.rs
+++ b/ledger/store/src/transaction/fee.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/transaction/mod.rs
+++ b/ledger/store/src/transaction/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/transition/input.rs
+++ b/ledger/store/src/transition/input.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/transition/mod.rs
+++ b/ledger/store/src/transition/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/store/src/transition/output.rs
+++ b/ledger/store/src/transition/output.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/examples/inclusion.rs
+++ b/parameters/examples/inclusion.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/examples/setup.rs
+++ b/parameters/examples/setup.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/canary/genesis.rs
+++ b/parameters/src/canary/genesis.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/canary/mod.rs
+++ b/parameters/src/canary/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/errors/mod.rs
+++ b/parameters/src/errors/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/errors/parameter.rs
+++ b/parameters/src/errors/parameter.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/lib.rs
+++ b/parameters/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/mainnet/genesis.rs
+++ b/parameters/src/mainnet/genesis.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/mainnet/powers.rs
+++ b/parameters/src/mainnet/powers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/testnet/genesis.rs
+++ b/parameters/src/testnet/genesis.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parameters/src/testnet/mod.rs
+++ b/parameters/src/testnet/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/benches/kary_merkle_tree.rs
+++ b/synthesizer/benches/kary_merkle_tree.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/benches/check_deployment.rs
+++ b/synthesizer/process/benches/check_deployment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/benches/stack_operations.rs
+++ b/synthesizer/process/benches/stack_operations.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/authorize.rs
+++ b/synthesizer/process/src/authorize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/evaluate.rs
+++ b/synthesizer/process/src/evaluate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/execute.rs
+++ b/synthesizer/process/src/execute.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/authorization/bytes.rs
+++ b/synthesizer/process/src/stack/authorization/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/authorization/serialize.rs
+++ b/synthesizer/process/src/stack/authorization/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/authorization/string.rs
+++ b/synthesizer/process/src/stack/authorization/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/authorize.rs
+++ b/synthesizer/process/src/stack/authorize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/finalize_registers/load.rs
+++ b/synthesizer/process/src/stack/finalize_registers/load.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/finalize_registers/mod.rs
+++ b/synthesizer/process/src/stack/finalize_registers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/finalize_registers/store.rs
+++ b/synthesizer/process/src/stack/finalize_registers/store.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/finalize_types/matches.rs
+++ b/synthesizer/process/src/stack/finalize_types/matches.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/helpers/mod.rs
+++ b/synthesizer/process/src/stack/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/helpers/synthesize.rs
+++ b/synthesizer/process/src/stack/helpers/synthesize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/register_types/matches.rs
+++ b/synthesizer/process/src/stack/register_types/matches.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/registers/call.rs
+++ b/synthesizer/process/src/stack/registers/call.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/registers/caller.rs
+++ b/synthesizer/process/src/stack/registers/caller.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/registers/load.rs
+++ b/synthesizer/process/src/stack/registers/load.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/registers/mod.rs
+++ b/synthesizer/process/src/stack/registers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/stack/registers/store.rs
+++ b/synthesizer/process/src/stack/registers/store.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/tests/mod.rs
+++ b/synthesizer/process/src/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/tests/test_random.rs
+++ b/synthesizer/process/src/tests/test_random.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/tests/test_utils.rs
+++ b/synthesizer/process/src/tests/test_utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/trace/call_metrics/mod.rs
+++ b/synthesizer/process/src/trace/call_metrics/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/trace/inclusion/mod.rs
+++ b/synthesizer/process/src/trace/inclusion/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/trace/inclusion/prepare.rs
+++ b/synthesizer/process/src/trace/inclusion/prepare.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/traits/mod.rs
+++ b/synthesizer/process/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/verify_deployment.rs
+++ b/synthesizer/process/src/verify_deployment.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/process/src/verify_fee.rs
+++ b/synthesizer/process/src/verify_fee.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/benches/instruction.rs
+++ b/synthesizer/program/benches/instruction.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/bytes.rs
+++ b/synthesizer/program/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/bytes.rs
+++ b/synthesizer/program/src/closure/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/input/bytes.rs
+++ b/synthesizer/program/src/closure/input/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/input/mod.rs
+++ b/synthesizer/program/src/closure/input/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/input/parse.rs
+++ b/synthesizer/program/src/closure/input/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/mod.rs
+++ b/synthesizer/program/src/closure/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/output/bytes.rs
+++ b/synthesizer/program/src/closure/output/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/output/mod.rs
+++ b/synthesizer/program/src/closure/output/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/output/parse.rs
+++ b/synthesizer/program/src/closure/output/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/closure/parse.rs
+++ b/synthesizer/program/src/closure/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/finalize/bytes.rs
+++ b/synthesizer/program/src/finalize/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/finalize/input/bytes.rs
+++ b/synthesizer/program/src/finalize/input/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/finalize/input/mod.rs
+++ b/synthesizer/program/src/finalize/input/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/finalize/input/parse.rs
+++ b/synthesizer/program/src/finalize/input/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/finalize/mod.rs
+++ b/synthesizer/program/src/finalize/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/finalize/parse.rs
+++ b/synthesizer/program/src/finalize/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/bytes.rs
+++ b/synthesizer/program/src/function/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/input/bytes.rs
+++ b/synthesizer/program/src/function/input/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/input/mod.rs
+++ b/synthesizer/program/src/function/input/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/input/parse.rs
+++ b/synthesizer/program/src/function/input/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/mod.rs
+++ b/synthesizer/program/src/function/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/output/bytes.rs
+++ b/synthesizer/program/src/function/output/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/output/mod.rs
+++ b/synthesizer/program/src/function/output/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/output/parse.rs
+++ b/synthesizer/program/src/function/output/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/function/parse.rs
+++ b/synthesizer/program/src/function/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/import/bytes.rs
+++ b/synthesizer/program/src/import/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/import/mod.rs
+++ b/synthesizer/program/src/import/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/import/parse.rs
+++ b/synthesizer/program/src/import/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/await_.rs
+++ b/synthesizer/program/src/logic/command/await_.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/branch.rs
+++ b/synthesizer/program/src/logic/command/branch.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/contains.rs
+++ b/synthesizer/program/src/logic/command/contains.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/get.rs
+++ b/synthesizer/program/src/logic/command/get.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/get_or_use.rs
+++ b/synthesizer/program/src/logic/command/get_or_use.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/position.rs
+++ b/synthesizer/program/src/logic/command/position.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/remove.rs
+++ b/synthesizer/program/src/logic/command/remove.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/command/set.rs
+++ b/synthesizer/program/src/logic/command/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/finalize_global_state/mod.rs
+++ b/synthesizer/program/src/logic/finalize_global_state/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/finalize_operation/bits.rs
+++ b/synthesizer/program/src/logic/finalize_operation/bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/finalize_operation/bytes.rs
+++ b/synthesizer/program/src/logic/finalize_operation/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/finalize_operation/mod.rs
+++ b/synthesizer/program/src/logic/finalize_operation/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/finalize_operation/serialize.rs
+++ b/synthesizer/program/src/logic/finalize_operation/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/finalize_operation/string.rs
+++ b/synthesizer/program/src/logic/finalize_operation/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/bytes.rs
+++ b/synthesizer/program/src/logic/instruction/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/opcode/mod.rs
+++ b/synthesizer/program/src/logic/instruction/opcode/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operand/bytes.rs
+++ b/synthesizer/program/src/logic/instruction/operand/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operand/mod.rs
+++ b/synthesizer/program/src/logic/instruction/operand/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operand/parse.rs
+++ b/synthesizer/program/src/logic/instruction/operand/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/assert.rs
+++ b/synthesizer/program/src/logic/instruction/operation/assert.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/async_.rs
+++ b/synthesizer/program/src/logic/instruction/operation/async_.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/call.rs
+++ b/synthesizer/program/src/logic/instruction/operation/call.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/cast.rs
+++ b/synthesizer/program/src/logic/instruction/operation/cast.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/commit.rs
+++ b/synthesizer/program/src/logic/instruction/operation/commit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/is.rs
+++ b/synthesizer/program/src/logic/instruction/operation/is.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/literals.rs
+++ b/synthesizer/program/src/logic/instruction/operation/literals.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/macros.rs
+++ b/synthesizer/program/src/logic/instruction/operation/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/mod.rs
+++ b/synthesizer/program/src/logic/instruction/operation/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/operation/sign_verify.rs
+++ b/synthesizer/program/src/logic/instruction/operation/sign_verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/instruction/parse.rs
+++ b/synthesizer/program/src/logic/instruction/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/logic/mod.rs
+++ b/synthesizer/program/src/logic/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/bytes.rs
+++ b/synthesizer/program/src/mapping/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/key/bytes.rs
+++ b/synthesizer/program/src/mapping/key/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/key/mod.rs
+++ b/synthesizer/program/src/mapping/key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/key/parse.rs
+++ b/synthesizer/program/src/mapping/key/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/mod.rs
+++ b/synthesizer/program/src/mapping/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/parse.rs
+++ b/synthesizer/program/src/mapping/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/value/bytes.rs
+++ b/synthesizer/program/src/mapping/value/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/value/mod.rs
+++ b/synthesizer/program/src/mapping/value/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/mapping/value/parse.rs
+++ b/synthesizer/program/src/mapping/value/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/parse.rs
+++ b/synthesizer/program/src/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/resources/credits.aleo
+++ b/synthesizer/program/src/resources/credits.aleo
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/serialize.rs
+++ b/synthesizer/program/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/traits/command.rs
+++ b/synthesizer/program/src/traits/command.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/traits/finalize_store.rs
+++ b/synthesizer/program/src/traits/finalize_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/traits/instruction.rs
+++ b/synthesizer/program/src/traits/instruction.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/traits/mod.rs
+++ b/synthesizer/program/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/helpers/macros.rs
+++ b/synthesizer/program/tests/helpers/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/helpers/mod.rs
+++ b/synthesizer/program/tests/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/helpers/sample.rs
+++ b/synthesizer/program/tests/helpers/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/instruction/assert.rs
+++ b/synthesizer/program/tests/instruction/assert.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/instruction/commit.rs
+++ b/synthesizer/program/tests/instruction/commit.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/instruction/hash.rs
+++ b/synthesizer/program/tests/instruction/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/instruction/is.rs
+++ b/synthesizer/program/tests/instruction/is.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/instruction/mod.rs
+++ b/synthesizer/program/tests/instruction/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/program/tests/lib.rs
+++ b/synthesizer/program/tests/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/certificate/bytes.rs
+++ b/synthesizer/snark/src/certificate/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/certificate/mod.rs
+++ b/synthesizer/snark/src/certificate/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/certificate/parse.rs
+++ b/synthesizer/snark/src/certificate/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/certificate/serialize.rs
+++ b/synthesizer/snark/src/certificate/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/lib.rs
+++ b/synthesizer/snark/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proof/bytes.rs
+++ b/synthesizer/snark/src/proof/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proof/mod.rs
+++ b/synthesizer/snark/src/proof/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proof/parse.rs
+++ b/synthesizer/snark/src/proof/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proof/serialize.rs
+++ b/synthesizer/snark/src/proof/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proving_key/bytes.rs
+++ b/synthesizer/snark/src/proving_key/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proving_key/parse.rs
+++ b/synthesizer/snark/src/proving_key/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/proving_key/serialize.rs
+++ b/synthesizer/snark/src/proving_key/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/universal_srs.rs
+++ b/synthesizer/snark/src/universal_srs.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/verifying_key/bytes.rs
+++ b/synthesizer/snark/src/verifying_key/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/verifying_key/parse.rs
+++ b/synthesizer/snark/src/verifying_key/parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/snark/src/verifying_key/serialize.rs
+++ b/synthesizer/snark/src/verifying_key/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/lib.rs
+++ b/synthesizer/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/restrictions/helpers/argument_locator.rs
+++ b/synthesizer/src/restrictions/helpers/argument_locator.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/restrictions/helpers/block_range.rs
+++ b/synthesizer/src/restrictions/helpers/block_range.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/restrictions/helpers/mod.rs
+++ b/synthesizer/src/restrictions/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/restrictions/mod.rs
+++ b/synthesizer/src/restrictions/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/restrictions/serialize.rs
+++ b/synthesizer/src/restrictions/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/restrictions/string.rs
+++ b/synthesizer/src/restrictions/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/authorize.rs
+++ b/synthesizer/src/vm/authorize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/helpers/committee.rs
+++ b/synthesizer/src/vm/helpers/committee.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/helpers/history.rs
+++ b/synthesizer/src/vm/helpers/history.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/helpers/macros.rs
+++ b/synthesizer/src/vm/helpers/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/helpers/mod.rs
+++ b/synthesizer/src/vm/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/helpers/rewards.rs
+++ b/synthesizer/src/vm/helpers/rewards.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/test_command_parse.rs
+++ b/synthesizer/tests/test_command_parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/test_instruction_parse.rs
+++ b/synthesizer/tests/test_instruction_parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/test_process_execute.rs
+++ b/synthesizer/tests/test_process_execute.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/test_program_parse.rs
+++ b/synthesizer/tests/test_program_parse.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/utilities/expectation.rs
+++ b/synthesizer/tests/utilities/expectation.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/utilities/mod.rs
+++ b/synthesizer/tests/utilities/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/utilities/tests/file_parse_test.rs
+++ b/synthesizer/tests/utilities/tests/file_parse_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/utilities/tests/line_parse_test.rs
+++ b/synthesizer/tests/utilities/tests/line_parse_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/utilities/tests/mod.rs
+++ b/synthesizer/tests/utilities/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/synthesizer/tests/utilities/tests/program_test.rs
+++ b/synthesizer/tests/utilities/tests/program_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/derives/src/canonical_deserialize.rs
+++ b/utilities/derives/src/canonical_deserialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/derives/src/canonical_serialize.rs
+++ b/utilities/derives/src/canonical_serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/derives/src/lib.rs
+++ b/utilities/derives/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/biginteger/bigint_256.rs
+++ b/utilities/src/biginteger/bigint_256.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/biginteger/bigint_384.rs
+++ b/utilities/src/biginteger/bigint_384.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/biginteger/mod.rs
+++ b/utilities/src/biginteger/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/biginteger/tests.rs
+++ b/utilities/src/biginteger/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/bititerator.rs
+++ b/utilities/src/bititerator.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/error.rs
+++ b/utilities/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/io.rs
+++ b/utilities/src/io.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/iterator.rs
+++ b/utilities/src/iterator.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/serialize/error.rs
+++ b/utilities/src/serialize/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/serialize/flags.rs
+++ b/utilities/src/serialize/flags.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/serialize/helpers.rs
+++ b/utilities/src/serialize/helpers.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/serialize/mod.rs
+++ b/utilities/src/serialize/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/src/serialize/traits.rs
+++ b/utilities/src/serialize/traits.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/cli.rs
+++ b/vm/cli/cli.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/commands/build.rs
+++ b/vm/cli/commands/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/commands/clean.rs
+++ b/vm/cli/commands/clean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/commands/execute.rs
+++ b/vm/cli/commands/execute.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/commands/mod.rs
+++ b/vm/cli/commands/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/commands/new.rs
+++ b/vm/cli/commands/new.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/commands/run.rs
+++ b/vm/cli/commands/run.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/commands/update.rs
+++ b/vm/cli/commands/update.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/errors.rs
+++ b/vm/cli/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/helpers/env.rs
+++ b/vm/cli/helpers/env.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/helpers/mod.rs
+++ b/vm/cli/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/helpers/updater.rs
+++ b/vm/cli/helpers/updater.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/main.rs
+++ b/vm/cli/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/cli/mod.rs
+++ b/vm/cli/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/file/aleo.rs
+++ b/vm/file/aleo.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/file/avm.rs
+++ b/vm/file/avm.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/file/manifest.rs
+++ b/vm/file/manifest.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/file/mod.rs
+++ b/vm/file/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/file/readme_file.rs
+++ b/vm/file/readme_file.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/lib.rs
+++ b/vm/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/package/build.rs
+++ b/vm/package/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/package/clean.rs
+++ b/vm/package/clean.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/package/execute.rs
+++ b/vm/package/execute.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/package/is_build_required.rs
+++ b/vm/package/is_build_required.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vm/package/run.rs
+++ b/vm/package/run.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/wasm/src/tests.rs
+++ b/wasm/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Aleo Network Foundation
+// Copyright (c) 2019-2025 Provable Inc.
 // This file is part of the snarkVM library.
 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Motivation

This PR updates the snarkVM license headers to `Copyright (c) 2019-2025 Provable Inc.`.

Closes https://github.com/ProvableHQ/snarkVM/issues/2690