### PR TITLE
Clear cache on all `ConsenusVersion` changes

### DIFF
--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -405,8 +405,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Unpause the atomic writes, executing the ones queued from block insertion and finalization.
                 #[cfg(feature = "rocks")]
                 self.block_store().unpause_atomic_writes::<false>()?;
-                // If the block advances to `ConsensusVersion::V4`, clear the partial verification cache.
-                if N::CONSENSUS_HEIGHT(ConsensusVersion::V4).unwrap_or_default() == block.height() {
+                // If the block advances to a new consensus version, clear the partial verification cache.
+                if N::CONSENSUS_VERSION_HEIGHTS.iter().any(|(_, height)| height == &block.height()) {
                     self.partially_verified_transactions().write().clear();
                 }
                 Ok(())

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -406,6 +406,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 #[cfg(feature = "rocks")]
                 self.block_store().unpause_atomic_writes::<false>()?;
                 // If the block advances to a new consensus version, clear the partial verification cache.
+                // TODO: This may have performance implications if the version
+                // list grows large as it is in the hot path.
                 if N::CONSENSUS_VERSION_HEIGHTS.iter().any(|(_, height)| height == &block.height()) {
                     self.partially_verified_transactions().write().clear();
                 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR clears the `partially_verified_transactions` on all the `ConsenusVersion` changes rather than just `ConsenusVersion::V4`.

All `ConsenusVersion`s change consensus rules and regardless if it is transaction related or not, we clear the `partially_verified_transactions` out of abundance of caution. This will also prevent us from missing this step in the future for subsequent consensus versions.