### PR TITLE
Create evaluate_commit and evaluate_hash.

### DIFF
--- a/circuit/program/src/data/literal/mod.rs
+++ b/circuit/program/src/data/literal/mod.rs
@@ -72,6 +72,31 @@ pub enum Literal<A: Aleo> {
     String(StringType<A>),
 }
 
+macro_rules! impl_from {
+    ($($name: ident)*) => {
+        $(
+            impl<A: Aleo> From<$name<A>> for Literal<A> {
+                fn from(value: $name<A>) -> Self {
+                    Literal::$name(value)
+                }
+            }
+        )*
+    };
+}
+
+impl_from! {
+    Address Boolean Field Group
+    I8 I16 I32 I64 I128
+    U8 U16 U32 U64 U128
+    Scalar
+}
+
+impl<A: Aleo> From<Signature<A>> for Literal<A> {
+    fn from(value: Signature<A>) -> Self {
+        Literal::Signature(Box::new(value))
+    }
+}
+
 #[cfg(feature = "console")]
 impl<A: Aleo> Inject for Literal<A> {
     type Primitive = console::Literal<A::Network>;

--- a/console/program/src/data/literal/mod.rs
+++ b/console/program/src/data/literal/mod.rs
@@ -73,3 +73,28 @@ pub enum Literal<N: Network> {
     /// The string type.
     String(StringType<N>),
 }
+
+macro_rules! impl_from {
+    ($($name: ident)*) => {
+        $(
+            impl<N: Network> From<$name<N>> for Literal<N> {
+                fn from(value: $name<N>) -> Self {
+                    Literal::$name(value)
+                }
+            }
+        )*
+    };
+}
+
+impl_from! {
+    Address Boolean Field Group
+    I8 I16 I32 I64 I128
+    U8 U16 U32 U64 U128
+    Scalar
+}
+
+impl<N: Network> From<Signature<N>> for Literal<N> {
+    fn from(value: Signature<N>) -> Self {
+        Literal::Signature(Box::new(value))
+    }
+}

--- a/synthesizer/program/src/logic/instruction/operation/commit.rs
+++ b/synthesizer/program/src/logic/instruction/operation/commit.rs
@@ -20,24 +20,25 @@ use crate::{
 };
 use console::{
     network::prelude::*,
-    program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
+    program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Scalar, Value},
 };
 
 /// BHP256 is a collision-resistant function that processes inputs in 256-bit chunks.
-pub type CommitBHP256<N> = CommitInstruction<N, { Committer::CommitBHP256 as u8 }>;
+pub type CommitBHP256<N> = CommitInstruction<N, { CommitVariant::CommitBHP256 as u8 }>;
 /// BHP512 is a collision-resistant function that processes inputs in 512-bit chunks.
-pub type CommitBHP512<N> = CommitInstruction<N, { Committer::CommitBHP512 as u8 }>;
+pub type CommitBHP512<N> = CommitInstruction<N, { CommitVariant::CommitBHP512 as u8 }>;
 /// BHP768 is a collision-resistant function that processes inputs in 768-bit chunks.
-pub type CommitBHP768<N> = CommitInstruction<N, { Committer::CommitBHP768 as u8 }>;
+pub type CommitBHP768<N> = CommitInstruction<N, { CommitVariant::CommitBHP768 as u8 }>;
 /// BHP1024 is a collision-resistant function that processes inputs in 1024-bit chunks.
-pub type CommitBHP1024<N> = CommitInstruction<N, { Committer::CommitBHP1024 as u8 }>;
+pub type CommitBHP1024<N> = CommitInstruction<N, { CommitVariant::CommitBHP1024 as u8 }>;
 
 /// Pedersen64 is a collision-resistant function that processes inputs in 64-bit chunks.
-pub type CommitPED64<N> = CommitInstruction<N, { Committer::CommitPED64 as u8 }>;
+pub type CommitPED64<N> = CommitInstruction<N, { CommitVariant::CommitPED64 as u8 }>;
 /// Pedersen128 is a collision-resistant function that processes inputs in 128-bit chunks.
-pub type CommitPED128<N> = CommitInstruction<N, { Committer::CommitPED128 as u8 }>;
+pub type CommitPED128<N> = CommitInstruction<N, { CommitVariant::CommitPED128 as u8 }>;
 
-enum Committer {
+/// Which commit function to use.
+pub enum CommitVariant {
     CommitBHP256,
     CommitBHP512,
     CommitBHP768,
@@ -110,6 +111,50 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     }
 }
 
+// This code is nearly identical in `execute` and `evaluate`; we
+// extract it here in a macro.
+//
+// The `$q` parameter allows us to wrap a value in `Result::Ok`, since
+// the `Aleo` functions don't return a `Result` but the `Network` ones do.
+macro_rules! docommit {
+    ($N: ident, $variant: expr, $destination_type: expr, $input: expr, $randomizer: expr, $ty: ty, $q: expr) => {{
+        let func = match $variant {
+            0 => $N::commit_to_group_bhp256,
+            1 => $N::commit_to_group_bhp512,
+            2 => $N::commit_to_group_bhp768,
+            3 => $N::commit_to_group_bhp1024,
+            4 => $N::commit_to_group_ped64,
+            5 => $N::commit_to_group_ped128,
+            6.. => bail!("Invalid 'commit' variant: {}", $variant),
+        };
+
+        let literal_output: $ty = $q(func(&$input.to_bits_le(), $randomizer))?.into();
+        literal_output.cast_lossy($destination_type)?
+    }};
+}
+
+/// Evaluate a commit operation.
+///
+/// This allows running the commit without the machinery of stacks and registers.
+/// This is necessary for the Leo interpeter.
+pub fn evaluate_commit<N: Network>(
+    variant: CommitVariant,
+    input: &Value<N>,
+    randomizer: &Scalar<N>,
+    destination_type: LiteralType,
+) -> Result<Literal<N>> {
+    evaluate_commit_private(variant as u8, input, randomizer, destination_type)
+}
+
+fn evaluate_commit_private<N: Network>(
+    variant: u8,
+    input: &Value<N>,
+    randomizer: &Scalar<N>,
+    destination_type: LiteralType,
+) -> Result<Literal<N>> {
+    Ok(docommit!(N, variant, destination_type, input, randomizer, Literal<N>, |x| x))
+}
+
 impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
     /// Evaluates the instruction.
     #[inline]
@@ -134,18 +179,8 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
             _ => bail!("Invalid randomizer type for the commit evaluation, expected a scalar"),
         };
 
-        // Commit the input.
-        let output = match VARIANT {
-            0 => Literal::Group(N::commit_to_group_bhp256(&input.to_bits_le(), &randomizer)?),
-            1 => Literal::Group(N::commit_to_group_bhp512(&input.to_bits_le(), &randomizer)?),
-            2 => Literal::Group(N::commit_to_group_bhp768(&input.to_bits_le(), &randomizer)?),
-            3 => Literal::Group(N::commit_to_group_bhp1024(&input.to_bits_le(), &randomizer)?),
-            4 => Literal::Group(N::commit_to_group_ped64(&input.to_bits_le(), &randomizer)?),
-            5 => Literal::Group(N::commit_to_group_ped128(&input.to_bits_le(), &randomizer)?),
-            6.. => bail!("Invalid 'commit' variant: {VARIANT}"),
-        };
-        // Cast the output to the destination type.
-        let output = output.cast_lossy(self.destination_type)?;
+        let output = evaluate_commit_private(VARIANT, &input, &randomizer, self.destination_type)?;
+
         // Store the output.
         registers.store(stack, &self.destination, Value::Plaintext(Plaintext::from(output)))
     }
@@ -177,17 +212,9 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
             _ => bail!("Invalid randomizer type for the commit execution, expected a scalar"),
         };
 
-        // Commits the input.
-        let output = match VARIANT {
-            0 => circuit::Literal::Group(A::commit_to_group_bhp256(&input.to_bits_le(), &randomizer)),
-            1 => circuit::Literal::Group(A::commit_to_group_bhp512(&input.to_bits_le(), &randomizer)),
-            2 => circuit::Literal::Group(A::commit_to_group_bhp768(&input.to_bits_le(), &randomizer)),
-            3 => circuit::Literal::Group(A::commit_to_group_bhp1024(&input.to_bits_le(), &randomizer)),
-            4 => circuit::Literal::Group(A::commit_to_group_ped64(&input.to_bits_le(), &randomizer)),
-            5 => circuit::Literal::Group(A::commit_to_group_ped128(&input.to_bits_le(), &randomizer)),
-            6.. => bail!("Invalid 'commit' variant: {VARIANT}"),
-        };
-        let output = output.cast_lossy(self.destination_type)?;
+        let output =
+            docommit!(A, VARIANT, self.destination_type, &input, &randomizer, circuit::Literal<A>, Result::<_>::Ok);
+
         // Convert the output to a stack value.
         let output = circuit::Value::Plaintext(circuit::Plaintext::Literal(output, Default::default()));
         // Store the output.

--- a/synthesizer/program/src/logic/instruction/operation/commit.rs
+++ b/synthesizer/program/src/logic/instruction/operation/commit.rs
@@ -143,10 +143,10 @@ pub fn evaluate_commit<N: Network>(
     randomizer: &Scalar<N>,
     destination_type: LiteralType,
 ) -> Result<Literal<N>> {
-    evaluate_commit_private(variant as u8, input, randomizer, destination_type)
+    evaluate_commit_internal(variant as u8, input, randomizer, destination_type)
 }
 
-fn evaluate_commit_private<N: Network>(
+fn evaluate_commit_internal<N: Network>(
     variant: u8,
     input: &Value<N>,
     randomizer: &Scalar<N>,
@@ -179,7 +179,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
             _ => bail!("Invalid randomizer type for the commit evaluation, expected a scalar"),
         };
 
-        let output = evaluate_commit_private(VARIANT, &input, &randomizer, self.destination_type)?;
+        let output = evaluate_commit_internal(VARIANT, &input, &randomizer, self.destination_type)?;
 
         // Store the output.
         registers.store(stack, &self.destination, Value::Plaintext(Plaintext::from(output)))

--- a/synthesizer/program/src/logic/instruction/operation/commit.rs
+++ b/synthesizer/program/src/logic/instruction/operation/commit.rs
@@ -116,7 +116,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
 //
 // The `$q` parameter allows us to wrap a value in `Result::Ok`, since
 // the `Aleo` functions don't return a `Result` but the `Network` ones do.
-macro_rules! docommit {
+macro_rules! do_commit {
     ($N: ident, $variant: expr, $destination_type: expr, $input: expr, $randomizer: expr, $ty: ty, $q: expr) => {{
         let func = match $variant {
             0 => $N::commit_to_group_bhp256,
@@ -152,7 +152,7 @@ fn evaluate_commit_private<N: Network>(
     randomizer: &Scalar<N>,
     destination_type: LiteralType,
 ) -> Result<Literal<N>> {
-    Ok(docommit!(N, variant, destination_type, input, randomizer, Literal<N>, |x| x))
+    Ok(do_commit!(N, variant, destination_type, input, randomizer, Literal<N>, |x| x))
 }
 
 impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
@@ -213,7 +213,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
         };
 
         let output =
-            docommit!(A, VARIANT, self.destination_type, &input, &randomizer, circuit::Literal<A>, Result::<_>::Ok);
+            do_commit!(A, VARIANT, self.destination_type, &input, &randomizer, circuit::Literal<A>, Result::<_>::Ok);
 
         // Convert the output to a stack value.
         let output = circuit::Value::Plaintext(circuit::Plaintext::Literal(output, Default::default()));

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -202,7 +202,7 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
 //
 // The `$q` parameter allows us to wrap a value in `Result::Ok`, since
 // the `Aleo` functions don't return a `Result` but the `Network` ones do.
-macro_rules! dohash {
+macro_rules! do_hash {
     ($N: ident, $variant: expr, $destination_type: expr, $input: expr, $ty: ty, $q: expr) => {{
         let bits = || $input.to_bits_le();
 
@@ -260,7 +260,7 @@ fn evaluate_hash_private<N: Network>(
     input: &Value<N>,
     destination_type: &PlaintextType<N>,
 ) -> Result<Literal<N>> {
-    Ok(dohash!(N, variant, destination_type, input, Literal<N>, |x| x))
+    Ok(do_hash!(N, variant, destination_type, input, Literal<N>, |x| x))
 }
 
 impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
@@ -302,7 +302,7 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
         // Load the operand.
         let input = registers.load_circuit(stack, &self.operands[0])?;
 
-        let output = dohash!(A, VARIANT, &self.destination_type, input, circuit::Literal<A>, Result::<_>::Ok);
+        let output = do_hash!(A, VARIANT, &self.destination_type, input, circuit::Literal<A>, Result::<_>::Ok);
 
         // Convert the output to a stack value.
         let output = circuit::Value::Plaintext(circuit::Plaintext::Literal(output, Default::default()));

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -24,48 +24,49 @@ use console::{
 };
 
 /// BHP256 is a collision-resistant hash function that processes inputs in 256-bit chunks.
-pub type HashBHP256<N> = HashInstruction<N, { Hasher::HashBHP256 as u8 }>;
+pub type HashBHP256<N> = HashInstruction<N, { HashVariant::HashBHP256 as u8 }>;
 /// BHP512 is a collision-resistant hash function that processes inputs in 512-bit chunks.
-pub type HashBHP512<N> = HashInstruction<N, { Hasher::HashBHP512 as u8 }>;
+pub type HashBHP512<N> = HashInstruction<N, { HashVariant::HashBHP512 as u8 }>;
 /// BHP768 is a collision-resistant hash function that processes inputs in 768-bit chunks.
-pub type HashBHP768<N> = HashInstruction<N, { Hasher::HashBHP768 as u8 }>;
+pub type HashBHP768<N> = HashInstruction<N, { HashVariant::HashBHP768 as u8 }>;
 /// BHP1024 is a collision-resistant hash function that processes inputs in 1024-bit chunks.
-pub type HashBHP1024<N> = HashInstruction<N, { Hasher::HashBHP1024 as u8 }>;
+pub type HashBHP1024<N> = HashInstruction<N, { HashVariant::HashBHP1024 as u8 }>;
 
 /// Keccak256 is a cryptographic hash function that outputs a 256-bit digest.
-pub type HashKeccak256<N> = HashInstruction<N, { Hasher::HashKeccak256 as u8 }>;
+pub type HashKeccak256<N> = HashInstruction<N, { HashVariant::HashKeccak256 as u8 }>;
 /// Keccak384 is a cryptographic hash function that outputs a 384-bit digest.
-pub type HashKeccak384<N> = HashInstruction<N, { Hasher::HashKeccak384 as u8 }>;
+pub type HashKeccak384<N> = HashInstruction<N, { HashVariant::HashKeccak384 as u8 }>;
 /// Keccak512 is a cryptographic hash function that outputs a 512-bit digest.
-pub type HashKeccak512<N> = HashInstruction<N, { Hasher::HashKeccak512 as u8 }>;
+pub type HashKeccak512<N> = HashInstruction<N, { HashVariant::HashKeccak512 as u8 }>;
 
 /// Pedersen64 is a collision-resistant hash function that processes inputs in 64-bit chunks.
-pub type HashPED64<N> = HashInstruction<N, { Hasher::HashPED64 as u8 }>;
+pub type HashPED64<N> = HashInstruction<N, { HashVariant::HashPED64 as u8 }>;
 /// Pedersen128 is a collision-resistant hash function that processes inputs in 128-bit chunks.
-pub type HashPED128<N> = HashInstruction<N, { Hasher::HashPED128 as u8 }>;
+pub type HashPED128<N> = HashInstruction<N, { HashVariant::HashPED128 as u8 }>;
 
 /// Poseidon2 is a cryptographic hash function that processes inputs in 2-field chunks.
-pub type HashPSD2<N> = HashInstruction<N, { Hasher::HashPSD2 as u8 }>;
+pub type HashPSD2<N> = HashInstruction<N, { HashVariant::HashPSD2 as u8 }>;
 /// Poseidon4 is a cryptographic hash function that processes inputs in 4-field chunks.
-pub type HashPSD4<N> = HashInstruction<N, { Hasher::HashPSD4 as u8 }>;
+pub type HashPSD4<N> = HashInstruction<N, { HashVariant::HashPSD4 as u8 }>;
 /// Poseidon8 is a cryptographic hash function that processes inputs in 8-field chunks.
-pub type HashPSD8<N> = HashInstruction<N, { Hasher::HashPSD8 as u8 }>;
+pub type HashPSD8<N> = HashInstruction<N, { HashVariant::HashPSD8 as u8 }>;
 
 /// SHA3-256 is a cryptographic hash function that outputs a 256-bit digest.
-pub type HashSha3_256<N> = HashInstruction<N, { Hasher::HashSha3_256 as u8 }>;
+pub type HashSha3_256<N> = HashInstruction<N, { HashVariant::HashSha3_256 as u8 }>;
 /// SHA3-384 is a cryptographic hash function that outputs a 384-bit digest.
-pub type HashSha3_384<N> = HashInstruction<N, { Hasher::HashSha3_384 as u8 }>;
+pub type HashSha3_384<N> = HashInstruction<N, { HashVariant::HashSha3_384 as u8 }>;
 /// SHA3-512 is a cryptographic hash function that outputs a 512-bit digest.
-pub type HashSha3_512<N> = HashInstruction<N, { Hasher::HashSha3_512 as u8 }>;
+pub type HashSha3_512<N> = HashInstruction<N, { HashVariant::HashSha3_512 as u8 }>;
 
 /// Poseidon2 is a cryptographic hash function that processes inputs in 2-field chunks.
-pub type HashManyPSD2<N> = HashInstruction<N, { Hasher::HashManyPSD2 as u8 }>;
+pub type HashManyPSD2<N> = HashInstruction<N, { HashVariant::HashManyPSD2 as u8 }>;
 /// Poseidon4 is a cryptographic hash function that processes inputs in 4-field chunks.
-pub type HashManyPSD4<N> = HashInstruction<N, { Hasher::HashManyPSD4 as u8 }>;
+pub type HashManyPSD4<N> = HashInstruction<N, { HashVariant::HashManyPSD4 as u8 }>;
 /// Poseidon8 is a cryptographic hash function that processes inputs in 8-field chunks.
-pub type HashManyPSD8<N> = HashInstruction<N, { Hasher::HashManyPSD8 as u8 }>;
+pub type HashManyPSD8<N> = HashInstruction<N, { HashVariant::HashManyPSD8 as u8 }>;
 
-enum Hasher {
+/// Which hash function to use.
+pub enum HashVariant {
     HashBHP256,
     HashBHP512,
     HashBHP768,
@@ -196,6 +197,72 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     }
 }
 
+// This code is nearly identical in `execute` and `evaluate`; we
+// extract it here in a macro.
+//
+// The `$q` parameter allows us to wrap a value in `Result::Ok`, since
+// the `Aleo` functions don't return a `Result` but the `Network` ones do.
+macro_rules! dohash {
+    ($N: ident, $variant: expr, $destination_type: expr, $input: expr, $ty: ty, $q: expr) => {{
+        let bits = || $input.to_bits_le();
+
+        let fields = || $q($input.to_fields());
+
+        let literal_type = match $destination_type {
+            PlaintextType::Literal(literal_type) => *literal_type,
+            PlaintextType::Struct(..) => bail!("Cannot hash into a struct"),
+            PlaintextType::Array(..) => bail!("Cannot hash into an array (yet)"),
+        };
+
+        let literal_output: $ty = match ($variant, literal_type) {
+            (0, _) => $q($N::hash_to_group_bhp256(&bits()))?.into(),
+            (1, _) => $q($N::hash_to_group_bhp512(&bits()))?.into(),
+            (2, _) => $q($N::hash_to_group_bhp768(&bits()))?.into(),
+            (3, _) => $q($N::hash_to_group_bhp1024(&bits()))?.into(),
+            (4, _) => $q($N::hash_to_group_bhp256(&$q($N::hash_keccak256(&bits()))?))?.into(),
+            (5, _) => $q($N::hash_to_group_bhp512(&$q($N::hash_keccak384(&bits()))?))?.into(),
+            (6, _) => $q($N::hash_to_group_bhp512(&$q($N::hash_keccak512(&bits()))?))?.into(),
+            (7, _) => $q($N::hash_to_group_ped64(&bits()))?.into(),
+            (8, _) => $q($N::hash_to_group_ped128(&bits()))?.into(),
+            (9, LiteralType::Address | LiteralType::Group) => $q($N::hash_to_group_psd2(&fields()?))?.into(),
+            (9, _) => $q($N::hash_psd2(&fields()?))?.into(),
+            (10, LiteralType::Address | LiteralType::Group) => $q($N::hash_to_group_psd4(&fields()?))?.into(),
+            (10, _) => $q($N::hash_psd4(&fields()?))?.into(),
+            (11, LiteralType::Address | LiteralType::Group) => $q($N::hash_to_group_psd8(&fields()?))?.into(),
+            (11, _) => $q($N::hash_psd8(&fields()?))?.into(),
+            (12, _) => $q($N::hash_to_group_bhp256(&$q($N::hash_sha3_256(&bits()))?))?.into(),
+            (13, _) => $q($N::hash_to_group_bhp512(&$q($N::hash_sha3_384(&bits()))?))?.into(),
+            (14, _) => $q($N::hash_to_group_bhp512(&$q($N::hash_sha3_512(&bits()))?))?.into(),
+            (15, _) => bail!("'hash_many.psd2' is not yet implemented"),
+            (16, _) => bail!("'hash_many.psd4' is not yet implemented"),
+            (17, _) => bail!("'hash_many.psd8' is not yet implemented"),
+            (18.., _) => bail!("Invalid 'hash' variant: {}", $variant),
+        };
+
+        literal_output.cast_lossy(literal_type)?
+    }};
+}
+
+/// Evaluate a hash operation.
+///
+/// This allows running the hash without the machinery of stacks and registers.
+/// This is necessary for the Leo interpeter.
+pub fn evaluate_hash<N: Network>(
+    variant: HashVariant,
+    input: &Value<N>,
+    destination_type: &PlaintextType<N>,
+) -> Result<Literal<N>> {
+    evaluate_hash_private(variant as u8, input, destination_type)
+}
+
+fn evaluate_hash_private<N: Network>(
+    variant: u8,
+    input: &Value<N>,
+    destination_type: &PlaintextType<N>,
+) -> Result<Literal<N>> {
+    Ok(dohash!(N, variant, destination_type, input, Literal<N>, |x| x))
+}
+
 impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
     /// Evaluates the instruction.
     #[inline]
@@ -211,57 +278,9 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
 
         // Load the operand.
         let input = registers.load(stack, &self.operands[0])?;
-        // Hash the input.
-        let output = match (VARIANT, &self.destination_type) {
-            (0, PlaintextType::Literal(..)) => Literal::Group(N::hash_to_group_bhp256(&input.to_bits_le())?),
-            (1, PlaintextType::Literal(..)) => Literal::Group(N::hash_to_group_bhp512(&input.to_bits_le())?),
-            (2, PlaintextType::Literal(..)) => Literal::Group(N::hash_to_group_bhp768(&input.to_bits_le())?),
-            (3, PlaintextType::Literal(..)) => Literal::Group(N::hash_to_group_bhp1024(&input.to_bits_le())?),
-            (4, PlaintextType::Literal(..)) => {
-                Literal::Group(N::hash_to_group_bhp256(&N::hash_keccak256(&input.to_bits_le())?)?)
-            }
-            (5, PlaintextType::Literal(..)) => {
-                Literal::Group(N::hash_to_group_bhp512(&N::hash_keccak384(&input.to_bits_le())?)?)
-            }
-            (6, PlaintextType::Literal(..)) => {
-                Literal::Group(N::hash_to_group_bhp512(&N::hash_keccak512(&input.to_bits_le())?)?)
-            }
-            (7, PlaintextType::Literal(..)) => Literal::Group(N::hash_to_group_ped64(&input.to_bits_le())?),
-            (8, PlaintextType::Literal(..)) => Literal::Group(N::hash_to_group_ped128(&input.to_bits_le())?),
-            (9, PlaintextType::Literal(LiteralType::Address)) | (9, PlaintextType::Literal(LiteralType::Group)) => {
-                Literal::Group(N::hash_to_group_psd2(&input.to_fields()?)?)
-            }
-            (9, PlaintextType::Literal(..)) => Literal::Field(N::hash_psd2(&input.to_fields()?)?),
-            (10, PlaintextType::Literal(LiteralType::Address)) | (10, PlaintextType::Literal(LiteralType::Group)) => {
-                Literal::Group(N::hash_to_group_psd4(&input.to_fields()?)?)
-            }
-            (10, PlaintextType::Literal(..)) => Literal::Field(N::hash_psd4(&input.to_fields()?)?),
-            (11, PlaintextType::Literal(LiteralType::Address)) | (11, PlaintextType::Literal(LiteralType::Group)) => {
-                Literal::Group(N::hash_to_group_psd8(&input.to_fields()?)?)
-            }
-            (11, PlaintextType::Literal(..)) => Literal::Field(N::hash_psd8(&input.to_fields()?)?),
-            (12, PlaintextType::Literal(..)) => {
-                Literal::Group(N::hash_to_group_bhp256(&N::hash_sha3_256(&input.to_bits_le())?)?)
-            }
-            (13, PlaintextType::Literal(..)) => {
-                Literal::Group(N::hash_to_group_bhp512(&N::hash_sha3_384(&input.to_bits_le())?)?)
-            }
-            (14, PlaintextType::Literal(..)) => {
-                Literal::Group(N::hash_to_group_bhp512(&N::hash_sha3_512(&input.to_bits_le())?)?)
-            }
-            (15, _) => bail!("'hash_many.psd2' is not yet implemented"),
-            (16, _) => bail!("'hash_many.psd4' is not yet implemented"),
-            (17, _) => bail!("'hash_many.psd8' is not yet implemented"),
-            (18.., _) => bail!("Invalid 'hash' variant: {VARIANT}"),
-            (_, PlaintextType::Struct(..)) => bail!("Cannot hash into a struct"),
-            (_, PlaintextType::Array(..)) => bail!("Cannot hash into an array (yet)"),
-        };
-        // Cast the output to the destination type.
-        let output = match self.destination_type {
-            PlaintextType::Literal(literal_type) => output.cast_lossy(literal_type)?,
-            PlaintextType::Struct(..) => bail!("Cannot hash into a struct"),
-            PlaintextType::Array(..) => bail!("Cannot hash into an array (yet)"),
-        };
+
+        let output = evaluate_hash_private(VARIANT, &input, &self.destination_type)?;
+
         // Store the output.
         registers.store(stack, &self.destination, Value::Plaintext(Plaintext::from(output)))
     }
@@ -282,57 +301,9 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
 
         // Load the operand.
         let input = registers.load_circuit(stack, &self.operands[0])?;
-        // Hash the input.
-        let output = match (VARIANT, &self.destination_type) {
-            (0, PlaintextType::Literal(..)) => circuit::Literal::Group(A::hash_to_group_bhp256(&input.to_bits_le())),
-            (1, PlaintextType::Literal(..)) => circuit::Literal::Group(A::hash_to_group_bhp512(&input.to_bits_le())),
-            (2, PlaintextType::Literal(..)) => circuit::Literal::Group(A::hash_to_group_bhp768(&input.to_bits_le())),
-            (3, PlaintextType::Literal(..)) => circuit::Literal::Group(A::hash_to_group_bhp1024(&input.to_bits_le())),
-            (4, PlaintextType::Literal(..)) => {
-                circuit::Literal::Group(A::hash_to_group_bhp256(&A::hash_keccak256(&input.to_bits_le())))
-            }
-            (5, PlaintextType::Literal(..)) => {
-                circuit::Literal::Group(A::hash_to_group_bhp512(&A::hash_keccak384(&input.to_bits_le())))
-            }
-            (6, PlaintextType::Literal(..)) => {
-                circuit::Literal::Group(A::hash_to_group_bhp512(&A::hash_keccak512(&input.to_bits_le())))
-            }
-            (7, PlaintextType::Literal(..)) => circuit::Literal::Group(A::hash_to_group_ped64(&input.to_bits_le())),
-            (8, PlaintextType::Literal(..)) => circuit::Literal::Group(A::hash_to_group_ped128(&input.to_bits_le())),
-            (9, PlaintextType::Literal(LiteralType::Address)) | (9, PlaintextType::Literal(LiteralType::Group)) => {
-                circuit::Literal::Group(A::hash_to_group_psd2(&input.to_fields()))
-            }
-            (9, PlaintextType::Literal(..)) => circuit::Literal::Field(A::hash_psd2(&input.to_fields())),
-            (10, PlaintextType::Literal(LiteralType::Address)) | (10, PlaintextType::Literal(LiteralType::Group)) => {
-                circuit::Literal::Group(A::hash_to_group_psd4(&input.to_fields()))
-            }
-            (10, PlaintextType::Literal(..)) => circuit::Literal::Field(A::hash_psd4(&input.to_fields())),
-            (11, PlaintextType::Literal(LiteralType::Address)) | (11, PlaintextType::Literal(LiteralType::Group)) => {
-                circuit::Literal::Group(A::hash_to_group_psd8(&input.to_fields()))
-            }
-            (11, PlaintextType::Literal(..)) => circuit::Literal::Field(A::hash_psd8(&input.to_fields())),
-            (12, PlaintextType::Literal(..)) => {
-                circuit::Literal::Group(A::hash_to_group_bhp256(&A::hash_sha3_256(&input.to_bits_le())))
-            }
-            (13, PlaintextType::Literal(..)) => {
-                circuit::Literal::Group(A::hash_to_group_bhp512(&A::hash_sha3_384(&input.to_bits_le())))
-            }
-            (14, PlaintextType::Literal(..)) => {
-                circuit::Literal::Group(A::hash_to_group_bhp512(&A::hash_sha3_512(&input.to_bits_le())))
-            }
-            (15, _) => bail!("'hash_many.psd2' is not yet implemented"),
-            (16, _) => bail!("'hash_many.psd4' is not yet implemented"),
-            (17, _) => bail!("'hash_many.psd8' is not yet implemented"),
-            (18.., _) => bail!("Invalid 'hash' variant: {VARIANT}"),
-            (_, PlaintextType::Struct(..)) => bail!("Cannot hash into a struct"),
-            (_, PlaintextType::Array(..)) => bail!("Cannot hash into an array (yet)"),
-        };
-        // Cast the output to the destination type.
-        let output = match self.destination_type {
-            PlaintextType::Literal(literal_type) => output.cast_lossy(literal_type)?,
-            PlaintextType::Struct(..) => bail!("Cannot hash into a struct"),
-            PlaintextType::Array(..) => bail!("Cannot hash into an array (yet)"),
-        };
+
+        let output = dohash!(A, VARIANT, &self.destination_type, input, circuit::Literal<A>, Result::<_>::Ok);
+
         // Convert the output to a stack value.
         let output = circuit::Value::Plaintext(circuit::Plaintext::Literal(output, Default::default()));
         // Store the output.

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -252,10 +252,10 @@ pub fn evaluate_hash<N: Network>(
     input: &Value<N>,
     destination_type: &PlaintextType<N>,
 ) -> Result<Literal<N>> {
-    evaluate_hash_private(variant as u8, input, destination_type)
+    evaluate_hash_internal(variant as u8, input, destination_type)
 }
 
-fn evaluate_hash_private<N: Network>(
+fn evaluate_hash_internal<N: Network>(
     variant: u8,
     input: &Value<N>,
     destination_type: &PlaintextType<N>,
@@ -279,7 +279,7 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
         // Load the operand.
         let input = registers.load(stack, &self.operands[0])?;
 
-        let output = evaluate_hash_private(VARIANT, &input, &self.destination_type)?;
+        let output = evaluate_hash_internal(VARIANT, &input, &self.destination_type)?;
 
         // Store the output.
         registers.store(stack, &self.destination, Value::Plaintext(Plaintext::from(output)))


### PR DESCRIPTION
The primary purpose is to create evaluate_commit and evaluate_hash functions which allow evaluating commits and hashes without the full Aleo machinery of stacks and registers. This is for the Leo interpreter to call to make sure its hash and commit results are identical to those in snarkVM.

CommitVariant and HashVariant (formerly Committer and Hasher) are now public, as evaluate_commit and evaluate_hash need to accept a parameter specifying which variant to use.

As long as I was making largish changes to operation/commit.rs and operation/hash.rs ...

A secondary purpose was to extract out a common implementation of evaluate and execute instead of the copy+pasted duplication that exists currently. This is done through a combination of traits (see HashCore and CommitCore) and macros (see define_run_hash, define_run_commit, and define_evaluate_or_execute) because the Network and Aleo traits are not written to allow easily abstracting their common functionality into a trait without a decent bit of shim code. The implementation is split into two parts (`run_hash` or `run_commit` plus evaluate_or_execute) because the new evaluate_commit and evaluate_hash functions need the functionality without registers and stacks on its own.

A tertiary purpose was to replace the VARIANT u8
generic parameter of CommitInstruction and HashInstruction with a type parameter constrained by a sealed trait. This better exploits the type system to express the intent: the type parameters via the trait CommitVariantTag or HashVariantTag now directly correspond to variants of CommitVariant or HashVariant, and only valid values of this parameter exist, unlike with the u8 VARIANT where the connection is arbitrary and must constantly be matched against and checked for invalid values.

I also added missing `From<V>` implementations for the console and circuit versions of Literal, which allows much briefer code (see all the `.into()` in `define_run_hash`).