### PR TITLE
Remove some misleading comments.

### DIFF
--- a/circuit/program/src/data/literal/cast_lossy/scalar.rs
+++ b/circuit/program/src/data/literal/cast_lossy/scalar.rs
@@ -65,9 +65,6 @@ impl<E: Environment, I: IntegerType> CastLossy<Integer<E, I>> for Scalar<E> {
     /// Casts a `Scalar` to an `Integer`, with lossy truncation.
     #[inline]
     fn cast_lossy(&self) -> Integer<E, I> {
-        // Note: We are reconstituting the integer from the scalar field.
-        // This is safe as the number of bits in the integer is less than the scalar field modulus,
-        // and thus will always fit within a single scalar field element.
         debug_assert!(I::BITS < <console::Scalar<E::Network> as console::SizeInBits>::size_in_bits() as u64);
 
         // Truncate the field to the size of the integer domain.

--- a/circuit/types/integers/src/helpers/from_field_lossy.rs
+++ b/circuit/types/integers/src/helpers/from_field_lossy.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment, I: IntegerType> Integer<E, I> {
     /// Casts an integer from a base field, with lossy truncation.
     ///
-    /// This method is commonly-used by hash-to-integer algorithms,
+    /// This method is commonly used by hash-to-integer algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
         debug_assert!(I::BITS < E::BaseField::size_in_bits() as u64);

--- a/circuit/types/integers/src/helpers/from_field_lossy.rs
+++ b/circuit/types/integers/src/helpers/from_field_lossy.rs
@@ -21,9 +21,6 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
     /// This method is commonly-used by hash-to-integer algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
-        // Note: We are reconstituting the integer from the base field.
-        // This is safe as the number of bits in the integer is less than the base field modulus,
-        // and thus will always fit within a single base field element.
         debug_assert!(I::BITS < E::BaseField::size_in_bits() as u64);
 
         // Truncate the field to the size in bits of the integer.

--- a/circuit/types/scalar/src/helpers/from_bits.rs
+++ b/circuit/types/scalar/src/helpers/from_bits.rs
@@ -22,9 +22,6 @@ impl<E: Environment> FromBits for Scalar<E> {
     ///   - If `bits_le` is longer than `E::ScalarField::size_in_bits()`, the excess bits are enforced to be `0`s.
     ///   - If `bits_le` is shorter than `E::ScalarField::size_in_bits()`, it is padded with `0`s up to scalar field size.
     fn from_bits_le(bits_le: &[Self::Boolean]) -> Self {
-        // Note: We are reconstituting the scalar field into a base field.
-        // This is safe as the scalar field modulus is less than the base field modulus,
-        // and thus will always fit within a single base field element.
         debug_assert!(console::Scalar::<E::Network>::size_in_bits() < console::Field::<E::Network>::size_in_bits());
 
         // Retrieve the data and scalar field size.

--- a/circuit/types/scalar/src/helpers/from_field_lossy.rs
+++ b/circuit/types/scalar/src/helpers/from_field_lossy.rs
@@ -21,9 +21,6 @@ impl<E: Environment> Scalar<E> {
     /// This method is commonly-used by hash-to-scalar algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
-        // Note: We are reconstituting the integer from the base field.
-        // This is safe as the number of bits in the integer is less than the base field modulus,
-        // and thus will always fit within a single base field element.
         debug_assert!(E::ScalarField::size_in_bits() < E::BaseField::size_in_bits());
 
         // Truncate the output to the size in data bits (1 bit less than the MODULUS) of the scalar.

--- a/circuit/types/scalar/src/helpers/from_field_lossy.rs
+++ b/circuit/types/scalar/src/helpers/from_field_lossy.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment> Scalar<E> {
     /// Casts a scalar from a base field, with lossy truncation.
     ///
-    /// This method is commonly-used by hash-to-scalar algorithms,
+    /// This method is commonly used by hash-to-scalar algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
         debug_assert!(E::ScalarField::size_in_bits() < E::BaseField::size_in_bits());

--- a/circuit/types/scalar/src/helpers/to_bits.rs
+++ b/circuit/types/scalar/src/helpers/to_bits.rs
@@ -36,9 +36,6 @@ impl<E: Environment> ToBits for &Scalar<E> {
     fn write_bits_le(&self, vec: &mut Vec<Self::Boolean>) {
         // Compute the bits of the scalar.
         let bits = self.bits_le.get_or_init(|| {
-            // Note: We are reconstituting the scalar field into a base field.
-            // This is safe as the scalar field modulus is less than the base field modulus,
-            // and thus will always fit within a single base field element.
             debug_assert!(console::Scalar::<E::Network>::size_in_bits() < console::Field::<E::Network>::size_in_bits());
 
             // Construct a vector of `Boolean`s comprising the bits of the scalar value.

--- a/circuit/types/scalar/src/lib.rs
+++ b/circuit/types/scalar/src/lib.rs
@@ -50,9 +50,6 @@ impl<E: Environment> Inject for Scalar<E> {
 
     /// Initializes a scalar circuit from a console scalar.
     fn new(mode: Mode, scalar: Self::Primitive) -> Self {
-        // Note: We are reconstituting the scalar field into a base field.
-        // This is safe as the scalar field modulus is less than the base field modulus,
-        // and thus will always fit within a single base field element.
         debug_assert!(console::Scalar::<E::Network>::size_in_bits() < console::Field::<E::Network>::size_in_bits());
 
         // Initialize the scalar as a field element.

--- a/console/types/integers/src/from_field_lossy.rs
+++ b/console/types/integers/src/from_field_lossy.rs
@@ -21,9 +21,6 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
     /// This method is commonly-used by hash-to-integer algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
-        // Note: We are reconstituting the integer from the base field.
-        // This is safe as the number of bits in the integer is less than the base field modulus,
-        // and thus will always fit within a single base field element.
         debug_assert!(I::BITS < Field::<E>::size_in_bits() as u64);
 
         // Truncate the field to the size of the integer domain.

--- a/console/types/integers/src/from_field_lossy.rs
+++ b/console/types/integers/src/from_field_lossy.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment, I: IntegerType> Integer<E, I> {
     /// Casts an integer from a base field, with lossy truncation.
     ///
-    /// This method is commonly-used by hash-to-integer algorithms,
+    /// This method is commonly used by hash-to-integer algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
         debug_assert!(I::BITS < Field::<E>::size_in_bits() as u64);

--- a/console/types/scalar/src/from_field_lossy.rs
+++ b/console/types/scalar/src/from_field_lossy.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment> Scalar<E> {
     /// Casts a scalar from a base field, with lossy truncation.
     ///
-    /// This method is commonly-used by hash-to-scalar algorithms,
+    /// This method is commonly used by hash-to-scalar algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
         debug_assert!(Scalar::<E>::size_in_bits() < Field::<E>::size_in_bits());

--- a/console/types/scalar/src/from_field_lossy.rs
+++ b/console/types/scalar/src/from_field_lossy.rs
@@ -21,15 +21,12 @@ impl<E: Environment> Scalar<E> {
     /// This method is commonly-used by hash-to-scalar algorithms,
     /// where the hash output does not need to preserve the full base field.
     pub fn from_field_lossy(field: &Field<E>) -> Self {
-        // Note: We are reconstituting the base field into a scalar field.
-        // This is safe as the scalar field modulus is less than the base field modulus,
-        // and thus will always fit within a single base field element.
         debug_assert!(Scalar::<E>::size_in_bits() < Field::<E>::size_in_bits());
 
         // Truncate the field to the size in data bits (1 bit less than the MODULUS) of the scalar.
         // Slicing here is safe as the base field is larger than the scalar field.
         let result = Self::from_bits_le(&field.to_bits_le()[..Scalar::<E>::size_in_data_bits()]);
-        debug_assert!(result.is_ok(), "A lossy integer should always be able to be constructed from scalar bits");
+        debug_assert!(result.is_ok(), "A lossy scalar should always be able to be constructed from field bits");
         result.unwrap()
     }
 }


### PR DESCRIPTION
There are multiple comments scattered about
to the effect of it being safe to
reconstitute one type from another as there
are more bits available to represent the first.

Some of these comments were backwards, in that
we're creating the type with fewer bits.

