### PR TITLE
[Build] Support compilation w/o default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,7 @@ dependencies = [
  "rusty-hook",
  "self_update",
  "serde_json",
+ "snarkvm",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,6 @@ cli = [
   "package",
   "dep:clap",
   "dep:colored",
-  "dep:dotenvy",
   "dep:self_update",
   "dep:thiserror",
   "dep:ureq",
@@ -139,7 +138,8 @@ package = [
   "file",
   "ledger",
   "snarkvm-synthesizer/process",
-  "dep:ureq"
+  "dep:ureq",
+  "dep:dotenvy"
 ]
 aleo-cli = [ "snarkvm-synthesizer/aleo-cli" ]
 async = [ "snarkvm-ledger/async", "snarkvm-synthesizer/async" ]
@@ -271,6 +271,11 @@ optional = true
 workspace = true
 features = ["json"]
 optional = true
+
+# Some cli helper functions are used in the tests.
+[dev-dependencies.snarkvm]
+path = "."
+features = [ "cli" ]
 
 [dev-dependencies.bincode]
 version = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,29 +105,41 @@ default = [
   "parameters",
   "synthesizer",
   "utilities",
-  "cli"
+  "package",
+  "file",
 ]
 full = [
-  "algorithms",
-  "circuit",
-  "console",
+  "cli",
+  "default",
   "curves",
   "fields",
-  "ledger",
-  "parameters",
-  "synthesizer",
-  "utilities"
 ]
 cli = [
-  "anyhow",
-  "clap",
-  "colored",
-  "dotenvy",
-  "rand",
-  "self_update",
-  "serde_json",
-  "thiserror",
-  "ureq"
+  "circuit",
+  "utilities",
+  "package",
+  "dep:clap",
+  "dep:colored",
+  "dep:dotenvy",
+  "dep:self_update",
+  "dep:thiserror",
+  "dep:ureq",
+  "dep:serde_json",
+]
+file = [
+  "console",
+  "synthesizer",
+  "snarkvm-synthesizer/snark",
+  "snarkvm-synthesizer/program",
+  "dep:serde_json"
+]
+package = [
+  "algorithms",
+  "circuit",
+  "file",
+  "ledger",
+  "snarkvm-synthesizer/process",
+  "dep:ureq"
 ]
 aleo-cli = [ "snarkvm-synthesizer/aleo-cli" ]
 async = [ "snarkvm-ledger/async", "snarkvm-synthesizer/async" ]
@@ -222,7 +234,6 @@ version = "1"
 
 [dependencies.anyhow]
 version = "1.0.73"
-optional = true
 
 [dependencies.clap]
 version = "4.4"
@@ -242,7 +253,6 @@ version = "0.4.4"
 
 [dependencies.rand]
 version = "0.8"
-optional = true
 
 [dependencies.self_update]
 version = "0.41"

--- a/synthesizer/src/lib.rs
+++ b/synthesizer/src/lib.rs
@@ -18,6 +18,7 @@
 // TODO (howardwu): Update the return type on `execute` after stabilizing the interface.
 #![allow(clippy::type_complexity)]
 
+#[allow(unused_imports)] // Only needed for some features
 #[macro_use]
 extern crate tracing;
 

--- a/vm/lib.rs
+++ b/vm/lib.rs
@@ -23,7 +23,9 @@ extern crate thiserror;
 
 #[cfg(feature = "cli")]
 pub mod cli;
+#[cfg(feature = "file")]
 pub mod file;
+#[cfg(feature = "package")]
 pub mod package;
 
 #[cfg(feature = "algorithms")]


### PR DESCRIPTION
## Motivation
Fixes #2721. This change enables us to build leaner test binaries by disabling unwanted features, and (hopefully) speeds up snarkOS compilation slightly.

## Overview
This PR introduces two new features, `package` and `file`, which are both enabled by default. This change more clearly defines dependencies for each feature. It also allows compiling without any default features or only the `file` feature.

Finally, the PR removes `cli` from the default features, as this flag depends on `ureq`, `self_update`, and a few other large dependencies. `cli` is only needed for the `snarkvm` binary, and it would be great if we could disable it in snarkOS.

## Testing
I manually tested each feature compiles by running `cargo check --no-default-features --features=<feature_name>`.

## Notes
We should consider removing features flags. snarkVM already has a lot of them, and it looks like `file` and its dependencies (`console` and `synthesizer`) should always be enabled.
I was not sure if removing existing features would break anything, so I did not make such a change.