### PR TITLE
[Fix] Return unconfirmed transaction from fee ID

### DIFF
--- a/ledger/block/src/transactions/confirmed/mod.rs
+++ b/ledger/block/src/transactions/confirmed/mod.rs
@@ -151,6 +151,12 @@ impl<N: Network> ConfirmedTransaction<N> {
     }
 
     /// Returns a new instance of a rejected execute transaction.
+    ///
+    /// Arguments:
+    /// - `index`: The index of the tranaction within the block.
+    /// - `transaction`: The associated fee transaction.
+    /// - `rejected`: The rejected execute transaction.
+    /// - `finalize_operations`: The finalize operations for the fee transaction.
     pub fn rejected_execute(
         index: u32,
         transaction: Transaction<N>,
@@ -222,7 +228,10 @@ impl<N: Network> ConfirmedTransaction<N> {
         }
     }
 
-    /// Returns the transaction.
+    /// Returns the underlying transaction.
+    ///
+    /// For an accepted transaction, it is the original/unconfirmed transaction issued by the client.
+    /// For a rejected transaction, it is the fee transaction, not the original transaction.
     pub const fn transaction(&self) -> &Transaction<N> {
         match self {
             Self::AcceptedDeploy(_, transaction, _) => transaction,

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -48,6 +48,7 @@ use indexmap::IndexMap;
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 
+/// The set of transactions included in a block.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Transactions<N: Network> {
     /// The transactions included in a block.
@@ -134,8 +135,27 @@ impl<N: Network> Transactions<N> {
     }
 
     /// Returns the transaction with the given transition ID, if it exists.
+    ///
+    /// If the given transition ID is a fee transition for a rejected transaction,
+    /// this will return the fee transaction.
     pub fn find_transaction_for_transition_id(&self, transition_id: &N::TransitionID) -> Option<&Transaction<N>> {
         cfg_find!(self.transactions, transition_id, contains_transition).map(|tx| tx.transaction())
+    }
+
+    /// Returns the unconfirmed transaction with the given transition ID, if it exists.
+    ///
+    /// If the given transition ID is a fee transition for a rejected transaction,
+    /// this will return the original/unconfirmed transaction, not the fee transaction.
+    pub fn find_unconfirmed_transaction_for_transition_id(
+        &self,
+        transition_id: &N::TransitionID,
+    ) -> Result<Option<Transaction<N>>> {
+        let result = cfg_find!(self.transactions, transition_id, contains_transition);
+
+        match result {
+            Some(txn) => Ok(Some(txn.to_unconfirmed_transaction()?)),
+            None => Ok(None),
+        }
     }
 
     /// Returns the transaction with the given serial number, if it exists.

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -881,7 +881,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         }
     }
 
-    /// Returns the transaction for the given `transaction ID`.
+    /// Returns the transaction for the given `TransactionID`.
     fn get_transaction(&self, transaction_id: &N::TransactionID) -> Result<Option<Transaction<N>>> {
         // Check if the transaction was rejected or aborted.
         // Note: We can only retrieve accepted or rejected transactions. We cannot retrieve aborted transactions.
@@ -925,7 +925,11 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         to_confirmed_transaction(confirmed_type, transaction, finalize_operations).map(Some)
     }
 
-    /// Returns the unconfirmed transaction for the given `transaction ID`.
+    /// Get the unconfirmed transaction for the given `TransactionID`.
+    ///
+    /// For unconfirmed and accepted transactions, this will return original transaction issued by the client.
+    /// This function also returns the original execution/deployment for a rejected transaction,
+    /// even when the given `TransactionID` is of a fee transaction.
     fn get_unconfirmed_transaction(&self, transaction_id: &N::TransactionID) -> Result<Option<Transaction<N>>> {
         // Check if the transaction was rejected or aborted.
         // Note: We can only retrieve accepted or rejected transactions. We cannot retrieve aborted transactions.
@@ -939,7 +943,26 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
                 }
                 None => bail!("Missing transactions for block '{block_hash}' in block storage"),
             },
-            None => self.transaction_store().get_transaction(transaction_id),
+            None => {
+                let Some(txn) = self.transaction_store().get_transaction(transaction_id)? else {
+                    return Ok(None);
+                };
+
+                // If the transaction is a fee transaction, return the original execution/deployment instead.
+                if let Transaction::Fee(_, fee) = txn {
+                    // Look up the original transaction in its block.
+                    let Some(block_hash) = self.find_block_hash(transaction_id)? else {
+                        bail!("Missing fee transaction '{transaction_id}' in block storage");
+                    };
+
+                    match self.get_block_transactions(&block_hash)? {
+                        Some(transactions) => transactions.find_unconfirmed_transaction_for_transition_id(fee.id()),
+                        None => bail!("Missing transactions for block '{block_hash}' in block storage"),
+                    }
+                } else {
+                    Ok(Some(txn))
+                }
+            }
         }
     }
 
@@ -1264,6 +1287,8 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     }
 
     /// Returns the transaction for the given `transaction ID`.
+    ///
+    /// For a rejected transaction, this returns the fee transaction, not the original/unconfirmed one.
     pub fn get_transaction(&self, transaction_id: &N::TransactionID) -> Result<Option<Transaction<N>>> {
         self.storage.get_transaction(transaction_id)
     }
@@ -1277,6 +1302,8 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     }
 
     /// Returns the unconfirmed transaction for the given `transaction ID`.
+    ///
+    /// For a rejected transaction, this returns the origin transaction issued by the user, not the fee transaction.
     pub fn get_unconfirmed_transaction(&self, transaction_id: &N::TransactionID) -> Result<Option<Transaction<N>>> {
         self.storage.get_unconfirmed_transaction(transaction_id)
     }
@@ -1513,5 +1540,60 @@ mod tests {
                 confirmed.to_unconfirmed_transaction().unwrap()
             );
         }
+    }
+
+    /// Test that we can look up a rejected transaction using the fee transaction ID.
+    #[test]
+    fn test_rejected_transaction() {
+        let rng = &mut TestRng::default();
+
+        let private_key = ledger_test_helpers::sample_genesis_private_key(rng);
+
+        let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
+
+        let fee = ledger_test_helpers::sample_fee_public_transaction(rng);
+        let rejected = ledger_test_helpers::sample_rejected_execution(false, rng);
+        let transactions =
+            Transactions::from_iter([
+                ConfirmedTransaction::rejected_execute(0, fee.clone(), rejected.clone(), vec![]).unwrap()
+            ]);
+        let ratifications = Ratifications::try_from(vec![]).unwrap();
+
+        let header = Header::genesis(&ratifications, &transactions, vec![]).unwrap();
+        let previous_hash = <CurrentNetwork as Network>::BlockHash::default();
+
+        let fee_id = fee.id();
+        let unconfirmed_id = rejected.to_unconfirmed_id(&fee.fee_transition()).unwrap().into();
+
+        // Construct the block.
+        let block = Block::new_beacon(
+            &private_key,
+            previous_hash,
+            header,
+            ratifications,
+            None.into(),
+            vec![],
+            transactions,
+            vec![unconfirmed_id],
+            rng,
+        )
+        .unwrap();
+
+        block_store.insert(&block).unwrap();
+
+        let txn1 = block_store.get_unconfirmed_transaction(&unconfirmed_id).unwrap().unwrap();
+        let txn2 = block_store.get_unconfirmed_transaction(&fee_id).unwrap().unwrap();
+
+        // Ensure the execute transaction is returned in both cases.
+        assert!(matches!(txn2, Transaction::Execute(..)));
+        assert_eq!(txn1, txn2);
+
+        let txn3 = block_store.get_transaction(&unconfirmed_id).unwrap().unwrap();
+        let txn4 = block_store.get_transaction(&fee_id).unwrap().unwrap();
+
+        // For get_transaction the Fee must be returned in both cases.
+        assert!(matches!(txn3, Transaction::Fee(..)));
+        assert_ne!(txn1, txn3);
+        assert_eq!(txn3, txn4);
     }
 }

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -498,12 +498,20 @@ pub fn sample_genesis_block_and_components(
     INSTANCE.get_or_init(|| crate::sample_genesis_block_and_components_raw(rng)).clone()
 }
 
+pub fn sample_genesis_private_key(rng: &mut TestRng) -> PrivateKey<CurrentNetwork> {
+    static INSTANCE: OnceCell<PrivateKey<CurrentNetwork>> = OnceCell::new();
+    *INSTANCE.get_or_init(|| {
+        // Initialize a new caller.
+        PrivateKey::<CurrentNetwork>::new(rng).unwrap()
+    })
+}
+
 /// Samples a random genesis block, the transaction from the genesis block, and the genesis private key.
 fn sample_genesis_block_and_components_raw(
     rng: &mut TestRng,
 ) -> (Block<CurrentNetwork>, Transaction<CurrentNetwork>, PrivateKey<CurrentNetwork>) {
     // Sample the genesis private key.
-    let private_key = PrivateKey::new(rng).unwrap();
+    let private_key = sample_genesis_private_key(rng);
     let address = Address::<CurrentNetwork>::try_from(private_key).unwrap();
 
     // Prepare the locator.


### PR DESCRIPTION
When given the transaction ID of a fee txn, `BlockStorage::get_unconfirmed_transaction` would not actually return the original/unconfirmed transaction but the free transaction.

This PR changes `BlockStorage` to behave as intended.