### PR TITLE
[Perf] Use the global rayon thread pool when available

### DIFF
--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -80,8 +80,12 @@ pub fn execute_with_max_available_threads<T>(f: impl FnOnce() -> T + Send) -> T 
 #[cfg(not(any(feature = "serial", feature = "wasm")))]
 #[inline(always)]
 fn execute_with_threads<T: Sync + Send>(f: impl FnOnce() -> T + Send, num_threads: usize) -> T {
-    let pool = rayon::ThreadPoolBuilder::new().num_threads(num_threads).build().unwrap();
-    pool.install(f)
+    if rayon::current_thread_index().is_none() {
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(num_threads).build().unwrap();
+        pool.install(f)
+    } else {
+        f()
+    }
 }
 
 /// Creates parallel iterator over refs if `parallel` feature is enabled.


### PR DESCRIPTION
Currently, a new rayon thread pool is created for specific operations in the proving hot path. This is costly: the L1/L2 caches start cold, short-lived threads increases work stealing (as can be seen on flamegraphs) and the latency of spinning up fresh threads adds to the proving time and CPU utilisation. 

This PR reuses the global rayon thread pool, if it exists. 