### PR TITLE
Don't make invalid Scalars in Scalar::from_bits_le

### DIFF
--- a/circuit/account/src/signature/helpers/from_bits.rs
+++ b/circuit/account/src/signature/helpers/from_bits.rs
@@ -124,12 +124,12 @@ mod tests {
 
     #[test]
     fn test_from_bits_le_public() {
-        check_from_bits_le(Mode::Public, 9, 0, 1875, 1881);
+        check_from_bits_le(Mode::Public, 9, 0, 1877, 1883);
     }
 
     #[test]
     fn test_from_bits_le_private() {
-        check_from_bits_le(Mode::Private, 9, 0, 1875, 1881);
+        check_from_bits_le(Mode::Private, 9, 0, 1877, 1883);
     }
 
     #[test]
@@ -139,11 +139,11 @@ mod tests {
 
     #[test]
     fn test_from_bits_be_public() {
-        check_from_bits_be(Mode::Public, 9, 0, 1875, 1881);
+        check_from_bits_be(Mode::Public, 9, 0, 1877, 1883);
     }
 
     #[test]
     fn test_from_bits_be_private() {
-        check_from_bits_be(Mode::Private, 9, 0, 1875, 1881);
+        check_from_bits_be(Mode::Private, 9, 0, 1877, 1883);
     }
 }

--- a/circuit/program/src/data/literal/cast/field.rs
+++ b/circuit/program/src/data/literal/cast/field.rs
@@ -183,8 +183,8 @@ mod tests {
     #[test]
     fn test_field_to_scalar() {
         check_cast::<Scalar<Circuit>, console_root::types::Scalar<MainnetV0>>(Mode::Constant, count_is!(253, 0, 0, 0));
-        check_cast::<Scalar<Circuit>, console_root::types::Scalar<MainnetV0>>(Mode::Public, count_is!(0, 0, 755, 759));
-        check_cast::<Scalar<Circuit>, console_root::types::Scalar<MainnetV0>>(Mode::Private, count_is!(0, 0, 755, 759));
+        check_cast::<Scalar<Circuit>, console_root::types::Scalar<MainnetV0>>(Mode::Public, count_is!(0, 0, 756, 760));
+        check_cast::<Scalar<Circuit>, console_root::types::Scalar<MainnetV0>>(Mode::Private, count_is!(0, 0, 756, 760));
     }
 
     #[test]

--- a/circuit/types/scalar/src/helpers/from_bits.rs
+++ b/circuit/types/scalar/src/helpers/from_bits.rs
@@ -43,26 +43,31 @@ impl<E: Environment> FromBits for Scalar<E> {
             // and `bits_le` is greater than `size_in_data_bits`, it is safe to truncate `bits_le` to `size_in_bits`.
             let bits_le = &bits_le[..size_in_bits];
 
-            // Reconstruct the bits as a linear combination representing the original scalar as a field.
-            let mut accumulator = Field::zero();
-            let mut coefficient = Field::one();
-            for bit in bits_le {
-                accumulator += Field::from_boolean(bit) * &coefficient;
-                coefficient = coefficient.double();
-            }
-
-            // Construct the scalar.
-            let scalar = Scalar { field: accumulator, bits_le: OnceCell::with_value(bits_le.to_vec()) };
-
             // Retrieve the modulus & subtract by 1 as we'll check `bits_le` is less than or *equal* to this value.
             // (For advanced users) ScalarField::MODULUS - 1 is equivalent to -1 in the field.
             let modulus_minus_one = -E::ScalarField::one();
 
             // Assert `bits_le <= (ScalarField::MODULUS - 1)`, which is equivalent to `bits_le < ScalarField::MODULUS`.
-            Boolean::assert_less_than_or_equal_constant(bits_le, &modulus_minus_one.to_bits_le());
+            let modulus_minus_one_bits_le = modulus_minus_one.to_bits_le();
+            let is_less_or_equal = Boolean::is_less_than_or_equal_constant(bits_le, &modulus_minus_one_bits_le);
+            E::assert(is_less_or_equal.clone());
 
-            // Return the scalar.
-            scalar
+            // If our assertion failed, set the most significant bit to 0.
+            // In this case it doesn't matter what value we construct; we just need
+            // its bits to be <= modulus_minus_one_bits_le.
+            let mut bits = bits_le.to_vec();
+            bits.last_mut().unwrap().bitand_assign(is_less_or_equal);
+
+            // Reconstruct the bits as a linear combination representing the value as a field.
+            let mut accumulator = Field::zero();
+            let mut coefficient = Field::one();
+            for bit in &bits {
+                accumulator += Field::from_boolean(bit) * &coefficient;
+                coefficient = coefficient.double();
+            }
+
+            // Construct and return the scalar.
+            Scalar { field: accumulator, bits_le: OnceCell::with_value(bits) }
         } else {
             // Construct the sanitized list of bits, resizing up if necessary.
             let mut bits_le = bits_le.iter().take(size_in_bits).cloned().collect::<Vec<_>>();
@@ -188,12 +193,12 @@ mod tests {
 
     #[test]
     fn test_from_bits_le_public() {
-        check_from_bits_le(Mode::Public, 0, 0, 250, 251);
+        check_from_bits_le(Mode::Public, 0, 0, 251, 252);
     }
 
     #[test]
     fn test_from_bits_le_private() {
-        check_from_bits_le(Mode::Private, 0, 0, 250, 251);
+        check_from_bits_le(Mode::Private, 0, 0, 251, 252);
     }
 
     #[test]
@@ -203,11 +208,11 @@ mod tests {
 
     #[test]
     fn test_from_bits_be_public() {
-        check_from_bits_be(Mode::Public, 0, 0, 250, 251);
+        check_from_bits_be(Mode::Public, 0, 0, 251, 252);
     }
 
     #[test]
     fn test_from_bits_be_private() {
-        check_from_bits_be(Mode::Private, 0, 0, 250, 251);
+        check_from_bits_be(Mode::Private, 0, 0, 251, 252);
     }
 }

--- a/circuit/types/scalar/src/helpers/from_field.rs
+++ b/circuit/types/scalar/src/helpers/from_field.rs
@@ -59,7 +59,7 @@ mod tests {
                 assert_eq!(expected, candidate.eject_value());
                 match mode {
                     Mode::Constant => assert_scope!(253, 0, 0, 0),
-                    _ => assert_scope!(0, 0, 755, 759),
+                    _ => assert_scope!(0, 0, 756, 760),
                 }
             });
             Circuit::reset();


### PR DESCRIPTION
Previously, if the bits represented a value
greater than or equal to the modulus, an invalid
Scalar would be constructed. This can be a problem for instance during key synthesis when deploying,
because `eject_value` will panic, leading to a
failed deployment.

Fixes #2801