### PR TITLE
Don't change MAX_CERTIFICATES with the test_consensus_heights feature

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -174,7 +174,7 @@ impl Network for CanaryV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
@@ -182,7 +182,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V6, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -174,7 +174,7 @@ impl Network for TestnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = MainnetV0::INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
+    #[cfg(not(any(test, feature = "test")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
@@ -182,7 +182,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V6, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
+    #[cfg(any(test, feature = "test"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),


### PR DESCRIPTION
## Motivation

The `test_consensus_heights` feature should only lower the consensus version heights, but not change the `MAX_CERTIFICATES`. This PR introduces such a fix.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2693
https://github.com/ProvableHQ/snarkOS/pull/3572
