### PR TITLE
Expose constants to they can be used elsewhere

### DIFF
--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -33,7 +33,7 @@ macro_rules! ensure_is_unique {
 }
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
-    /// The maximum number of deployments to verify in parallel.
+    /// The maximum number of deployments that the VM can verify in parallel.
     pub const MAX_PARALLEL_DEPLOY_VERIFICATIONS: usize = 5;
     /// The maximum number of executions to verify in parallel.
     pub const MAX_PARALLEL_EXECUTE_VERIFICATIONS: usize = 1000;

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -34,9 +34,9 @@ macro_rules! ensure_is_unique {
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// The maximum number of deployments to verify in parallel.
-    pub(crate) const MAX_PARALLEL_DEPLOY_VERIFICATIONS: usize = 5;
+    pub const MAX_PARALLEL_DEPLOY_VERIFICATIONS: usize = 5;
     /// The maximum number of executions to verify in parallel.
-    pub(crate) const MAX_PARALLEL_EXECUTE_VERIFICATIONS: usize = 1000;
+    pub const MAX_PARALLEL_EXECUTE_VERIFICATIONS: usize = 1000;
 
     /// Verifies the list of transactions in the VM. On failure, returns an error.
     pub fn check_transactions<R: CryptoRng + Rng>(


### PR DESCRIPTION
## Motivation

For example in: https://github.com/ProvableHQ/snarkOS/pull/3753/commits/875a5d9ca227f10212e5ef9645ee65e67a87e66d
