### PR TITLE
[Perf] Remove a redundant outer lock from the Process

### DIFF
--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -263,7 +263,7 @@ function main:
         let inputs = [Value::from_str("2group").unwrap()].into_iter();
 
         // Add the program to the VM.
-        vm.process().write().add_program(&program).unwrap();
+        vm.process().add_program(&program).unwrap();
 
         // Create an execution transaction that is 164613 bytes in size.
         let transaction = vm.execute(&private_key, ("too_big.aleo", "main"), inputs, None, 0, None, rng).unwrap();

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2350,7 +2350,7 @@ fn test_deployment_exceeding_max_transaction_spend() {
 
         // Attempt to initialize a `Stack` for the program.
         // If this fails, then by `Stack::initialize` the finalize cost exceeds the `TRANSACTION_SPEND_LIMIT`.
-        if Stack::<CurrentNetwork>::new(&ledger.vm().process().read(), &program).is_err() {
+        if Stack::<CurrentNetwork>::new(&ledger.vm().process(), &program).is_err() {
             exceeding_program = Some(program);
             break;
         } else {
@@ -2727,11 +2727,10 @@ function foo:
             };
             let deployment = deployment_tx.deployment().unwrap().clone();
             for _ in 0..ITERATIONS {
-                let result =
-                    match try_vm_runtime!(|| process.read().verify_deployment::<CurrentAleo, _>(&deployment, rng)) {
-                        Ok(result) => result.is_ok(),
-                        Err(_) => false,
-                    };
+                let result = match try_vm_runtime!(|| process.verify_deployment::<CurrentAleo, _>(&deployment, rng)) {
+                    Ok(result) => result.is_ok(),
+                    Err(_) => false,
+                };
                 assert_eq!(result, expected_result);
             }
         };

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -401,7 +401,7 @@ pub fn sample_large_execution_transaction(rng: &mut TestRng) -> Transaction<Curr
             let program = large_transaction_program();
 
             // Construct the process.
-            let mut process = synthesizer_process::Process::load().unwrap();
+            let process = synthesizer_process::Process::load().unwrap();
             // Add the program.
             process.add_program(&program).unwrap();
 

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -531,7 +531,7 @@ function compute:
         .unwrap();
 
         // Initialize a new process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Deploy the program.
         let deployment = process.deploy::<CurrentAleo, _>(&program, rng).unwrap();
 

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -93,7 +93,7 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process:setup");
 
         // Initialize the process.
-        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
+        let process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -122,7 +122,7 @@ impl<N: Network> Process<N> {
     /// Adds a new program to the process.
     /// If you intend to `execute` the program, use `deploy` and `finalize_deployment` instead.
     #[inline]
-    pub fn add_program(&mut self, program: &Program<N>) -> Result<()> {
+    pub fn add_program(&self, program: &Program<N>) -> Result<()> {
         // Initialize the 'credits.aleo' program ID.
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
@@ -135,13 +135,19 @@ impl<N: Network> Process<N> {
     /// Adds a new stack to the process.
     /// If you intend to `execute` the program, use `deploy` and `finalize_deployment` instead.
     #[inline]
-    pub fn add_stack(&mut self, stack: Stack<N>) {
+    pub fn add_stack(&self, stack: Stack<N>) {
         // Get the program ID.
         let program_id = *stack.program_id();
         // Arc the stack first to limit the scope of the write lock.
         let stack = Arc::new(stack);
         // Insert the stack into the process, replacing the existing stack if it exists.
         self.stacks.write().insert(program_id, stack);
+    }
+
+    /// Returns a reference to all the stacks.
+    #[inline]
+    pub fn stacks(&self) -> &Arc<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>> {
+        &self.stacks
     }
 }
 
@@ -152,7 +158,7 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process::load");
 
         // Initialize the process.
-        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
+        let process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -190,7 +196,7 @@ impl<N: Network> Process<N> {
     #[cfg(feature = "wasm")]
     pub fn load_web() -> Result<Self> {
         // Initialize the process.
-        let mut process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
+        let process = Self { universal_srs: UniversalSRS::load()?, stacks: Default::default() };
 
         // Initialize the 'credits.aleo' program.
         let program = Program::credits()?;
@@ -459,7 +465,7 @@ function compute:
     /// Initializes a new process with the given program.
     pub(crate) fn sample_process(program: &Program<CurrentNetwork>) -> Process<CurrentNetwork> {
         // Construct a new process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Add the program to the process.
         process.add_program(program).unwrap();
         // Return the process.

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -1084,7 +1084,7 @@ function transfer:
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program0);
+    let process = crate::test_helpers::sample_process(&program0);
     // Initialize another program.
     let (string, program1) = Program::<CurrentNetwork>::parse(
         r"
@@ -1243,7 +1243,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1355,7 +1355,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1482,7 +1482,7 @@ finalize mint_public:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1611,7 +1611,7 @@ finalize mint_public:
     process.synthesize_key::<CurrentAleo, _>(program0.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1769,7 +1769,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1852,7 +1852,7 @@ function c:
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program0);
+    let process = crate::test_helpers::sample_process(&program0);
 
     // Initialize another program.
     let (string, program1) = Program::<CurrentNetwork>::parse(
@@ -1990,7 +1990,7 @@ fn test_complex_execution_order() {
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program0);
+    let process = crate::test_helpers::sample_process(&program0);
 
     // Initialize another program.
     let (string, program1) = Program::<CurrentNetwork>::parse(
@@ -2198,7 +2198,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -2425,7 +2425,7 @@ function {function_name}:
     .unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -2501,7 +2501,7 @@ fn test_long_import_chain() {
     .unwrap();
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program);
+    let process = crate::test_helpers::sample_process(&program);
 
     // Add `MAX_PROGRAM_DEPTH` programs to the process.
     for i in 1..=MAX_PROGRAM_DEPTH {
@@ -2546,7 +2546,7 @@ fn test_long_import_chain_with_calls() {
     .unwrap();
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program);
+    let process = crate::test_helpers::sample_process(&program);
 
     // Check that the number of calls, up to `Transaction::MAX_TRANSITIONS - 1`, is correct.
     for i in 1..(Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1) {
@@ -2590,7 +2590,7 @@ fn test_long_import_chain_with_calls() {
 #[test]
 fn test_max_imports() {
     // Construct the process.
-    let mut process = Process::<CurrentNetwork>::load().unwrap();
+    let process = Process::<CurrentNetwork>::load().unwrap();
 
     // Add `MAX_IMPORTS` programs to the process.
     for i in 0..CurrentNetwork::MAX_IMPORTS {
@@ -2641,7 +2641,7 @@ fn test_program_exceeding_transaction_spend_limit() {
     .unwrap();
 
     // Initialize a `Process`.
-    let mut process = Process::<CurrentNetwork>::load().unwrap();
+    let process = Process::<CurrentNetwork>::load().unwrap();
 
     // Attempt to add the program to the process, which should fail.
     let result = process.add_program(&program);

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -81,9 +81,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Compute the minimum execution cost.
                 let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
                 let (minimum_execution_cost, (_, _)) = if consensus_version == ConsensusVersion::V1 {
-                    execution_cost_v1(&self.process().read(), &execution)?
+                    execution_cost_v1(&self.process(), &execution)?
                 } else {
-                    execution_cost_v2(&self.process().read(), &execution)?
+                    execution_cost_v2(&self.process(), &execution)?
                 };
                 // Compute the execution ID.
                 let execution_id = execution.to_execution_id()?;
@@ -420,8 +420,8 @@ mod tests {
 
         let query = Query::VM(vm.block_store().clone());
         let (execution, _) = vm.execute_authorization_raw(authorization, &query, rng).unwrap();
-        let (cost, _) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
-        let (old_cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
+        let (cost, _) = execution_cost_v2(&vm.process(), &execution).unwrap();
+        let (old_cost, _) = execution_cost_v1(&vm.process(), &execution).unwrap();
 
         assert_eq!(34_060, cost);
         assert_eq!(51_060, old_cost);
@@ -557,7 +557,7 @@ finalize test:
 
         let query = Query::VM(vm.block_store().clone());
         let (execution, _) = vm.execute_authorization_raw(authorization, &query, rng).unwrap();
-        let (cost, _) = execution_cost_v1(&vm.process().read(), &execution).unwrap();
+        let (cost, _) = execution_cost_v1(&vm.process(), &execution).unwrap();
         println!("Cost: {}", cost);
     }
 
@@ -942,7 +942,7 @@ finalize test:
         assert_eq!(execution.transitions().len(), <CurrentNetwork as Network>::MAX_INPUTS + 1);
 
         // Get the finalize cost of the execution.
-        let (_, (_, finalize_cost)) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
+        let (_, (_, finalize_cost)) = execution_cost_v2(&vm.process(), &execution).unwrap();
 
         // Compute the expected cost as the sum of the cost in microcredits of each command in each finalize block of each transition in the execution.
         let mut expected_cost = 0;
@@ -951,7 +951,7 @@ finalize test:
             let program_id = transition.program_id();
             let function_name = transition.function_name();
             // Get the stack.
-            let stack = vm.process().read().get_stack(program_id).unwrap().clone();
+            let stack = vm.process().get_stack(program_id).unwrap().clone();
             // Get the finalize block of the transition and sum the cost of each command.
             let cost = match stack.get_function(function_name).unwrap().finalize_logic() {
                 None => 0,
@@ -1078,7 +1078,7 @@ finalize test:
         assert_eq!(execution.transitions().len(), Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1);
 
         // Get the finalize cost of the execution.
-        let (_, (_, finalize_cost)) = execution_cost_v2(&vm.process().read(), &execution).unwrap();
+        let (_, (_, finalize_cost)) = execution_cost_v2(&vm.process(), &execution).unwrap();
 
         // Compute the expected cost as the sum of the cost in microcredits of each command in each finalize block of each transition in the execution.
         let mut expected_cost = 0;
@@ -1087,7 +1087,7 @@ finalize test:
             let program_id = transition.program_id();
             let function_name = transition.function_name();
             // Get the stack.
-            let stack = vm.process().read().get_stack(program_id).unwrap().clone();
+            let stack = vm.process().get_stack(program_id).unwrap().clone();
             // Get the finalize block of the transition and sum the cost of each command.
             let cost = match stack.get_function(function_name).unwrap().finalize_logic() {
                 None => 0,

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -16,6 +16,7 @@
 use super::*;
 
 use ledger_committee::{MAX_DELEGATORS, MIN_DELEGATOR_STAKE, MIN_VALIDATOR_SELF_STAKE};
+use synthesizer_program::StackProgram;
 use utilities::cfg_sort_by_cached_key;
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
@@ -275,10 +276,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             /* Perform the atomic finalize over the transactions. */
 
-            // Acquire the write lock on the process.
+            // Acquire the write lock on the stacks.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
             // we choose to acquire the write lock for the entire duration of this atomic batch.
-            let process = self.process.write();
+            let process = &self.process;
+            let _stacks = self.process.stacks().write();
 
             // Initialize a list of the confirmed transactions.
             let mut confirmed = Vec::with_capacity(num_transactions);
@@ -586,10 +588,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             /* Perform the atomic finalize over the transactions. */
 
-            // Acquire the write lock on the process.
+            // Acquire the write lock on the stacks.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
             // we choose to acquire the write lock for the entire duration of this atomic batch.
-            let mut process = self.process.write();
+            let process = &self.process;
+            let mut process_stacks = self.process.stacks().write();
 
             // Initialize a list for the deployed stacks.
             let mut stacks = Vec::new();
@@ -769,7 +772,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             // Commit all of the stacks to the process.
             if !stacks.is_empty() {
-                stacks.into_iter().for_each(|stack| process.add_stack(stack))
+                stacks.into_iter().for_each(|stack| {
+                    process_stacks.insert(*stack.program_id(), Arc::new(stack));
+                })
             }
 
             finish!(timer); // <- Note: This timer does **not** include the time to write batch to DB.

--- a/synthesizer/src/vm/helpers/macros.rs
+++ b/synthesizer/src/vm/helpers/macros.rs
@@ -85,26 +85,26 @@ macro_rules! process {
             console::network::MainnetV0::ID => {
                 // Cast the process.
                 let process = (&$self.process as &dyn std::any::Any)
-                    .downcast_ref::<Arc<RwLock<Process<console::network::MainnetV0>>>>()
+                    .downcast_ref::<Process<console::network::MainnetV0>>()
                     .ok_or_else(|| anyhow!("Failed to downcast {}", stringify!($self.process)))?;
                 // Process the logic.
-                $logic!(process.read(), console::network::MainnetV0, circuit::AleoV0)
+                $logic!(process, console::network::MainnetV0, circuit::AleoV0)
             }
             console::network::TestnetV0::ID => {
                 // Cast the process.
                 let process = (&$self.process as &dyn std::any::Any)
-                    .downcast_ref::<Arc<RwLock<Process<console::network::TestnetV0>>>>()
+                    .downcast_ref::<Process<console::network::TestnetV0>>()
                     .ok_or_else(|| anyhow!("Failed to downcast {}", stringify!($self.process)))?;
                 // Process the logic.
-                $logic!(process.read(), console::network::TestnetV0, circuit::AleoTestnetV0)
+                $logic!(process, console::network::TestnetV0, circuit::AleoTestnetV0)
             }
             console::network::CanaryV0::ID => {
                 // Cast the process.
                 let process = (&$self.process as &dyn std::any::Any)
-                    .downcast_ref::<Arc<RwLock<Process<console::network::CanaryV0>>>>()
+                    .downcast_ref::<Process<console::network::CanaryV0>>()
                     .ok_or_else(|| anyhow!("Failed to downcast {}", stringify!($self.process)))?;
                 // Process the logic.
-                $logic!(process.read(), console::network::CanaryV0, circuit::AleoCanaryV0)
+                $logic!(process, console::network::CanaryV0, circuit::AleoCanaryV0)
             }
             _ => bail!("Unsupported VM configuration for network: {}", N::ID),
         }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -80,7 +80,7 @@ use rayon::prelude::*;
 #[derive(Clone)]
 pub struct VM<N: Network, C: ConsensusStorage<N>> {
     /// The process.
-    process: Arc<RwLock<Process<N>>>,
+    process: Process<N>,
     /// The puzzle.
     puzzle: Puzzle<N>,
     /// The VM store.
@@ -162,7 +162,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // Return the new VM.
         Ok(Self {
-            process: Arc::new(RwLock::new(process)),
+            process,
             puzzle: Self::new_puzzle()?,
             store,
             partially_verified_transactions: Arc::new(RwLock::new(LruCache::new(
@@ -177,12 +177,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Returns `true` if a program with the given program ID exists.
     #[inline]
     pub fn contains_program(&self, program_id: &ProgramID<N>) -> bool {
-        self.process.read().contains_program(program_id)
+        self.process.contains_program(program_id)
     }
 
     /// Returns the process.
     #[inline]
-    pub fn process(&self) -> Arc<RwLock<Process<N>>> {
+    pub fn process(&self) -> Process<N> {
         self.process.clone()
     }
 
@@ -3026,7 +3026,7 @@ function check:
         assert!(vm.contains_program(&ProgramID::from_str("grandparent_program.aleo").unwrap()));
 
         // Initialize the process.
-        let mut process = Process::<CurrentNetwork>::load().unwrap();
+        let process = Process::<CurrentNetwork>::load().unwrap();
 
         // Load the child and parent program
         process.add_program(&child_program_1).unwrap();
@@ -3177,7 +3177,7 @@ function adder:
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_1.fee_amount().unwrap(), 2483025);
         // Add the first program to the off-chain VM.
-        off_chain_vm.process().write().add_program(&program_1).unwrap();
+        off_chain_vm.process().add_program(&program_1).unwrap();
         // Deploy the second program.
         let deployment_2 = off_chain_vm.deploy(&private_key_2, &program_2, None, 0, None, rng).unwrap();
         // Check that the account has enough to pay for the deployment.
@@ -3190,7 +3190,7 @@ function adder:
         vm.add_next_block(&block).unwrap();
 
         // Check that only `child_program.aleo` is in the VM.
-        assert!(vm.process().read().contains_program(&ProgramID::from_str("child_program.aleo").unwrap()));
+        assert!(vm.process().contains_program(&ProgramID::from_str("child_program.aleo").unwrap()));
     }
 
     #[cfg(feature = "test")]

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -239,9 +239,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             .unwrap_or_default();
                         let consensus_version = N::CONSENSUS_VERSION(block_height)?;
                         let (cost, (_, _)) = if consensus_version == ConsensusVersion::V1 {
-                            execution_cost_v1(&self.process().read(), execution)?
+                            execution_cost_v1(&self.process(), execution)?
                         } else {
-                            execution_cost_v2(&self.process().read(), execution)?
+                            execution_cost_v2(&self.process(), execution)?
                         };
                         // Ensure the cost does not exceed the transaction spend limit.
                         ensure!(
@@ -331,7 +331,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Verify the execution proof, if it has not been partially-verified before.
         let verification = match is_partially_verified {
             true => Ok(()),
-            false => self.process.read().verify_execution(varuna_version, execution),
+            false => self.process.verify_execution(varuna_version, execution),
         };
         lap!(timer, "Verify the execution");
 
@@ -380,7 +380,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Verify the fee, if it has not been partially-verified before.
         let verification = match is_partially_verified {
             true => Ok(()),
-            false => self.process.read().verify_fee(varuna_version, fee, deployment_or_execution_id),
+            false => self.process.verify_fee(varuna_version, fee, deployment_or_execution_id),
         };
         lap!(timer, "Verify the fee");
 

--- a/synthesizer/tests/test_process_execute.rs
+++ b/synthesizer/tests/test_process_execute.rs
@@ -55,7 +55,7 @@ fn run_test(process: Process<CurrentNetwork>, test: &ProgramTest) -> serde_yaml:
     );
 
     // Add the programs into the process.
-    let mut process = process.clone();
+    let process = process.clone();
     for program in test.programs() {
         if let Err(err) = process.add_program(program) {
             output

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -228,7 +228,7 @@ function compute:
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
         // Construct the process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Add the program to the process.
         process.add_program(&program).unwrap();
 

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -228,7 +228,7 @@ function compute:
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
         // Construct the process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Add the program to the process.
         process.add_program(&program).unwrap();
 

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -124,7 +124,7 @@ impl<N: Network> Package<N> {
         println!("⏳ Deploying '{}'...\n", program_id.to_string().bold());
 
         // Construct the process.
-        let mut process = Process::<N>::load()?;
+        let process = Process::<N>::load()?;
 
         // Add program imports to the process.
         let imports_directory = self.imports_directory();

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -154,7 +154,7 @@ impl<N: Network> Package<N> {
     /// Returns a new process for the package.
     pub fn get_process(&self) -> Result<Process<N>> {
         // Create the process.
-        let mut process = Process::load()?;
+        let process = Process::load()?;
 
         // Prepare the imports directory.
         let imports_directory = self.imports_directory();


### PR DESCRIPTION
This is the `Process`:
```
#[derive(Clone)]
pub struct Process<N: Network> {
    /// The universal SRS.
    universal_srs: UniversalSRS<N>,
    /// The mapping of program IDs to stacks.
    stacks: Arc<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>>,
}
```
and this is where it resides:
```
#[derive(Clone)]
pub struct VM<N: Network, C: ConsensusStorage<N>> {
    /// The process.
    process: Arc<RwLock<Process<N>>>,
    (...)
```
With `UniversalSRS` being immutable after its initialization, this setup basically leaves us with the following "meat" of the `Process` within the `VM`:
```
Arc<RwLock<Arc<RwLock< MAP_OF_STACKS >>>>
```
This means that the outer lock is redundant; the only place we ever use a write guard is finalization, which I retained in this PR by applying it to the underlying map of stacks (the only object within `Process` that can be altered).