### PR TITLE
Allow external structs.

### DIFF
--- a/circuit/program/src/data/value/mod.rs
+++ b/circuit/program/src/data/value/mod.rs
@@ -66,3 +66,24 @@ impl<A: Aleo> Eject for Value<A> {
         }
     }
 }
+
+impl<A: Aleo> From<Plaintext<A>> for Value<A> {
+    /// Initializes the value from a plaintext.
+    fn from(plaintext: Plaintext<A>) -> Self {
+        Self::Plaintext(plaintext)
+    }
+}
+
+impl<A: Aleo> From<Record<A, Plaintext<A>>> for Value<A> {
+    /// Initializes the value from a record.
+    fn from(record: Record<A, Plaintext<A>>) -> Self {
+        Self::Record(record)
+    }
+}
+
+impl<A: Aleo> From<Future<A>> for Value<A> {
+    /// Initializes the value from a future.
+    fn from(future: Future<A>) -> Self {
+        Self::Future(future)
+    }
+}

--- a/console/program/src/data_types/array_type/bytes.rs
+++ b/console/program/src/data_types/array_type/bytes.rs
@@ -58,7 +58,7 @@ impl<N: Network> ToBytes for ArrayType<N> {
         // Note that the lengths are in the order of the outermost dimension to the innermost dimension.
         for _ in 1..N::MAX_DATA_DEPTH {
             element_type = match element_type {
-                PlaintextType::Literal(_) | PlaintextType::Struct(_) => break,
+                PlaintextType::Literal(_) | PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_) => break,
                 PlaintextType::Array(array_type) => {
                     lengths.push(*array_type.length());
                     array_type.next_element_type().clone()
@@ -85,6 +85,10 @@ impl<N: Network> ToBytes for ArrayType<N> {
                 // This is technically unreachable by definition, however we return an error
                 // out of an abundance of caution.
                 return Err(error(format!("Array type exceeds the maximum depth of {}.", N::MAX_DATA_DEPTH)));
+            }
+            PlaintextType::ExternalStruct(locator) => {
+                3u8.write_le(&mut writer)?;
+                locator.write_le(&mut writer)?;
             }
         }
 

--- a/console/program/src/data_types/plaintext_type/bytes.rs
+++ b/console/program/src/data_types/plaintext_type/bytes.rs
@@ -23,7 +23,8 @@ impl<N: Network> FromBytes for PlaintextType<N> {
             0 => Ok(Self::Literal(LiteralType::read_le(&mut reader)?)),
             1 => Ok(Self::Struct(Identifier::read_le(&mut reader)?)),
             2 => Ok(Self::Array(ArrayType::read_le(&mut reader)?)),
-            3.. => Err(error(format!("Failed to deserialize annotation variant {variant}"))),
+            3 => Ok(Self::ExternalStruct(Locator::read_le(&mut reader)?)),
+            4.. => Err(error(format!("Failed to deserialize annotation variant {variant}"))),
         }
     }
 }
@@ -43,6 +44,10 @@ impl<N: Network> ToBytes for PlaintextType<N> {
             Self::Array(array_type) => {
                 2u8.write_le(&mut writer)?;
                 array_type.write_le(&mut writer)
+            }
+            Self::ExternalStruct(locator) => {
+                3u8.write_le(&mut writer)?;
+                locator.write_le(&mut writer)
             }
         }
     }

--- a/console/program/src/data_types/plaintext_type/mod.rs
+++ b/console/program/src/data_types/plaintext_type/mod.rs
@@ -17,7 +17,7 @@ mod bytes;
 mod parse;
 mod serialize;
 
-use crate::{ArrayType, Identifier, LiteralType};
+use crate::{ArrayType, Identifier, LiteralType, Locator};
 use snarkvm_console_network::prelude::*;
 
 /// A `PlaintextType` defines the type parameter for a literal, struct, or array.
@@ -26,9 +26,11 @@ pub enum PlaintextType<N: Network> {
     /// A literal type contains its type name.
     /// The format of the type is `<type_name>`.
     Literal(LiteralType),
-    /// An struct type contains its identifier.
+    /// A struct type contains its identifier.
     /// The format of the type is `<identifier>`.
     Struct(Identifier<N>),
+    /// An external struct type contains its locator.
+    ExternalStruct(Locator<N>),
     /// An array type contains its element type and length.
     /// The format of the type is `[<element_type>; <length>]`.
     Array(ArrayType<N>),

--- a/console/program/src/data_types/plaintext_type/parse.rs
+++ b/console/program/src/data_types/plaintext_type/parse.rs
@@ -22,6 +22,7 @@ impl<N: Network> Parser for PlaintextType<N> {
         // Parse to determine the plaintext type (order matters).
         alt((
             map(ArrayType::parse, |type_| Self::Array(type_)),
+            map(Locator::parse, |locator| Self::ExternalStruct(locator)),
             map(Identifier::parse, |identifier| Self::Struct(identifier)),
             map(LiteralType::parse, |type_| Self::Literal(type_)),
         ))(string)
@@ -60,6 +61,7 @@ impl<N: Network> Display for PlaintextType<N> {
             Self::Literal(literal) => Display::fmt(literal, f),
             // Prints the struct, i.e. signature
             Self::Struct(struct_) => Display::fmt(struct_, f),
+            Self::ExternalStruct(locator) => Display::fmt(locator, f),
             // Prints the array type, i.e. [field; 2u32]
             Self::Array(array) => Display::fmt(array, f),
         }

--- a/console/program/src/data_types/register_type/mod.rs
+++ b/console/program/src/data_types/register_type/mod.rs
@@ -34,6 +34,22 @@ pub enum RegisterType<N: Network> {
     Future(Locator<N>),
 }
 
+impl<N: Network> RegisterType<N> {
+    /// Are the two types either equal, or both structs?
+    ///
+    /// Since struct types are compared by structure, we can't determine equality
+    /// by only looking at their names.
+    pub fn equal_or_structs(&self, rhs: &Self) -> bool {
+        use RegisterType::*;
+        for x in [self, rhs] {
+            if !matches!(x, Plaintext(PlaintextType::Struct(..) | PlaintextType::ExternalStruct(..))) {
+                return self == rhs;
+            }
+        }
+        true
+    }
+}
+
 impl<N: Network> From<ValueType<N>> for RegisterType<N> {
     /// Converts a value type to a register type.
     fn from(value: ValueType<N>) -> Self {

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -155,6 +155,10 @@ fn plaintext_size_in_bytes<N: Network>(stack: &Stack<N>, plaintext_type: &Plaint
             // Return the size of the struct.
             Ok(size_of_name.saturating_add(size_of_members))
         }
+        PlaintextType::ExternalStruct(locator) => {
+            let external_stack = stack.get_external_stack(locator.program_id())?;
+            plaintext_size_in_bytes(&*external_stack, &PlaintextType::Struct(*locator.resource()))
+        }
         PlaintextType::Array(array_type) => {
             // Retrieve the number of elements in the array.
             let num_elements = **array_type.length() as u64;
@@ -266,7 +270,9 @@ pub fn cost_per_command<N: Network>(
                 FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::Field)) => Ok(1_500),
                 FinalizeType::Plaintext(PlaintextType::Literal(_)) => Ok(500),
                 FinalizeType::Plaintext(PlaintextType::Array(_)) => bail!("'div' does not support arrays"),
-                FinalizeType::Plaintext(PlaintextType::Struct(_)) => bail!("'div' does not support structs"),
+                FinalizeType::Plaintext(PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_)) => {
+                    bail!("'div' does not support structs")
+                }
                 FinalizeType::Future(_) => bail!("'div' does not support futures"),
             }
         }
@@ -345,7 +351,9 @@ pub fn cost_per_command<N: Network>(
                 FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::Scalar)) => Ok(10_000),
                 FinalizeType::Plaintext(PlaintextType::Literal(_)) => Ok(500),
                 FinalizeType::Plaintext(PlaintextType::Array(_)) => bail!("'mul' does not support arrays"),
-                FinalizeType::Plaintext(PlaintextType::Struct(_)) => bail!("'mul' does not support structs"),
+                FinalizeType::Plaintext(PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_)) => {
+                    bail!("'mul' does not support structs")
+                }
                 FinalizeType::Future(_) => bail!("'mul' does not support futures"),
             }
         }
@@ -365,7 +373,9 @@ pub fn cost_per_command<N: Network>(
                 FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::Field)) => Ok(1_500),
                 FinalizeType::Plaintext(PlaintextType::Literal(_)) => Ok(500),
                 FinalizeType::Plaintext(PlaintextType::Array(_)) => bail!("'pow' does not support arrays"),
-                FinalizeType::Plaintext(PlaintextType::Struct(_)) => bail!("'pow' does not support structs"),
+                FinalizeType::Plaintext(PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_)) => {
+                    bail!("'pow' does not support structs")
+                }
                 FinalizeType::Future(_) => bail!("'pow' does not support futures"),
             }
         }

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -143,6 +143,10 @@ impl<N: Network> FinalizeTypes<N> {
             FinalizeType::Plaintext(PlaintextType::Struct(struct_name)) => {
                 RegisterTypes::check_struct(stack, struct_name)?
             }
+            FinalizeType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                return self.check_input(&*external_stack, register, finalize_type);
+            }
             FinalizeType::Plaintext(PlaintextType::Array(array_type)) => RegisterTypes::check_array(stack, array_type)?,
             FinalizeType::Future(..) => (),
         };
@@ -670,6 +674,18 @@ impl<N: Network> FinalizeTypes<N> {
                             let struct_ = stack.program().get_struct(struct_name)?;
                             // Ensure the operand types match the struct.
                             self.matches_struct(stack, instruction.operands(), struct_)?;
+                        }
+                        CastType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                            let external_stack = stack.get_external_stack(locator.program_id())?;
+                            let struct_name = locator.resource();
+                            // Ensure the struct name exists in the program.
+                            if !external_stack.program().contains_struct(struct_name) {
+                                bail!("Struct '{locator}' is not defined.")
+                            }
+                            // Retrieve the struct.
+                            let struct_ = external_stack.program().get_struct(struct_name)?;
+                            // Ensure the operand types match the struct.
+                            self.matches_struct(&*external_stack, instruction.operands(), struct_)?;
                         }
                         CastType::Plaintext(PlaintextType::Array(array_type)) => {
                             // Ensure that the array type is valid.

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -152,6 +152,17 @@ impl<N: Network> FinalizeTypes<N> {
                         None => bail!("'{identifier}' does not exist in struct '{struct_name}'"),
                     }
                 }
+                // Access the member on the path to output the register type.
+                (FinalizeType::Plaintext(PlaintextType::ExternalStruct(locator)), Access::Member(identifier)) => {
+                    // Retrieve the member type from the struct and check that it exists.
+                    let external_stack = stack.get_external_stack(locator.program_id())?;
+                    match external_stack.program().get_struct(locator.resource())?.members().get(identifier) {
+                        // Retrieve the member and update `finalize_type` for the next iteration.
+                        Some(member_type) => finalize_type = FinalizeType::Plaintext(member_type.clone()),
+                        // Halts if the member does not exist.
+                        None => bail!("'{identifier}' does not exist in struct '{locator}'"),
+                    }
+                }
                 // Access the member on the path to output the register type and check that it is in bounds.
                 (FinalizeType::Plaintext(PlaintextType::Array(array_type)), Access::Index(index)) => {
                     match index < array_type.length() {
@@ -188,7 +199,10 @@ impl<N: Network> FinalizeTypes<N> {
                         None => bail!("Index out of bounds"),
                     }
                 }
-                (FinalizeType::Plaintext(PlaintextType::Struct(..)), Access::Index(..))
+                (
+                    FinalizeType::Plaintext(PlaintextType::Struct(..) | PlaintextType::ExternalStruct(..)),
+                    Access::Index(..),
+                )
                 | (FinalizeType::Plaintext(PlaintextType::Array(..)), Access::Member(..))
                 | (FinalizeType::Future(..), Access::Member(..)) => {
                     bail!("Invalid access `{access}`")

--- a/synthesizer/process/src/stack/helpers/matches.rs
+++ b/synthesizer/process/src/stack/helpers/matches.rs
@@ -204,6 +204,11 @@ impl<N: Network> Stack<N> {
                 // If `plaintext` is an array, this is a mismatch.
                 Plaintext::Array(..) => bail!("'{plaintext_type}' is invalid: expected literal, found array"),
             },
+            PlaintextType::ExternalStruct(locator) => {
+                let external_stack = self.get_external_stack(locator.program_id())?;
+                let new_type = PlaintextType::Struct(*locator.resource());
+                external_stack.matches_plaintext_internal(plaintext, &new_type, depth)
+            }
             PlaintextType::Struct(struct_name) => {
                 // Ensure the struct name is valid.
                 ensure!(!Program::is_reserved_keyword(struct_name), "Struct '{struct_name}' is reserved");

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -137,6 +137,11 @@ impl<N: Network> Stack<N> {
 
                 Plaintext::Struct(members, Default::default())
             }
+            PlaintextType::ExternalStruct(locator) => {
+                let external_stack = self.get_external_stack(locator.program_id())?;
+                let new_type = PlaintextType::Struct(*locator.resource());
+                return external_stack.sample_plaintext_internal(&new_type, depth, rng);
+            }
             // Sample an array.
             PlaintextType::Array(array_type) => {
                 // Sample each element of the array.

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -267,6 +267,10 @@ impl<N: Network> RegisterTypes<N> {
         match register_type {
             RegisterType::Plaintext(PlaintextType::Literal(..)) => (),
             RegisterType::Plaintext(PlaintextType::Struct(struct_name)) => Self::check_struct(stack, struct_name)?,
+            RegisterType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                Self::check_struct(&*external_stack, locator.resource())?;
+            }
             RegisterType::Plaintext(PlaintextType::Array(array_type)) => Self::check_array(stack, array_type)?,
             RegisterType::Record(identifier) => {
                 // Ensure the record type is defined in the program.
@@ -321,6 +325,10 @@ impl<N: Network> RegisterTypes<N> {
         match register_type {
             RegisterType::Plaintext(PlaintextType::Literal(..)) => (),
             RegisterType::Plaintext(PlaintextType::Struct(struct_name)) => Self::check_struct(stack, struct_name)?,
+            RegisterType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                Self::check_struct(&*external_stack, locator.resource())?;
+            }
             RegisterType::Plaintext(PlaintextType::Array(array_type)) => Self::check_array(stack, array_type)?,
             RegisterType::Record(identifier) => {
                 // Ensure the record type is defined in the program.
@@ -348,10 +356,11 @@ impl<N: Network> RegisterTypes<N> {
         };
 
         // Ensure the operand type and the output type match.
-        if *register_type != self.get_type_from_operand(stack, operand)? {
+        let operand_type = self.get_type_from_operand(stack, operand)?;
+        if !register_type.equal_or_structs(&operand_type) {
             bail!(
                 "Output '{operand}' does not match the expected output operand type: expected '{}', found '{}'",
-                self.get_type_from_operand(stack, operand)?,
+                operand_type,
                 register_type
             )
         }
@@ -536,6 +545,18 @@ impl<N: Network> RegisterTypes<N> {
                             // Ensure the operand types match the struct.
                             self.matches_struct(stack, instruction.operands(), struct_)?;
                         }
+                        CastType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                            // Ensure the struct name exists in the external program.
+                            let external_stack = stack.get_external_stack(locator.program_id())?;
+                            let struct_name = locator.resource();
+                            if !external_stack.program().contains_struct(struct_name) {
+                                bail!("Struct '{locator}' is not defined.")
+                            }
+                            // Retrieve the struct.
+                            let struct_ = external_stack.program().get_struct(struct_name)?;
+                            // Ensure the operand types match the struct.
+                            self.matches_struct(&*external_stack, instruction.operands(), struct_)?;
+                        }
                         CastType::Plaintext(PlaintextType::Array(array_type)) => {
                             // Ensure that the array type is valid.
                             RegisterTypes::check_array(stack, array_type)?;
@@ -671,6 +692,10 @@ impl<N: Network> RegisterTypes<N> {
             match member {
                 PlaintextType::Literal(..) => (),
                 PlaintextType::Struct(struct_name) => Self::check_struct(stack, struct_name)?,
+                PlaintextType::ExternalStruct(locator) => {
+                    let external_stack = stack.get_external_stack(locator.program_id())?;
+                    Self::check_struct(&*external_stack, locator.resource())?;
+                }
                 PlaintextType::Array(array_type) => Self::check_array(stack, array_type)?,
             }
         }

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -221,6 +221,15 @@ impl<N: Network> RegisterTypes<N> {
                         None => bail!("'{identifier}' does not exist in struct '{struct_name}'"),
                     }
                 }
+                (RegisterAccessType::Plaintext(PlaintextType::ExternalStruct(locator)), Access::Member(identifier)) => {
+                    let external_stack = stack.get_external_stack(locator.program_id())?;
+                    // Retrieve the member type from the struct.
+                    match external_stack.program().get_struct(locator.resource())?.members().get(identifier) {
+                        // Update the member type.
+                        Some(member_type) => register_type = RegisterAccessType::Plaintext(member_type.clone()),
+                        None => bail!("'{identifier}' does not exist in struct '{locator}'"),
+                    }
+                }
                 // Traverse the path to output the register type.
                 (RegisterAccessType::Plaintext(PlaintextType::Array(array_type)), Access::Index(index)) => {
                     match index < array_type.length() {
@@ -262,7 +271,10 @@ impl<N: Network> RegisterTypes<N> {
                         None => bail!("Index out of bounds"),
                     }
                 }
-                (RegisterAccessType::Plaintext(PlaintextType::Struct(..)), Access::Index(..))
+                (
+                    RegisterAccessType::Plaintext(PlaintextType::Struct(..) | PlaintextType::ExternalStruct(..)),
+                    Access::Index(..),
+                )
                 | (RegisterAccessType::Plaintext(PlaintextType::Array(..)), Access::Member(..))
                 | (RegisterAccessType::Future(..), Access::Member(..)) => {
                     bail!("Invalid access `{access}`")

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -396,6 +396,14 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
                         bail!("'{member_identifier}' in struct '{}' is not defined.", struct_name)
                     }
                 }
+                PlaintextType::ExternalStruct(locator) => {
+                    if !self.imports.contains_key(locator.program_id()) {
+                        bail!(
+                            "External program {} referenced in struct '{struct_name}' does not exist",
+                            locator.program_id()
+                        );
+                    }
+                }
                 PlaintextType::Array(array_type) => {
                     if let PlaintextType::Struct(struct_name) = array_type.base_element_type() {
                         // Ensure the member struct name exists in the program.
@@ -451,6 +459,14 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Pro
                 PlaintextType::Struct(identifier) => {
                     if !self.structs.contains_key(identifier) {
                         bail!("Struct '{identifier}' in record '{record_name}' is not defined.")
+                    }
+                }
+                PlaintextType::ExternalStruct(locator) => {
+                    if !self.imports.contains_key(locator.program_id()) {
+                        bail!(
+                            "External program {} referenced in record '{record_name}' does not exist",
+                            locator.program_id()
+                        );
                     }
                 }
                 PlaintextType::Array(array_type) => {

--- a/synthesizer/program/src/logic/instruction/operation/call.rs
+++ b/synthesizer/program/src/logic/instruction/operation/call.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use console::{
     network::prelude::*,
-    program::{Identifier, Locator, Register, RegisterType, ValueType},
+    program::{Identifier, Locator, PlaintextType, Register, RegisterType, ValueType},
 };
 
 /// The operator references a function name or closure name.
@@ -197,10 +197,12 @@ impl<N: Network> Call<N> {
         stack: &impl StackProgram<N>,
         input_types: &[RegisterType<N>],
     ) -> Result<Vec<RegisterType<N>>> {
-        // Retrieve the external stack, if needed, and the resource.
-        let (external_stack, resource) = match &self.operator {
+        let stack_value;
+        let (is_external, program, name) = match &self.operator {
             CallOperator::Locator(locator) => {
-                (Some(stack.get_external_stack(locator.program_id())?), locator.resource())
+                let program_name = locator.program_id();
+                stack_value = Some(stack.get_external_stack(program_name)?);
+                (true, stack_value.as_ref().unwrap().program(), locator.resource())
             }
             CallOperator::Resource(resource) => {
                 // TODO (howardwu): Revisit this decision to forbid calling internal functions. A record cannot be spent again.
@@ -209,16 +211,12 @@ impl<N: Network> Call<N> {
                 if stack.program().contains_function(resource) {
                     bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
                 }
-                (None, resource)
+                (false, stack.program(), resource)
             }
         };
-        // Retrieve the program.
-        let (is_external, program) = match &external_stack {
-            Some(external_stack) => (true, external_stack.program()),
-            None => (false, stack.program()),
-        };
+
         // If the operator is a closure, retrieve the closure and compute the output types.
-        if let Ok(closure) = program.get_closure(resource) {
+        if let Ok(closure) = program.get_closure(name) {
             // Ensure the number of operands matches the number of input statements.
             if closure.inputs().len() != self.operands.len() {
                 bail!("Expected {} inputs, found {}", closure.inputs().len(), self.operands.len())
@@ -235,7 +233,7 @@ impl<N: Network> Call<N> {
             Ok(closure.outputs().iter().map(|output| output.register_type()).cloned().collect())
         }
         // If the operator is a function, retrieve the function and compute the output types.
-        else if let Ok(function) = program.get_function(resource) {
+        else if let Ok(function) = program.get_function(name) {
             // Ensure the number of operands matches the number of input statements.
             if function.inputs().len() != self.operands.len() {
                 bail!("Expected {} inputs, found {}", function.inputs().len(), self.operands.len())
@@ -254,9 +252,19 @@ impl<N: Network> Call<N> {
                 .into_iter()
                 .map(|output_type| match (is_external, output_type) {
                     // If the output is a record and the function is external, return the external record type.
-                    (true, ValueType::Record(record_name)) => Ok(RegisterType::ExternalRecord(Locator::from_str(
-                        &format!("{}/{}", program.id(), record_name),
-                    )?)),
+                    (true, ValueType::Record(record_name)) => {
+                        Ok(RegisterType::ExternalRecord(Locator::new(*program.id(), record_name)))
+                    }
+                    // If the output is a simple Struct and the function is external, return an external struct type.
+                    (
+                        true,
+                        ValueType::Constant(PlaintextType::Struct(identifier))
+                        | ValueType::Public(PlaintextType::Struct(identifier))
+                        | ValueType::Private(PlaintextType::Struct(identifier)),
+                    ) => Ok(RegisterType::Plaintext(PlaintextType::ExternalStruct(Locator::new(
+                        *program.id(),
+                        identifier,
+                    )))),
                     // Else, return the register type.
                     (_, output_type) => Ok(RegisterType::from(output_type)),
                 })

--- a/synthesizer/program/src/logic/instruction/operation/cast.rs
+++ b/synthesizer/program/src/logic/instruction/operation/cast.rs
@@ -248,7 +248,13 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
                 registers.store(stack, &self.destination, Value::Plaintext(Plaintext::from(value)))
             }
             CastType::Plaintext(PlaintextType::Struct(struct_name)) => {
-                self.cast_to_struct(stack, registers, *struct_name, inputs)
+                let plaintext = self.evaluate_cast_to_struct(stack, *struct_name, inputs)?;
+                registers.store(stack, &self.destination, plaintext.into())
+            }
+            CastType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                let plaintext = self.evaluate_cast_to_struct(&*external_stack, *locator.resource(), inputs)?;
+                registers.store(stack, &self.destination, plaintext.into())
             }
             CastType::Plaintext(PlaintextType::Array(array_type)) => {
                 self.cast_to_array(stack, registers, array_type, inputs)
@@ -396,57 +402,16 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
                     circuit::Value::Plaintext(circuit::Plaintext::from(value)),
                 )
             }
-            CastType::Plaintext(PlaintextType::Struct(struct_)) => {
-                // Ensure the operands length is at least the minimum.
-                if inputs.len() < N::MIN_STRUCT_ENTRIES {
-                    bail!("Casting to a struct requires at least {} operand(s)", N::MIN_STRUCT_ENTRIES)
-                }
-                // Ensure the number of members does not exceed the maximum.
-                if inputs.len() > N::MAX_STRUCT_ENTRIES {
-                    bail!("Casting to struct '{struct_}' cannot exceed {} members", N::MAX_STRUCT_ENTRIES)
-                }
-
-                // Retrieve the struct and ensure it is defined in the program.
-                let struct_ = stack.program().get_struct(struct_)?;
-
-                // Ensure that the number of operands is equal to the number of struct members.
-                if inputs.len() != struct_.members().len() {
-                    bail!(
-                        "Casting to the struct {} requires {} operands, but {} were provided",
-                        struct_.name(),
-                        struct_.members().len(),
-                        inputs.len()
-                    )
-                }
-
-                // Initialize the struct members.
-                let mut members = IndexMap::new();
-                for (member, (member_name, member_type)) in inputs.iter().zip_eq(struct_.members()) {
-                    // Retrieve the plaintext value from the entry.
-                    let plaintext = match member {
-                        circuit::Value::Plaintext(plaintext) => {
-                            // Ensure the member matches the register type.
-                            stack.matches_plaintext(&plaintext.eject_value(), member_type)?;
-                            // Output the plaintext.
-                            plaintext.clone()
-                        }
-                        // Ensure the struct member is not a record.
-                        circuit::Value::Record(..) => {
-                            bail!("Casting a record into a struct member is illegal")
-                        }
-                        // Ensure the struct member is not a future.
-                        circuit::Value::Future(..) => {
-                            bail!("Casting a future into a struct member is illegal")
-                        }
-                    };
-                    // Append the member to the struct members.
-                    members.insert(circuit::Identifier::constant(*member_name), plaintext);
-                }
-
-                // Construct the struct.
-                let struct_ = circuit::Plaintext::Struct(members, Default::default());
+            CastType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                let plaintext = self.execute_cast_to_struct(&*external_stack, *locator.resource(), inputs)?;
                 // Store the struct.
-                registers.store_circuit(stack, &self.destination, circuit::Value::Plaintext(struct_))
+                registers.store_circuit(stack, &self.destination, plaintext.into())
+            }
+            CastType::Plaintext(PlaintextType::Struct(struct_name)) => {
+                let plaintext = self.execute_cast_to_struct(stack, *struct_name, inputs)?;
+                // Store the struct.
+                registers.store_circuit(stack, &self.destination, plaintext.into())
             }
             CastType::Plaintext(PlaintextType::Array(array_type)) => {
                 // Ensure the operands length is at least the minimum.
@@ -630,7 +595,13 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
                 registers.store(stack, &self.destination, Value::Plaintext(Plaintext::from(value)))
             }
             CastType::Plaintext(PlaintextType::Struct(struct_name)) => {
-                self.cast_to_struct(stack, registers, *struct_name, inputs)
+                let plaintext = self.evaluate_cast_to_struct(stack, *struct_name, inputs)?;
+                registers.store(stack, &self.destination, plaintext.into())
+            }
+            CastType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                let plaintext = self.evaluate_cast_to_struct(&*external_stack, *locator.resource(), inputs)?;
+                registers.store(stack, &self.destination, plaintext.into())
             }
             CastType::Plaintext(PlaintextType::Array(array_type)) => {
                 self.cast_to_array(stack, registers, array_type, inputs)
@@ -680,6 +651,10 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
             }
             CastType::Plaintext(PlaintextType::Literal(..)) => {
                 ensure!(input_types.len() == 1, "Casting to a literal requires exactly 1 operand");
+            }
+            CastType::Plaintext(PlaintextType::ExternalStruct(locator)) => {
+                let external_stack = stack.get_external_stack(locator.program_id())?;
+                return self.output_types(&*external_stack, input_types);
             }
             CastType::Plaintext(PlaintextType::Struct(struct_name)) => {
                 // Retrieve the struct and ensure it is defined in the program.
@@ -849,57 +824,102 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
     }
 }
 
-impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
-    /// A helper method to handle casting to a struct.
-    fn cast_to_struct(
-        &self,
-        stack: &(impl StackMatches<N> + StackProgram<N>),
-        registers: &mut impl RegistersStore<N>,
-        struct_name: Identifier<N>,
-        inputs: Vec<Value<N>>,
-    ) -> Result<()> {
+macro_rules! cast_to_struct_common {
+    ($N: ident, $struct_name: expr, $inputs: expr, $stack: expr, $plaintext: path, $record: path, $future: path,
+     $eject_value: expr, $process_member: expr
+    ) => {{
         // Ensure the operands length is at least the minimum.
-        if inputs.len() < N::MIN_STRUCT_ENTRIES {
-            bail!("Casting to a struct requires at least {} operand", N::MIN_STRUCT_ENTRIES)
+        if $inputs.len() < $N::MIN_STRUCT_ENTRIES {
+            bail!("Casting to a struct requires at least {} operand(s)", N::MIN_STRUCT_ENTRIES)
+        }
+        // Ensure the number of members does not exceed the maximum.
+        if $inputs.len() > $N::MAX_STRUCT_ENTRIES {
+            bail!("Casting to a struct cannot exceed {} members", N::MAX_STRUCT_ENTRIES)
         }
 
         // Retrieve the struct and ensure it is defined in the program.
-        let struct_ = stack.program().get_struct(&struct_name)?;
+        let struct_ = $stack.program().get_struct($struct_name)?;
 
         // Ensure that the number of operands is equal to the number of struct members.
-        if inputs.len() != struct_.members().len() {
+        if $inputs.len() != struct_.members().len() {
             bail!(
                 "Casting to the struct {} requires {} operands, but {} were provided",
                 struct_.name(),
                 struct_.members().len(),
-                inputs.len()
+                $inputs.len()
             )
         }
 
         // Initialize the struct members.
         let mut members = IndexMap::new();
-        for (member, (member_name, member_type)) in inputs.iter().zip_eq(struct_.members()) {
+        for (member, (member_name, member_type)) in $inputs.iter().zip_eq(struct_.members()) {
             // Retrieve the plaintext value from the entry.
             let plaintext = match member {
-                Value::Plaintext(plaintext) => {
-                    // Ensure the plaintext matches the member type.
-                    stack.matches_plaintext(plaintext, member_type)?;
+                $plaintext(plaintext) => {
+                    // Ensure the member matches the register type.
+                    $stack.matches_plaintext(&$eject_value(plaintext), member_type)?;
                     // Output the plaintext.
                     plaintext.clone()
                 }
                 // Ensure the struct member is not a record.
-                Value::Record(..) => bail!("Casting a record into a struct member is illegal"),
+                $record(..) => {
+                    bail!("Casting a record into a struct member is illegal")
+                }
                 // Ensure the struct member is not a future.
-                Value::Future(..) => bail!("Casting a future into a struct member is illegal"),
+                $future(..) => {
+                    bail!("Casting a future into a struct member is illegal")
+                }
             };
             // Append the member to the struct members.
-            members.insert(*member_name, plaintext);
+            members.insert($process_member(member_name), plaintext);
         }
 
+        members
+    }};
+}
+
+impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
+    fn evaluate_cast_to_struct(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        struct_name: Identifier<N>,
+        inputs: Vec<Value<N>>,
+    ) -> Result<Plaintext<N>> {
+        let members = cast_to_struct_common!(
+            N,
+            &struct_name,
+            inputs,
+            stack,
+            Value::Plaintext,
+            Value::Record,
+            Value::Future,
+            |x: &Plaintext<_>| x.clone(),
+            |x: &Identifier<_>| *x
+        );
         // Construct the struct.
-        let struct_ = Plaintext::Struct(members, Default::default());
-        // Store the struct.
-        registers.store(stack, &self.destination, Value::Plaintext(struct_))
+        Ok(Plaintext::Struct(members, Default::default()))
+    }
+
+    fn execute_cast_to_struct<A: circuit::Aleo<Network = N>>(
+        &self,
+        stack: &(impl StackMatches<N> + StackProgram<N>),
+        struct_name: Identifier<N>,
+        inputs: Vec<circuit::Value<A>>,
+    ) -> Result<circuit::Plaintext<A>> {
+        use circuit::{Eject, Inject};
+        let members = cast_to_struct_common!(
+            N,
+            &struct_name,
+            inputs,
+            stack,
+            circuit::Value::Plaintext,
+            circuit::Value::Record,
+            circuit::Value::Future,
+            |x: &circuit::Plaintext<_>| x.eject_value(),
+            |x: &Identifier<N>| circuit::Identifier::constant(*x)
+        );
+        // Construct the struct.
+        Ok(circuit::Plaintext::Struct(members, Default::default()))
     }
 
     /// A helper method to handle casting to an array.
@@ -989,7 +1009,7 @@ impl<N: Network, const VARIANT: u8> Parser for CastOperation<N, VARIANT> {
             CastType::GroupXCoordinate
             | CastType::GroupYCoordinate
             | CastType::Plaintext(PlaintextType::Literal(_)) => 1,
-            CastType::Plaintext(PlaintextType::Struct(_)) => N::MAX_STRUCT_ENTRIES,
+            CastType::Plaintext(PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_)) => N::MAX_STRUCT_ENTRIES,
             CastType::Plaintext(PlaintextType::Array(_)) => N::MAX_ARRAY_ELEMENTS,
             CastType::Record(_) | CastType::ExternalRecord(_) => N::MAX_RECORD_ENTRIES,
         };
@@ -1037,7 +1057,7 @@ impl<N: Network, const VARIANT: u8> Display for CastOperation<N, VARIANT> {
             CastType::GroupYCoordinate
             | CastType::GroupXCoordinate
             | CastType::Plaintext(PlaintextType::Literal(_)) => 1,
-            CastType::Plaintext(PlaintextType::Struct(_)) => N::MAX_STRUCT_ENTRIES,
+            CastType::Plaintext(PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_)) => N::MAX_STRUCT_ENTRIES,
             CastType::Plaintext(PlaintextType::Array(_)) => N::MAX_ARRAY_ELEMENTS,
             CastType::Record(_) | CastType::ExternalRecord(_) => N::MAX_RECORD_ENTRIES,
         };
@@ -1082,7 +1102,7 @@ impl<N: Network, const VARIANT: u8> FromBytes for CastOperation<N, VARIANT> {
             CastType::GroupYCoordinate
             | CastType::GroupXCoordinate
             | CastType::Plaintext(PlaintextType::Literal(_)) => 1,
-            CastType::Plaintext(PlaintextType::Struct(_)) => N::MAX_STRUCT_ENTRIES,
+            CastType::Plaintext(PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_)) => N::MAX_STRUCT_ENTRIES,
             CastType::Plaintext(PlaintextType::Array(_)) => N::MAX_ARRAY_ELEMENTS,
             CastType::Record(_) | CastType::ExternalRecord(_) => N::MAX_RECORD_ENTRIES,
         };
@@ -1103,7 +1123,7 @@ impl<N: Network, const VARIANT: u8> ToBytes for CastOperation<N, VARIANT> {
             CastType::GroupYCoordinate
             | CastType::GroupXCoordinate
             | CastType::Plaintext(PlaintextType::Literal(_)) => 1,
-            CastType::Plaintext(PlaintextType::Struct(_)) => N::MAX_STRUCT_ENTRIES,
+            CastType::Plaintext(PlaintextType::Struct(_) | PlaintextType::ExternalStruct(_)) => N::MAX_STRUCT_ENTRIES,
             CastType::Plaintext(PlaintextType::Array(_)) => N::MAX_ARRAY_ELEMENTS,
             CastType::Record(_) | CastType::ExternalRecord(_) => N::MAX_RECORD_ENTRIES,
         };

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -210,7 +210,7 @@ macro_rules! do_hash {
 
         let literal_type = match $destination_type {
             PlaintextType::Literal(literal_type) => *literal_type,
-            PlaintextType::Struct(..) => bail!("Cannot hash into a struct"),
+            PlaintextType::Struct(..) | PlaintextType::ExternalStruct(..) => bail!("Cannot hash into a struct"),
             PlaintextType::Array(..) => bail!("Cannot hash into an array (yet)"),
         };
 

--- a/synthesizer/program/src/logic/instruction/operation/literals.rs
+++ b/synthesizer/program/src/logic/instruction/operation/literals.rs
@@ -175,6 +175,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
             .map(|input_type| match input_type {
                 RegisterType::Plaintext(PlaintextType::Literal(literal_type)) => Ok(*literal_type),
                 RegisterType::Plaintext(PlaintextType::Struct(..))
+                | RegisterType::Plaintext(PlaintextType::ExternalStruct(..))
                 | RegisterType::Plaintext(PlaintextType::Array(..))
                 | RegisterType::Record(..)
                 | RegisterType::ExternalRecord(..)

--- a/synthesizer/tests/expectations/parser/program/external_struct.out
+++ b/synthesizer/tests/expectations/parser/program/external_struct.out
@@ -1,0 +1,1 @@
+Program was successfully parsed.

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct.out
@@ -1,0 +1,31 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    child.aleo/foo:
+      outputs:
+      - '{"type":"public","id":"2350840600140409389137831672144244415445587846230763964853051651298887510503field","value":"{\n  x: 12field\n}"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+- verified: true
+  execute:
+    child.aleo/foo2:
+      outputs:
+      - '{"type":"public","id":"7331629081299854905480391761611819086099931092397925132063203844743464604769field","value":"{\n  x: 12field\n}"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    parent.aleo/foo:
+      outputs:
+      - '{"type":"public","id":"7898223222506841996221608631372856695087628615673668950780913049080336222942field","value":"{\n  x: 12field\n}"}'
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"1190653336164197878999669469623725774560414906651527332799248561245380091764field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx,\n    1923u64\n  ]\n}"}'
+- child_outputs:
+    parent.aleo/foo:
+      outputs:
+      - '{"type":"public","id":"771452373065719064891340069414988846371747412001263614424488741531858896068field","value":"{\n  x: 12field\n}"}'
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"8322159061176592684357823490461924985193735969130652648549793091733727943770field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx,\n    1924u64\n  ]\n}"}'

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct_removed.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct_removed.out
@@ -1,0 +1,19 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    child.aleo/foo:
+      outputs: []
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    parent0.aleo/foo:
+      outputs:
+      - '{"type":"public","id":"6448260230717673003223478757145209815080058090345295700202663329455426952493field","value":"{\n  x: 12field\n}"}'
+    parent1.aleo/foo:
+      outputs:
+      - '{"type":"public","id":"885872919638524645838485642209354866002760158757501681201313125565346268957field","value":"{\n  x: 12field\n}"}'
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"3329606591783081622386721859561743677947217907434924521279363563620798058477field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx,\n    2560u64\n  ]\n}"}'

--- a/synthesizer/tests/tests/parser/program/external_struct.aleo
+++ b/synthesizer/tests/tests/parser/program/external_struct.aleo
@@ -1,0 +1,5 @@
+program child.aleo;
+
+function child:
+    call parent.aleo/parent into r0;
+    output r0 as parent.aleo/S.public;

--- a/synthesizer/tests/tests/vm/execute_and_finalize/external_struct.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/external_struct.aleo
@@ -1,0 +1,36 @@
+/*
+randomness: 45791624
+cases:
+  - program: child.aleo
+    function: foo
+    inputs: []
+  - program: child.aleo
+    function: foo2
+    inputs: []
+*/
+
+program parent.aleo;
+
+struct S:
+    x as field;
+
+function foo:
+    cast 12field into r0 as S;
+    output r0 as S.public;
+
+/////////////////////////////////////////////////
+
+import parent.aleo;
+
+program child.aleo;
+
+struct T:
+    x as field;
+
+function foo:
+    call parent.aleo/foo into r0;
+    output r0 as parent.aleo/S.public;
+
+function foo2:
+    call parent.aleo/foo into r0;
+    output r0 as T.public;

--- a/synthesizer/tests/tests/vm/execute_and_finalize/external_struct_removed.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/external_struct_removed.aleo
@@ -1,0 +1,36 @@
+/*
+randomness: 45791624
+cases:
+  - program: child.aleo
+    function: foo
+    inputs: []
+*/
+
+program parent0.aleo;
+
+struct S:
+    x as field;
+
+function foo:
+    cast 12field into r0 as S;
+    output r0 as S.public;
+
+/////////////////////////////////////////////////
+
+import parent0.aleo;
+
+program parent1.aleo;
+
+function foo:
+    call parent0.aleo/foo into r0;
+    output r0 as parent0.aleo/S.public;
+
+/////////////////////////////////////////////////
+
+import parent0.aleo;
+import parent1.aleo;
+
+program child.aleo;
+
+function foo:
+    call parent1.aleo/foo into r0;


### PR DESCRIPTION
Specifically,

1. Introduce a PlaintextType::ExternalStruct, and allow referring to such a type in code by a Locator.

2. Allow casting to external struct types.

3. Let two struct types be considered the same type as long as they are structurally the same.