### PR TITLE
Make StaticQuery part of the Query Enum.

### DIFF
--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::QueryTrait;
+use crate::{QueryTrait, StaticQuery};
 use console::{
     network::prelude::*,
     program::{ProgramID, StatePath},
@@ -31,6 +31,7 @@ pub enum Query<N: Network, B: BlockStorage<N>> {
     VM(BlockStore<N, B>),
     /// The base URL of the node.
     REST(String),
+    STATIC(StaticQuery<N>),
 }
 
 impl<N: Network, B: BlockStorage<N>> From<BlockStore<N, B>> for Query<N, B> {
@@ -46,20 +47,31 @@ impl<N: Network, B: BlockStorage<N>> From<&BlockStore<N, B>> for Query<N, B> {
 }
 
 impl<N: Network, B: BlockStorage<N>> From<String> for Query<N, B> {
-    fn from(url: String) -> Self {
-        Self::REST(url)
+    fn from(string_representation: String) -> Self {
+        match string_representation.parse::<StaticQuery<N>>() {
+            Ok(query) => Self::STATIC(query),
+            Err(_) => Self::REST(string_representation),
+        }
     }
 }
 
 impl<N: Network, B: BlockStorage<N>> From<&String> for Query<N, B> {
-    fn from(url: &String) -> Self {
-        Self::REST(url.to_string())
+    fn from(string_representation_ref: &String) -> Self {
+        let string_representation = string_representation_ref.to_string();
+        match string_representation.parse::<StaticQuery<N>>() {
+            Ok(query) => Self::STATIC(query),
+            Err(_) => Self::REST(string_representation),
+        }
     }
 }
 
 impl<N: Network, B: BlockStorage<N>> From<&str> for Query<N, B> {
-    fn from(url: &str) -> Self {
-        Self::REST(url.to_string())
+    fn from(str_representation_ref: &str) -> Self {
+        let string_representation = str_representation_ref.to_string();
+        match string_representation.parse::<StaticQuery<N>>() {
+            Ok(query) => Self::STATIC(query),
+            Err(_) => Self::REST(string_representation),
+        }
     }
 }
 
@@ -81,6 +93,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(query) => query.current_state_root(),
         }
     }
 
@@ -101,6 +114,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(_query) => unimplemented!("Async calls are not supported by StaticQuery"),
         }
     }
 
@@ -120,6 +134,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(query) => query.get_state_path_for_commitment(commitment),
         }
     }
 
@@ -140,6 +155,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(_query) => unimplemented!("Async calls are not supported by StaticQuery"),
         }
     }
 
@@ -159,6 +175,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(query) => query.current_block_height(),
         }
     }
 
@@ -179,6 +196,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(_query) => unimplemented!("Async calls are not supported by StaticQuery"),
         }
     }
 }
@@ -202,6 +220,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(_query) => unimplemented!("get_program is not supported by StaticQuery"),
         }
     }
 
@@ -224,6 +243,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
+            Self::STATIC(_query) => unimplemented!("get_program_async is not supported by StaticQuery"),
         }
     }
 

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -114,7 +114,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
-            Self::STATIC(_query) => unimplemented!("Async calls are not supported by StaticQuery"),
+            Self::STATIC(_query) => bail!("Async calls are not supported by StaticQuery"),
         }
     }
 
@@ -155,7 +155,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
-            Self::STATIC(_query) => unimplemented!("Async calls are not supported by StaticQuery"),
+            Self::STATIC(_query) => bail!("Async calls are not supported by StaticQuery"),
         }
     }
 
@@ -196,7 +196,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
                 }
                 _ => bail!("Unsupported network ID in inclusion query"),
             },
-            Self::STATIC(_query) => unimplemented!("Async calls are not supported by StaticQuery"),
+            Self::STATIC(_query) => bail!("Async calls are not supported by StaticQuery"),
         }
     }
 }


### PR DESCRIPTION
## Motivation

As per this comment from @vicsn https://github.com/ProvableHQ/snarkOS/pull/3723#discussion_r2239329029 I am making the StaticQuery part of the Query enum, so it is easier to just create it form string representations and not Box it and cast it (as it is done in the SnarkOs PR).

## Test Plan

Using the stress tests I'm testing the static queries for days and all works as expected.

(Write your test plan here)

## Related PRs

https://github.com/ProvableHQ/snarkOS/pull/3723
