### PR TITLE
[Feat] Introduce new Program rules 

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -136,24 +136,26 @@ impl Network for CanaryV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
         (ConsensusVersion::V4, 5_730_000),
         (ConsensusVersion::V5, 5_780_000),
         (ConsensusVersion::V6, 6_240_000),
+        (ConsensusVersion::V7, 6_895_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
         (ConsensusVersion::V4, 12),
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
+        (ConsensusVersion::V7, 15),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -85,6 +85,8 @@ pub enum ConsensusVersion {
     V5 = 5,
     /// V6: Update to the number of validators.
     V6 = 6,
+    /// V7: Update to program rules.
+    V7 = 7,
 }
 
 pub trait Network:
@@ -224,7 +226,7 @@ pub trait Network:
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7];
     ///  A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     //  Note: This value must **not** decrease without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -137,24 +137,26 @@ impl Network for MainnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_800_000),
         (ConsensusVersion::V3, 4_900_000),
         (ConsensusVersion::V4, 6_135_000),
         (ConsensusVersion::V5, 7_060_000),
-        (ConsensusVersion::V6, 7_900_000),
+        (ConsensusVersion::V6, 7_560_000),
+        (ConsensusVersion::V7, 7_570_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
         (ConsensusVersion::V4, 12),
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
+        (ConsensusVersion::V7, 15),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -136,24 +136,26 @@ impl Network for TestnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_950_000),
         (ConsensusVersion::V3, 4_800_000),
         (ConsensusVersion::V4, 6_625_000),
         (ConsensusVersion::V5, 6_765_000),
         (ConsensusVersion::V6, 7_600_000),
+        (ConsensusVersion::V7, 8_365_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 6] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
         (ConsensusVersion::V4, 12),
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
+        (ConsensusVersion::V7, 15),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -94,6 +94,7 @@ use console::{
 };
 
 use indexmap::{IndexMap, IndexSet};
+use std::collections::BTreeSet;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 enum ProgramDefinition {
@@ -734,6 +735,52 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
                 }
             }
         }
+        Ok(())
+    }
+}
+
+impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> ProgramCore<N, Instruction, Command> {
+    /// Returns `true` if the program structure is well formed under the following rules:
+    ///  1. The program ID must not contain the keyword "aleo" in the program name.
+    ///  2. The record name must not contain the keyword "aleo".
+    ///  3. Record names must not be prefixes of other record names.
+    ///  4. Record entry names must not contain the keyword "aleo".
+    pub fn check_program_naming_structure(&self) -> Result<()> {
+        // 1. Check if the program ID contains the "aleo" substring
+        let program_id = self.id().name().to_string();
+        if program_id.contains("aleo") {
+            bail!("Program ID '{program_id}' can't contain the reserved keyword 'aleo'.");
+        }
+
+        // Fetch the record names in a sorted BTreeSet.
+        let record_names: BTreeSet<String> = self.records.keys().map(|name| name.to_string()).collect();
+
+        // 2. Check if any record name contains the "aleo" substring.
+        for record_name in &record_names {
+            if record_name.contains("aleo") {
+                bail!("Record name '{record_name}' can't contain the reserved keyword 'aleo'.");
+            }
+        }
+
+        // 3. Check if any of the record names are a prefix of another.
+        let mut record_names_iter = record_names.iter();
+        let mut previous_record_name = record_names_iter.next();
+        for record_name in record_names_iter {
+            if let Some(previous) = previous_record_name {
+                if record_name.starts_with(previous) {
+                    bail!("Record name '{previous}' can't be a prefix of record name '{record_name}'.");
+                }
+            }
+            previous_record_name = Some(record_name);
+        }
+
+        // 4. Check if any record entry names contain the "aleo" substring.
+        for record_entry_name in self.records.values().flat_map(|record_type| record_type.entries().keys()) {
+            if record_entry_name.to_string().contains("aleo") {
+                bail!("Record entry name '{record_entry_name}' can't contain the reserved keyword 'aleo'.");
+            }
+        }
+
         Ok(())
     }
 }

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -165,6 +165,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 let current_block_height = self.block_store().current_block_height();
                 let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
                 deployment.program().check_restricted_keywords_for_consensus_version(consensus_version)?;
+                // TODO (raychu86): Program Rules - Update the consensus height.
+                // Perform additional program checks if the consensus version is V6 or beyond.
+                if self.block_store().current_block_height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V6)? {
+                    deployment.program().check_program_naming_structure()?;
+                }
                 // Verify the deployment if it has not been verified before.
                 if !is_partially_verified {
                     // Verify the deployment.
@@ -955,5 +960,162 @@ function compute:
         assert!(new_vm.check_transaction(&transaction_v1, None, rng).is_ok());
         // Check that v2 transaction is invalid.
         assert!(new_vm.check_transaction(&transaction_v2, None, rng).is_err());
+    }
+
+    #[cfg(feature = "test")]
+    #[test]
+    fn test_program_rules_migration() {
+        let rng = &mut TestRng::default();
+
+        // Initialize the VM.
+        let vm = crate::vm::test_helpers::sample_vm();
+        // Initialize the genesis block.
+        let genesis = crate::vm::test_helpers::sample_genesis_block(rng);
+        // Update the VM.
+        vm.add_next_block(&genesis).unwrap();
+
+        // Track the vm blocks.
+        let mut vm_blocks = vec![genesis.clone()];
+
+        // Fetch the private key.
+        let private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+        // Advance the ledger past ConsensusV4 where the new varuna version starts to take place.
+        let transactions: [Transaction<CurrentNetwork>; 0] = [];
+        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V4).unwrap()
+        {
+            // Call the function
+            let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
+            vm.add_next_block(&next_block).unwrap();
+            vm_blocks.push(next_block);
+        }
+
+        // Create a new program that contains "aleo" in the name.
+        let program_1 = Program::from_str(
+            r"
+program testing_1_aleo.aleo;
+
+record token:
+    owner as address.private;
+    amount as u64.private;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    output r1 as u32.public;",
+        )
+        .unwrap();
+
+        // Create a new program that contains "aleo" in the record name.
+        let program_2 = Program::from_str(
+            r"
+program testing_2.aleo;
+
+record token_aleo:
+    owner as address.private;
+    amount as u64.private;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    output r1 as u32.public;",
+        )
+        .unwrap();
+
+        // Create a new program with records names that have other record names as a prefix.
+        let program_3 = Program::from_str(
+            r"
+program testing_3.aleo;
+
+record token:
+    owner as address.private;
+    amount as u64.private;
+
+record token_2:
+    owner as address.private;
+    amount as u64.private;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    output r1 as u32.public;",
+        )
+        .unwrap();
+
+        // Create a new program with records that has an entry containing "aleo".
+        let program_4 = Program::from_str(
+            r"
+program testing_4.aleo;
+
+record token:
+    owner as address.private;
+    test_aleo as u64.private;
+    amount as u64.private;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    output r1 as u32.public;",
+        )
+        .unwrap();
+
+        // Create a deployment transaction for the first program.
+        let deploy_1 = vm.deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
+
+        // Create a deployment transaction for the second program.
+        let deploy_2 = vm.deploy(&private_key, &program_2, None, 0, None, rng).unwrap();
+
+        // Create a deployment transaction for the third program.
+        let deploy_3 = vm.deploy(&private_key, &program_3, None, 0, None, rng).unwrap();
+
+        // Create a deployment transaction for the fourth program.
+        let deploy_4 = vm.deploy(&private_key, &program_4, None, 0, None, rng).unwrap();
+
+        // // Ensure that the deployments are valid.
+        assert!(vm.check_transaction(&deploy_1, None, rng).is_ok());
+        assert!(vm.check_transaction(&deploy_2, None, rng).is_ok());
+        assert!(vm.check_transaction(&deploy_3, None, rng).is_ok());
+        assert!(vm.check_transaction(&deploy_4, None, rng).is_ok());
+
+        // TODO (raychu86): Update this to the proper consensus version used in the migration.
+        // Advance the ledger past ConsensusV6
+        let transactions: [Transaction<CurrentNetwork>; 0] = [];
+        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V6).unwrap()
+        {
+            // // Ensure that the deployments are valid.
+            assert!(vm.check_transaction(&deploy_1, None, rng).is_ok());
+            assert!(vm.check_transaction(&deploy_2, None, rng).is_ok());
+            assert!(vm.check_transaction(&deploy_3, None, rng).is_ok());
+            assert!(vm.check_transaction(&deploy_4, None, rng).is_ok());
+            // Call the function
+            let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
+            vm.add_next_block(&next_block).unwrap();
+            vm_blocks.push(next_block);
+        }
+
+        // Ensure that the deployments are no longer valid.
+        assert!(vm.check_transaction(&deploy_1, None, rng).is_err());
+        assert!(vm.check_transaction(&deploy_2, None, rng).is_err());
+        assert!(vm.check_transaction(&deploy_3, None, rng).is_err());
+        assert!(vm.check_transaction(&deploy_4, None, rng).is_err());
+
+        // Check that the next block will abort the deployments.
+        let deploy_1_tx_id = deploy_1.id();
+        let deploy_2_tx_id = deploy_2.id();
+        let deploy_3_tx_id = deploy_3.id();
+        let deploy_4_tx_id = deploy_4.id();
+        let next_block = crate::vm::test_helpers::sample_next_block(
+            &vm,
+            &private_key,
+            &[deploy_1, deploy_2, deploy_3, deploy_4],
+            rng,
+        )
+        .unwrap();
+        assert_eq!(next_block.aborted_transaction_ids(), &vec![
+            deploy_1_tx_id,
+            deploy_2_tx_id,
+            deploy_3_tx_id,
+            deploy_4_tx_id
+        ]);
     }
 }

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -165,9 +165,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 let current_block_height = self.block_store().current_block_height();
                 let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
                 deployment.program().check_restricted_keywords_for_consensus_version(consensus_version)?;
-                // TODO (raychu86): Program Rules - Update the consensus height.
-                // Perform additional program checks if the consensus version is V6 or beyond.
-                if self.block_store().current_block_height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V6)? {
+                // Perform additional program checks if the consensus version is V7 or beyond.
+                if self.block_store().current_block_height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V7)? {
                     deployment.program().check_program_naming_structure()?;
                 }
                 // Verify the deployment if it has not been verified before.
@@ -1077,10 +1076,9 @@ function compute:
         assert!(vm.check_transaction(&deploy_3, None, rng).is_ok());
         assert!(vm.check_transaction(&deploy_4, None, rng).is_ok());
 
-        // TODO (raychu86): Update this to the proper consensus version used in the migration.
-        // Advance the ledger past ConsensusV6
+        // Advance the ledger past ConsensusVersion::V7
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
-        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V6).unwrap()
+        while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V7).unwrap()
         {
             // // Ensure that the deployments are valid.
             assert!(vm.check_transaction(&deploy_1, None, rng).is_ok());


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates adds 3 additional rules for programs:

1. The program ID must not contain the keyword "aleo" in the program name.
2. The record name must not contain the keyword "aleo".
3. Record names must not be prefixes of other record names.
4. Record entry names must not contain the keyword "aleo".


`ConsensusVersion::V7` was introduced as a migration path for the above rules. After migration, any deployment with a program that fails to follow any of these new rules will be aborted.

Note that `ConsensusVersion::V7` will be executed on mainnet before the other networks. Prior to the next release on canary and testnet, these version heights will be reevaluated to ensure that the heights align with the proper release schedules
