### PR TITLE
Ureq default features to enable tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +945,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2383,11 +2402,22 @@ version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4209,12 +4239,17 @@ checksum = "b7a3e9af6113ecd57b8c63d3cd76a385b2e3881365f1f489e54f49801d0c83ea"
 dependencies = [
  "base64",
  "cookie_store",
+ "flate2",
  "log",
  "percent-encoding",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "ureq-proto",
  "utf-8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4438,6 +4473,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,3 +318,4 @@ debug-assertions = true
 
 [workspace.dependencies.ureq]
 version = "3"
+default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,6 +272,7 @@ optional = true
 workspace = true
 features = ["json"]
 optional = true
+default-features = true
 
 # Some cli helper functions are used in the tests.
 [dev-dependencies.snarkvm]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,4 +318,3 @@ debug-assertions = true
 
 [workspace.dependencies.ureq]
 version = "3"
-default-features = false

--- a/ledger/query/Cargo.toml
+++ b/ledger/query/Cargo.toml
@@ -65,7 +65,6 @@ optional = true
 workspace = true
 features = [ "json" ]
 optional = true
-default-features = true
 
 [dependencies.http]
 version = "1"

--- a/ledger/query/Cargo.toml
+++ b/ledger/query/Cargo.toml
@@ -65,6 +65,7 @@ optional = true
 workspace = true
 features = [ "json" ]
 optional = true
+default-features = true
 
 [dependencies.http]
 version = "1"

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -182,16 +182,14 @@ impl<N: Network> Authorization<N> {
             .flat_map(|transition| transition.outputs().iter().filter_map(|output| output.record()));
         // Ensure the records are valid.
         for (_, record) in output_records {
-            // If the consensus version are before `ConsensusVersion::V8`, ensure the output record is on Version 0.
             // if the consensus version is on or after `ConsensusVersion::V8`, ensure the output record is on Version 1.
-            if (ConsensusVersion::V1..=ConsensusVersion::V7).contains(&consensus_version) {
-                #[cfg(not(any(test, feature = "test")))]
-                ensure!(record.version().is_zero(), "Output record must be Version 0 before Consensus V8");
-                #[cfg(any(test, feature = "test"))]
-                ensure!(record.version().is_one(), "Output record must be Version 1 before Consensus V8 in tests.");
-            } else {
+            if consensus_version >= ConsensusVersion::V8 {
                 ensure!(record.version().is_one(), "Output record must be Version 1 on or after Consensus V8");
             }
+            // We do not impose checks on record versions before
+            // `ConsensusVersion::V8`, to avoid:
+            // - breaking snarkOS tests which have version 1 records in their genesis blocks.
+            // - breaking production wallets which use version 0 records before ConsensusVersion::V8.
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation

`rusttls` is part of ureq's default features.
But because we're since recently enabling `json`, we need to manually enable `default-features`

## Test Plan

Tested `snarkos developer execute` on macOS.

CI issues:
- [x] `error: could not compile rustls (lib) due to 16 previous errors.   full command: cd "/home/circleci/project/wasm" && "cargo" "build" "--tests" "--target" "wasm32-unknown-unknown"`. Perhaps a newer ureq or a newer Rust version might help.
- [x] `Output record must be Version 0 before Consensus V8` - caused by some test innapropriately sampling record version 1 in combination with https://github.com/ProvableHQ/snarkVM/pull/2800
