### PR TITLE
[Feature] Enable safe external loading of inclusion prover for `wasm` targets

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -241,10 +241,27 @@ impl Network for CanaryV0 {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             // Skipping the first byte, which is the encoded version.
-            Arc::new(
+            #[cfg(feature = "wasm")]
+            let inclusion_key = inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::canary::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_V0_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                });
+            #[cfg(not(feature = "wasm"))]
+            let inclusion_key = Arc::new(
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_V0_PROVING_KEY[1..])
-                    .expect("Failed to load inclusion_v0 proving key."),
-            )
+                    .expect("Failed to load inclusion proving key."),
+            );
+            inclusion_key
         })
     }
 

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -234,34 +234,16 @@ impl Network for CanaryV0 {
             .ok_or_else(|| anyhow!("Verifying key for credits.aleo/{function_name}' not found"))
     }
 
-    /// Returns the `proving key` for the inclusion_v0 circuit.
     #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion_v0 circuit.
     fn inclusion_v0_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             // Skipping the first byte, which is the encoded version.
-            #[cfg(feature = "wasm")]
-            let inclusion_key = inclusion_key_bytes
-                .map(|bytes| {
-                    snarkvm_parameters::canary::InclusionProver::verify_bytes(&bytes)
-                        .expect("Bytes provided did not match expected inclusion checksum.");
-                    Arc::new(
-                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
-                    )
-                })
-                .unwrap_or_else(|| {
-                    Arc::new(
-                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_V0_PROVING_KEY[1..])
-                            .expect("Failed to load inclusion proving key."),
-                    )
-                });
-            #[cfg(not(feature = "wasm"))]
-            let inclusion_key = Arc::new(
+            Arc::new(
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_V0_PROVING_KEY[1..])
-                    .expect("Failed to load inclusion proving key."),
-            );
-            inclusion_key
+                    .expect("Failed to load inclusion_v0 proving key."),
+            )
         })
     }
 
@@ -272,7 +254,7 @@ impl Network for CanaryV0 {
         INSTANCE.get_or_init(|| {
             inclusion_key_bytes
                 .map(|bytes| {
-                    snarkvm_parameters::canary::InclusionProver::verify_bytes(&bytes)
+                    snarkvm_parameters::canary::InclusionV0Prover::verify_bytes(&bytes)
                         .expect("Bytes provided did not match expected inclusion checksum.");
                     Arc::new(
                         CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -235,6 +235,8 @@ impl Network for CanaryV0 {
     }
 
     /// Returns the `proving key` for the inclusion_v0 circuit.
+    #[cfg(not(feature = "wasm"))]
+    /// Returns the `proving key` for the inclusion_v0 circuit.
     fn inclusion_v0_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
@@ -243,6 +245,28 @@ impl Network for CanaryV0 {
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_V0_PROVING_KEY[1..])
                     .expect("Failed to load inclusion_v0 proving key."),
             )
+        })
+    }
+
+    #[cfg(feature = "wasm")]
+    /// Returns the `proving key` for the inclusion_v0 circuit.
+    fn inclusion_v0_proving_key(inclusion_key_bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>> {
+        static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::canary::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_V0_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                })
         })
     }
 
@@ -258,6 +282,7 @@ impl Network for CanaryV0 {
         })
     }
 
+    #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion circuit.
     fn inclusion_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
@@ -267,6 +292,28 @@ impl Network for CanaryV0 {
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_PROVING_KEY[1..])
                     .expect("Failed to load inclusion proving key."),
             )
+        })
+    }
+
+    #[cfg(feature = "wasm")]
+    /// Returns the `proving key` for the inclusion circuit.
+    fn inclusion_proving_key(inclusion_key_bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>> {
+        static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::canary::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::canary::INCLUSION_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                })
         })
     }
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -313,14 +313,23 @@ pub trait Network:
     /// Returns the verifying key for the given function name in `credits.aleo`.
     fn get_credits_verifying_key(function_name: String) -> Result<&'static Arc<VarunaVerifyingKey<Self>>>;
 
+    #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion_v0 circuit.
     fn inclusion_v0_proving_key() -> &'static Arc<VarunaProvingKey<Self>>;
+
+    #[cfg(feature = "wasm")]
+    /// Returns the `proving key` for the inclusion_v0 circuit.
+    fn inclusion_v0_proving_key(bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>>;
 
     /// Returns the `verifying key` for the inclusion_v0 circuit.
     fn inclusion_v0_verifying_key() -> &'static Arc<VarunaVerifyingKey<Self>>;
 
+    #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion circuit.
     fn inclusion_proving_key() -> &'static Arc<VarunaProvingKey<Self>>;
+
+    #[cfg(feature = "wasm")]
+    fn inclusion_proving_key(bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>>;
 
     /// Returns the `verifying key` for the inclusion circuit.
     fn inclusion_verifying_key() -> &'static Arc<VarunaVerifyingKey<Self>>;

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -240,6 +240,8 @@ impl Network for MainnetV0 {
     }
 
     /// Returns the `proving key` for the inclusion_v0 circuit.
+    #[cfg(not(feature = "wasm"))]
+    /// Returns the `proving key` for the inclusion_v0 circuit.
     fn inclusion_v0_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
@@ -248,6 +250,28 @@ impl Network for MainnetV0 {
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_V0_PROVING_KEY[1..])
                     .expect("Failed to load inclusion_v0 proving key."),
             )
+        })
+    }
+
+    #[cfg(feature = "wasm")]
+    /// Returns the `proving key` for the inclusion_v0 circuit.
+    fn inclusion_v0_proving_key(inclusion_key_bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>> {
+        static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::mainnet::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_V0_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                })
         })
     }
 
@@ -263,6 +287,7 @@ impl Network for MainnetV0 {
         })
     }
 
+    #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion circuit.
     fn inclusion_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
@@ -272,6 +297,28 @@ impl Network for MainnetV0 {
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_PROVING_KEY[1..])
                     .expect("Failed to load inclusion proving key."),
             )
+        })
+    }
+
+    #[cfg(feature = "wasm")]
+    /// Returns the `proving key` for the inclusion circuit.
+    fn inclusion_proving_key(inclusion_key_bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>> {
+        static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::mainnet::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                })
         })
     }
 

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -246,10 +246,27 @@ impl Network for MainnetV0 {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             // Skipping the first byte, which is the encoded version.
-            Arc::new(
+            #[cfg(feature = "wasm")]
+            let inclusion_key = inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::mainnet::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_V0_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                });
+            #[cfg(not(feature = "wasm"))]
+            let inclusion_key = Arc::new(
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_V0_PROVING_KEY[1..])
-                    .expect("Failed to load inclusion_v0 proving key."),
-            )
+                    .expect("Failed to load inclusion proving key."),
+            );
+            inclusion_key
         })
     }
 

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -239,34 +239,16 @@ impl Network for MainnetV0 {
             .ok_or_else(|| anyhow!("Verifying key for credits.aleo/{function_name}' not found"))
     }
 
-    /// Returns the `proving key` for the inclusion_v0 circuit.
     #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion_v0 circuit.
     fn inclusion_v0_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             // Skipping the first byte, which is the encoded version.
-            #[cfg(feature = "wasm")]
-            let inclusion_key = inclusion_key_bytes
-                .map(|bytes| {
-                    snarkvm_parameters::mainnet::InclusionProver::verify_bytes(&bytes)
-                        .expect("Bytes provided did not match expected inclusion checksum.");
-                    Arc::new(
-                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
-                    )
-                })
-                .unwrap_or_else(|| {
-                    Arc::new(
-                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_V0_PROVING_KEY[1..])
-                            .expect("Failed to load inclusion proving key."),
-                    )
-                });
-            #[cfg(not(feature = "wasm"))]
-            let inclusion_key = Arc::new(
+            Arc::new(
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::mainnet::INCLUSION_V0_PROVING_KEY[1..])
-                    .expect("Failed to load inclusion proving key."),
-            );
-            inclusion_key
+                    .expect("Failed to load inclusion_v0 proving key."),
+            )
         })
     }
 
@@ -277,7 +259,7 @@ impl Network for MainnetV0 {
         INSTANCE.get_or_init(|| {
             inclusion_key_bytes
                 .map(|bytes| {
-                    snarkvm_parameters::mainnet::InclusionProver::verify_bytes(&bytes)
+                    snarkvm_parameters::mainnet::InclusionV0Prover::verify_bytes(&bytes)
                         .expect("Bytes provided did not match expected inclusion checksum.");
                     Arc::new(
                         CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -241,10 +241,27 @@ impl Network for TestnetV0 {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             // Skipping the first byte, which is the encoded version.
-            Arc::new(
+            #[cfg(feature = "wasm")]
+            let inclusion_key = inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::testnet::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_V0_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                });
+            #[cfg(not(feature = "wasm"))]
+            let inclusion_key = Arc::new(
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_V0_PROVING_KEY[1..])
-                    .expect("Failed to load inclusion_v0 proving key."),
-            )
+                    .expect("Failed to load inclusion proving key."),
+            );
+            inclusion_key
         })
     }
 

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -234,7 +234,9 @@ impl Network for TestnetV0 {
             .ok_or_else(|| anyhow!("Verifying key for credits.aleo/{function_name}' not found"))
     }
 
-    /// Returns the `proving key` for the inclusion circuit.
+    /// Returns the `proving key` for the inclusion_v0 circuit.
+    #[cfg(not(feature = "wasm"))]
+    /// Returns the `proving key` for the inclusion_v0 circuit.
     fn inclusion_v0_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
@@ -243,6 +245,28 @@ impl Network for TestnetV0 {
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_V0_PROVING_KEY[1..])
                     .expect("Failed to load inclusion_v0 proving key."),
             )
+        })
+    }
+
+    #[cfg(feature = "wasm")]
+    /// Returns the `proving key` for the inclusion_v0 circuit.
+    fn inclusion_v0_proving_key(inclusion_key_bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>> {
+        static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::testnet::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_V0_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                })
         })
     }
 
@@ -258,6 +282,7 @@ impl Network for TestnetV0 {
         })
     }
 
+    #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion circuit.
     fn inclusion_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
@@ -267,6 +292,28 @@ impl Network for TestnetV0 {
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_PROVING_KEY[1..])
                     .expect("Failed to load inclusion proving key."),
             )
+        })
+    }
+
+    #[cfg(feature = "wasm")]
+    /// Returns the `proving key` for the inclusion circuit.
+    fn inclusion_proving_key(inclusion_key_bytes: Option<Vec<u8>>) -> &'static Arc<VarunaProvingKey<Self>> {
+        static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            inclusion_key_bytes
+                .map(|bytes| {
+                    snarkvm_parameters::testnet::InclusionProver::verify_bytes(&bytes)
+                        .expect("Bytes provided did not match expected inclusion checksum.");
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    Arc::new(
+                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_PROVING_KEY[1..])
+                            .expect("Failed to load inclusion proving key."),
+                    )
+                })
         })
     }
 

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -234,34 +234,16 @@ impl Network for TestnetV0 {
             .ok_or_else(|| anyhow!("Verifying key for credits.aleo/{function_name}' not found"))
     }
 
-    /// Returns the `proving key` for the inclusion_v0 circuit.
     #[cfg(not(feature = "wasm"))]
     /// Returns the `proving key` for the inclusion_v0 circuit.
     fn inclusion_v0_proving_key() -> &'static Arc<VarunaProvingKey<Self>> {
         static INSTANCE: OnceLock<Arc<VarunaProvingKey<Console>>> = OnceLock::new();
         INSTANCE.get_or_init(|| {
             // Skipping the first byte, which is the encoded version.
-            #[cfg(feature = "wasm")]
-            let inclusion_key = inclusion_key_bytes
-                .map(|bytes| {
-                    snarkvm_parameters::testnet::InclusionProver::verify_bytes(&bytes)
-                        .expect("Bytes provided did not match expected inclusion checksum.");
-                    Arc::new(
-                        CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),
-                    )
-                })
-                .unwrap_or_else(|| {
-                    Arc::new(
-                        CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_V0_PROVING_KEY[1..])
-                            .expect("Failed to load inclusion proving key."),
-                    )
-                });
-            #[cfg(not(feature = "wasm"))]
-            let inclusion_key = Arc::new(
+            Arc::new(
                 CircuitProvingKey::from_bytes_le(&snarkvm_parameters::testnet::INCLUSION_V0_PROVING_KEY[1..])
-                    .expect("Failed to load inclusion proving key."),
-            );
-            inclusion_key
+                    .expect("Failed to load inclusion_v0 proving key."),
+            )
         })
     }
 
@@ -272,7 +254,7 @@ impl Network for TestnetV0 {
         INSTANCE.get_or_init(|| {
             inclusion_key_bytes
                 .map(|bytes| {
-                    snarkvm_parameters::testnet::InclusionProver::verify_bytes(&bytes)
+                    snarkvm_parameters::testnet::InclusionV0Prover::verify_bytes(&bytes)
                         .expect("Bytes provided did not match expected inclusion checksum.");
                     Arc::new(
                         CircuitProvingKey::from_bytes_le(&bytes[1..]).expect("Failed to load inclusion proving key."),

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -376,8 +376,7 @@ macro_rules! impl_remote {
             #[cfg(feature = "wasm")]
             /// Verify external bytes.
             pub fn verify_bytes(buffer: &[u8]) -> Result<(), $crate::errors::ParameterError> {
-                let metadata: serde_json::Value =
-                    serde_json::from_str(Self::METADATA).expect("Metadata was not well-formatted");
+                let metadata: serde_json::Value = serde_json::from_str(Self::METADATA).expect("Metadata was not well-formatted");
                 let expected_checksum: String =
                     metadata[concat!($ftype, "_checksum")].as_str().expect("Failed to parse checksum").to_string();
                 let expected_size: usize =

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -375,10 +375,13 @@ macro_rules! impl_remote {
 
             #[cfg(feature = "wasm")]
             /// Verify external bytes.
-            pub fn verify_bytes(buffer: &Vec<u8>) -> Result<(), $crate::errors::ParameterError> {
-                let metadata: serde_json::Value = serde_json::from_str(Self::METADATA).expect("Metadata was not well-formatted");
-                let expected_checksum: String = metadata["checksum"].as_str().expect("Failed to parse checksum").to_string();
-                let expected_size: usize = metadata["size"].to_string().parse().expect("Failed to retrieve the file size");
+            pub fn verify_bytes(buffer: &[u8]) -> Result<(), $crate::errors::ParameterError> {
+                let metadata: serde_json::Value =
+                    serde_json::from_str(Self::METADATA).expect("Metadata was not well-formatted");
+                let expected_checksum: String =
+                    metadata[concat!($ftype, "_checksum")].as_str().expect("Failed to parse checksum").to_string();
+                let expected_size: usize =
+                    metadata[concat!($ftype, "_size")].to_string().parse().expect("Failed to retrieve the file size");
 
                 // Ensure the size matches.
                 if buffer.len() != expected_size {

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -372,6 +372,26 @@ macro_rules! impl_remote {
 
                 impl_load_bytes_logic_remote!($remote_url, $local_dir, &filename, metadata, expected_checksum, expected_size);
             }
+
+            #[cfg(feature = "wasm")]
+            /// Verify external bytes.
+            pub fn verify_bytes(buffer: &Vec<u8>) -> Result<(), $crate::errors::ParameterError> {
+                let metadata: serde_json::Value = serde_json::from_str(Self::METADATA).expect("Metadata was not well-formatted");
+                let expected_checksum: String = metadata["checksum"].as_str().expect("Failed to parse checksum").to_string();
+                let expected_size: usize = metadata["size"].to_string().parse().expect("Failed to retrieve the file size");
+
+                // Ensure the size matches.
+                if buffer.len() != expected_size {
+                    return Err($crate::errors::ParameterError::SizeMismatch(expected_size, buffer.len()));
+                }
+
+                // Ensure the checksum matches.
+                let candidate_checksum = checksum!(buffer);
+                if expected_checksum != candidate_checksum {
+                    return checksum_error!(expected_checksum, candidate_checksum);
+                }
+                Ok(())
+            }
         }
 
         paste::item! {

--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -340,9 +340,20 @@ impl<N: Network> Trace<N> {
 
         if !batch_inclusions.is_empty() {
             // Fetch the inclusion proving key.
+            #[cfg(not(feature = "wasm"))]
             let proving_key = match inclusion_version {
                 Some(InclusionAssignmentWrapper::V0(..)) => ProvingKey::<N>::new(N::inclusion_v0_proving_key().clone()),
                 Some(InclusionAssignmentWrapper::V1(..)) => ProvingKey::<N>::new(N::inclusion_proving_key().clone()),
+                None => bail!("Invalid or missing inclusion version"),
+            };
+            #[cfg(feature = "wasm")]
+            let proving_key = match inclusion_version {
+                Some(InclusionAssignmentWrapper::V0(..)) => {
+                    ProvingKey::<N>::new(N::inclusion_v0_proving_key(None).clone())
+                }
+                Some(InclusionAssignmentWrapper::V1(..)) => {
+                    ProvingKey::<N>::new(N::inclusion_proving_key(None).clone())
+                }
                 None => bail!("Invalid or missing inclusion version"),
             };
             // Insert the inclusion proving key and assignments.


### PR DESCRIPTION
## Motivation

SnarkVM process stores the inclusion prover and verifier in static location in memory. It is initialized via `load_bytes` method defined by the `impl_remote!` macro in the `parameters` and lazily loaded into a static location the first time the `inclusion_proving_key` is called. If trying to build a transaction offline using a SnarkVM process running in userspace, this will first check if the inclusion prover is located at a specific location on disk, otherwise it will attempt to download it from the internet.

As a matter of security, wasm runtimes run in a sandboxed environment and generally do not have access to their host machine's file system directly. Thus, the normal approach of checking the local filesystem is not available, and the sole option for initializing the inclusion prover is download it.

If desiring to build a transaction on an offline machine that is using a `wasm` binary, the inclusion prover is unable to be loaded and offline transaction building will fail. This effectively means offline transaction creation is not available in a javascript environment. Many offline wallets, custodians, and other developers generally desire to write their applications in `node.js` and thus are currently blocked from doing so.

This PR introduces an option to insert the inclusion prover bytes from an external source, and verify that the checksum and byte buffer length match the expected values for the inclusion prover, allowing safe external insertion of the inclusion prover. 

## Test Plan

Add tests that ensure
* Bytes that do not match the expected inclusion prover bytes do not pass.
* The inclusion prover is successfully loaded from external sources.
* All functionality surrounding the inclusion prover that exists when the wasm flag is not present remains unaffected.

## Steps Before Marking PR as Ready for Review

* Write described tests.
* Code & style cleanup.
* Rebase onto the `staging` branch (this was branched from v3.8.0 tag in order to provide the SDK the ability to test offline transaction building against the latest stable `mainnet` tag)