### PR TITLE
Fail loudly when using the wrong program or record version

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo +nightly fmt --all -- --check && cargo clippy --workspace --all-targets --all-features"
+pre-commit = "cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo +nightly fmt --all -- --check"
 
 [logging]
 verbose = true

--- a/console/program/src/request/sign.rs
+++ b/console/program/src/request/sign.rs
@@ -174,13 +174,6 @@ impl<N: Network> Request<N> {
                     };
                     // Ensure the record belongs to the signer.
                     ensure!(**record.owner() == signer, "Input record for '{program_id}' must belong to the signer");
-                    // Ensure version 0 credits.aleo Records are only allowed when calling upgrade().
-                    if program_id == ProgramID::from_str("credits.aleo")?
-                        && record.version() == &U8::zero()
-                        && function_name != Identifier::from_str("upgrade")?
-                    {
-                        bail!("Version 0 credits.aleo Records are only allowed when calling 'upgrade()'");
-                    }
                     // Compute the record view key.
                     let record_view_key = (*record.nonce() * *view_key).to_x_coordinate();
                     // Compute the record commitment.

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -152,13 +152,11 @@ impl<N: Network> Authorization<N> {
     /// Checks whether the authorization is for a valid program edition.
     pub fn check_valid_edition(&self, process: &crate::Process<N>, consensus_version: ConsensusVersion) -> Result<()> {
         // Determine the root transition's program ID.
-        let root_program_id = {
-            let transitions = self.transitions.read();
-            *transitions
-                .first()
-                .map(|(_, t)| t.program_id())
-                .ok_or_else(|| anyhow!("No transitions found in the Authorization."))?
-        };
+        let transitions = self.transitions.read();
+        let root_program_id = *transitions
+            .first()
+            .map(|(_, t)| t.program_id())
+            .ok_or_else(|| anyhow!("No transitions found in the Authorization."))?;
         // There is only one credits.aleo edition, so we can safely skip this case.
         if root_program_id.to_string() != "credits.aleo" {
             // Get the program's current edition.
@@ -166,6 +164,52 @@ impl<N: Network> Authorization<N> {
             // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
             if consensus_version >= ConsensusVersion::V8 && program_edition == 0 {
                 bail!("Cannot execute {} on edition {program_edition}", root_program_id.to_string());
+            }
+        }
+        Ok(())
+    }
+
+    /// Checks whether the authorization creates valid records.
+    pub fn check_valid_records(&self, consensus_version: ConsensusVersion) -> Result<()> {
+        let transitions = self.transitions.read();
+        // Collect the transition's records.
+        let records = transitions.values().map(|transition| {
+            let program_id = transition.program_id();
+            let function_name = transition.function_name();
+            let input_records = transition.outputs().iter().filter_map(|output| output.record());
+            let output_records = transition.outputs().iter().filter_map(|output| output.record());
+            (program_id, function_name, input_records, output_records)
+        });
+        // Ensure the records are valid.
+        for (program_id, function_name, input_records, output_records) in records {
+            for (_, record) in output_records {
+                // If the consensus version are before `ConsensusVersion::V8`, ensure the output record is on Version 0.
+                // if the consensus version is on or after `ConsensusVersion::V8`, ensure the output record is on Version 1.
+                if (ConsensusVersion::V1..=ConsensusVersion::V7).contains(&consensus_version) {
+                    #[cfg(not(any(test, feature = "test")))]
+                    ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
+                    #[cfg(any(test, feature = "test"))]
+                    ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
+                } else {
+                    ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
+                }
+            }
+            for (_, record) in input_records {
+                // if the consensus version is on or after `ConsensusVersion::V8`,
+                // Ensure version 0 credits.aleo records can only be used when calling upgrade().
+                if consensus_version >= ConsensusVersion::V8
+                    && **record.version() == 0
+                    && program_id.to_string() == "credits.aleo"
+                    && function_name.to_string() != "upgrade"
+                {
+                    bail!(
+                        "Cannot input record version {} on consensus version {:?} for program {} and function {}",
+                        record.version(),
+                        consensus_version,
+                        program_id,
+                        function_name
+                    );
+                }
             }
         }
         Ok(())

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -153,22 +153,21 @@ impl<N: Network> Authorization<N> {
     pub fn check_valid_edition(&self, process: &crate::Process<N>, _consensus_version: ConsensusVersion) -> Result<()> {
         // Determine the root transition's program ID.
         let transitions = self.transitions.read();
-        let root_program_id = *transitions
-            .first()
-            .map(|(_, t)| t.program_id())
-            .ok_or_else(|| anyhow!("No transitions found in the Authorization."))?;
-        // There is only one credits.aleo edition, so we can safely skip this case.
-        if root_program_id.to_string() != "credits.aleo" {
-            // Get the program's current edition.
-            let _program_edition = *process.get_stack(root_program_id)?.program_edition();
-            // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
-            // TODO: Once upgradability lands, this check will be different. We
-            // can't just check the program edition anymore, it will need to be
-            // programs that are edition 0 with no constructor that can't be
-            // called.
-            #[cfg(not(any(test, feature = "test")))]
-            if _consensus_version >= ConsensusVersion::V8 && _program_edition == 0 {
-                bail!("Cannot execute {root_program_id} on edition {_program_edition}");
+        let program_ids = transitions.iter().map(|(_, t)| t.program_id());
+        for program_id in program_ids {
+            // There is only one credits.aleo edition, so we can safely skip this case.
+            if program_id.to_string() != "credits.aleo" {
+                // Get the program's current edition.
+                let _program_edition = *process.get_stack(program_id)?.program_edition();
+                // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
+                // TODO: Once upgradability lands, this check will be different. We
+                // can't just check the program edition anymore, it will need to be
+                // programs that are edition 0 with no constructor that can't be
+                // called.
+                #[cfg(not(any(test, feature = "test")))]
+                if _consensus_version >= ConsensusVersion::V8 && _program_edition == 0 {
+                    bail!("Cannot execute {root_program_id} on edition {_program_edition}");
+                }
             }
         }
         Ok(())

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -19,6 +19,7 @@ mod string;
 
 use console::{network::prelude::*, program::Request, types::Field};
 use ledger_block::{Transaction, Transition};
+use synthesizer_program::StackProgram;
 
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
@@ -146,6 +147,28 @@ impl<N: Network> Authorization<N> {
             }
             _ => false,
         }
+    }
+
+    /// Checks whether the authorization is for a valid program edition.
+    pub fn check_valid_edition(&self, process: &crate::Process<N>, consensus_version: ConsensusVersion) -> Result<()> {
+        // Determine the root transition's program ID.
+        let root_program_id = {
+            let transitions = self.transitions.read();
+            *transitions
+                .first()
+                .map(|(_, t)| t.program_id())
+                .ok_or_else(|| anyhow!("No transitions found in the Authorization."))?
+        };
+        // There is only one credits.aleo edition, so we can safely skip this case.
+        if root_program_id.to_string() != "credits.aleo" {
+            // Get the program's current edition.
+            let program_edition = *process.get_stack(root_program_id)?.program_edition();
+            // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
+            if consensus_version >= ConsensusVersion::V8 && program_edition == 0 {
+                bail!("Cannot execute {} on edition {program_edition}", root_program_id.to_string());
+            }
+        }
+        Ok(())
     }
 }
 

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -164,7 +164,7 @@ impl<N: Network> Authorization<N> {
             // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
             #[cfg(not(any(test, feature = "test")))]
             if _consensus_version >= ConsensusVersion::V8 && _program_edition == 0 {
-                bail!("Cannot execute {} on edition {program_edition}", root_program_id.to_string());
+                bail!("Cannot execute {} on edition {_program_edition}", root_program_id.to_string());
             }
         }
         Ok(())

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -166,7 +166,7 @@ impl<N: Network> Authorization<N> {
                 // called.
                 #[cfg(not(any(test, feature = "test")))]
                 if _consensus_version >= ConsensusVersion::V8 && _program_edition == 0 {
-                    bail!("Cannot execute {root_program_id} on edition {_program_edition}");
+                    bail!("Cannot execute {program_id} on edition {_program_edition}");
                 }
             }
         }

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -177,44 +177,21 @@ impl<N: Network> Authorization<N> {
     /// Checks whether the authorization creates valid records.
     pub fn check_valid_records(&self, consensus_version: ConsensusVersion) -> Result<()> {
         let transitions = self.transitions.read();
-        // Collect the transition's records.
-        let records = transitions.values().map(|transition| {
-            let program_id = transition.program_id();
-            let function_name = transition.function_name();
-            let input_records = transition.outputs().iter().filter_map(|output| output.record());
-            let output_records = transition.outputs().iter().filter_map(|output| output.record());
-            (program_id, function_name, input_records, output_records)
-        });
+        // Collect the transition's output records.
+        let output_records = transitions
+            .values()
+            .flat_map(|transition| transition.outputs().iter().filter_map(|output| output.record()));
         // Ensure the records are valid.
-        for (program_id, function_name, input_records, output_records) in records {
-            for (_, record) in output_records {
-                // If the consensus version are before `ConsensusVersion::V8`, ensure the output record is on Version 0.
-                // if the consensus version is on or after `ConsensusVersion::V8`, ensure the output record is on Version 1.
-                if (ConsensusVersion::V1..=ConsensusVersion::V7).contains(&consensus_version) {
-                    #[cfg(not(any(test, feature = "test")))]
-                    ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
-                    #[cfg(any(test, feature = "test"))]
-                    ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
-                } else {
-                    ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
-                }
-            }
-            for (_, record) in input_records {
-                // if the consensus version is on or after `ConsensusVersion::V8`,
-                // Ensure version 0 credits.aleo records can only be used when calling upgrade().
-                if consensus_version >= ConsensusVersion::V8
-                    && **record.version() == 0
-                    && program_id.to_string() == "credits.aleo"
-                    && function_name.to_string() != "upgrade"
-                {
-                    bail!(
-                        "Cannot input record version {} on consensus version {:?} for program {} and function {}",
-                        record.version(),
-                        consensus_version,
-                        program_id,
-                        function_name
-                    );
-                }
+        for (_, record) in output_records {
+            // If the consensus version are before `ConsensusVersion::V8`, ensure the output record is on Version 0.
+            // if the consensus version is on or after `ConsensusVersion::V8`, ensure the output record is on Version 1.
+            if (ConsensusVersion::V1..=ConsensusVersion::V7).contains(&consensus_version) {
+                #[cfg(not(any(test, feature = "test")))]
+                ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
+                #[cfg(any(test, feature = "test"))]
+                ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
+            } else {
+                ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
             }
         }
         Ok(())

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -162,6 +162,10 @@ impl<N: Network> Authorization<N> {
             // Get the program's current edition.
             let _program_edition = *process.get_stack(root_program_id)?.program_edition();
             // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
+            // TODO: Once upgradability lands, this check will be different. We
+            // can't just check the program edition anymore, it will need to be
+            // programs that are edition 0 with no constructor that can't be
+            // called.
             #[cfg(not(any(test, feature = "test")))]
             if _consensus_version >= ConsensusVersion::V8 && _program_edition == 0 {
                 bail!("Cannot execute {root_program_id} on edition {_program_edition}");

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -150,7 +150,7 @@ impl<N: Network> Authorization<N> {
     }
 
     /// Checks whether the authorization is for a valid program edition.
-    pub fn check_valid_edition(&self, process: &crate::Process<N>, consensus_version: ConsensusVersion) -> Result<()> {
+    pub fn check_valid_edition(&self, process: &crate::Process<N>, _consensus_version: ConsensusVersion) -> Result<()> {
         // Determine the root transition's program ID.
         let transitions = self.transitions.read();
         let root_program_id = *transitions
@@ -160,9 +160,10 @@ impl<N: Network> Authorization<N> {
         // There is only one credits.aleo edition, so we can safely skip this case.
         if root_program_id.to_string() != "credits.aleo" {
             // Get the program's current edition.
-            let program_edition = *process.get_stack(root_program_id)?.program_edition();
+            let _program_edition = *process.get_stack(root_program_id)?.program_edition();
             // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
-            if consensus_version >= ConsensusVersion::V8 && program_edition == 0 {
+            #[cfg(not(any(test, feature = "test")))]
+            if _consensus_version >= ConsensusVersion::V8 && _program_edition == 0 {
                 bail!("Cannot execute {} on edition {program_edition}", root_program_id.to_string());
             }
         }

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -188,7 +188,7 @@ impl<N: Network> Authorization<N> {
                 #[cfg(not(any(test, feature = "test")))]
                 ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
                 #[cfg(any(test, feature = "test"))]
-                ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
+                ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8 in tests.");
             } else {
                 ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
             }

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -164,7 +164,7 @@ impl<N: Network> Authorization<N> {
             // If we're past ConsensusVersion::V8, ensure new stacks are not on edition 0.
             #[cfg(not(any(test, feature = "test")))]
             if _consensus_version >= ConsensusVersion::V8 && _program_edition == 0 {
-                bail!("Cannot execute {} on edition {_program_edition}", root_program_id.to_string());
+                bail!("Cannot execute {root_program_id} on edition {_program_edition}");
             }
         }
         Ok(())

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -113,9 +113,9 @@ impl<N: Network> Process<N> {
                         #[cfg(not(any(test, feature = "test")))]
                         ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
                         #[cfg(any(test, feature = "test"))]
-                        ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
-                    } else {
                         ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
+                    } else {
+                        ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
                     }
                 }
                 // Ensure the output is valid.

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -115,7 +115,7 @@ impl<N: Network> Process<N> {
                         #[cfg(any(test, feature = "test"))]
                         ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
                     } else {
-                        ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
+                        ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
                     }
                 }
                 // Ensure the output is valid.

--- a/synthesizer/process/src/verify_execution.rs
+++ b/synthesizer/process/src/verify_execution.rs
@@ -113,7 +113,10 @@ impl<N: Network> Process<N> {
                         #[cfg(not(any(test, feature = "test")))]
                         ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
                         #[cfg(any(test, feature = "test"))]
-                        ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
+                        ensure!(
+                            record.version().is_one(),
+                            "Output record must be Version 1 before Consensus V8 in tests."
+                        );
                     } else {
                         ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
                     }

--- a/synthesizer/process/src/verify_fee.rs
+++ b/synthesizer/process/src/verify_fee.rs
@@ -133,7 +133,10 @@ impl<N: Network> Process<N> {
                     #[cfg(not(any(test, feature = "test")))]
                     ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
                     #[cfg(any(test, feature = "test"))]
-                    ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
+                    ensure!(
+                        record.version().is_one(),
+                        "Output record must be Version 1 before Consensus V8  in tests."
+                    );
                 } else {
                     ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
                 }

--- a/synthesizer/process/src/verify_fee.rs
+++ b/synthesizer/process/src/verify_fee.rs
@@ -133,7 +133,7 @@ impl<N: Network> Process<N> {
                     #[cfg(not(any(test, feature = "test")))]
                     ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
                     #[cfg(any(test, feature = "test"))]
-                    ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
+                    ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8");
                 } else {
                     ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
                 }

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -190,6 +190,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // Determine the consensus version.
         let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
+        // Check whether the authorization is for a valid program edition.
+        authorization.check_valid_edition(&self.process.read(), consensus_version)?;
         // Determine which Varuna version to use.
         let varuna_version = match (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             true => VarunaVersion::V1,
@@ -235,6 +237,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // Determine the consensus version.
         let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
+        // Check whether the authorization is for a valid program edition.
+        authorization.check_valid_edition(&self.process.read(), consensus_version)?;
         // Determine which Varuna version to use.
         let varuna_version = match (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             true => VarunaVersion::V1,

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -192,6 +192,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
         // Check whether the authorization is for a valid program edition.
         authorization.check_valid_edition(&self.process.read(), consensus_version)?;
+        // Check whether the authorization is creating valid records.
+        authorization.check_valid_records(consensus_version)?;
         // Determine which Varuna version to use.
         let varuna_version = match (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             true => VarunaVersion::V1,
@@ -239,6 +241,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
         // Check whether the authorization is for a valid program edition.
         authorization.check_valid_edition(&self.process.read(), consensus_version)?;
+        // Check whether the authorization is creating valid records.
+        authorization.check_valid_records(consensus_version)?;
         // Determine which Varuna version to use.
         let varuna_version = match (ConsensusVersion::V1..=ConsensusVersion::V3).contains(&consensus_version) {
             true => VarunaVersion::V1,


### PR DESCRIPTION
## Motivation

An execution service in the wild which is on the latest snarkVM version but either 1. isn't synced 2. cached outdated verifying keys 3. uses the wrong record at the wrong time, will find their transactions don't land without clear error.

## Test Plan

- [x] Should be E2E tested on latest snarkOS.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2796 introduces a similar protection, but we deprecate it in favour of this PR so we can still flexibly test any behaviour during testing.