### PR TITLE
[Do Not Merge] Fall back to int deserialization for block metadata

### DIFF
--- a/ledger/block/src/header/metadata/serialize.rs
+++ b/ledger/block/src/header/metadata/serialize.rs
@@ -24,8 +24,8 @@ impl<N: Network> Serialize for Metadata<N> {
                 metadata.serialize_field("network", &self.network)?;
                 metadata.serialize_field("round", &self.round)?;
                 metadata.serialize_field("height", &self.height)?;
-                metadata.serialize_field("cumulative_weight", &self.cumulative_weight.to_string())?;
-                metadata.serialize_field("cumulative_proof_target", &self.cumulative_proof_target.to_string())?;
+                metadata.serialize_field("cumulative_weight", &self.cumulative_weight)?;
+                metadata.serialize_field("cumulative_proof_target", &self.cumulative_proof_target)?;
                 metadata.serialize_field("coinbase_target", &self.coinbase_target)?;
                 metadata.serialize_field("proof_target", &self.proof_target)?;
                 metadata.serialize_field("last_coinbase_target", &self.last_coinbase_target)?;
@@ -48,14 +48,14 @@ impl<'de, N: Network> Deserialize<'de> for Metadata<N> {
                 // If it fails, fall back to parsing as a u128.
                 // This is necessary due to the non-backwards-compatible change introduced in https://github.com/ProvableHQ/snarkVM/pull/2559
                 let cumulative_weight: u128 = if let Ok(cumulative_weight) =
-                    <String as DeserializeExt>::take_from_value::<D>(&mut metadata, "cumulative_weight")
+                    <String as DeserializeExt>::take_from_value::<D>(&mut metadata.clone(), "cumulative_weight")
                 {
                     cumulative_weight.parse::<u128>().map_err(de::Error::custom)?
                 } else {
                     DeserializeExt::take_from_value::<D>(&mut metadata, "cumulative_weight")?
                 };
                 let cumulative_proof_target: u128 = if let Ok(cumulative_proof_target) =
-                    <String as DeserializeExt>::take_from_value::<D>(&mut metadata, "cumulative_proof_target")
+                    <String as DeserializeExt>::take_from_value::<D>(&mut metadata.clone(), "cumulative_proof_target")
                 {
                     cumulative_proof_target.parse::<u128>().map_err(de::Error::custom)?
                 } else {

--- a/ledger/block/src/header/metadata/serialize.rs
+++ b/ledger/block/src/header/metadata/serialize.rs
@@ -44,12 +44,23 @@ impl<'de, N: Network> Deserialize<'de> for Metadata<N> {
         match deserializer.is_human_readable() {
             true => {
                 let mut metadata = serde_json::Value::deserialize(deserializer)?;
-                let cumulative_weight: String =
-                    DeserializeExt::take_from_value::<D>(&mut metadata, "cumulative_weight")?;
-                let cumulative_proof_target: String =
-                    DeserializeExt::take_from_value::<D>(&mut metadata, "cumulative_proof_target")?;
-                let cumulative_weight = cumulative_weight.parse::<u128>().map_err(de::Error::custom)?;
-                let cumulative_proof_target = cumulative_proof_target.parse::<u128>().map_err(de::Error::custom)?;
+                // Try parsing as a string for cumulative_weight and cumulative_proof_target.
+                // If it fails, fall back to parsing as a u128.
+                // This is necessary due to the non-backwards-compatible change introduced in https://github.com/ProvableHQ/snarkVM/pull/2559
+                let cumulative_weight: u128 = if let Ok(cumulative_weight) =
+                    <String as DeserializeExt>::take_from_value::<D>(&mut metadata, "cumulative_weight")
+                {
+                    cumulative_weight.parse::<u128>().map_err(de::Error::custom)?
+                } else {
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "cumulative_weight")?
+                };
+                let cumulative_proof_target: u128 = if let Ok(cumulative_proof_target) =
+                    <String as DeserializeExt>::take_from_value::<D>(&mut metadata, "cumulative_proof_target")
+                {
+                    cumulative_proof_target.parse::<u128>().map_err(de::Error::custom)?
+                } else {
+                    DeserializeExt::take_from_value::<D>(&mut metadata, "cumulative_proof_target")?
+                };
                 Ok(Self::new(
                     DeserializeExt::take_from_value::<D>(&mut metadata, "network")?,
                     DeserializeExt::take_from_value::<D>(&mut metadata, "round")?,


### PR DESCRIPTION
## Motivation

This old PR: https://github.com/ProvableHQ/snarkVM/pull/2559 introduced a backwards-incompatible change. We just changed serialization of data. This PR tries both versions in the deserialization.

Alternatively to this PR, explorers and indexers re-index their data to use the new format. Keen to hear your feedback on the preferred way forward. CC @miazn @HarukaMa 

## Test Plan

- [ ] Test that deserialization and `snarkos developer scan` now succeeds. 