### PR TITLE
[Perf] Reduce the number of allocs in Mul for LinearAssignment

### DIFF
--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -436,9 +436,8 @@ impl<F: PrimeField> Mul<&F> for LinearCombination<F> {
         let mut output = self;
         output.constant *= coefficient;
         output.terms.retain_mut(|(_v, current_coefficient)| {
-            let res = *current_coefficient * coefficient;
-            *current_coefficient = res;
-            !res.is_zero()
+            *current_coefficient *= coefficient;
+            !current_coefficient.is_zero()
         });
         output.value *= coefficient;
         output

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -435,14 +435,11 @@ impl<F: PrimeField> Mul<&F> for LinearCombination<F> {
     fn mul(self, coefficient: &F) -> Self::Output {
         let mut output = self;
         output.constant *= coefficient;
-        output.terms = output
-            .terms
-            .into_iter()
-            .filter_map(|(v, current_coefficient)| {
-                let res = current_coefficient * coefficient;
-                (!res.is_zero()).then_some((v, res))
-            })
-            .collect();
+        output.terms.retain_mut(|(_v, current_coefficient)| {
+            let res = *current_coefficient * coefficient;
+            *current_coefficient = res;
+            !res.is_zero()
+        });
         output.value *= coefficient;
         output
     }


### PR DESCRIPTION
I found this one while heap-profiling a small binary performing `execute_authorization`. This refactoring resulted in the following perf improvements:

- runtime -1.5%
- all allocs -17.6%
- temp allocs -51%