### PR TITLE
Introduce heights for consensus v8

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -144,7 +144,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V5, 5_780_000),
         (ConsensusVersion::V6, 6_240_000),
         (ConsensusVersion::V7, 6_880_000),
-        (ConsensusVersion::V8, 7_460_000),
+        (ConsensusVersion::V8, 7_562_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -136,7 +136,7 @@ impl Network for CanaryV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
@@ -144,11 +144,12 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V5, 5_780_000),
         (ConsensusVersion::V6, 6_240_000),
         (ConsensusVersion::V7, 6_880_000),
+        (ConsensusVersion::V8, 7_460_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
@@ -156,6 +157,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
         (ConsensusVersion::V7, 15),
+        (ConsensusVersion::V8, 16),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -87,6 +87,7 @@ pub enum ConsensusVersion {
     V6 = 6,
     /// V7: Update to program rules.
     V7 = 7,
+    V8 = 8,
 }
 
 pub trait Network:
@@ -226,7 +227,7 @@ pub trait Network:
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8];
     ///  A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     //  Note: This value must **not** decrease without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -145,7 +145,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V5, 7_060_000),
         (ConsensusVersion::V6, 7_560_000),
         (ConsensusVersion::V7, 7_570_000),
-        (ConsensusVersion::V8, 9_850_000),
+        (ConsensusVersion::V8, 9_410_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -137,7 +137,7 @@ impl Network for MainnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_800_000),
         (ConsensusVersion::V3, 4_900_000),
@@ -145,11 +145,12 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V5, 7_060_000),
         (ConsensusVersion::V6, 7_560_000),
         (ConsensusVersion::V7, 7_570_000),
+        (ConsensusVersion::V8, 9_850_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
@@ -157,6 +158,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
         (ConsensusVersion::V7, 15),
+        (ConsensusVersion::V8, 16),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -136,7 +136,7 @@ impl Network for TestnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_950_000),
         (ConsensusVersion::V3, 4_800_000),
@@ -144,11 +144,12 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V5, 6_765_000),
         (ConsensusVersion::V6, 7_600_000),
         (ConsensusVersion::V7, 8_365_000),
+        (ConsensusVersion::V8, 9_200_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
@@ -156,6 +157,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
         (ConsensusVersion::V7, 15),
+        (ConsensusVersion::V8, 16),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -144,7 +144,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V5, 6_765_000),
         (ConsensusVersion::V6, 7_600_000),
         (ConsensusVersion::V7, 8_365_000),
-        (ConsensusVersion::V8, 9_200_000),
+        (ConsensusVersion::V8, 9_150_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.


### PR DESCRIPTION

Activation estimates:
| Network | Release Date | Buffer | Consensus v8 |
|---------|--------------|--------|--------------|
| Canary  | July 1, 2025 | 3 days | July 4, 2025 |
| Testnet | July 15, 2025 | 5 days | July 20, 2025 |
| Mainnet | July 22, 2025  | 14 days | August 5, 2025 |