### PR TITLE
Update Groth16 reference link to current arkworks-rs repository

### DIFF
--- a/algorithms/src/snark/varuna/README.md
+++ b/algorithms/src/snark/varuna/README.md
@@ -30,7 +30,7 @@ Benchmarks were run on a machine with an Intel Xeon 6136 CPU running at 3.0 GHz.
 
 ### Running time compared to Groth16 
 
-The graphs below compare the running time, in single-thread execution, of Marlin's indexer, prover, and verifier algorithms with the corresponding algorithms of [Groth16][groth16] (the state of the art in preprocessing zkSNARKs for R1CS with circuit-specific SRS) as implemented in [`groth16`](https://github.com/scipr-lab/zexe/tree/master/groth16).
+The graphs below compare the running time, in single-thread execution, of Marlin's indexer, prover, and verifier algorithms with the corresponding algorithms of [Groth16][groth16] (the state of the art in preprocessing zkSNARKs for R1CS with circuit-specific SRS) as implemented in [`groth16`](https://github.com/arkworks-rs/groth16).
 We evaluate Marlin's algorithms when instantiated with the PC scheme from [[CHMMVW20]][marlin] (denoted "M-AHP w/ PC of [[CHMMVW20]][marlin]"), and the PC scheme from [[MBKM19]][sonic] (denoted "M-AHP w/ PC of [[MBKM19]][sonic]").
 
 <p align="center">


### PR DESCRIPTION
Replaced the outdated and broken link to the Groth16 implementation in the zexe repository with the correct and up-to-date link to the arkworks-rs/groth16 repository in the README. This ensures that readers are directed to the maintained and relevant implementation of Groth16 for R1CS zkSNARKs. No other content was changed.