### PR TITLE
[Fix] Don't panic on current_block_height with an empty block store

### DIFF
--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1197,7 +1197,7 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
     /// Returns the current block height.
     pub fn current_block_height(&self) -> u32 {
-        u32::try_from(self.tree.read().number_of_leaves()).unwrap() - 1
+        u32::try_from(self.tree.read().number_of_leaves()).unwrap().saturating_sub(1)
     }
 
     /// Returns the state root that contains the given `block height`.
@@ -1383,6 +1383,18 @@ mod tests {
     use crate::helpers::memory::BlockMemory;
 
     type CurrentNetwork = console::network::MainnetV0;
+
+    #[test]
+    fn test_current_block_height_empty() {
+        // Initialize a new block store.
+        let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
+
+        // Current_block_height shouldn't panic.
+        assert_eq!(block_store.current_block_height(), 0);
+
+        // Verify the equivalence of the alternative method.
+        assert_eq!(block_store.max_height().unwrap_or_default(), 0);
+    }
 
     #[test]
     fn test_insert_get_remove() {


### PR DESCRIPTION
This was quite surprising; stumbled upon it while working on https://github.com/ProvableHQ/snarkVM/pull/2736. Not a big issue, of course, it can only happen with an empty ledger.