### PR TITLE
Clean up Record V0 error

### DIFF
--- a/circuit/program/src/request/verify.rs
+++ b/circuit/program/src/request/verify.rs
@@ -337,8 +337,9 @@ mod tests {
             let function_name = console::Identifier::from_str("transfer")?;
 
             // Prepare a record belonging to the address.
-            let record_string =
-                format!("{{ owner: {address}.private, token_amount: 100u64.private, _nonce: 0group.public }}");
+            let record_string = format!(
+                "{{ owner: {address}.private, token_amount: 100u64.private, _nonce: 0group.public, _version: 1u8.public }}"
+            );
 
             // Construct the inputs.
             let input_constant =

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -174,7 +174,13 @@ impl<N: Network> Request<N> {
                     };
                     // Ensure the record belongs to the signer.
                     ensure!(**record.owner() == signer, "Input record for '{program_id}' must belong to the signer");
-
+                    // Ensure version 0 credits.aleo Records are only allowed when calling upgrade().
+                    if program_id == ProgramID::from_str("credits.aleo")?
+                        && record.version() == &U8::zero()
+                        && function_name != Identifier::from_str("upgrade")?
+                    {
+                        bail!("Version 0 credits.aleo Records are only allowed when calling 'upgrade()'");
+                    }
                     // Compute the record view key.
                     let record_view_key = (*record.nonce() * *view_key).to_x_coordinate();
                     // Compute the record commitment.

--- a/synthesizer/process/src/execute.rs
+++ b/synthesizer/process/src/execute.rs
@@ -88,7 +88,7 @@ mod tests {
         // Sample a credits record.
         let fee_in_microcredits = base_fee_in_microcredits.saturating_add(priority_fee_in_microcredits);
         let credits = Record::<CurrentNetwork, Plaintext<_>>::from_str(&format!(
-            "{{ owner: {owner}.private, microcredits: {fee_in_microcredits}u64.private, _nonce: 0group.public }}"
+            "{{ owner: {owner}.private, microcredits: {fee_in_microcredits}u64.private, _nonce: 0group.public, _version: 1u8.public }}"
         ))
         .unwrap();
 

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -2968,7 +2968,7 @@ mod sanity_checks {
 
         // Declare the inputs.
         let r0 = Value::from_str(&format!(
-            "{{ owner: {caller}.private, microcredits: 1_500_000_000_000_000_u64.private, _nonce: {}.public }}",
+            "{{ owner: {caller}.private, microcredits: 1_500_000_000_000_000_u64.private, _nonce: {}.public, _version: 1u8.public }}",
             console::types::Group::<CurrentNetwork>::zero()
         ))
         .unwrap();

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -2879,7 +2879,7 @@ mod sanity_checks {
 
         // Declare the inputs.
         let r0 = Value::from_str(&format!(
-            "{{ owner: {caller}.private, microcredits: 1_500_000_000_000_000_u64.private, _nonce: {}.public }}",
+            "{{ owner: {caller}.private, microcredits: 1_500_000_000_000_000_u64.private, _nonce: {}.public, _version: 1u8.public }}",
             console::types::Group::<CurrentNetwork>::zero()
         ))
         .unwrap();


### PR DESCRIPTION
## Motivation

This PR introduces a cleaner error when a user tries to create an authorization which is not allowed using V0 records.

## Test Plan

This should not influence any deserialization or syncing, as signing is a client- or prover-side operation. Some unit tests might not be happy because we fail earlier than before: during authorization instead of execution, and it is not guarded by consensus versions.
