### PR TITLE
[ARC-0046] Staking for Puzzle Solution Submissions

### DIFF
--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -234,7 +234,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                         let prover_address = solution.address();
                         let num_accepted_solutions = accepted_solutions.get(&prover_address).copied().unwrap_or(0);
                         // Determine the the prover has reached their solution limit.
-                        if self.has_reached_solution_limit(&prover_address, num_accepted_solutions) {
+                        if self.is_solution_limit_reached(&prover_address, num_accepted_solutions) {
                             return false;
                         }
                         // Check if the solution is valid.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -117,7 +117,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             *self.current_committee.write() = Some(current_committee);
         }
 
-        // If the block is the start of a new epoch, or the epoch hash has not been set, update the current epoch hash.
+        // If the block is the start of a new epoch, or the epoch hash has not been set,
+        // update the current epoch hash and clear the epoch prover cache.
         if block.height() % N::NUM_BLOCKS_PER_EPOCH == 0 || self.current_epoch_hash.read().is_none() {
             // Update and log the current epoch hash.
             match self.get_epoch_hash(block.height()).ok() {
@@ -127,6 +128,16 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 }
                 None => {
                     error!("Failed to update the current epoch hash at block {}", block.height());
+                }
+            }
+            // Clear the epoch provers cache.
+            self.epoch_provers_cache.write().clear();
+        } else {
+            // If the block is not part of a new epoch, add the new provers to the epoch prover cache.
+            if let Some(solutions) = block.solutions().as_deref() {
+                let mut epoch_provers_cache = self.epoch_provers_cache.write();
+                for (_, s) in solutions.iter() {
+                    let _ = *epoch_provers_cache.entry(s.address()).and_modify(|e| *e += 1).or_insert(1);
                 }
             }
         }
@@ -139,11 +150,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 pub fn split_candidate_solutions<T, F>(
     mut candidate_solutions: Vec<T>,
     max_solutions: usize,
-    verification_fn: F,
+    mut verification_fn: F,
 ) -> (Vec<T>, Vec<T>)
 where
     T: Sized + Copy,
-    F: Fn(&mut T) -> bool,
+    F: FnMut(&mut T) -> bool,
 {
     // Separate the candidate solutions into valid and aborted solutions.
     let mut valid_candidate_solutions = Vec::with_capacity(max_solutions);
@@ -217,9 +228,23 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 // Retrieve the latest proof target.
                 let latest_proof_target = self.latest_proof_target();
                 // Separate the candidate solutions into valid and aborted solutions.
+                let mut accepted_solutions: IndexMap<Address<N>, u64> = IndexMap::new();
                 let (valid_candidate_solutions, aborted_candidate_solutions) =
                     split_candidate_solutions(candidate_solutions, N::MAX_SOLUTIONS, |solution| {
-                        self.puzzle().check_solution_mut(solution, latest_epoch_hash, latest_proof_target).is_ok()
+                        let prover_address = solution.address();
+                        let num_accepted_solutions = accepted_solutions.get(&prover_address).copied().unwrap_or(0);
+                        // Determine the the prover has reached their solution limit.
+                        if self.has_reached_solution_limit(&prover_address, num_accepted_solutions) {
+                            return false;
+                        }
+                        // Check if the solution is valid.
+                        let is_valid =
+                            self.puzzle().check_solution_mut(solution, latest_epoch_hash, latest_proof_target).is_ok();
+                        // Add the solution to the accepted solutions if it is valid.
+                        if is_valid {
+                            *accepted_solutions.entry(prover_address).or_insert(0) += 1;
+                        }
+                        is_valid
                     });
 
                 // Check if there are any valid solutions.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -233,18 +233,20 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                     split_candidate_solutions(candidate_solutions, N::MAX_SOLUTIONS, |solution| {
                         let prover_address = solution.address();
                         let num_accepted_solutions = accepted_solutions.get(&prover_address).copied().unwrap_or(0);
-                        // Determine the the prover has reached their solution limit.
+                        // Check if the prover has reached their solution limit.
                         if self.is_solution_limit_reached(&prover_address, num_accepted_solutions) {
                             return false;
                         }
-                        // Check if the solution is valid.
-                        let is_valid =
-                            self.puzzle().check_solution_mut(solution, latest_epoch_hash, latest_proof_target).is_ok();
-                        // Add the solution to the accepted solutions if it is valid.
-                        if is_valid {
-                            *accepted_solutions.entry(prover_address).or_insert(0) += 1;
+                        // Check if the solution is valid and update the number of accepted solutions.
+                        match self.puzzle().check_solution_mut(solution, latest_epoch_hash, latest_proof_target) {
+                            // Increment the number of accepted solutions for the prover.
+                            Ok(()) => {
+                                *accepted_solutions.entry(prover_address).or_insert(0) += 1;
+                                true
+                            }
+                            // The solution is invalid, so we do not increment the number of accepted solutions.
+                            Err(_) => false,
                         }
-                        is_valid
                     });
 
                 // Check if there are any valid solutions.

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -116,7 +116,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 let prover_address = solution.address();
                 let num_accepted_solutions = *accepted_solutions.get(&prover_address).unwrap_or(&0);
                 // Check if the prover has reached their solution limit.
-                if self.has_reached_solution_limit(&prover_address, num_accepted_solutions) {
+                if self.is_solution_limit_reached(&prover_address, num_accepted_solutions) {
                     bail!("Prover '{prover_address}' has reached their solution limit for the current epoch");
                 }
                 // Track the already accepted solutions.

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -109,6 +109,21 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             ratified_finalize_operations,
         )?;
 
+        // Ensure that the provers are within their stake bounds.
+        if let Some(solutions) = block.solutions().deref() {
+            let mut accepted_solutions: IndexMap<Address<N>, u64> = IndexMap::new();
+            for solution in solutions.values() {
+                let prover_address = solution.address();
+                let num_accepted_solutions = *accepted_solutions.get(&prover_address).unwrap_or(&0);
+                // Check if the prover has reached their solution limit.
+                if self.has_reached_solution_limit(&prover_address, num_accepted_solutions) {
+                    bail!("Prover '{prover_address}' has reached their solution limit for the current epoch");
+                }
+                // Track the already accepted solutions.
+                *accepted_solutions.entry(prover_address).or_insert(0) += 1;
+            }
+        }
+
         // Ensure the certificates in the block subdag have met quorum requirements.
         self.check_block_subdag_quorum(block)?;
 

--- a/ledger/src/check_solution_limit.rs
+++ b/ledger/src/check_solution_limit.rs
@@ -15,7 +15,6 @@
 
 use super::*;
 
-// TODO (raychu86): Finalize these values.
 /// The stake required to land one solution per epoch at various points in time.
 ///
 /// Each entry represents a threshold where, starting from the given timestamp,
@@ -25,15 +24,15 @@ use super::*;
 ///
 /// Format: `(timestamp, stake_required_per_solution)`
 pub const STAKE_REQUIREMENTS_PER_SOLUTION: [(i64, u64); 9] = [
-    (1751328000i64, 100_000u64),   /* 2025-07-01 00:00:00 UTC */
-    (1759276800i64, 250_000u64),   /* 2025-10-01 00:00:00 UTC */
-    (1767225600i64, 500_000u64),   /* 2026-01-01 00:00:00 UTC */
-    (1775001600i64, 750_000u64),   /* 2026-04-01 00:00:00 UTC */
-    (1782864000i64, 1_000_000u64), /* 2026-07-01 00:00:00 UTC */
-    (1790812800i64, 1_250_000u64), /* 2026-10-01 00:00:00 UTC */
-    (1798761600i64, 1_500_000u64), /* 2027-01-01 00:00:00 UTC */
-    (1806537600i64, 2_000_000u64), /* 2027-04-01 00:00:00 UTC */
-    (1814400000i64, 2_500_000u64), /* 2027-07-01 00:00:00 UTC */
+    (1754006399i64, 100_000u64),   /* 2025-07-31 23:59:59 UTC */
+    (1761955199i64, 250_000u64),   /* 2025-10-31 23:59:59 UTC */
+    (1769903999i64, 500_000u64),   /* 2026-01-31 23:59:59 UTC */
+    (1777593599i64, 750_000u64),   /* 2026-04-30 23:59:59 UTC */
+    (1785542399i64, 1_000_000u64), /* 2026-07-31 23:59:59 UTC */
+    (1793491199i64, 1_250_000u64), /* 2026-10-31 23:59:59 UTC */
+    (1801439999i64, 1_500_000u64), /* 2027-01-31 23:59:59 UTC */
+    (1809129599i64, 2_000_000u64), /* 2027-04-30 23:59:59 UTC */
+    (1817078399i64, 2_500_000u64), /* 2027-07-31 23:59:59 UTC */
 ];
 
 /// Returns the maximum number of allowed solutions per epoch based on the provided stake and timestamp.

--- a/ledger/src/check_solution_limit.rs
+++ b/ledger/src/check_solution_limit.rs
@@ -1,0 +1,147 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+// TODO (raychu86): Finalize these values.
+/// The stake required to land one solution per epoch at various points in time.
+///
+/// Each entry represents a threshold where, starting from the given timestamp,
+/// a prover must have at least the specified amount of stake to land one solution.
+///
+/// A prover with `n * stake` may land up to `n` solutions per epoch.
+///
+/// Format: `(timestamp, stake_required_per_solution)`
+pub const STAKE_REQUIREMENTS_PER_SOLUTION: [(i64, u64); 9] = [
+    (1751328000i64, 100_000u64),   /* 2025-07-01 00:00:00 UTC */
+    (1759276800i64, 250_000u64),   /* 2025-10-01 00:00:00 UTC */
+    (1767225600i64, 500_000u64),   /* 2026-01-01 00:00:00 UTC */
+    (1775001600i64, 750_000u64),   /* 2026-04-01 00:00:00 UTC */
+    (1782864000i64, 1_000_000u64), /* 2026-07-01 00:00:00 UTC */
+    (1790812800i64, 1_250_000u64), /* 2026-10-01 00:00:00 UTC */
+    (1798761600i64, 1_500_000u64), /* 2027-01-01 00:00:00 UTC */
+    (1806537600i64, 2_000_000u64), /* 2027-04-01 00:00:00 UTC */
+    (1814400000i64, 2_500_000u64), /* 2027-07-01 00:00:00 UTC */
+];
+
+/// Returns the maximum number of allowed solutions per epoch based on the provided stake and timestamp.
+pub fn maximum_allowed_solutions_per_epoch(prover_stake: u64, current_time: i64) -> u64 {
+    // If the block height is earlier than the starting enforcement, do not restrict the maximum number of solutions per epoch.
+    if current_time < STAKE_REQUIREMENTS_PER_SOLUTION.first().map(|(t, _)| *t).unwrap_or(i64::MAX) {
+        return u64::MAX;
+    }
+
+    // Find the minimum stake required for one solution per epoch.
+    let minimum_stake_per_solution_per_epoch =
+        match STAKE_REQUIREMENTS_PER_SOLUTION.binary_search_by_key(&current_time, |(t, _)| *t) {
+            // If a stake limit was found at this height, return it.
+            Ok(index) => STAKE_REQUIREMENTS_PER_SOLUTION[index].1,
+            // If the specified height was not found, determine which limit to return.
+            Err(index) => STAKE_REQUIREMENTS_PER_SOLUTION[index.saturating_sub(1)].1,
+        };
+
+    // Return the number of allowed solutions per epoch.
+    prover_stake.saturating_div(minimum_stake_per_solution_per_epoch)
+}
+
+impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
+    /// Determine if the given prover address has reached their solution limit for the current epoch.
+    pub fn has_reached_solution_limit(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> bool {
+        // Fetch the prover's stake.
+        let prover_stake = self.get_bonded_amount(prover_address).unwrap_or(0);
+
+        // Determine the maximum number of solutions allowed based on this prover's stake.
+        let maximum_allowed_solutions = maximum_allowed_solutions_per_epoch(prover_stake, self.latest_timestamp());
+
+        // Fetch the number of solutions the prover has earned rewards for in the current epoch.
+        let prover_num_solutions_in_epoch = *self.epoch_provers_cache.read().get(prover_address).unwrap_or(&0);
+
+        // Determine if the prover has reached their solution limit.
+        (prover_num_solutions_in_epoch as u64).saturating_add(additional_solutions_in_block)
+            >= maximum_allowed_solutions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ITERATIONS: u64 = 100;
+
+    #[test]
+    fn test_solution_limit_per_epoch() {
+        let mut rng = TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            for window in STAKE_REQUIREMENTS_PER_SOLUTION.windows(2) {
+                let (prev_time, stake_per_solution) = window[0];
+                let (next_time, _) = window[1];
+
+                // Choose a time strictly between the steps.
+                let timestamp = rng.gen_range(prev_time..next_time);
+                // Generate a random prover stake.
+                let prover_stake: u64 = rng.gen();
+                let expected_num_solutions = prover_stake / stake_per_solution;
+
+                assert_eq!(maximum_allowed_solutions_per_epoch(prover_stake, timestamp), expected_num_solutions,);
+            }
+        }
+    }
+
+    #[test]
+    fn test_solution_limit_before_enforcement() {
+        let mut rng = TestRng::default();
+
+        // Fetch the first timestamp from the table.
+        let first_timestamp = STAKE_REQUIREMENTS_PER_SOLUTION.first().unwrap().0;
+        let time_before_first = first_timestamp - 1;
+
+        // Check that before enforcement, the number of solutions is unrestricted even without prover stake.
+        let prover_stake = 0;
+        assert_eq!(maximum_allowed_solutions_per_epoch(prover_stake, time_before_first), u64::MAX);
+
+        // Check that before enforcement, the number of solutions is unrestricted for any prover stake.
+        for _ in 0..ITERATIONS {
+            assert_eq!(maximum_allowed_solutions_per_epoch(rng.gen(), rng.gen_range(0..time_before_first)), u64::MAX);
+        }
+    }
+
+    #[test]
+    fn test_solution_limit_after_final_timestamp() {
+        let mut rng = TestRng::default();
+        let (last_timestamp, stake_per_solution) = *STAKE_REQUIREMENTS_PER_SOLUTION.last().unwrap();
+
+        // Check that all timestamps after the last one are treated as the last one.
+        for _ in 0..ITERATIONS {
+            let prover_stake: u64 = rng.gen();
+            let time_after_last = rng.gen_range(last_timestamp..i64::MAX);
+            let expected_num_solutions = prover_stake / stake_per_solution;
+
+            assert_eq!(maximum_allowed_solutions_per_epoch(prover_stake, time_after_last), expected_num_solutions);
+        }
+    }
+
+    #[test]
+    fn test_solution_limit_exact_timestamps() {
+        let mut rng = TestRng::default();
+        // Check that the maximum allowed solutions per epoch is correct for each timestamp in the table.
+        for &(timestamp, stake_per_solution) in STAKE_REQUIREMENTS_PER_SOLUTION.iter() {
+            let expected_num_solutions = rng.gen_range(1..=100);
+            let prover_stake = expected_num_solutions * stake_per_solution;
+
+            assert_eq!(maximum_allowed_solutions_per_epoch(prover_stake, timestamp), expected_num_solutions,);
+        }
+    }
+}

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -87,36 +87,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         Ok(epoch_hash)
     }
 
-    /// Returns the provers and the number of solutions they have submitted for the current epoch.
-    pub fn get_epoch_provers(&self) -> IndexMap<Address<N>, u32> {
-        // Fetch the block heights that belong to the current epoch.
-        let current_block_height = self.vm().block_store().current_block_height();
-        let start_of_epoch = current_block_height.saturating_sub(current_block_height % N::NUM_BLOCKS_PER_EPOCH);
-        let existing_epoch_blocks: Vec<_> = (start_of_epoch..=current_block_height).collect();
-        // Count the prover occurrences across epoch blocks using parallel map-reduce.
-        cfg_reduce!(
-            cfg_iter!(existing_epoch_blocks).filter_map(|height| {
-                match self.get_solutions(*height).as_deref() {
-                    Ok(Some(solutions)) => {
-                        let mut local = IndexMap::new();
-                        for (_, s) in solutions.iter() {
-                            *local.entry(s.address()).or_insert(0) += 1;
-                        }
-                        Some(local)
-                    }
-                    _ => None,
-                }
-            }),
-            IndexMap::new,
-            |mut acc, local| {
-                for (addr, count) in local {
-                    *acc.entry(addr).or_insert(0) += count;
-                }
-                acc
-            }
-        )
-    }
-
     /// Returns the block for the given block height.
     pub fn get_block(&self, height: u32) -> Result<Block<N>> {
         // If the height is 0, return the genesis block.

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -87,6 +87,26 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         Ok(epoch_hash)
     }
 
+    /// Returns the provers and the number of solutions they have submitted for the current epoch.
+    pub fn get_epoch_provers(&self) -> Arc<RwLock<IndexMap<Address<N>, u32>>> {
+        // Fetch the blocks that have been created in the current epoch.
+        let current_block_height = self.vm().block_store().current_block_height();
+        let start_of_epoch = current_block_height.saturating_sub(current_block_height % N::NUM_BLOCKS_PER_EPOCH);
+        let existing_epoch_blocks: Vec<_> = (start_of_epoch..=current_block_height).collect();
+
+        // Create the epoch provers cache.
+        let epoch_provers = Arc::new(RwLock::new(IndexMap::new()));
+        cfg_iter!(existing_epoch_blocks).for_each(|height| {
+            if let Ok(Some(solutions)) = self.get_solutions(*height).as_deref() {
+                for (_, s) in solutions.iter() {
+                    epoch_provers.write().entry(s.address()).and_modify(|e| *e += 1).or_insert(1);
+                }
+            }
+        });
+
+        epoch_provers
+    }
+
     /// Returns the block for the given block height.
     pub fn get_block(&self, height: u32) -> Result<Block<N>> {
         // If the height is 0, return the genesis block.
@@ -313,5 +333,30 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 (mapping_validator == validator && bonded_address != *validator).then_some(Ok(bonded_address))
             })
             .collect::<Result<_>>()
+    }
+
+    /// Returns the amount of microcredits that the given address has bonded.
+    pub fn get_bonded_amount(&self, address: &Address<N>) -> Result<u64> {
+        // Construct the credits.aleo program ID.
+        let credits_program_id = ProgramID::from_str("credits.aleo")?;
+        // Construct the bonded mapping name.
+        let bonded_mapping = Identifier::from_str("bonded")?;
+        // Construct the bonded mapping key name.
+        let bonded_mapping_key = Plaintext::from(Literal::Address(*address));
+        // Construct the bond_state microcredits key.
+        let microcredits_key = Identifier::from_str("microcredits")?;
+        // Get the bond state for the given staker.
+        let bond_state =
+            self.vm.finalize_store().get_value_confirmed(credits_program_id, bonded_mapping, &bonded_mapping_key)?;
+        // Find the microcredits in the bond state.
+        match bond_state {
+            Some(Value::Plaintext(Plaintext::Struct(bond_state, _))) => match bond_state.get(&microcredits_key) {
+                Some(Plaintext::Literal(Literal::U64(amount), _)) => Ok(**amount),
+                _ => bail!("Expected 'microcredits' as a u64 in bond_state struct."),
+            },
+            // If the address is not bonded, then return 0.
+            None => Ok(0),
+            _ => bail!("Invalid bond_state in finalize storage."),
+        }
     }
 }

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -88,23 +88,33 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns the provers and the number of solutions they have submitted for the current epoch.
-    pub fn get_epoch_provers(&self) -> Arc<RwLock<IndexMap<Address<N>, u32>>> {
-        // Fetch the blocks that have been created in the current epoch.
+    pub fn get_epoch_provers(&self) -> IndexMap<Address<N>, u32> {
+        // Fetch the block heights that belong to the current epoch.
         let current_block_height = self.vm().block_store().current_block_height();
         let start_of_epoch = current_block_height.saturating_sub(current_block_height % N::NUM_BLOCKS_PER_EPOCH);
         let existing_epoch_blocks: Vec<_> = (start_of_epoch..=current_block_height).collect();
-
-        // Create the epoch provers cache.
-        let epoch_provers = Arc::new(RwLock::new(IndexMap::new()));
-        cfg_iter!(existing_epoch_blocks).for_each(|height| {
-            if let Ok(Some(solutions)) = self.get_solutions(*height).as_deref() {
-                for (_, s) in solutions.iter() {
-                    epoch_provers.write().entry(s.address()).and_modify(|e| *e += 1).or_insert(1);
+        // Count the prover occurrences across epoch blocks using parallel map-reduce.
+        cfg_reduce!(
+            cfg_iter!(existing_epoch_blocks).filter_map(|height| {
+                match self.get_solutions(*height).as_deref() {
+                    Ok(Some(solutions)) => {
+                        let mut local = IndexMap::new();
+                        for (_, s) in solutions.iter() {
+                            *local.entry(s.address()).or_insert(0) += 1;
+                        }
+                        Some(local)
+                    }
+                    _ => None,
                 }
+            }),
+            IndexMap::new,
+            |mut acc, local| {
+                for (addr, count) in local {
+                    *acc.entry(addr).or_insert(0) += count;
+                }
+                acc
             }
-        });
-
-        epoch_provers
+        )
     }
 
     /// Returns the block for the given block height.

--- a/ledger/src/is_solution_limit_reached.rs
+++ b/ledger/src/is_solution_limit_reached.rs
@@ -57,7 +57,7 @@ pub fn maximum_allowed_solutions_per_epoch(prover_stake: u64, current_time: i64)
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Determine if the given prover address has reached their solution limit for the current epoch.
-    pub fn has_reached_solution_limit(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> bool {
+    pub fn is_solution_limit_reached(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> bool {
         // Fetch the prover's stake.
         let prover_stake = self.get_bonded_amount(prover_address).unwrap_or(0);
 

--- a/ledger/src/is_solution_limit_reached.rs
+++ b/ledger/src/is_solution_limit_reached.rs
@@ -56,7 +56,7 @@ pub fn maximum_allowed_solutions_per_epoch(prover_stake: u64, current_time: i64)
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
-    /// Determine if the given prover address has reached their solution limit for the current epoch.
+    /// Returns `true` if the given prover address has reached their solution limit for the current epoch.
     pub fn is_solution_limit_reached(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> bool {
         // Fetch the prover's stake.
         let prover_stake = self.get_bonded_amount(prover_address).unwrap_or(0);

--- a/ledger/src/is_solution_limit_reached.rs
+++ b/ledger/src/is_solution_limit_reached.rs
@@ -18,21 +18,21 @@ use super::*;
 /// The stake required to land one solution per epoch at various points in time.
 ///
 /// Each entry represents a threshold where, starting from the given timestamp,
-/// a prover must have at least the specified amount of stake to land one solution.
+/// a prover must have at least the specified amount of stake (in microcredits) to land one solution.
 ///
 /// A prover with `n * stake` may land up to `n` solutions per epoch.
 ///
 /// Format: `(timestamp, stake_required_per_solution)`
 pub const STAKE_REQUIREMENTS_PER_SOLUTION: [(i64, u64); 9] = [
-    (1754006399i64, 100_000u64),   /* 2025-07-31 23:59:59 UTC */
-    (1761955199i64, 250_000u64),   /* 2025-10-31 23:59:59 UTC */
-    (1769903999i64, 500_000u64),   /* 2026-01-31 23:59:59 UTC */
-    (1777593599i64, 750_000u64),   /* 2026-04-30 23:59:59 UTC */
-    (1785542399i64, 1_000_000u64), /* 2026-07-31 23:59:59 UTC */
-    (1793491199i64, 1_250_000u64), /* 2026-10-31 23:59:59 UTC */
-    (1801439999i64, 1_500_000u64), /* 2027-01-31 23:59:59 UTC */
-    (1809129599i64, 2_000_000u64), /* 2027-04-30 23:59:59 UTC */
-    (1817078399i64, 2_500_000u64), /* 2027-07-31 23:59:59 UTC */
+    (1754006399i64, 100_000_000_000u64),   /* 2025-07-31 23:59:59 UTC */
+    (1761955199i64, 250_000_000_000u64),   /* 2025-10-31 23:59:59 UTC */
+    (1769903999i64, 500_000_000_000u64),   /* 2026-01-31 23:59:59 UTC */
+    (1777593599i64, 750_000_000_000u64),   /* 2026-04-30 23:59:59 UTC */
+    (1785542399i64, 1_000_000_000_000u64), /* 2026-07-31 23:59:59 UTC */
+    (1793491199i64, 1_250_000_000_000u64), /* 2026-10-31 23:59:59 UTC */
+    (1801439999i64, 1_500_000_000_000u64), /* 2027-01-31 23:59:59 UTC */
+    (1809129599i64, 2_000_000_000_000u64), /* 2027-04-30 23:59:59 UTC */
+    (1817078399i64, 2_500_000_000_000u64), /* 2027-07-31 23:59:59 UTC */
 ];
 
 /// Returns the maximum number of allowed solutions per epoch based on the provided stake and timestamp.
@@ -56,8 +56,8 @@ pub fn maximum_allowed_solutions_per_epoch(prover_stake: u64, current_time: i64)
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
-    /// Returns `true` if the given prover address has reached their solution limit for the current epoch.
-    pub fn is_solution_limit_reached(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> bool {
+    /// Returns the number of remaining solutions a prover can submit in the current epoch.
+    pub fn num_remaining_solutions(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> u64 {
         // Fetch the prover's stake.
         let prover_stake = self.get_bonded_amount(prover_address).unwrap_or(0);
 
@@ -67,9 +67,20 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Fetch the number of solutions the prover has earned rewards for in the current epoch.
         let prover_num_solutions_in_epoch = *self.epoch_provers_cache.read().get(prover_address).unwrap_or(&0);
 
-        // Determine if the prover has reached their solution limit.
-        (prover_num_solutions_in_epoch as u64).saturating_add(additional_solutions_in_block)
-            >= maximum_allowed_solutions
+        // Calculate the total number of solutions the prover has submitted in the current epoch including the current block.
+        let num_solutions = (prover_num_solutions_in_epoch as u64).saturating_add(additional_solutions_in_block);
+
+        // Return the number of remaining solutions.
+        maximum_allowed_solutions.saturating_sub(num_solutions)
+    }
+
+    /// Returns `true` if the given prover address has reached their solution limit for the current epoch.
+    pub fn is_solution_limit_reached(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> bool {
+        // Calculate the number of remaining solutions for the prover.
+        let num_remaining_solutions = self.num_remaining_solutions(prover_address, additional_solutions_in_block);
+
+        // If the number of remaining solutions is zero, the limit is reached.
+        num_remaining_solutions == 0
     }
 }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -235,10 +235,40 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Set the current epoch hash.
         ledger.current_epoch_hash = Arc::new(RwLock::new(Some(ledger.get_epoch_hash(latest_height)?)));
         // Set the epoch prover cache.
-        ledger.epoch_provers_cache = Arc::new(RwLock::new(ledger.get_epoch_provers()));
+        ledger.epoch_provers_cache = Arc::new(RwLock::new(ledger.load_epoch_provers()));
 
         finish!(timer, "Initialize ledger");
         Ok(ledger)
+    }
+
+    /// Loads the provers and the number of solutions they have submitted for the current epoch.
+    pub fn load_epoch_provers(&self) -> IndexMap<Address<N>, u32> {
+        // Fetch the block heights that belong to the current epoch.
+        let current_block_height = self.vm().block_store().current_block_height();
+        let start_of_epoch = current_block_height.saturating_sub(current_block_height % N::NUM_BLOCKS_PER_EPOCH);
+        let existing_epoch_blocks: Vec<_> = (start_of_epoch..=current_block_height).collect();
+        // Count the prover occurrences across epoch blocks using parallel map-reduce.
+        cfg_reduce!(
+            cfg_iter!(existing_epoch_blocks).filter_map(|height| {
+                match self.get_solutions(*height).as_deref() {
+                    Ok(Some(solutions)) => {
+                        let mut local = IndexMap::new();
+                        for (_, s) in solutions.iter() {
+                            *local.entry(s.address()).or_insert(0) += 1;
+                        }
+                        Some(local)
+                    }
+                    _ => None,
+                }
+            }),
+            IndexMap::new,
+            |mut acc, local| {
+                for (addr, count) in local {
+                    *acc.entry(addr).or_insert(0) += count;
+                }
+                acc
+            }
+        )
     }
 
     /// Returns the VM.
@@ -249,6 +279,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the puzzle.
     pub const fn puzzle(&self) -> &Puzzle<N> {
         self.vm.puzzle()
+    }
+
+    /// Returns the provers and the number of solutions they have submitted for the current epoch.
+    pub fn epoch_provers(&self) -> Arc<RwLock<IndexMap<Address<N>, u32>>> {
+        self.epoch_provers_cache.clone()
     }
 
     /// Returns the latest committee,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -37,6 +37,7 @@ pub use helpers::*;
 
 mod advance;
 mod check_next_block;
+mod check_solution_limit;
 mod check_transaction_basic;
 mod contains;
 mod find;
@@ -142,6 +143,8 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
     /// If `L` is the lookback round distance, `C` is the active committee at round `R + L`
     /// (i.e. the committee in charge of running consensus at round `R + L`).
     committee_cache: Arc<Mutex<LruCache<u64, Committee<N>>>>,
+    /// The cache that holds the provers and the number of solutions they have submitted for the current epoch.
+    epoch_provers_cache: Arc<RwLock<IndexMap<Address<N>, u32>>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
@@ -207,6 +210,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             current_committee: Arc::new(RwLock::new(current_committee)),
             current_block: Arc::new(RwLock::new(genesis_block.clone())),
             committee_cache,
+            epoch_provers_cache: Default::default(),
         };
 
         // If the block store is empty, add the genesis block.
@@ -230,6 +234,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         ledger.current_committee = Arc::new(RwLock::new(Some(ledger.latest_committee()?)));
         // Set the current epoch hash.
         ledger.current_epoch_hash = Arc::new(RwLock::new(Some(ledger.get_epoch_hash(latest_height)?)));
+        // Set the epoch prover cache.
+        ledger.epoch_provers_cache = ledger.get_epoch_provers();
 
         finish!(timer, "Initialize ledger");
         Ok(ledger)

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -37,11 +37,11 @@ pub use helpers::*;
 
 mod advance;
 mod check_next_block;
-mod check_solution_limit;
 mod check_transaction_basic;
 mod contains;
 mod find;
 mod get;
+mod is_solution_limit_reached;
 mod iterators;
 
 #[cfg(test)]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -247,28 +247,21 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let current_block_height = self.vm().block_store().current_block_height();
         let start_of_epoch = current_block_height.saturating_sub(current_block_height % N::NUM_BLOCKS_PER_EPOCH);
         let existing_epoch_blocks: Vec<_> = (start_of_epoch..=current_block_height).collect();
-        // Count the prover occurrences across epoch blocks using parallel map-reduce.
-        cfg_reduce!(
-            cfg_iter!(existing_epoch_blocks).filter_map(|height| {
-                match self.get_solutions(*height).as_deref() {
-                    Ok(Some(solutions)) => {
-                        let mut local = IndexMap::new();
-                        for (_, s) in solutions.iter() {
-                            *local.entry(s.address()).or_insert(0) += 1;
-                        }
-                        Some(local)
-                    }
-                    _ => None,
-                }
-            }),
-            IndexMap::new,
-            |mut acc, local| {
-                for (addr, count) in local {
-                    *acc.entry(addr).or_insert(0) += count;
-                }
-                acc
-            }
-        )
+
+        // Collect the addresses of the solutions submitted in the current epoch.
+        let solution_addresses = cfg_iter!(existing_epoch_blocks)
+            .flat_map(|height| match self.get_solutions(*height).as_deref() {
+                Ok(Some(solutions)) => solutions.iter().map(|(_, s)| s.address()).collect::<Vec<_>>(),
+                _ => vec![],
+            })
+            .collect::<Vec<_>>();
+
+        // Count the number of occurrences of each address in the epoch blocks.
+        let mut epoch_provers = IndexMap::new();
+        for address in solution_addresses {
+            epoch_provers.entry(address).and_modify(|e| *e += 1).or_insert(1);
+        }
+        epoch_provers
     }
 
     /// Returns the VM.

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -235,7 +235,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Set the current epoch hash.
         ledger.current_epoch_hash = Arc::new(RwLock::new(Some(ledger.get_epoch_hash(latest_height)?)));
         // Set the epoch prover cache.
-        ledger.epoch_provers_cache = ledger.get_epoch_provers();
+        ledger.epoch_provers_cache = Arc::new(RwLock::new(ledger.get_epoch_provers()));
 
         finish!(timer, "Initialize ledger");
         Ok(ledger)

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -150,18 +150,6 @@ impl TestChainBuilder {
         )
     }
 
-    /// Create a new unchecked block, with a fully-connected DAG, a specified timestamp, and custom transmissions.
-    ///
-    /// This will "fill in " any gaps left in earlier rounds from non participating nodes.
-    fn generate_custom_block_unchecked(
-        &mut self,
-        timestamp: i64,
-        transmissions: IndexMap<TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>>,
-        rng: &mut TestRng,
-    ) -> Block<CurrentNetwork> {
-        self.generate_block_with_partition(&Default::default(), timestamp, transmissions, true, rng)
-    }
-
     /// Same as `generate_block` but with some nodes not participating in batch generation.
     ///
     /// This can result in blocks covering more than two rounds, because an anchor block might be skipped.
@@ -3023,9 +3011,11 @@ mod valid_solutions {
         );
         // Create a block that advances the ledger past the first solution limit timestamp.
         let timestamp_1 = STAKE_REQUIREMENTS_PER_SOLUTION[0].0;
-        let next_block = chain_builder.generate_custom_block_unchecked(
+        let next_block = chain_builder.generate_block_with_partition(
+            &Default::default(),
             timestamp_1,
             IndexMap::from([(transmission_id, transfer_transmission)]),
+            true,
             rng,
         );
         // Advance to the next block.
@@ -3036,9 +3026,11 @@ mod valid_solutions {
         assert!(ledger.is_solution_limit_reached(&prover_address, 0));
 
         // Create a block with a solution.
-        let next_block = chain_builder.generate_custom_block_unchecked(
+        let next_block = chain_builder.generate_block_with_partition(
+            &Default::default(),
             timestamp_1,
             IndexMap::from([(valid_solution_1_transmission_id, valid_solution_1_transmission.clone())]),
+            true,
             rng,
         );
         // Check that the solution is aborted.
@@ -3062,9 +3054,11 @@ mod valid_solutions {
         let bond_transmission = Transmission::from(bond_transaction.clone());
         let bond_transmission_transmission_id =
             TransmissionID::Transaction(bond_transaction.id(), bond_transmission.to_checksum().unwrap().unwrap());
-        let next_block = chain_builder.generate_custom_block_unchecked(
+        let next_block = chain_builder.generate_block_with_partition(
+            &Default::default(),
             timestamp_1,
             IndexMap::from([(bond_transmission_transmission_id, bond_transmission)]),
+            true,
             rng,
         );
         // Advance to the next block.
@@ -3078,12 +3072,14 @@ mod valid_solutions {
 
         // 5. Check that the next block will accept the solution and abort any excess.
 
-        let next_block = chain_builder.generate_custom_block_unchecked(
+        let next_block = chain_builder.generate_block_with_partition(
+            &Default::default(),
             timestamp_1,
             IndexMap::from([
                 (valid_solution_1_transmission_id, valid_solution_1_transmission.clone()),
                 (valid_solution_2_transmission_id, valid_solution_2_transmission.clone()),
             ]),
+            true,
             rng,
         );
 

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -124,14 +124,42 @@ impl TestChainBuilder {
     ) -> Vec<Block<CurrentNetwork>> {
         assert!(num_blocks > 0, "Need to build at least one block");
 
-        (0..num_blocks).map(|_| self.generate_block_with_partition(skip_nodes, rng)).collect()
+        (0..num_blocks)
+            .map(|_| {
+                self.generate_block_with_partition(
+                    skip_nodes,
+                    OffsetDateTime::now_utc().unix_timestamp(),
+                    Default::default(),
+                    false,
+                    rng,
+                )
+            })
+            .collect()
     }
 
     /// Create a new block, with a fully-connected DAG.
     ///
     /// This will "fill in " any gaps left in earlier rounds from non participating nodes.
     pub fn generate_block(&mut self, rng: &mut TestRng) -> Block<CurrentNetwork> {
-        self.generate_block_with_partition(&Default::default(), rng)
+        self.generate_block_with_partition(
+            &Default::default(),
+            OffsetDateTime::now_utc().unix_timestamp(),
+            Default::default(),
+            false,
+            rng,
+        )
+    }
+
+    /// Create a new unchecked block, with a fully-connected DAG, a specified timestamp, and custom transmissions.
+    ///
+    /// This will "fill in " any gaps left in earlier rounds from non participating nodes.
+    fn generate_custom_block_unchecked(
+        &mut self,
+        timestamp: i64,
+        transmissions: IndexMap<TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>>,
+        rng: &mut TestRng,
+    ) -> Block<CurrentNetwork> {
+        self.generate_block_with_partition(&Default::default(), timestamp, transmissions, true, rng)
     }
 
     /// Same as `generate_block` but with some nodes not participating in batch generation.
@@ -140,6 +168,9 @@ impl TestChainBuilder {
     pub fn generate_block_with_partition(
         &mut self,
         skip_nodes: &HashSet<usize>,
+        timestamp: i64,
+        transmissions: IndexMap<TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>>,
+        skip_verification: bool,
         rng: &mut TestRng,
     ) -> Block<CurrentNetwork> {
         assert!(self.current_height > 0);
@@ -153,6 +184,8 @@ impl TestChainBuilder {
         } else {
             self.last_block_round - BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64 + 2
         };
+
+        let transmission_ids = transmissions.keys().cloned().collect::<IndexSet<_>>();
 
         // Create certificates for each round.
         loop {
@@ -180,9 +213,9 @@ impl TestChainBuilder {
                 let batch_header = BatchHeader::new(
                     private_key_1,
                     round,
-                    OffsetDateTime::now_utc().unix_timestamp(),
+                    timestamp,
                     committee.id(),
-                    Default::default(),
+                    transmission_ids.clone(),
                     previous_certificate_ids.clone(),
                     rng,
                 )
@@ -265,8 +298,10 @@ impl TestChainBuilder {
 
         // Construct the block.
         let subdag = Subdag::from(subdag_map).unwrap();
-        let block = self.ledger.prepare_advance_to_next_quorum_block(subdag, Default::default(), rng).unwrap();
-        self.ledger.check_next_block(&block, rng).unwrap();
+        let block = self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions, rng).unwrap();
+        if !skip_verification {
+            self.ledger.check_next_block(&block, rng).unwrap();
+        }
 
         // Update state.
         self.ledger.advance_to_next_block(&block).unwrap();
@@ -2729,6 +2764,7 @@ function foo:
 #[cfg(feature = "test")]
 mod valid_solutions {
     use super::*;
+    use crate::is_solution_limit_reached::STAKE_REQUIREMENTS_PER_SOLUTION;
     use ledger_puzzle::Solution;
     use rand::prelude::SliceRandom;
     use std::collections::HashSet;
@@ -2894,8 +2930,8 @@ mod valid_solutions {
 
         // Fetch the epoch provers cache.
         let epoch_provers = ledger.epoch_provers_cache.read();
-        // Fetch the epoch provers from DB.
-        let expected_epoch_provers = ledger.get_epoch_provers();
+        // Load the epoch provers from the blocks in the current epoch.
+        let expected_epoch_provers = ledger.load_epoch_provers();
         // Check that the epoch solutions are correct
         assert_eq!(epoch_provers.values().sum::<u32>(), u32::try_from(total_epoch_solutions).unwrap());
         assert_eq!(epoch_provers.len(), expected_epoch_provers.len());
@@ -2905,6 +2941,162 @@ mod valid_solutions {
             assert_eq!(expected_address, address);
             assert_eq!(expected_count, count);
         }
+    }
+
+    #[test]
+    fn test_solution_limits() {
+        let rng = &mut TestRng::default();
+
+        // Sample the genesis private key.
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        let validator_address = Address::try_from(&private_key).unwrap();
+
+        // Initialize the store.
+        let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+        // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
+        let seed: u64 = rng.gen();
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, genesis_rng).unwrap();
+
+        // Extract the private keys from the genesis committee by using the same RNG to sample private keys.
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let private_keys = [
+            private_key,
+            PrivateKey::new(genesis_rng).unwrap(),
+            PrivateKey::new(genesis_rng).unwrap(),
+            PrivateKey::new(genesis_rng).unwrap(),
+        ];
+
+        // Construct the chain builder.
+        let mut chain_builder = TestChainBuilder::new(private_keys.to_vec(), genesis.clone());
+
+        // Construct the ledger.
+        let ledger =
+            Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(genesis, StorageMode::new_test(None)).unwrap();
+
+        // Retrieve the puzzle parameters.
+        let puzzle = ledger.puzzle();
+        let latest_epoch_hash = ledger.latest_epoch_hash().unwrap();
+        let minimum_proof_target = ledger.latest_proof_target();
+
+        // Create new prover account.
+        let prover_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        let prover_address = Address::try_from(&prover_private_key).unwrap();
+
+        let mut valid_solutions = Vec::with_capacity(2);
+        // Create solutions that are greater than the minimum proof target.
+        while valid_solutions.len() < 2 {
+            let solution = puzzle.prove(latest_epoch_hash, prover_address, rng.gen(), None).unwrap();
+            if puzzle.get_proof_target(&solution).unwrap() >= minimum_proof_target {
+                valid_solutions.push(solution);
+            }
+        }
+        let valid_solution_1 = valid_solutions.remove(0);
+        let valid_solution_2 = valid_solutions.remove(0);
+        let valid_solution_1_transmission = Transmission::from(valid_solution_1);
+        let valid_solution_1_transmission_id = TransmissionID::Solution(
+            valid_solution_1.id(),
+            valid_solution_1_transmission.to_checksum().unwrap().unwrap(),
+        );
+        let valid_solution_2_transmission = Transmission::from(valid_solution_2);
+        let valid_solution_2_transmission_id = TransmissionID::Solution(
+            valid_solution_2.id(),
+            valid_solution_2_transmission.to_checksum().unwrap().unwrap(),
+        );
+
+        // 1. Advance to the latest timestamp.
+
+        assert!(!ledger.is_solution_limit_reached(&prover_address, 0));
+
+        // Transfer a public balance to the prover address.
+        let inputs =
+            [Value::from_str(&format!("{prover_address}")).unwrap(), Value::from_str("10_000_000_000_000u64").unwrap()];
+        let transfer_transaction = ledger
+            .vm
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .unwrap();
+        let transfer_transmission = Transmission::from(transfer_transaction.clone());
+        // Construct the transmission ID.
+        let transmission_id = TransmissionID::Transaction(
+            transfer_transaction.id(),
+            transfer_transmission.to_checksum().unwrap().unwrap(),
+        );
+        // Create a block that advances the ledger past the first solution limit timestamp.
+        let timestamp_1 = STAKE_REQUIREMENTS_PER_SOLUTION[0].0;
+        let next_block = chain_builder.generate_custom_block_unchecked(
+            timestamp_1,
+            IndexMap::from([(transmission_id, transfer_transmission)]),
+            rng,
+        );
+        // Advance to the next block.
+        ledger.advance_to_next_block(&next_block).unwrap();
+
+        // 2. Check that the solution limit is reached because the prover does not have any stake.
+        assert_eq!(ledger.num_remaining_solutions(&prover_address, 0), 0);
+        assert!(ledger.is_solution_limit_reached(&prover_address, 0));
+
+        // Create a block with a solution.
+        let next_block = chain_builder.generate_custom_block_unchecked(
+            timestamp_1,
+            IndexMap::from([(valid_solution_1_transmission_id, valid_solution_1_transmission.clone())]),
+            rng,
+        );
+        // Check that the solution is aborted.
+        assert!(next_block.solutions().is_empty());
+        assert_eq!(next_block.aborted_solution_ids().len(), 1);
+        // Advance to the next block.
+        ledger.advance_to_next_block(&next_block).unwrap();
+
+        // 3. Bond the required stake.
+
+        // Bond the required stake.
+        let inputs = [
+            Value::<CurrentNetwork>::from_str(&validator_address.to_string()).unwrap(),
+            Value::<CurrentNetwork>::from_str(&prover_address.to_string()).unwrap(),
+            Value::<CurrentNetwork>::from_str(&format!("{}u64", STAKE_REQUIREMENTS_PER_SOLUTION[0].1)).unwrap(),
+        ];
+        let bond_transaction = ledger
+            .vm
+            .execute(&prover_private_key, ("credits.aleo", "bond_public"), inputs.iter(), None, 0, None, rng)
+            .unwrap();
+        let bond_transmission = Transmission::from(bond_transaction.clone());
+        let bond_transmission_transmission_id =
+            TransmissionID::Transaction(bond_transaction.id(), bond_transmission.to_checksum().unwrap().unwrap());
+        let next_block = chain_builder.generate_custom_block_unchecked(
+            timestamp_1,
+            IndexMap::from([(bond_transmission_transmission_id, bond_transmission)]),
+            rng,
+        );
+        // Advance to the next block.
+        ledger.advance_to_next_block(&next_block).unwrap();
+
+        // 4. Check that the solution is valid with sufficient stake.
+
+        // Check that the prover can submit solutions.
+        assert_eq!(ledger.num_remaining_solutions(&prover_address, 0), 1);
+        assert!(!ledger.is_solution_limit_reached(&prover_address, 0));
+
+        // 5. Check that the next block will accept the solution and abort any excess.
+
+        let next_block = chain_builder.generate_custom_block_unchecked(
+            timestamp_1,
+            IndexMap::from([
+                (valid_solution_1_transmission_id, valid_solution_1_transmission.clone()),
+                (valid_solution_2_transmission_id, valid_solution_2_transmission.clone()),
+            ]),
+            rng,
+        );
+
+        // Check that the first solution is accepted and the second is aborted.
+        assert!(next_block.solutions().solution_ids().contains(&valid_solution_1.id()));
+        assert_eq!(next_block.aborted_solution_ids(), &vec![valid_solution_2.id()]);
+
+        // Advance to the next block.
+        ledger.advance_to_next_block(&next_block).unwrap();
+
+        // Check that the prover can no longer submit solutions.
+        assert_eq!(ledger.num_remaining_solutions(&prover_address, 0), 0);
+        assert!(ledger.is_solution_limit_reached(&prover_address, 0));
     }
 
     #[test]

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -342,6 +342,27 @@ fn test_get_block() {
 }
 
 #[test]
+fn test_get_bonded_balances() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    // Initialize the test environment.
+    let crate::test_helpers::TestEnv { ledger, .. } = crate::test_helpers::sample_test_env(rng);
+
+    // Fetch the bonded mapping.
+    let credits_program_id = ProgramID::from_str("credits.aleo").unwrap();
+    let bonded_mapping = Identifier::from_str("bonded").unwrap();
+    let bonded_mapping =
+        ledger.vm().finalize_store().get_mapping_confirmed(credits_program_id, bonded_mapping).unwrap();
+    // Deserialize the bonded stakers.
+    let stakers = synthesizer::vm::bonded_map_into_stakers(bonded_mapping).unwrap();
+    // Check that the bonded amounts match the bonded mapping.
+    for (staker, (_, amount)) in stakers {
+        assert_eq!(amount, ledger.get_bonded_amount(&staker).unwrap());
+    }
+}
+
+#[test]
 fn test_state_path() {
     let rng = &mut TestRng::default();
 
@@ -2797,6 +2818,9 @@ mod valid_solutions {
         // Start a local counter of proof targets.
         let mut combined_targets = 0;
 
+        // Track the total number of solutions in the current epoch.
+        let mut total_epoch_solutions = 0;
+
         // Run through 25 blocks of target adjustment.
         while block_height < NUM_BLOCKS {
             // Get coinbase puzzle data from the latest block.
@@ -2863,6 +2887,23 @@ mod valid_solutions {
 
             // Set the latest block height.
             block_height = ledger.latest_height();
+
+            // Update the epoch solutions count.
+            total_epoch_solutions += num_solutions;
+        }
+
+        // Fetch the epoch provers cache.
+        let epoch_provers = ledger.epoch_provers_cache.read();
+        // Fetch the epoch provers from DB.
+        let expected_epoch_provers = ledger.get_epoch_provers();
+        // Check that the epoch solutions are correct
+        assert_eq!(epoch_provers.values().sum::<u32>(), u32::try_from(total_epoch_solutions).unwrap());
+        assert_eq!(epoch_provers.len(), expected_epoch_provers.len());
+        for ((expected_address, expected_count), (address, count)) in
+            expected_epoch_provers.iter().zip(epoch_provers.iter())
+        {
+            assert_eq!(expected_address, address);
+            assert_eq!(expected_count, count);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR is implements the new features highlighted in the [ARC-0046 Proposal](https://github.com/AleoNet/ARCs/discussions/97).

This is done by:

1. Tracking the provers and the number of solutions they have landed in the current epoch.
2. Aborting solutions from provers that exceeds their solution limit.
3. Invalidating blocks that have solutions that exceed a prover's solution limit.
4. Implementing a stepwise function to calculate the number of solutions a prover can land in an epoch based on the prover stake and current block timestamp.

Note that there is no need for a new `ConsensusVersion` if the first enforcement timestamp is after all validators upgrade.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Tests have been added to ensure solution limits are properly calculated based on timestamp.