### PR TITLE
Use generic queries in the VM

### DIFF
--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -24,7 +24,8 @@ use console::{
     program::{Plaintext, Record, Value},
 };
 use ledger_block::Transition;
-use ledger_store::ConsensusStore;
+use ledger_query::Query;
+use ledger_store::{ConsensusStorage, ConsensusStore};
 use synthesizer::{VM, program::Program};
 
 use aleo_std::StorageMode;
@@ -83,11 +84,30 @@ function hello:
     .unwrap();
 
     c.bench_function("Transaction::Deploy", |b| {
-        b.iter(|| vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None, rng).unwrap())
+        b.iter(|| {
+            vm.deploy(
+                &private_key,
+                &program,
+                Some(records[0].clone()),
+                600000,
+                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap()
+        })
     });
 
     c.bench_function("Transaction::Deploy - verify", |b| {
-        let transaction = vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &private_key,
+                &program,
+                Some(records[0].clone()),
+                600000,
+                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         b.iter(|| vm.check_transaction(&transaction, None, rng).unwrap())
     });
 }
@@ -122,7 +142,7 @@ fn execute(c: &mut Criterion) {
                 vm.execute_authorization(
                     execute_authorization.replicate(),
                     Some(fee_authorization.replicate()),
-                    None,
+                    None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
                     rng,
                 )
                 .unwrap();
@@ -130,7 +150,12 @@ fn execute(c: &mut Criterion) {
         });
 
         let transaction = vm
-            .execute_authorization(execute_authorization.replicate(), Some(fee_authorization.replicate()), None, rng)
+            .execute_authorization(
+                execute_authorization.replicate(),
+                Some(fee_authorization.replicate()),
+                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Bench the Transaction.write_le method using the LimitedWriter.
@@ -168,7 +193,7 @@ fn execute(c: &mut Criterion) {
                 vm.execute_authorization(
                     execute_authorization.replicate(),
                     Some(fee_authorization.replicate()),
-                    None,
+                    None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
                     rng,
                 )
                 .unwrap();
@@ -176,7 +201,12 @@ fn execute(c: &mut Criterion) {
         });
 
         let transaction = vm
-            .execute_authorization(execute_authorization.replicate(), Some(fee_authorization.replicate()), None, rng)
+            .execute_authorization(
+                execute_authorization.replicate(),
+                Some(fee_authorization.replicate()),
+                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Bench the Transaction.write_le method using the LimitedWriter.
@@ -266,7 +296,17 @@ function main:
         vm.process().write().add_program(&program).unwrap();
 
         // Create an execution transaction that is 164613 bytes in size.
-        let transaction = vm.execute(&private_key, ("too_big.aleo", "main"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("too_big.aleo", "main"),
+                inputs,
+                None,
+                0,
+                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Bench the Transaction.write_le method using the LimitedWriter.
         c.bench_function("LimitedWriter::new - too_big.aleo", |b| {

--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -33,14 +33,16 @@ use criterion::Criterion;
 use indexmap::IndexMap;
 
 #[cfg(not(feature = "rocks"))]
-type LedgerType<N> = ledger_store::helpers::memory::ConsensusMemory<N>;
+type LedgerType = ledger_store::helpers::memory::ConsensusMemory<MainnetV0>;
 #[cfg(feature = "rocks")]
-type LedgerType<N> = ledger_store::helpers::rocksdb::ConsensusDB<N>;
+type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<MainnetV0>;
+
+type NoQuery = Query<MainnetV0, <LedgerType as ConsensusStorage<MainnetV0>>::BlockStorage>;
 
 fn initialize_vm<R: Rng + CryptoRng>(
     private_key: &PrivateKey<MainnetV0>,
     rng: &mut R,
-) -> (VM<MainnetV0, LedgerType<MainnetV0>>, Vec<Record<MainnetV0, Plaintext<MainnetV0>>>) {
+) -> (VM<MainnetV0, LedgerType>, Vec<Record<MainnetV0, Plaintext<MainnetV0>>>) {
     // Initialize the VM.
     let vm = VM::from(ConsensusStore::open(StorageMode::new_test(None)).unwrap()).unwrap();
 
@@ -84,30 +86,12 @@ function hello:
     .unwrap();
 
     c.bench_function("Transaction::Deploy", |b| {
-        b.iter(|| {
-            vm.deploy(
-                &private_key,
-                &program,
-                Some(records[0].clone()),
-                600000,
-                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap()
-        })
+        b.iter(|| vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None::<NoQuery>, rng).unwrap())
     });
 
     c.bench_function("Transaction::Deploy - verify", |b| {
-        let transaction = vm
-            .deploy(
-                &private_key,
-                &program,
-                Some(records[0].clone()),
-                600000,
-                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction =
+            vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None::<NoQuery>, rng).unwrap();
         b.iter(|| vm.check_transaction(&transaction, None, rng).unwrap())
     });
 }
@@ -142,7 +126,7 @@ fn execute(c: &mut Criterion) {
                 vm.execute_authorization(
                     execute_authorization.replicate(),
                     Some(fee_authorization.replicate()),
-                    None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                    None::<NoQuery>,
                     rng,
                 )
                 .unwrap();
@@ -153,7 +137,7 @@ fn execute(c: &mut Criterion) {
             .execute_authorization(
                 execute_authorization.replicate(),
                 Some(fee_authorization.replicate()),
-                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -193,7 +177,7 @@ fn execute(c: &mut Criterion) {
                 vm.execute_authorization(
                     execute_authorization.replicate(),
                     Some(fee_authorization.replicate()),
-                    None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                    None::<NoQuery>,
                     rng,
                 )
                 .unwrap();
@@ -204,7 +188,7 @@ fn execute(c: &mut Criterion) {
             .execute_authorization(
                 execute_authorization.replicate(),
                 Some(fee_authorization.replicate()),
-                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -296,17 +280,8 @@ function main:
         vm.process().write().add_program(&program).unwrap();
 
         // Create an execution transaction that is 164613 bytes in size.
-        let transaction = vm
-            .execute(
-                &private_key,
-                ("too_big.aleo", "main"),
-                inputs,
-                None,
-                0,
-                None::<Query<MainnetV0, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("too_big.aleo", "main"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Bench the Transaction.write_le method using the LimitedWriter.
         c.bench_function("LimitedWriter::new - too_big.aleo", |b| {

--- a/ledger/query/src/traits.rs
+++ b/ledger/query/src/traits.rs
@@ -16,7 +16,7 @@
 use console::{network::Network, prelude::Result, program::StatePath, types::Field};
 
 #[cfg_attr(feature = "async", async_trait(?Send))]
-pub trait QueryTrait<N: Network> {
+pub trait QueryTrait<N: Network>: Clone {
     /// Returns the current state root.
     fn current_state_root(&self) -> Result<N::StateRoot>;
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -56,7 +56,7 @@ use ledger_authority::Authority;
 use ledger_committee::Committee;
 use ledger_narwhal::{BatchCertificate, Subdag, Transmission, TransmissionID};
 use ledger_puzzle::{Puzzle, PuzzleSolutions, Solution, SolutionID};
-use ledger_query::Query;
+use ledger_query::QueryTrait;
 use ledger_store::{ConsensusStorage, ConsensusStore};
 use synthesizer::{
     program::{FinalizeGlobalState, Program},
@@ -362,12 +362,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Creates a deploy transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the deployment fee.
-    pub fn create_deploy<R: Rng + CryptoRng>(
+    pub fn create_deploy<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         program: &Program<N>,
         priority_fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         // Fetch the unspent records.
@@ -385,13 +385,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Creates a transfer transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the execution fee.
-    pub fn create_transfer<R: Rng + CryptoRng>(
+    pub fn create_transfer<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         to: Address<N>,
         amount_in_microcredits: u64,
         priority_fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         // Fetch the unspent records.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -30,7 +30,8 @@ use ledger_authority::Authority;
 use ledger_block::{Block, ConfirmedTransaction, Execution, Ratify, Rejected, Transaction};
 use ledger_committee::{Committee, MIN_VALIDATOR_STAKE};
 use ledger_narwhal::{BatchCertificate, BatchHeader, Data, Subdag, Transmission, TransmissionID};
-use ledger_store::ConsensusStore;
+use ledger_query::Query;
+use ledger_store::{ConsensusStorage, ConsensusStore};
 use snarkvm_utilities::try_vm_runtime;
 use synthesizer::{Stack, program::Program, vm::VM};
 
@@ -388,7 +389,15 @@ fn test_insufficient_private_fees() {
         // Prepare a `split` execution without a fee.
         let inputs = [Value::Record(record_1.clone()), Value::from_str("100u64").unwrap()];
         let authorization = ledger.vm.authorize(&private_key, "credits.aleo", "split", inputs, rng).unwrap();
-        let split_transaction_without_fee = ledger.vm.execute_authorization(authorization, None, None, rng).unwrap();
+        let split_transaction_without_fee = ledger
+            .vm
+            .execute_authorization(
+                authorization,
+                None,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(ledger.check_transaction_basic(&split_transaction_without_fee, None, rng).is_ok());
     }
 
@@ -401,7 +410,15 @@ fn test_insufficient_private_fees() {
             Value::from_str("100u64").unwrap(),
         ];
         let authorization = ledger.vm.authorize(&private_key, "credits.aleo", "transfer_private", inputs, rng).unwrap();
-        let transaction_without_fee = ledger.vm.execute_authorization(authorization, None, None, rng).unwrap();
+        let transaction_without_fee = ledger
+            .vm
+            .execute_authorization(
+                authorization,
+                None,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let execution = transaction_without_fee.execution().unwrap();
 
         // Check that a transaction with sufficient fee will succeed.
@@ -416,7 +433,14 @@ fn test_insufficient_private_fees() {
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+        let fee = ledger
+            .vm
+            .execute_fee_authorization(
+                fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let sufficient_fee_transaction = Transaction::from_execution(execution.clone(), Some(fee)).unwrap();
         assert!(ledger.check_transaction_basic(&sufficient_fee_transaction, None, rng).is_ok());
 
@@ -425,7 +449,14 @@ fn test_insufficient_private_fees() {
             .vm
             .authorize_fee_private(&private_key, record_2.clone(), 1, 0, execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let insufficient_fee = ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None, rng).unwrap();
+        let insufficient_fee = ledger
+            .vm
+            .execute_fee_authorization(
+                insufficient_fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let insufficient_fee_transaction =
             Transaction::from_execution(execution.clone(), Some(insufficient_fee)).unwrap();
         assert!(ledger.check_transaction_basic(&insufficient_fee_transaction, None, rng).is_err());
@@ -449,7 +480,17 @@ finalize foo:
         .unwrap();
 
         // Check that a deployment transaction with sufficient fee will succeed.
-        let transaction = ledger.vm.deploy(&private_key, &program, Some(record_2.clone()), 0, None, rng).unwrap();
+        let transaction = ledger
+            .vm
+            .deploy(
+                &private_key,
+                &program,
+                Some(record_2.clone()),
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(ledger.check_transaction_basic(&transaction, None, rng).is_ok());
 
         // Check that a deployment transaction with insufficient fee will fail.
@@ -458,7 +499,14 @@ finalize foo:
             .vm
             .authorize_fee_private(&private_key, record_2, 1, 0, deployment.to_deployment_id().unwrap(), rng)
             .unwrap();
-        let insufficient_fee = ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None, rng).unwrap();
+        let insufficient_fee = ledger
+            .vm
+            .execute_fee_authorization(
+                insufficient_fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let insufficient_fee_transaction =
             Transaction::from_deployment(*transaction.owner().unwrap(), deployment.clone(), insufficient_fee).unwrap();
         assert!(ledger.check_transaction_basic(&insufficient_fee_transaction, None, rng).is_err());
@@ -484,7 +532,15 @@ fn test_insufficient_public_fees() {
             [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1000000000000u64").unwrap()];
         let transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.into_iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         let block =
@@ -505,7 +561,15 @@ fn test_insufficient_public_fees() {
         ];
         let transaction = ledger
             .vm
-            .execute(&recipient_private_key, ("credits.aleo", "bond_validator"), inputs.into_iter(), None, 0, None, rng)
+            .execute(
+                &recipient_private_key,
+                ("credits.aleo", "bond_validator"),
+                inputs.into_iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         let block =
@@ -559,7 +623,17 @@ finalize foo:
     let credits = Some(records.values().next().unwrap().clone());
 
     // Deploy.
-    let transaction = ledger.vm.deploy(&private_key, &program, credits, 0, None, rng).unwrap();
+    let transaction = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program,
+            credits,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -572,7 +646,16 @@ finalize foo:
     assert_eq!(ledger.latest_hash(), block.hash());
 
     // Create a transfer transaction to produce a record with insufficient balance to pay for fees.
-    let transfer_transaction = ledger.create_transfer(&private_key, address, 100, 0, None, rng).unwrap();
+    let transfer_transaction = ledger
+        .create_transfer(
+            &private_key,
+            address,
+            100,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     // Construct the next block.
     let block = ledger
@@ -606,14 +689,32 @@ finalize foo:
     assert!(
         ledger
             .vm
-            .execute(&private_key, ("dummy.aleo", "foo"), inputs.clone(), Some(insufficient_record), 0, None, rng)
+            .execute(
+                &private_key,
+                ("dummy.aleo", "foo"),
+                inputs.clone(),
+                Some(insufficient_record),
+                0,
+                None::<Query<CurrentNetwork, <LedgerType::<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng
+            )
             .is_err()
     );
 
     let sufficient_record = records[1].clone();
     // Execute with enough fees.
-    let transaction =
-        ledger.vm.execute(&private_key, ("dummy.aleo", "foo"), inputs, Some(sufficient_record), 0, None, rng).unwrap();
+    let transaction = ledger
+        .vm
+        .execute(
+            &private_key,
+            ("dummy.aleo", "foo"),
+            inputs,
+            Some(sufficient_record),
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Verify.
     ledger.vm.check_transaction(&transaction, None, rng).unwrap();
     // Ensure that the ledger deems the transaction valid.
@@ -661,7 +762,17 @@ finalize failed_assert:
     let record_2 = records[1].clone();
 
     // Deploy the program.
-    let deployment_transaction = ledger.vm().deploy(&private_key, &program, Some(record_1), 0, None, rng).unwrap();
+    let deployment_transaction = ledger
+        .vm()
+        .deploy(
+            &private_key,
+            &program,
+            Some(record_1),
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     // Construct the deployment block.
     let deployment_block = ledger
@@ -683,7 +794,7 @@ finalize failed_assert:
             Vec::<Value<_>>::new().into_iter(),
             Some(record_2),
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -745,7 +856,17 @@ finalize foo:
     .unwrap();
 
     // Deploy.
-    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    let transaction = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -780,7 +901,15 @@ fn test_bond_and_unbond_validator() {
     ];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let inputs = [
         Value::from_str(&format!("{new_member_withdrawal_address}")).unwrap(),
@@ -788,7 +917,15 @@ fn test_bond_and_unbond_validator() {
     ];
     let transfer_to_withdrawal_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Construct the next block.
@@ -818,7 +955,15 @@ fn test_bond_and_unbond_validator() {
     ];
     let bond_validator_transaction = ledger
         .vm
-        .execute(&new_member_private_key, ("credits.aleo", "bond_validator"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &new_member_private_key,
+            ("credits.aleo", "bond_validator"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Construct the next block.
@@ -871,7 +1016,7 @@ fn test_bond_and_unbond_validator() {
             inputs.iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -928,7 +1073,15 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("185000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Construct the next block.
@@ -946,7 +1099,15 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address_2}")).unwrap(), Value::from_str("1u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&recipient_private_key_2, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &recipient_private_key_2,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let aborted_transaction_id = transfer_transaction.id();
 
@@ -954,7 +1115,15 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address_2}")).unwrap(), Value::from_str("1u64").unwrap()];
     let transfer_transaction_2 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Create a block.
@@ -1000,7 +1169,15 @@ fn test_aborted_solution_ids() {
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Create a block.
@@ -1069,7 +1246,15 @@ fn test_execute_duplicate_input_ids() {
         // Execute.
         let execution = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_private"), inputs.clone().iter(), None, 0, None, rng)
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_private"),
+                inputs.clone().iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
         execution_ids.push(execution.id());
         executions.push(execution);
@@ -1087,8 +1272,17 @@ finalize foo:
     add r0 r0 into r1;",
         ))
         .unwrap();
-        let deployment =
-            ledger.vm.deploy(&private_key, &program, Some(record_deployment.clone()), 0, None, rng).unwrap();
+        let deployment = ledger
+            .vm
+            .deploy(
+                &private_key,
+                &program,
+                Some(record_deployment.clone()),
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         deployment_ids.push(deployment.id());
         deployments.push(deployment);
     }
@@ -1103,7 +1297,7 @@ finalize foo:
             inputs.clone().iter(),
             Some(record_execution.clone()),
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -1138,7 +1332,14 @@ finalize foo:
             rng,
         )
         .unwrap();
-    let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+    let fee = ledger
+        .vm
+        .execute_fee_authorization(
+            fee_authorization,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Create a mutated transaction.
     let mutated_transaction = Transaction::from_execution(mutated_execution, Some(fee)).unwrap();
     execution_ids.push(mutated_transaction.id());
@@ -1202,7 +1403,15 @@ finalize foo:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let transfer_id = transfer.id();
 
@@ -1260,7 +1469,17 @@ function create_duplicate_record:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    let deployment_transaction = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1306,7 +1525,7 @@ function create_duplicate_record:
                 inputs.into_iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
                 fixed_rng,
             )
             .unwrap();
@@ -1324,7 +1543,14 @@ function create_duplicate_record:
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+        let fee = ledger
+            .vm
+            .execute_fee_authorization(
+                fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1351,7 +1577,17 @@ function create_duplicate_record:
         .unwrap();
 
         // Create a transaction with a fixed rng.
-        let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, fixed_rng).unwrap();
+        let transaction = ledger
+            .vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                fixed_rng,
+            )
+            .unwrap();
 
         // Extract the deployment and owner.
         let deployment = transaction.deployment().unwrap().clone();
@@ -1369,7 +1605,14 @@ function create_duplicate_record:
                 fixed_rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, fixed_rng).unwrap();
+        let fee = ledger
+            .vm
+            .execute_fee_authorization(
+                fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                fixed_rng,
+            )
+            .unwrap();
 
         Transaction::from_deployment(owner, deployment, fee).unwrap()
     };
@@ -1445,7 +1688,15 @@ function create_duplicate_record:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_4 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let transfer_4_id = transfer_4.id();
 
@@ -1496,7 +1747,17 @@ function empty_function:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    let deployment_transaction = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1528,7 +1789,7 @@ function empty_function:
                 inputs.into_iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
                 fixed_rng,
             )
             .unwrap();
@@ -1546,7 +1807,14 @@ function empty_function:
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+        let fee = ledger
+            .vm
+            .execute_fee_authorization(
+                fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1595,7 +1863,15 @@ function empty_function:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let transfer_transaction_id = transfer_transaction.id();
 
@@ -1648,7 +1924,17 @@ function simple_output:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    let deployment_transaction = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1674,7 +1960,15 @@ function simple_output:
         let inputs: [Value<_>; 0] = [];
         let transaction = ledger
             .vm
-            .execute(&private_key, ("dummy_program.aleo", function), inputs.into_iter(), None, 0, None, fixed_rng)
+            .execute(
+                &private_key,
+                ("dummy_program.aleo", function),
+                inputs.into_iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                fixed_rng,
+            )
             .unwrap();
         // Extract the execution.
         let execution = transaction.execution().unwrap().clone();
@@ -1690,7 +1984,14 @@ function simple_output:
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+        let fee = ledger
+            .vm
+            .execute_fee_authorization(
+                fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1745,7 +2046,15 @@ function simple_output:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let transfer_transaction_id = transfer_transaction.id();
 
@@ -1804,11 +2113,31 @@ function empty_function:
     .unwrap();
 
     // Create a deployment transaction for the first program with the same public payer.
-    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
+    let deployment_1 = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program_1,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let deployment_1_id = deployment_1.id();
 
     // Create a deployment transaction for the second program with the same public payer.
-    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, None, 0, None, rng).unwrap();
+    let deployment_2 = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program_2,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let deployment_2_id = deployment_2.id();
 
     // Create a block.
@@ -1848,14 +2177,30 @@ fn test_abort_fee_transaction() {
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone().into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.clone().into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let transaction_id = transaction.id();
 
     // Convert a fee transaction.
     let transaction_to_convert_to_fee = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let fee_transaction = Transaction::from_fee(transaction_to_convert_to_fee.fee_transition().unwrap()).unwrap();
     let fee_transaction_id = fee_transaction.id();
@@ -1895,7 +2240,15 @@ fn test_abort_invalid_transaction() {
     // Generate a transaction that will be invalid on another network.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let invalid_transaction = vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone().into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.clone().into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let invalid_transaction_id = invalid_transaction.id();
 
@@ -1905,11 +2258,27 @@ fn test_abort_invalid_transaction() {
     // Construct valid transactions for the ledger.
     let valid_transaction_1 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone().into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.clone().into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let valid_transaction_2 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.into_iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let valid_transaction_id_1 = valid_transaction_1.id();
     let valid_transaction_id_2 = valid_transaction_2.id();
@@ -1995,12 +2364,32 @@ finalize foo2:
     .unwrap();
 
     // Create a deployment transaction for the first program.
-    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, Some(record_1), 0, None, rng).unwrap();
+    let deployment_1 = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program_1,
+            Some(record_1),
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let deployment_1_id = deployment_1.id();
     assert!(ledger.check_transaction_basic(&deployment_1, None, rng).is_ok());
 
     // Create a deployment transaction for the second program.
-    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, Some(record_2), 0, None, rng).unwrap();
+    let deployment_2 = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program_2,
+            Some(record_2),
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let deployment_2_id = deployment_2.id();
     assert!(ledger.check_transaction_basic(&deployment_2, None, rng).is_ok());
 
@@ -2134,7 +2523,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -2178,7 +2567,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -2225,7 +2614,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -2244,7 +2633,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -2326,7 +2715,17 @@ fn test_deployment_exceeding_max_transaction_spend() {
     let exceeding_program = exceeding_program.unwrap();
 
     // Deploy the allowed program.
-    let deployment = ledger.vm().deploy(&private_key, &allowed_program, None, 0, None, rng).unwrap();
+    let deployment = ledger
+        .vm()
+        .deploy(
+            &private_key,
+            &allowed_program,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     // Verify the deployment transaction.
     assert!(ledger.vm().check_transaction(&deployment, None, rng).is_ok());
@@ -2345,7 +2744,14 @@ fn test_deployment_exceeding_max_transaction_spend() {
     assert!(ledger.vm().contains_program(allowed_program.id()));
 
     // Attempt to deploy the exceeding program.
-    let result = ledger.vm().deploy(&private_key, &exceeding_program, None, 0, None, rng);
+    let result = ledger.vm().deploy(
+        &private_key,
+        &exceeding_program,
+        None,
+        0,
+        None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+        rng,
+    );
 
     // Check that the deployment failed.
     assert!(result.is_err());
@@ -2376,7 +2782,15 @@ fn test_transaction_ordering() {
         [Value::from_str(&format!("{address_2}")).unwrap(), Value::from_str(&format!("{amount_1}u64")).unwrap()];
     let transfer_1 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     let amount_2 = 100000000u64;
@@ -2384,7 +2798,15 @@ fn test_transaction_ordering() {
         [Value::from_str(&format!("{address_3}")).unwrap(), Value::from_str(&format!("{amount_2}u64")).unwrap()];
     let transfer_2 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Update the public balance.
@@ -2446,39 +2868,101 @@ finalize foo:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000u64").unwrap()];
     let initial_transfer = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let initial_transfer_id = initial_transfer.id();
 
     // Create a deployment transaction.
-    let deployment_transaction = ledger.vm.deploy(&private_key_2, &program_1, None, 0, None, rng).unwrap();
+    let deployment_transaction = ledger
+        .vm
+        .deploy(
+            &private_key_2,
+            &program_1,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     // Create a deployment transaction.
-    let deployment_transaction_2 = ledger.vm.deploy(&private_key_3, &program_2, None, 0, None, rng).unwrap();
+    let deployment_transaction_2 = ledger
+        .vm
+        .deploy(
+            &private_key_3,
+            &program_2,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     // Create a transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Create a rejected transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000000000000u64").unwrap()];
     let rejected_transfer = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Create an aborted transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
     let aborted_transfer = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, public_balance - 10, None, rng)
+        .execute(
+            &private_key,
+            ("credits.aleo", "transfer_public"),
+            inputs.iter(),
+            None,
+            public_balance - 10,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
 
     // Create an aborted deployment transaction.
-    let aborted_deployment = ledger.vm.deploy(&private_key, &program_3, None, public_balance - 10, None, rng).unwrap();
+    let aborted_deployment = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program_3,
+            None,
+            public_balance - 10,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     const ITERATIONS: usize = 100;
     for _ in 0..ITERATIONS {
@@ -2569,7 +3053,17 @@ finalize is_id:
     .unwrap();
 
     // Deploy.
-    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    let transaction = ledger
+        .vm
+        .deploy(
+            &private_key,
+            &program,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -2584,10 +3078,31 @@ finalize is_id:
 
     // Execute functions `is_block` and `is_id` to assert that the on-chain state is as expected.
     let inputs_block: [Value<CurrentNetwork>; 1] = [Value::from_str("2u32").unwrap()];
-    let tx_block =
-        ledger.vm.execute(&private_key, (&program_id, "is_block"), inputs_block.iter(), None, 0, None, rng).unwrap();
+    let tx_block = ledger
+        .vm
+        .execute(
+            &private_key,
+            (&program_id, "is_block"),
+            inputs_block.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let inputs_id: [Value<CurrentNetwork>; 1] = [Value::from(Literal::U16(U16::new(CurrentNetwork::ID)))];
-    let tx_id = ledger.vm.execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None, rng).unwrap();
+    let tx_id = ledger
+        .vm
+        .execute(
+            &private_key,
+            (&program_id, "is_id"),
+            inputs_id.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     // Construct the next block.
     let block_2 =
@@ -2597,10 +3112,30 @@ finalize is_id:
 
     // Execute the program.
     let inputs_block_2: [Value<CurrentNetwork>; 1] = [Value::from_str("3u32").unwrap()];
-    let tx_block_2 =
-        ledger.vm.execute(&private_key, (&program_id, "is_block"), inputs_block_2.iter(), None, 0, None, rng).unwrap();
-    let tx_id_2 =
-        ledger.vm.execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None, rng).unwrap();
+    let tx_block_2 = ledger
+        .vm
+        .execute(
+            &private_key,
+            (&program_id, "is_block"),
+            inputs_block_2.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
+    let tx_id_2 = ledger
+        .vm
+        .execute(
+            &private_key,
+            (&program_id, "is_id"),
+            inputs_id.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
 
     // Construct the next block.
     let block_3 = ledger
@@ -2664,7 +3199,14 @@ function foo:
             if attempts >= ITERATIONS {
                 panic!("Failed to craft deployment after {ITERATIONS} attempts");
             }
-            match try_vm_runtime!(|| ledger.vm().deploy(&private_key, program, None, 0, None, rng)) {
+            match try_vm_runtime!(|| ledger.vm().deploy(
+                &private_key,
+                program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType::<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng
+            )) {
                 Ok(result) => break result.unwrap(),
                 Err(_) => attempts += 1,
             }
@@ -2741,7 +3283,15 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Check that block creation fails when duplicate solution IDs are provided.
@@ -2838,7 +3388,15 @@ mod valid_solutions {
             let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
             let transfer_transaction = ledger
                 .vm
-                .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+                .execute(
+                    &private_key,
+                    ("credits.aleo", "transfer_public"),
+                    inputs.iter(),
+                    None,
+                    0,
+                    None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
                 .unwrap();
 
             // Generate the next prospective block.
@@ -2920,7 +3478,15 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Create a block.
@@ -2992,7 +3558,15 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Create a block.
@@ -3071,7 +3645,15 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Check that the block creation fixes the malformed solution.
@@ -3140,7 +3722,15 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Create a block.
@@ -3513,13 +4103,33 @@ function create_and_consume:
     .unwrap();
 
     // Deploy the programs.
-    let deployment_0 = ledger.vm().deploy(&private_key, &program_0, None, 0, None, rng).unwrap();
+    let deployment_0 = ledger
+        .vm()
+        .deploy(
+            &private_key,
+            &program_0,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_0], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     ledger.advance_to_next_block(&block).unwrap();
 
-    let deployment_1 = ledger.vm().deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
+    let deployment_1 = ledger
+        .vm()
+        .deploy(
+            &private_key,
+            &program_1,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_1], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
@@ -3528,7 +4138,15 @@ function create_and_consume:
     // Call the `mint` function.
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("child.aleo", "mint"), Vec::<Value<CurrentNetwork>>::new().iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("child.aleo", "mint"),
+            Vec::<Value<CurrentNetwork>>::new().iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let mint_record = transaction.records().last().unwrap().1.decrypt(&view_key).unwrap();
     let block =
@@ -3554,7 +4172,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -3577,7 +4195,15 @@ function create_and_consume:
     let record = block.records().collect_vec().last().unwrap().1.decrypt(&view_key).unwrap();
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("child.aleo", "burn"), vec![Value::Record(record)].iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("child.aleo", "burn"),
+            vec![Value::Record(record)].iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();
@@ -3602,7 +4228,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -3629,7 +4255,7 @@ function create_and_consume:
             vec![Value::Record(mint_record.clone())].iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();
@@ -3650,7 +4276,15 @@ function create_and_consume:
     // Call the `consume` function.
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("parent.aleo", "consume"), vec![Value::Record(mint_record)].iter(), None, 0, None, rng)
+        .execute(
+            &private_key,
+            ("parent.aleo", "consume"),
+            vec![Value::Record(mint_record)].iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();
@@ -3675,7 +4309,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
             rng,
         )
         .unwrap();

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -41,14 +41,15 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use time::OffsetDateTime;
 
 #[cfg(not(feature = "rocks"))]
-type LedgerType<N> = ledger_store::helpers::memory::ConsensusMemory<N>;
+type LedgerType = ledger_store::helpers::memory::ConsensusMemory<CurrentNetwork>;
 #[cfg(feature = "rocks")]
-type LedgerType<N> = ledger_store::helpers::rocksdb::ConsensusDB<N>;
+type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
+
+type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
 
 /// Initializes a sample VM.
-fn sample_vm() -> VM<CurrentNetwork, LedgerType<CurrentNetwork>> {
-    VM::from(ConsensusStore::<CurrentNetwork, LedgerType<CurrentNetwork>>::open(StorageMode::new_test(None)).unwrap())
-        .unwrap()
+fn sample_vm() -> VM<CurrentNetwork, LedgerType> {
+    VM::from(ConsensusStore::<CurrentNetwork, LedgerType>::open(StorageMode::new_test(None)).unwrap()).unwrap()
 }
 
 /// Extract the transmissions from a block.
@@ -74,7 +75,7 @@ struct TestChainBuilder {
     /// The keys of all validators.
     private_keys: Vec<PrivateKey<CurrentNetwork>>,
 
-    ledger: Ledger<CurrentNetwork, LedgerType<CurrentNetwork>>,
+    ledger: Ledger<CurrentNetwork, LedgerType>,
 
     last_block_round: u64,
 
@@ -95,9 +96,7 @@ impl TestChainBuilder {
     /// Initialize the builder with the specified committee and genesis block
     pub fn new(private_keys: Vec<PrivateKey<CurrentNetwork>>, genesis: Block<CurrentNetwork>) -> Self {
         // Initialize the ledger with the genesis block.
-        let ledger =
-            Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(genesis.clone(), StorageMode::new_test(None))
-                .unwrap();
+        let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
 
         Self {
             private_keys,
@@ -285,7 +284,7 @@ fn test_load() {
     // Sample the genesis private key.
     let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     // Initialize the store.
-    let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+    let store = ConsensusStore::<_, LedgerType>::open(StorageMode::new_test(None)).unwrap();
     // Create a genesis block.
     let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
 
@@ -304,7 +303,7 @@ fn test_load_unchecked() {
     // Sample the genesis private key.
     let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     // Initialize the store.
-    let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+    let store = ConsensusStore::<_, LedgerType>::open(StorageMode::new_test(None)).unwrap();
     // Create a genesis block.
     let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
 
@@ -330,7 +329,7 @@ fn test_get_block() {
     // Sample the genesis private key.
     let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     // Initialize the store.
-    let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+    let store = ConsensusStore::<_, LedgerType>::open(StorageMode::new_test(None)).unwrap();
     // Create a genesis block.
     let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
 
@@ -389,15 +388,8 @@ fn test_insufficient_private_fees() {
         // Prepare a `split` execution without a fee.
         let inputs = [Value::Record(record_1.clone()), Value::from_str("100u64").unwrap()];
         let authorization = ledger.vm.authorize(&private_key, "credits.aleo", "split", inputs, rng).unwrap();
-        let split_transaction_without_fee = ledger
-            .vm
-            .execute_authorization(
-                authorization,
-                None,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let split_transaction_without_fee =
+            ledger.vm.execute_authorization(authorization, None, None::<NoQuery>, rng).unwrap();
         assert!(ledger.check_transaction_basic(&split_transaction_without_fee, None, rng).is_ok());
     }
 
@@ -410,15 +402,8 @@ fn test_insufficient_private_fees() {
             Value::from_str("100u64").unwrap(),
         ];
         let authorization = ledger.vm.authorize(&private_key, "credits.aleo", "transfer_private", inputs, rng).unwrap();
-        let transaction_without_fee = ledger
-            .vm
-            .execute_authorization(
-                authorization,
-                None,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction_without_fee =
+            ledger.vm.execute_authorization(authorization, None, None::<NoQuery>, rng).unwrap();
         let execution = transaction_without_fee.execution().unwrap();
 
         // Check that a transaction with sufficient fee will succeed.
@@ -433,14 +418,7 @@ fn test_insufficient_private_fees() {
                 rng,
             )
             .unwrap();
-        let fee = ledger
-            .vm
-            .execute_fee_authorization(
-                fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
         let sufficient_fee_transaction = Transaction::from_execution(execution.clone(), Some(fee)).unwrap();
         assert!(ledger.check_transaction_basic(&sufficient_fee_transaction, None, rng).is_ok());
 
@@ -449,14 +427,8 @@ fn test_insufficient_private_fees() {
             .vm
             .authorize_fee_private(&private_key, record_2.clone(), 1, 0, execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let insufficient_fee = ledger
-            .vm
-            .execute_fee_authorization(
-                insufficient_fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let insufficient_fee =
+            ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None::<NoQuery>, rng).unwrap();
         let insufficient_fee_transaction =
             Transaction::from_execution(execution.clone(), Some(insufficient_fee)).unwrap();
         assert!(ledger.check_transaction_basic(&insufficient_fee_transaction, None, rng).is_err());
@@ -480,17 +452,8 @@ finalize foo:
         .unwrap();
 
         // Check that a deployment transaction with sufficient fee will succeed.
-        let transaction = ledger
-            .vm
-            .deploy(
-                &private_key,
-                &program,
-                Some(record_2.clone()),
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction =
+            ledger.vm.deploy(&private_key, &program, Some(record_2.clone()), 0, None::<NoQuery>, rng).unwrap();
         assert!(ledger.check_transaction_basic(&transaction, None, rng).is_ok());
 
         // Check that a deployment transaction with insufficient fee will fail.
@@ -499,14 +462,8 @@ finalize foo:
             .vm
             .authorize_fee_private(&private_key, record_2, 1, 0, deployment.to_deployment_id().unwrap(), rng)
             .unwrap();
-        let insufficient_fee = ledger
-            .vm
-            .execute_fee_authorization(
-                insufficient_fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let insufficient_fee =
+            ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None::<NoQuery>, rng).unwrap();
         let insufficient_fee_transaction =
             Transaction::from_deployment(*transaction.owner().unwrap(), deployment.clone(), insufficient_fee).unwrap();
         assert!(ledger.check_transaction_basic(&insufficient_fee_transaction, None, rng).is_err());
@@ -538,7 +495,7 @@ fn test_insufficient_public_fees() {
                 inputs.into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -567,7 +524,7 @@ fn test_insufficient_public_fees() {
                 inputs.into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -623,17 +580,7 @@ finalize foo:
     let credits = Some(records.values().next().unwrap().clone());
 
     // Deploy.
-    let transaction = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program,
-            credits,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let transaction = ledger.vm.deploy(&private_key, &program, credits, 0, None::<NoQuery>, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -646,16 +593,7 @@ finalize foo:
     assert_eq!(ledger.latest_hash(), block.hash());
 
     // Create a transfer transaction to produce a record with insufficient balance to pay for fees.
-    let transfer_transaction = ledger
-        .create_transfer(
-            &private_key,
-            address,
-            100,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let transfer_transaction = ledger.create_transfer(&private_key, address, 100, 0, None::<NoQuery>, rng).unwrap();
 
     // Construct the next block.
     let block = ledger
@@ -695,7 +633,7 @@ finalize foo:
                 inputs.clone(),
                 Some(insufficient_record),
                 0,
-                None::<Query<CurrentNetwork, <LedgerType::<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng
             )
             .is_err()
@@ -705,15 +643,7 @@ finalize foo:
     // Execute with enough fees.
     let transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("dummy.aleo", "foo"),
-            inputs,
-            Some(sufficient_record),
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("dummy.aleo", "foo"), inputs, Some(sufficient_record), 0, None::<NoQuery>, rng)
         .unwrap();
     // Verify.
     ledger.vm.check_transaction(&transaction, None, rng).unwrap();
@@ -762,17 +692,8 @@ finalize failed_assert:
     let record_2 = records[1].clone();
 
     // Deploy the program.
-    let deployment_transaction = ledger
-        .vm()
-        .deploy(
-            &private_key,
-            &program,
-            Some(record_1),
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_transaction =
+        ledger.vm().deploy(&private_key, &program, Some(record_1), 0, None::<NoQuery>, rng).unwrap();
 
     // Construct the deployment block.
     let deployment_block = ledger
@@ -794,7 +715,7 @@ finalize failed_assert:
             Vec::<Value<_>>::new().into_iter(),
             Some(record_2),
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -856,17 +777,7 @@ finalize foo:
     .unwrap();
 
     // Deploy.
-    let transaction = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -901,15 +812,7 @@ fn test_bond_and_unbond_validator() {
     ];
     let transfer_transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let inputs = [
         Value::from_str(&format!("{new_member_withdrawal_address}")).unwrap(),
@@ -917,15 +820,7 @@ fn test_bond_and_unbond_validator() {
     ];
     let transfer_to_withdrawal_transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Construct the next block.
@@ -961,7 +856,7 @@ fn test_bond_and_unbond_validator() {
             inputs.iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -1016,7 +911,7 @@ fn test_bond_and_unbond_validator() {
             inputs.iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -1073,15 +968,7 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("185000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Construct the next block.
@@ -1105,7 +992,7 @@ fn test_aborted_transaction_indexing() {
             inputs.iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -1115,15 +1002,7 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address_2}")).unwrap(), Value::from_str("1u64").unwrap()];
     let transfer_transaction_2 = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Create a block.
@@ -1169,15 +1048,7 @@ fn test_aborted_solution_ids() {
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Create a block.
@@ -1252,7 +1123,7 @@ fn test_execute_duplicate_input_ids() {
                 inputs.clone().iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1272,17 +1143,8 @@ finalize foo:
     add r0 r0 into r1;",
         ))
         .unwrap();
-        let deployment = ledger
-            .vm
-            .deploy(
-                &private_key,
-                &program,
-                Some(record_deployment.clone()),
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment =
+            ledger.vm.deploy(&private_key, &program, Some(record_deployment.clone()), 0, None::<NoQuery>, rng).unwrap();
         deployment_ids.push(deployment.id());
         deployments.push(deployment);
     }
@@ -1297,7 +1159,7 @@ finalize foo:
             inputs.clone().iter(),
             Some(record_execution.clone()),
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -1332,14 +1194,7 @@ finalize foo:
             rng,
         )
         .unwrap();
-    let fee = ledger
-        .vm
-        .execute_fee_authorization(
-            fee_authorization,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
     // Create a mutated transaction.
     let mutated_transaction = Transaction::from_execution(mutated_execution, Some(fee)).unwrap();
     execution_ids.push(mutated_transaction.id());
@@ -1403,15 +1258,7 @@ finalize foo:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.into_iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let transfer_id = transfer.id();
 
@@ -1469,17 +1316,7 @@ function create_duplicate_record:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1525,7 +1362,7 @@ function create_duplicate_record:
                 inputs.into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 fixed_rng,
             )
             .unwrap();
@@ -1543,14 +1380,7 @@ function create_duplicate_record:
                 rng,
             )
             .unwrap();
-        let fee = ledger
-            .vm
-            .execute_fee_authorization(
-                fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1577,17 +1407,7 @@ function create_duplicate_record:
         .unwrap();
 
         // Create a transaction with a fixed rng.
-        let transaction = ledger
-            .vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                fixed_rng,
-            )
-            .unwrap();
+        let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, fixed_rng).unwrap();
 
         // Extract the deployment and owner.
         let deployment = transaction.deployment().unwrap().clone();
@@ -1605,14 +1425,7 @@ function create_duplicate_record:
                 fixed_rng,
             )
             .unwrap();
-        let fee = ledger
-            .vm
-            .execute_fee_authorization(
-                fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                fixed_rng,
-            )
-            .unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, fixed_rng).unwrap();
 
         Transaction::from_deployment(owner, deployment, fee).unwrap()
     };
@@ -1688,15 +1501,7 @@ function create_duplicate_record:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_4 = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.into_iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let transfer_4_id = transfer_4.id();
 
@@ -1747,17 +1552,7 @@ function empty_function:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1789,7 +1584,7 @@ function empty_function:
                 inputs.into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 fixed_rng,
             )
             .unwrap();
@@ -1807,14 +1602,7 @@ function empty_function:
                 rng,
             )
             .unwrap();
-        let fee = ledger
-            .vm
-            .execute_fee_authorization(
-                fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1863,15 +1651,7 @@ function empty_function:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.into_iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let transfer_transaction_id = transfer_transaction.id();
 
@@ -1924,17 +1704,7 @@ function simple_output:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1966,7 +1736,7 @@ function simple_output:
                 inputs.into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 fixed_rng,
             )
             .unwrap();
@@ -1984,14 +1754,7 @@ function simple_output:
                 rng,
             )
             .unwrap();
-        let fee = ledger
-            .vm
-            .execute_fee_authorization(
-                fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -2046,15 +1809,7 @@ function simple_output:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.into_iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let transfer_transaction_id = transfer_transaction.id();
 
@@ -2113,31 +1868,11 @@ function empty_function:
     .unwrap();
 
     // Create a deployment transaction for the first program with the same public payer.
-    let deployment_1 = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program_1,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
     let deployment_1_id = deployment_1.id();
 
     // Create a deployment transaction for the second program with the same public payer.
-    let deployment_2 = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program_2,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
     let deployment_2_id = deployment_2.id();
 
     // Create a block.
@@ -2183,7 +1918,7 @@ fn test_abort_fee_transaction() {
             inputs.clone().into_iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -2192,15 +1927,7 @@ fn test_abort_fee_transaction() {
     // Convert a fee transaction.
     let transaction_to_convert_to_fee = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.into_iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let fee_transaction = Transaction::from_fee(transaction_to_convert_to_fee.fee_transition().unwrap()).unwrap();
     let fee_transaction_id = fee_transaction.id();
@@ -2246,7 +1973,7 @@ fn test_abort_invalid_transaction() {
             inputs.clone().into_iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -2264,21 +1991,13 @@ fn test_abort_invalid_transaction() {
             inputs.clone().into_iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
     let valid_transaction_2 = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.into_iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let valid_transaction_id_1 = valid_transaction_1.id();
     let valid_transaction_id_2 = valid_transaction_2.id();
@@ -2364,32 +2083,12 @@ finalize foo2:
     .unwrap();
 
     // Create a deployment transaction for the first program.
-    let deployment_1 = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program_1,
-            Some(record_1),
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, Some(record_1), 0, None::<NoQuery>, rng).unwrap();
     let deployment_1_id = deployment_1.id();
     assert!(ledger.check_transaction_basic(&deployment_1, None, rng).is_ok());
 
     // Create a deployment transaction for the second program.
-    let deployment_2 = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program_2,
-            Some(record_2),
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, Some(record_2), 0, None::<NoQuery>, rng).unwrap();
     let deployment_2_id = deployment_2.id();
     assert!(ledger.check_transaction_basic(&deployment_2, None, rng).is_ok());
 
@@ -2506,8 +2205,7 @@ fn test_max_committee_limit_with_bonds() {
         .unwrap();
 
     // Initialize a Ledger from the genesis block.
-    let ledger =
-        Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(genesis_block, StorageMode::new_test(None)).unwrap();
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis_block, StorageMode::new_test(None)).unwrap();
 
     // Bond the first validator.
     let bond_first_transaction = ledger
@@ -2523,7 +2221,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -2567,7 +2265,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -2614,7 +2312,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -2633,7 +2331,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -2715,17 +2413,7 @@ fn test_deployment_exceeding_max_transaction_spend() {
     let exceeding_program = exceeding_program.unwrap();
 
     // Deploy the allowed program.
-    let deployment = ledger
-        .vm()
-        .deploy(
-            &private_key,
-            &allowed_program,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment = ledger.vm().deploy(&private_key, &allowed_program, None, 0, None::<NoQuery>, rng).unwrap();
 
     // Verify the deployment transaction.
     assert!(ledger.vm().check_transaction(&deployment, None, rng).is_ok());
@@ -2744,14 +2432,7 @@ fn test_deployment_exceeding_max_transaction_spend() {
     assert!(ledger.vm().contains_program(allowed_program.id()));
 
     // Attempt to deploy the exceeding program.
-    let result = ledger.vm().deploy(
-        &private_key,
-        &exceeding_program,
-        None,
-        0,
-        None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-        rng,
-    );
+    let result = ledger.vm().deploy(&private_key, &exceeding_program, None, 0, None::<NoQuery>, rng);
 
     // Check that the deployment failed.
     assert!(result.is_err());
@@ -2782,15 +2463,7 @@ fn test_transaction_ordering() {
         [Value::from_str(&format!("{address_2}")).unwrap(), Value::from_str(&format!("{amount_1}u64")).unwrap()];
     let transfer_1 = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     let amount_2 = 100000000u64;
@@ -2798,15 +2471,7 @@ fn test_transaction_ordering() {
         [Value::from_str(&format!("{address_3}")).unwrap(), Value::from_str(&format!("{amount_2}u64")).unwrap()];
     let transfer_2 = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Update the public balance.
@@ -2868,72 +2533,28 @@ finalize foo:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000u64").unwrap()];
     let initial_transfer = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let initial_transfer_id = initial_transfer.id();
 
     // Create a deployment transaction.
-    let deployment_transaction = ledger
-        .vm
-        .deploy(
-            &private_key_2,
-            &program_1,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key_2, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
 
     // Create a deployment transaction.
-    let deployment_transaction_2 = ledger
-        .vm
-        .deploy(
-            &private_key_3,
-            &program_2,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_transaction_2 = ledger.vm.deploy(&private_key_3, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
 
     // Create a transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Create a rejected transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000000000000u64").unwrap()];
     let rejected_transfer = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Create an aborted transfer transaction.
@@ -2946,23 +2567,14 @@ finalize foo:
             inputs.iter(),
             None,
             public_balance - 10,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
 
     // Create an aborted deployment transaction.
-    let aborted_deployment = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program_3,
-            None,
-            public_balance - 10,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let aborted_deployment =
+        ledger.vm.deploy(&private_key, &program_3, None, public_balance - 10, None::<NoQuery>, rng).unwrap();
 
     const ITERATIONS: usize = 100;
     for _ in 0..ITERATIONS {
@@ -3053,17 +2665,7 @@ finalize is_id:
     .unwrap();
 
     // Deploy.
-    let transaction = ledger
-        .vm
-        .deploy(
-            &private_key,
-            &program,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -3080,28 +2682,12 @@ finalize is_id:
     let inputs_block: [Value<CurrentNetwork>; 1] = [Value::from_str("2u32").unwrap()];
     let tx_block = ledger
         .vm
-        .execute(
-            &private_key,
-            (&program_id, "is_block"),
-            inputs_block.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, (&program_id, "is_block"), inputs_block.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let inputs_id: [Value<CurrentNetwork>; 1] = [Value::from(Literal::U16(U16::new(CurrentNetwork::ID)))];
     let tx_id = ledger
         .vm
-        .execute(
-            &private_key,
-            (&program_id, "is_id"),
-            inputs_id.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Construct the next block.
@@ -3114,27 +2700,11 @@ finalize is_id:
     let inputs_block_2: [Value<CurrentNetwork>; 1] = [Value::from_str("3u32").unwrap()];
     let tx_block_2 = ledger
         .vm
-        .execute(
-            &private_key,
-            (&program_id, "is_block"),
-            inputs_block_2.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, (&program_id, "is_block"), inputs_block_2.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
     let tx_id_2 = ledger
         .vm
-        .execute(
-            &private_key,
-            (&program_id, "is_id"),
-            inputs_id.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
+        .execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None::<NoQuery>, rng)
         .unwrap();
 
     // Construct the next block.
@@ -3204,7 +2774,7 @@ function foo:
                 program,
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType::<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng
             )) {
                 Ok(result) => break result.unwrap(),
@@ -3283,15 +2853,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.iter(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Check that block creation fails when duplicate solution IDs are provided.
@@ -3394,7 +2956,7 @@ mod valid_solutions {
                     inputs.iter(),
                     None,
                     0,
-                    None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                    None::<NoQuery>,
                     rng,
                 )
                 .unwrap();
@@ -3478,15 +3040,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.iter(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Create a block.
@@ -3558,15 +3112,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.iter(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Create a block.
@@ -3645,15 +3191,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.iter(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Check that the block creation fixes the malformed solution.
@@ -3722,15 +3260,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.iter(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Create a block.
@@ -3769,7 +3299,7 @@ fn test_forged_block_subdags() {
     // Sample the genesis private key.
     let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     // Initialize the store.
-    let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+    let store = ConsensusStore::<_, LedgerType>::open(StorageMode::new_test(None)).unwrap();
     // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
     let seed: u64 = rng.gen();
     let genesis_rng = &mut TestRng::from_seed(seed);
@@ -3793,8 +3323,7 @@ fn test_forged_block_subdags() {
     let block_3 = quorum_blocks.remove(0);
 
     // Construct the ledger.
-    let ledger =
-        Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(genesis, StorageMode::new_test(None)).unwrap();
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis, StorageMode::new_test(None)).unwrap();
 
     // Advance to block 1.
     ledger.advance_to_next_block(&block_1).unwrap();
@@ -3904,7 +3433,7 @@ fn test_subdag_with_long_branch() {
     // Sample the genesis private key.
     let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     // Initialize the store.
-    let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+    let store = ConsensusStore::<_, LedgerType>::open(StorageMode::new_test(None)).unwrap();
     // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
     let seed: u64 = rng.gen();
     let genesis_rng = &mut TestRng::from_seed(seed);
@@ -3929,8 +3458,7 @@ fn test_subdag_with_long_branch() {
     );
 
     // Construct the ledger.
-    let ledger =
-        Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(genesis, StorageMode::new_test(None)).unwrap();
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis, StorageMode::new_test(None)).unwrap();
 
     for block in blocks {
         ledger.advance_to_next_block(&block).unwrap();
@@ -3951,7 +3479,7 @@ fn test_subdag_with_gc_length() {
     // Sample the genesis private key.
     let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
     // Initialize the store.
-    let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+    let store = ConsensusStore::<_, LedgerType>::open(StorageMode::new_test(None)).unwrap();
     // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
     let seed: u64 = rng.gen();
     let genesis_rng = &mut TestRng::from_seed(seed);
@@ -3976,8 +3504,7 @@ fn test_subdag_with_gc_length() {
     );
 
     // Construct the ledger.
-    let ledger =
-        Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(genesis, StorageMode::new_test(None)).unwrap();
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis, StorageMode::new_test(None)).unwrap();
 
     for block in blocks {
         ledger.advance_to_next_block(&block).unwrap();
@@ -4103,33 +3630,13 @@ function create_and_consume:
     .unwrap();
 
     // Deploy the programs.
-    let deployment_0 = ledger
-        .vm()
-        .deploy(
-            &private_key,
-            &program_0,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_0 = ledger.vm().deploy(&private_key, &program_0, None, 0, None::<NoQuery>, rng).unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_0], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     ledger.advance_to_next_block(&block).unwrap();
 
-    let deployment_1 = ledger
-        .vm()
-        .deploy(
-            &private_key,
-            &program_1,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let deployment_1 = ledger.vm().deploy(&private_key, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_1], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
@@ -4144,7 +3651,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -4172,7 +3679,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -4201,7 +3708,7 @@ function create_and_consume:
             vec![Value::Record(record)].iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -4228,7 +3735,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -4255,7 +3762,7 @@ function create_and_consume:
             vec![Value::Record(mint_record.clone())].iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -4282,7 +3789,7 @@ function create_and_consume:
             vec![Value::Record(mint_record)].iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();
@@ -4309,7 +3816,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            None::<NoQuery>,
             rng,
         )
         .unwrap();

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -22,13 +22,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// otherwise, a public fee will be included in the transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the deployment fee.
-    pub fn deploy<R: Rng + CryptoRng>(
+    pub fn deploy<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         program: &Program<N>,
         fee_record: Option<Record<N, Plaintext<N>>>,
         priority_fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         // Compute the deployment.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -24,14 +24,14 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// otherwise, a public fee will be included in the transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the execution fee.
-    pub fn execute<R: Rng + CryptoRng>(
+    pub fn execute<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         (program_id, function_name): (impl TryInto<ProgramID<N>>, impl TryInto<Identifier<N>>),
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         fee_record: Option<Record<N, Plaintext<N>>>,
         priority_fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         let (execution, _) = self.execute_with_response(
@@ -74,8 +74,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let fee = match is_fee_required || is_priority_fee_declared {
             true => {
                 // Compute the minimum execution cost.
-                let query = query.clone().unwrap_or(Query::VM(self.block_store().clone()));
-                let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
+                let consensus_version = if let Some(query) = &query {
+                    N::CONSENSUS_VERSION(query.current_block_height()?)?
+                } else {
+                    N::CONSENSUS_VERSION(self.block_store().max_height().unwrap_or_default())?
+                };
                 let (minimum_execution_cost, (_, _)) = if consensus_version == ConsensusVersion::V1 {
                     execution_cost_v1(&self.process().read(), &execution)?
                 } else {
@@ -102,7 +105,15 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     )?,
                 };
                 // Execute the fee.
-                Some(self.execute_fee_authorization_raw(authorization, Some(query), rng)?)
+                if query.is_some() {
+                    Some(self.execute_fee_authorization_raw(authorization, query, rng)?)
+                } else {
+                    Some(self.execute_fee_authorization_raw(
+                        authorization,
+                        Some(Query::VM(self.block_store().clone())),
+                        rng,
+                    )?)
+                }
             }
             false => None,
         };
@@ -114,11 +125,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     ///
     /// This is identical to `execute_authorization_with_response` except that it
     /// discards the `Response`.
-    pub fn execute_authorization<R: Rng + CryptoRng>(
+    pub fn execute_authorization<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         execute_authorization: Authorization<N>,
         fee_authorization: Option<Authorization<N>>,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         let (execution, _) =
@@ -127,11 +138,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     }
 
     /// Returns a new execute transaction and response for the given authorization.
-    pub fn execute_authorization_with_response<R: Rng + CryptoRng>(
+    pub fn execute_authorization_with_response<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         execute_authorization: Authorization<N>,
         fee_authorization: Option<Authorization<N>>,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<(Transaction<N>, Response<N>)> {
         // Compute the execution.
@@ -147,10 +158,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     }
 
     /// Returns a new fee for the given authorization.
-    pub fn execute_fee_authorization<R: Rng + CryptoRng>(
+    pub fn execute_fee_authorization<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<Fee<N>> {
         debug_assert!(authorization.is_fee_private() || authorization.is_fee_public(), "Expected a fee authorization");
@@ -162,10 +173,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Executes a call to the program function for the given authorization.
     /// Returns the execution.
     #[inline]
-    fn execute_authorization_raw<R: Rng + CryptoRng>(
+    fn execute_authorization_raw<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<(Execution<N>, Response<N>)> {
         let timer = timer!("VM::execute_authorization_raw");
@@ -175,15 +186,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             let request = authorization.peek_next()?;
             Locator::new(*request.program_id(), *request.function_name()).to_string()
         };
-        // Prepare the query.
-        let query = match query {
-            Some(query) => query,
-            None => Query::VM(self.block_store().clone()),
-        };
-        lap!(timer, "Prepare the query");
 
         // Determine which Varuna version to use.
-        let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
+        let consensus_version = if let Some(query) = &query {
+            N::CONSENSUS_VERSION(query.current_block_height()?)?
+        } else {
+            N::CONSENSUS_VERSION(self.block_store().max_height().unwrap_or_default())?
+        };
         let varuna_version = if (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             VarunaVersion::V1
         } else {
@@ -199,7 +208,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Execute the call");
 
                 // Prepare the assignments.
-                cast_mut_ref!(trace as Trace<N>).prepare(query)?;
+                if let Some(query) = query {
+                    cast_mut_ref!(trace as Trace<N>).prepare(query)?;
+                } else {
+                    cast_mut_ref!(trace as Trace<N>).prepare(Query::VM(self.block_store().clone()))?;
+                }
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the proof and construct the execution.
@@ -220,23 +233,20 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Executes a call to the program function for the given fee authorization.
     /// Returns the fee.
     #[inline]
-    fn execute_fee_authorization_raw<R: Rng + CryptoRng>(
+    fn execute_fee_authorization_raw<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<Fee<N>> {
         let timer = timer!("VM::execute_fee_authorization_raw");
 
-        // Prepare the query.
-        let query = match query {
-            Some(query) => query,
-            None => Query::VM(self.block_store().clone()),
-        };
-        lap!(timer, "Prepare the query");
-
         // Determine which Varuna version to use.
-        let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
+        let consensus_version = if let Some(query) = &query {
+            N::CONSENSUS_VERSION(query.current_block_height()?)?
+        } else {
+            N::CONSENSUS_VERSION(self.block_store().max_height().unwrap_or_default())?
+        };
         let varuna_version = if (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             VarunaVersion::V1
         } else {
@@ -252,7 +262,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Execute the call");
 
                 // Prepare the assignments.
-                cast_mut_ref!(trace as Trace<N>).prepare(query)?;
+                if let Some(query) = query {
+                    cast_mut_ref!(trace as Trace<N>).prepare(query)?;
+                } else {
+                    cast_mut_ref!(trace as Trace<N>).prepare(Query::VM(self.block_store().clone()))?;
+                }
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the proof and construct the fee.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -52,14 +52,14 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// otherwise, a public fee will be included in the transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the execution fee.
-    pub fn execute_with_response<R: Rng + CryptoRng>(
+    pub fn execute_with_response<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         (program_id, function_name): (impl TryInto<ProgramID<N>>, impl TryInto<Identifier<N>>),
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         fee_record: Option<Record<N, Plaintext<N>>>,
         priority_fee_in_microcredits: u64,
-        query: Option<Query<N, C::BlockStorage>>,
+        query: Option<Q>,
         rng: &mut R,
     ) -> Result<(Transaction<N>, Response<N>)> {
         // Compute the authorization.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -351,8 +351,17 @@ mod tests {
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&validator_private_key, ("credits.aleo", "bond_validator"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &validator_private_key,
+                ("credits.aleo", "bond_validator"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Ensure the transaction is a bond public transition.
         assert_eq!(transaction.transitions().count(), 2);
@@ -392,8 +401,17 @@ mod tests {
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&delegator_private_key, ("credits.aleo", "bond_public"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &delegator_private_key,
+                ("credits.aleo", "bond_public"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Ensure the transaction is a bond public transition.
         assert_eq!(transaction.transitions().count(), 2);
@@ -432,7 +450,13 @@ mod tests {
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let (execution, _) = vm.execute_authorization_raw(authorization, None, rng).unwrap();
+        let (execution, _) = vm
+            .execute_authorization_raw(
+                authorization,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let (cost, _) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
         let (old_cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
 
@@ -463,8 +487,17 @@ mod tests {
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.clone(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         assert_eq!(51_060, *transaction.base_fee_amount().unwrap());
 
@@ -475,8 +508,17 @@ mod tests {
             vm.add_next_block(&next_block).unwrap();
         }
 
-        let transaction =
-            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs.clone(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         assert_eq!(34_060, *transaction.base_fee_amount().unwrap());
     }
@@ -513,7 +555,16 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &private_key, &[transaction], rng).unwrap();
@@ -525,8 +576,17 @@ finalize test:
         let inputs = [Value::<CurrentNetwork>::from_str("1_000_000u64").unwrap()].into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("nested_call.aleo", "test"),
+                inputs.clone(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // This fee should be at least the old credits.aleo/transfer_public fee, 51_060
         assert_eq!(62_776, *transaction.base_fee_amount().unwrap());
@@ -538,8 +598,17 @@ finalize test:
             vm.add_next_block(&next_block).unwrap();
         }
 
-        let transaction =
-            vm.execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("nested_call.aleo", "test"),
+                inputs.clone(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // The difference in old vs new fees is 8_500 * 3 = 25_500 for the three get/get.or_use's
         // There are two get.or_use's in transfer_public and an additional one in the nested_call.aleo/test
@@ -568,7 +637,13 @@ finalize test:
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let (execution, _) = vm.execute_authorization_raw(authorization, None, rng).unwrap();
+        let (execution, _) = vm
+            .execute_authorization_raw(
+                authorization,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let (cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
         println!("Cost: {}", cost);
     }
@@ -592,8 +667,17 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&caller_private_key, ("credits.aleo", "unbond_public"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "unbond_public"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Ensure the transaction is an unbond public transition.
         assert_eq!(transaction.transitions().count(), 2);
@@ -635,8 +719,17 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&caller_private_key, ("credits.aleo", "transfer_private"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "transfer_private"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -669,8 +762,17 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -703,8 +805,17 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&signer, ("credits.aleo", "transfer_public_as_signer"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &signer,
+                ("credits.aleo", "transfer_public_as_signer"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -738,8 +849,17 @@ finalize test:
         let inputs = [Value::<CurrentNetwork>::Record(record_1), Value::<CurrentNetwork>::Record(record_2)].into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&caller_private_key, ("credits.aleo", "join"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "join"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -772,8 +892,17 @@ finalize test:
             [Value::<CurrentNetwork>::Record(record), Value::<CurrentNetwork>::from_str("1u64").unwrap()].into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&caller_private_key, ("credits.aleo", "split"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("credits.aleo", "split"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Ensure the transaction is a split transition.
         assert_eq!(transaction.transitions().count(), 1);
@@ -864,7 +993,16 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &caller_private_key,
+                &child_program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -933,7 +1071,16 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &caller_private_key,
+                &parent_program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -943,7 +1090,15 @@ finalize test:
 
         // Execute the parent program.
         let Transaction::Execute(_, _, execution, _) = vm
-            .execute(&caller_private_key, ("parent.aleo", "test"), Vec::<Value<_>>::new().iter(), None, 0, None, rng)
+            .execute(
+                &caller_private_key,
+                ("parent.aleo", "test"),
+                Vec::<Value<_>>::new().iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap()
         else {
             unreachable!("VM::execute always produces an `Execution`")
@@ -1021,7 +1176,16 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&caller_private_key, &base_program, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &caller_private_key,
+                &base_program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -1060,7 +1224,16 @@ finalize test:
             .unwrap();
 
             // Deploy the program.
-            let transaction = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+            let transaction = vm
+                .deploy(
+                    &caller_private_key,
+                    &program,
+                    None,
+                    0,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
 
             // Construct the next block.
             let next_block =
@@ -1078,7 +1251,7 @@ finalize test:
                 vec![Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap()

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -307,6 +307,8 @@ mod tests {
     #[cfg(feature = "rocks")]
     type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
 
+    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
+
     fn prepare_vm(
         rng: &mut TestRng,
     ) -> Result<(
@@ -352,15 +354,7 @@ mod tests {
 
         // Execute.
         let transaction = vm
-            .execute(
-                &validator_private_key,
-                ("credits.aleo", "bond_validator"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&validator_private_key, ("credits.aleo", "bond_validator"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Ensure the transaction is a bond public transition.
@@ -402,15 +396,7 @@ mod tests {
 
         // Execute.
         let transaction = vm
-            .execute(
-                &delegator_private_key,
-                ("credits.aleo", "bond_public"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&delegator_private_key, ("credits.aleo", "bond_public"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Ensure the transaction is a bond public transition.
@@ -450,13 +436,7 @@ mod tests {
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let (execution, _) = vm
-            .execute_authorization_raw(
-                authorization,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let (execution, _) = vm.execute_authorization_raw(authorization, None::<NoQuery>, rng).unwrap();
         let (cost, _) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
         let (old_cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
 
@@ -488,15 +468,7 @@ mod tests {
 
         // Execute.
         let transaction = vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.clone(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         assert_eq!(51_060, *transaction.base_fee_amount().unwrap());
@@ -509,15 +481,7 @@ mod tests {
         }
 
         let transaction = vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.clone(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         assert_eq!(34_060, *transaction.base_fee_amount().unwrap());
@@ -555,16 +519,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &private_key, &[transaction], rng).unwrap();
@@ -577,15 +532,7 @@ finalize test:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &private_key,
-                ("nested_call.aleo", "test"),
-                inputs.clone(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // This fee should be at least the old credits.aleo/transfer_public fee, 51_060
@@ -599,15 +546,7 @@ finalize test:
         }
 
         let transaction = vm
-            .execute(
-                &private_key,
-                ("nested_call.aleo", "test"),
-                inputs.clone(),
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // The difference in old vs new fees is 8_500 * 3 = 25_500 for the three get/get.or_use's
@@ -637,13 +576,7 @@ finalize test:
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let (execution, _) = vm
-            .execute_authorization_raw(
-                authorization,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let (execution, _) = vm.execute_authorization_raw(authorization, None::<NoQuery>, rng).unwrap();
         let (cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
         println!("Cost: {}", cost);
     }
@@ -668,15 +601,7 @@ finalize test:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &caller_private_key,
-                ("credits.aleo", "unbond_public"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&caller_private_key, ("credits.aleo", "unbond_public"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Ensure the transaction is an unbond public transition.
@@ -720,15 +645,7 @@ finalize test:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &caller_private_key,
-                ("credits.aleo", "transfer_private"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&caller_private_key, ("credits.aleo", "transfer_private"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Assert the size of the transaction.
@@ -763,15 +680,7 @@ finalize test:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &caller_private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Assert the size of the transaction.
@@ -806,15 +715,7 @@ finalize test:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &signer,
-                ("credits.aleo", "transfer_public_as_signer"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&signer, ("credits.aleo", "transfer_public_as_signer"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Assert the size of the transaction.
@@ -849,17 +750,8 @@ finalize test:
         let inputs = [Value::<CurrentNetwork>::Record(record_1), Value::<CurrentNetwork>::Record(record_2)].into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(
-                &caller_private_key,
-                ("credits.aleo", "join"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction =
+            vm.execute(&caller_private_key, ("credits.aleo", "join"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -892,17 +784,8 @@ finalize test:
             [Value::<CurrentNetwork>::Record(record), Value::<CurrentNetwork>::from_str("1u64").unwrap()].into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(
-                &caller_private_key,
-                ("credits.aleo", "split"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction =
+            vm.execute(&caller_private_key, ("credits.aleo", "split"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Ensure the transaction is a split transition.
         assert_eq!(transaction.transitions().count(), 1);
@@ -993,16 +876,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm
-            .deploy(
-                &caller_private_key,
-                &child_program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction = vm.deploy(&caller_private_key, &child_program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -1071,16 +945,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm
-            .deploy(
-                &caller_private_key,
-                &parent_program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction = vm.deploy(&caller_private_key, &parent_program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -1096,7 +961,7 @@ finalize test:
                 Vec::<Value<_>>::new().iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap()
@@ -1176,16 +1041,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm
-            .deploy(
-                &caller_private_key,
-                &base_program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction = vm.deploy(&caller_private_key, &base_program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -1224,16 +1080,7 @@ finalize test:
             .unwrap();
 
             // Deploy the program.
-            let transaction = vm
-                .deploy(
-                    &caller_private_key,
-                    &program,
-                    None,
-                    0,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let transaction = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
             // Construct the next block.
             let next_block =
@@ -1251,7 +1098,7 @@ finalize test:
                 vec![Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap()

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -69,7 +69,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Determine if a priority fee is declared.
         let is_priority_fee_declared = priority_fee_in_microcredits > 0;
         // Compute the execution.
-        let (execution, response) = self.execute_authorization_raw(authorization, query.clone(), rng)?;
+        let (execution, response) = if let Some(query) = &query {
+            self.execute_authorization_raw(authorization, query.clone(), rng)?
+        } else {
+            self.execute_authorization_raw(authorization, Query::VM(self.block_store().clone()), rng)?
+        };
         // Compute the fee.
         let fee = match is_fee_required || is_priority_fee_declared {
             true => {
@@ -105,12 +109,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     )?,
                 };
                 // Execute the fee.
-                if query.is_some() {
+                if let Some(query) = query {
                     Some(self.execute_fee_authorization_raw(authorization, query, rng)?)
                 } else {
                     Some(self.execute_fee_authorization_raw(
                         authorization,
-                        Some(Query::VM(self.block_store().clone())),
+                        Query::VM(self.block_store().clone()),
                         rng,
                     )?)
                 }
@@ -146,11 +150,23 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         rng: &mut R,
     ) -> Result<(Transaction<N>, Response<N>)> {
         // Compute the execution.
-        let (execution, response) = self.execute_authorization_raw(execute_authorization, query.clone(), rng)?;
-        // Compute the fee.
-        let fee = match fee_authorization {
-            Some(authorization) => Some(self.execute_fee_authorization_raw(authorization, query, rng)?),
-            None => None,
+        let (execution, response, fee) = if let Some(query) = query {
+            let (execution, response) = self.execute_authorization_raw(execute_authorization, query.clone(), rng)?;
+            let fee = match fee_authorization {
+                Some(authorization) => Some(self.execute_fee_authorization_raw(authorization, query, rng)?),
+                None => None,
+            };
+
+            (execution, response, fee)
+        } else {
+            let query = Query::VM(self.block_store().clone());
+            let (execution, response) = self.execute_authorization_raw(execute_authorization, query.clone(), rng)?;
+            let fee = match fee_authorization {
+                Some(authorization) => Some(self.execute_fee_authorization_raw(authorization, query, rng)?),
+                None => None,
+            };
+
+            (execution, response, fee)
         };
         // Return the execute transaction and response.
         let transaction = Transaction::from_execution(execution, fee)?;
@@ -165,7 +181,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         rng: &mut R,
     ) -> Result<Fee<N>> {
         debug_assert!(authorization.is_fee_private() || authorization.is_fee_public(), "Expected a fee authorization");
-        self.execute_fee_authorization_raw(authorization, query, rng)
+        if let Some(query) = query {
+            self.execute_fee_authorization_raw(authorization, query, rng)
+        } else {
+            self.execute_fee_authorization_raw(authorization, Query::VM(self.block_store().clone()), rng)
+        }
     }
 }
 
@@ -176,7 +196,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     fn execute_authorization_raw<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Option<Q>,
+        query: Q,
         rng: &mut R,
     ) -> Result<(Execution<N>, Response<N>)> {
         let timer = timer!("VM::execute_authorization_raw");
@@ -188,11 +208,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         };
 
         // Determine which Varuna version to use.
-        let consensus_version = if let Some(query) = &query {
-            N::CONSENSUS_VERSION(query.current_block_height()?)?
-        } else {
-            N::CONSENSUS_VERSION(self.block_store().max_height().unwrap_or_default())?
-        };
+        let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
         let varuna_version = if (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             VarunaVersion::V1
         } else {
@@ -208,11 +224,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Execute the call");
 
                 // Prepare the assignments.
-                if let Some(query) = query {
-                    cast_mut_ref!(trace as Trace<N>).prepare(query)?;
-                } else {
-                    cast_mut_ref!(trace as Trace<N>).prepare(Query::VM(self.block_store().clone()))?;
-                }
+                cast_mut_ref!(trace as Trace<N>).prepare(query)?;
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the proof and construct the execution.
@@ -236,17 +248,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     fn execute_fee_authorization_raw<Q: QueryTrait<N>, R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Option<Q>,
+        query: Q,
         rng: &mut R,
     ) -> Result<Fee<N>> {
         let timer = timer!("VM::execute_fee_authorization_raw");
 
         // Determine which Varuna version to use.
-        let consensus_version = if let Some(query) = &query {
-            N::CONSENSUS_VERSION(query.current_block_height()?)?
-        } else {
-            N::CONSENSUS_VERSION(self.block_store().max_height().unwrap_or_default())?
-        };
+        let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
         let varuna_version = if (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             VarunaVersion::V1
         } else {
@@ -262,11 +270,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 lap!(timer, "Execute the call");
 
                 // Prepare the assignments.
-                if let Some(query) = query {
-                    cast_mut_ref!(trace as Trace<N>).prepare(query)?;
-                } else {
-                    cast_mut_ref!(trace as Trace<N>).prepare(Query::VM(self.block_store().clone()))?;
-                }
+                cast_mut_ref!(trace as Trace<N>).prepare(query)?;
                 lap!(timer, "Prepare the assignments");
 
                 // Compute the proof and construct the fee.
@@ -436,7 +440,8 @@ mod tests {
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let (execution, _) = vm.execute_authorization_raw(authorization, None::<NoQuery>, rng).unwrap();
+        let query = Query::VM(vm.block_store().clone());
+        let (execution, _) = vm.execute_authorization_raw(authorization, query, rng).unwrap();
         let (cost, _) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
         let (old_cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
 
@@ -576,7 +581,8 @@ finalize test:
 
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
-        let (execution, _) = vm.execute_authorization_raw(authorization, None::<NoQuery>, rng).unwrap();
+        let query = Query::VM(vm.block_store().clone());
+        let (execution, _) = vm.execute_authorization_raw(authorization, query, rng).unwrap();
         let (cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
         println!("Cost: {}", cost);
     }

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1470,7 +1470,14 @@ finalize transfer_public:
         let credits = Some(unspent_records.pop().unwrap().decrypt(&view_key)?);
 
         // Deploy.
-        let transaction = vm.deploy(private_key, &program, credits, 10, None, rng)?;
+        let transaction = vm.deploy(
+            private_key,
+            &program,
+            credits,
+            10,
+            None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )?;
 
         // Construct the new block.
         let next_block = sample_next_block(vm, private_key, &[transaction], previous_block, unspent_records, rng)?;
@@ -1578,7 +1585,17 @@ finalize transfer_public:
             .into_iter();
 
             // Execute.
-            let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs, None, 0, None, rng).unwrap();
+            let transaction = vm
+                .execute(
+                    private_key,
+                    ("credits.aleo", "split"),
+                    inputs,
+                    None,
+                    0,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
 
             transactions.push(transaction);
         }
@@ -1605,7 +1622,15 @@ finalize transfer_public:
 
         // Execute.
         let transaction = vm
-            .execute(&caller_private_key, (program_id, function_name), inputs.into_iter(), credits, 1, None, rng)
+            .execute(
+                &caller_private_key,
+                (program_id, function_name),
+                inputs.into_iter(),
+                credits,
+                1,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
         // Verify.
         vm.check_transaction(&transaction, None, rng).unwrap();
@@ -1881,7 +1906,7 @@ finalize transfer_public:
                 inputs.into_iter(),
                 None,
                 1,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2006,7 +2031,7 @@ finalize transfer_public:
                 inputs.clone().into_iter(),
                 None,
                 1,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2320,7 +2345,16 @@ function ped_hash:
             let credits = Some(unspent_records.pop().unwrap().decrypt(&caller_view_key).unwrap());
 
             // Deploy the program.
-            let deployment_transaction = vm.deploy(&caller_private_key, &program, credits, 10, None, rng).unwrap();
+            let deployment_transaction = vm
+                .deploy(
+                    &caller_private_key,
+                    &program,
+                    credits,
+                    10,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
 
             // Construct the deployment block.
             let deployment_block = sample_next_block(
@@ -2435,7 +2469,16 @@ finalize compute:
             let credits = Some(unspent_records.pop().unwrap().decrypt(&view_key).unwrap());
 
             // Deploy.
-            let transaction = vm.deploy(&private_key, &program, credits, 10, None, rng).unwrap();
+            let transaction = vm
+                .deploy(
+                    &private_key,
+                    &program,
+                    credits,
+                    10,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
 
             // Construct the new block.
             sample_next_block(&vm, &private_key, &[transaction], &splits_block, &mut unspent_records, rng).unwrap()
@@ -2965,7 +3008,7 @@ finalize compute:
                     .into_iter(),
                     None,
                     0,
-                    None,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                     rng,
                 )
                 .unwrap();
@@ -3370,7 +3413,7 @@ finalize compute:
                 .into_iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -3409,7 +3452,7 @@ finalize compute:
                 .into_iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1410,6 +1410,8 @@ mod tests {
     #[cfg(feature = "rocks")]
     type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
 
+    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
+
     /// Sample a new program and deploy it to the VM. Returns the program name.
     fn new_program_deployment<R: Rng + CryptoRng>(
         vm: &VM<CurrentNetwork, LedgerType>,
@@ -1470,14 +1472,7 @@ finalize transfer_public:
         let credits = Some(unspent_records.pop().unwrap().decrypt(&view_key)?);
 
         // Deploy.
-        let transaction = vm.deploy(
-            private_key,
-            &program,
-            credits,
-            10,
-            None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )?;
+        let transaction = vm.deploy(private_key, &program, credits, 10, None::<NoQuery>, rng)?;
 
         // Construct the new block.
         let next_block = sample_next_block(vm, private_key, &[transaction], previous_block, unspent_records, rng)?;
@@ -1585,17 +1580,8 @@ finalize transfer_public:
             .into_iter();
 
             // Execute.
-            let transaction = vm
-                .execute(
-                    private_key,
-                    ("credits.aleo", "split"),
-                    inputs,
-                    None,
-                    0,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let transaction =
+                vm.execute(private_key, ("credits.aleo", "split"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
 
             transactions.push(transaction);
         }
@@ -1628,7 +1614,7 @@ finalize transfer_public:
                 inputs.into_iter(),
                 credits,
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1906,7 +1892,7 @@ finalize transfer_public:
                 inputs.into_iter(),
                 None,
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2031,7 +2017,7 @@ finalize transfer_public:
                 inputs.clone().into_iter(),
                 None,
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2345,16 +2331,8 @@ function ped_hash:
             let credits = Some(unspent_records.pop().unwrap().decrypt(&caller_view_key).unwrap());
 
             // Deploy the program.
-            let deployment_transaction = vm
-                .deploy(
-                    &caller_private_key,
-                    &program,
-                    credits,
-                    10,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let deployment_transaction =
+                vm.deploy(&caller_private_key, &program, credits, 10, None::<NoQuery>, rng).unwrap();
 
             // Construct the deployment block.
             let deployment_block = sample_next_block(
@@ -2469,16 +2447,7 @@ finalize compute:
             let credits = Some(unspent_records.pop().unwrap().decrypt(&view_key).unwrap());
 
             // Deploy.
-            let transaction = vm
-                .deploy(
-                    &private_key,
-                    &program,
-                    credits,
-                    10,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let transaction = vm.deploy(&private_key, &program, credits, 10, None::<NoQuery>, rng).unwrap();
 
             // Construct the new block.
             sample_next_block(&vm, &private_key, &[transaction], &splits_block, &mut unspent_records, rng).unwrap()
@@ -3008,7 +2977,7 @@ finalize compute:
                     .into_iter(),
                     None,
                     0,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    None::<NoQuery>,
                     rng,
                 )
                 .unwrap();
@@ -3413,7 +3382,7 @@ finalize compute:
                 .into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -3452,7 +3421,7 @@ finalize compute:
                 .into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -596,7 +596,16 @@ function compute:
                 vm.add_next_block(&genesis).unwrap();
 
                 // Deploy.
-                let transaction = vm.deploy(&caller_private_key, &program, credits, 10, None, rng).unwrap();
+                let transaction = vm
+                    .deploy(
+                        &caller_private_key,
+                        &program,
+                        credits,
+                        10,
+                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                        rng,
+                    )
+                    .unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
                 // Return the transaction.
@@ -639,7 +648,14 @@ function compute:
                 assert_eq!(authorization.len(), 1);
 
                 // Construct the execute transaction.
-                let transaction = vm.execute_authorization(authorization, None, None, rng).unwrap();
+                let transaction = vm
+                    .execute_authorization(
+                        authorization,
+                        None,
+                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                        rng,
+                    )
+                    .unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
                 // Return the transaction.
@@ -682,7 +698,15 @@ function compute:
 
                 // Execute.
                 let transaction = vm
-                    .execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, record, 0, None, rng)
+                    .execute(
+                        &caller_private_key,
+                        ("credits.aleo", "transfer_public"),
+                        inputs,
+                        record,
+                        0,
+                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                        rng,
+                    )
                     .unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
@@ -717,7 +741,15 @@ function compute:
 
                 // Execute.
                 let transaction_without_fee = vm
-                    .execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng)
+                    .execute(
+                        &caller_private_key,
+                        ("credits.aleo", "transfer_public"),
+                        inputs,
+                        None,
+                        0,
+                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                        rng,
+                    )
                     .unwrap();
                 let execution = transaction_without_fee.execution().unwrap().clone();
 
@@ -732,7 +764,13 @@ function compute:
                     )
                     .unwrap();
                 // Compute the fee.
-                let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
+                let fee = vm
+                    .execute_fee_authorization(
+                        authorization,
+                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                        rng,
+                    )
+                    .unwrap();
 
                 // Construct the transaction.
                 let transaction = Transaction::from_execution(execution, Some(fee)).unwrap();
@@ -768,7 +806,13 @@ function compute:
         let authorization =
             vm.authorize_fee_public(&caller_private_key, fee, 100, execution.to_execution_id().unwrap(), rng).unwrap();
         // Compute the fee.
-        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
+        let fee = vm
+            .execute_fee_authorization(
+                authorization,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Construct the transaction.
         Transaction::from_execution(execution, Some(fee)).unwrap()
@@ -865,7 +909,7 @@ function compute:
                 [Value::Record(record), Value::from_str("1000000000u64").unwrap()].iter(), // 1000 credits
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -884,7 +928,7 @@ function compute:
                 [Value::Record(first_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -900,7 +944,7 @@ function compute:
                 [Value::Record(second_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -946,10 +990,24 @@ finalize getter:
     get map_0[0field] into r0;
         ";
         let first_deployment = vm
-            .deploy(&caller_private_key, &Program::from_str(first_program).unwrap(), Some(first_record), 1, None, rng)
+            .deploy(
+                &caller_private_key,
+                &Program::from_str(first_program).unwrap(),
+                Some(first_record),
+                1,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
         let second_deployment = vm
-            .deploy(&caller_private_key, &Program::from_str(second_program).unwrap(), Some(second_record), 1, None, rng)
+            .deploy(
+                &caller_private_key,
+                &Program::from_str(second_program).unwrap(),
+                Some(second_record),
+                1,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
         let deployment_block =
             sample_next_block(&vm, &caller_private_key, &[first_deployment, second_deployment], rng).unwrap();
@@ -963,7 +1021,7 @@ finalize getter:
                 Vec::<Value<MainnetV0>>::new().iter(),
                 Some(third_record),
                 1,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -974,7 +1032,7 @@ finalize getter:
                 Vec::<Value<MainnetV0>>::new().iter(),
                 Some(fourth_record),
                 1,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -1018,7 +1076,14 @@ function c:
     output r2 as u8.private;
         ";
         let deployment_1 = vm
-            .deploy(&caller_private_key, &Program::from_str(program_1).unwrap(), Some(record_0), 0, None, rng)
+            .deploy(
+                &caller_private_key,
+                &Program::from_str(program_1).unwrap(),
+                Some(record_0),
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Deploy the first program.
@@ -1038,7 +1103,14 @@ function b:
     output r2 as u8.private;
         ";
         let deployment_2 = vm
-            .deploy(&caller_private_key, &Program::from_str(program_2).unwrap(), Some(record_1), 0, None, rng)
+            .deploy(
+                &caller_private_key,
+                &Program::from_str(program_2).unwrap(),
+                Some(record_1),
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Deploy the second program.
@@ -1058,7 +1130,14 @@ function a:
     output r2 as u8.private;
         ";
         let deployment_3 = vm
-            .deploy(&caller_private_key, &Program::from_str(program_3).unwrap(), Some(record_2), 0, None, rng)
+            .deploy(
+                &caller_private_key,
+                &Program::from_str(program_3).unwrap(),
+                Some(record_2),
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Create the deployment for the fourth program.
@@ -1075,7 +1154,14 @@ function a:
     output r2 as u8.private;
         ";
         let deployment_4 = vm
-            .deploy(&caller_private_key, &Program::from_str(program_4).unwrap(), Some(record_3), 0, None, rng)
+            .deploy(
+                &caller_private_key,
+                &Program::from_str(program_4).unwrap(),
+                Some(record_3),
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
             .unwrap();
 
         // Deploy the third and fourth program together.
@@ -1144,7 +1230,16 @@ function multitransfer:
     ",
         )
         .unwrap();
-        let deployment = vm.deploy(&caller_private_key, &program, Some(record_0), 1, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                Some(record_0),
+                1,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         vm.add_next_block(&sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap()).unwrap();
 
         // Execute the programs.
@@ -1160,7 +1255,7 @@ function multitransfer:
                 inputs.into_iter(),
                 Some(record_2),
                 1,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -1194,7 +1289,16 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1215,7 +1319,16 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1255,7 +1368,16 @@ function transfer:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1314,7 +1436,16 @@ function call_fee_private:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1329,8 +1460,16 @@ function call_fee_private:
             Value::<MainnetV0>::from_str("1field").unwrap(),
         ];
         assert!(
-            vm.execute(&private_key, ("test_program.aleo", "call_fee_public"), inputs.into_iter(), None, 0, None, rng)
-                .is_err()
+            vm.execute(
+                &private_key,
+                ("test_program.aleo", "call_fee_public"),
+                inputs.into_iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng
+            )
+            .is_err()
         );
 
         // Ensure that the transaction that calls `fee_private` internally cannot be generated.
@@ -1341,8 +1480,16 @@ function call_fee_private:
             Value::<MainnetV0>::from_str("1field").unwrap(),
         ];
         assert!(
-            vm.execute(&private_key, ("test_program.aleo", "call_fee_private"), inputs.into_iter(), None, 0, None, rng)
-                .is_err()
+            vm.execute(
+                &private_key,
+                ("test_program.aleo", "call_fee_private"),
+                inputs.into_iter(),
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng
+            )
+            .is_err()
         );
     }
 
@@ -1375,7 +1522,16 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Verify the deployment transaction. It should fail because there are too many constraints.
         assert!(vm.check_transaction(&deployment, None, rng).is_err());
@@ -1416,7 +1572,16 @@ function do2:
             .unwrap();
 
         // Create the deployment transaction.
-        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Verify the deployment transaction. It should fail because there are too many constants.
         let check_tx_res = vm.check_transaction(&deployment, None, rng);
@@ -1451,7 +1616,16 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(_, _, program_owner, deployment, fee) = transaction else {
@@ -1474,7 +1648,13 @@ function do:
             .authorize_fee_public(&private_key, required_fee, 0, deployment.as_ref().to_deployment_id().unwrap(), rng)
             .unwrap();
         // Compute the fee.
-        let fee = vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
+        let fee = vm
+            .execute_fee_authorization(
+                fee_authorization,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Create a new deployment transaction with the overreported verifying keys.
         let adjusted_deployment =
@@ -1515,7 +1695,16 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(txid, _, program_owner, deployment, fee) = transaction else {
@@ -1551,8 +1740,17 @@ function do:
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Check that the deployment transaction will be aborted if injected into a block.
         let block = sample_next_block(&vm, &private_key, &[transaction, adjusted_transaction.clone()], rng).unwrap();
@@ -1592,7 +1790,16 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(txid, _, program_owner, deployment, fee) = transaction else {
@@ -1626,8 +1833,17 @@ function do:
         .into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Check that the deployment transaction will be aborted if injected into a block.
         let block = sample_next_block(&vm, &private_key, &[transaction, adjusted_transaction.clone()], rng).unwrap();
@@ -1680,7 +1896,16 @@ finalize do:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
         // For each layer, deploy a program that calls the program from the previous layer.
@@ -1715,7 +1940,16 @@ finalize do:
             let program = Program::from_str(&program_string).unwrap();
 
             // Deploy the program.
-            let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
+            let deployment = vm
+                .deploy(
+                    &private_key,
+                    &program,
+                    None,
+                    0,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
 
             vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
         }
@@ -1731,8 +1965,17 @@ finalize do:
         let inputs = [Value::<CurrentNetwork>::from_str("1u32").unwrap()].into_iter();
 
         // Execute.
-        let transaction =
-            vm.execute(&private_key, ("program_layer_30.aleo", "do"), inputs, record, 0, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &private_key,
+                ("program_layer_30.aleo", "do"),
+                inputs,
+                record,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Verify.
         vm.check_transaction(&transaction, None, rng).unwrap();
@@ -1784,7 +2027,7 @@ finalize do:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -1875,7 +2118,7 @@ finalize do:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -1983,7 +2226,16 @@ finalize transfer_public:
         let wrapper_program_address = wrapper_program_id.to_address().unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2000,7 +2252,7 @@ finalize transfer_public:
                     .iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2052,7 +2304,7 @@ finalize transfer_public:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2175,7 +2427,16 @@ finalize transfer_public_as_signer:
         let wrapper_program_address = wrapper_program_id.to_address().unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2191,7 +2452,7 @@ finalize transfer_public_as_signer:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2329,7 +2590,16 @@ finalize transfer_public_to_private:
         let wrapper_program_id = ProgramID::from_str("credits_wrapper.aleo").unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2345,7 +2615,7 @@ finalize transfer_public_to_private:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2464,7 +2734,7 @@ finalize transfer_public_to_private:
                 inputs.iter(),
                 None,
                 0u64,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2550,7 +2820,13 @@ finalize transfer_public_to_private:
         let authorization = vm
             .authorize_fee_public(&caller_private_key, 10_000_000, 0, new_execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
+        let fee = vm
+            .execute_fee_authorization(
+                authorization,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let new_transaction = Transaction::from_execution(new_execution, Some(fee)).unwrap();
 
         // Verify the new transaction.
@@ -2588,7 +2864,7 @@ finalize transfer_public_to_private:
                 inputs.iter(),
                 None,
                 0u64,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2712,7 +2988,16 @@ function add_thrice:
         ",
         )
         .unwrap();
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
         vm.add_next_block(&block).unwrap();
 
@@ -2724,7 +3009,7 @@ function add_thrice:
                 [Value::from_str("1u64").unwrap(), Value::from_str("2u64").unwrap()].iter(),
                 None,
                 0u64,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2814,7 +3099,13 @@ function add_thrice:
         let authorization = vm
             .authorize_fee_public(&caller_private_key, 10_000_000, 0, new_execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
+        let fee = vm
+            .execute_fee_authorization(
+                authorization,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         let new_transaction = Transaction::from_execution(new_execution, Some(fee)).unwrap();
 
         // Verify the new transaction.
@@ -2841,7 +3132,16 @@ function add_thrice:
         let program = small_transaction_program();
 
         // Deploy the program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2853,7 +3153,16 @@ function add_thrice:
         let program = large_transaction_program();
 
         // Deploy the program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2869,7 +3178,7 @@ function add_thrice:
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2894,7 +3203,7 @@ function add_thrice:
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -2967,11 +3276,29 @@ function check:
         .unwrap();
 
         // Deploy the child programs and add them to a block
-        let deployment_1 = vm.deploy(&private_key, &child_program_1, None, 0, None, rng).unwrap();
+        let deployment_1 = vm
+            .deploy(
+                &private_key,
+                &child_program_1,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment_1, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment_1], rng).unwrap()).unwrap();
 
-        let deployment_2 = vm.deploy(&private_key, &child_program_2, None, 0, None, rng).unwrap();
+        let deployment_2 = vm
+            .deploy(
+                &private_key,
+                &child_program_2,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment_2, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment_2], rng).unwrap()).unwrap();
 
@@ -2995,7 +3322,16 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &parent_program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &parent_program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -3018,7 +3354,16 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &grandparent_program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &private_key,
+                &grandparent_program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -3119,7 +3464,7 @@ function check:
                 [Value::from_str(&format!("{address_1}")).unwrap(), Value::from_str("100000000u64").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -3130,7 +3475,7 @@ function check:
                 [Value::from_str(&format!("{address_2}")).unwrap(), Value::from_str("100000000u64").unwrap()].iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -3173,13 +3518,31 @@ function adder:
         off_chain_vm.add_next_block(&genesis).unwrap();
         off_chain_vm.add_next_block(&block).unwrap();
         // Deploy the first program.
-        let deployment_1 = off_chain_vm.deploy(&private_key_1, &program_1, None, 0, None, rng).unwrap();
+        let deployment_1 = off_chain_vm
+            .deploy(
+                &private_key_1,
+                &program_1,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_1.fee_amount().unwrap(), 2483025);
         // Add the first program to the off-chain VM.
         off_chain_vm.process().write().add_program(&program_1).unwrap();
         // Deploy the second program.
-        let deployment_2 = off_chain_vm.deploy(&private_key_2, &program_2, None, 0, None, rng).unwrap();
+        let deployment_2 = off_chain_vm
+            .deploy(
+                &private_key_2,
+                &program_2,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_2.fee_amount().unwrap(), 2659575);
         // Drop the off-chain VM.
@@ -3223,7 +3586,16 @@ function adder:
         for (i, body) in invalid_program_bodies.iter().enumerate() {
             println!("Deploying 'valid' test program {}: {}", i, body);
             let program = Program::from_str(&format!("program test_valid_{}.aleo;\n{}", i, body)).unwrap();
-            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+            let deployment = vm
+                .deploy(
+                    &caller_private_key,
+                    &program,
+                    None,
+                    0,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
             let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
             assert_eq!(block.transactions().num_accepted(), 1);
             assert_eq!(block.transactions().num_rejected(), 0);
@@ -3238,7 +3610,16 @@ function adder:
         for (i, body) in invalid_program_bodies.iter().enumerate() {
             println!("Deploying 'invalid' test program {}: {}", i, body);
             let program = Program::from_str(&format!("program test_invalid_{}.aleo;\n{}", i, body)).unwrap();
-            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+            let deployment = vm
+                .deploy(
+                    &caller_private_key,
+                    &program,
+                    None,
+                    0,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
             if let Err(e) = vm.check_transaction(&deployment, None, rng) {
                 println!("Error: {}", e);
             } else {
@@ -3249,7 +3630,16 @@ function adder:
         // Attempt to deploy a program with the name `constructor`.
         // Verify that `check_transaction` fails.
         let program = Program::from_str(r"program constructor.aleo; function dummy:").unwrap();
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+        let deployment = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
         if let Err(e) = vm.check_transaction(&deployment, None, rng) {
             println!("Error: {}", e);
         } else {

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -328,7 +328,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let aborted_solution_ids = vec![];
         // Prepare the transactions.
         let transactions = (0..Block::<N>::NUM_GENESIS_TRANSACTIONS)
-            .map(|_| self.execute(private_key, locator, inputs.iter(), None, 0, None, rng))
+            .map(|_| self.execute(private_key, locator, inputs.iter(), None, 0, None::<Query<N, C::BlockStorage>>, rng))
             .collect::<Result<Vec<_>, _>>()?;
 
         // Construct the finalize state.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -469,6 +469,8 @@ pub(crate) mod test_helpers {
     #[cfg(feature = "rocks")]
     type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
 
+    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
+
     /// Samples a new finalize state.
     pub(crate) fn sample_finalize_state(block_height: u32) -> FinalizeGlobalState {
         FinalizeGlobalState::from(block_height as u64, block_height, [0u8; 32])
@@ -596,16 +598,7 @@ function compute:
                 vm.add_next_block(&genesis).unwrap();
 
                 // Deploy.
-                let transaction = vm
-                    .deploy(
-                        &caller_private_key,
-                        &program,
-                        credits,
-                        10,
-                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                        rng,
-                    )
-                    .unwrap();
+                let transaction = vm.deploy(&caller_private_key, &program, credits, 10, None::<NoQuery>, rng).unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
                 // Return the transaction.
@@ -648,14 +641,7 @@ function compute:
                 assert_eq!(authorization.len(), 1);
 
                 // Construct the execute transaction.
-                let transaction = vm
-                    .execute_authorization(
-                        authorization,
-                        None,
-                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                        rng,
-                    )
-                    .unwrap();
+                let transaction = vm.execute_authorization(authorization, None, None::<NoQuery>, rng).unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
                 // Return the transaction.
@@ -704,7 +690,7 @@ function compute:
                         inputs,
                         record,
                         0,
-                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                        None::<NoQuery>,
                         rng,
                     )
                     .unwrap();
@@ -747,7 +733,7 @@ function compute:
                         inputs,
                         None,
                         0,
-                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                        None::<NoQuery>,
                         rng,
                     )
                     .unwrap();
@@ -764,13 +750,7 @@ function compute:
                     )
                     .unwrap();
                 // Compute the fee.
-                let fee = vm
-                    .execute_fee_authorization(
-                        authorization,
-                        None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                        rng,
-                    )
-                    .unwrap();
+                let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
 
                 // Construct the transaction.
                 let transaction = Transaction::from_execution(execution, Some(fee)).unwrap();
@@ -806,13 +786,7 @@ function compute:
         let authorization =
             vm.authorize_fee_public(&caller_private_key, fee, 100, execution.to_execution_id().unwrap(), rng).unwrap();
         // Compute the fee.
-        let fee = vm
-            .execute_fee_authorization(
-                authorization,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
 
         // Construct the transaction.
         Transaction::from_execution(execution, Some(fee)).unwrap()
@@ -909,7 +883,7 @@ function compute:
                 [Value::Record(record), Value::from_str("1000000000u64").unwrap()].iter(), // 1000 credits
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -928,7 +902,7 @@ function compute:
                 [Value::Record(first_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -944,7 +918,7 @@ function compute:
                 [Value::Record(second_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -995,7 +969,7 @@ finalize getter:
                 &Program::from_str(first_program).unwrap(),
                 Some(first_record),
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1005,7 +979,7 @@ finalize getter:
                 &Program::from_str(second_program).unwrap(),
                 Some(second_record),
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1021,7 +995,7 @@ finalize getter:
                 Vec::<Value<MainnetV0>>::new().iter(),
                 Some(third_record),
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1032,7 +1006,7 @@ finalize getter:
                 Vec::<Value<MainnetV0>>::new().iter(),
                 Some(fourth_record),
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1081,7 +1055,7 @@ function c:
                 &Program::from_str(program_1).unwrap(),
                 Some(record_0),
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1108,7 +1082,7 @@ function b:
                 &Program::from_str(program_2).unwrap(),
                 Some(record_1),
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1135,7 +1109,7 @@ function a:
                 &Program::from_str(program_3).unwrap(),
                 Some(record_2),
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1159,7 +1133,7 @@ function a:
                 &Program::from_str(program_4).unwrap(),
                 Some(record_3),
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1230,16 +1204,7 @@ function multitransfer:
     ",
         )
         .unwrap();
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                Some(record_0),
-                1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, Some(record_0), 1, None::<NoQuery>, rng).unwrap();
         vm.add_next_block(&sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap()).unwrap();
 
         // Execute the programs.
@@ -1255,7 +1220,7 @@ function multitransfer:
                 inputs.into_iter(),
                 Some(record_2),
                 1,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -1289,16 +1254,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1319,16 +1275,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1368,16 +1315,7 @@ function transfer:
         )
         .unwrap();
 
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1436,16 +1374,7 @@ function call_fee_private:
         )
         .unwrap();
 
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1466,7 +1395,7 @@ function call_fee_private:
                 inputs.into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng
             )
             .is_err()
@@ -1486,7 +1415,7 @@ function call_fee_private:
                 inputs.into_iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng
             )
             .is_err()
@@ -1522,16 +1451,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Verify the deployment transaction. It should fail because there are too many constraints.
         assert!(vm.check_transaction(&deployment, None, rng).is_err());
@@ -1572,16 +1492,7 @@ function do2:
             .unwrap();
 
         // Create the deployment transaction.
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Verify the deployment transaction. It should fail because there are too many constants.
         let check_tx_res = vm.check_transaction(&deployment, None, rng);
@@ -1616,16 +1527,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(_, _, program_owner, deployment, fee) = transaction else {
@@ -1648,13 +1550,7 @@ function do:
             .authorize_fee_public(&private_key, required_fee, 0, deployment.as_ref().to_deployment_id().unwrap(), rng)
             .unwrap();
         // Compute the fee.
-        let fee = vm
-            .execute_fee_authorization(
-                fee_authorization,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
 
         // Create a new deployment transaction with the overreported verifying keys.
         let adjusted_deployment =
@@ -1695,16 +1591,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(txid, _, program_owner, deployment, fee) = transaction else {
@@ -1741,15 +1628,7 @@ function do:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Check that the deployment transaction will be aborted if injected into a block.
@@ -1790,16 +1669,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(txid, _, program_owner, deployment, fee) = transaction else {
@@ -1834,15 +1704,7 @@ function do:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Check that the deployment transaction will be aborted if injected into a block.
@@ -1896,16 +1758,7 @@ finalize do:
         )
         .unwrap();
 
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
         // For each layer, deploy a program that calls the program from the previous layer.
@@ -1940,16 +1793,7 @@ finalize do:
             let program = Program::from_str(&program_string).unwrap();
 
             // Deploy the program.
-            let deployment = vm
-                .deploy(
-                    &private_key,
-                    &program,
-                    None,
-                    0,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
             vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
         }
@@ -1965,17 +1809,8 @@ finalize do:
         let inputs = [Value::<CurrentNetwork>::from_str("1u32").unwrap()].into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(
-                &private_key,
-                ("program_layer_30.aleo", "do"),
-                inputs,
-                record,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("program_layer_30.aleo", "do"), inputs, record, 0, None::<NoQuery>, rng).unwrap();
 
         // Verify.
         vm.check_transaction(&transaction, None, rng).unwrap();
@@ -2027,7 +1862,7 @@ finalize do:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2118,7 +1953,7 @@ finalize do:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2226,16 +2061,7 @@ finalize transfer_public:
         let wrapper_program_address = wrapper_program_id.to_address().unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2252,7 +2078,7 @@ finalize transfer_public:
                     .iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2304,7 +2130,7 @@ finalize transfer_public:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2427,16 +2253,7 @@ finalize transfer_public_as_signer:
         let wrapper_program_address = wrapper_program_id.to_address().unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2452,7 +2269,7 @@ finalize transfer_public_as_signer:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2590,16 +2407,7 @@ finalize transfer_public_to_private:
         let wrapper_program_id = ProgramID::from_str("credits_wrapper.aleo").unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2615,7 +2423,7 @@ finalize transfer_public_to_private:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2734,7 +2542,7 @@ finalize transfer_public_to_private:
                 inputs.iter(),
                 None,
                 0u64,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2820,13 +2628,7 @@ finalize transfer_public_to_private:
         let authorization = vm
             .authorize_fee_public(&caller_private_key, 10_000_000, 0, new_execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let fee = vm
-            .execute_fee_authorization(
-                authorization,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
         let new_transaction = Transaction::from_execution(new_execution, Some(fee)).unwrap();
 
         // Verify the new transaction.
@@ -2864,7 +2666,7 @@ finalize transfer_public_to_private:
                 inputs.iter(),
                 None,
                 0u64,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -2988,16 +2790,7 @@ function add_thrice:
         ",
         )
         .unwrap();
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
         vm.add_next_block(&block).unwrap();
 
@@ -3009,7 +2802,7 @@ function add_thrice:
                 [Value::from_str("1u64").unwrap(), Value::from_str("2u64").unwrap()].iter(),
                 None,
                 0u64,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -3099,13 +2892,7 @@ function add_thrice:
         let authorization = vm
             .authorize_fee_public(&caller_private_key, 10_000_000, 0, new_execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let fee = vm
-            .execute_fee_authorization(
-                authorization,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
         let new_transaction = Transaction::from_execution(new_execution, Some(fee)).unwrap();
 
         // Verify the new transaction.
@@ -3132,16 +2919,7 @@ function add_thrice:
         let program = small_transaction_program();
 
         // Deploy the program.
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -3153,16 +2931,7 @@ function add_thrice:
         let program = large_transaction_program();
 
         // Deploy the program.
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -3178,7 +2947,7 @@ function add_thrice:
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -3203,7 +2972,7 @@ function add_thrice:
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -3276,29 +3045,11 @@ function check:
         .unwrap();
 
         // Deploy the child programs and add them to a block
-        let deployment_1 = vm
-            .deploy(
-                &private_key,
-                &child_program_1,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment_1 = vm.deploy(&private_key, &child_program_1, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment_1, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment_1], rng).unwrap()).unwrap();
 
-        let deployment_2 = vm
-            .deploy(
-                &private_key,
-                &child_program_2,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment_2 = vm.deploy(&private_key, &child_program_2, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment_2, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment_2], rng).unwrap()).unwrap();
 
@@ -3322,16 +3073,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &parent_program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &parent_program, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -3354,16 +3096,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm
-            .deploy(
-                &private_key,
-                &grandparent_program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&private_key, &grandparent_program, None, 0, None::<NoQuery>, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -3464,7 +3197,7 @@ function check:
                 [Value::from_str(&format!("{address_1}")).unwrap(), Value::from_str("100000000u64").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -3475,7 +3208,7 @@ function check:
                 [Value::from_str(&format!("{address_2}")).unwrap(), Value::from_str("100000000u64").unwrap()].iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -3518,31 +3251,13 @@ function adder:
         off_chain_vm.add_next_block(&genesis).unwrap();
         off_chain_vm.add_next_block(&block).unwrap();
         // Deploy the first program.
-        let deployment_1 = off_chain_vm
-            .deploy(
-                &private_key_1,
-                &program_1,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment_1 = off_chain_vm.deploy(&private_key_1, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_1.fee_amount().unwrap(), 2483025);
         // Add the first program to the off-chain VM.
         off_chain_vm.process().write().add_program(&program_1).unwrap();
         // Deploy the second program.
-        let deployment_2 = off_chain_vm
-            .deploy(
-                &private_key_2,
-                &program_2,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment_2 = off_chain_vm.deploy(&private_key_2, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_2.fee_amount().unwrap(), 2659575);
         // Drop the off-chain VM.
@@ -3586,16 +3301,7 @@ function adder:
         for (i, body) in invalid_program_bodies.iter().enumerate() {
             println!("Deploying 'valid' test program {}: {}", i, body);
             let program = Program::from_str(&format!("program test_valid_{}.aleo;\n{}", i, body)).unwrap();
-            let deployment = vm
-                .deploy(
-                    &caller_private_key,
-                    &program,
-                    None,
-                    0,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
             let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
             assert_eq!(block.transactions().num_accepted(), 1);
             assert_eq!(block.transactions().num_rejected(), 0);
@@ -3610,16 +3316,7 @@ function adder:
         for (i, body) in invalid_program_bodies.iter().enumerate() {
             println!("Deploying 'invalid' test program {}: {}", i, body);
             let program = Program::from_str(&format!("program test_invalid_{}.aleo;\n{}", i, body)).unwrap();
-            let deployment = vm
-                .deploy(
-                    &caller_private_key,
-                    &program,
-                    None,
-                    0,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
             if let Err(e) = vm.check_transaction(&deployment, None, rng) {
                 println!("Error: {}", e);
             } else {
@@ -3630,16 +3327,7 @@ function adder:
         // Attempt to deploy a program with the name `constructor`.
         // Verify that `check_transaction` fails.
         let program = Program::from_str(r"program constructor.aleo; function dummy:").unwrap();
-        let deployment = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
         if let Err(e) = vm.check_transaction(&deployment, None, rng) {
             println!("Error: {}", e);
         } else {

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -438,6 +438,8 @@ mod tests {
     #[cfg(feature = "rocks")]
     type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
 
+    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
+
     #[test]
     fn test_verify() {
         let rng = &mut TestRng::default();
@@ -621,16 +623,8 @@ mod tests {
 
         // Deploy.
         let program = crate::vm::test_helpers::sample_program();
-        let deployment_transaction = vm
-            .deploy(
-                &caller_private_key,
-                &program,
-                Some(credits),
-                10,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deployment_transaction =
+            vm.deploy(&caller_private_key, &program, Some(credits), 10, None::<NoQuery>, rng).unwrap();
 
         // Construct the new block header.
         let time_since_last_block = CurrentNetwork::BLOCK_TIME as i64;
@@ -705,15 +699,7 @@ mod tests {
 
         // Execute.
         let transaction = vm
-            .execute(
-                &caller_private_key,
-                ("testing.aleo", "initialize"),
-                inputs,
-                credits,
-                10,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&caller_private_key, ("testing.aleo", "initialize"), inputs, credits, 10, None::<NoQuery>, rng)
             .unwrap();
 
         // Verify.
@@ -815,13 +801,7 @@ function compute:
             )
             .unwrap();
         // Compute the fee.
-        let fee = vm
-            .execute_fee_authorization(
-                authorization,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
 
         // Construct the transaction.
         let mutated_transaction = Transaction::from_execution(mutated_execution, Some(fee)).unwrap();
@@ -890,15 +870,7 @@ function compute:
 
             // Execute.
             let transaction_without_fee = vm
-                .execute(
-                    &private_key,
-                    ("credits.aleo", "transfer_public"),
-                    inputs,
-                    None,
-                    0,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
+                .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
                 .unwrap();
             let execution = transaction_without_fee.execution().unwrap().clone();
 
@@ -907,13 +879,7 @@ function compute:
                 .authorize_fee_public(&private_key, 10_000_000, 100, execution.to_execution_id().unwrap(), rng)
                 .unwrap();
             // Compute the fee.
-            let fee = vm
-                .execute_fee_authorization(
-                    authorization,
-                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                    rng,
-                )
-                .unwrap();
+            let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
 
             // Construct the transaction.
             Transaction::from_execution(execution, Some(fee)).unwrap()
@@ -964,15 +930,7 @@ function compute:
         ]
         .into_iter();
         let transaction_v1 = vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Advance the ledger past ConsensusV4
@@ -996,15 +954,7 @@ function compute:
         ]
         .into_iter();
         let transaction_v2 = vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
             .unwrap();
 
         // Check that the v2 transaction is valid
@@ -1121,52 +1071,16 @@ function compute:
         .unwrap();
 
         // Create a deployment transaction for the first program.
-        let deploy_1 = vm
-            .deploy(
-                &private_key,
-                &program_1,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deploy_1 = vm.deploy(&private_key, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Create a deployment transaction for the second program.
-        let deploy_2 = vm
-            .deploy(
-                &private_key,
-                &program_2,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deploy_2 = vm.deploy(&private_key, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Create a deployment transaction for the third program.
-        let deploy_3 = vm
-            .deploy(
-                &private_key,
-                &program_3,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deploy_3 = vm.deploy(&private_key, &program_3, None, 0, None::<NoQuery>, rng).unwrap();
 
         // Create a deployment transaction for the fourth program.
-        let deploy_4 = vm
-            .deploy(
-                &private_key,
-                &program_4,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng,
-            )
-            .unwrap();
+        let deploy_4 = vm.deploy(&private_key, &program_4, None, 0, None::<NoQuery>, rng).unwrap();
 
         // // Ensure that the deployments are valid.
         assert!(vm.check_transaction(&deploy_1, None, rng).is_ok());

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -433,6 +433,11 @@ mod tests {
 
     type CurrentNetwork = test_helpers::CurrentNetwork;
 
+    #[cfg(not(feature = "rocks"))]
+    type LedgerType = ledger_store::helpers::memory::ConsensusMemory<CurrentNetwork>;
+    #[cfg(feature = "rocks")]
+    type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
+
     #[test]
     fn test_verify() {
         let rng = &mut TestRng::default();
@@ -616,7 +621,16 @@ mod tests {
 
         // Deploy.
         let program = crate::vm::test_helpers::sample_program();
-        let deployment_transaction = vm.deploy(&caller_private_key, &program, Some(credits), 10, None, rng).unwrap();
+        let deployment_transaction = vm
+            .deploy(
+                &caller_private_key,
+                &program,
+                Some(credits),
+                10,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Construct the new block header.
         let time_since_last_block = CurrentNetwork::BLOCK_TIME as i64;
@@ -690,8 +704,17 @@ mod tests {
         let credits = Some(records.values().next().unwrap().decrypt(&caller_view_key).unwrap());
 
         // Execute.
-        let transaction =
-            vm.execute(&caller_private_key, ("testing.aleo", "initialize"), inputs, credits, 10, None, rng).unwrap();
+        let transaction = vm
+            .execute(
+                &caller_private_key,
+                ("testing.aleo", "initialize"),
+                inputs,
+                credits,
+                10,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Verify.
         vm.check_transaction(&transaction, None, rng).unwrap();
@@ -792,7 +815,13 @@ function compute:
             )
             .unwrap();
         // Compute the fee.
-        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
+        let fee = vm
+            .execute_fee_authorization(
+                authorization,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Construct the transaction.
         let mutated_transaction = Transaction::from_execution(mutated_execution, Some(fee)).unwrap();
@@ -860,8 +889,17 @@ function compute:
             .into_iter();
 
             // Execute.
-            let transaction_without_fee =
-                vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
+            let transaction_without_fee = vm
+                .execute(
+                    &private_key,
+                    ("credits.aleo", "transfer_public"),
+                    inputs,
+                    None,
+                    0,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
             let execution = transaction_without_fee.execution().unwrap().clone();
 
             // Authorize the fee.
@@ -869,7 +907,13 @@ function compute:
                 .authorize_fee_public(&private_key, 10_000_000, 100, execution.to_execution_id().unwrap(), rng)
                 .unwrap();
             // Compute the fee.
-            let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
+            let fee = vm
+                .execute_fee_authorization(
+                    authorization,
+                    None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                    rng,
+                )
+                .unwrap();
 
             // Construct the transaction.
             Transaction::from_execution(execution, Some(fee)).unwrap()
@@ -919,8 +963,17 @@ function compute:
             Value::<CurrentNetwork>::from_str("1u64").unwrap(),
         ]
         .into_iter();
-        let transaction_v1 =
-            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
+        let transaction_v1 = vm
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Advance the ledger past ConsensusV4
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
@@ -942,8 +995,17 @@ function compute:
             Value::<CurrentNetwork>::from_str("1u64").unwrap(),
         ]
         .into_iter();
-        let transaction_v2 =
-            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
+        let transaction_v2 = vm
+            .execute(
+                &private_key,
+                ("credits.aleo", "transfer_public"),
+                inputs,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Check that the v2 transaction is valid
         assert!(vm.check_transaction(&transaction_v2, None, rng).is_ok());
@@ -1059,16 +1121,52 @@ function compute:
         .unwrap();
 
         // Create a deployment transaction for the first program.
-        let deploy_1 = vm.deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
+        let deploy_1 = vm
+            .deploy(
+                &private_key,
+                &program_1,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Create a deployment transaction for the second program.
-        let deploy_2 = vm.deploy(&private_key, &program_2, None, 0, None, rng).unwrap();
+        let deploy_2 = vm
+            .deploy(
+                &private_key,
+                &program_2,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Create a deployment transaction for the third program.
-        let deploy_3 = vm.deploy(&private_key, &program_3, None, 0, None, rng).unwrap();
+        let deploy_3 = vm
+            .deploy(
+                &private_key,
+                &program_3,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // Create a deployment transaction for the fourth program.
-        let deploy_4 = vm.deploy(&private_key, &program_4, None, 0, None, rng).unwrap();
+        let deploy_4 = vm
+            .deploy(
+                &private_key,
+                &program_4,
+                None,
+                0,
+                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            )
+            .unwrap();
 
         // // Ensure that the deployments are valid.
         assert!(vm.check_transaction(&deploy_1, None, rng).is_ok());

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -32,6 +32,7 @@ use ledger_block::{
     Transactions,
     Transition,
 };
+use ledger_query::Query;
 use ledger_store::{ConsensusStorage, ConsensusStore};
 use snarkvm_synthesizer::{VM, program::FinalizeOperation};
 use synthesizer_program::FinalizeGlobalState;
@@ -92,7 +93,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
                 .iter(),
                 None,
                 0,
-                None,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
                 rng,
             )
             .unwrap();
@@ -125,7 +126,14 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
 
     // Deploy the programs.
     for program in test.programs() {
-        let transaction = match vm.deploy(&genesis_private_key, program, None, 0, None, rng) {
+        let transaction = match vm.deploy(
+            &genesis_private_key,
+            program,
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        ) {
             Ok(transaction) => transaction,
             Err(error) => {
                 let mut output = serde_yaml::Mapping::new();
@@ -224,18 +232,25 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
             let mut other = serde_yaml::Mapping::new();
 
             // Execute the function, extracting the transaction.
-            let transaction =
-                match vm.execute(&private_key, (program_id, function_name), inputs.iter(), None, 0u64, None, rng) {
-                    Ok(transaction) => transaction,
-                    // If the execution fails, return the error.
-                    Err(err) => {
-                        result.insert(
-                            serde_yaml::Value::String("execute".to_string()),
-                            serde_yaml::Value::String(err.to_string()),
-                        );
-                        return (serde_yaml::Value::Mapping(result), serde_yaml::Value::Mapping(Default::default()));
-                    }
-                };
+            let transaction = match vm.execute(
+                &private_key,
+                (program_id, function_name),
+                inputs.iter(),
+                None,
+                0u64,
+                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                rng,
+            ) {
+                Ok(transaction) => transaction,
+                // If the execution fails, return the error.
+                Err(err) => {
+                    result.insert(
+                        serde_yaml::Value::String("execute".to_string()),
+                        serde_yaml::Value::String(err.to_string()),
+                    );
+                    return (serde_yaml::Value::Mapping(result), serde_yaml::Value::Mapping(Default::default()));
+                }
+            };
 
             // Attempt to verify the transaction.
             let verified = vm.check_transaction(&transaction, None, rng).is_ok();
@@ -535,7 +550,17 @@ fn split<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>(
     rng: &mut R,
 ) -> (Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>, Vec<Transaction<CurrentNetwork>>) {
     let inputs = vec![Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
-    let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs.iter(), None, 0, None, rng).unwrap();
+    let transaction = vm
+        .execute(
+            private_key,
+            ("credits.aleo", "split"),
+            inputs.iter(),
+            None,
+            0,
+            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+            rng,
+        )
+        .unwrap();
     let records = transaction
         .records()
         .map(|(_, record)| record.decrypt(&ViewKey::try_from(private_key).unwrap()).unwrap())

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -44,9 +44,11 @@ use rayon::prelude::*;
 use utilities::*;
 
 #[cfg(not(feature = "rocks"))]
-type LedgerType<N> = ledger_store::helpers::memory::ConsensusMemory<N>;
+type LedgerType = ledger_store::helpers::memory::ConsensusMemory<CurrentNetwork>;
 #[cfg(feature = "rocks")]
-type LedgerType<N> = ledger_store::helpers::rocksdb::ConsensusDB<N>;
+type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
+
+type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
 
 #[test]
 fn test_vm_execute_and_finalize() {
@@ -93,7 +95,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
                 .iter(),
                 None,
                 0,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             )
             .unwrap();
@@ -126,14 +128,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
 
     // Deploy the programs.
     for program in test.programs() {
-        let transaction = match vm.deploy(
-            &genesis_private_key,
-            program,
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        ) {
+        let transaction = match vm.deploy(&genesis_private_key, program, None, 0, None::<NoQuery>, rng) {
             Ok(transaction) => transaction,
             Err(error) => {
                 let mut output = serde_yaml::Mapping::new();
@@ -238,7 +233,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
                 inputs.iter(),
                 None,
                 0u64,
-                None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
+                None::<NoQuery>,
                 rng,
             ) {
                 Ok(transaction) => transaction,
@@ -386,9 +381,9 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
 fn initialize_vm<R: Rng + CryptoRng>(
     private_key: &PrivateKey<CurrentNetwork>,
     rng: &mut R,
-) -> (VM<CurrentNetwork, LedgerType<CurrentNetwork>>, Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>) {
+) -> (VM<CurrentNetwork, LedgerType>, Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>) {
     // Initialize a VM.
-    let vm: VM<CurrentNetwork, LedgerType<CurrentNetwork>> =
+    let vm: VM<CurrentNetwork, LedgerType> =
         VM::from(ConsensusStore::open(StorageMode::new_test(None)).unwrap()).unwrap();
 
     // Initialize the genesis block.
@@ -550,17 +545,8 @@ fn split<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>(
     rng: &mut R,
 ) -> (Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>, Vec<Transaction<CurrentNetwork>>) {
     let inputs = vec![Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
-    let transaction = vm
-        .execute(
-            private_key,
-            ("credits.aleo", "split"),
-            inputs.iter(),
-            None,
-            0,
-            None::<Query<CurrentNetwork, <LedgerType<_> as ConsensusStorage<_>>::BlockStorage>>,
-            rng,
-        )
-        .unwrap();
+    let transaction =
+        vm.execute(private_key, ("credits.aleo", "split"), inputs.iter(), None, 0, None::<NoQuery>, rng).unwrap();
     let records = transaction
         .records()
         .map(|(_, record)| record.decrypt(&ViewKey::try_from(private_key).unwrap()).unwrap())


### PR DESCRIPTION
Caveats:
- `QueryTrait` now requires that the implementors are `Clone`
- if a query is not supplied (i.e. it's `None`), it gets recreated in functions that need to use it more than once; this is perfectly fine with the current `Query` object, or if we assume the query to typically be provided

The 1st commit is the actual change, and the related diff is small; the second commit, and the vast majority of the PR's diff, is the formatting fallout from adjusting the tests to disambiguate the `None` values.