### PR TITLE
[Perf] Reduce the number of allocs in Poseidon::permute

### DIFF
--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -164,8 +164,7 @@ impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
 
     /// Apply the Maximally Distance Separating (MDS) matrix in-place.
     #[inline]
-    fn apply_mds(&self, state: &mut [Field<E>]) {
-        let mut new_state = Vec::with_capacity(state.len());
+    fn apply_mds(&self, state: &mut [Field<E>], new_state: &mut Vec<Field<E>>) {
         for i in 0..state.len() {
             let mut accumulator = Field::zero();
             for (j, element) in state.iter().enumerate() {
@@ -173,7 +172,7 @@ impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
             }
             new_state.push(accumulator);
         }
-        state.clone_from_slice(&new_state);
+        state.swap_with_slice(new_state);
     }
 
     /// Apply the permutation for all rounds in-place.
@@ -184,11 +183,13 @@ impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
         let partial_round_range = full_rounds_over_2..(full_rounds_over_2 + self.partial_rounds);
 
         // Iterate through all rounds to permute.
+        let mut new_state = Vec::with_capacity(state.len());
         for i in 0..(self.partial_rounds + self.full_rounds) {
             let is_full_round = !partial_round_range.contains(&i);
             self.apply_ark(state, i);
             self.apply_s_box(state, is_full_round);
-            self.apply_mds(state);
+            self.apply_mds(state, &mut new_state);
+            new_state.clear();
         }
     }
 }

--- a/circuit/algorithms/src/poseidon/hash_many.rs
+++ b/circuit/algorithms/src/poseidon/hash_many.rs
@@ -165,6 +165,7 @@ impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
     /// Apply the Maximally Distance Separating (MDS) matrix in-place.
     #[inline]
     fn apply_mds(&self, state: &mut [Field<E>], new_state: &mut Vec<Field<E>>) {
+        new_state.clear();
         for i in 0..state.len() {
             let mut accumulator = Field::zero();
             for (j, element) in state.iter().enumerate() {
@@ -189,7 +190,6 @@ impl<E: Environment, const RATE: usize> Poseidon<E, RATE> {
             self.apply_ark(state, i);
             self.apply_s_box(state, is_full_round);
             self.apply_mds(state, &mut new_state);
-            new_state.clear();
         }
     }
 }


### PR DESCRIPTION
Salvaged from https://github.com/ProvableHQ/snarkVM-fork/pull/1. The other change (related to `MulAssign`) is no longer significant with the upcoming https://github.com/ProvableHQ/snarkVM/pull/2766.

Perf improvements in a simple `execute_authorization` operation:
- total allocs -1%
- temp allocs -1.5%
- runtime -1%

While these are modest, the change is trivial and its effects would be more pronounced with more Poseidon hashing/permutations involved.