### PR TITLE
Use `QueryTrait` as a trait object.

### DIFF
--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -24,8 +24,7 @@ use console::{
     program::{Plaintext, Record, Value},
 };
 use ledger_block::Transition;
-use ledger_query::Query;
-use ledger_store::{ConsensusStorage, ConsensusStore};
+use ledger_store::ConsensusStore;
 use synthesizer::{VM, program::Program};
 
 use aleo_std::StorageMode;
@@ -36,8 +35,6 @@ use indexmap::IndexMap;
 type LedgerType = ledger_store::helpers::memory::ConsensusMemory<MainnetV0>;
 #[cfg(feature = "rocks")]
 type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<MainnetV0>;
-
-type NoQuery = Query<MainnetV0, <LedgerType as ConsensusStorage<MainnetV0>>::BlockStorage>;
 
 fn initialize_vm<R: Rng + CryptoRng>(
     private_key: &PrivateKey<MainnetV0>,
@@ -86,12 +83,11 @@ function hello:
     .unwrap();
 
     c.bench_function("Transaction::Deploy", |b| {
-        b.iter(|| vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None::<NoQuery>, rng).unwrap())
+        b.iter(|| vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None, rng).unwrap())
     });
 
     c.bench_function("Transaction::Deploy - verify", |b| {
-        let transaction =
-            vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&private_key, &program, Some(records[0].clone()), 600000, None, rng).unwrap();
         b.iter(|| vm.check_transaction(&transaction, None, rng).unwrap())
     });
 }
@@ -126,7 +122,7 @@ fn execute(c: &mut Criterion) {
                 vm.execute_authorization(
                     execute_authorization.replicate(),
                     Some(fee_authorization.replicate()),
-                    None::<NoQuery>,
+                    None,
                     rng,
                 )
                 .unwrap();
@@ -134,12 +130,7 @@ fn execute(c: &mut Criterion) {
         });
 
         let transaction = vm
-            .execute_authorization(
-                execute_authorization.replicate(),
-                Some(fee_authorization.replicate()),
-                None::<NoQuery>,
-                rng,
-            )
+            .execute_authorization(execute_authorization.replicate(), Some(fee_authorization.replicate()), None, rng)
             .unwrap();
 
         // Bench the Transaction.write_le method using the LimitedWriter.
@@ -177,7 +168,7 @@ fn execute(c: &mut Criterion) {
                 vm.execute_authorization(
                     execute_authorization.replicate(),
                     Some(fee_authorization.replicate()),
-                    None::<NoQuery>,
+                    None,
                     rng,
                 )
                 .unwrap();
@@ -185,12 +176,7 @@ fn execute(c: &mut Criterion) {
         });
 
         let transaction = vm
-            .execute_authorization(
-                execute_authorization.replicate(),
-                Some(fee_authorization.replicate()),
-                None::<NoQuery>,
-                rng,
-            )
+            .execute_authorization(execute_authorization.replicate(), Some(fee_authorization.replicate()), None, rng)
             .unwrap();
 
         // Bench the Transaction.write_le method using the LimitedWriter.
@@ -280,8 +266,7 @@ function main:
         vm.process().write().add_program(&program).unwrap();
 
         // Create an execution transaction that is 164613 bytes in size.
-        let transaction =
-            vm.execute(&private_key, ("too_big.aleo", "main"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.execute(&private_key, ("too_big.aleo", "main"), inputs, None, 0, None, rng).unwrap();
 
         // Bench the Transaction.write_le method using the LimitedWriter.
         c.bench_function("LimitedWriter::new - too_big.aleo", |b| {

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -677,7 +677,7 @@ pub mod test_helpers {
         let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
 
         // Prepare the assignments.
-        trace.prepare(Query::from(block_store)).unwrap();
+        trace.prepare(&Query::from(block_store)).unwrap();
         // Compute the proof and construct the execution.
         let execution = trace.prove_execution::<CurrentAleo, _>(locator.0, VarunaVersion::V1, rng).unwrap();
         // Convert the execution.

--- a/ledger/block/src/transaction/fee/mod.rs
+++ b/ledger/block/src/transaction/fee/mod.rs
@@ -265,7 +265,7 @@ pub mod test_helpers {
         block_store.insert(&FromStr::from_str(&block.to_string()).unwrap()).unwrap();
 
         // Prepare the assignments.
-        trace.prepare(Query::from(block_store)).unwrap();
+        trace.prepare(&Query::from(block_store)).unwrap();
         // Compute the proof and construct the fee.
         let fee = trace.prove_fee::<CurrentAleo, _>(VarunaVersion::V1, rng).unwrap();
 
@@ -321,7 +321,7 @@ pub mod test_helpers {
         block_store.insert(&FromStr::from_str(&block.to_string()).unwrap()).unwrap();
 
         // Prepare the assignments.
-        trace.prepare(Query::from(block_store)).unwrap();
+        trace.prepare(&Query::from(block_store)).unwrap();
         // Compute the proof and construct the fee.
         let fee = trace.prove_fee::<CurrentAleo, _>(VarunaVersion::V1, rng).unwrap();
 

--- a/ledger/query/src/traits.rs
+++ b/ledger/query/src/traits.rs
@@ -16,7 +16,7 @@
 use console::{network::Network, prelude::Result, program::StatePath, types::Field};
 
 #[cfg_attr(feature = "async", async_trait(?Send))]
-pub trait QueryTrait<N: Network>: Clone {
+pub trait QueryTrait<N: Network> {
     /// Returns the current state root.
     fn current_state_root(&self) -> Result<N::StateRoot>;
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -362,12 +362,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Creates a deploy transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the deployment fee.
-    pub fn create_deploy<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn create_deploy<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         program: &Program<N>,
         priority_fee_in_microcredits: u64,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         // Fetch the unspent records.
@@ -385,13 +385,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Creates a transfer transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the execution fee.
-    pub fn create_transfer<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn create_transfer<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         to: Address<N>,
         amount_in_microcredits: u64,
         priority_fee_in_microcredits: u64,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         // Fetch the unspent records.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -30,8 +30,7 @@ use ledger_authority::Authority;
 use ledger_block::{Block, ConfirmedTransaction, Execution, Ratify, Rejected, Transaction};
 use ledger_committee::{Committee, MIN_VALIDATOR_STAKE};
 use ledger_narwhal::{BatchCertificate, BatchHeader, Data, Subdag, Transmission, TransmissionID};
-use ledger_query::Query;
-use ledger_store::{ConsensusStorage, ConsensusStore};
+use ledger_store::ConsensusStore;
 use snarkvm_utilities::try_vm_runtime;
 use synthesizer::{Stack, program::Program, vm::VM};
 
@@ -44,8 +43,6 @@ use time::OffsetDateTime;
 type LedgerType = ledger_store::helpers::memory::ConsensusMemory<CurrentNetwork>;
 #[cfg(feature = "rocks")]
 type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
-
-type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
 
 /// Initializes a sample VM.
 fn sample_vm() -> VM<CurrentNetwork, LedgerType> {
@@ -388,8 +385,7 @@ fn test_insufficient_private_fees() {
         // Prepare a `split` execution without a fee.
         let inputs = [Value::Record(record_1.clone()), Value::from_str("100u64").unwrap()];
         let authorization = ledger.vm.authorize(&private_key, "credits.aleo", "split", inputs, rng).unwrap();
-        let split_transaction_without_fee =
-            ledger.vm.execute_authorization(authorization, None, None::<NoQuery>, rng).unwrap();
+        let split_transaction_without_fee = ledger.vm.execute_authorization(authorization, None, None, rng).unwrap();
         assert!(ledger.check_transaction_basic(&split_transaction_without_fee, None, rng).is_ok());
     }
 
@@ -402,8 +398,7 @@ fn test_insufficient_private_fees() {
             Value::from_str("100u64").unwrap(),
         ];
         let authorization = ledger.vm.authorize(&private_key, "credits.aleo", "transfer_private", inputs, rng).unwrap();
-        let transaction_without_fee =
-            ledger.vm.execute_authorization(authorization, None, None::<NoQuery>, rng).unwrap();
+        let transaction_without_fee = ledger.vm.execute_authorization(authorization, None, None, rng).unwrap();
         let execution = transaction_without_fee.execution().unwrap();
 
         // Check that a transaction with sufficient fee will succeed.
@@ -418,7 +413,7 @@ fn test_insufficient_private_fees() {
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
         let sufficient_fee_transaction = Transaction::from_execution(execution.clone(), Some(fee)).unwrap();
         assert!(ledger.check_transaction_basic(&sufficient_fee_transaction, None, rng).is_ok());
 
@@ -427,8 +422,7 @@ fn test_insufficient_private_fees() {
             .vm
             .authorize_fee_private(&private_key, record_2.clone(), 1, 0, execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let insufficient_fee =
-            ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None::<NoQuery>, rng).unwrap();
+        let insufficient_fee = ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None, rng).unwrap();
         let insufficient_fee_transaction =
             Transaction::from_execution(execution.clone(), Some(insufficient_fee)).unwrap();
         assert!(ledger.check_transaction_basic(&insufficient_fee_transaction, None, rng).is_err());
@@ -452,8 +446,7 @@ finalize foo:
         .unwrap();
 
         // Check that a deployment transaction with sufficient fee will succeed.
-        let transaction =
-            ledger.vm.deploy(&private_key, &program, Some(record_2.clone()), 0, None::<NoQuery>, rng).unwrap();
+        let transaction = ledger.vm.deploy(&private_key, &program, Some(record_2.clone()), 0, None, rng).unwrap();
         assert!(ledger.check_transaction_basic(&transaction, None, rng).is_ok());
 
         // Check that a deployment transaction with insufficient fee will fail.
@@ -462,8 +455,7 @@ finalize foo:
             .vm
             .authorize_fee_private(&private_key, record_2, 1, 0, deployment.to_deployment_id().unwrap(), rng)
             .unwrap();
-        let insufficient_fee =
-            ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None::<NoQuery>, rng).unwrap();
+        let insufficient_fee = ledger.vm.execute_fee_authorization(insufficient_fee_authorization, None, rng).unwrap();
         let insufficient_fee_transaction =
             Transaction::from_deployment(*transaction.owner().unwrap(), deployment.clone(), insufficient_fee).unwrap();
         assert!(ledger.check_transaction_basic(&insufficient_fee_transaction, None, rng).is_err());
@@ -489,15 +481,7 @@ fn test_insufficient_public_fees() {
             [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1000000000000u64").unwrap()];
         let transaction = ledger
             .vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_public"),
-                inputs.into_iter(),
-                None,
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
             .unwrap();
 
         let block =
@@ -518,15 +502,7 @@ fn test_insufficient_public_fees() {
         ];
         let transaction = ledger
             .vm
-            .execute(
-                &recipient_private_key,
-                ("credits.aleo", "bond_validator"),
-                inputs.into_iter(),
-                None,
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .execute(&recipient_private_key, ("credits.aleo", "bond_validator"), inputs.into_iter(), None, 0, None, rng)
             .unwrap();
 
         let block =
@@ -580,7 +556,7 @@ finalize foo:
     let credits = Some(records.values().next().unwrap().clone());
 
     // Deploy.
-    let transaction = ledger.vm.deploy(&private_key, &program, credits, 0, None::<NoQuery>, rng).unwrap();
+    let transaction = ledger.vm.deploy(&private_key, &program, credits, 0, None, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -593,7 +569,7 @@ finalize foo:
     assert_eq!(ledger.latest_hash(), block.hash());
 
     // Create a transfer transaction to produce a record with insufficient balance to pay for fees.
-    let transfer_transaction = ledger.create_transfer(&private_key, address, 100, 0, None::<NoQuery>, rng).unwrap();
+    let transfer_transaction = ledger.create_transfer(&private_key, address, 100, 0, None, rng).unwrap();
 
     // Construct the next block.
     let block = ledger
@@ -627,24 +603,14 @@ finalize foo:
     assert!(
         ledger
             .vm
-            .execute(
-                &private_key,
-                ("dummy.aleo", "foo"),
-                inputs.clone(),
-                Some(insufficient_record),
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng
-            )
+            .execute(&private_key, ("dummy.aleo", "foo"), inputs.clone(), Some(insufficient_record), 0, None, rng)
             .is_err()
     );
 
     let sufficient_record = records[1].clone();
     // Execute with enough fees.
-    let transaction = ledger
-        .vm
-        .execute(&private_key, ("dummy.aleo", "foo"), inputs, Some(sufficient_record), 0, None::<NoQuery>, rng)
-        .unwrap();
+    let transaction =
+        ledger.vm.execute(&private_key, ("dummy.aleo", "foo"), inputs, Some(sufficient_record), 0, None, rng).unwrap();
     // Verify.
     ledger.vm.check_transaction(&transaction, None, rng).unwrap();
     // Ensure that the ledger deems the transaction valid.
@@ -692,8 +658,7 @@ finalize failed_assert:
     let record_2 = records[1].clone();
 
     // Deploy the program.
-    let deployment_transaction =
-        ledger.vm().deploy(&private_key, &program, Some(record_1), 0, None::<NoQuery>, rng).unwrap();
+    let deployment_transaction = ledger.vm().deploy(&private_key, &program, Some(record_1), 0, None, rng).unwrap();
 
     // Construct the deployment block.
     let deployment_block = ledger
@@ -715,7 +680,7 @@ finalize failed_assert:
             Vec::<Value<_>>::new().into_iter(),
             Some(record_2),
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -777,7 +742,7 @@ finalize foo:
     .unwrap();
 
     // Deploy.
-    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -812,7 +777,7 @@ fn test_bond_and_unbond_validator() {
     ];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
     let inputs = [
         Value::from_str(&format!("{new_member_withdrawal_address}")).unwrap(),
@@ -820,7 +785,7 @@ fn test_bond_and_unbond_validator() {
     ];
     let transfer_to_withdrawal_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Construct the next block.
@@ -850,15 +815,7 @@ fn test_bond_and_unbond_validator() {
     ];
     let bond_validator_transaction = ledger
         .vm
-        .execute(
-            &new_member_private_key,
-            ("credits.aleo", "bond_validator"),
-            inputs.iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&new_member_private_key, ("credits.aleo", "bond_validator"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Construct the next block.
@@ -911,7 +868,7 @@ fn test_bond_and_unbond_validator() {
             inputs.iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -968,7 +925,7 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("185000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Construct the next block.
@@ -986,15 +943,7 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address_2}")).unwrap(), Value::from_str("1u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(
-            &recipient_private_key_2,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&recipient_private_key_2, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
     let aborted_transaction_id = transfer_transaction.id();
 
@@ -1002,7 +951,7 @@ fn test_aborted_transaction_indexing() {
     let inputs = [Value::from_str(&format!("{recipient_address_2}")).unwrap(), Value::from_str("1u64").unwrap()];
     let transfer_transaction_2 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Create a block.
@@ -1048,7 +997,7 @@ fn test_aborted_solution_ids() {
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Create a block.
@@ -1117,15 +1066,7 @@ fn test_execute_duplicate_input_ids() {
         // Execute.
         let execution = ledger
             .vm
-            .execute(
-                &private_key,
-                ("credits.aleo", "transfer_private"),
-                inputs.clone().iter(),
-                None,
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .execute(&private_key, ("credits.aleo", "transfer_private"), inputs.clone().iter(), None, 0, None, rng)
             .unwrap();
         execution_ids.push(execution.id());
         executions.push(execution);
@@ -1144,7 +1085,7 @@ finalize foo:
         ))
         .unwrap();
         let deployment =
-            ledger.vm.deploy(&private_key, &program, Some(record_deployment.clone()), 0, None::<NoQuery>, rng).unwrap();
+            ledger.vm.deploy(&private_key, &program, Some(record_deployment.clone()), 0, None, rng).unwrap();
         deployment_ids.push(deployment.id());
         deployments.push(deployment);
     }
@@ -1159,7 +1100,7 @@ finalize foo:
             inputs.clone().iter(),
             Some(record_execution.clone()),
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -1194,7 +1135,7 @@ finalize foo:
             rng,
         )
         .unwrap();
-    let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
+    let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
     // Create a mutated transaction.
     let mutated_transaction = Transaction::from_execution(mutated_execution, Some(fee)).unwrap();
     execution_ids.push(mutated_transaction.id());
@@ -1258,7 +1199,7 @@ finalize foo:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
         .unwrap();
     let transfer_id = transfer.id();
 
@@ -1316,7 +1257,7 @@ function create_duplicate_record:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1362,7 +1303,7 @@ function create_duplicate_record:
                 inputs.into_iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 fixed_rng,
             )
             .unwrap();
@@ -1380,7 +1321,7 @@ function create_duplicate_record:
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1407,7 +1348,7 @@ function create_duplicate_record:
         .unwrap();
 
         // Create a transaction with a fixed rng.
-        let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, fixed_rng).unwrap();
+        let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, fixed_rng).unwrap();
 
         // Extract the deployment and owner.
         let deployment = transaction.deployment().unwrap().clone();
@@ -1425,7 +1366,7 @@ function create_duplicate_record:
                 fixed_rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, fixed_rng).unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, fixed_rng).unwrap();
 
         Transaction::from_deployment(owner, deployment, fee).unwrap()
     };
@@ -1501,7 +1442,7 @@ function create_duplicate_record:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_4 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
         .unwrap();
     let transfer_4_id = transfer_4.id();
 
@@ -1552,7 +1493,7 @@ function empty_function:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1584,7 +1525,7 @@ function empty_function:
                 inputs.into_iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 fixed_rng,
             )
             .unwrap();
@@ -1602,7 +1543,7 @@ function empty_function:
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1651,7 +1592,7 @@ function empty_function:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
         .unwrap();
     let transfer_transaction_id = transfer_transaction.id();
 
@@ -1704,7 +1645,7 @@ function simple_output:
     .unwrap();
 
     // Deploy.
-    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&deployment_transaction, None, rng).unwrap();
 
@@ -1730,15 +1671,7 @@ function simple_output:
         let inputs: [Value<_>; 0] = [];
         let transaction = ledger
             .vm
-            .execute(
-                &private_key,
-                ("dummy_program.aleo", function),
-                inputs.into_iter(),
-                None,
-                0,
-                None::<NoQuery>,
-                fixed_rng,
-            )
+            .execute(&private_key, ("dummy_program.aleo", function), inputs.into_iter(), None, 0, None, fixed_rng)
             .unwrap();
         // Extract the execution.
         let execution = transaction.execution().unwrap().clone();
@@ -1754,7 +1687,7 @@ function simple_output:
                 rng,
             )
             .unwrap();
-        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
+        let fee = ledger.vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
 
         Transaction::from_execution(execution, Some(fee)).unwrap()
     };
@@ -1809,7 +1742,7 @@ function simple_output:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
         .unwrap();
     let transfer_transaction_id = transfer_transaction.id();
 
@@ -1868,11 +1801,11 @@ function empty_function:
     .unwrap();
 
     // Create a deployment transaction for the first program with the same public payer.
-    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
     let deployment_1_id = deployment_1.id();
 
     // Create a deployment transaction for the second program with the same public payer.
-    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, None, 0, None, rng).unwrap();
     let deployment_2_id = deployment_2.id();
 
     // Create a block.
@@ -1912,22 +1845,14 @@ fn test_abort_fee_transaction() {
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let transaction = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.clone().into_iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone().into_iter(), None, 0, None, rng)
         .unwrap();
     let transaction_id = transaction.id();
 
     // Convert a fee transaction.
     let transaction_to_convert_to_fee = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
         .unwrap();
     let fee_transaction = Transaction::from_fee(transaction_to_convert_to_fee.fee_transition().unwrap()).unwrap();
     let fee_transaction_id = fee_transaction.id();
@@ -1967,15 +1892,7 @@ fn test_abort_invalid_transaction() {
     // Generate a transaction that will be invalid on another network.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000u64").unwrap()];
     let invalid_transaction = vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.clone().into_iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone().into_iter(), None, 0, None, rng)
         .unwrap();
     let invalid_transaction_id = invalid_transaction.id();
 
@@ -1985,19 +1902,11 @@ fn test_abort_invalid_transaction() {
     // Construct valid transactions for the ledger.
     let valid_transaction_1 = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.clone().into_iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone().into_iter(), None, 0, None, rng)
         .unwrap();
     let valid_transaction_2 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.into_iter(), None, 0, None, rng)
         .unwrap();
     let valid_transaction_id_1 = valid_transaction_1.id();
     let valid_transaction_id_2 = valid_transaction_2.id();
@@ -2083,12 +1992,12 @@ finalize foo2:
     .unwrap();
 
     // Create a deployment transaction for the first program.
-    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, Some(record_1), 0, None::<NoQuery>, rng).unwrap();
+    let deployment_1 = ledger.vm.deploy(&private_key, &program_1, Some(record_1), 0, None, rng).unwrap();
     let deployment_1_id = deployment_1.id();
     assert!(ledger.check_transaction_basic(&deployment_1, None, rng).is_ok());
 
     // Create a deployment transaction for the second program.
-    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, Some(record_2), 0, None::<NoQuery>, rng).unwrap();
+    let deployment_2 = ledger.vm.deploy(&private_key, &program_2, Some(record_2), 0, None, rng).unwrap();
     let deployment_2_id = deployment_2.id();
     assert!(ledger.check_transaction_basic(&deployment_2, None, rng).is_ok());
 
@@ -2221,7 +2130,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -2265,7 +2174,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -2312,7 +2221,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -2331,7 +2240,7 @@ fn test_max_committee_limit_with_bonds() {
             .iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -2413,7 +2322,7 @@ fn test_deployment_exceeding_max_transaction_spend() {
     let exceeding_program = exceeding_program.unwrap();
 
     // Deploy the allowed program.
-    let deployment = ledger.vm().deploy(&private_key, &allowed_program, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment = ledger.vm().deploy(&private_key, &allowed_program, None, 0, None, rng).unwrap();
 
     // Verify the deployment transaction.
     assert!(ledger.vm().check_transaction(&deployment, None, rng).is_ok());
@@ -2432,7 +2341,7 @@ fn test_deployment_exceeding_max_transaction_spend() {
     assert!(ledger.vm().contains_program(allowed_program.id()));
 
     // Attempt to deploy the exceeding program.
-    let result = ledger.vm().deploy(&private_key, &exceeding_program, None, 0, None::<NoQuery>, rng);
+    let result = ledger.vm().deploy(&private_key, &exceeding_program, None, 0, None, rng);
 
     // Check that the deployment failed.
     assert!(result.is_err());
@@ -2463,7 +2372,7 @@ fn test_transaction_ordering() {
         [Value::from_str(&format!("{address_2}")).unwrap(), Value::from_str(&format!("{amount_1}u64")).unwrap()];
     let transfer_1 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     let amount_2 = 100000000u64;
@@ -2471,7 +2380,7 @@ fn test_transaction_ordering() {
         [Value::from_str(&format!("{address_3}")).unwrap(), Value::from_str(&format!("{amount_2}u64")).unwrap()];
     let transfer_2 = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Update the public balance.
@@ -2533,48 +2442,39 @@ finalize foo:
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000u64").unwrap()];
     let initial_transfer = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
     let initial_transfer_id = initial_transfer.id();
 
     // Create a deployment transaction.
-    let deployment_transaction = ledger.vm.deploy(&private_key_2, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_transaction = ledger.vm.deploy(&private_key_2, &program_1, None, 0, None, rng).unwrap();
 
     // Create a deployment transaction.
-    let deployment_transaction_2 = ledger.vm.deploy(&private_key_3, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_transaction_2 = ledger.vm.deploy(&private_key_3, &program_2, None, 0, None, rng).unwrap();
 
     // Create a transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000u64").unwrap()];
     let transfer_transaction = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Create a rejected transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("1000000000000000u64").unwrap()];
     let rejected_transfer = ledger
         .vm
-        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
         .unwrap();
 
     // Create an aborted transfer transaction.
     let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
     let aborted_transfer = ledger
         .vm
-        .execute(
-            &private_key,
-            ("credits.aleo", "transfer_public"),
-            inputs.iter(),
-            None,
-            public_balance - 10,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, public_balance - 10, None, rng)
         .unwrap();
 
     // Create an aborted deployment transaction.
-    let aborted_deployment =
-        ledger.vm.deploy(&private_key, &program_3, None, public_balance - 10, None::<NoQuery>, rng).unwrap();
+    let aborted_deployment = ledger.vm.deploy(&private_key, &program_3, None, public_balance - 10, None, rng).unwrap();
 
     const ITERATIONS: usize = 100;
     for _ in 0..ITERATIONS {
@@ -2665,7 +2565,7 @@ finalize is_id:
     .unwrap();
 
     // Deploy.
-    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+    let transaction = ledger.vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
     // Verify.
     ledger.vm().check_transaction(&transaction, None, rng).unwrap();
 
@@ -2680,15 +2580,10 @@ finalize is_id:
 
     // Execute functions `is_block` and `is_id` to assert that the on-chain state is as expected.
     let inputs_block: [Value<CurrentNetwork>; 1] = [Value::from_str("2u32").unwrap()];
-    let tx_block = ledger
-        .vm
-        .execute(&private_key, (&program_id, "is_block"), inputs_block.iter(), None, 0, None::<NoQuery>, rng)
-        .unwrap();
+    let tx_block =
+        ledger.vm.execute(&private_key, (&program_id, "is_block"), inputs_block.iter(), None, 0, None, rng).unwrap();
     let inputs_id: [Value<CurrentNetwork>; 1] = [Value::from(Literal::U16(U16::new(CurrentNetwork::ID)))];
-    let tx_id = ledger
-        .vm
-        .execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None::<NoQuery>, rng)
-        .unwrap();
+    let tx_id = ledger.vm.execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None, rng).unwrap();
 
     // Construct the next block.
     let block_2 =
@@ -2698,14 +2593,10 @@ finalize is_id:
 
     // Execute the program.
     let inputs_block_2: [Value<CurrentNetwork>; 1] = [Value::from_str("3u32").unwrap()];
-    let tx_block_2 = ledger
-        .vm
-        .execute(&private_key, (&program_id, "is_block"), inputs_block_2.iter(), None, 0, None::<NoQuery>, rng)
-        .unwrap();
-    let tx_id_2 = ledger
-        .vm
-        .execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None::<NoQuery>, rng)
-        .unwrap();
+    let tx_block_2 =
+        ledger.vm.execute(&private_key, (&program_id, "is_block"), inputs_block_2.iter(), None, 0, None, rng).unwrap();
+    let tx_id_2 =
+        ledger.vm.execute(&private_key, (&program_id, "is_id"), inputs_id.iter(), None, 0, None, rng).unwrap();
 
     // Construct the next block.
     let block_3 = ledger
@@ -2769,14 +2660,7 @@ function foo:
             if attempts >= ITERATIONS {
                 panic!("Failed to craft deployment after {ITERATIONS} attempts");
             }
-            match try_vm_runtime!(|| ledger.vm().deploy(
-                &private_key,
-                program,
-                None,
-                0,
-                None::<Query<CurrentNetwork, <LedgerType as ConsensusStorage<_>>::BlockStorage>>,
-                rng
-            )) {
+            match try_vm_runtime!(|| ledger.vm().deploy(&private_key, program, None, 0, None, rng)) {
                 Ok(result) => break result.unwrap(),
                 Err(_) => attempts += 1,
             }
@@ -2853,7 +2737,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
             .unwrap();
 
         // Check that block creation fails when duplicate solution IDs are provided.
@@ -2950,15 +2834,7 @@ mod valid_solutions {
             let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
             let transfer_transaction = ledger
                 .vm
-                .execute(
-                    &private_key,
-                    ("credits.aleo", "transfer_public"),
-                    inputs.iter(),
-                    None,
-                    0,
-                    None::<NoQuery>,
-                    rng,
-                )
+                .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
                 .unwrap();
 
             // Generate the next prospective block.
@@ -3040,7 +2916,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
             .unwrap();
 
         // Create a block.
@@ -3112,7 +2988,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
             .unwrap();
 
         // Create a block.
@@ -3191,7 +3067,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
             .unwrap();
 
         // Check that the block creation fixes the malformed solution.
@@ -3260,7 +3136,7 @@ mod valid_solutions {
         let inputs = [Value::from_str(&format!("{address}")).unwrap(), Value::from_str("10u64").unwrap()];
         let transfer_transaction = ledger
             .vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None::<NoQuery>, rng)
+            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.iter(), None, 0, None, rng)
             .unwrap();
 
         // Create a block.
@@ -3630,13 +3506,13 @@ function create_and_consume:
     .unwrap();
 
     // Deploy the programs.
-    let deployment_0 = ledger.vm().deploy(&private_key, &program_0, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_0 = ledger.vm().deploy(&private_key, &program_0, None, 0, None, rng).unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_0], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     ledger.advance_to_next_block(&block).unwrap();
 
-    let deployment_1 = ledger.vm().deploy(&private_key, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
+    let deployment_1 = ledger.vm().deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment_1], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
@@ -3645,15 +3521,7 @@ function create_and_consume:
     // Call the `mint` function.
     let transaction = ledger
         .vm()
-        .execute(
-            &private_key,
-            ("child.aleo", "mint"),
-            Vec::<Value<CurrentNetwork>>::new().iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&private_key, ("child.aleo", "mint"), Vec::<Value<CurrentNetwork>>::new().iter(), None, 0, None, rng)
         .unwrap();
     let mint_record = transaction.records().last().unwrap().1.decrypt(&view_key).unwrap();
     let block =
@@ -3679,7 +3547,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -3702,15 +3570,7 @@ function create_and_consume:
     let record = block.records().collect_vec().last().unwrap().1.decrypt(&view_key).unwrap();
     let transaction = ledger
         .vm()
-        .execute(
-            &private_key,
-            ("child.aleo", "burn"),
-            vec![Value::Record(record)].iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&private_key, ("child.aleo", "burn"), vec![Value::Record(record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();
@@ -3735,7 +3595,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -3762,7 +3622,7 @@ function create_and_consume:
             vec![Value::Record(mint_record.clone())].iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();
@@ -3783,15 +3643,7 @@ function create_and_consume:
     // Call the `consume` function.
     let transaction = ledger
         .vm()
-        .execute(
-            &private_key,
-            ("parent.aleo", "consume"),
-            vec![Value::Record(mint_record)].iter(),
-            None,
-            0,
-            None::<NoQuery>,
-            rng,
-        )
+        .execute(&private_key, ("parent.aleo", "consume"), vec![Value::Record(mint_record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();
@@ -3816,7 +3668,7 @@ function create_and_consume:
             Vec::<Value<CurrentNetwork>>::new().iter(),
             None,
             0,
-            None::<NoQuery>,
+            None,
             rng,
         )
         .unwrap();

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -254,7 +254,7 @@ pub fn sample_fee_private(deployment_or_execution_id: Field<CurrentNetwork>, rng
     block_store.insert(&FromStr::from_str(&block.to_string()).unwrap()).unwrap();
 
     // Prepare the assignments.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Compute the proof and construct the fee.
     let fee = trace.prove_fee::<CurrentAleo, _>(VarunaVersion::V1, rng).unwrap();
 
@@ -307,7 +307,7 @@ pub fn sample_fee_public(deployment_or_execution_id: Field<CurrentNetwork>, rng:
     block_store.insert(&FromStr::from_str(&block.to_string()).unwrap()).unwrap();
 
     // Prepare the assignments.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Compute the proof and construct the fee.
     let fee = trace.prove_fee::<CurrentAleo, _>(VarunaVersion::V1, rng).unwrap();
 
@@ -429,7 +429,7 @@ pub fn sample_large_execution_transaction(rng: &mut TestRng) -> Transaction<Curr
                 .unwrap();
 
             // Prepare the assignments.
-            trace.prepare(ledger_query::Query::from(block_store)).unwrap();
+            trace.prepare(&ledger_query::Query::from(block_store)).unwrap();
             // Compute the proof and construct the execution.
             let execution = trace.prove_execution::<CurrentAleo, _>("testing.aleo", VarunaVersion::V1, rng).unwrap();
             // Reconstruct the execution from bytes.
@@ -533,7 +533,7 @@ fn sample_genesis_block_and_components_raw(
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
 
     // Prepare the assignments.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Compute the proof and construct the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>(locator.0, VarunaVersion::V1, rng).unwrap();
     // Convert the execution.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -340,7 +340,7 @@ pub mod test_helpers {
         let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
 
         // Prepare the assignments from the block store.
-        trace.prepare(ledger_query::Query::from(block_store)).unwrap();
+        trace.prepare(&ledger_query::Query::from(block_store)).unwrap();
 
         // Get the locator.
         let locator = format!("{:?}:{function_name:?}", program.id());
@@ -440,7 +440,7 @@ function compute:
                 assert_eq!(trace.transitions().len(), 1);
 
                 // Prepare the trace.
-                trace.prepare(Query::from(block_store)).unwrap();
+                trace.prepare(&Query::from(block_store)).unwrap();
                 // Compute the execution.
                 trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap()
             })

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -330,7 +330,7 @@ fn execute_function<F: FinalizeStorage<CurrentNetwork>>(
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None))?;
 
     // Prepare the trace.
-    trace.prepare(Query::from(&block_store))?;
+    trace.prepare(&Query::from(&block_store))?;
 
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>(function, VarunaVersion::V1, rng)?;

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -93,7 +93,7 @@ pub fn sample_fee<N: Network, A: Aleo<Network = N>, B: BlockStorage<N>, P: Final
     // Execute the fee.
     let (_, mut trace) = process.execute::<A, _>(authorization, rng).unwrap();
     // Prepare the assignments.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Compute the proof and construct the fee.
     trace.prove_fee::<A, _>(VarunaVersion::V1, rng).unwrap()
 }
@@ -1291,7 +1291,7 @@ finalize compute:
     assert_eq!(1, candidate.len());
 
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap();
     // Verify the execution.
@@ -1403,7 +1403,7 @@ finalize compute:
     assert_eq!(1, candidate.len());
 
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap();
 
@@ -1534,7 +1534,7 @@ finalize mint_public:
     assert_eq!(1, candidate.len());
 
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("token", VarunaVersion::V1, rng).unwrap();
 
@@ -1702,7 +1702,7 @@ finalize init:
     assert_eq!(1, candidate.len());
 
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("public_wallet", VarunaVersion::V1, rng).unwrap();
 
@@ -1817,7 +1817,7 @@ finalize compute:
     assert_eq!(1, candidate.len());
 
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap();
 
@@ -1947,7 +1947,7 @@ function a:
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("two", VarunaVersion::V1, rng).unwrap();
 
@@ -2134,7 +2134,7 @@ fn test_complex_execution_order() {
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("four", VarunaVersion::V1, rng).unwrap();
 
@@ -2245,7 +2245,7 @@ finalize compute:
     assert_eq!(1, candidate.len());
 
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap();
 
@@ -2354,7 +2354,7 @@ function compute:
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
     // Prepare the trace.
-    trace.prepare(Query::from(block_store)).unwrap();
+    trace.prepare(&Query::from(block_store)).unwrap();
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap();
 
@@ -2459,7 +2459,7 @@ function {function_name}:
         assert_eq!(response.outputs().len(), 0);
 
         // Prepare the trace.
-        trace.prepare(Query::from(block_store.clone())).unwrap();
+        trace.prepare(&Query::from(block_store.clone())).unwrap();
         // Prove the execution.
         trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap()
     };
@@ -2478,7 +2478,7 @@ function {function_name}:
         assert_eq!(response.outputs().len(), 0);
 
         // Prepare the trace.
-        trace.prepare(Query::from(block_store)).unwrap();
+        trace.prepare(&Query::from(block_store)).unwrap();
         // Prove the execution.
         trace.prove_execution::<CurrentAleo, _>("testing", VarunaVersion::V1, rng).unwrap()
     };

--- a/synthesizer/process/src/tests/test_utils.rs
+++ b/synthesizer/process/src/tests/test_utils.rs
@@ -245,7 +245,7 @@ fn execute_function<F: FinalizeStorage<CurrentNetwork>>(
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(0u16)?;
 
     // Prepare the trace.
-    trace.prepare(Query::from(&block_store))?;
+    trace.prepare(&Query::from(&block_store))?;
 
     // Prove the execution.
     let execution = trace.prove_execution::<CurrentAleo, _>(function, VarunaVersion::V1, rng)?;

--- a/synthesizer/process/src/trace/inclusion/prepare.rs
+++ b/synthesizer/process/src/trace/inclusion/prepare.rs
@@ -106,7 +106,7 @@ impl<N: Network> Inclusion<N> {
     pub fn prepare(
         &self,
         transitions: &[Transition<N>],
-        query: impl QueryTrait<N>,
+        query: &dyn QueryTrait<N>,
     ) -> Result<(Vec<InclusionAssignment<N>>, N::StateRoot)> {
         prepare_impl!(self, transitions, query, current_state_root, get_state_path_for_commitment)
     }
@@ -116,7 +116,7 @@ impl<N: Network> Inclusion<N> {
     pub async fn prepare_async(
         &self,
         transitions: &[Transition<N>],
-        query: impl QueryTrait<N>,
+        query: &dyn QueryTrait<N>,
     ) -> Result<(Vec<InclusionAssignment<N>>, N::StateRoot)> {
         prepare_impl!(self, transitions, query, current_state_root_async, get_state_path_for_commitment_async, await)
     }

--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -123,7 +123,7 @@ impl<N: Network> Trace<N> {
 
 impl<N: Network> Trace<N> {
     /// Returns the inclusion assignments and global state root for the current transition(s).
-    pub fn prepare(&mut self, query: impl QueryTrait<N>) -> Result<()> {
+    pub fn prepare(&mut self, query: &dyn QueryTrait<N>) -> Result<()> {
         // Compute the inclusion assignments.
         let (inclusion_assignments, global_state_root) = self.inclusion_tasks.prepare(&self.transitions, query)?;
         // Store the inclusion assignments and global state root.
@@ -136,7 +136,7 @@ impl<N: Network> Trace<N> {
 
     /// Returns the inclusion assignments and global state root for the current transition(s).
     #[cfg(feature = "async")]
-    pub async fn prepare_async(&mut self, query: impl QueryTrait<N>) -> Result<()> {
+    pub async fn prepare_async(&mut self, query: &dyn QueryTrait<N>) -> Result<()> {
         // Compute the inclusion assignments.
         let (inclusion_assignments, global_state_root) =
             self.inclusion_tasks.prepare_async(&self.transitions, query).await?;

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -22,13 +22,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// otherwise, a public fee will be included in the transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the deployment fee.
-    pub fn deploy<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn deploy<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         program: &Program<N>,
         fee_record: Option<Record<N, Plaintext<N>>>,
         priority_fee_in_microcredits: u64,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         // Compute the deployment.

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -24,14 +24,14 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// otherwise, a public fee will be included in the transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the execution fee.
-    pub fn execute<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn execute<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         (program_id, function_name): (impl TryInto<ProgramID<N>>, impl TryInto<Identifier<N>>),
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         fee_record: Option<Record<N, Plaintext<N>>>,
         priority_fee_in_microcredits: u64,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         let (execution, _) = self.execute_with_response(
@@ -52,16 +52,21 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// otherwise, a public fee will be included in the transaction.
     ///
     /// The `priority_fee_in_microcredits` is an additional fee **on top** of the execution fee.
-    pub fn execute_with_response<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn execute_with_response<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
         (program_id, function_name): (impl TryInto<ProgramID<N>>, impl TryInto<Identifier<N>>),
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         fee_record: Option<Record<N, Plaintext<N>>>,
         priority_fee_in_microcredits: u64,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<(Transaction<N>, Response<N>)> {
+        // Get a default query if one is not provided.
+        let query = match query {
+            Some(q) => q,
+            None => &Query::VM(self.block_store().clone()),
+        };
         // Compute the authorization.
         let authorization = self.authorize(private_key, program_id, function_name, inputs, rng)?;
         // Determine if a fee is required.
@@ -69,20 +74,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Determine if a priority fee is declared.
         let is_priority_fee_declared = priority_fee_in_microcredits > 0;
         // Compute the execution.
-        let (execution, response) = if let Some(query) = &query {
-            self.execute_authorization_raw(authorization, query.clone(), rng)?
-        } else {
-            self.execute_authorization_raw(authorization, Query::VM(self.block_store().clone()), rng)?
-        };
+        let (execution, response) = self.execute_authorization_raw(authorization, query, rng)?;
         // Compute the fee.
         let fee = match is_fee_required || is_priority_fee_declared {
             true => {
                 // Compute the minimum execution cost.
-                let consensus_version = if let Some(query) = &query {
-                    N::CONSENSUS_VERSION(query.current_block_height()?)?
-                } else {
-                    N::CONSENSUS_VERSION(self.block_store().max_height().unwrap_or_default())?
-                };
+                let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
                 let (minimum_execution_cost, (_, _)) = if consensus_version == ConsensusVersion::V1 {
                     execution_cost_v1(&self.process().read(), &execution)?
                 } else {
@@ -109,15 +106,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     )?,
                 };
                 // Execute the fee.
-                if let Some(query) = query {
-                    Some(self.execute_fee_authorization_raw(authorization, query, rng)?)
-                } else {
-                    Some(self.execute_fee_authorization_raw(
-                        authorization,
-                        Query::VM(self.block_store().clone()),
-                        rng,
-                    )?)
-                }
+                Some(self.execute_fee_authorization_raw(authorization, query, rng)?)
             }
             false => None,
         };
@@ -129,11 +118,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     ///
     /// This is identical to `execute_authorization_with_response` except that it
     /// discards the `Response`.
-    pub fn execute_authorization<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn execute_authorization<R: Rng + CryptoRng>(
         &self,
         execute_authorization: Authorization<N>,
         fee_authorization: Option<Authorization<N>>,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<Transaction<N>> {
         let (execution, _) =
@@ -142,31 +131,23 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     }
 
     /// Returns a new execute transaction and response for the given authorization.
-    pub fn execute_authorization_with_response<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn execute_authorization_with_response<R: Rng + CryptoRng>(
         &self,
         execute_authorization: Authorization<N>,
         fee_authorization: Option<Authorization<N>>,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<(Transaction<N>, Response<N>)> {
+        // Get a default query if one is not provided.
+        let query = match query {
+            Some(q) => q,
+            None => &Query::VM(self.block_store().clone()),
+        };
         // Compute the execution.
-        let (execution, response, fee) = if let Some(query) = query {
-            let (execution, response) = self.execute_authorization_raw(execute_authorization, query.clone(), rng)?;
-            let fee = match fee_authorization {
-                Some(authorization) => Some(self.execute_fee_authorization_raw(authorization, query, rng)?),
-                None => None,
-            };
-
-            (execution, response, fee)
-        } else {
-            let query = Query::VM(self.block_store().clone());
-            let (execution, response) = self.execute_authorization_raw(execute_authorization, query.clone(), rng)?;
-            let fee = match fee_authorization {
-                Some(authorization) => Some(self.execute_fee_authorization_raw(authorization, query, rng)?),
-                None => None,
-            };
-
-            (execution, response, fee)
+        let (execution, response) = self.execute_authorization_raw(execute_authorization, query, rng)?;
+        let fee = match fee_authorization {
+            Some(authorization) => Some(self.execute_fee_authorization_raw(authorization, query, rng)?),
+            None => None,
         };
         // Return the execute transaction and response.
         let transaction = Transaction::from_execution(execution, fee)?;
@@ -174,18 +155,19 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     }
 
     /// Returns a new fee for the given authorization.
-    pub fn execute_fee_authorization<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    pub fn execute_fee_authorization<R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Option<Q>,
+        query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
     ) -> Result<Fee<N>> {
         debug_assert!(authorization.is_fee_private() || authorization.is_fee_public(), "Expected a fee authorization");
-        if let Some(query) = query {
-            self.execute_fee_authorization_raw(authorization, query, rng)
-        } else {
-            self.execute_fee_authorization_raw(authorization, Query::VM(self.block_store().clone()), rng)
-        }
+        // Get a default query if one is not provided.
+        let query = match query {
+            Some(q) => q,
+            None => &Query::VM(self.block_store().clone()),
+        };
+        self.execute_fee_authorization_raw(authorization, query, rng)
     }
 }
 
@@ -193,10 +175,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Executes a call to the program function for the given authorization.
     /// Returns the execution.
     #[inline]
-    fn execute_authorization_raw<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    fn execute_authorization_raw<R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Q,
+        query: &dyn QueryTrait<N>,
         rng: &mut R,
     ) -> Result<(Execution<N>, Response<N>)> {
         let timer = timer!("VM::execute_authorization_raw");
@@ -245,10 +227,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Executes a call to the program function for the given fee authorization.
     /// Returns the fee.
     #[inline]
-    fn execute_fee_authorization_raw<Q: QueryTrait<N>, R: Rng + CryptoRng>(
+    fn execute_fee_authorization_raw<R: Rng + CryptoRng>(
         &self,
         authorization: Authorization<N>,
-        query: Q,
+        query: &dyn QueryTrait<N>,
         rng: &mut R,
     ) -> Result<Fee<N>> {
         let timer = timer!("VM::execute_fee_authorization_raw");
@@ -311,8 +293,6 @@ mod tests {
     #[cfg(feature = "rocks")]
     type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
 
-    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
-
     fn prepare_vm(
         rng: &mut TestRng,
     ) -> Result<(
@@ -357,9 +337,8 @@ mod tests {
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&validator_private_key, ("credits.aleo", "bond_validator"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&validator_private_key, ("credits.aleo", "bond_validator"), inputs, None, 0, None, rng).unwrap();
 
         // Ensure the transaction is a bond public transition.
         assert_eq!(transaction.transitions().count(), 2);
@@ -399,9 +378,8 @@ mod tests {
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&delegator_private_key, ("credits.aleo", "bond_public"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&delegator_private_key, ("credits.aleo", "bond_public"), inputs, None, 0, None, rng).unwrap();
 
         // Ensure the transaction is a bond public transition.
         assert_eq!(transaction.transitions().count(), 2);
@@ -441,7 +419,7 @@ mod tests {
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
         let query = Query::VM(vm.block_store().clone());
-        let (execution, _) = vm.execute_authorization_raw(authorization, query, rng).unwrap();
+        let (execution, _) = vm.execute_authorization_raw(authorization, &query, rng).unwrap();
         let (cost, _) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
         let (old_cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
 
@@ -472,9 +450,8 @@ mod tests {
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None, rng).unwrap();
 
         assert_eq!(51_060, *transaction.base_fee_amount().unwrap());
 
@@ -485,9 +462,8 @@ mod tests {
             vm.add_next_block(&next_block).unwrap();
         }
 
-        let transaction = vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs.clone(), None, 0, None, rng).unwrap();
 
         assert_eq!(34_060, *transaction.base_fee_amount().unwrap());
     }
@@ -524,7 +500,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &private_key, &[transaction], rng).unwrap();
@@ -536,9 +512,8 @@ finalize test:
         let inputs = [Value::<CurrentNetwork>::from_str("1_000_000u64").unwrap()].into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None, rng).unwrap();
 
         // This fee should be at least the old credits.aleo/transfer_public fee, 51_060
         assert_eq!(62_776, *transaction.base_fee_amount().unwrap());
@@ -550,9 +525,8 @@ finalize test:
             vm.add_next_block(&next_block).unwrap();
         }
 
-        let transaction = vm
-            .execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("nested_call.aleo", "test"), inputs.clone(), None, 0, None, rng).unwrap();
 
         // The difference in old vs new fees is 8_500 * 3 = 25_500 for the three get/get.or_use's
         // There are two get.or_use's in transfer_public and an additional one in the nested_call.aleo/test
@@ -582,7 +556,7 @@ finalize test:
         let authorization = vm.authorize(&caller_private_key, credits_program, function_name, inputs, rng).unwrap();
 
         let query = Query::VM(vm.block_store().clone());
-        let (execution, _) = vm.execute_authorization_raw(authorization, query, rng).unwrap();
+        let (execution, _) = vm.execute_authorization_raw(authorization, &query, rng).unwrap();
         let (cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
         println!("Cost: {}", cost);
     }
@@ -606,9 +580,8 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&caller_private_key, ("credits.aleo", "unbond_public"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&caller_private_key, ("credits.aleo", "unbond_public"), inputs, None, 0, None, rng).unwrap();
 
         // Ensure the transaction is an unbond public transition.
         assert_eq!(transaction.transitions().count(), 2);
@@ -650,9 +623,8 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&caller_private_key, ("credits.aleo", "transfer_private"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&caller_private_key, ("credits.aleo", "transfer_private"), inputs, None, 0, None, rng).unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -685,9 +657,8 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -720,9 +691,8 @@ finalize test:
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&signer, ("credits.aleo", "transfer_public_as_signer"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&signer, ("credits.aleo", "transfer_public_as_signer"), inputs, None, 0, None, rng).unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -757,7 +727,7 @@ finalize test:
 
         // Execute.
         let transaction =
-            vm.execute(&caller_private_key, ("credits.aleo", "join"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
+            vm.execute(&caller_private_key, ("credits.aleo", "join"), inputs, None, 0, None, rng).unwrap();
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
@@ -791,7 +761,7 @@ finalize test:
 
         // Execute.
         let transaction =
-            vm.execute(&caller_private_key, ("credits.aleo", "split"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
+            vm.execute(&caller_private_key, ("credits.aleo", "split"), inputs, None, 0, None, rng).unwrap();
 
         // Ensure the transaction is a split transition.
         assert_eq!(transaction.transitions().count(), 1);
@@ -882,7 +852,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&caller_private_key, &child_program, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -951,7 +921,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&caller_private_key, &parent_program, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -961,15 +931,7 @@ finalize test:
 
         // Execute the parent program.
         let Transaction::Execute(_, _, execution, _) = vm
-            .execute(
-                &caller_private_key,
-                ("parent.aleo", "test"),
-                Vec::<Value<_>>::new().iter(),
-                None,
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .execute(&caller_private_key, ("parent.aleo", "test"), Vec::<Value<_>>::new().iter(), None, 0, None, rng)
             .unwrap()
         else {
             unreachable!("VM::execute always produces an `Execution`")
@@ -1047,7 +1009,7 @@ finalize test:
         .unwrap();
 
         // Deploy the program.
-        let transaction = vm.deploy(&caller_private_key, &base_program, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&caller_private_key, &base_program, None, 0, None, rng).unwrap();
 
         // Construct the next block.
         let next_block = crate::test_helpers::sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
@@ -1086,7 +1048,7 @@ finalize test:
             .unwrap();
 
             // Deploy the program.
-            let transaction = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+            let transaction = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
 
             // Construct the next block.
             let next_block =
@@ -1104,7 +1066,7 @@ finalize test:
                 vec![Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap()

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1410,8 +1410,6 @@ mod tests {
     #[cfg(feature = "rocks")]
     type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
 
-    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
-
     /// Sample a new program and deploy it to the VM. Returns the program name.
     fn new_program_deployment<R: Rng + CryptoRng>(
         vm: &VM<CurrentNetwork, LedgerType>,
@@ -1472,7 +1470,7 @@ finalize transfer_public:
         let credits = Some(unspent_records.pop().unwrap().decrypt(&view_key)?);
 
         // Deploy.
-        let transaction = vm.deploy(private_key, &program, credits, 10, None::<NoQuery>, rng)?;
+        let transaction = vm.deploy(private_key, &program, credits, 10, None, rng)?;
 
         // Construct the new block.
         let next_block = sample_next_block(vm, private_key, &[transaction], previous_block, unspent_records, rng)?;
@@ -1580,8 +1578,7 @@ finalize transfer_public:
             .into_iter();
 
             // Execute.
-            let transaction =
-                vm.execute(private_key, ("credits.aleo", "split"), inputs, None, 0, None::<NoQuery>, rng).unwrap();
+            let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs, None, 0, None, rng).unwrap();
 
             transactions.push(transaction);
         }
@@ -1608,15 +1605,7 @@ finalize transfer_public:
 
         // Execute.
         let transaction = vm
-            .execute(
-                &caller_private_key,
-                (program_id, function_name),
-                inputs.into_iter(),
-                credits,
-                1,
-                None::<NoQuery>,
-                rng,
-            )
+            .execute(&caller_private_key, (program_id, function_name), inputs.into_iter(), credits, 1, None, rng)
             .unwrap();
         // Verify.
         vm.check_transaction(&transaction, None, rng).unwrap();
@@ -1892,7 +1881,7 @@ finalize transfer_public:
                 inputs.into_iter(),
                 None,
                 1,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2017,7 +2006,7 @@ finalize transfer_public:
                 inputs.clone().into_iter(),
                 None,
                 1,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2331,8 +2320,7 @@ function ped_hash:
             let credits = Some(unspent_records.pop().unwrap().decrypt(&caller_view_key).unwrap());
 
             // Deploy the program.
-            let deployment_transaction =
-                vm.deploy(&caller_private_key, &program, credits, 10, None::<NoQuery>, rng).unwrap();
+            let deployment_transaction = vm.deploy(&caller_private_key, &program, credits, 10, None, rng).unwrap();
 
             // Construct the deployment block.
             let deployment_block = sample_next_block(
@@ -2447,7 +2435,7 @@ finalize compute:
             let credits = Some(unspent_records.pop().unwrap().decrypt(&view_key).unwrap());
 
             // Deploy.
-            let transaction = vm.deploy(&private_key, &program, credits, 10, None::<NoQuery>, rng).unwrap();
+            let transaction = vm.deploy(&private_key, &program, credits, 10, None, rng).unwrap();
 
             // Construct the new block.
             sample_next_block(&vm, &private_key, &[transaction], &splits_block, &mut unspent_records, rng).unwrap()
@@ -2977,7 +2965,7 @@ finalize compute:
                     .into_iter(),
                     None,
                     0,
-                    None::<NoQuery>,
+                    None,
                     rng,
                 )
                 .unwrap();
@@ -3382,7 +3370,7 @@ finalize compute:
                 .into_iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -3421,7 +3409,7 @@ finalize compute:
                 .into_iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -328,7 +328,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let aborted_solution_ids = vec![];
         // Prepare the transactions.
         let transactions = (0..Block::<N>::NUM_GENESIS_TRANSACTIONS)
-            .map(|_| self.execute(private_key, locator, inputs.iter(), None, 0, None::<Query<N, C::BlockStorage>>, rng))
+            .map(|_| self.execute(private_key, locator, inputs.iter(), None, 0, None, rng))
             .collect::<Result<Vec<_>, _>>()?;
 
         // Construct the finalize state.
@@ -469,8 +469,6 @@ pub(crate) mod test_helpers {
     #[cfg(feature = "rocks")]
     type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
 
-    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
-
     /// Samples a new finalize state.
     pub(crate) fn sample_finalize_state(block_height: u32) -> FinalizeGlobalState {
         FinalizeGlobalState::from(block_height as u64, block_height, [0u8; 32])
@@ -598,7 +596,7 @@ function compute:
                 vm.add_next_block(&genesis).unwrap();
 
                 // Deploy.
-                let transaction = vm.deploy(&caller_private_key, &program, credits, 10, None::<NoQuery>, rng).unwrap();
+                let transaction = vm.deploy(&caller_private_key, &program, credits, 10, None, rng).unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
                 // Return the transaction.
@@ -641,7 +639,7 @@ function compute:
                 assert_eq!(authorization.len(), 1);
 
                 // Construct the execute transaction.
-                let transaction = vm.execute_authorization(authorization, None, None::<NoQuery>, rng).unwrap();
+                let transaction = vm.execute_authorization(authorization, None, None, rng).unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
                 // Return the transaction.
@@ -684,15 +682,7 @@ function compute:
 
                 // Execute.
                 let transaction = vm
-                    .execute(
-                        &caller_private_key,
-                        ("credits.aleo", "transfer_public"),
-                        inputs,
-                        record,
-                        0,
-                        None::<NoQuery>,
-                        rng,
-                    )
+                    .execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, record, 0, None, rng)
                     .unwrap();
                 // Verify.
                 vm.check_transaction(&transaction, None, rng).unwrap();
@@ -727,15 +717,7 @@ function compute:
 
                 // Execute.
                 let transaction_without_fee = vm
-                    .execute(
-                        &caller_private_key,
-                        ("credits.aleo", "transfer_public"),
-                        inputs,
-                        None,
-                        0,
-                        None::<NoQuery>,
-                        rng,
-                    )
+                    .execute(&caller_private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng)
                     .unwrap();
                 let execution = transaction_without_fee.execution().unwrap().clone();
 
@@ -750,7 +732,7 @@ function compute:
                     )
                     .unwrap();
                 // Compute the fee.
-                let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
+                let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
 
                 // Construct the transaction.
                 let transaction = Transaction::from_execution(execution, Some(fee)).unwrap();
@@ -786,7 +768,7 @@ function compute:
         let authorization =
             vm.authorize_fee_public(&caller_private_key, fee, 100, execution.to_execution_id().unwrap(), rng).unwrap();
         // Compute the fee.
-        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
 
         // Construct the transaction.
         Transaction::from_execution(execution, Some(fee)).unwrap()
@@ -883,7 +865,7 @@ function compute:
                 [Value::Record(record), Value::from_str("1000000000u64").unwrap()].iter(), // 1000 credits
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -902,7 +884,7 @@ function compute:
                 [Value::Record(first_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -918,7 +900,7 @@ function compute:
                 [Value::Record(second_record), Value::from_str("100000000u64").unwrap()].iter(), // 100 credits
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -964,24 +946,10 @@ finalize getter:
     get map_0[0field] into r0;
         ";
         let first_deployment = vm
-            .deploy(
-                &caller_private_key,
-                &Program::from_str(first_program).unwrap(),
-                Some(first_record),
-                1,
-                None::<NoQuery>,
-                rng,
-            )
+            .deploy(&caller_private_key, &Program::from_str(first_program).unwrap(), Some(first_record), 1, None, rng)
             .unwrap();
         let second_deployment = vm
-            .deploy(
-                &caller_private_key,
-                &Program::from_str(second_program).unwrap(),
-                Some(second_record),
-                1,
-                None::<NoQuery>,
-                rng,
-            )
+            .deploy(&caller_private_key, &Program::from_str(second_program).unwrap(), Some(second_record), 1, None, rng)
             .unwrap();
         let deployment_block =
             sample_next_block(&vm, &caller_private_key, &[first_deployment, second_deployment], rng).unwrap();
@@ -995,7 +963,7 @@ finalize getter:
                 Vec::<Value<MainnetV0>>::new().iter(),
                 Some(third_record),
                 1,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -1006,7 +974,7 @@ finalize getter:
                 Vec::<Value<MainnetV0>>::new().iter(),
                 Some(fourth_record),
                 1,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -1050,14 +1018,7 @@ function c:
     output r2 as u8.private;
         ";
         let deployment_1 = vm
-            .deploy(
-                &caller_private_key,
-                &Program::from_str(program_1).unwrap(),
-                Some(record_0),
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .deploy(&caller_private_key, &Program::from_str(program_1).unwrap(), Some(record_0), 0, None, rng)
             .unwrap();
 
         // Deploy the first program.
@@ -1077,14 +1038,7 @@ function b:
     output r2 as u8.private;
         ";
         let deployment_2 = vm
-            .deploy(
-                &caller_private_key,
-                &Program::from_str(program_2).unwrap(),
-                Some(record_1),
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .deploy(&caller_private_key, &Program::from_str(program_2).unwrap(), Some(record_1), 0, None, rng)
             .unwrap();
 
         // Deploy the second program.
@@ -1104,14 +1058,7 @@ function a:
     output r2 as u8.private;
         ";
         let deployment_3 = vm
-            .deploy(
-                &caller_private_key,
-                &Program::from_str(program_3).unwrap(),
-                Some(record_2),
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .deploy(&caller_private_key, &Program::from_str(program_3).unwrap(), Some(record_2), 0, None, rng)
             .unwrap();
 
         // Create the deployment for the fourth program.
@@ -1128,14 +1075,7 @@ function a:
     output r2 as u8.private;
         ";
         let deployment_4 = vm
-            .deploy(
-                &caller_private_key,
-                &Program::from_str(program_4).unwrap(),
-                Some(record_3),
-                0,
-                None::<NoQuery>,
-                rng,
-            )
+            .deploy(&caller_private_key, &Program::from_str(program_4).unwrap(), Some(record_3), 0, None, rng)
             .unwrap();
 
         // Deploy the third and fourth program together.
@@ -1204,7 +1144,7 @@ function multitransfer:
     ",
         )
         .unwrap();
-        let deployment = vm.deploy(&caller_private_key, &program, Some(record_0), 1, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, Some(record_0), 1, None, rng).unwrap();
         vm.add_next_block(&sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap()).unwrap();
 
         // Execute the programs.
@@ -1220,7 +1160,7 @@ function multitransfer:
                 inputs.into_iter(),
                 Some(record_2),
                 1,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -1254,7 +1194,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1275,7 +1215,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1315,7 +1255,7 @@ function transfer:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1374,7 +1314,7 @@ function call_fee_private:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -1389,16 +1329,8 @@ function call_fee_private:
             Value::<MainnetV0>::from_str("1field").unwrap(),
         ];
         assert!(
-            vm.execute(
-                &private_key,
-                ("test_program.aleo", "call_fee_public"),
-                inputs.into_iter(),
-                None,
-                0,
-                None::<NoQuery>,
-                rng
-            )
-            .is_err()
+            vm.execute(&private_key, ("test_program.aleo", "call_fee_public"), inputs.into_iter(), None, 0, None, rng)
+                .is_err()
         );
 
         // Ensure that the transaction that calls `fee_private` internally cannot be generated.
@@ -1409,16 +1341,8 @@ function call_fee_private:
             Value::<MainnetV0>::from_str("1field").unwrap(),
         ];
         assert!(
-            vm.execute(
-                &private_key,
-                ("test_program.aleo", "call_fee_private"),
-                inputs.into_iter(),
-                None,
-                0,
-                None::<NoQuery>,
-                rng
-            )
-            .is_err()
+            vm.execute(&private_key, ("test_program.aleo", "call_fee_private"), inputs.into_iter(), None, 0, None, rng)
+                .is_err()
         );
     }
 
@@ -1451,7 +1375,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
         // Verify the deployment transaction. It should fail because there are too many constraints.
         assert!(vm.check_transaction(&deployment, None, rng).is_err());
@@ -1492,7 +1416,7 @@ function do2:
             .unwrap();
 
         // Create the deployment transaction.
-        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
         // Verify the deployment transaction. It should fail because there are too many constants.
         let check_tx_res = vm.check_transaction(&deployment, None, rng);
@@ -1527,7 +1451,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(_, _, program_owner, deployment, fee) = transaction else {
@@ -1550,7 +1474,7 @@ function do:
             .authorize_fee_public(&private_key, required_fee, 0, deployment.as_ref().to_deployment_id().unwrap(), rng)
             .unwrap();
         // Compute the fee.
-        let fee = vm.execute_fee_authorization(fee_authorization, None::<NoQuery>, rng).unwrap();
+        let fee = vm.execute_fee_authorization(fee_authorization, None, rng).unwrap();
 
         // Create a new deployment transaction with the overreported verifying keys.
         let adjusted_deployment =
@@ -1591,7 +1515,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(txid, _, program_owner, deployment, fee) = transaction else {
@@ -1627,9 +1551,8 @@ function do:
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
 
         // Check that the deployment transaction will be aborted if injected into a block.
         let block = sample_next_block(&vm, &private_key, &[transaction, adjusted_transaction.clone()], rng).unwrap();
@@ -1669,7 +1592,7 @@ function do:
         .unwrap();
 
         // Create the deployment transaction.
-        let transaction = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let transaction = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
         // Destructure the deployment transaction.
         let Transaction::Deploy(txid, _, program_owner, deployment, fee) = transaction else {
@@ -1703,9 +1626,8 @@ function do:
         .into_iter();
 
         // Execute.
-        let transaction = vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
 
         // Check that the deployment transaction will be aborted if injected into a block.
         let block = sample_next_block(&vm, &private_key, &[transaction, adjusted_transaction.clone()], rng).unwrap();
@@ -1758,7 +1680,7 @@ finalize do:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
         // For each layer, deploy a program that calls the program from the previous layer.
@@ -1793,7 +1715,7 @@ finalize do:
             let program = Program::from_str(&program_string).unwrap();
 
             // Deploy the program.
-            let deployment = vm.deploy(&private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+            let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
             vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
         }
@@ -1810,7 +1732,7 @@ finalize do:
 
         // Execute.
         let transaction =
-            vm.execute(&private_key, ("program_layer_30.aleo", "do"), inputs, record, 0, None::<NoQuery>, rng).unwrap();
+            vm.execute(&private_key, ("program_layer_30.aleo", "do"), inputs, record, 0, None, rng).unwrap();
 
         // Verify.
         vm.check_transaction(&transaction, None, rng).unwrap();
@@ -1862,7 +1784,7 @@ finalize do:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -1953,7 +1875,7 @@ finalize do:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2061,7 +1983,7 @@ finalize transfer_public:
         let wrapper_program_address = wrapper_program_id.to_address().unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2078,7 +2000,7 @@ finalize transfer_public:
                     .iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2130,7 +2052,7 @@ finalize transfer_public:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2253,7 +2175,7 @@ finalize transfer_public_as_signer:
         let wrapper_program_address = wrapper_program_id.to_address().unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2269,7 +2191,7 @@ finalize transfer_public_as_signer:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2407,7 +2329,7 @@ finalize transfer_public_to_private:
         let wrapper_program_id = ProgramID::from_str("credits_wrapper.aleo").unwrap();
 
         // Deploy the wrapper program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2423,7 +2345,7 @@ finalize transfer_public_to_private:
                 [Value::from_str(&format!("{recipient_address}")).unwrap(), Value::from_str("1u64").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2542,7 +2464,7 @@ finalize transfer_public_to_private:
                 inputs.iter(),
                 None,
                 0u64,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2628,7 +2550,7 @@ finalize transfer_public_to_private:
         let authorization = vm
             .authorize_fee_public(&caller_private_key, 10_000_000, 0, new_execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
         let new_transaction = Transaction::from_execution(new_execution, Some(fee)).unwrap();
 
         // Verify the new transaction.
@@ -2666,7 +2588,7 @@ finalize transfer_public_to_private:
                 inputs.iter(),
                 None,
                 0u64,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2790,7 +2712,7 @@ function add_thrice:
         ",
         )
         .unwrap();
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
         vm.add_next_block(&block).unwrap();
 
@@ -2802,7 +2724,7 @@ function add_thrice:
                 [Value::from_str("1u64").unwrap(), Value::from_str("2u64").unwrap()].iter(),
                 None,
                 0u64,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2892,7 +2814,7 @@ function add_thrice:
         let authorization = vm
             .authorize_fee_public(&caller_private_key, 10_000_000, 0, new_execution.to_execution_id().unwrap(), rng)
             .unwrap();
-        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
         let new_transaction = Transaction::from_execution(new_execution, Some(fee)).unwrap();
 
         // Verify the new transaction.
@@ -2919,7 +2841,7 @@ function add_thrice:
         let program = small_transaction_program();
 
         // Deploy the program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2931,7 +2853,7 @@ function add_thrice:
         let program = large_transaction_program();
 
         // Deploy the program.
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
 
         // Add the deployment to a block and update the VM.
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
@@ -2947,7 +2869,7 @@ function add_thrice:
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -2972,7 +2894,7 @@ function add_thrice:
                 Vec::<Value<CurrentNetwork>>::new().iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -3045,11 +2967,11 @@ function check:
         .unwrap();
 
         // Deploy the child programs and add them to a block
-        let deployment_1 = vm.deploy(&private_key, &child_program_1, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment_1 = vm.deploy(&private_key, &child_program_1, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment_1, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment_1], rng).unwrap()).unwrap();
 
-        let deployment_2 = vm.deploy(&private_key, &child_program_2, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment_2 = vm.deploy(&private_key, &child_program_2, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment_2, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment_2], rng).unwrap()).unwrap();
 
@@ -3073,7 +2995,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &parent_program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &parent_program, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -3096,7 +3018,7 @@ function check:
         )
         .unwrap();
 
-        let deployment = vm.deploy(&private_key, &grandparent_program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&private_key, &grandparent_program, None, 0, None, rng).unwrap();
         assert!(vm.check_transaction(&deployment, None, rng).is_ok());
         vm.add_next_block(&sample_next_block(&vm, &private_key, &[deployment], rng).unwrap()).unwrap();
 
@@ -3197,7 +3119,7 @@ function check:
                 [Value::from_str(&format!("{address_1}")).unwrap(), Value::from_str("100000000u64").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -3208,7 +3130,7 @@ function check:
                 [Value::from_str(&format!("{address_2}")).unwrap(), Value::from_str("100000000u64").unwrap()].iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -3251,13 +3173,13 @@ function adder:
         off_chain_vm.add_next_block(&genesis).unwrap();
         off_chain_vm.add_next_block(&block).unwrap();
         // Deploy the first program.
-        let deployment_1 = off_chain_vm.deploy(&private_key_1, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment_1 = off_chain_vm.deploy(&private_key_1, &program_1, None, 0, None, rng).unwrap();
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_1.fee_amount().unwrap(), 2483025);
         // Add the first program to the off-chain VM.
         off_chain_vm.process().write().add_program(&program_1).unwrap();
         // Deploy the second program.
-        let deployment_2 = off_chain_vm.deploy(&private_key_2, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment_2 = off_chain_vm.deploy(&private_key_2, &program_2, None, 0, None, rng).unwrap();
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_2.fee_amount().unwrap(), 2659575);
         // Drop the off-chain VM.
@@ -3301,7 +3223,7 @@ function adder:
         for (i, body) in invalid_program_bodies.iter().enumerate() {
             println!("Deploying 'valid' test program {}: {}", i, body);
             let program = Program::from_str(&format!("program test_valid_{}.aleo;\n{}", i, body)).unwrap();
-            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
             let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
             assert_eq!(block.transactions().num_accepted(), 1);
             assert_eq!(block.transactions().num_rejected(), 0);
@@ -3316,7 +3238,7 @@ function adder:
         for (i, body) in invalid_program_bodies.iter().enumerate() {
             println!("Deploying 'invalid' test program {}: {}", i, body);
             let program = Program::from_str(&format!("program test_invalid_{}.aleo;\n{}", i, body)).unwrap();
-            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+            let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
             if let Err(e) = vm.check_transaction(&deployment, None, rng) {
                 println!("Error: {}", e);
             } else {
@@ -3327,7 +3249,7 @@ function adder:
         // Attempt to deploy a program with the name `constructor`.
         // Verify that `check_transaction` fails.
         let program = Program::from_str(r"program constructor.aleo; function dummy:").unwrap();
-        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None::<NoQuery>, rng).unwrap();
+        let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
         if let Err(e) = vm.check_transaction(&deployment, None, rng) {
             println!("Error: {}", e);
         } else {

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -433,13 +433,6 @@ mod tests {
 
     type CurrentNetwork = test_helpers::CurrentNetwork;
 
-    #[cfg(not(feature = "rocks"))]
-    type LedgerType = ledger_store::helpers::memory::ConsensusMemory<CurrentNetwork>;
-    #[cfg(feature = "rocks")]
-    type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
-
-    type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
-
     #[test]
     fn test_verify() {
         let rng = &mut TestRng::default();
@@ -623,8 +616,7 @@ mod tests {
 
         // Deploy.
         let program = crate::vm::test_helpers::sample_program();
-        let deployment_transaction =
-            vm.deploy(&caller_private_key, &program, Some(credits), 10, None::<NoQuery>, rng).unwrap();
+        let deployment_transaction = vm.deploy(&caller_private_key, &program, Some(credits), 10, None, rng).unwrap();
 
         // Construct the new block header.
         let time_since_last_block = CurrentNetwork::BLOCK_TIME as i64;
@@ -698,9 +690,8 @@ mod tests {
         let credits = Some(records.values().next().unwrap().decrypt(&caller_view_key).unwrap());
 
         // Execute.
-        let transaction = vm
-            .execute(&caller_private_key, ("testing.aleo", "initialize"), inputs, credits, 10, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction =
+            vm.execute(&caller_private_key, ("testing.aleo", "initialize"), inputs, credits, 10, None, rng).unwrap();
 
         // Verify.
         vm.check_transaction(&transaction, None, rng).unwrap();
@@ -801,7 +792,7 @@ function compute:
             )
             .unwrap();
         // Compute the fee.
-        let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
+        let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
 
         // Construct the transaction.
         let mutated_transaction = Transaction::from_execution(mutated_execution, Some(fee)).unwrap();
@@ -869,9 +860,8 @@ function compute:
             .into_iter();
 
             // Execute.
-            let transaction_without_fee = vm
-                .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
-                .unwrap();
+            let transaction_without_fee =
+                vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
             let execution = transaction_without_fee.execution().unwrap().clone();
 
             // Authorize the fee.
@@ -879,7 +869,7 @@ function compute:
                 .authorize_fee_public(&private_key, 10_000_000, 100, execution.to_execution_id().unwrap(), rng)
                 .unwrap();
             // Compute the fee.
-            let fee = vm.execute_fee_authorization(authorization, None::<NoQuery>, rng).unwrap();
+            let fee = vm.execute_fee_authorization(authorization, None, rng).unwrap();
 
             // Construct the transaction.
             Transaction::from_execution(execution, Some(fee)).unwrap()
@@ -929,9 +919,8 @@ function compute:
             Value::<CurrentNetwork>::from_str("1u64").unwrap(),
         ]
         .into_iter();
-        let transaction_v1 = vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction_v1 =
+            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
 
         // Advance the ledger past ConsensusV4
         let transactions: [Transaction<CurrentNetwork>; 0] = [];
@@ -953,9 +942,8 @@ function compute:
             Value::<CurrentNetwork>::from_str("1u64").unwrap(),
         ]
         .into_iter();
-        let transaction_v2 = vm
-            .execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None::<NoQuery>, rng)
-            .unwrap();
+        let transaction_v2 =
+            vm.execute(&private_key, ("credits.aleo", "transfer_public"), inputs, None, 0, None, rng).unwrap();
 
         // Check that the v2 transaction is valid
         assert!(vm.check_transaction(&transaction_v2, None, rng).is_ok());
@@ -1071,16 +1059,16 @@ function compute:
         .unwrap();
 
         // Create a deployment transaction for the first program.
-        let deploy_1 = vm.deploy(&private_key, &program_1, None, 0, None::<NoQuery>, rng).unwrap();
+        let deploy_1 = vm.deploy(&private_key, &program_1, None, 0, None, rng).unwrap();
 
         // Create a deployment transaction for the second program.
-        let deploy_2 = vm.deploy(&private_key, &program_2, None, 0, None::<NoQuery>, rng).unwrap();
+        let deploy_2 = vm.deploy(&private_key, &program_2, None, 0, None, rng).unwrap();
 
         // Create a deployment transaction for the third program.
-        let deploy_3 = vm.deploy(&private_key, &program_3, None, 0, None::<NoQuery>, rng).unwrap();
+        let deploy_3 = vm.deploy(&private_key, &program_3, None, 0, None, rng).unwrap();
 
         // Create a deployment transaction for the fourth program.
-        let deploy_4 = vm.deploy(&private_key, &program_4, None, 0, None::<NoQuery>, rng).unwrap();
+        let deploy_4 = vm.deploy(&private_key, &program_4, None, 0, None, rng).unwrap();
 
         // // Ensure that the deployments are valid.
         assert!(vm.check_transaction(&deploy_1, None, rng).is_ok());

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -32,7 +32,6 @@ use ledger_block::{
     Transactions,
     Transition,
 };
-use ledger_query::Query;
 use ledger_store::{ConsensusStorage, ConsensusStore};
 use snarkvm_synthesizer::{VM, program::FinalizeOperation};
 use synthesizer_program::FinalizeGlobalState;
@@ -47,8 +46,6 @@ use utilities::*;
 type LedgerType = ledger_store::helpers::memory::ConsensusMemory<CurrentNetwork>;
 #[cfg(feature = "rocks")]
 type LedgerType = ledger_store::helpers::rocksdb::ConsensusDB<CurrentNetwork>;
-
-type NoQuery = Query<CurrentNetwork, <LedgerType as ConsensusStorage<CurrentNetwork>>::BlockStorage>;
 
 #[test]
 fn test_vm_execute_and_finalize() {
@@ -95,7 +92,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
                 .iter(),
                 None,
                 0,
-                None::<NoQuery>,
+                None,
                 rng,
             )
             .unwrap();
@@ -128,7 +125,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
 
     // Deploy the programs.
     for program in test.programs() {
-        let transaction = match vm.deploy(&genesis_private_key, program, None, 0, None::<NoQuery>, rng) {
+        let transaction = match vm.deploy(&genesis_private_key, program, None, 0, None, rng) {
             Ok(transaction) => transaction,
             Err(error) => {
                 let mut output = serde_yaml::Mapping::new();
@@ -227,25 +224,18 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
             let mut other = serde_yaml::Mapping::new();
 
             // Execute the function, extracting the transaction.
-            let transaction = match vm.execute(
-                &private_key,
-                (program_id, function_name),
-                inputs.iter(),
-                None,
-                0u64,
-                None::<NoQuery>,
-                rng,
-            ) {
-                Ok(transaction) => transaction,
-                // If the execution fails, return the error.
-                Err(err) => {
-                    result.insert(
-                        serde_yaml::Value::String("execute".to_string()),
-                        serde_yaml::Value::String(err.to_string()),
-                    );
-                    return (serde_yaml::Value::Mapping(result), serde_yaml::Value::Mapping(Default::default()));
-                }
-            };
+            let transaction =
+                match vm.execute(&private_key, (program_id, function_name), inputs.iter(), None, 0u64, None, rng) {
+                    Ok(transaction) => transaction,
+                    // If the execution fails, return the error.
+                    Err(err) => {
+                        result.insert(
+                            serde_yaml::Value::String("execute".to_string()),
+                            serde_yaml::Value::String(err.to_string()),
+                        );
+                        return (serde_yaml::Value::Mapping(result), serde_yaml::Value::Mapping(Default::default()));
+                    }
+                };
 
             // Attempt to verify the transaction.
             let verified = vm.check_transaction(&transaction, None, rng).is_ok();
@@ -545,8 +535,7 @@ fn split<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>(
     rng: &mut R,
 ) -> (Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>, Vec<Transaction<CurrentNetwork>>) {
     let inputs = vec![Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
-    let transaction =
-        vm.execute(private_key, ("credits.aleo", "split"), inputs.iter(), None, 0, None::<NoQuery>, rng).unwrap();
+    let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs.iter(), None, 0, None, rng).unwrap();
     let records = transaction
         .records()
         .map(|(_, record)| record.decrypt(&ViewKey::try_from(private_key).unwrap()).unwrap())

--- a/vm/package/execute.rs
+++ b/vm/package/execute.rs
@@ -118,7 +118,7 @@ impl<N: Network> Package<N> {
             VarunaVersion::V2
         };
         // Prepare the trace.
-        trace.prepare(query)?;
+        trace.prepare(&query)?;
 
         // Prove the execution.
         let execution = trace.prove_execution::<A, R>(&locator.to_string(), varuna_version, rng)?;


### PR DESCRIPTION
Two reasons:

1. Significantly improves the ergonomics of using these functions. Otherwise the caller has to import multiple types just to define something like
`type NoQuery =
   Query<MainnetV0,
       <LedgerType as ConsensusStorage<MainnetV0>>::BlockStorage>;`
and use `None::<NoQuery>`.
just to specify to use a default implementation. Now we can just pass `None`.

2. Reduce code bloat. These functions have 3 type parameters already.