### PR TITLE
Speed up subDAG check

### DIFF
--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -166,7 +166,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
 
             // Ensure that the certificate is associated with a previous block.
-            if self.vm.block_store().get_block_for_certificate(prev_id)?.is_none() {
+            if !self.vm.block_store().has_block_for_certificate(prev_id)? {
                 bail!(
                     "Batch(es) in the block point(s) to a certificate {prev_id} in round {prev_round} that is not associated with a previous block"
                 )

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -166,7 +166,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
 
             // Ensure that the certificate is associated with a previous block.
-            if !self.vm.block_store().has_block_for_certificate(prev_id)? {
+            if !self.vm.block_store().contains_block_for_certificate(prev_id)? {
                 bail!(
                     "Batch(es) in the block point(s) to a certificate {prev_id} in round {prev_round} that is not associated with a previous block"
                 )

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -773,8 +773,8 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     }
 
     /// Returns true if there is a block that contains the specified certificate.
-    fn has_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
-        Ok(self.certificate_map().get_confirmed(certificate_id)?.is_some())
+    fn contains_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
+        self.certificate_map().contains_key_confirmed(certificate_id)
     }
 
     /// Returns the batch certificate for the given `certificate ID`.
@@ -1292,8 +1292,8 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     }
 
     /// Returns true if there is a block for the given certificate.
-    pub fn has_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
-        self.storage.has_block_for_certificate(certificate_id)
+    pub fn contains_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
+        self.storage.contains_block_for_certificate(certificate_id)
     }
 
     /// Returns the batch certificate for the given `certificate ID`.

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -772,20 +772,9 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         }
     }
 
-    /// Returns the block that contains the specified certificate (if any).
-    fn get_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<Option<Block<N>>> {
-        // Retrieve the height and round for the given certificate ID.
-        let (block_height, _) = match self.certificate_map().get_confirmed(certificate_id)? {
-            Some(res) => cow_to_copied!(res),
-            None => return Ok(None),
-        };
-
-        // Retrieve the block hash.
-        let Some(block_hash) = self.get_block_hash(block_height)? else {
-            bail!("The block hash for block '{block_height}' is missing in block storage")
-        };
-        // Retrieve the block.
-        self.get_block(&block_hash)
+    /// Returns true if there is a block that contains the specified certificate.
+    fn has_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
+        Ok(self.certificate_map().get_confirmed(certificate_id)?.is_some())
     }
 
     /// Returns the batch certificate for the given `certificate ID`.
@@ -1302,9 +1291,9 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.transaction_store().get_program(program_id)
     }
 
-    /// Returns the block for a given certificate (if any).
-    pub fn get_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<Option<Block<N>>> {
-        self.storage.get_block_for_certificate(certificate_id)
+    /// Returns true if there is a block for the given certificate.
+    pub fn has_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
+        self.storage.has_block_for_certificate(certificate_id)
     }
 
     /// Returns the batch certificate for the given `certificate ID`.


### PR DESCRIPTION
This PR removes an unnecessary block retrieval. 

`Ledger::check_block_subdag_leaves` only needs to know that there exists a block for a given certificate ID, but the function does not inspect the block's content. 