### PR TITLE
Introduce ConsensusVersion V8 and increase constraint limit

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -16,8 +16,22 @@
 use super::*;
 use crate::TRANSACTION_PREFIX;
 use snarkvm_console_algorithms::{
-    BHP256, BHP512, BHP768, BHP1024, Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen64, Pedersen128, Poseidon2,
-    Poseidon4, Poseidon8, Sha3_256, Sha3_384, Sha3_512,
+    BHP256,
+    BHP512,
+    BHP768,
+    BHP1024,
+    Blake2Xs,
+    Keccak256,
+    Keccak384,
+    Keccak512,
+    Pedersen64,
+    Pedersen128,
+    Poseidon2,
+    Poseidon4,
+    Poseidon8,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
 };
 
 lazy_static! {

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -16,22 +16,8 @@
 use super::*;
 use crate::TRANSACTION_PREFIX;
 use snarkvm_console_algorithms::{
-    BHP256,
-    BHP512,
-    BHP768,
-    BHP1024,
-    Blake2Xs,
-    Keccak256,
-    Keccak384,
-    Keccak512,
-    Pedersen64,
-    Pedersen128,
-    Poseidon2,
-    Poseidon4,
-    Poseidon8,
-    Sha3_256,
-    Sha3_384,
-    Sha3_512,
+    BHP256, BHP512, BHP768, BHP1024, Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen64, Pedersen128, Poseidon2,
+    Poseidon4, Poseidon8, Sha3_256, Sha3_384, Sha3_512,
 };
 
 lazy_static! {
@@ -136,7 +122,7 @@ impl Network for CanaryV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_900_000),
         (ConsensusVersion::V3, 4_560_000),
@@ -144,11 +130,12 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V5, 5_780_000),
         (ConsensusVersion::V6, 6_240_000),
         (ConsensusVersion::V7, 6_880_000),
+        (ConsensusVersion::V8, 7_565_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
@@ -156,6 +143,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
         (ConsensusVersion::V7, 15),
+        (ConsensusVersion::V8, 16),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -87,6 +87,7 @@ pub enum ConsensusVersion {
     V6 = 6,
     /// V7: Update to program rules.
     V7 = 7,
+    V8 = 8,
 }
 
 pub trait Network:
@@ -226,7 +227,7 @@ pub trait Network:
 
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `N::CONSENSUS_VERSION`
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7];
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8];
     ///  A list of (consensus_version, size) pairs indicating the maximum number of validators in a committee.
     //  Note: This value must **not** decrease without considering the impact on serialization.
     //  Decreasing this value will break backwards compatibility of serialization without explicit

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -137,9 +137,9 @@ pub trait Network:
     /// The cost in microcredits per constraint for the deployment transaction.
     const SYNTHESIS_FEE_MULTIPLIER: u64 = 25; // 25 microcredits per constraint
     /// The maximum number of variables in a deployment.
-    const MAX_DEPLOYMENT_VARIABLES: u64 = 1 << 20; // 1,048,576 variables
+    const MAX_DEPLOYMENT_VARIABLES: u64 = (1 << 20) + (1 << 19); // 1,572,864 variables
     /// The maximum number of constraints in a deployment.
-    const MAX_DEPLOYMENT_CONSTRAINTS: u64 = 1 << 20; // 1,048,576 constraints
+    const MAX_DEPLOYMENT_CONSTRAINTS: u64 = (1 << 20) + (1 << 19); // 1,572,864 constraints
     /// The maximum number of microcredits that can be spent as a fee.
     const MAX_FEE: u64 = 1_000_000_000_000_000;
     /// The maximum number of microcredits that can be spent on a transaction's finalize scope.

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -15,22 +15,8 @@
 
 use super::*;
 use snarkvm_console_algorithms::{
-    BHP256,
-    BHP512,
-    BHP768,
-    BHP1024,
-    Blake2Xs,
-    Keccak256,
-    Keccak384,
-    Keccak512,
-    Pedersen64,
-    Pedersen128,
-    Poseidon2,
-    Poseidon4,
-    Poseidon8,
-    Sha3_256,
-    Sha3_384,
-    Sha3_512,
+    BHP256, BHP512, BHP768, BHP1024, Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen64, Pedersen128, Poseidon2,
+    Poseidon4, Poseidon8, Sha3_256, Sha3_384, Sha3_512,
 };
 
 lazy_static! {
@@ -137,7 +123,7 @@ impl Network for MainnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_800_000),
         (ConsensusVersion::V3, 4_900_000),
@@ -145,11 +131,12 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V5, 7_060_000),
         (ConsensusVersion::V6, 7_560_000),
         (ConsensusVersion::V7, 7_570_000),
+        (ConsensusVersion::V8, 9_417_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
@@ -157,6 +144,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
         (ConsensusVersion::V7, 15),
+        (ConsensusVersion::V8, 16),
     ];
     /// The network edition.
     const EDITION: u16 = 0;

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -15,8 +15,22 @@
 
 use super::*;
 use snarkvm_console_algorithms::{
-    BHP256, BHP512, BHP768, BHP1024, Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen64, Pedersen128, Poseidon2,
-    Poseidon4, Poseidon8, Sha3_256, Sha3_384, Sha3_512,
+    BHP256,
+    BHP512,
+    BHP768,
+    BHP1024,
+    Blake2Xs,
+    Keccak256,
+    Keccak384,
+    Keccak512,
+    Pedersen64,
+    Pedersen128,
+    Poseidon2,
+    Poseidon4,
+    Poseidon8,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
 };
 
 lazy_static! {

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -16,8 +16,22 @@
 use super::*;
 use crate::TRANSACTION_PREFIX;
 use snarkvm_console_algorithms::{
-    BHP256, BHP512, BHP768, BHP1024, Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen64, Pedersen128, Poseidon2,
-    Poseidon4, Poseidon8, Sha3_256, Sha3_384, Sha3_512,
+    BHP256,
+    BHP512,
+    BHP768,
+    BHP1024,
+    Blake2Xs,
+    Keccak256,
+    Keccak384,
+    Keccak512,
+    Pedersen64,
+    Pedersen128,
+    Poseidon2,
+    Poseidon4,
+    Poseidon8,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
 };
 
 lazy_static! {

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -16,22 +16,8 @@
 use super::*;
 use crate::TRANSACTION_PREFIX;
 use snarkvm_console_algorithms::{
-    BHP256,
-    BHP512,
-    BHP768,
-    BHP1024,
-    Blake2Xs,
-    Keccak256,
-    Keccak384,
-    Keccak512,
-    Pedersen64,
-    Pedersen128,
-    Poseidon2,
-    Poseidon4,
-    Poseidon8,
-    Sha3_256,
-    Sha3_384,
-    Sha3_512,
+    BHP256, BHP512, BHP768, BHP1024, Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen64, Pedersen128, Poseidon2,
+    Poseidon4, Poseidon8, Sha3_256, Sha3_384, Sha3_512,
 };
 
 lazy_static! {
@@ -136,7 +122,7 @@ impl Network for TestnetV0 {
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 2_950_000),
         (ConsensusVersion::V3, 4_800_000),
@@ -144,11 +130,12 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V5, 6_765_000),
         (ConsensusVersion::V6, 7_600_000),
         (ConsensusVersion::V7, 8_365_000),
+        (ConsensusVersion::V8, 9_155_000),
     ];
     /// A list of (consensus_version, block_height) pairs indicating when each consensus version takes effect.
     /// Documentation for what is changed at each version can be found in `ConsensusVersion`.
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
-    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 7] = [
+    const CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 8] = [
         (ConsensusVersion::V1, 0),
         (ConsensusVersion::V2, 10),
         (ConsensusVersion::V3, 11),
@@ -156,6 +143,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V5, 13),
         (ConsensusVersion::V6, 14),
         (ConsensusVersion::V7, 15),
+        (ConsensusVersion::V8, 16),
     ];
     /// The network edition.
     const EDITION: u16 = 0;


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR introduces the heights for ConsensusVersion::V8 with the following estimated activation dates:

| Network | Release Date | Buffer | Consensus v8 |
|---------|--------------|--------|--------------|
| Canary  | July 8, 2025 9AM PT | 4 hours | July 8, 2025 1PM PT |
| Testnet | July 15, 2025 9AM PT | 4 hours | July 15, 2025 1PM PT |
| Mainnet | July 22, 2025 9AM PT  | 4 hours | July 22, 2025 1PM PT |


In addition, the program constraint limit was increased by 50% from 1 million to 1.5 million. This will allow developers to deploy programs with richer and more complex circuit logic.