### PR TITLE
[Refactor] Simplify and document cfg_find

### DIFF
--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -131,7 +131,7 @@ impl<N: Network> Transactions<N> {
         &self,
         unconfirmed_transaction_id: &N::TransactionID,
     ) -> Option<&ConfirmedTransaction<N>> {
-        cfg_find!(self.transactions, unconfirmed_transaction_id, contains_unconfirmed_transaction_id)
+        cfg_find!(self.transactions, |txn| txn.contains_unconfirmed_transaction_id(unconfirmed_transaction_id))
     }
 
     /// Returns the transaction with the given transition ID, if it exists.
@@ -139,7 +139,7 @@ impl<N: Network> Transactions<N> {
     /// If the given transition ID is a fee transition for a rejected transaction,
     /// this will return the fee transaction.
     pub fn find_transaction_for_transition_id(&self, transition_id: &N::TransitionID) -> Option<&Transaction<N>> {
-        cfg_find!(self.transactions, transition_id, contains_transition).map(|tx| tx.transaction())
+        cfg_find!(self.transactions, |txn| txn.contains_transition(transition_id)).map(|tx| tx.transaction())
     }
 
     /// Returns the unconfirmed transaction with the given transition ID, if it exists.
@@ -150,7 +150,7 @@ impl<N: Network> Transactions<N> {
         &self,
         transition_id: &N::TransitionID,
     ) -> Result<Option<Transaction<N>>> {
-        let result = cfg_find!(self.transactions, transition_id, contains_transition);
+        let result = cfg_find!(self.transactions, |tx| tx.contains_transition(transition_id));
 
         match result {
             Some(txn) => Ok(Some(txn.to_unconfirmed_transaction()?)),
@@ -160,32 +160,32 @@ impl<N: Network> Transactions<N> {
 
     /// Returns the transaction with the given serial number, if it exists.
     pub fn find_transaction_for_serial_number(&self, serial_number: &Field<N>) -> Option<&Transaction<N>> {
-        cfg_find!(self.transactions, serial_number, contains_serial_number).map(|tx| tx.transaction())
+        cfg_find!(self.transactions, |txn| txn.contains_serial_number(serial_number)).map(|tx| tx.transaction())
     }
 
     /// Returns the transaction with the given commitment, if it exists.
     pub fn find_transaction_for_commitment(&self, commitment: &Field<N>) -> Option<&Transaction<N>> {
-        cfg_find!(self.transactions, commitment, contains_commitment).map(|tx| tx.transaction())
+        cfg_find!(self.transactions, |txn| txn.contains_commitment(commitment)).map(|tx| tx.transaction())
     }
 
     /// Returns the transition with the corresponding transition ID, if it exists.
     pub fn find_transition(&self, transition_id: &N::TransitionID) -> Option<&Transition<N>> {
-        cfg_find_map!(self.transactions, transition_id, find_transition)
+        cfg_find_map!(self.transactions, |txn| txn.find_transition(transition_id))
     }
 
     /// Returns the transition for the given serial number, if it exists.
     pub fn find_transition_for_serial_number(&self, serial_number: &Field<N>) -> Option<&Transition<N>> {
-        cfg_find_map!(self.transactions, serial_number, find_transition_for_serial_number)
+        cfg_find_map!(self.transactions, |txn| txn.find_transition_for_serial_number(serial_number))
     }
 
     /// Returns the transition for the given commitment, if it exists.
     pub fn find_transition_for_commitment(&self, commitment: &Field<N>) -> Option<&Transition<N>> {
-        cfg_find_map!(self.transactions, commitment, find_transition_for_commitment)
+        cfg_find_map!(self.transactions, |txn| txn.find_transition_for_commitment(commitment))
     }
 
     /// Returns the record with the corresponding commitment, if it exists.
     pub fn find_record(&self, commitment: &Field<N>) -> Option<&Record<N, Ciphertext<N>>> {
-        cfg_find_map!(self.transactions, commitment, find_record)
+        cfg_find_map!(self.transactions, |txn| txn.find_record(commitment))
     }
 }
 

--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -225,29 +225,37 @@ macro_rules! cfg_values {
     }};
 }
 
-/// Finds the first element that satisfies the predicate function
+/// Find an element `e` where `lambda(e)` evalutes to true (if any).
+///
+/// # Notes
+/// - This returns at most one entry that satisfies the given condition, not necessarily the first one.
+/// - `closure` must be a lambda function returning a boolean, e.g., `|e| e > 0`.
 #[macro_export]
 macro_rules! cfg_find {
-    ($self:expr, $object:expr, $func:ident) => {{
+    ($object:expr, $closure:expr) => {{
         #[cfg(not(feature = "serial"))]
-        let result = $self.par_values().find_any(|tx| tx.$func($object));
+        let result = $object.par_values().find_any($closure);
 
         #[cfg(feature = "serial")]
-        let result = $self.values().find(|tx| tx.$func($object));
+        let result = $object.values().find($closure);
 
         result
     }};
 }
 
-/// Applies a function and returns the first value that is not None
+/// Applies a function and returns an entry where `lambda(e)` is not None.
+///
+/// # Notes
+/// - This returns at most one entry that satisfies the given condition, not necessarily the first one.
+/// - `closure` must be a lambda function returning Option, e.g., `|e| Some(e)`.
 #[macro_export]
 macro_rules! cfg_find_map {
-    ($self:expr, $object:expr, $func:ident) => {{
+    ($object:expr, $closure:expr) => {{
         #[cfg(not(feature = "serial"))]
-        let result = $self.par_values().filter_map(|tx| tx.$func($object)).find_any(|_| true);
+        let result = $object.par_values().filter_map($closure).find_any(|_| true);
 
         #[cfg(feature = "serial")]
-        let result = $self.values().find_map(|tx| tx.$func($object));
+        let result = $object.values().find_map($closure);
 
         result
     }};


### PR DESCRIPTION
## Motivation
I found `cfg_find` much harder to read than it should be, while working on fixes to the REST API. 

For code like the following `cfg_find!(collection, argument, func)` the macro evaluates to `collection.iter().find(|e| e.func(argument))`. It is not intuitive to pass the argument before the function, to allow only a single argument, and that you need to pass the name of the function, not a reference to it.

## Propose Change
We can now simply pass a closure to `cfg_find`, like we already do with some other macros in that module. The code about changes to simply `cfg_find!(collection, |e| e.func(argument))`.

The PR also adds more documentation to `cfg_find` and `cfg_find_map`.

Finally, I changed some of the variable names inside the macro to make more sense. The first one is now `object`, not `self` (you are not passing a reference to self necessarily) and any references to transactions are removed (this utility function is not specific to transactions).

## Notes
The macros in `utilities/src/parallel.rs` can be converted to inline functions, which would make them even easier to use, but that is a much bigger change and does not seem worth it.