### PR TITLE
[Fix] Remove `console` feature for wasm

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -30,7 +30,6 @@ crate-type = [ "cdylib", "rlib" ]
 default = [ "full" ]
 full = [
   "circuit",
-  "console",
   "curves",
   "fields",
   "ledger",
@@ -38,7 +37,6 @@ full = [
   "utilities"
 ]
 circuit = [ ]
-console = [ "snarkvm-console" ]
 curves = [ "snarkvm-curves" ]
 fields = [ "snarkvm-fields" ]
 ledger = [
@@ -53,7 +51,6 @@ dev-print = [ "snarkvm-utilities/dev-print" ]
 [dependencies.snarkvm-console]
 workspace = true
 features = [ "wasm" ]
-optional = true
 
 [dependencies.snarkvm-curves]
 workspace = true
@@ -94,6 +91,10 @@ features = [ "js" ]
 
 [dev-dependencies.wasm-bindgen-test]
 version = "0.3.37"
+
+[dev-dependencies.snarkvm-utilities]
+workspace = true
+features = [ "wasm" ]
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "console")]
 pub use snarkvm_console as console;
 #[cfg(feature = "curves")]
 pub use snarkvm_curves as curves;


### PR DESCRIPTION
#2783 removed the console feature for other crates, this PR also removes it for wasm. Further, it makes `utilities` a dev-dependency because the wasm tests rely on it.

## Outcome
Before this PR building without default features fails:
```
~> cargo clippy --workspace --all-targets --no-default-features
    Checking snarkvm-curves v3.8.0 (/Users/kaimast/dev/snarkVM/curves)
   Compiling snarkvm-algorithms-cuda v3.8.0 (/Users/kaimast/dev/snarkVM/algorithms/cuda)
    Checking snarkvm-wasm v3.8.0 (/Users/kaimast/dev/snarkVM/wasm)
error[E0433]: failed to resolve: use of undeclared crate or module `snarkvm_console`
  --> wasm/src/tests.rs:16:5
   |
16 | use snarkvm_console::{
   |     ^^^^^^^^^^^^^^^ use of undeclared crate or module `snarkvm_console`

error[E0432]: unresolved import `snarkvm_utilities`
  --> wasm/src/tests.rs:20:5
   |
20 | use snarkvm_utilities::TestRng;
   |     ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `snarkvm_utilities`

warning: unused import: `core::str::FromStr`
  --> wasm/src/tests.rs:22:5
   |
22 | use core::str::FromStr;
   |     ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
warning: `snarkvm-wasm` (lib test) generated 1 warning
error: could not compile `snarkvm-wasm` (lib test) due to 2 previous errors; 1 warning emitted
```

After this PR, things work as expected:
```
~> cargo clippy --workspace --all-targets --no-default-features
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.39s
```

## Notes
We should consider adding a check for building for a WebAssembly target and a check for building without default features to CI.