### PR TITLE
[Perf] Cache the state root in the Query

### DIFF
--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::{Arc, OnceLock};
+
 use crate::QueryTrait;
 use console::{
     network::prelude::*,
@@ -23,7 +25,19 @@ use ledger_store::{BlockStorage, BlockStore};
 use synthesizer_program::Program;
 
 #[derive(Clone)]
-pub enum Query<N: Network, B: BlockStorage<N>> {
+pub struct Query<N: Network, B: BlockStorage<N>> {
+    target: QueryTarget<N, B>,
+    cached_state_root: Arc<OnceLock<N::StateRoot>>,
+}
+
+impl<N: Network, B: BlockStorage<N>> Query<N, B> {
+    pub fn new(target: QueryTarget<N, B>) -> Self {
+        Self { target, cached_state_root: Default::default() }
+    }
+}
+
+#[derive(Clone)]
+pub enum QueryTarget<N: Network, B: BlockStorage<N>> {
     /// The block store from the VM.
     VM(BlockStore<N, B>),
     /// The base URL of the node.
@@ -32,31 +46,31 @@ pub enum Query<N: Network, B: BlockStorage<N>> {
 
 impl<N: Network, B: BlockStorage<N>> From<BlockStore<N, B>> for Query<N, B> {
     fn from(block_store: BlockStore<N, B>) -> Self {
-        Self::VM(block_store)
+        Self::new(QueryTarget::VM(block_store))
     }
 }
 
 impl<N: Network, B: BlockStorage<N>> From<&BlockStore<N, B>> for Query<N, B> {
     fn from(block_store: &BlockStore<N, B>) -> Self {
-        Self::VM(block_store.clone())
+        Self::new(QueryTarget::VM(block_store.clone()))
     }
 }
 
 impl<N: Network, B: BlockStorage<N>> From<String> for Query<N, B> {
     fn from(url: String) -> Self {
-        Self::REST(url)
+        Self::new(QueryTarget::REST(url))
     }
 }
 
 impl<N: Network, B: BlockStorage<N>> From<&String> for Query<N, B> {
     fn from(url: &String) -> Self {
-        Self::REST(url.to_string())
+        Self::new(QueryTarget::REST(url.to_string()))
     }
 }
 
 impl<N: Network, B: BlockStorage<N>> From<&str> for Query<N, B> {
     fn from(url: &str) -> Self {
-        Self::REST(url.to_string())
+        Self::new(QueryTarget::REST(url.to_string()))
     }
 }
 
@@ -64,48 +78,65 @@ impl<N: Network, B: BlockStorage<N>> From<&str> for Query<N, B> {
 impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     /// Returns the current state root.
     fn current_state_root(&self) -> Result<N::StateRoot> {
-        match self {
-            Self::VM(block_store) => Ok(block_store.current_state_root()),
-            Self::REST(url) => match N::ID {
-                console::network::MainnetV0::ID => {
-                    Ok(Self::get_request(&format!("{url}/mainnet/stateRoot/latest"))?.into_json()?)
-                }
-                console::network::TestnetV0::ID => {
-                    Ok(Self::get_request(&format!("{url}/testnet/stateRoot/latest"))?.into_json()?)
-                }
-                console::network::CanaryV0::ID => {
-                    Ok(Self::get_request(&format!("{url}/canary/stateRoot/latest"))?.into_json()?)
-                }
-                _ => bail!("Unsupported network ID in inclusion query"),
-            },
+        if let Some(csr) = self.cached_state_root.get() {
+            return Ok(csr.clone());
+        }
+
+        match &self.target {
+            QueryTarget::VM(block_store) => {
+                let csr = block_store.current_state_root();
+                let _ = self.cached_state_root.set(csr.clone());
+                Ok(csr)
+            }
+            QueryTarget::REST(url) => {
+                let network = match N::ID {
+                    console::network::MainnetV0::ID => "mainnet",
+                    console::network::TestnetV0::ID => "testnet",
+                    console::network::CanaryV0::ID => "canary",
+                    _ => bail!("Unsupported network ID in inclusion query"),
+                };
+                let csr: N::StateRoot = Self::get_request(&format!("{url}/{network}/stateRoot/latest"))?.into_json()?;
+                let _ = self.cached_state_root.set(csr.clone());
+
+                Ok(csr)
+            }
         }
     }
 
     /// Returns the current state root.
     #[cfg(feature = "async")]
     async fn current_state_root_async(&self) -> Result<N::StateRoot> {
-        match self {
-            Self::VM(block_store) => Ok(block_store.current_state_root()),
-            Self::REST(url) => match N::ID {
-                console::network::MainnetV0::ID => {
-                    Ok(Self::get_request_async(&format!("{url}/mainnet/stateRoot/latest")).await?.json().await?)
-                }
-                console::network::TestnetV0::ID => {
-                    Ok(Self::get_request_async(&format!("{url}/testnet/stateRoot/latest")).await?.json().await?)
-                }
-                console::network::CanaryV0::ID => {
-                    Ok(Self::get_request_async(&format!("{url}/canary/stateRoot/latest")).await?.json().await?)
-                }
-                _ => bail!("Unsupported network ID in inclusion query"),
-            },
+        if let Some(csr) = self.cached_state_root.get() {
+            return Ok(csr.clone());
+        }
+
+        match &self.target {
+            QueryTarget::VM(block_store) => {
+                let csr = block_store.current_state_root();
+                let _ = self.cached_state_root.set(csr.clone());
+                Ok(csr)
+            }
+            QueryTarget::REST(url) => {
+                let network = match N::ID {
+                    console::network::MainnetV0::ID => "mainnet",
+                    console::network::TestnetV0::ID => "testnet",
+                    console::network::CanaryV0::ID => "canary",
+                    _ => bail!("Unsupported network ID in inclusion query"),
+                };
+                let csr: N::StateRoot =
+                    Self::get_request_async(&format!("{url}/{network}/stateRoot/latest")).await?.json().await?;
+                let _ = self.cached_state_root.set(csr.clone());
+
+                Ok(csr)
+            }
         }
     }
 
     /// Returns a state path for the given `commitment`.
     fn get_state_path_for_commitment(&self, commitment: &Field<N>) -> Result<StatePath<N>> {
-        match self {
-            Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
-            Self::REST(url) => match N::ID {
+        match &self.target {
+            QueryTarget::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
+            QueryTarget::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
                     Ok(Self::get_request(&format!("{url}/mainnet/statePath/{commitment}"))?.into_json()?)
                 }
@@ -123,9 +154,9 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     /// Returns a state path for the given `commitment`.
     #[cfg(feature = "async")]
     async fn get_state_path_for_commitment_async(&self, commitment: &Field<N>) -> Result<StatePath<N>> {
-        match self {
-            Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
-            Self::REST(url) => match N::ID {
+        match &self.target {
+            QueryTarget::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
+            QueryTarget::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
                     Ok(Self::get_request_async(&format!("{url}/mainnet/statePath/{commitment}")).await?.json().await?)
                 }
@@ -142,9 +173,9 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
 
     /// Returns a state path for the given `commitment`.
     fn current_block_height(&self) -> Result<u32> {
-        match self {
-            Self::VM(block_store) => Ok(block_store.max_height().unwrap_or_default()),
-            Self::REST(url) => match N::ID {
+        match &self.target {
+            QueryTarget::VM(block_store) => Ok(block_store.max_height().unwrap_or_default()),
+            QueryTarget::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
                     Ok(Self::get_request(&format!("{url}/mainnet/block/height/latest"))?.into_json()?)
                 }
@@ -162,9 +193,9 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     /// Returns a state path for the given `commitment`.
     #[cfg(feature = "async")]
     async fn current_block_height_async(&self) -> Result<u32> {
-        match self {
-            Self::VM(block_store) => Ok(block_store.max_height().unwrap_or_default()),
-            Self::REST(url) => match N::ID {
+        match &self.target {
+            QueryTarget::VM(block_store) => Ok(block_store.max_height().unwrap_or_default()),
+            QueryTarget::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
                     Ok(Self::get_request_async(&format!("{url}/mainnet/block/height/latest")).await?.json().await?)
                 }
@@ -183,11 +214,11 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
 impl<N: Network, B: BlockStorage<N>> Query<N, B> {
     /// Returns the program for the given program ID.
     pub fn get_program(&self, program_id: &ProgramID<N>) -> Result<Program<N>> {
-        match self {
-            Self::VM(block_store) => {
+        match &self.target {
+            QueryTarget::VM(block_store) => {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
             }
-            Self::REST(url) => match N::ID {
+            QueryTarget::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
                     Ok(Self::get_request(&format!("{url}/mainnet/program/{program_id}"))?.into_json()?)
                 }
@@ -205,11 +236,11 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
     /// Returns the program for the given program ID.
     #[cfg(feature = "async")]
     pub async fn get_program_async(&self, program_id: &ProgramID<N>) -> Result<Program<N>> {
-        match self {
-            Self::VM(block_store) => {
+        match &self.target {
+            QueryTarget::VM(block_store) => {
                 block_store.get_program(program_id)?.ok_or_else(|| anyhow!("Program {program_id} not found in storage"))
             }
-            Self::REST(url) => match N::ID {
+            QueryTarget::REST(url) => match N::ID {
                 console::network::MainnetV0::ID => {
                     Ok(Self::get_request_async(&format!("{url}/mainnet/program/{program_id}")).await?.json().await?)
                 }

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -83,13 +83,13 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     /// Returns the current state root.
     fn current_state_root(&self) -> Result<N::StateRoot> {
         if let Some(csr) = self.cached_state_root.get() {
-            return Ok(csr.clone());
+            return Ok(*csr);
         }
 
         match &self.target {
             QueryTarget::VM(block_store) => {
                 let csr = block_store.current_state_root();
-                let _ = self.cached_state_root.set(csr.clone());
+                let _ = self.cached_state_root.set(csr);
                 Ok(csr)
             }
             QueryTarget::REST(url) => {
@@ -100,7 +100,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                     _ => bail!("Unsupported network ID in inclusion query"),
                 };
                 let csr: N::StateRoot = Self::get_request(&format!("{url}/{network}/stateRoot/latest"))?.into_json()?;
-                let _ = self.cached_state_root.set(csr.clone());
+                let _ = self.cached_state_root.set(csr);
 
                 Ok(csr)
             }
@@ -111,13 +111,13 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     #[cfg(feature = "async")]
     async fn current_state_root_async(&self) -> Result<N::StateRoot> {
         if let Some(csr) = self.cached_state_root.get() {
-            return Ok(csr.clone());
+            return Ok(*csr);
         }
 
         match &self.target {
             QueryTarget::VM(block_store) => {
                 let csr = block_store.current_state_root();
-                let _ = self.cached_state_root.set(csr.clone());
+                let _ = self.cached_state_root.set(csr);
                 Ok(csr)
             }
             QueryTarget::REST(url) => {
@@ -129,7 +129,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 };
                 let csr: N::StateRoot =
                     Self::get_request_async(&format!("{url}/{network}/stateRoot/latest")).await?.json().await?;
-                let _ = self.cached_state_root.set(csr.clone());
+                let _ = self.cached_state_root.set(csr);
 
                 Ok(csr)
             }

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -34,6 +34,10 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
     pub fn new(target: QueryTarget<N, B>) -> Self {
         Self { target, cached_state_root: Default::default() }
     }
+
+    pub fn new_with_state_root(target: QueryTarget<N, B>, state_root: N::StateRoot) -> Self {
+        Self { target, cached_state_root: Arc::new(OnceLock::from(state_root)) }
+    }
 }
 
 #[derive(Clone)]

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -15,6 +15,8 @@
 
 #![allow(clippy::too_many_arguments)]
 
+use ledger_query::QueryTarget;
+
 use super::*;
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
@@ -46,7 +48,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let fee = match is_fee_required || is_priority_fee_declared {
             true => {
                 // Compute the minimum execution cost.
-                let query = query.clone().unwrap_or(Query::VM(self.block_store().clone()));
+                let query = query.clone().unwrap_or(Query::new(QueryTarget::VM(self.block_store().clone())));
                 let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
                 let (minimum_execution_cost, (_, _)) = if consensus_version == ConsensusVersion::V1 {
                     execution_cost_v1(&self.process().read(), &execution)?
@@ -150,7 +152,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Prepare the query.
         let query = match query {
             Some(query) => query,
-            None => Query::VM(self.block_store().clone()),
+            None => Query::new(QueryTarget::VM(self.block_store().clone())),
         };
         lap!(timer, "Prepare the query");
 
@@ -203,7 +205,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Prepare the query.
         let query = match query {
             Some(query) => query,
-            None => Query::VM(self.block_store().clone()),
+            None => Query::new(QueryTarget::VM(self.block_store().clone())),
         };
         lap!(timer, "Prepare the query");
 


### PR DESCRIPTION
A `Query` may currently look up the current state root more than once. This PR instead caches it and also allows a `Query` to be created with the given state root.