### PR TITLE
Increase to 40 validators

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -172,19 +172,21 @@ impl Network for CanaryV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::canary::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
         (ConsensusVersion::V5, 100),
         (ConsensusVersion::V6, 100),
+        (ConsensusVersion::V9, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 25),
         (ConsensusVersion::V6, 25),
+        (ConsensusVersion::V9, 25),
     ];
     /// The network name.
     const NAME: &'static str = "Aleo Canary (v0)";

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -25,7 +25,7 @@ pub const CANARY_V0_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 9] = [
     (ConsensusVersion::V6, 6_240_000),
     (ConsensusVersion::V7, 6_880_000),
     (ConsensusVersion::V8, 7_565_000),
-    (ConsensusVersion::V9, 999_999_999),
+    (ConsensusVersion::V9, 8_028_000),
 ];
 
 /// The consensus version height for `MainnetV0`.
@@ -38,7 +38,7 @@ pub const MAINNET_V0_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 9] = [
     (ConsensusVersion::V6, 7_560_000),
     (ConsensusVersion::V7, 7_570_000),
     (ConsensusVersion::V8, 9_430_000),
-    (ConsensusVersion::V9, 999_999_999),
+    (ConsensusVersion::V9, 10_272_000),
 ];
 
 /// The consensus version heights for `TestnetV0`.
@@ -51,7 +51,7 @@ pub const TESTNET_V0_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); 9] = [
     (ConsensusVersion::V6, 7_600_000),
     (ConsensusVersion::V7, 8_365_000),
     (ConsensusVersion::V8, 9_173_000),
-    (ConsensusVersion::V9, 999_999_999),
+    (ConsensusVersion::V9, 9_800_000),
 ];
 
 /// The consensus version heights when the `test_consensus_heights` feature is enabled.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -257,7 +257,7 @@ pub trait Network:
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5];
 
     /// Returns the consensus version which is active at the given height.
     #[allow(non_snake_case)]

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -177,19 +177,21 @@ impl Network for MainnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 16),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 30),
         (ConsensusVersion::V6, 35),
+        (ConsensusVersion::V9, 40),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 101),
         (ConsensusVersion::V5, 102),
         (ConsensusVersion::V6, 103),
+        (ConsensusVersion::V9, 104),
     ];
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -172,19 +172,21 @@ impl Network for TestnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::testnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
         (ConsensusVersion::V5, 100),
         (ConsensusVersion::V6, 100),
+        (ConsensusVersion::V9, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 4] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 25),
         (ConsensusVersion::V6, 25),
+        (ConsensusVersion::V9, 25),
     ];
     /// The network name.
     const NAME: &'static str = "Aleo Testnet (v0)";


### PR DESCRIPTION
## Motivation

This was postponed due to the recently rushed release where we still experienced syncing issues.

## Test Plan

- We now have automated stress-testing runs succeeding with 40 validators.
- We have extensive unit tests in `test_consensus_constants` which validate that we don't insert wonky values in these constants.