### PR TITLE
[Chore] Remove unused dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -894,6 +894,23 @@ jobs:
       - clear_environment:
           cache_key: v1.3.0-rust-1.83.0-snarkvm-fmt-cache
 
+  check-unused-dependencies:
+    docker:
+      - image: cimg/rust:1.83.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+    resource_class: << pipeline.parameters.medium >>
+    steps:
+      - checkout
+      - setup_environment:
+          cache_key: v3.3.1-rust-1.83.0--cache
+      - run:
+          name: Check for unused dependencies
+          no_output_timeout: 35m
+          command: |
+            cargo install cargo-machete@0.7.0
+            cargo machete
+      - clear_environment:
+          cache_key: v3.3.1-rust-1.83.0-machete-cache
+
   check-clippy:
     docker:
       - image: cimg/rust:1.83.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,17 +443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cl3"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823f24e72fa0c68aa14a250ae1c0848e68d4ae188b71c3972343e45b46f8644"
-dependencies = [
- "libc",
- "opencl-sys",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,15 +599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,24 +637,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "cuda-config"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
-dependencies = [
- "glob",
-]
-
-[[package]]
-name = "cuda-driver-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
-dependencies = [
- "cuda-config",
 ]
 
 [[package]]
@@ -945,18 +907,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fil-rustacuda"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40666d4072d5353fd2fd3aa26e4ddb225c38c6440e8c467cae9b17688ae6191c"
-dependencies = [
- "bitflags 1.3.2",
- "cuda-driver-sys",
- "rustacuda_core",
- "rustacuda_derive",
-]
 
 [[package]]
 name = "flate2"
@@ -1714,40 +1664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-exporter-prometheus"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
-dependencies = [
- "base64 0.21.7",
- "hyper",
- "hyper-tls",
- "indexmap 2.9.0",
- "ipnet",
- "metrics",
- "metrics-util",
- "quanta",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "metrics",
- "num_cpus",
- "quanta",
- "sketches-ddsketch",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,25 +1840,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "opencl-sys"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de15dd01496ae90c5799f5266184ab020082b4065800ff0b732f489371d0e5cf"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "opencl3"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ab4a90cb496f787d3934deb0c54fa9d65e7bed710c10071234aab0196fba04"
-dependencies = [
- "cl3",
- "libc",
-]
 
 [[package]]
 name = "openssl"
@@ -2142,21 +2039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,15 +2121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
-dependencies = [
- "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2396,40 +2269,6 @@ checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
-]
-
-[[package]]
-name = "rust-gpu-tools"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ce78d5548a74fad25177825d0c20f4cfbc6eaf796bcee53afe792e39ede4e2"
-dependencies = [
- "fil-rustacuda",
- "hex",
- "home",
- "log",
- "once_cell",
- "opencl3",
- "sha2",
- "temp-env",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "rustacuda_core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
-
-[[package]]
-name = "rustacuda_derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
-dependencies = [
- "proc-macro2",
- "quote 1.0.40",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2758,12 +2597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sketches-ddsketch"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,13 +2630,8 @@ dependencies = [
  "clap",
  "colored",
  "dotenvy",
- "indexmap 2.9.0",
- "locktick",
  "num-format",
- "once_cell",
- "parking_lot",
  "rand",
- "rayon",
  "rusty-hook",
  "self_update",
  "serde_json",
@@ -2834,22 +2662,16 @@ dependencies = [
  "blake2",
  "cfg-if",
  "criterion",
- "crossbeam-channel",
  "expect-test",
  "fxhash",
  "hashbrown 0.14.5",
  "hex",
  "indexmap 2.9.0",
  "itertools 0.11.0",
- "lazy_static",
- "locktick",
  "num-traits",
- "parking_lot",
  "rand",
- "rand_chacha",
  "rand_core",
  "rayon",
- "rust-gpu-tools",
  "serde",
  "serde_json",
  "serial_test",
@@ -2861,7 +2683,6 @@ dependencies = [
  "snarkvm-parameters",
  "snarkvm-utilities",
  "thiserror 2.0.12",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2892,7 +2713,6 @@ name = "snarkvm-circuit-account"
 version = "3.7.1"
 dependencies = [
  "anyhow",
- "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
  "snarkvm-console-account",
@@ -2968,7 +2788,6 @@ name = "snarkvm-circuit-program"
 version = "3.7.1"
 dependencies = [
  "anyhow",
- "paste",
  "rand",
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3136,7 +2955,6 @@ version = "3.7.1"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
- "itertools 0.11.0",
  "lazy_static",
  "once_cell",
  "paste",
@@ -3147,9 +2965,7 @@ dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types",
  "snarkvm-curves",
- "snarkvm-fields",
  "snarkvm-parameters",
- "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3181,7 +2997,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
- "paste",
  "serde_json",
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3515,7 +3330,6 @@ dependencies = [
  "indexmap 2.9.0",
  "locktick",
  "lru",
- "once_cell",
  "parking_lot",
  "rand",
  "rand_chacha",
@@ -3611,7 +3425,6 @@ name = "snarkvm-metrics"
 version = "3.7.1"
 dependencies = [
  "metrics",
- "metrics-exporter-prometheus",
 ]
 
 [[package]]
@@ -3620,14 +3433,11 @@ version = "3.7.1"
 dependencies = [
  "aleo-std",
  "anyhow",
- "bincode",
  "cfg-if",
  "colored",
  "curl",
  "encoding",
  "hex",
- "indexmap 2.9.0",
- "itertools 0.11.0",
  "js-sys",
  "lazy_static",
  "locktick",
@@ -3783,7 +3593,6 @@ name = "snarkvm-wasm"
 version = "3.7.1"
 dependencies = [
  "getrandom 0.2.15",
- "snarkvm-circuit-network",
  "snarkvm-console",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -3934,15 +3743,6 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "temp-env"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ save_r1cs_hashes = [ "snarkvm-circuit/save_r1cs_hashes" ]
 history = [ "snarkvm-synthesizer/history" ]
 parameters_no_std_out = [ "snarkvm-parameters/no_std_out" ]
 locktick = [
-  "dep:locktick",
   "snarkvm-algorithms?/locktick",
   "snarkvm-ledger?/locktick",
   "snarkvm-parameters?/locktick",
@@ -238,30 +237,12 @@ optional = true
 version = "0.15"
 optional = true
 
-[dependencies.indexmap]
-version = "2.0"
-features = [ "rayon" ]
-
-[dependencies.locktick]
-version = "0.3"
-features = [ "parking_lot" ]
-optional = true
-
 [dependencies.num-format]
 version = "0.4.4"
-
-[dependencies.once_cell]
-version = "1.18"
-
-[dependencies.parking_lot]
-version = "0.12"
 
 [dependencies.rand]
 version = "0.8"
 optional = true
-
-[dependencies.rayon]
-version = "1"
 
 [dependencies.self_update]
 version = "0.38"

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -85,10 +85,6 @@ default-features = true
 version = "1.0.0"
 optional = true
 
-[dependencies.crossbeam-channel]
-version = "0.5"
-optional = true
-
 [dependencies.fxhash]
 version = "0.2.1"
 optional = true
@@ -106,18 +102,6 @@ optional = true
 [dependencies.itertools]
 version = "0.11.0"
 
-[dependencies.lazy_static]
-version = "1.4"
-optional = true
-
-[dependencies.locktick]
-version = "0.3"
-features = [ "parking_lot" ]
-optional = true
-
-[dependencies.parking_lot]
-version = "0.12"
-
 [dependencies.rand]
 version = "0.8"
 
@@ -126,16 +110,8 @@ version = "0.6"
 default-features = false
 optional = true
 
-[dependencies.rand_chacha]
-version = "0.3"
-default-features = false
-
 [dependencies.rayon]
 version = "1"
-
-[dependencies.rust-gpu-tools]
-version = "0.7.0"
-optional = true
 
 [dependencies.serde]
 version = "1.0"
@@ -153,10 +129,6 @@ features = [ "const_generics", "const_new" ]
 
 [dependencies.thiserror]
 version = "2.0.11"
-
-[dependencies.wasm-bindgen-futures]
-version = "0.4"
-optional = true
 
 [dependencies.num-traits]
 version = "0.2"
@@ -199,13 +171,12 @@ wasm = [
   "polycommit_wasm",
   "r1cs",
   "snark",
-  "wasm-bindgen-futures"
 ]
 cuda = [ "snarkvm-algorithms-cuda" ]
 profiler = [ "aleo-std/profiler" ]
 crypto_hash = [ ]
 fft = [ ]
-locktick = [ "dep:locktick", "snarkvm-parameters?/locktick" ]
+locktick = [ "snarkvm-parameters?/locktick" ]
 msm = [ ]
 test = [ ]
 polycommit = [ "crypto_hash", "fft", "msm", "rand_core" ]

--- a/circuit/account/Cargo.toml
+++ b/circuit/account/Cargo.toml
@@ -14,10 +14,6 @@ path = "../../console/account"
 version = "=3.7.1"
 optional = true
 
-[dependencies.snarkvm-circuit-algorithms]
-path = "../algorithms"
-version = "=3.7.1"
-
 [dependencies.snarkvm-circuit-network]
 path = "../network"
 version = "=3.7.1"

--- a/circuit/program/Cargo.toml
+++ b/circuit/program/Cargo.toml
@@ -38,9 +38,6 @@ version = "=3.7.1"
 path = "../../utilities"
 version = "=3.7.1"
 
-[dependencies.paste]
-version = "1.0"
-
 [dev-dependencies.console_root]
 package = "snarkvm-console"
 path = "../../console"

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -47,17 +47,8 @@ path = "../../curves"
 version = "=3.7.1"
 default-features = false
 
-[dependencies.snarkvm-fields]
-path = "../../fields"
-version = "=3.7.1"
-default-features = false
-
 [dependencies.snarkvm-parameters]
 path = "../../parameters"
-version = "=3.7.1"
-
-[dependencies.snarkvm-utilities]
-path = "../../utilities"
 version = "=3.7.1"
 
 [dependencies.anyhow]
@@ -66,17 +57,17 @@ version = "1.0.73"
 [dependencies.indexmap]
 version = "2"
 
-[dependencies.itertools]
-version = "0.11.0"
-
 [dependencies.lazy_static]
 version = "1.4"
 
 [dependencies.once_cell]
 version = "1.18"
 
-[dependencies.paste]
-version = "1"
-
 [dependencies.serde]
 version = "1.0"
+
+[dependencies.paste]
+version = "1.0"
+
+[package.metadata.cargo-machete]
+ignored = ["paste"]

--- a/console/program/Cargo.toml
+++ b/console/program/Cargo.toml
@@ -57,9 +57,6 @@ version = "0.2"
 [dependencies.once_cell]
 version = "1.18.0"
 
-[dependencies.paste]
-version = "1.0"
-
 [dependencies.serde_json]
 version = "1.0"
 features = [ "preserve_order" ]

--- a/ledger/puzzle/Cargo.toml
+++ b/ledger/puzzle/Cargo.toml
@@ -69,9 +69,6 @@ optional = true
 [dependencies.lru]
 version = "0.12"
 
-[dependencies.once_cell]
-version = "1.18"
-
 [dependencies.parking_lot]
 version = "0.12"
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -25,6 +25,3 @@ edition = "2021"
 
 [dependencies.metrics]
 version = "0.22"
-
-[dependencies.metrics-exporter-prometheus]
-version = "0.13"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -49,9 +49,6 @@ features = [ "storage" ]
 [dependencies.anyhow]
 version = "1"
 
-[dependencies.bincode]
-version = "1"
-
 [dependencies.cfg-if]
 version = "1.0"
 
@@ -65,12 +62,6 @@ optional = true
 
 [dependencies.hex]
 version = "0.4.3"
-
-[dependencies.indexmap]
-version = "2.0"
-
-[dependencies.itertools]
-version = "0.11.0"
 
 [dependencies.js-sys]
 version = "0.3.64"
@@ -140,3 +131,8 @@ version = "0.4.3"
 
 [dev-dependencies.rand]
 version = "0.8"
+
+[package.metadata.cargo-machete]
+ignored = [
+  "js-sys", # needed for wasm feature
+]

--- a/synthesizer/src/vm/helpers/history.rs
+++ b/synthesizer/src/vm/helpers/history.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use console::prelude::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use aleo_std::{StorageMode, aleo_ledger_dir};
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -37,7 +37,7 @@ full = [
   "synthesizer",
   "utilities"
 ]
-circuit = [ "snarkvm-circuit-network" ]
+circuit = [ ]
 console = [ "snarkvm-console" ]
 curves = [ "snarkvm-curves" ]
 fields = [ "snarkvm-fields" ]
@@ -48,12 +48,6 @@ ledger = [
 ]
 synthesizer = [ "snarkvm-synthesizer" ]
 utilities = [ "snarkvm-utilities" ]
-
-[dependencies.snarkvm-circuit-network]
-path = "../circuit/network"
-version = "=3.7.1"
-features = [ "wasm" ]
-optional = true
 
 [dependencies.snarkvm-console]
 path = "../console"
@@ -108,3 +102,8 @@ features = [ "js" ]
 
 [dev-dependencies.wasm-bindgen-test]
 version = "0.3.37"
+
+[package.metadata.cargo-machete]
+ignored = [
+  "getrandom", # Needed to enable js feature
+]


### PR DESCRIPTION
Analogous PR to [snarkOS#3644](https://github.com/ProvableHQ/snarkOS/pull/3644).

This removes 16 unused dependencies detected by `cargo machete` and adds a CI action to automatically check for unused dependencies.