### PR TITLE
Actually enable hashing of R1CS

### DIFF
--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -351,6 +351,9 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_private());
             assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
+            // Optionally save a hash of the R1CS.
+            #[cfg(feature = "save_r1cs_hashes")]
+            r1cs.save_hash();
             // Convert the R1CS instance to an assignment.
             Assignment::from(r1cs)
         })

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -104,6 +104,7 @@ impl<N: Network> Stack<N> {
 
         #[cfg(not(any(test, feature = "test")))]
         // Skip the certificate verification if the consensus version is before ConsensusVersion::V8.
+        // Circuit synthesis was changed in a backwards incompatible way in ConsensusVersion::V8.
         if (ConsensusVersion::V1..=ConsensusVersion::V7).contains(&_consensus_version) {
             finish!(timer);
             return Ok(());


### PR DESCRIPTION
## Motivation

Previous attempts to hash R1CS seems to have hashed empty vectors.

## Test Plan

- [ ] Test ongoing in https://github.com/ProvableHQ/aleo-program-regressions/tree/update-argument
