### PR TITLE
deny clippy warnings in commit git-hook

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo +nightly fmt --all -- --check && cargo clippy --workspace --all-targets --all-features"
+pre-commit = "cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo +nightly fmt --all -- --check"
 
 [logging]
 verbose = true


### PR DESCRIPTION
snarkVM version of [snarkOS#3642](https://github.com/ProvableHQ/snarkOS/pull/3642).

This also changes `.rusty-hook.toml` to be identical to the file with the same name in `snarkOS`.