### PR TITLE
[Feature] Improve Error Handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - run_test: # This runs a single test with profiler enabled
           workspace_member: snarkvm-algorithms
           flags: varuna::prove_and_verify_with_square_matrix --features profiler
-          cache_key_suffix: -profiler
+          cache_key_suffix: -profiler-test
   
   circuit:
     executor: rust-docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,9 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"
@@ -292,9 +295,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "blake2"
@@ -382,9 +385,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",
@@ -563,7 +566,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "log",
  "serde",
  "serde_derive",
@@ -1003,9 +1006,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1172,7 +1175,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1448,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1479,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1504,11 +1507,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -1570,9 +1573,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -1628,7 +1631,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
 ]
 
@@ -1950,7 +1953,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2031,9 +2034,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2138,13 +2141,13 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2179,7 +2182,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -2200,7 +2203,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2354,7 +2357,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -2370,14 +2373,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2391,13 +2394,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2408,9 +2411,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -2515,7 +2518,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2528,7 +2531,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2646,7 +2649,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2725,7 +2728,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2750,7 +2753,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "ryu",
  "serde",
@@ -2866,7 +2869,7 @@ dependencies = [
  "snarkvm-utilities",
  "snarkvm-wasm",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "ureq",
  "walkdir",
 ]
@@ -2885,7 +2888,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -2900,7 +2903,7 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2968,7 +2971,7 @@ name = "snarkvm-circuit-environment"
 version = "4.1.0"
 dependencies = [
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -3159,7 +3162,7 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "snarkvm-console-algorithms",
  "snarkvm-console-network",
@@ -3172,7 +3175,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "lazy_static",
  "paste",
  "serde",
@@ -3210,7 +3213,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "num-derive",
  "num-traits",
  "serde_json",
@@ -3330,7 +3333,7 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3347,7 +3350,7 @@ dependencies = [
  "serde",
  "snarkvm-curves",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -3359,7 +3362,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3402,7 +3405,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -3420,6 +3423,7 @@ dependencies = [
  "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3428,7 +3432,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3461,7 +3465,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3475,7 +3479,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3501,7 +3505,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3543,7 +3547,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3563,7 +3567,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3602,7 +3606,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3629,6 +3633,7 @@ name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
 dependencies = [
  "aleo-std",
+ "anyhow",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -3637,6 +3642,7 @@ dependencies = [
  "snarkvm-ledger-store",
  "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-program",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3673,7 +3679,7 @@ dependencies = [
  "snarkvm-ledger-store",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "wasm-bindgen-test",
  "web-sys",
 ]
@@ -3686,7 +3692,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "locktick",
  "lru",
@@ -3725,7 +3731,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3752,7 +3758,7 @@ version = "4.1.0"
 dependencies = [
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3794,7 +3800,8 @@ dependencies = [
  "serde_json",
  "smol_str",
  "snarkvm-utilities-derives",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
+ "tracing",
  "zeroize",
 ]
 
@@ -3962,7 +3969,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4013,11 +4020,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.15",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -4033,9 +4040,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4215,7 +4222,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytes",
  "futures-util",
  "http",
@@ -4404,13 +4411,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4879,7 +4887,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -694,7 +694,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.6.0",
+ "socket2",
  "windows-sys 0.59.0",
 ]
 
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width",
 ]
@@ -1147,7 +1147,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1355,7 +1355,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1840,12 +1840,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1992,12 +1991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,9 +2085,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -2147,7 +2140,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
- "regex-syntax 0.8.6",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2170,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2181,7 +2174,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -2190,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -2211,16 +2204,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2379,17 +2372,8 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2400,14 +2384,8 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3832,16 +3810,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -4155,7 +4123,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "windows-sys 0.59.0",
 ]
 
@@ -4291,14 +4259,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -4499,11 +4467,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4882,13 +4850,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.3",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ name = "snarkvm-ledger-block"
 version = "4.1.0"
 dependencies = [
  "aleo-std",
+ "anyhow",
  "bincode",
  "indexmap 2.10.0",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -439,6 +439,7 @@ version = "1.0.1"
 
 [workspace.dependencies.anyhow]
 version = "1.0.73"
+features = ["backtrace"]
 
 [workspace.dependencies.bincode]
 version = "1.3.3"

--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ snarkvm
 Alternatively, you can install `snarkvm` by building from the source code as follows:
 
 ```bash
-# Download the source code
-git clone --branch mainnet --single-branch https://github.com/ProvableHQ/snarkVM.git 
+# Fetch the repository's development (staging) branch
+git clone --branch staging --single-branch https://github.com/ProvableHQ/snarkVM.git 
 cd snarkVM
-git checkout tags/testnet-beta
+# Optional: pick a specific release of snarkOS
+git checkout v3.8.0
 # Install snarkVM
-cargo install --path .
+cargo install --path . --features=cli
 ```
 
 Now to use `snarkvm`, in your terminal, run:

--- a/algorithms/src/polycommit/kzg10/data_structures.rs
+++ b/algorithms/src/polycommit/kzg10/data_structures.rs
@@ -24,6 +24,7 @@ use snarkvm_utilities::{
     FromBytes,
     ToBytes,
     error,
+    into_io_error,
     serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate},
 };
 
@@ -424,13 +425,15 @@ impl<E: PairingEngine> KZGProof<E> {
 
 impl<E: PairingEngine> FromBytes for KZGProof<E> {
     fn read_le<R: Read>(mut reader: R) -> io::Result<Self> {
-        CanonicalDeserialize::deserialize_compressed(&mut reader).map_err(|_| error("could not deserialize KZG proof"))
+        CanonicalDeserialize::deserialize_compressed(&mut reader)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize KZG proof")))
     }
 }
 
 impl<E: PairingEngine> ToBytes for KZGProof<E> {
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        CanonicalSerialize::serialize_compressed(self, &mut writer).map_err(|_| error("could not serialize KZG proof"))
+        CanonicalSerialize::serialize_compressed(self, &mut writer)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not serialize KZG proof")))
     }
 }
 

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -18,7 +18,7 @@ use crate::{crypto_hash::sha256::sha256, fft::EvaluationDomain, polycommit::kzg1
 use snarkvm_curves::PairingEngine;
 use snarkvm_fields::{ConstraintFieldError, Field, PrimeField, ToConstraintField};
 use snarkvm_parameters::mainnet::MAX_NUM_POWERS;
-use snarkvm_utilities::{FromBytes, ToBytes, error, serialize::*};
+use snarkvm_utilities::{FromBytes, ToBytes, error, into_io_error, serialize::*};
 
 use hashbrown::HashMap;
 use std::{
@@ -683,12 +683,14 @@ impl<E: PairingEngine> BatchLCProof<E> {
 
 impl<E: PairingEngine> FromBytes for BatchLCProof<E> {
     fn read_le<R: Read>(mut reader: R) -> io::Result<Self> {
-        CanonicalDeserialize::deserialize_compressed(&mut reader).map_err(|_| error("could not deserialize struct"))
+        CanonicalDeserialize::deserialize_compressed(&mut reader)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize struct")))
     }
 }
 
 impl<E: PairingEngine> ToBytes for BatchLCProof<E> {
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        CanonicalSerialize::serialize_compressed(self, &mut writer).map_err(|_| error("could not serialize struct"))
+        CanonicalSerialize::serialize_compressed(self, &mut writer)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not serialize struct")))
     }
 }

--- a/algorithms/src/snark/varuna/ahp/prover/message.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/message.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, io};
 
 use crate::snark::varuna::{CircuitId, verifier::BatchCombiners};
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{ToBytes, Write, error, serialize::*};
+use snarkvm_utilities::{ToBytes, Write, into_io_error, serialize::*};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct MatrixSums<F: PrimeField> {
@@ -58,7 +58,8 @@ impl<F: PrimeField> ThirdMessage<F> {
 
 impl<F: PrimeField> ToBytes for ThirdMessage<F> {
     fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
-        CanonicalSerialize::serialize_compressed(self, &mut w).map_err(|_| error("Could not serialize ThirdMessage"))
+        CanonicalSerialize::serialize_compressed(self, &mut w)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("Could not serialize ThirdMessage")))
     }
 }
 
@@ -70,6 +71,7 @@ pub struct FourthMessage<F: PrimeField> {
 
 impl<F: PrimeField> ToBytes for FourthMessage<F> {
     fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
-        CanonicalSerialize::serialize_compressed(self, &mut w).map_err(|_| error("Could not serialize FourthMessage"))
+        CanonicalSerialize::serialize_compressed(self, &mut w)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("Could not serialize FourthMessage")))
     }
 }

--- a/algorithms/src/snark/varuna/data_structures/certificate.rs
+++ b/algorithms/src/snark/varuna/data_structures/certificate.rs
@@ -15,7 +15,7 @@
 
 use crate::polycommit::sonic_pc;
 use snarkvm_curves::PairingEngine;
-use snarkvm_utilities::{FromBytes, ToBytes, error, serialize::*};
+use snarkvm_utilities::{FromBytes, ToBytes, into_io_error, serialize::*};
 use std::io::{self, Read, Write};
 
 /// A certificate for the verifying key.
@@ -34,12 +34,14 @@ impl<E: PairingEngine> Certificate<E> {
 
 impl<E: PairingEngine> ToBytes for Certificate<E> {
     fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
-        Self::serialize_compressed(self, &mut w).map_err(|_| error("Failed to serialize certificate"))
+        Self::serialize_compressed(self, &mut w)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("Failed to serialize certificate")))
     }
 }
 
 impl<E: PairingEngine> FromBytes for Certificate<E> {
     fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
-        Self::deserialize_compressed(&mut r).map_err(|_| error("Failed to deserialize certificate"))
+        Self::deserialize_compressed(&mut r)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("Failed to deserialize certificate")))
     }
 }

--- a/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
@@ -15,7 +15,7 @@
 
 use crate::{polycommit::sonic_pc, snark::varuna::ahp::indexer::*};
 use snarkvm_curves::PairingEngine;
-use snarkvm_utilities::{FromBytes, FromBytesDeserializer, ToBytes, ToBytesSerializer, error, serialize::*};
+use snarkvm_utilities::{FromBytes, FromBytesDeserializer, ToBytes, ToBytesSerializer, into_io_error, serialize::*};
 
 use anyhow::Result;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -40,13 +40,15 @@ pub struct CircuitVerifyingKey<E: PairingEngine> {
 
 impl<E: PairingEngine> FromBytes for CircuitVerifyingKey<E> {
     fn read_le<R: Read>(r: R) -> io::Result<Self> {
-        Self::deserialize_compressed(r).map_err(|_| error("could not deserialize CircuitVerifyingKey"))
+        Self::deserialize_compressed(r)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize CircuitVerifyingKey")))
     }
 }
 
 impl<E: PairingEngine> ToBytes for CircuitVerifyingKey<E> {
     fn write_le<W: Write>(&self, w: W) -> io::Result<()> {
-        self.serialize_compressed(w).map_err(|_| error("could not serialize CircuitVerifyingKey"))
+        self.serialize_compressed(w)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not serialize CircuitVerifyingKey")))
     }
 }
 

--- a/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
@@ -16,15 +16,16 @@
 use crate::{polycommit::sonic_pc, snark::varuna::ahp::indexer::*};
 use snarkvm_curves::PairingEngine;
 use snarkvm_utilities::{FromBytes, FromBytesDeserializer, ToBytes, ToBytesSerializer, error, serialize::*};
-use std::{
-    io::{self, Read, Write},
-    string::String,
-};
 
 use anyhow::Result;
-use core::{fmt, str::FromStr};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
-use std::cmp::Ordering;
+use std::{
+    cmp::Ordering,
+    fmt,
+    io::{self, Read, Write},
+    str::FromStr,
+    string::String,
+};
 
 /// Verification key for a specific index (i.e., R1CS matrices).
 #[derive(Debug, Clone, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -23,9 +23,11 @@ use ahp::prover::{FourthMessage, ThirdMessage};
 use snarkvm_curves::PairingEngine;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{FromBytes, ToBytes, error, serialize::*};
-use std::io::{self, Read, Write};
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    io::{self, Read, Write},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Commitments<E: PairingEngine> {

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -22,7 +22,7 @@ use crate::{
 use ahp::prover::{FourthMessage, ThirdMessage};
 use snarkvm_curves::PairingEngine;
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{FromBytes, ToBytes, error, serialize::*};
+use snarkvm_utilities::{FromBytes, ToBytes, into_io_error, serialize::*};
 
 use std::{
     collections::BTreeMap,
@@ -366,13 +366,15 @@ impl<E: PairingEngine> CanonicalDeserialize for Proof<E> {
 
 impl<E: PairingEngine> ToBytes for Proof<E> {
     fn write_le<W: Write>(&self, mut w: W) -> io::Result<()> {
-        Self::serialize_compressed(self, &mut w).map_err(|_| error("could not serialize Proof"))
+        Self::serialize_compressed(self, &mut w)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not serialize Proof")))
     }
 }
 
 impl<E: PairingEngine> FromBytes for Proof<E> {
     fn read_le<R: Read>(mut r: R) -> io::Result<Self> {
-        Self::deserialize_compressed(&mut r).map_err(|_| error("could not deserialize Proof"))
+        Self::deserialize_compressed(&mut r)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize Proof")))
     }
 }
 

--- a/console/account/src/compute_key/bytes.rs
+++ b/console/account/src/compute_key/bytes.rs
@@ -19,11 +19,9 @@ impl<N: Network> FromBytes for ComputeKey<N> {
     /// Reads an account compute key from a buffer.
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let pk_sig =
-            Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(|e| error(format!("{e}")))?;
-        let pr_sig =
-            Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(|e| error(format!("{e}")))?;
-        Self::try_from((pk_sig, pr_sig)).map_err(|e| error(format!("{e}")))
+        let pk_sig = Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(error)?;
+        let pr_sig = Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(error)?;
+        Self::try_from((pk_sig, pr_sig)).map_err(error)
     }
 }
 

--- a/console/account/src/compute_key/bytes.rs
+++ b/console/account/src/compute_key/bytes.rs
@@ -19,9 +19,9 @@ impl<N: Network> FromBytes for ComputeKey<N> {
     /// Reads an account compute key from a buffer.
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let pk_sig = Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(error)?;
-        let pr_sig = Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(error)?;
-        Self::try_from((pk_sig, pr_sig)).map_err(error)
+        let pk_sig = Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(into_io_error)?;
+        let pr_sig = Group::from_x_coordinate(Field::new(N::Field::read_le(&mut reader)?)).map_err(into_io_error)?;
+        Self::try_from((pk_sig, pr_sig)).map_err(into_io_error)
     }
 }
 

--- a/console/account/src/graph_key/bytes.rs
+++ b/console/account/src/graph_key/bytes.rs
@@ -19,8 +19,8 @@ impl<N: Network> FromBytes for GraphKey<N> {
     /// Reads an account graph key from a buffer.
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let sk_tag = Field::<N>::read_le(&mut reader).map_err(error)?;
-        Self::try_from(sk_tag).map_err(error)
+        let sk_tag = Field::<N>::read_le(&mut reader).map_err(into_io_error)?;
+        Self::try_from(sk_tag).map_err(into_io_error)
     }
 }
 

--- a/console/account/src/graph_key/bytes.rs
+++ b/console/account/src/graph_key/bytes.rs
@@ -19,8 +19,8 @@ impl<N: Network> FromBytes for GraphKey<N> {
     /// Reads an account graph key from a buffer.
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        let sk_tag = Field::<N>::read_le(&mut reader).map_err(|e| error(format!("{e}")))?;
-        Self::try_from(sk_tag).map_err(|e| error(format!("{e}")))
+        let sk_tag = Field::<N>::read_le(&mut reader).map_err(error)?;
+        Self::try_from(sk_tag).map_err(error)
     }
 }
 

--- a/console/account/src/private_key/bytes.rs
+++ b/console/account/src/private_key/bytes.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> FromBytes for PrivateKey<N> {
     /// Reads an account private key from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        Self::try_from(Field::new(FromBytes::read_le(&mut reader)?)).map_err(|e| error(format!("{e}")))
+        Self::try_from(Field::new(FromBytes::read_le(&mut reader)?)).map_err(error)
     }
 }
 

--- a/console/account/src/private_key/bytes.rs
+++ b/console/account/src/private_key/bytes.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> FromBytes for PrivateKey<N> {
     /// Reads an account private key from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
-        Self::try_from(Field::new(FromBytes::read_le(&mut reader)?)).map_err(error)
+        Self::try_from(Field::new(FromBytes::read_le(&mut reader)?)).map_err(into_io_error)
     }
 }
 

--- a/console/account/src/private_key/string.rs
+++ b/console/account/src/private_key/string.rs
@@ -30,7 +30,7 @@ impl<N: Network> FromStr for PrivateKey<N> {
             bail!("Invalid account private key prefix: found {:?}, expected {:?}", &data[0..11], PRIVATE_KEY_PREFIX)
         }
         // Output the private key.
-        Ok(Self::try_from(Field::new(FromBytes::read_le(&data[11..43])?)).map_err(|e| error(format!("{e}")))?)
+        Ok(Self::try_from(Field::new(FromBytes::read_le(&data[11..43])?)).map_err(error)?)
     }
 }
 

--- a/console/account/src/private_key/string.rs
+++ b/console/account/src/private_key/string.rs
@@ -30,7 +30,7 @@ impl<N: Network> FromStr for PrivateKey<N> {
             bail!("Invalid account private key prefix: found {:?}, expected {:?}", &data[0..11], PRIVATE_KEY_PREFIX)
         }
         // Output the private key.
-        Ok(Self::try_from(Field::new(FromBytes::read_le(&data[11..43])?)).map_err(error)?)
+        Ok(Self::try_from(Field::new(FromBytes::read_le(&data[11..43])?)).map_err(into_io_error)?)
     }
 }
 

--- a/console/collections/src/kary_merkle_tree/path/mod.rs
+++ b/console/collections/src/kary_merkle_tree/path/mod.rs
@@ -132,7 +132,7 @@ impl<PH: PathHash, const DEPTH: u8, const ARITY: u8> FromBytes for KaryMerklePat
             .map(|_| (0..ARITY).map(|_| FromBytes::read_le(&mut reader)).collect::<IoResult<Vec<_>>>())
             .collect::<IoResult<Vec<_>>>()?;
         // Return the Merkle path.
-        Self::try_from((leaf_index, siblings)).map_err(error)
+        Self::try_from((leaf_index, siblings)).map_err(into_io_error)
     }
 }
 

--- a/console/collections/src/merkle_tree/path/mod.rs
+++ b/console/collections/src/merkle_tree/path/mod.rs
@@ -117,7 +117,7 @@ impl<E: Environment, const DEPTH: u8> FromBytes for MerklePath<E, DEPTH> {
         let siblings =
             (0..DEPTH).map(|_| Ok(Field::new(FromBytes::read_le(&mut reader)?))).collect::<IoResult<Vec<_>>>()?;
         // Return the Merkle path.
-        Self::try_from((U64::new(leaf_index), siblings)).map_err(error)
+        Self::try_from((U64::new(leaf_index), siblings)).map_err(into_io_error)
     }
 }
 

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -89,6 +89,8 @@ pub mod prelude {
         cfg_zip_fold,
         error,
         has_duplicates,
+        into_io_error,
+        io_error,
     };
 
     pub use std::io::{Read, Result as IoResult, Write};

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -42,17 +42,21 @@ pub use testnet_v0::*;
 pub mod prelude {
     pub use crate::{
         CANARY_V0_CONSENSUS_VERSION_HEIGHTS,
+        CanaryV0,
         ConsensusVersion,
         MAINNET_V0_CONSENSUS_VERSION_HEIGHTS,
+        MainnetV0,
         Network,
         TEST_CONSENSUS_VERSION_HEIGHTS,
         TESTNET_V0_CONSENSUS_VERSION_HEIGHTS,
+        TestnetV0,
         consensus_config_value,
         environment::prelude::*,
     };
 }
 
-use crate::environment::prelude::*;
+pub use crate::environment::prelude::*;
+
 use snarkvm_algorithms::{
     AlgebraicSponge,
     crypto_hash::PoseidonSponge,

--- a/console/program/src/id/bytes.rs
+++ b/console/program/src/id/bytes.rs
@@ -20,7 +20,7 @@ impl<N: Network> FromBytes for ProgramID<N> {
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let name = FromBytes::read_le(&mut reader)?;
         let network = FromBytes::read_le(&mut reader)?;
-        Self::try_from((name, network)).map_err(error)
+        Self::try_from((name, network)).map_err(into_io_error)
     }
 }
 

--- a/console/program/src/id/bytes.rs
+++ b/console/program/src/id/bytes.rs
@@ -20,7 +20,7 @@ impl<N: Network> FromBytes for ProgramID<N> {
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let name = FromBytes::read_le(&mut reader)?;
         let network = FromBytes::read_le(&mut reader)?;
-        Self::try_from((name, network)).map_err(|e| error(format!("{e}")))
+        Self::try_from((name, network)).map_err(error)
     }
 }
 

--- a/console/types/string/src/bytes.rs
+++ b/console/types/string/src/bytes.rs
@@ -29,7 +29,7 @@ impl<E: Environment> FromBytes for StringType<E> {
         let mut bytes = vec![0u8; num_bytes as usize];
         reader.read_exact(&mut bytes)?;
         // Return the string.
-        Ok(Self::new(&String::from_utf8(bytes).map_err(|e| error(e.to_string()))?))
+        Ok(Self::new(&String::from_utf8(bytes).map_err(error)?))
     }
 }
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -57,11 +57,19 @@ serial = [
   "snarkvm-ledger-store/serial",
   "snarkvm-synthesizer/serial"
 ]
-test = [ "snarkvm-console/test", "snarkvm-ledger-block/test", "snarkvm-ledger-store/test", "snarkvm-synthesizer/test" ]
+test = [
+  "snarkvm-console/test",
+  "snarkvm-ledger-block/test",
+  "snarkvm-ledger-store/test",
+  "snarkvm-synthesizer/test"
+]
 test-helpers = [
   "snarkvm-ledger-test-helpers",
   "snarkvm-ledger-committee/test-helpers",
   "snarkvm-ledger-narwhal/test-helpers"
+]
+test_targets = [
+  "snarkvm-console/test_targets",
 ]
 timer = [ "aleo-std/timer" ]
 

--- a/ledger/benches/block.rs
+++ b/ledger/benches/block.rs
@@ -25,7 +25,10 @@ type CurrentNetwork = MainnetV0;
 
 /// Loads the genesis block.
 fn load_genesis_block() -> Block<CurrentNetwork> {
-    Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap()
+    match Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()) {
+        Ok(block) => block,
+        Err(err) => panic!("Failed to load genesis block: {err:?}"),
+    }
 }
 
 /// Helper method to benchmark serialization.

--- a/ledger/benches/block.rs
+++ b/ledger/benches/block.rs
@@ -18,6 +18,7 @@ extern crate criterion;
 
 use snarkvm_console::{network::MainnetV0, prelude::*};
 use snarkvm_ledger_block::Block;
+use snarkvm_utilities::PrettyUnwrap;
 
 use criterion::Criterion;
 
@@ -25,10 +26,7 @@ type CurrentNetwork = MainnetV0;
 
 /// Loads the genesis block.
 fn load_genesis_block() -> Block<CurrentNetwork> {
-    match Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()) {
-        Ok(block) => block,
-        Err(err) => panic!("Failed to load genesis block: {err:?}"),
-    }
+    Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).pretty_unwrap()
 }
 
 /// Helper method to benchmark serialization.

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -68,6 +68,9 @@ workspace = true
 [dependencies.snarkvm-synthesizer-snark]
 workspace = true
 
+[dependencies.snarkvm-utilities]
+workspace = true
+
 [dependencies.anyhow]
 version = "1"
 

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -68,6 +68,9 @@ workspace = true
 [dependencies.snarkvm-synthesizer-snark]
 workspace = true
 
+[dependencies.anyhow]
+version = "1"
+
 [dependencies.indexmap]
 workspace = true
 features = [ "serde" ]

--- a/ledger/block/src/genesis.rs
+++ b/ledger/block/src/genesis.rs
@@ -20,25 +20,32 @@ impl<N: Network> Block<N> {
     pub const NUM_GENESIS_TRANSACTIONS: usize = 4;
 
     /// Returns `true` if the block is a genesis block.
-    pub fn is_genesis(&self) -> bool {
-        // Ensure the previous block hash is zero.
-        self.previous_hash == N::BlockHash::default()
-            // Ensure the header is a genesis block header.
-            && self.header.is_genesis()
-            // Ensure the genesis authority is a beacon.
-            && self.authority.is_beacon()
-            // Ensure there is the correct number of ratification operations in the genesis block.
-            && self.ratifications.len() == 1
-            // Ensure there are no solutions in the genesis block.
-            && self.solutions.is_empty()
-            // Ensure there is the correct number of accepted transaction in the genesis block.
-            && self.transactions.num_accepted() == Self::NUM_GENESIS_TRANSACTIONS
-            // Ensure there is the correct number of rejected transaction in the genesis block.
-            && self.transactions.num_rejected() == 0
-            // Ensure there is the correct number of finalize operations in the genesis block.
-            && self.transactions.num_finalize() == 2 * Self::NUM_GENESIS_TRANSACTIONS
-            // Ensure there are no aborted transaction IDs in the genesis block.
-            && self.aborted_transaction_ids.is_empty()
+    pub fn is_genesis(&self) -> Result<bool> {
+        if !self.header.is_genesis()? {
+            return Ok(false);
+        }
+
+        ensure!(self.previous_hash == N::BlockHash::default(), "Invalid previous hash");
+        ensure!(self.authority.is_beacon(), "Invalid block authority");
+        ensure!(self.solutions.is_empty(), "Invalid solutins");
+        ensure!(self.transactions.num_rejected() == 0, "Invalid number of rejected transactions");
+        ensure!(self.aborted_transaction_ids.is_empty(), "Genesis block must not contain aborted transactions");
+
+        // Perform additional checks in production
+        #[cfg(not(any(test, feature = "test")))]
+        {
+            ensure!(self.ratifications.len() == 1, "Invalid number of ratifications");
+            ensure!(
+                self.transactions.num_accepted() == Self::NUM_GENESIS_TRANSACTIONS,
+                "Invalid number of accepted transactions"
+            );
+            ensure!(
+                self.transactions.num_finalize() == 2 * Self::NUM_GENESIS_TRANSACTIONS,
+                "Invalid number of finalized transactions"
+            );
+        }
+
+        Ok(true)
     }
 }
 
@@ -53,6 +60,6 @@ mod tests {
     fn test_genesis() {
         // Load the genesis block.
         let genesis_block = Block::<CurrentNetwork>::read_le(CurrentNetwork::genesis_bytes()).unwrap();
-        assert!(genesis_block.is_genesis());
+        assert!(genesis_block.is_genesis().unwrap());
     }
 }

--- a/ledger/block/src/header/bytes.rs
+++ b/ledger/block/src/header/bytes.rs
@@ -45,7 +45,7 @@ impl<N: Network> FromBytes for Header<N> {
             subdag_root,
             metadata,
         )
-        .map_err(|e| error(e.to_string()))
+        .map_err(|e| error(format!("{e:#?}")))
     }
 }
 

--- a/ledger/block/src/header/genesis.rs
+++ b/ledger/block/src/header/genesis.rs
@@ -49,21 +49,22 @@ impl<N: Network> Header<N> {
     }
 
     /// Returns `true` if the block header is a genesis block header.
-    pub fn is_genesis(&self) -> bool {
-        // Ensure the previous ledger root is zero.
-        *self.previous_state_root == Field::zero()
-            // Ensure the transactions root is nonzero.
-            && self.transactions_root != Field::zero()
-            // Ensure the finalize root is nonzero.
-            && self.finalize_root != Field::zero()
-            // Ensure the ratifications root is nonzero.
-            && self.ratifications_root != Field::zero()
-            // Ensure the solutions root is zero.
-            && self.solutions_root == Field::zero()
-            // Ensure the subdag root is zero.
-            && self.subdag_root == Field::zero()
-            // Ensure the metadata is a genesis metadata.
-            && self.metadata.is_genesis()
+    ///
+    /// Return an error if the header is malformed.
+    pub fn is_genesis(&self) -> Result<bool> {
+        if !self.metadata.is_genesis()? {
+            return Ok(false);
+        }
+
+        // Ensure the header is valid otherwise
+        ensure!(*self.previous_state_root == Field::zero(), "Invalid previous state root");
+        ensure!(self.transactions_root != Field::zero(), "Invalid transactions root");
+        ensure!(self.finalize_root != Field::zero(), "Invalid finalize root");
+        ensure!(self.ratifications_root != Field::zero(), "Invalid ratifications root");
+        ensure!(self.solutions_root == Field::zero(), "Invalid solutions root");
+        ensure!(self.subdag_root == Field::zero(), "Invalid subdag root");
+
+        Ok(true)
     }
 }
 
@@ -104,7 +105,7 @@ mod tests {
         // Prepare the genesis block header.
         let header = crate::header::test_helpers::sample_block_header(rng);
         // Ensure the block header is a genesis block header.
-        assert!(header.is_genesis());
+        assert!(header.is_genesis().unwrap());
 
         // Ensure the genesis block contains the following.
         assert_eq!(*header.previous_state_root(), Field::zero());

--- a/ledger/block/src/header/merkle.rs
+++ b/ledger/block/src/header/merkle.rs
@@ -133,8 +133,10 @@ mod tests {
                     u64::rand(rng),
                     rng.gen_range(0..i64::MAX),
                     rng.gen_range(0..i64::MAX),
-                )?,
-            )?;
+                )
+                .with_context(|| "Failed to generate block metadata")?,
+            )
+            .with_context(|| "Failed to create block header")?;
 
             // Compute the header root.
             let root = header.to_root()?;

--- a/ledger/block/src/header/metadata/bytes.rs
+++ b/ledger/block/src/header/metadata/bytes.rs
@@ -51,7 +51,7 @@ impl<N: Network> FromBytes for Metadata<N> {
             last_coinbase_timestamp,
             timestamp,
         )
-        .map_err(|e| error(e.to_string()))
+        .map_err(into_io_error)
     }
 }
 

--- a/ledger/block/src/header/metadata/genesis.rs
+++ b/ledger/block/src/header/metadata/genesis.rs
@@ -15,34 +15,29 @@
 
 use super::*;
 
+use snarkvm_utilities::ensure_equals;
+
+const GENESIS_ROUND: u64 = 0;
+const GENESIS_HEIGHT: u32 = 0;
+const GENESIS_CUMULATIVE_WEIGHT: u128 = 0;
+const GENESIS_CUMULATIVE_PROOF_TARGET: u128 = 0;
+
 impl<N: Network> Metadata<N> {
     /// Initializes the genesis metadata.
     pub fn genesis() -> Result<Self> {
-        // Prepare a genesis metadata.
-        let network = N::ID;
-        let round = 0;
-        let height = 0;
-        let cumulative_weight = 0;
-        let cumulative_proof_target = 0;
-        let coinbase_target = N::GENESIS_COINBASE_TARGET;
-        let proof_target = N::GENESIS_PROOF_TARGET;
-        let last_coinbase_target = N::GENESIS_COINBASE_TARGET;
-        let last_coinbase_timestamp = N::GENESIS_TIMESTAMP;
-        let timestamp = N::GENESIS_TIMESTAMP;
-
-        // Return the genesis metadata.
         Self::new(
-            network,
-            round,
-            height,
-            cumulative_weight,
-            cumulative_proof_target,
-            coinbase_target,
-            proof_target,
-            last_coinbase_target,
-            last_coinbase_timestamp,
-            timestamp,
+            N::ID,
+            GENESIS_ROUND,
+            GENESIS_HEIGHT,
+            GENESIS_CUMULATIVE_WEIGHT,
+            GENESIS_CUMULATIVE_PROOF_TARGET,
+            N::GENESIS_COINBASE_TARGET,
+            N::GENESIS_PROOF_TARGET,
+            N::GENESIS_COINBASE_TARGET,
+            N::GENESIS_TIMESTAMP,
+            N::GENESIS_TIMESTAMP,
         )
+        .with_context(|| "Failed to create genesis block")
     }
 
     /// Returns `true` if the metadata is a genesis metadata.i
@@ -55,15 +50,30 @@ impl<N: Network> Metadata<N> {
         }
 
         // Check the genesis block header is valid otherwise.
+        // We cannot call `Self::check_validity` here as that function calls `is_genesis` internally.
         ensure!(self.network == N::ID, "Invalid network ID");
-        ensure!(self.round == 0, "Invalid round");
-        ensure!(self.cumulative_weight == 0u128, "Invalid cumulative weight");
-        ensure!(self.cumulative_proof_target == 0u128, "Invalid proof target");
-        ensure!(self.coinbase_target == N::GENESIS_COINBASE_TARGET, "Invalid coinbase target");
-        ensure!(self.proof_target == N::GENESIS_PROOF_TARGET, "Invalid proof target");
-        ensure!(self.last_coinbase_target == N::GENESIS_COINBASE_TARGET, "Invalid last coinbase target");
-        ensure!(self.last_coinbase_timestamp == N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
-        ensure!(self.timestamp == N::GENESIS_TIMESTAMP, "Invalid timestamp");
+        ensure!(self.round == GENESIS_ROUND, "Genesis block not at genesis round");
+        ensure!(self.height == GENESIS_HEIGHT, "Genesis block not at genesis height");
+
+        ensure_equals!(self.cumulative_weight, GENESIS_CUMULATIVE_WEIGHT, "Invalid cumulative weight");
+        ensure_equals!(
+            self.cumulative_proof_target,
+            GENESIS_CUMULATIVE_PROOF_TARGET,
+            "Invalid cumulative proof target"
+        );
+        ensure_equals!(self.last_coinbase_timestamp, N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
+        ensure_equals!(self.last_coinbase_timestamp, N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
+        ensure_equals!(
+            self.coinbase_target,
+            N::GENESIS_COINBASE_TARGET,
+            "Invalid coinsbase target for genesis block expected {expected}."
+        );
+        ensure_equals!(
+            self.last_coinbase_target,
+            N::GENESIS_COINBASE_TARGET,
+            "Invalid last coinbase target for genesis block"
+        );
+        ensure_equals!(self.proof_target, N::GENESIS_PROOF_TARGET, "Invalid proof target for genesis block");
 
         Ok(true)
     }

--- a/ledger/block/src/header/metadata/genesis.rs
+++ b/ledger/block/src/header/metadata/genesis.rs
@@ -40,7 +40,7 @@ impl<N: Network> Metadata<N> {
         .with_context(|| "Failed to create genesis block")
     }
 
-    /// Returns `true` if the metadata is a genesis metadata.i
+    /// Returns `true` if the metadata is a genesis metadata.
     ///
     /// Return an error if the block is at height 0 but not a valid genesis header.
     pub fn is_genesis(&self) -> Result<bool> {
@@ -61,7 +61,7 @@ impl<N: Network> Metadata<N> {
             GENESIS_CUMULATIVE_PROOF_TARGET,
             "Invalid cumulative proof target"
         );
-        ensure_equals!(self.last_coinbase_timestamp, N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
+        ensure_equals!(self.timestamp, N::GENESIS_TIMESTAMP, "Invalid timestamp");
         ensure_equals!(self.last_coinbase_timestamp, N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
         ensure_equals!(
             self.coinbase_target,

--- a/ledger/block/src/header/metadata/genesis.rs
+++ b/ledger/block/src/header/metadata/genesis.rs
@@ -45,28 +45,27 @@ impl<N: Network> Metadata<N> {
         )
     }
 
-    /// Returns `true` if the metadata is a genesis metadata.
-    pub fn is_genesis(&self) -> bool {
-        // Ensure the network ID is correct.
-        self.network == N::ID
-            // Ensure the round in the genesis block is 0.
-            && self.round == 0u64
-            // Ensure the height in the genesis block is 0.
-            && self.height == 0u32
-            // Ensure the cumulative weight in the genesis block is 0.
-            && self.cumulative_weight == 0u128
-            // Ensure the cumulative proof target in the genesis block is 0.
-            && self.cumulative_proof_target == 0u128
-            // Ensure the coinbase target in the genesis block is `GENESIS_COINBASE_TARGET`.
-            && self.coinbase_target == N::GENESIS_COINBASE_TARGET
-            // Ensure the proof target in the genesis block is `GENESIS_PROOF_TARGET`.
-            && self.proof_target == N::GENESIS_PROOF_TARGET
-            // Ensure the last coinbase target in the genesis block is `GENESIS_COINBASE_TARGET`.
-            && self.last_coinbase_target == N::GENESIS_COINBASE_TARGET
-            // Ensure the last coinbase timestamp in the genesis block is `GENESIS_TIMESTAMP`.
-            && self.last_coinbase_timestamp == N::GENESIS_TIMESTAMP
-            // Ensure the timestamp in the genesis block is `GENESIS_TIMESTAMP`.
-            && self.timestamp == N::GENESIS_TIMESTAMP
+    /// Returns `true` if the metadata is a genesis metadata.i
+    ///
+    /// Return an error if the block is at height 0 but not a valid genesis header.
+    pub fn is_genesis(&self) -> Result<bool> {
+        // Only blocks at height 0 are genesis blocks.
+        if self.round != 0u64 {
+            return Ok(false);
+        }
+
+        // Check the genesis block header is valid otherwise.
+        ensure!(self.network == N::ID, "Invalid network ID");
+        ensure!(self.round == 0, "Invalid round");
+        ensure!(self.cumulative_weight == 0u128, "Invalid cumulative weight");
+        ensure!(self.cumulative_proof_target == 0u128, "Invalid proof target");
+        ensure!(self.coinbase_target == N::GENESIS_COINBASE_TARGET, "Invalid coinbase target");
+        ensure!(self.proof_target == N::GENESIS_PROOF_TARGET, "Invalid proof target");
+        ensure!(self.last_coinbase_target == N::GENESIS_COINBASE_TARGET, "Invalid last coinbase target");
+        ensure!(self.last_coinbase_timestamp == N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
+        ensure!(self.timestamp == N::GENESIS_TIMESTAMP, "Invalid timestamp");
+
+        Ok(true)
     }
 }
 
@@ -105,7 +104,7 @@ mod tests {
         // Prepare the genesis metadata.
         let metadata = crate::header::metadata::test_helpers::sample_block_metadata(rng);
         // Ensure the metadata is a genesis metadata.
-        assert!(metadata.is_genesis());
+        assert!(metadata.is_genesis().unwrap());
 
         // Ensure the genesis block contains the following.
         assert_eq!(metadata.network(), CurrentNetwork::ID);

--- a/ledger/block/src/header/metadata/mod.rs
+++ b/ledger/block/src/header/metadata/mod.rs
@@ -23,6 +23,7 @@ mod verify;
 
 use console::{network::prelude::*, types::Field};
 
+use anyhow::Context;
 use core::marker::PhantomData;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
@@ -81,39 +82,33 @@ impl<N: Network> Metadata<N> {
             _phantom: PhantomData,
         };
         // Ensure the header is valid.
-        match metadata.is_valid() {
-            true => Ok(metadata),
-            false => bail!("Invalid block metadata: {:?}", metadata),
+        match metadata.check_validity() {
+            Ok(()) => Ok(metadata),
+            Err(err) => bail!("Invalid block metadata: {err}"),
         }
     }
 
     /// Returns `true` if the block metadata is well-formed.
-    pub fn is_valid(&self) -> bool {
-        match self.height == 0u32 {
-            true => self.is_genesis(),
-            false => {
-                // Ensure the network ID is correct.
-                self.network == N::ID
-                    // Ensure the round is nonzero.
-                    && self.round != 0u64
-                    // Ensure the height is nonzero.
-                    && self.height != 0u32
-                    // Ensure the round is at least as large as the height.
-                    && self.round >= self.height as u64
-                    // Ensure the coinbase target is at or above the minimum.
-                    && self.coinbase_target >= N::GENESIS_COINBASE_TARGET
-                    // Ensure the proof target is at or above the minimum.
-                    && self.proof_target >= N::GENESIS_PROOF_TARGET
-                    // Ensure the coinbase target is larger than the proof target.
-                    && self.coinbase_target > self.proof_target
-                    // Ensure the last coinbase target is at or above the minimum.
-                    && self.last_coinbase_target >= N::GENESIS_COINBASE_TARGET
-                    // Ensure the last coinbase timestamp is after the genesis timestamp.
-                    && self.last_coinbase_timestamp >= N::GENESIS_TIMESTAMP
-                    // Ensure the timestamp in the block is after the genesis timestamp.
-                    && self.timestamp > N::GENESIS_TIMESTAMP
+    pub fn check_validity(&self) -> Result<()> {
+        if self.height == 0u32 {
+            if !self.is_genesis().with_context(|| "Genesis block check failed")? {
+                bail!("Block at height 0 is not a genesis block");
             }
+            return Ok(());
         }
+
+        // Ensure the network ID is correct.
+        ensure!(self.network == N::ID, "Invalid network ID");
+        ensure!(self.round > 0u64, "Invalid round");
+        ensure!(self.round >= self.height as u64, "Round must be greater or equal to height");
+        ensure!(self.coinbase_target >= N::GENESIS_COINBASE_TARGET, "Invalid coinbase target");
+        ensure!(self.proof_target >= N::GENESIS_PROOF_TARGET, "Invalid proof target");
+        ensure!(self.coinbase_target > self.proof_target, "Invalid coinbase target");
+        ensure!(self.last_coinbase_target >= N::GENESIS_COINBASE_TARGET, "Invalid last coinbase target");
+        ensure!(self.last_coinbase_timestamp >= N::GENESIS_TIMESTAMP, "Ensure last coinbase timestamp");
+        ensure!(self.timestamp > N::GENESIS_TIMESTAMP, "Invalid timeestamp");
+
+        Ok(())
     }
 }
 

--- a/ledger/block/src/header/metadata/mod.rs
+++ b/ledger/block/src/header/metadata/mod.rs
@@ -81,16 +81,17 @@ impl<N: Network> Metadata<N> {
             timestamp,
             _phantom: PhantomData,
         };
+
         // Ensure the header is valid.
-        match metadata.check_validity() {
-            Ok(()) => Ok(metadata),
-            Err(err) => bail!("Invalid block metadata: {err}"),
-        }
+        metadata.check_validity().with_context(|| "Invalid block metadata")?;
+
+        Ok(metadata)
     }
 
     /// Returns `true` if the block metadata is well-formed.
     pub fn check_validity(&self) -> Result<()> {
         if self.height == 0u32 {
+            // [`Self::is_genesis`] performs its own validity checks.
             if !self.is_genesis().with_context(|| "Genesis block check failed")? {
                 bail!("Block at height 0 is not a genesis block");
             }
@@ -101,13 +102,28 @@ impl<N: Network> Metadata<N> {
         ensure!(self.network == N::ID, "Invalid network ID");
         ensure!(self.round > 0u64, "Invalid round");
         ensure!(self.round >= self.height as u64, "Round must be greater or equal to height");
-        ensure!(self.coinbase_target >= N::GENESIS_COINBASE_TARGET, "Invalid coinbase target");
         ensure!(self.proof_target >= N::GENESIS_PROOF_TARGET, "Invalid proof target");
-        ensure!(self.coinbase_target > self.proof_target, "Invalid coinbase target");
-        ensure!(self.last_coinbase_target >= N::GENESIS_COINBASE_TARGET, "Invalid last coinbase target");
+
         ensure!(self.last_coinbase_timestamp >= N::GENESIS_TIMESTAMP, "Ensure last coinbase timestamp");
         ensure!(self.timestamp > N::GENESIS_TIMESTAMP, "Invalid timeestamp");
 
+        if self.coinbase_target < N::GENESIS_COINBASE_TARGET {
+            bail!(
+                "Invalid coinbase target: Was {actual} but expected {min} or greater.",
+                actual = self.coinbase_target,
+                min = N::GENESIS_COINBASE_TARGET,
+            );
+        }
+
+        if self.proof_target < N::GENESIS_PROOF_TARGET {
+            bail!(
+                "Invalid proof target: Was {actual} but expected {min} or greater.",
+                actual = self.proof_target,
+                min = N::GENESIS_PROOF_TARGET,
+            );
+        }
+
+        ensure!(self.coinbase_target > self.proof_target, "Invalid coinbase target: must be greater than proof target");
         Ok(())
     }
 }

--- a/ledger/block/src/header/metadata/mod.rs
+++ b/ledger/block/src/header/metadata/mod.rs
@@ -89,6 +89,13 @@ impl<N: Network> Metadata<N> {
     }
 
     /// Returns `true` if the block metadata is well-formed.
+    ///
+    /// Consider using [`Self::check_validity`] to get more information on invalid block metadata.
+    pub fn is_valid(&self) -> bool {
+        self.check_validity().is_ok()
+    }
+
+    /// Returns `Ok(())` if the block metadata is well-formed, and error describing (one of) the problem(s) in the block header.
     pub fn check_validity(&self) -> Result<()> {
         if self.height == 0u32 {
             // [`Self::is_genesis`] performs its own validity checks.

--- a/ledger/block/src/header/metadata/verify.rs
+++ b/ledger/block/src/header/metadata/verify.rs
@@ -15,6 +15,8 @@
 
 #![allow(clippy::too_many_arguments)]
 
+use snarkvm_utilities::ensure_equals;
+
 use super::*;
 
 impl<N: Network> Metadata<N> {
@@ -37,77 +39,46 @@ impl<N: Network> Metadata<N> {
             bail!("Metadata is malformed in block {expected_height}: {err}");
         }
 
-        // Ensure the round is correct.
-        ensure!(
-            self.round == expected_round,
-            "Round is incorrect in block {expected_height} (found '{}', expected '{}')",
-            self.round,
-            expected_round
-        );
-        // Ensure the height is correct.
-        ensure!(
-            self.height == expected_height,
-            "Height is incorrect in block {expected_height} (found '{}', expected '{}')",
-            self.height,
-            expected_height
-        );
-        // Ensure the cumulative weight is correct.
-        ensure!(
-            self.cumulative_weight == expected_cumulative_weight,
-            "Cumulative weight is incorrect in block {expected_height} (found '{}', expected '{}')",
+        ensure_equals!(self.round, expected_round, "Round is incorrect in block {expected_height}");
+        ensure_equals!(self.height, expected_height, "Height is incorrect in block {expected_height}");
+        ensure_equals!(
             self.cumulative_weight,
-            expected_cumulative_weight
+            expected_cumulative_weight,
+            "Cumulative weight is incorrect in block {expected_height}"
         );
-        // Ensure the cumulative proof target is correct.
-        ensure!(
-            self.cumulative_proof_target == expected_cumulative_proof_target,
-            "Cumulative proof target is incorrect in block {expected_height} (found '{}', expected '{}')",
+        ensure_equals!(
             self.cumulative_proof_target,
-            expected_cumulative_proof_target
+            expected_cumulative_proof_target,
+            "Cumulative proof target is incorrect in block {expected_height}"
         );
-        // Ensure the coinbase target is correct.
-        ensure!(
-            self.coinbase_target == expected_coinbase_target,
-            "Coinbase target is incorrect in block {expected_height} (found '{}', expected '{}')",
+        ensure_equals!(
             self.coinbase_target,
-            expected_coinbase_target
+            expected_coinbase_target,
+            "Coinbase target is incorrect in block {expected_height}"
         );
-        // Ensure the proof target is correct.
-        ensure!(
-            self.proof_target == expected_proof_target,
-            "Proof target is incorrect in block {expected_height} (found '{}', expected '{}')",
+        ensure_equals!(
             self.proof_target,
-            expected_proof_target
+            expected_proof_target,
+            "Proof target is incorrect in block {expected_height}"
         );
-        // Ensure the last coinbase target is correct.
-        ensure!(
-            self.last_coinbase_target == expected_last_coinbase_target,
-            "Last coinbase target is incorrect in block {expected_height} (found '{}', expected '{}')",
+        ensure_equals!(
             self.last_coinbase_target,
-            expected_last_coinbase_target
+            expected_last_coinbase_target,
+            "Last coinbase target is incorrect in block {expected_height}"
         );
-        // Ensure the last coinbase timestamp is correct.
-        ensure!(
-            self.last_coinbase_timestamp == expected_last_coinbase_timestamp,
-            "Last coinbase timestamp is incorrect in block {expected_height} (found '{}', expected '{}')",
+        ensure_equals!(
             self.last_coinbase_timestamp,
-            expected_last_coinbase_timestamp
+            expected_last_coinbase_timestamp,
+            "Last coinbase timestamp is incorrect in block {expected_height}"
         );
-        // Ensure the timestamp is correct.
-        ensure!(
-            self.timestamp == expected_timestamp,
-            "Timestamp is incorrect in block {expected_height} (found '{}', expected '{}')",
-            self.timestamp,
-            expected_timestamp
-        );
-        // Ensure the timestamp is after the current timestamp.
+        ensure_equals!(self.timestamp, expected_timestamp, "Timestamp is incorrect in block {expected_height}");
         ensure!(
             self.timestamp <= current_timestamp,
             "Timestamp is in the future in block {expected_height} (found '{}', expected before '{}')",
             self.timestamp,
             current_timestamp
         );
-        // Return success.
+
         Ok(())
     }
 }

--- a/ledger/block/src/header/metadata/verify.rs
+++ b/ledger/block/src/header/metadata/verify.rs
@@ -33,7 +33,10 @@ impl<N: Network> Metadata<N> {
         current_timestamp: i64,
     ) -> Result<()> {
         // Ensure the block metadata is well-formed.
-        ensure!(self.is_valid(), "Metadata is malformed in block {expected_height}");
+        if let Err(err) = self.check_validity() {
+            bail!("Metadata is malformed in block {expected_height}: {err}");
+        }
+
         // Ensure the round is correct.
         ensure!(
             self.round == expected_round,

--- a/ledger/block/src/header/mod.rs
+++ b/ledger/block/src/header/mod.rs
@@ -79,6 +79,13 @@ impl<N: Network> Header<N> {
     }
 
     /// Returns `true` if the block header is well-formed.
+    ///
+    /// Consider using [`Self::check_validity`] to get more information on invalid block headers.
+    pub fn is_valid(&self) -> bool {
+        self.check_validity().is_ok()
+    }
+
+    /// Returns `Ok(())` if the block header is well-formed, and error describing (one of) the problem(s) in the block header.
     pub fn check_validity(&self) -> Result<()> {
         if self.height() == 0u32 {
             if !self.is_genesis()? {
@@ -89,10 +96,10 @@ impl<N: Network> Header<N> {
 
         self.metadata.check_validity().with_context(|| "Invalid metadata")?;
 
-        ensure!(*self.previous_state_root != Field::zero(), "Previous state root is invalid");
-        ensure!(self.transactions_root != Field::zero());
-        ensure!(self.finalize_root != Field::zero());
-        ensure!(self.ratifications_root != Field::zero());
+        ensure!(*self.previous_state_root != Field::zero(), "Previous state root cannot be zero");
+        ensure!(self.transactions_root != Field::zero(), "Transactions root cannot be zero");
+        ensure!(self.finalize_root != Field::zero(), "Finalize root cannot be zero");
+        ensure!(self.ratifications_root != Field::zero(), "Ratifications root cannot be zero");
 
         Ok(())
     }

--- a/ledger/block/src/header/mod.rs
+++ b/ledger/block/src/header/mod.rs
@@ -74,10 +74,8 @@ impl<N: Network> Header<N> {
             metadata,
         };
         // Ensure the header is valid.
-        match header.check_validity() {
-            Ok(()) => Ok(header),
-            Err(err) => bail!("Invalid block header: {err}"),
-        }
+        header.check_validity().with_context(|| "Invalid block header")?;
+        Ok(header)
     }
 
     /// Returns `true` if the block header is well-formed.

--- a/ledger/block/src/header/mod.rs
+++ b/ledger/block/src/header/mod.rs
@@ -31,6 +31,8 @@ use console::{
 };
 use snarkvm_synthesizer_program::FinalizeOperation;
 
+use anyhow::Context;
+
 /// The header for the block contains metadata that uniquely identifies the block.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Header<N: Network> {
@@ -72,29 +74,29 @@ impl<N: Network> Header<N> {
             metadata,
         };
         // Ensure the header is valid.
-        match header.is_valid() {
-            true => Ok(header),
-            false => bail!("Invalid block header: {:?}", header),
+        match header.check_validity() {
+            Ok(()) => Ok(header),
+            Err(err) => bail!("Invalid block header: {err}"),
         }
     }
 
     /// Returns `true` if the block header is well-formed.
-    pub fn is_valid(&self) -> bool {
-        match self.height() == 0u32 {
-            true => self.is_genesis(),
-            false => {
-                // Ensure the previous ledger root is nonzero.
-                *self.previous_state_root != Field::zero()
-                    // Ensure the transactions root is nonzero.
-                    && self.transactions_root != Field::zero()
-                    // Ensure the finalize root is nonzero.
-                    && self.finalize_root != Field::zero()
-                    // Ensure the ratifications root is nonzero.
-                    && self.ratifications_root != Field::zero()
-                    // Ensure the metadata is valid.
-                    && self.metadata.is_valid()
+    pub fn check_validity(&self) -> Result<()> {
+        if self.height() == 0u32 {
+            if !self.is_genesis()? {
+                bail!("Block at height 0 is not a gensis block");
             }
+            return Ok(());
         }
+
+        self.metadata.check_validity().with_context(|| "Invalid metadata")?;
+
+        ensure!(*self.previous_state_root != Field::zero(), "Previous state root is invalid");
+        ensure!(self.transactions_root != Field::zero());
+        ensure!(self.finalize_root != Field::zero());
+        ensure!(self.ratifications_root != Field::zero());
+
+        Ok(())
     }
 
     /// Returns the previous state root from the block header.

--- a/ledger/block/src/header/verify.rs
+++ b/ledger/block/src/header/verify.rs
@@ -39,7 +39,10 @@ impl<N: Network> Header<N> {
         current_timestamp: i64,
     ) -> Result<()> {
         // Ensure the block header is well-formed.
-        ensure!(self.is_valid(), "Header is malformed in block {expected_height}");
+        if let Err(err) = self.check_validity() {
+            anyhow::bail!("Header is malformed in block {expected_height}: {err}");
+        }
+
         // Ensure the previous state root is correct.
         ensure!(
             self.previous_state_root == expected_previous_state_root,

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -613,11 +613,13 @@ impl<N: Network> Block<N> {
 #[cfg(test)]
 pub mod test_helpers {
     use super::*;
-    use console::account::{Address, PrivateKey};
+
     use snarkvm_algorithms::snark::varuna::VarunaVersion;
+    use snarkvm_console::account::{Address, PrivateKey};
     use snarkvm_ledger_query::Query;
     use snarkvm_ledger_store::{BlockStore, helpers::memory::BlockMemory};
     use snarkvm_synthesizer_process::Process;
+    use snarkvm_utilities::PrettyUnwrap;
 
     use aleo_std::StorageMode;
     use std::sync::OnceLock;
@@ -714,7 +716,7 @@ pub mod test_helpers {
             rng,
         )
         .unwrap();
-        assert!(block.header().is_genesis().unwrap(), "Failed to initialize a genesis block");
+        assert!(block.header().is_genesis().pretty_unwrap(), "Failed to initialize a genesis block");
         // Return the block, transaction, and private key.
         (block, transaction, private_key)
     }
@@ -730,6 +732,7 @@ pub mod test_helpers {
         let last_coinbase_target = u64::MAX;
         let timestamp = i64::MAX - 1;
         let last_coinbase_timestamp = timestamp - 1;
+
         Metadata::new(
             network,
             round,
@@ -742,7 +745,7 @@ pub mod test_helpers {
             last_coinbase_timestamp,
             timestamp,
         )
-        .unwrap()
+        .pretty_unwrap()
     }
 }
 

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -714,7 +714,7 @@ pub mod test_helpers {
             rng,
         )
         .unwrap();
-        assert!(block.header().is_genesis(), "Failed to initialize a genesis block");
+        assert!(block.header().is_genesis().unwrap(), "Failed to initialize a genesis block");
         // Return the block, transaction, and private key.
         (block, transaction, private_key)
     }

--- a/ledger/block/src/ratifications/bytes.rs
+++ b/ledger/block/src/ratifications/bytes.rs
@@ -34,7 +34,7 @@ impl<N: Network> FromBytes for Ratifications<N> {
         // Read the ratifications.
         let ratifications = (0..num_ratify).map(|_| FromBytes::read_le(&mut reader)).collect::<Result<Vec<_>, _>>()?;
         // Return the ratifications.
-        Self::try_from(ratifications).map_err(error)
+        Self::try_from(ratifications).map_err(into_io_error)
     }
 }
 

--- a/ledger/block/src/solutions/mod.rs
+++ b/ledger/block/src/solutions/mod.rs
@@ -18,7 +18,10 @@ mod merkle;
 mod serialize;
 mod string;
 
-use console::{network::prelude::*, types::Field};
+use console::{
+    network::{error, prelude::*},
+    types::Field,
+};
 use snarkvm_ledger_committee::Committee;
 use snarkvm_ledger_narwhal_batch_header::BatchHeader;
 use snarkvm_ledger_puzzle::{PuzzleSolutions, SolutionID};

--- a/ledger/block/src/transaction/serialize.rs
+++ b/ledger/block/src/transaction/serialize.rs
@@ -62,7 +62,8 @@ impl<'de, N: Network> Deserialize<'de> for Transaction<N> {
                 // Deserialize the transaction into a JSON value.
                 let mut transaction = serde_json::Value::deserialize(deserializer)?;
                 // Retrieve the transaction ID.
-                let id: N::TransactionID = DeserializeExt::take_from_value::<D>(&mut transaction, "id")?;
+                let id: N::TransactionID = DeserializeExt::take_from_value::<D>(&mut transaction, "id")
+                    .map_err(|err| de::Error::custom(format!("Failed to parse transaction ID: {err}")))?;
 
                 // Recover the transaction.
                 let transaction = match transaction

--- a/ledger/narwhal/transmission/src/lib.rs
+++ b/ledger/narwhal/transmission/src/lib.rs
@@ -22,7 +22,7 @@ mod bytes;
 mod serialize;
 mod string;
 
-use console::prelude::*;
+use console::{network::error, prelude::*};
 use snarkvm_ledger_block::Transaction;
 use snarkvm_ledger_narwhal_data::Data;
 use snarkvm_ledger_puzzle::Solution;

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use anyhow::Context;
+
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns a candidate for the next block in the ledger, using a committed subdag and its transmissions.
     pub fn prepare_advance_to_next_quorum_block<R: Rng + CryptoRng>(
@@ -31,8 +33,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Currently, we do not support ratifications from the memory pool.
         ensure!(ratifications.is_empty(), "Ratifications are currently unsupported from the memory pool");
         // Construct the block template.
-        let (header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids) =
-            self.construct_block_template(&previous_block, Some(&subdag), ratifications, solutions, transactions, rng)?;
+        let (header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids) = self
+            .construct_block_template(&previous_block, Some(&subdag), ratifications, solutions, transactions, rng)
+            .with_context(|| "Failed to construct block template")?;
 
         // Construct the new quorum block.
         Block::new_quorum(
@@ -71,7 +74,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 candidate_solutions,
                 candidate_transactions,
                 rng,
-            )?;
+            )
+            .with_context(|| "Failed to construct block template")?;
 
         // Construct the new beacon block.
         Block::new_beacon(

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -92,7 +92,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Acquire the write lock on the current block.
         let mut current_block = self.current_block.write();
         // Check again for any possible race conditions.
-        if current_block.is_genesis() {
+        if current_block.is_genesis()? {
             // current block is initialized as the genesis block, but the ledger will
             // also advance to it on startup.
             ensure!(

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -230,7 +230,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Fetch the latest block.
         let block = ledger
             .get_block(latest_height)
-            .map_err(|_| anyhow!("Failed to load block {latest_height} from the ledger"))?;
+            .map_err(|err| err.context("Failed to load block {latest_height} from the ledger"))?;
 
         // Set the current block.
         ledger.current_block = Arc::new(RwLock::new(block));

--- a/ledger/test-helpers/Cargo.toml
+++ b/ledger/test-helpers/Cargo.toml
@@ -42,6 +42,12 @@ workspace = true
 [dependencies.snarkvm-synthesizer-process]
 workspace = true
 
+[dependencies.snarkvm-utilities]
+workspace = true
+
 [dependencies.aleo-std]
 workspace = true
 features = [ "storage" ]
+
+[dependencies.anyhow]
+workspace = true

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -42,8 +42,10 @@ use snarkvm_ledger_query::Query;
 use snarkvm_ledger_store::{BlockStore, helpers::memory::BlockMemory};
 use snarkvm_synthesizer_process::Process;
 use snarkvm_synthesizer_program::Program;
+use snarkvm_utilities::PrettyUnwrap;
 
 use aleo_std::StorageMode;
+use anyhow::Context;
 use std::sync::OnceLock;
 
 type CurrentNetwork = console::network::MainnetV0;
@@ -653,7 +655,9 @@ fn sample_genesis_block_and_components_raw(
     let ratifications = Ratifications::try_from(vec![]).unwrap();
 
     // Prepare the block header.
-    let header = Header::genesis(&ratifications, &transactions, vec![]).unwrap();
+    let header = Header::genesis(&ratifications, &transactions, vec![])
+        .with_context(|| "Failed to generate genesis sample header")
+        .pretty_unwrap();
     // Prepare the previous block hash.
     let previous_hash = <CurrentNetwork as Network>::BlockHash::default();
 

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -670,7 +670,7 @@ fn sample_genesis_block_and_components_raw(
         rng,
     )
     .unwrap();
-    assert!(block.header().is_genesis(), "Failed to initialize a genesis block");
+    assert!(block.header().is_genesis().unwrap(), "Failed to initialize a genesis block");
     // Return the block, transaction, and private key.
     (block, transactions, private_key)
 }

--- a/synthesizer/process/src/stack/authorization/bytes.rs
+++ b/synthesizer/process/src/stack/authorization/bytes.rs
@@ -59,7 +59,7 @@ impl<N: Network> FromBytes for Authorization<N> {
             (0..num_transitions).map(|_| Transition::read_le(&mut reader)).collect::<IoResult<Vec<_>>>()?;
 
         // Return the new `Authorization` instance.
-        Self::try_from((requests, transitions)).map_err(error)
+        Self::try_from((requests, transitions)).map_err(into_io_error)
     }
 }
 

--- a/synthesizer/program/src/closure/mod.rs
+++ b/synthesizer/program/src/closure/mod.rs
@@ -25,7 +25,7 @@ mod bytes;
 mod parse;
 
 use console::{
-    network::prelude::*,
+    network::{error, prelude::*},
     program::{Identifier, Register, RegisterType},
 };
 

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     StackTrait,
 };
 use console::{
-    network::prelude::*,
+    network::{error, prelude::*},
     program::{Identifier, Register},
 };
 

--- a/synthesizer/program/src/logic/finalize_operation/mod.rs
+++ b/synthesizer/program/src/logic/finalize_operation/mod.rs
@@ -18,7 +18,10 @@ mod bytes;
 mod serialize;
 mod string;
 
-use console::{network::prelude::*, types::Field};
+use console::{
+    network::{error, prelude::*},
+    types::Field,
+};
 
 /// Enum to represent the allowed set of Merkle tree operations.
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -239,7 +239,7 @@ macro_rules! do_hash {
 /// Evaluate a hash operation.
 ///
 /// This allows running the hash without the machinery of stacks and registers.
-/// This is necessary for the Leo interpeter.
+/// This is necessary for the Leo interpreter.
 pub fn evaluate_hash<N: Network>(
     variant: HashVariant,
     input: &Value<N>,

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -409,7 +409,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             rng,
         )?;
         // Ensure the block is valid genesis block.
-        match block.is_genesis() {
+        match block.is_genesis()? {
             true => Ok(block),
             false => bail!("Failed to initialize a genesis block"),
         }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -60,6 +60,9 @@ features = [ "preserve_order" ]
 [dependencies.smol_str]
 version = "0.2"
 
+[dependencies.tracing]
+workspace = true
+
 [dependencies.thiserror]
 workspace = true
 

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -28,8 +28,6 @@ use serde::{
 };
 use smol_str::SmolStr;
 
-use crate::error;
-
 /// Takes as input a sequence of structs, and converts them to a series of little-endian bytes.
 /// All traits that implement `ToBytes` can be automatically converted to bytes in this manner.
 #[macro_export]
@@ -292,7 +290,7 @@ impl FromBytes for bool {
         match u8::read_le(reader) {
             Ok(0) => Ok(false),
             Ok(1) => Ok(true),
-            Ok(_) => Err(error("FromBytes::read failed")),
+            Ok(_) => Err(std::io::Error::other("FromBytes::read failed")),
             Err(err) => Err(err),
         }
     }
@@ -325,7 +323,7 @@ impl FromBytes for SocketAddr {
         let ip = match u8::read_le(&mut reader)? {
             0 => IpAddr::V4(Ipv4Addr::from(u32::read_le(&mut reader)?)),
             1 => IpAddr::V6(Ipv6Addr::from(u128::read_le(&mut reader)?)),
-            _ => return Err(error("Invalid IP address")),
+            _ => return Err(std::io::Error::other("Invalid IP address")),
         };
         // Read the port.
         let port = u16::read_le(&mut reader)?;

--- a/utilities/src/errors.rs
+++ b/utilities/src/errors.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Generates an `io::Error` from the given string.
+pub fn io_error<S: ToString>(err: S) -> std::io::Error {
+    std::io::Error::other(err.to_string())
+}
+
+/// Generates an `io::Error` from the given `anyhow::Error`.
+///
+/// This will flatten the existing error chain so that it fits in a single-line string.
+pub fn into_io_error<E: Into<anyhow::Error>>(err: E) -> std::io::Error {
+    let err: anyhow::Error = err.into();
+    std::io::Error::other(flatten_anyhow_error(&err))
+}
+
+/// Helper function for `log_error` and `log_warning`.
+#[inline]
+fn flatten_anyhow_error(error: &anyhow::Error) -> String {
+    let mut output = error.to_string();
+    for next in error.chain().skip(1) {
+        output = format!("{output} — {next}");
+    }
+    output
+}
+
+/// Logs `anyhow::Error`'s its error chain using the `ERROR` log level.
+///
+/// This follows the existing convention in the codebase that joins errors using em dashes.
+/// For example, an error "Invalid transaction" with a cause "Proof failed"would be logged
+/// as "Invalid transaction — Proof failed".
+pub fn log_error(error: &anyhow::Error) {
+    tracing::error!("{}", flatten_anyhow_error(error));
+}
+
+/// Logs `anyhow::Error`'s its error chain using the `WARN` log level.
+///
+/// This follows the existing convention in the codebase that joins errors using em dashes.
+/// For example, an error "Invalid transaction" with a cause "Proof failed"would be logged
+/// as "Invalid transaction — Proof failed".
+pub fn log_warning(error: &anyhow::Error) {
+    tracing::warn!("{}", flatten_anyhow_error(error));
+}
+
+/// Displays an `anyhow::Error`'s main error and its error chain to stderr.
+///
+/// This can be used to show a "pretty" error to the end user.
+pub fn display_error(error: &anyhow::Error) {
+    eprintln!("⚠️ {error}");
+    error.chain().skip(1).for_each(|cause| eprintln!("     ↳ {cause}"));
+}
+
+/// Ensures that two values are equal, otherwise bails with a formatted error message.
+///
+/// # Arguments
+/// * `actual` - The actual value
+/// * `expected` - The expected value  
+/// * `message` - A description of what was being checked
+///
+/// This will generate an error message like:
+#[macro_export]
+macro_rules! ensure_equals {
+    ($actual:expr, $expected:expr, $message:expr) => {
+        if $actual != $expected {
+            anyhow::bail!("{}: Was {} but expected {}.", $message, $actual, $expected);
+        }
+    };
+}
+
+/// A trait to provide a nicer way to unwarp `anyhow::Result`.
+pub trait PrettyUnwrap {
+    type Inner;
+
+    /// Behaves like [`std::Result::unwrap`] but will print the entire anyhow chain to stderr.
+    fn pretty_unwrap(self) -> Self::Inner;
+}
+
+/// Helper for `PrettyUnwrap`:
+/// Creates a panic with the `anyhow::Error` nicely formatted.
+#[track_caller]
+#[inline]
+fn pretty_panic(error: &anyhow::Error) -> ! {
+    let mut string = format!("⚠️ {error}");
+    error.chain().skip(1).for_each(|cause| string.push_str(&format!("\n     ↳ {cause}")));
+    let caller = std::panic::Location::caller();
+
+    tracing::error!("[{}:{}] {string}", caller.file(), caller.line());
+    panic!("{string}");
+}
+
+/// Implement the trait for `anyhow::Result`.
+impl<T> PrettyUnwrap for anyhow::Result<T> {
+    type Inner = T;
+
+    #[track_caller]
+    fn pretty_unwrap(self) -> Self::Inner {
+        match self {
+            Ok(result) => result,
+            Err(error) => {
+                pretty_panic(&error);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PrettyUnwrap, flatten_anyhow_error, pretty_panic};
+
+    use anyhow::{Context, Result, anyhow, bail};
+
+    const ERRORS: [&str; 3] = ["Third error", "Second error", "First error"];
+
+    #[test]
+    fn flatten_error() {
+        let expected = format!("{} — {} — {}", ERRORS[0], ERRORS[1], ERRORS[2]);
+
+        let my_error = anyhow!(ERRORS[2]).context(ERRORS[1]).context(ERRORS[0]);
+        let result = flatten_anyhow_error(&my_error);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn chained_error_panic_format() {
+        let expected = format!("⚠️ {}\n     ↳ {}\n     ↳ {}", ERRORS[0], ERRORS[1], ERRORS[2]);
+
+        let result = std::panic::catch_unwind(|| {
+            let my_error = anyhow!(ERRORS[2]).context(ERRORS[1]).context(ERRORS[0]);
+            pretty_panic(&my_error);
+        })
+        .unwrap_err();
+
+        assert_eq!(*result.downcast::<String>().expect("Error was not a string"), expected);
+    }
+
+    #[test]
+    fn chained_pretty_unwrap_format() {
+        let expected = format!("⚠️ {}\n     ↳ {}\n     ↳ {}", ERRORS[0], ERRORS[1], ERRORS[2]);
+
+        // Also test `pretty_unwrap` and chaining errors across functions.
+        let result = std::panic::catch_unwind(|| {
+            fn level2() -> Result<()> {
+                bail!(ERRORS[2]);
+            }
+
+            fn level1() -> Result<()> {
+                level2().with_context(|| ERRORS[1])?;
+                Ok(())
+            }
+
+            fn level0() -> Result<()> {
+                level1().with_context(|| ERRORS[0])?;
+                Ok(())
+            }
+
+            level0().pretty_unwrap();
+        })
+        .unwrap_err();
+
+        assert_eq!(*result.downcast::<String>().expect("Error was not a string"), expected);
+    }
+
+    /// Ensure catch_unwind does not break `try_vm_runtime`.
+    #[test]
+    fn test_nested_with_try_vm_runtime() {
+        use crate::try_vm_runtime;
+
+        let result = std::panic::catch_unwind(|| {
+            // try_vm_runtime uses catch_unwind internally
+            let vm_result = try_vm_runtime!(|| {
+                panic!("VM operation failed!");
+            });
+
+            assert!(vm_result.is_err(), "try_vm_runtime should catch VM panic");
+
+            // We can handle the VM error gracefully
+            "handled_vm_error"
+        });
+
+        assert!(result.is_ok(), "Should handle VM error gracefully");
+        assert_eq!(result.unwrap(), "handled_vm_error");
+    }
+}

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -34,8 +34,8 @@ pub use bytes::*;
 pub mod defer;
 pub use defer::*;
 
-pub mod error;
-pub use error::*;
+mod vm_error;
+pub use vm_error::*;
 
 pub mod iterator;
 pub use iterator::*;
@@ -53,6 +53,8 @@ pub use self::rand::*;
 pub mod serialize;
 pub use serialize::*;
 
-pub fn error<S: ToString>(msg: S) -> std::io::Error {
-    std::io::Error::other(msg.to_string())
-}
+mod errors;
+pub use errors::*;
+
+/// Use old name for backward-compatibility.
+pub use errors::io_error as error;

--- a/utilities/src/serialize/mod.rs
+++ b/utilities/src/serialize/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod error;
+mod error;
 pub use error::*;
 
 mod helpers;

--- a/utilities/src/vm_error.rs
+++ b/utilities/src/vm_error.rs
@@ -23,22 +23,24 @@ macro_rules! try_vm_runtime {
     ($e:expr) => {{
         use std::panic;
 
+        // Store the previous hook (if any).
+        let previous_hook = panic::take_hook();
+
         // Set a custom hook before calling catch_unwind to
         // indicate that the panic was expected and handled.
         panic::set_hook(Box::new(|e| {
-            let msg = e.to_string();
-            let msg = msg.split_ascii_whitespace().skip_while(|&word| word != "panicked").collect::<Vec<&str>>();
-            let mut msg = msg.join(" ");
-            msg = msg.replacen("panicked", "VM safely halted", 1);
             #[cfg(debug_assertions)]
-            eprintln!("{msg}");
+            {
+                let msg = e.to_string().replacen("panicked", "VM safely halted", 1);
+                eprintln!("{msg}");
+            }
         }));
 
         // Perform the operation that may panic.
         let result = panic::catch_unwind(panic::AssertUnwindSafe($e));
 
         // Restore the standard panic hook.
-        let _ = panic::take_hook();
+        panic::set_hook(previous_hook);
 
         // Return the result, allowing regular error-handling.
         result

--- a/utilities/src/vm_error.rs
+++ b/utilities/src/vm_error.rs
@@ -28,10 +28,19 @@ macro_rules! try_vm_runtime {
 
         // Set a custom hook before calling catch_unwind to
         // indicate that the panic was expected and handled.
-        panic::set_hook(Box::new(|e| {
+        panic::set_hook(Box::new(|err| {
             #[cfg(debug_assertions)]
             {
-                let msg = e.to_string().replacen("panicked", "VM safely halted", 1);
+                // Remove all words up to "panicked".
+                let trimmed = err
+                    .to_string()
+                    .split_ascii_whitespace()
+                    .skip_while(|&word| word != "panicked")
+                    .collect::<Vec<&str>>()
+                    .join(" ");
+
+                // Have the message start with "VM safely halted".
+                let msg = trimmed.replacen("panicked", "VM safely halted", 1);
                 eprintln!("{msg}");
             }
         }));

--- a/vm/cli/commands/execute.rs
+++ b/vm/cli/commands/execute.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use anyhow::Context;
+
 /// Executes an Aleo program function locally
 #[derive(Debug, Parser)]
 pub struct Execute {
@@ -46,14 +48,16 @@ impl Execute {
         let rng = &mut rand::thread_rng();
 
         // Execute the request.
-        let (response, execution, metrics) =
-            package.execute::<Aleo, _>(self.endpoint, &private_key, self.function, &self.inputs, rng)?;
+        let (response, execution, metrics) = package
+            .execute::<Aleo, _>(self.endpoint, &private_key, self.function, &self.inputs, rng)
+            .with_context(|| "Execution failed")?;
 
         // TODO (howardwu): Include the option to execute a fee.
         let fee = None;
 
         // Construct the transaction.
-        let transaction = Transaction::from_execution(execution, fee)?;
+        let transaction =
+            Transaction::from_execution(execution, fee).with_context(|| "Failed to construct transaction")?;
 
         // Count the number of times a function is called.
         let mut program_frequency = HashMap::<String, usize>::new();

--- a/vm/cli/commands/run.rs
+++ b/vm/cli/commands/run.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use anyhow::Context;
+
 /// Runs an Aleo program function
 #[derive(Debug, Parser)]
 pub struct Run {
@@ -40,7 +42,10 @@ impl Run {
         let rng = &mut rand::thread_rng();
 
         // Execute the request.
-        let (response, metrics) = package.run::<Aleo, _>(&private_key, self.function, &self.inputs, rng)?;
+        let (response, metrics) =
+            package.run::<Aleo, _>(&private_key, self.function, &self.inputs, rng).with_context(|| {
+                format!("Running {}:{} with inputs {:?} failed", package.program_id(), &self.function, &self.inputs)
+            })?;
 
         // Count the number of times a function is called.
         let mut program_frequency = HashMap::<String, usize>::new();

--- a/vm/cli/helpers/updater.rs
+++ b/vm/cli/helpers/updater.rs
@@ -78,15 +78,15 @@ impl Updater {
         }
     }
 
-    /// Display the CLI message.
-    pub fn print_cli() -> String {
+    /// Returns the message to print on the CLI, if any.
+    pub fn print_cli() -> Option<String> {
         if let Ok(latest_version) = Self::update_available() {
             let mut output = "🟢 A new version is available! Run".bold().green().to_string();
             output += &" `aleo update` ".bold().white();
             output += &format!("to update to v{latest_version}.").bold().green();
-            output
+            Some(output)
         } else {
-            "".to_string()
+            None
         }
     }
 }

--- a/vm/cli/main.rs
+++ b/vm/cli/main.rs
@@ -13,19 +13,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkvm::cli::{CLI, Updater};
+use snarkvm::{
+    cli::{CLI, Updater},
+    utilities::display_error,
+};
 
 use clap::Parser;
 
-fn main() -> anyhow::Result<()> {
+use std::panic::catch_unwind;
+
+fn main() {
     // Parse the given arguments.
     let cli = CLI::parse();
     // Run the updater.
-    println!("{}", Updater::print_cli());
-    // Run the CLI.
-    match cli.command.parse() {
-        Ok(output) => println!("{output}\n"),
-        Err(error) => println!("⚠️  {error}\n"),
+    if let Some(msg) = Updater::print_cli() {
+        println!("{msg}");
     }
-    Ok(())
+
+    // Set a custom hook here to show "pretty" errors when panicking.
+    std::panic::set_hook(Box::new(|err| {
+        eprintln!("⚠️ {}", err.to_string().replace("panicked at", "snarkVM encountered an unexpected error at"));
+    }));
+
+    // Run the CLI.
+    // We use `catch_unwind` here to ensure a panic stops execution and not just a single thread.
+    // Note: `catch_unwind` can be nested without problems.
+    let result = catch_unwind(|| cli.command.parse());
+
+    // Process any errors (including panics).
+    match result {
+        Ok(Ok(output)) => {
+            println!("{output}\n");
+            std::process::exit(0);
+        }
+        Ok(Err(err)) => {
+            // A regular error occurred.
+            display_error(&err);
+            eprintln!();
+            eprintln!("Use `--help` for instructions on how to use this command");
+            std::process::exit(1);
+        }
+        Err(_) => {
+            eprintln!();
+            eprintln!("This is most likely a bug!");
+            eprintln!(
+                "Please report it to the snarkVM developers: https://github.com/ProvableHQ/snarkVM/issues/new?template=bug.md"
+            );
+            std::process::exit(1);
+        }
+    }
 }

--- a/vm/lib.rs
+++ b/vm/lib.rs
@@ -53,7 +53,7 @@ pub use snarkvm_wasm as wasm;
 
 pub mod prelude {
     #[cfg(feature = "console")]
-    pub use crate::console::{account::*, network::*, program::*};
+    pub use crate::console::{account::*, network::prelude::*, program::*};
     #[cfg(feature = "ledger")]
     pub use crate::ledger::*;
     #[cfg(feature = "synthesizer")]


### PR DESCRIPTION
## Motivation
Improve error handling in `snarkVM` to
* clearly differentiate user and I/O errors from internal errors that are bugs
* format `anyhow` error chains to show as much information as possible
* make testing and debugging easier (this PR serves a basis for #2789)
* provide helper functions for better error handling in snarkOS (see [snarkOS #3826](https://github.com/ProvableHQ/snarkOS/pull/3826))

## Changes
### Top-level panic handling
This PR now install a panic handler at `vm/cli/main.rs` and shows a "pretty" output when encountering panics. See the example below.
```
$> snarkvm execute foo

⚠️ snarkVM encountered an unexpected error at vm/cli/commands/execute.rs:49:20:
attempt to divide by zero

This is most likely a bug!
Please report it to the snarkVM developers: https://github.com/ProvableHQ/snarkVM/issues/new?template=bug.md
```

### Top-level handling for user errors
`snarkvm` will now print the entire chain of anyhow errors. For example, when passing invalid arguments to `snarkvm run` the following output is generated.

```
$> snarkvm run main 0u32 0u16
⚠️ Running leo_test.aleo:main with inputs [0u32, 0u16] failed
     ↳ 'u32' is invalid: expected u32, found 0u16

Use `--help` for instructions on how to use this command
```

## Other changes
* A `ensure_equals` macro that compares two values and `bail`s they do not match. This is used in the block validation functions to print the actual values when something goes wrong.
* Improvements to `ledger_test_helpers`
* A utility function to log an `anyhow::Error`. It "flattens" the error by joining the messages with an em dash. This is similar to how snarkOS currently handles such errors
* Avoid printing an empty line when there are no updates for snarkVM
* Minor fixes to the README

## Notes
* REST/Query changes were moved to #2901.
* As @ljedrz pointed out, we cannot use `panic = "abort"`, which was the case in an earlier version of the PR, due to how program errors are handled in snarkVM. Instead, the CLI uses a nested try_catch.
* This change just adds a panic handler as another layer of checks, and does not change existing errors in the code to panics. We would still need to discuss whether to allow panics in production code. 