### PR TITLE
Conditionally abort failed scoped atomic batches

### DIFF
--- a/ledger/store/src/helpers/mod.rs
+++ b/ledger/store/src/helpers/mod.rs
@@ -61,7 +61,11 @@ macro_rules! atomic_batch_scope {
             },
             // Rewind this atomic batch scope.
             Err(err) => {
-                $self.atomic_rewind();
+                if is_atomic_in_progress {
+                    $self.atomic_rewind();
+                } else {
+                    $self.abort_atomic();
+                }
                 Err(err)
             }
         }

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -642,6 +642,11 @@ mod tests {
             self.extra_maps.finish_atomic()
         }
 
+        fn abort_atomic(&self) {
+            self.own_map.abort_atomic();
+            self.extra_maps.abort_atomic();
+        }
+
         // While the methods above mimic the typical snarkVM ones, this method is purely for testing.
         fn is_atomic_in_progress_everywhere(&self) -> bool {
             self.own_map.is_atomic_in_progress()
@@ -701,6 +706,12 @@ mod tests {
             self.own_map2.finish_atomic()?;
             self.extra_maps.finish_atomic()
         }
+
+        fn abort_atomic(&self) {
+            self.own_map1.abort_atomic();
+            self.own_map2.abort_atomic();
+            self.extra_maps.abort_atomic();
+        }
     }
 
     struct TestStorage3 {
@@ -734,6 +745,10 @@ mod tests {
 
         fn finish_atomic(&self) -> Result<()> {
             self.own_map.finish_atomic()
+        }
+
+        fn abort_atomic(&self) {
+            self.own_map.abort_atomic();
         }
     }
 

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -873,6 +873,11 @@ mod tests {
             self.extra_maps.finish_atomic()
         }
 
+        fn abort_atomic(&self) {
+            self.own_map.abort_atomic();
+            self.extra_maps.abort_atomic();
+        }
+
         // While the methods above mimic the typical snarkVM ones, this method is purely for testing.
         fn is_atomic_in_progress_everywhere(&self) -> bool {
             self.own_map.is_atomic_in_progress()
@@ -932,6 +937,12 @@ mod tests {
             self.own_map2.finish_atomic()?;
             self.extra_maps.finish_atomic()
         }
+
+        fn abort_atomic(&self) {
+            self.own_map1.abort_atomic();
+            self.own_map2.abort_atomic();
+            self.extra_maps.abort_atomic();
+        }
     }
 
     struct TestStorage3 {
@@ -974,6 +985,11 @@ mod tests {
         fn finish_atomic(&self) -> Result<()> {
             self.own_nested_map.finish_atomic()?;
             self.own_map.finish_atomic()
+        }
+
+        fn abort_atomic(&self) {
+            self.own_nested_map.abort_atomic();
+            self.own_map.abort_atomic();
         }
     }
 


### PR DESCRIPTION
This is a "tightening" for the behavior of scoped atomic write batches; if an error occurs outside of an atomic batch operation (which is unlikely, but technically possible), an `abort_atomic` is more appropriate, as there are no pending operations to roll back.