### PR TITLE
[Perf] Compact subdag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,6 +484,20 @@ jobs:
       - run_test:
           workspace_member: snarkvm-ledger-narwhal-batch-header
 
+  ledger-narwhal-compact-certificate:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.twoxlarge >>
+    steps:
+      - run_test:
+          workspace_member: snarkvm-ledger-narwhal-compact-certificate
+
+  ledger-narwhal-compact-header:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.twoxlarge >>
+    steps:
+      - run_test:
+          workspace_member: snarkvm-ledger-narwhal-compact-header
+
   ledger-narwhal-data:
     executor: rust-docker
     resource_class: << pipeline.parameters.small >>
@@ -891,6 +905,8 @@ workflows:
       - ledger-narwhal
       - ledger-narwhal-batch-certificate
       - ledger-narwhal-batch-header
+      - ledger-narwhal-compact-certificate
+      - ledger-narwhal-compact-header
       - ledger-narwhal-data
       - ledger-narwhal-subdag
       - ledger-narwhal-transmission

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-compact-certificate"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "bincode",
  "indexmap 2.10.0",
@@ -3502,12 +3502,11 @@ dependencies = [
  "snarkvm-ledger-narwhal-compact-header",
  "snarkvm-ledger-narwhal-traits",
  "snarkvm-ledger-narwhal-transmission-id",
- "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-compact-header"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "bincode",
  "indexmap 2.10.0",
@@ -3516,7 +3515,6 @@ dependencies = [
  "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-ledger-narwhal-compact-header",
  "snarkvm-ledger-narwhal-transmission-id",
- "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
@@ -3547,13 +3545,12 @@ dependencies = [
  "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-traits",
  "snarkvm-ledger-narwhal-transmission-id",
- "snarkvm-ledger-puzzle",
  "tracing",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-traits"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "indexmap 2.10.0",
  "snarkvm-console",
@@ -3661,6 +3658,7 @@ dependencies = [
  "snarkvm-ledger-authority",
  "snarkvm-ledger-block",
  "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-transmission-id",
  "snarkvm-ledger-puzzle",
  "snarkvm-ledger-test-helpers",
  "snarkvm-synthesizer-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "bincode",
+ "bit-set",
  "indexmap 2.10.0",
  "rayon",
  "serde_json",
@@ -3407,7 +3408,9 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-authority",
  "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-compact-certificate",
  "snarkvm-ledger-narwhal-data",
  "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-transmission-id",
@@ -3447,8 +3450,11 @@ dependencies = [
  "snarkvm-ledger-narwhal",
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-compact-certificate",
+ "snarkvm-ledger-narwhal-compact-header",
  "snarkvm-ledger-narwhal-data",
  "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-ledger-narwhal-traits",
  "snarkvm-ledger-narwhal-transmission",
  "snarkvm-ledger-narwhal-transmission-id",
 ]
@@ -3464,6 +3470,7 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-traits",
  "snarkvm-ledger-narwhal-transmission-id",
 ]
 
@@ -3479,6 +3486,37 @@ dependencies = [
  "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-ledger-narwhal-transmission-id",
  "time",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-compact-certificate"
+version = "4.0.0"
+dependencies = [
+ "bincode",
+ "indexmap 2.10.0",
+ "rayon",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-compact-certificate",
+ "snarkvm-ledger-narwhal-compact-header",
+ "snarkvm-ledger-narwhal-traits",
+ "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-puzzle",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-compact-header"
+version = "4.0.0"
+dependencies = [
+ "bincode",
+ "indexmap 2.10.0",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-compact-header",
+ "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
@@ -3505,8 +3543,20 @@ dependencies = [
  "snarkvm-ledger-committee",
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-compact-certificate",
  "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-ledger-narwhal-traits",
  "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-puzzle",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-traits"
+version = "4.0.0"
+dependencies = [
+ "indexmap 2.10.0",
+ "snarkvm-console",
 ]
 
 [[package]]
@@ -3611,7 +3661,6 @@ dependencies = [
  "snarkvm-ledger-authority",
  "snarkvm-ledger-block",
  "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-puzzle",
  "snarkvm-ledger-test-helpers",
  "snarkvm-synthesizer-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ members = [
   "ledger/narwhal",
   "ledger/narwhal/batch-certificate",
   "ledger/narwhal/batch-header",
+  "ledger/narwhal/compact-certificate",
+  "ledger/narwhal/compact-header",
   "ledger/narwhal/data",
   "ledger/narwhal/subdag",
   "ledger/narwhal/transmission",
@@ -364,6 +366,18 @@ version = "=4.1.0"
 [workspace.dependencies.snarkvm-ledger-narwhal-batch-certificate]
 path = "ledger/narwhal/batch-certificate"
 version = "=4.1.0"
+
+[workspace.dependencies.snarkvm-ledger-narwhal-compact-certificate]
+path = "ledger/narwhal/compact-certificate"
+version = "=4.0.0"
+
+[workspace.dependencies.snarkvm-ledger-narwhal-compact-header]
+path = "ledger/narwhal/compact-header"
+version = "=4.0.0"
+
+[workspace.dependencies.snarkvm-ledger-narwhal-traits]
+path = "ledger/narwhal/traits"
+version = "=4.0.0"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-subdag]
 path = "ledger/narwhal/subdag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,15 +369,15 @@ version = "=4.1.0"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-compact-certificate]
 path = "ledger/narwhal/compact-certificate"
-version = "=4.0.0"
+version = "=4.1.0"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-compact-header]
 path = "ledger/narwhal/compact-header"
-version = "=4.0.0"
+version = "=4.1.0"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-traits]
 path = "ledger/narwhal/traits"
-version = "=4.0.0"
+version = "=4.1.0"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-subdag]
 path = "ledger/narwhal/subdag"

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -132,7 +132,7 @@ pub mod test_helpers {
     /// Returns a sample quorum authority.
     pub fn sample_quorum_authority(rng: &mut TestRng) -> Authority<CurrentNetwork> {
         // Return the quorum authority.
-        Authority::new_quorum(snarkvm_ledger_narwhal_subdag::test_helpers::sample_subdag(rng))
+        Authority::new_quorum(snarkvm_ledger_narwhal_subdag::test_helpers::sample_full_subdag(rng))
     }
 
     /// Returns a list of sample authorities.

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -50,6 +50,12 @@ features = [ "default" ]
 [dependencies.snarkvm-ledger-narwhal-batch-header]
 workspace = true
 
+[dependencies.snarkvm-ledger-narwhal-batch-certificate]
+workspace = true
+
+[dependencies.snarkvm-ledger-narwhal-compact-certificate]
+workspace = true
+
 [dependencies.snarkvm-ledger-narwhal-data]
 workspace = true
 
@@ -67,6 +73,9 @@ workspace = true
 
 [dependencies.snarkvm-synthesizer-snark]
 workspace = true
+
+[dependencies.bit-set]
+version = "0.8"
 
 [dependencies.indexmap]
 workspace = true

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -45,7 +45,10 @@ impl<N: Network> FromBytes for Block<N> {
         let (prior_solution_transmission_ids, aborted_solution_transmission_ids, aborted_solution_ids) = if version >= 2
         {
             // Read the number of prior solution transmission IDs.
-            let num_prior_solutions = u32::read_le(&mut reader)?; // TODO: what is a sane bound on this value?
+            let num_prior_solutions = u32::read_le(&mut reader)?;
+            if num_prior_solutions as usize > Solutions::<N>::max_aborted_solutions().map_err(error)? {
+                return Err(error("Invalid number of prior solutions IDs in the block"));
+            }
             // Read the prior solution transmission IDs.
             let mut prior_solution_transmission_ids = Vec::with_capacity(num_prior_solutions as usize);
             for _ in 0..num_prior_solutions {
@@ -61,7 +64,7 @@ impl<N: Network> FromBytes for Block<N> {
             for _ in 0..num_aborted_solutions {
                 aborted_solution_transmission_ids.push(FromBytes::read_le(&mut reader)?);
             }
-            (Some(prior_solution_transmission_ids), Some(aborted_solution_transmission_ids), vec![])
+            (Some(prior_solution_transmission_ids), Some(aborted_solution_transmission_ids), None)
         } else {
             // Read the number of aborted solution IDs.
             let num_aborted_solutions = u32::read_le(&mut reader)?;
@@ -74,7 +77,7 @@ impl<N: Network> FromBytes for Block<N> {
             for _ in 0..num_aborted_solutions {
                 aborted_solution_ids.push(FromBytes::read_le(&mut reader)?);
             }
-            (None, None, aborted_solution_ids)
+            (None, None, Some(aborted_solution_ids))
         };
 
         // Read the transactions.
@@ -99,7 +102,7 @@ impl<N: Network> FromBytes for Block<N> {
                 for _ in 0..num_aborted_transactions {
                     aborted_transaction_transmission_ids.push(FromBytes::read_le(&mut reader)?);
                 }
-                (Some(prior_transaction_transmission_ids), Some(aborted_transaction_transmission_ids), vec![])
+                (Some(prior_transaction_transmission_ids), Some(aborted_transaction_transmission_ids), None)
             } else {
                 // Read the number of aborted transaction IDs.
                 let num_aborted_transactions = u32::read_le(&mut reader)?;
@@ -112,7 +115,7 @@ impl<N: Network> FromBytes for Block<N> {
                 for _ in 0..num_aborted_transactions {
                     aborted_transaction_ids.push(FromBytes::read_le(&mut reader)?);
                 }
-                (None, None, aborted_transaction_ids)
+                (None, None, Some(aborted_transaction_ids))
             };
 
         // Construct the block.
@@ -168,8 +171,10 @@ impl<N: Network> ToBytes for Block<N> {
         match version {
             1 => {
                 // Write the aborted solution IDs.
-                (u32::try_from(self.aborted_solution_ids.len()).map_err(error))?.write_le(&mut writer)?;
-                self.aborted_solution_ids.write_le(&mut writer)?;
+                let aborted_solution_ids =
+                    self.aborted_solution_ids.as_ref().ok_or(error("missing aborted_solution_ids"))?;
+                (u32::try_from(aborted_solution_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                aborted_solution_ids.write_le(&mut writer)?;
             }
             _ => {
                 // Write the prior solution transmission ids.
@@ -195,8 +200,10 @@ impl<N: Network> ToBytes for Block<N> {
         match version {
             1 => {
                 // Write the aborted transaction ids.
-                (u32::try_from(self.aborted_transaction_ids.len()).map_err(error))?.write_le(&mut writer)?;
-                self.aborted_transaction_ids.write_le(&mut writer)?;
+                let aborted_transaction_ids =
+                    self.aborted_transaction_ids.as_ref().ok_or(error("missing aborted_transaction_ids"))?;
+                (u32::try_from(aborted_transaction_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                aborted_transaction_ids.write_le(&mut writer)?;
             }
             _ => {
                 // Write the prior transaction transmission ids.

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -22,7 +22,7 @@ impl<N: Network> FromBytes for Block<N> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
-        if version != 1 {
+        if ![1, 2].contains(&version) {
             return Err(error("Invalid block version"));
         }
 
@@ -42,32 +42,78 @@ impl<N: Network> FromBytes for Block<N> {
         // Read the solutions.
         let solutions: Solutions<N> = FromBytes::read_le(&mut reader)?;
 
-        // Read the number of aborted solution IDs.
-        let num_aborted_solutions = u32::read_le(&mut reader)?;
-        // Ensure the number of aborted solutions IDs is within bounds (this is an early safety check).
-        if num_aborted_solutions as usize > Solutions::<N>::max_aborted_solutions().map_err(error)? {
-            return Err(error("Invalid number of aborted solutions IDs in the block"));
-        }
-        // Read the aborted solution IDs.
-        let mut aborted_solution_ids = Vec::with_capacity(num_aborted_solutions as usize);
-        for _ in 0..num_aborted_solutions {
-            aborted_solution_ids.push(FromBytes::read_le(&mut reader)?);
-        }
+        let (prior_solution_transmission_ids, aborted_solution_transmission_ids, aborted_solution_ids) = if version >= 2
+        {
+            // Read the number of prior solution transmission IDs.
+            let num_prior_solutions = u32::read_le(&mut reader)?; // TODO: what is a sane bound on this value?
+            // Read the prior solution transmission IDs.
+            let mut prior_solution_transmission_ids = Vec::with_capacity(num_prior_solutions as usize);
+            for _ in 0..num_prior_solutions {
+                prior_solution_transmission_ids.push(FromBytes::read_le(&mut reader)?);
+            }
+            // Read the number of aborted solution transmission IDs.
+            let num_aborted_solutions = u32::read_le(&mut reader)?;
+            if num_aborted_solutions as usize > Solutions::<N>::max_aborted_solutions().map_err(error)? {
+                return Err(error("Invalid number of aborted solutions IDs in the block"));
+            }
+            // Read the aborted solution transmission IDs.
+            let mut aborted_solution_transmission_ids = Vec::with_capacity(num_aborted_solutions as usize);
+            for _ in 0..num_aborted_solutions {
+                aborted_solution_transmission_ids.push(FromBytes::read_le(&mut reader)?);
+            }
+            (Some(prior_solution_transmission_ids), Some(aborted_solution_transmission_ids), vec![])
+        } else {
+            // Read the number of aborted solution IDs.
+            let num_aborted_solutions = u32::read_le(&mut reader)?;
+            // Ensure the number of aborted solutions IDs is within bounds (this is an early safety check).
+            if num_aborted_solutions as usize > Solutions::<N>::max_aborted_solutions().map_err(error)? {
+                return Err(error("Invalid number of aborted solutions IDs in the block"));
+            }
+            // Read the aborted solution IDs.
+            let mut aborted_solution_ids = Vec::with_capacity(num_aborted_solutions as usize);
+            for _ in 0..num_aborted_solutions {
+                aborted_solution_ids.push(FromBytes::read_le(&mut reader)?);
+            }
+            (None, None, aborted_solution_ids)
+        };
 
         // Read the transactions.
         let transactions = FromBytes::read_le(&mut reader)?;
 
-        // Read the number of aborted transaction IDs.
-        let num_aborted_transactions = u32::read_le(&mut reader)?;
-        // Ensure the number of aborted transaction IDs is within bounds (this is an early safety check).
-        if num_aborted_transactions as usize > Transactions::<N>::max_aborted_transactions().map_err(error)? {
-            return Err(error("Invalid number of aborted transaction IDs in the block"));
-        }
-        // Read the aborted transaction IDs.
-        let mut aborted_transaction_ids = Vec::with_capacity(num_aborted_transactions as usize);
-        for _ in 0..num_aborted_transactions {
-            aborted_transaction_ids.push(FromBytes::read_le(&mut reader)?);
-        }
+        let (prior_transaction_transmission_ids, aborted_transaction_transmission_ids, aborted_transaction_ids) =
+            if version >= 2 {
+                // Read the number of prior transaction transmission IDs.
+                let num_prior_transactions = u32::read_le(&mut reader)?; // TODO: what is a sane bound on this value?
+                // Read the prior transaction transmission IDs.
+                let mut prior_transaction_transmission_ids = Vec::with_capacity(num_prior_transactions as usize);
+                for _ in 0..num_prior_transactions {
+                    prior_transaction_transmission_ids.push(FromBytes::read_le(&mut reader)?);
+                }
+                // Read the number of aborted transaction transmission IDs.
+                let num_aborted_transactions = u32::read_le(&mut reader)?;
+                if num_aborted_transactions as usize > Transactions::<N>::max_aborted_transactions().map_err(error)? {
+                    return Err(error("Invalid number of aborted transaction IDs in the block"));
+                }
+                // Read the aborted transaction transmission IDs.
+                let mut aborted_transaction_transmission_ids = Vec::with_capacity(num_aborted_transactions as usize);
+                for _ in 0..num_aborted_transactions {
+                    aborted_transaction_transmission_ids.push(FromBytes::read_le(&mut reader)?);
+                }
+                (Some(prior_transaction_transmission_ids), Some(aborted_transaction_transmission_ids), vec![])
+            } else {
+                // Read the number of aborted transaction IDs.
+                let num_aborted_transactions = u32::read_le(&mut reader)?;
+                // Ensure the number of aborted transaction IDs is within bounds (this is an early safety check).
+                if num_aborted_transactions as usize > Transactions::<N>::max_aborted_transactions().map_err(error)? {
+                    return Err(error("Invalid number of aborted transaction IDs in the block"));
+                }
+                // Read the aborted transaction IDs.
+                let mut aborted_transaction_ids = Vec::with_capacity(num_aborted_transactions as usize);
+                for _ in 0..num_aborted_transactions {
+                    aborted_transaction_ids.push(FromBytes::read_le(&mut reader)?);
+                }
+                (None, None, aborted_transaction_ids)
+            };
 
         // Construct the block.
         let block = Self::from(
@@ -76,8 +122,12 @@ impl<N: Network> FromBytes for Block<N> {
             authority,
             ratifications,
             solutions,
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
             aborted_solution_ids,
             transactions,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
             aborted_transaction_ids,
         )
         .map_err(error)?;
@@ -95,7 +145,9 @@ impl<N: Network> ToBytes for Block<N> {
     #[inline]
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the version.
-        1u8.write_le(&mut writer)?;
+        let version =
+            if N::CONSENSUS_VERSION(self.height()).map_err(error)? >= ConsensusVersion::V10 { 2u8 } else { 1 };
+        version.write_le(&mut writer)?;
 
         // Write the block hash.
         self.block_hash.write_le(&mut writer)?;
@@ -113,16 +165,57 @@ impl<N: Network> ToBytes for Block<N> {
         // Write the solutions.
         self.solutions.write_le(&mut writer)?;
 
-        // Write the aborted solution IDs.
-        (u32::try_from(self.aborted_solution_ids.len()).map_err(error))?.write_le(&mut writer)?;
-        self.aborted_solution_ids.write_le(&mut writer)?;
+        match version {
+            1 => {
+                // Write the aborted solution IDs.
+                (u32::try_from(self.aborted_solution_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                self.aborted_solution_ids.write_le(&mut writer)?;
+            }
+            _ => {
+                // Write the prior solution transmission ids.
+                let prior_solution_transmission_ids = self
+                    .prior_solution_transmission_ids
+                    .as_ref()
+                    .ok_or(error("missing prior_solution_transmission_ids"))?;
+                (u32::try_from(prior_solution_transmission_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                prior_solution_transmission_ids.write_le(&mut writer)?;
+                // Write the aborted solution transmission ids.
+                let aborted_solution_transmission_ids = self
+                    .aborted_solution_transmission_ids
+                    .as_ref()
+                    .ok_or(error("missing aborted_solution_transmission_ids"))?;
+                (u32::try_from(aborted_solution_transmission_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                aborted_solution_transmission_ids.write_le(&mut writer)?;
+            }
+        }
 
         // Write the transactions.
         self.transactions.write_le(&mut writer)?;
 
-        // Write the aborted transaction IDs.
-        (u32::try_from(self.aborted_transaction_ids.len()).map_err(error))?.write_le(&mut writer)?;
-        self.aborted_transaction_ids.write_le(&mut writer)
+        match version {
+            1 => {
+                // Write the aborted transaction ids.
+                (u32::try_from(self.aborted_transaction_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                self.aborted_transaction_ids.write_le(&mut writer)?;
+            }
+            _ => {
+                // Write the prior transaction transmission ids.
+                let prior_transaction_transmission_ids = self
+                    .prior_transaction_transmission_ids
+                    .as_ref()
+                    .ok_or(error("missing prior_transaction_transmission_ids"))?;
+                (u32::try_from(prior_transaction_transmission_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                prior_transaction_transmission_ids.write_le(&mut writer)?;
+                // Write the aborted transaction transmission ids.
+                let aborted_transaction_transmission_ids = self
+                    .aborted_transaction_transmission_ids
+                    .as_ref()
+                    .ok_or(error("missing aborted_transaction_transmission_ids"))?;
+                (u32::try_from(aborted_transaction_transmission_ids.len()).map_err(error))?.write_le(&mut writer)?;
+                aborted_transaction_transmission_ids.write_le(&mut writer)?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -138,6 +231,7 @@ mod tests {
         let rng = &mut TestRng::default();
 
         for expected in [crate::test_helpers::sample_genesis_block(rng)].into_iter() {
+            // todo: sample compact too for the Block tests
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Block::read_le(&expected_bytes[..])?);

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -86,7 +86,10 @@ impl<N: Network> FromBytes for Block<N> {
         let (prior_transaction_transmission_ids, aborted_transaction_transmission_ids, aborted_transaction_ids) =
             if version >= 2 {
                 // Read the number of prior transaction transmission IDs.
-                let num_prior_transactions = u32::read_le(&mut reader)?; // TODO: what is a sane bound on this value?
+                let num_prior_transactions = u32::read_le(&mut reader)?;
+                if num_prior_transactions as usize > Transactions::<N>::max_aborted_transactions().map_err(error)? {
+                    return Err(error("Invalid number of prior transaction IDs in the block"));
+                }
                 // Read the prior transaction transmission IDs.
                 let mut prior_transaction_transmission_ids = Vec::with_capacity(num_prior_transactions as usize);
                 for _ in 0..num_prior_transactions {
@@ -238,7 +241,6 @@ mod tests {
         let rng = &mut TestRng::default();
 
         for expected in [crate::test_helpers::sample_genesis_block(rng)].into_iter() {
-            // todo: sample compact too for the Block tests
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le()?;
             assert_eq!(expected, Block::read_le(&expected_bytes[..])?);

--- a/ledger/block/src/genesis.rs
+++ b/ledger/block/src/genesis.rs
@@ -38,7 +38,7 @@ impl<N: Network> Block<N> {
             // Ensure there is the correct number of finalize operations in the genesis block.
             && self.transactions.num_finalize() == 2 * Self::NUM_GENESIS_TRANSACTIONS
             // Ensure there are no aborted transaction IDs in the genesis block.
-            && self.aborted_transaction_ids.is_empty()
+            && self.aborted_transaction_ids == Some(vec![])
     }
 }
 

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -63,6 +63,9 @@ use snarkvm_ledger_narwhal_subdag::Subdag;
 use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
 use snarkvm_ledger_puzzle::{PuzzleSolutions, Solution, SolutionID};
 
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct Block<N: Network> {
     /// The hash of this block.
@@ -77,10 +80,20 @@ pub struct Block<N: Network> {
     ratifications: Ratifications<N>,
     /// The solutions in the block.
     solutions: Solutions<N>,
+    /// The transmission IDs of both accepted and aborted solutions in the previous block.
+    /// Technically prior checksums can be retrieved from the ledger, but that is unwieldy.
+    prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
+    /// The aborted solution transmission IDs in this block.
+    aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
     /// The aborted solution IDs in this block.
     aborted_solution_ids: Vec<SolutionID<N>>,
     /// The transactions in this block.
     transactions: Transactions<N>,
+    /// The transmission IDs of both accepted and aborted transactions in the previous block.
+    /// Technically prior checksums can be retrieved from the ledger, but that is unwieldy.
+    prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
+    /// The aborted transaction transmission IDs in this block.
+    aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
     /// The aborted transaction IDs in this block.
     aborted_transaction_ids: Vec<N::TransactionID>,
 }
@@ -110,8 +123,12 @@ impl<N: Network> Block<N> {
             authority,
             ratifications,
             solutions,
+            None,
+            None,
             aborted_solution_ids,
             transactions,
+            None,
+            None,
             aborted_transaction_ids,
         )
     }
@@ -124,8 +141,12 @@ impl<N: Network> Block<N> {
         subdag: Subdag<N>,
         ratifications: Ratifications<N>,
         solutions: Solutions<N>,
+        prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
+        aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_solution_ids: Vec<SolutionID<N>>,
         transactions: Transactions<N>,
+        prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
+        aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_transaction_ids: Vec<N::TransactionID>,
     ) -> Result<Self> {
         // Construct the beacon authority.
@@ -137,8 +158,12 @@ impl<N: Network> Block<N> {
             authority,
             ratifications,
             solutions,
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
             aborted_solution_ids,
             transactions,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
             aborted_transaction_ids,
         )
     }
@@ -151,8 +176,12 @@ impl<N: Network> Block<N> {
         authority: Authority<N>,
         ratifications: Ratifications<N>,
         solutions: Solutions<N>,
+        prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
+        aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_solution_ids: Vec<SolutionID<N>>,
         transactions: Transactions<N>,
+        prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
+        aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_transaction_ids: Vec<N::TransactionID>,
     ) -> Result<Self> {
         // Ensure the number of aborted solutions IDs is within the allowed range.
@@ -197,15 +226,9 @@ impl<N: Network> Block<N> {
                 // Ensure the signature is valid.
                 ensure!(signature.verify(&address, &[block_hash]), "Invalid signature for block {}", header.height());
             }
-            Authority::Quorum(subdag) => {
-                // Ensure the transmission IDs from the subdag correspond to the block.
-                Self::check_subdag_transmissions(
-                    subdag,
-                    &solutions,
-                    &aborted_solution_ids,
-                    &transactions,
-                    &aborted_transaction_ids,
-                )?;
+            Authority::Quorum(_subdag) => {
+                // We purposefully do not repeat expensive checks on the subdag,
+                // which are already performed in `fn verify_authority` in `verify.rs`.
             }
         }
 
@@ -231,14 +254,17 @@ impl<N: Network> Block<N> {
             authority,
             ratifications,
             solutions,
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
             aborted_solution_ids,
             transactions,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
             aborted_transaction_ids,
         )
     }
 
-    /// Initializes a new block from the given block hash, previous block hash, block header,
-    /// authority, ratifications, solutions, transactions, and aborted transaction IDs.
+    /// Initializes a new block.
     /// This is only called by [`Block::from`], which validates the block components.
     fn from_unchecked(
         block_hash: N::BlockHash,
@@ -247,8 +273,12 @@ impl<N: Network> Block<N> {
         authority: Authority<N>,
         ratifications: Ratifications<N>,
         solutions: Solutions<N>,
+        prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
+        aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_solution_ids: Vec<SolutionID<N>>,
         transactions: Transactions<N>,
+        prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
+        aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_transaction_ids: Vec<N::TransactionID>,
     ) -> Result<Self> {
         // Return the block.
@@ -259,10 +289,72 @@ impl<N: Network> Block<N> {
             authority,
             ratifications,
             solutions,
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
             aborted_solution_ids,
             transactions,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
             aborted_transaction_ids,
         })
+    }
+
+    /// Borrow the Block and return a Subdag with full batch certificates.
+    pub fn to_full_subdag(&self) -> Result<Subdag<N>> {
+        let Block {
+            solutions,
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
+            transactions,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
+            authority,
+            ..
+        } = self;
+
+        // Check if Authority is a Quorum
+        let Authority::Quorum(subdag) = authority else {
+            bail!("Can only convert block with Quorum Authority to full subdag");
+        };
+
+        if matches!(subdag, Subdag::Full { .. }) {
+            return Ok(subdag.clone());
+        }
+
+        // Prepare an iterator over the unconfirmed transactions.
+        let unconfirmed_transactions = cfg_iter!(transactions)
+            .map(|confirmed| confirmed.to_unconfirmed_transaction())
+            .collect::<Result<Vec<_>>>()?;
+        // Compute the transaction transmission IDs.
+        let transaction_transmission_ids = unconfirmed_transactions
+            .iter()
+            .map(|tx| {
+                let checksum = Data::<Transaction<N>>::Buffer(tx.to_bytes_le()?.into()).to_checksum::<N>()?;
+                Ok(TransmissionID::Transaction(tx.id(), checksum))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // Compute the solution transmission IDs.
+        let solution_transmission_ids = match solutions.as_puzzle_solutions() {
+            Some(solutions) => {
+                let mut transmission_ids = Vec::new(); //with_capacity(solutions.solution_ids().len());
+                for (id, solution) in solutions.iter() {
+                    let checksum = Data::<Solution<N>>::Buffer(solution.to_bytes_le()?.into()).to_checksum::<N>()?;
+                    transmission_ids.push(TransmissionID::Solution(*id, checksum));
+                }
+                transmission_ids
+            }
+            None => Vec::new(),
+        };
+
+        // Convert Quorum authority to subdag with full batch certificates.
+        subdag.clone().into_full(
+            solution_transmission_ids,
+            prior_solution_transmission_ids.clone().unwrap(),
+            aborted_solution_transmission_ids.clone().unwrap(),
+            transaction_transmission_ids,
+            prior_transaction_transmission_ids.clone().unwrap(),
+            aborted_transaction_transmission_ids.clone().unwrap(),
+        )
     }
 }
 
@@ -292,6 +384,16 @@ impl<N: Network> Block<N> {
         &self.solutions
     }
 
+    /// Returns the prior solution ids in the block.
+    pub const fn prior_solution_transmission_ids(&self) -> &Option<Vec<TransmissionID<N>>> {
+        &self.prior_solution_transmission_ids
+    }
+
+    /// Returns the aborted solution transmission ids in this block.
+    pub const fn aborted_solution_transmission_ids(&self) -> &Option<Vec<TransmissionID<N>>> {
+        &self.aborted_solution_transmission_ids
+    }
+
     /// Returns the aborted solution IDs in this block.
     pub const fn aborted_solution_ids(&self) -> &Vec<SolutionID<N>> {
         &self.aborted_solution_ids
@@ -300,6 +402,16 @@ impl<N: Network> Block<N> {
     /// Returns the transactions in this block.
     pub const fn transactions(&self) -> &Transactions<N> {
         &self.transactions
+    }
+
+    /// Returns the prior transactions ids in the block.
+    pub const fn prior_transaction_transmission_ids(&self) -> &Option<Vec<TransmissionID<N>>> {
+        &self.prior_transaction_transmission_ids
+    }
+
+    /// Returns the aborted transaction transmission ids in this block.
+    pub const fn aborted_transaction_transmission_ids(&self) -> &Option<Vec<TransmissionID<N>>> {
+        &self.aborted_transaction_transmission_ids
     }
 
     /// Returns the aborted transaction IDs in this block.

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -86,7 +86,7 @@ pub struct Block<N: Network> {
     /// The aborted solution transmission IDs in this block.
     aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
     /// The aborted solution IDs in this block.
-    aborted_solution_ids: Vec<SolutionID<N>>,
+    aborted_solution_ids: Option<Vec<SolutionID<N>>>,
     /// The transactions in this block.
     transactions: Transactions<N>,
     /// The transmission IDs of both accepted and aborted transactions in the previous block.
@@ -95,7 +95,7 @@ pub struct Block<N: Network> {
     /// The aborted transaction transmission IDs in this block.
     aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
     /// The aborted transaction IDs in this block.
-    aborted_transaction_ids: Vec<N::TransactionID>,
+    aborted_transaction_ids: Option<Vec<N::TransactionID>>,
 }
 
 impl<N: Network> Block<N> {
@@ -107,9 +107,9 @@ impl<N: Network> Block<N> {
         header: Header<N>,
         ratifications: Ratifications<N>,
         solutions: Solutions<N>,
-        aborted_solution_ids: Vec<SolutionID<N>>,
+        aborted_solution_ids: Option<Vec<SolutionID<N>>>,
         transactions: Transactions<N>,
-        aborted_transaction_ids: Vec<N::TransactionID>,
+        aborted_transaction_ids: Option<Vec<N::TransactionID>>,
         rng: &mut R,
     ) -> Result<Self> {
         // Compute the block hash.
@@ -143,11 +143,11 @@ impl<N: Network> Block<N> {
         solutions: Solutions<N>,
         prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
-        aborted_solution_ids: Vec<SolutionID<N>>,
+        aborted_solution_ids: Option<Vec<SolutionID<N>>>,
         transactions: Transactions<N>,
         prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
-        aborted_transaction_ids: Vec<N::TransactionID>,
+        aborted_transaction_ids: Option<Vec<N::TransactionID>>,
     ) -> Result<Self> {
         // Construct the beacon authority.
         let authority = Authority::new_quorum(subdag);
@@ -178,19 +178,21 @@ impl<N: Network> Block<N> {
         solutions: Solutions<N>,
         prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
-        aborted_solution_ids: Vec<SolutionID<N>>,
+        aborted_solution_ids: Option<Vec<SolutionID<N>>>,
         transactions: Transactions<N>,
         prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
-        aborted_transaction_ids: Vec<N::TransactionID>,
+        aborted_transaction_ids: Option<Vec<N::TransactionID>>,
     ) -> Result<Self> {
         // Ensure the number of aborted solutions IDs is within the allowed range.
-        if aborted_solution_ids.len() > Solutions::<N>::max_aborted_solutions()? {
-            bail!(
-                "Cannot initialize a block with {} aborted solutions IDs which exceed the maximum {}",
-                aborted_solution_ids.len(),
-                Solutions::<N>::max_aborted_solutions()?
-            );
+        if let Some(aborted_solution_ids) = aborted_solution_ids.as_ref() {
+            if aborted_solution_ids.len() > Solutions::<N>::max_aborted_solutions()? {
+                bail!(
+                    "Cannot initialize a block with {} aborted solutions IDs which exceed the maximum {}",
+                    aborted_solution_ids.len(),
+                    Solutions::<N>::max_aborted_solutions()?
+                );
+            }
         }
 
         // Ensure the number of transactions is within the allowed range.
@@ -207,12 +209,14 @@ impl<N: Network> Block<N> {
         // specifically in [`PuzzleSolutions::new()`].
 
         // Ensure the number of aborted transaction IDs is within the allowed range.
-        if aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
-            bail!(
-                "Cannot initialize a block with {} aborted transaction IDs which exceed the maximum {}",
-                aborted_transaction_ids.len(),
-                Transactions::<N>::max_aborted_transactions()?
-            );
+        if let Some(aborted_transaction_ids) = aborted_transaction_ids.as_ref() {
+            if aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
+                bail!(
+                    "Cannot initialize a block with {} aborted transaction IDs which exceed the maximum {}",
+                    aborted_transaction_ids.len(),
+                    Transactions::<N>::max_aborted_transactions()?
+                );
+            }
         }
 
         // Compute the block hash.
@@ -275,11 +279,11 @@ impl<N: Network> Block<N> {
         solutions: Solutions<N>,
         prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
-        aborted_solution_ids: Vec<SolutionID<N>>,
+        aborted_solution_ids: Option<Vec<SolutionID<N>>>,
         transactions: Transactions<N>,
         prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
         aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
-        aborted_transaction_ids: Vec<N::TransactionID>,
+        aborted_transaction_ids: Option<Vec<N::TransactionID>>,
     ) -> Result<Self> {
         // Return the block.
         Ok(Self {
@@ -336,7 +340,7 @@ impl<N: Network> Block<N> {
         // Compute the solution transmission IDs.
         let solution_transmission_ids = match solutions.as_puzzle_solutions() {
             Some(solutions) => {
-                let mut transmission_ids = Vec::new(); //with_capacity(solutions.solution_ids().len());
+                let mut transmission_ids = Vec::with_capacity(solutions.solution_ids().count());
                 for (id, solution) in solutions.iter() {
                     let checksum = Data::<Solution<N>>::Buffer(solution.to_bytes_le()?.into()).to_checksum::<N>()?;
                     transmission_ids.push(TransmissionID::Solution(*id, checksum));
@@ -395,8 +399,8 @@ impl<N: Network> Block<N> {
     }
 
     /// Returns the aborted solution IDs in this block.
-    pub const fn aborted_solution_ids(&self) -> &Vec<SolutionID<N>> {
-        &self.aborted_solution_ids
+    pub const fn aborted_solution_ids(&self) -> Option<&Vec<SolutionID<N>>> {
+        self.aborted_solution_ids.as_ref()
     }
 
     /// Returns the transactions in this block.
@@ -415,8 +419,8 @@ impl<N: Network> Block<N> {
     }
 
     /// Returns the aborted transaction IDs in this block.
-    pub const fn aborted_transaction_ids(&self) -> &Vec<N::TransactionID> {
-        &self.aborted_transaction_ids
+    pub const fn aborted_transaction_ids(&self) -> Option<&Vec<N::TransactionID>> {
+        self.aborted_transaction_ids.as_ref()
     }
 }
 
@@ -820,9 +824,9 @@ pub mod test_helpers {
             header,
             ratifications,
             None.into(),
-            vec![],
+            Some(vec![]),
             transactions,
-            vec![],
+            Some(vec![]),
             rng,
         )
         .unwrap();

--- a/ledger/block/src/lib.rs
+++ b/ledger/block/src/lib.rs
@@ -85,7 +85,8 @@ pub struct Block<N: Network> {
     prior_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
     /// The aborted solution transmission IDs in this block.
     aborted_solution_transmission_ids: Option<Vec<TransmissionID<N>>>,
-    /// The aborted solution IDs in this block.
+    /// The aborted solution IDs in this block, which are present in the absence of both
+    /// `prior_solution_transmission_ids` and `aborted_solution_transmission_ids`.
     aborted_solution_ids: Option<Vec<SolutionID<N>>>,
     /// The transactions in this block.
     transactions: Transactions<N>,
@@ -94,7 +95,8 @@ pub struct Block<N: Network> {
     prior_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
     /// The aborted transaction transmission IDs in this block.
     aborted_transaction_transmission_ids: Option<Vec<TransmissionID<N>>>,
-    /// The aborted transaction IDs in this block.
+    /// The aborted transaction IDs in this block, which are present in the absence of both
+    /// `prior_transaction_transmission_ids` and `aborted_transaction_transmission_ids`.
     aborted_transaction_ids: Option<Vec<N::TransactionID>>,
 }
 
@@ -352,12 +354,12 @@ impl<N: Network> Block<N> {
 
         // Convert Quorum authority to subdag with full batch certificates.
         subdag.clone().into_full(
-            solution_transmission_ids,
-            prior_solution_transmission_ids.clone().unwrap(),
-            aborted_solution_transmission_ids.clone().unwrap(),
-            transaction_transmission_ids,
-            prior_transaction_transmission_ids.clone().unwrap(),
-            aborted_transaction_transmission_ids.clone().unwrap(),
+            &solution_transmission_ids,
+            prior_solution_transmission_ids.as_ref().unwrap(),
+            aborted_solution_transmission_ids.as_ref().unwrap(),
+            &transaction_transmission_ids,
+            prior_transaction_transmission_ids.as_ref().unwrap(),
+            aborted_transaction_transmission_ids.as_ref().unwrap(),
         )
     }
 }

--- a/ledger/block/src/serialize.rs
+++ b/ledger/block/src/serialize.rs
@@ -20,16 +20,46 @@ impl<N: Network> Serialize for Block<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
             true => {
-                let mut block = serializer.serialize_struct("Block", 9)?;
+                let current_consensus_version = N::CONSENSUS_VERSION(self.height()).unwrap();
+                let mut block = if current_consensus_version >= ConsensusVersion::V10 {
+                    serializer.serialize_struct("Block", 12)?
+                } else {
+                    serializer.serialize_struct("Block", 9)?
+                };
+                if current_consensus_version >= ConsensusVersion::V10 {
+                    block.serialize_field("version", &2u8)?;
+                }
                 block.serialize_field("block_hash", &self.block_hash)?;
                 block.serialize_field("previous_hash", &self.previous_hash)?;
                 block.serialize_field("header", &self.header)?;
                 block.serialize_field("authority", &self.authority)?;
                 block.serialize_field("ratifications", &self.ratifications)?;
                 block.serialize_field("solutions", &self.solutions)?;
-                block.serialize_field("aborted_solution_ids", &self.aborted_solution_ids)?;
+                if current_consensus_version >= ConsensusVersion::V10 {
+                    block.serialize_field(
+                        "prior_solution_transmission_ids",
+                        self.prior_solution_transmission_ids.as_ref().unwrap(),
+                    )?;
+                    block.serialize_field(
+                        "aborted_solution_transmission_ids",
+                        self.aborted_solution_transmission_ids.as_ref().unwrap(),
+                    )?;
+                } else {
+                    block.serialize_field("aborted_solution_ids", &self.aborted_solution_ids)?;
+                }
                 block.serialize_field("transactions", &self.transactions)?;
-                block.serialize_field("aborted_transaction_ids", &self.aborted_transaction_ids)?;
+                if current_consensus_version >= ConsensusVersion::V10 {
+                    block.serialize_field(
+                        "prior_transaction_transmission_ids",
+                        self.prior_transaction_transmission_ids.as_ref().unwrap(),
+                    )?;
+                    block.serialize_field(
+                        "aborted_transaction_transmission_ids",
+                        self.aborted_transaction_transmission_ids.as_ref().unwrap(),
+                    )?;
+                } else {
+                    block.serialize_field("aborted_transaction_ids", &self.aborted_transaction_ids)?;
+                }
                 block.end()
             }
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
@@ -43,7 +73,39 @@ impl<'de, N: Network> Deserialize<'de> for Block<N> {
         match deserializer.is_human_readable() {
             true => {
                 let mut block = serde_json::Value::deserialize(deserializer)?;
+                // Retrieve the version and hash.
+                let version: u8 = DeserializeExt::take_from_value::<D>(&mut block, "version").unwrap_or(1);
                 let block_hash: N::BlockHash = DeserializeExt::take_from_value::<D>(&mut block, "block_hash")?;
+
+                let (prior_solution_transmission_ids, aborted_solution_transmission_ids, aborted_solution_ids) =
+                    if version >= 2 {
+                        (
+                            Some(DeserializeExt::take_from_value::<D>(&mut block, "prior_solution_transmission_ids")?),
+                            Some(DeserializeExt::take_from_value::<D>(
+                                &mut block,
+                                "aborted_solution_transmission_ids",
+                            )?),
+                            vec![],
+                        )
+                    } else {
+                        (None, None, DeserializeExt::take_from_value::<D>(&mut block, "aborted_solution_ids")?)
+                    };
+                let (prior_transaction_transmission_ids, aborted_transaction_transmission_ids, aborted_transaction_ids) =
+                    if version >= 2 {
+                        (
+                            Some(DeserializeExt::take_from_value::<D>(
+                                &mut block,
+                                "prior_transaction_transmission_ids",
+                            )?),
+                            Some(DeserializeExt::take_from_value::<D>(
+                                &mut block,
+                                "aborted_transaction_transmission_ids",
+                            )?),
+                            vec![],
+                        )
+                    } else {
+                        (None, None, DeserializeExt::take_from_value::<D>(&mut block, "aborted_transaction_ids")?)
+                    };
 
                 // Recover the block.
                 let block = Self::from(
@@ -52,9 +114,13 @@ impl<'de, N: Network> Deserialize<'de> for Block<N> {
                     DeserializeExt::take_from_value::<D>(&mut block, "authority")?,
                     DeserializeExt::take_from_value::<D>(&mut block, "ratifications")?,
                     DeserializeExt::take_from_value::<D>(&mut block, "solutions")?,
-                    DeserializeExt::take_from_value::<D>(&mut block, "aborted_solution_ids")?,
+                    prior_solution_transmission_ids,
+                    aborted_solution_transmission_ids,
+                    aborted_solution_ids,
                     DeserializeExt::take_from_value::<D>(&mut block, "transactions")?,
-                    DeserializeExt::take_from_value::<D>(&mut block, "aborted_transaction_ids")?,
+                    prior_transaction_transmission_ids,
+                    aborted_transaction_transmission_ids,
+                    aborted_transaction_ids,
                 )
                 .map_err(de::Error::custom)?;
 

--- a/ledger/block/src/serialize.rs
+++ b/ledger/block/src/serialize.rs
@@ -85,10 +85,10 @@ impl<'de, N: Network> Deserialize<'de> for Block<N> {
                                 &mut block,
                                 "aborted_solution_transmission_ids",
                             )?),
-                            vec![],
+                            None,
                         )
                     } else {
-                        (None, None, DeserializeExt::take_from_value::<D>(&mut block, "aborted_solution_ids")?)
+                        (None, None, Some(DeserializeExt::take_from_value::<D>(&mut block, "aborted_solution_ids")?))
                     };
                 let (prior_transaction_transmission_ids, aborted_transaction_transmission_ids, aborted_transaction_ids) =
                     if version >= 2 {
@@ -101,10 +101,10 @@ impl<'de, N: Network> Deserialize<'de> for Block<N> {
                                 &mut block,
                                 "aborted_transaction_transmission_ids",
                             )?),
-                            vec![],
+                            None,
                         )
                     } else {
-                        (None, None, DeserializeExt::take_from_value::<D>(&mut block, "aborted_transaction_ids")?)
+                        (None, None, Some(DeserializeExt::take_from_value::<D>(&mut block, "aborted_transaction_ids")?))
                     };
 
                 // Recover the block.

--- a/ledger/block/src/solutions/mod.rs
+++ b/ledger/block/src/solutions/mod.rs
@@ -65,6 +65,10 @@ impl<N: Network> Solutions<N> {
             None => 0,
         }
     }
+
+    pub fn as_puzzle_solutions(&self) -> Option<&PuzzleSolutions<N>> {
+        self.solutions.as_ref()
+    }
 }
 
 impl<N: Network> Solutions<N> {

--- a/ledger/block/src/transactions/mod.rs
+++ b/ledger/block/src/transactions/mod.rs
@@ -221,6 +221,14 @@ impl<N: Network> Transactions<N> {
         self.transactions.keys()
     }
 
+    /// Returns the unconfirmed transaction IDs, for all transactions in `self`.
+    pub fn unconfirmed_transaction_ids(&self) -> Result<Vec<N::TransactionID>> {
+        self.transactions
+            .values()
+            .map(|confirmed_tx| confirmed_tx.to_unconfirmed_transaction_id())
+            .collect::<Result<_>>()
+    }
+
     /// Returns an iterator over all transactions in `self` that are accepted deploy transactions.
     pub fn deployments(&self) -> impl '_ + Iterator<Item = &ConfirmedTransaction<N>> {
         self.iter().filter(|tx| tx.is_accepted() && tx.is_deploy())

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -20,7 +20,12 @@ use super::*;
 use snarkvm_ledger_puzzle::Puzzle;
 use snarkvm_synthesizer_program::FinalizeOperation;
 
-use std::collections::HashSet;
+use snarkvm_ledger_narwhal_batch_certificate::BatchCertificate;
+use snarkvm_ledger_narwhal_compact_certificate::CompactCertificate;
+
+use bit_set::BitSet;
+use indexmap::IndexSet;
+use std::collections::{BTreeMap, HashSet};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -178,7 +183,10 @@ impl<N: Network> Block<N> {
                 if previous_round != 0 {
                     for round in previous_round..=subdag.anchor_round() {
                         ensure!(
-                            subdag.contains_key(&round),
+                            match subdag {
+                                Subdag::Full { subdag } => subdag.contains_key(&round),
+                                Subdag::Compact { subdag } => subdag.contains_key(&round),
+                            },
                             "Subdag is missing round {round} in block {expected_height}",
                         );
                     }
@@ -225,16 +233,24 @@ impl<N: Network> Block<N> {
                     subdag.leader_address()
                 );
                 // Ensure the transmission IDs from the subdag correspond to the block.
-                // This is redundant if the block has been created via `Block::from()`;
-                // however, we need to obtain the solution and transaction IDs here,
-                // so may want to remove the redundant check in `Block::from()` and leave it here.
-                Self::check_subdag_transmissions(
-                    subdag,
-                    &self.solutions,
-                    &self.aborted_solution_ids,
-                    &self.transactions,
-                    &self.aborted_transaction_ids,
-                )?
+                match subdag {
+                    Subdag::Full { subdag } => Self::check_full_subdag_transmissions(
+                        subdag,
+                        &self.solutions,
+                        &self.aborted_solution_ids,
+                        &self.transactions,
+                        &self.aborted_transaction_ids,
+                    )?,
+                    Subdag::Compact { subdag } => Self::check_compact_subdag_transmissions(
+                        subdag,
+                        &self.solutions,
+                        self.prior_solution_transmission_ids.as_ref().unwrap(),
+                        self.aborted_solution_transmission_ids.as_ref().unwrap(),
+                        &self.transactions,
+                        self.prior_transaction_transmission_ids.as_ref().unwrap(),
+                        self.aborted_transaction_transmission_ids.as_ref().unwrap(),
+                    )?,
+                }
             }
         };
 
@@ -255,18 +271,7 @@ impl<N: Network> Block<N> {
             );
 
             // Check that all certificates on each round have the same committee ID.
-            cfg_iter!(subdag).try_for_each(|(round, certificates)| {
-                // Check that every certificate for a given round shares the same committee ID.
-                let expected_committee_id = certificates
-                    .first()
-                    .map(|certificate| certificate.committee_id())
-                    .ok_or(anyhow!("No certificates found for subdag round {round}"))?;
-                ensure!(
-                    certificates.iter().skip(1).all(|certificate| certificate.committee_id() == expected_committee_id),
-                    "Certificates on round {round} do not all have the same committee ID",
-                );
-                Ok(())
-            })?;
+            subdag.check_committee_id_coherence()?;
         }
 
         // Return success.
@@ -558,15 +563,13 @@ impl<N: Network> Block<N> {
 
     /// Checks that the transmission IDs in the given subdag matches the solutions and transactions in the block.
     /// Returns the IDs of the transactions and solutions that should already exist in the ledger.
-    pub(super) fn check_subdag_transmissions(
-        subdag: &Subdag<N>,
+    pub(super) fn check_full_subdag_transmissions(
+        subdag: &BTreeMap<u64, IndexSet<BatchCertificate<N>>>,
         solutions: &Option<PuzzleSolutions<N>>,
         aborted_solution_ids: &[SolutionID<N>],
         transactions: &Transactions<N>,
         aborted_transaction_ids: &[N::TransactionID],
     ) -> Result<(Vec<SolutionID<N>>, Vec<N::TransactionID>)> {
-        // Prepare an iterator over the solution IDs.
-        let mut solutions = solutions.as_ref().map(|s| s.deref()).into_iter().flatten().peekable();
         // Prepare an iterator over the unconfirmed transactions.
         let unconfirmed_transactions = cfg_iter!(transactions)
             .map(|confirmed| confirmed.to_unconfirmed_transaction())
@@ -574,16 +577,26 @@ impl<N: Network> Block<N> {
         let mut unconfirmed_transactions = unconfirmed_transactions.iter().peekable();
 
         // Initialize a set of already seen transaction and solution IDs.
-        let mut seen_transaction_ids = HashSet::new();
-        let mut seen_solution_ids = HashSet::new();
+        let mut seen_transaction_ids: HashSet<N::TransactionID> = HashSet::new();
+        let mut seen_solution_ids: HashSet<SolutionID<N>> = HashSet::new();
 
         // Initialize a set of aborted or already-existing solution IDs.
-        let mut aborted_or_existing_solution_ids = HashSet::new();
+        let mut aborted_or_existing_solution_ids: HashSet<SolutionID<N>> = HashSet::new();
         // Initialize a set of aborted or already-existing transaction IDs.
-        let mut aborted_or_existing_transaction_ids = HashSet::new();
+        let mut aborted_or_existing_transaction_ids: HashSet<N::TransactionID> = HashSet::new();
+
+        let transmission_ids = subdag
+            .values()
+            .flatten()
+            .flat_map(|cert| cert.transmission_ids())
+            .copied()
+            .collect::<Vec<TransmissionID<N>>>();
+
+        // Prepare an iterator over the solution IDs.
+        let mut solutions = solutions.as_ref().map(|s| s.deref()).into_iter().flatten().peekable();
 
         // Iterate over the transmission IDs.
-        for transmission_id in subdag.transmission_ids() {
+        for transmission_id in transmission_ids {
             // If the transaction or solution ID has already been seen, then continue.
             // Note: This is done instead of checking `TransmissionID` directly, because we need to
             // ensure that each transaction or solution ID is unique. The `TransmissionID` is guaranteed
@@ -608,14 +621,16 @@ impl<N: Network> Block<N> {
                 TransmissionID::Solution(solution_id, _checksum) => {
                     match solutions.peek() {
                         // Check the next solution matches the expected solution ID.
-                        // We don't check against the checksum, because check_solution_mut might mutate the solution.
-                        Some((_, solution)) if solution.id() == *solution_id => {
+                        // We don't check against the checksum, because
+                        // `check_solution_mut` might have mutated the solution
+                        // before ConsensusVersion::V10.
+                        Some((_, solution)) if solution.id() == solution_id => {
                             // Increment the solution iterator.
                             solutions.next();
                         }
                         // Otherwise, add the solution ID to the aborted or existing list.
                         _ => {
-                            if !aborted_or_existing_solution_ids.insert(*solution_id) {
+                            if !aborted_or_existing_solution_ids.insert(solution_id) {
                                 bail!("Block contains a duplicate aborted solution ID (found '{solution_id}')");
                             }
                         }
@@ -625,17 +640,17 @@ impl<N: Network> Block<N> {
                     match unconfirmed_transactions.peek() {
                         // Check the next transaction matches the expected transaction.
                         Some(transaction)
-                            if transaction.id() == *transaction_id
+                            if transaction.id() == transaction_id
                                 && Data::<Transaction<N>>::Buffer(transaction.to_bytes_le()?.into())
                                     .to_checksum::<N>()?
-                                    == *checksum =>
+                                    == checksum =>
                         {
                             // Increment the unconfirmed transaction iterator.
                             unconfirmed_transactions.next();
                         }
                         // Otherwise, add the transaction ID to the aborted or existing list.
                         _ => {
-                            if !aborted_or_existing_transaction_ids.insert(*transaction_id) {
+                            if !aborted_or_existing_transaction_ids.insert(transaction_id) {
                                 bail!("Block contains a duplicate aborted transaction ID (found '{transaction_id}')");
                             }
                         }
@@ -680,5 +695,95 @@ impl<N: Network> Block<N> {
             .collect();
 
         Ok((existing_solution_ids, existing_transaction_ids))
+    }
+
+    /// Checks that the transmission IDs in the given subdag matches the solutions and transactions in the block.
+    /// Returns the IDs of the transactions and solutions that should already exist in the ledger.
+    pub(super) fn check_compact_subdag_transmissions(
+        subdag: &BTreeMap<u64, IndexSet<CompactCertificate<N>>>,
+        solutions: &Option<PuzzleSolutions<N>>,
+        prior_solution_transmission_ids: &[TransmissionID<N>],
+        aborted_solution_transmission_ids: &[TransmissionID<N>],
+        transactions: &Transactions<N>,
+        prior_transaction_transmission_ids: &[TransmissionID<N>],
+        aborted_transaction_transmission_ids: &[TransmissionID<N>],
+    ) -> Result<(Vec<SolutionID<N>>, Vec<N::TransactionID>)> {
+        // Prepare an iterator over the unconfirmed transactions.
+        let unconfirmed_transactions = cfg_iter!(transactions)
+            .map(|confirmed| confirmed.to_unconfirmed_transaction())
+            .collect::<Result<Vec<_>>>()?;
+
+        // Compute the transaction transmission IDs.
+        let transaction_transmission_ids = unconfirmed_transactions
+            .iter()
+            .map(|tx| {
+                let checksum = Data::<Transaction<N>>::Buffer(tx.to_bytes_le()?.into()).to_checksum::<N>()?;
+                Ok(TransmissionID::Transaction(tx.id(), checksum))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Compute the solution transmission IDs.
+        let solution_transmission_ids = match solutions {
+            Some(solutions) => {
+                let mut transmission_ids = IndexSet::new(); // with_capacity(solutions.solution_ids().len());
+                for (id, solution) in solutions.iter() {
+                    let checksum = Data::<Solution<N>>::Buffer(solution.to_bytes_le()?.into()).to_checksum::<N>()?;
+                    transmission_ids.insert(TransmissionID::Solution(*id, checksum));
+                }
+                transmission_ids
+            }
+            None => IndexSet::new(),
+        };
+
+        // Prepare a bitset to track the seen transmission indices.
+        let max_expected_index = solutions.as_ref().map(|s| s.len()).unwrap_or(0)
+            + prior_solution_transmission_ids.len()
+            + aborted_solution_transmission_ids.len()
+            + transactions.len()
+            + prior_transaction_transmission_ids.len()
+            + aborted_transaction_transmission_ids.len();
+        let mut seen_indices = BitSet::with_capacity(max_expected_index);
+
+        // For each compact header, check the batch ID and insert the transmission indices into the bitset.
+        for compact_header in subdag.values().flatten().map(|cert| cert.compact_header()) {
+            for index in compact_header.transaction_indices() {
+                seen_indices.insert(*index as usize);
+            }
+            for index in compact_header.solution_indices() {
+                seen_indices.insert(*index as usize);
+            }
+            compact_header.check_batch_id(
+                solution_transmission_ids.iter(),
+                prior_solution_transmission_ids.iter(),
+                aborted_solution_transmission_ids.iter(),
+                transaction_transmission_ids.iter(),
+                prior_transaction_transmission_ids.iter(),
+                aborted_transaction_transmission_ids.iter(),
+            )?;
+        }
+
+        // Ensure that all transmission indices were seen.
+        ensure!(
+            (0..max_expected_index).all(|i| seen_indices.contains(i)),
+            "Found unused transmission ID in the subdag."
+        );
+
+        // Collect the prior solution and transaction IDs.
+        let prior_solution_ids = prior_solution_transmission_ids
+            .iter()
+            .map(|id| match id {
+                TransmissionID::Solution(id, _) => Ok(*id),
+                _ => bail!("Expected a solution transmission ID."),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let prior_transaction_ids = prior_transaction_transmission_ids
+            .iter()
+            .map(|id| match id {
+                TransmissionID::Transaction(id, _) => Ok(*id),
+                _ => bail!("Expected a transaction transmission ID."),
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok((prior_solution_ids, prior_transaction_ids))
     }
 }

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -237,18 +237,28 @@ impl<N: Network> Block<N> {
                     Subdag::Full { subdag } => Self::check_full_subdag_transmissions(
                         subdag,
                         &self.solutions,
-                        &self.aborted_solution_ids,
+                        self.aborted_solution_ids.as_ref().ok_or_else(|| error("Missing aborted_solution_ids"))?,
                         &self.transactions,
-                        &self.aborted_transaction_ids,
+                        self.aborted_transaction_ids
+                            .as_ref()
+                            .ok_or_else(|| error("Missing aborted_transaction_ids"))?,
                     )?,
                     Subdag::Compact { subdag } => Self::check_compact_subdag_transmissions(
                         subdag,
                         &self.solutions,
-                        self.prior_solution_transmission_ids.as_ref().unwrap(),
-                        self.aborted_solution_transmission_ids.as_ref().unwrap(),
+                        self.prior_solution_transmission_ids
+                            .as_ref()
+                            .ok_or_else(|| error("Missing prior_solution_transmission_ids"))?,
+                        self.aborted_solution_transmission_ids
+                            .as_ref()
+                            .ok_or_else(|| error("Missing aborted_solution_transmission_ids"))?,
                         &self.transactions,
-                        self.prior_transaction_transmission_ids.as_ref().unwrap(),
-                        self.aborted_transaction_transmission_ids.as_ref().unwrap(),
+                        self.prior_transaction_transmission_ids
+                            .as_ref()
+                            .ok_or_else(|| error("Missing prior_transaction_transmission_ids"))?,
+                        self.aborted_transaction_transmission_ids
+                            .as_ref()
+                            .ok_or_else(|| error("Missing aborted_transaction_transmission_ids"))?,
                     )?,
                 }
             }
@@ -339,11 +349,13 @@ impl<N: Network> Block<N> {
 
         // Ensure the number of aborted solution IDs is within the allowed range.
         // This check is redundant if the block has been created via `Block::from()`.
-        ensure!(
-            self.aborted_solution_ids.len() <= Solutions::<N>::max_aborted_solutions()?,
-            "Block {height} contains too many aborted solution IDs (found '{}')",
-            self.aborted_solution_ids.len(),
-        );
+        if let Some(aborted_solution_ids) = self.aborted_solution_ids.as_ref() {
+            ensure!(
+                aborted_solution_ids.len() <= Solutions::<N>::max_aborted_solutions()?,
+                "Block {height} contains too many aborted solution IDs (found '{}')",
+                aborted_solution_ids.len(),
+            );
+        }
 
         // Ensure there are no duplicate solution IDs.
         if has_duplicates(
@@ -352,7 +364,7 @@ impl<N: Network> Block<N> {
                 .map(PuzzleSolutions::solution_ids)
                 .into_iter()
                 .flatten()
-                .chain(self.aborted_solution_ids()),
+                .chain(self.aborted_solution_ids().into_iter().flatten()),
         ) {
             bail!("Found a duplicate solution in block {height}");
         }
@@ -456,15 +468,17 @@ impl<N: Network> Block<N> {
 
         // Ensure the number of aborted transaction IDs is within the allowed range.
         // This check is redundant if the block has been created via `Block::from()`.
-        if self.aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
-            bail!(
-                "Cannot validate a block with more than {} aborted transaction IDs",
-                Transactions::<N>::max_aborted_transactions()?
-            );
+        if let Some(aborted_transaction_ids) = self.aborted_transaction_ids.as_ref() {
+            if aborted_transaction_ids.len() > Transactions::<N>::max_aborted_transactions()? {
+                bail!(
+                    "Cannot validate a block with more than {} aborted transaction IDs",
+                    Transactions::<N>::max_aborted_transactions()?
+                );
+            }
         }
 
         // Ensure there are no duplicate transaction IDs.
-        if has_duplicates(self.transaction_ids().chain(self.aborted_transaction_ids.iter())) {
+        if has_duplicates(self.transaction_ids().chain(self.aborted_transaction_ids.iter().flatten())) {
             bail!("Found a duplicate transaction in block {height}");
         }
 
@@ -570,6 +584,8 @@ impl<N: Network> Block<N> {
         transactions: &Transactions<N>,
         aborted_transaction_ids: &[N::TransactionID],
     ) -> Result<(Vec<SolutionID<N>>, Vec<N::TransactionID>)> {
+        // Prepare an iterator over the solution IDs.
+        let mut solutions = solutions.as_ref().map(|s| s.deref()).into_iter().flatten().peekable();
         // Prepare an iterator over the unconfirmed transactions.
         let unconfirmed_transactions = cfg_iter!(transactions)
             .map(|confirmed| confirmed.to_unconfirmed_transaction())
@@ -585,15 +601,7 @@ impl<N: Network> Block<N> {
         // Initialize a set of aborted or already-existing transaction IDs.
         let mut aborted_or_existing_transaction_ids: HashSet<N::TransactionID> = HashSet::new();
 
-        let transmission_ids = subdag
-            .values()
-            .flatten()
-            .flat_map(|cert| cert.transmission_ids())
-            .copied()
-            .collect::<Vec<TransmissionID<N>>>();
-
-        // Prepare an iterator over the solution IDs.
-        let mut solutions = solutions.as_ref().map(|s| s.deref()).into_iter().flatten().peekable();
+        let transmission_ids = subdag.values().flatten().flat_map(|cert| cert.transmission_ids()).copied();
 
         // Iterate over the transmission IDs.
         for transmission_id in transmission_ids {

--- a/ledger/narwhal/Cargo.toml
+++ b/ledger/narwhal/Cargo.toml
@@ -27,8 +27,11 @@ edition = "2024"
 default = [
   "batch-certificate",
   "batch-header",
+  "compact-certificate",
+  "compact-header",
   "data",
   "subdag",
+  "traits",
   "transmission",
   "transmission-id"
 ]
@@ -36,6 +39,8 @@ async = [ "snarkvm-ledger-narwhal-data/async" ]
 serial = [
   "snarkvm-ledger-narwhal-batch-certificate/serial",
   "snarkvm-ledger-narwhal-batch-header/serial",
+  "snarkvm-ledger-narwhal-compact-certificate/serial",
+  "snarkvm-ledger-narwhal-compact-header/serial",
   "snarkvm-ledger-narwhal-subdag/serial",
   "snarkvm-ledger-narwhal-transmission/serial",
   "snarkvm-ledger-narwhal-transmission-id/serial"
@@ -43,6 +48,8 @@ serial = [
 wasm = [
   "snarkvm-ledger-narwhal-batch-certificate/wasm",
   "snarkvm-ledger-narwhal-batch-header/wasm",
+  "snarkvm-ledger-narwhal-compact-certificate/wasm",
+  "snarkvm-ledger-narwhal-compact-header/wasm",
   "snarkvm-ledger-narwhal-subdag/wasm",
   "snarkvm-ledger-narwhal-transmission/wasm",
   "snarkvm-ledger-narwhal-transmission-id/wasm"
@@ -50,14 +57,19 @@ wasm = [
 test-helpers = [
   "snarkvm-ledger-narwhal-batch-certificate/test-helpers",
   "snarkvm-ledger-narwhal-batch-header/test-helpers",
+  "snarkvm-ledger-narwhal-compact-certificate/test-helpers",
+  "snarkvm-ledger-narwhal-compact-header/test-helpers",
   "snarkvm-ledger-narwhal-subdag/test-helpers",
   "snarkvm-ledger-narwhal-transmission/test-helpers",
   "snarkvm-ledger-narwhal-transmission-id/test-helpers"
 ]
 batch-certificate = [ "snarkvm-ledger-narwhal-batch-certificate" ]
 batch-header = [ "snarkvm-ledger-narwhal-batch-header" ]
+compact-certificate = [ "snarkvm-ledger-narwhal-compact-certificate" ]
+compact-header = [ "snarkvm-ledger-narwhal-compact-header" ]
 data = [ "snarkvm-ledger-narwhal-data" ]
 subdag = [ "snarkvm-ledger-narwhal-subdag" ]
+traits = [ "snarkvm-ledger-narwhal-traits" ]
 transmission = [ "snarkvm-ledger-narwhal-transmission" ]
 transmission-id = [ "snarkvm-ledger-narwhal-transmission-id" ]
 
@@ -69,11 +81,23 @@ optional = true
 workspace = true
 optional = true
 
+[dependencies.snarkvm-ledger-narwhal-compact-certificate]
+workspace = true
+optional = true
+
+[dependencies.snarkvm-ledger-narwhal-compact-header]
+workspace = true
+optional = true
+
 [dependencies.snarkvm-ledger-narwhal-data]
 workspace = true
 optional = true
 
 [dependencies.snarkvm-ledger-narwhal-subdag]
+workspace = true
+optional = true
+
+[dependencies.snarkvm-ledger-narwhal-traits]
 workspace = true
 optional = true
 

--- a/ledger/narwhal/batch-certificate/Cargo.toml
+++ b/ledger/narwhal/batch-certificate/Cargo.toml
@@ -39,6 +39,9 @@ workspace = true
 [dependencies.snarkvm-ledger-narwhal-transmission-id]
 workspace = true
 
+[dependencies.snarkvm-ledger-narwhal-traits]
+workspace = true
+
 [dependencies.indexmap]
 workspace = true
 features = [ "serde" ]

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -43,7 +43,7 @@ pub struct BatchCertificate<N: Network> {
     /// The batch header.
     batch_header: BatchHeader<N>,
     /// The signatures for the batch ID from the committee.
-    pub signatures: IndexSet<Signature<N>>,
+    signatures: IndexSet<Signature<N>>,
 }
 
 impl<N: Network> BatchCertificate<N> {
@@ -84,6 +84,11 @@ impl<N: Network> BatchCertificate<N> {
         ensure!(!signatures.is_empty(), "Batch certificate must contain signatures");
         // Return the batch certificate.
         Ok(Self { batch_header, signatures })
+    }
+
+    pub fn into_components(self) -> (BatchHeader<N>, IndexSet<Signature<N>>) {
+        let Self { batch_header, signatures } = self;
+        (batch_header, signatures)
     }
 }
 

--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -28,6 +28,7 @@ use console::{
     types::Field,
 };
 use snarkvm_ledger_narwhal_batch_header::BatchHeader;
+use snarkvm_ledger_narwhal_traits::NarwhalCertificate;
 use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
 
 use core::hash::{Hash, Hasher};
@@ -42,7 +43,7 @@ pub struct BatchCertificate<N: Network> {
     /// The batch header.
     batch_header: BatchHeader<N>,
     /// The signatures for the batch ID from the committee.
-    signatures: IndexSet<Signature<N>>,
+    pub signatures: IndexSet<Signature<N>>,
 }
 
 impl<N: Network> BatchCertificate<N> {
@@ -111,43 +112,50 @@ impl<N: Network> BatchCertificate<N> {
         &self.batch_header
     }
 
-    /// Returns the batch ID.
-    pub const fn batch_id(&self) -> Field<N> {
-        self.batch_header().batch_id()
-    }
-
-    /// Returns the author.
-    pub const fn author(&self) -> Address<N> {
-        self.batch_header().author()
-    }
-
-    /// Returns the round.
-    pub const fn round(&self) -> u64 {
-        self.batch_header().round()
-    }
-
-    /// Returns the timestamp of the batch header.
-    pub fn timestamp(&self) -> i64 {
-        self.batch_header().timestamp()
-    }
-
-    /// Returns the committee ID.
-    pub const fn committee_id(&self) -> Field<N> {
-        self.batch_header().committee_id()
-    }
-
     /// Returns the transmission IDs.
     pub const fn transmission_ids(&self) -> &IndexSet<TransmissionID<N>> {
         self.batch_header().transmission_ids()
     }
+}
+
+impl<N: Network> NarwhalCertificate<N> for BatchCertificate<N> {
+    /// Returns the certificate ID.
+    fn id(&self) -> Field<N> {
+        self.batch_header().batch_id()
+    }
+
+    /// Returns the batch ID.
+    fn batch_id(&self) -> Field<N> {
+        self.batch_header().batch_id()
+    }
+
+    /// Returns the author.
+    fn author(&self) -> Address<N> {
+        self.batch_header().author()
+    }
+
+    /// Returns the round.
+    fn round(&self) -> u64 {
+        self.batch_header().round()
+    }
+
+    /// Returns the timestamp of the batch header.
+    fn timestamp(&self) -> i64 {
+        self.batch_header().timestamp()
+    }
+
+    /// Returns the committee ID.
+    fn committee_id(&self) -> Field<N> {
+        self.batch_header().committee_id()
+    }
 
     /// Returns the batch certificate IDs for the previous round.
-    pub const fn previous_certificate_ids(&self) -> &IndexSet<Field<N>> {
+    fn previous_certificate_ids(&self) -> &IndexSet<Field<N>> {
         self.batch_header().previous_certificate_ids()
     }
 
     /// Returns the signatures of the batch ID from the committee.
-    pub fn signatures(&self) -> Box<dyn '_ + ExactSizeIterator<Item = &Signature<N>>> {
+    fn signatures(&self) -> Box<dyn '_ + ExactSizeIterator<Item = &Signature<N>>> {
         Box::new(self.signatures.iter())
     }
 }

--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -187,6 +187,38 @@ impl<N: Network> BatchHeader<N> {
             signature,
         })
     }
+
+    /// Initializes a new batch header without performing checks.
+    pub fn from_unchecked(
+        author: Address<N>,
+        round: u64,
+        timestamp: i64,
+        committee_id: Field<N>,
+        transmission_ids: IndexSet<TransmissionID<N>>,
+        previous_certificate_ids: IndexSet<Field<N>>,
+        signature: Signature<N>,
+    ) -> Result<Self> {
+        // Compute the batch ID.
+        let batch_id = Self::compute_batch_id(
+            author,
+            round,
+            timestamp,
+            committee_id,
+            &transmission_ids,
+            &previous_certificate_ids,
+        )?;
+        // Return the batch header.
+        Ok(Self {
+            author,
+            batch_id,
+            round,
+            timestamp,
+            committee_id,
+            transmission_ids,
+            previous_certificate_ids,
+            signature,
+        })
+    }
 }
 
 impl<N: Network> BatchHeader<N> {

--- a/ledger/narwhal/compact-certificate/Cargo.toml
+++ b/ledger/narwhal/compact-certificate/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "snarkvm-ledger-narwhal-subdag"
-version = "4.1.0"
+name = "snarkvm-ledger-narwhal-compact-certificate"
+version = "4.0.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
-description = "A subdag for a Narwhal-style memory pool in a decentralized virtual machine"
+description = "A compact certificate for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"
 repository = "https://github.com/ProvableHQ/snarkVM"
 keywords = [
@@ -24,27 +24,19 @@ license = "Apache-2.0"
 edition = "2024"
 
 [features]
-default = [ "indexmap/rayon", "rayon" ]
+default = [ "rayon" ]
 serial = [ "snarkvm-console/serial" ]
 wasm = [ "snarkvm-console/wasm" ]
-test-helpers = [ "snarkvm-ledger-narwhal-batch-certificate/test-helpers" ]
+test-helpers = [ "snarkvm-ledger-narwhal-compact-header/test-helpers" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-batch-certificate]
 workspace = true
 
-[dependencies.snarkvm-ledger-narwhal-compact-certificate]
+[dependencies.snarkvm-ledger-narwhal-compact-header]
 workspace = true
-
-[dependencies.snarkvm-ledger-narwhal-batch-header]
-workspace = true
-
-[dependencies.snarkvm-ledger-committee]
-workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-traits]
 workspace = true
@@ -64,12 +56,9 @@ optional = true
 workspace = true
 features = [ "preserve_order" ]
 
-[dependencies.tracing]
-workspace = true
-
 [dev-dependencies.bincode]
 workspace = true
 
-[dev-dependencies.snarkvm-ledger-narwhal-subdag]
+[dev-dependencies.snarkvm-ledger-narwhal-compact-certificate]
 path = "."
 features = [ "test-helpers" ]

--- a/ledger/narwhal/compact-certificate/Cargo.toml
+++ b/ledger/narwhal/compact-certificate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-compact-certificate"
-version = "4.0.0"
+version = "4.1.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A compact certificate for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/compact-certificate/LICENSE.md
+++ b/ledger/narwhal/compact-certificate/LICENSE.md
@@ -1,0 +1,194 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/ledger/narwhal/compact-certificate/README.md
+++ b/ledger/narwhal/compact-certificate/README.md
@@ -1,0 +1,7 @@
+# snarkvm-ledger-narwhal-compact-certificate
+
+[![Crates.io](https://img.shields.io/crates/v/snarkvm-ledger-narwhal-compact-certificate.svg?color=neon)](https://crates.io/crates/snarkvm-ledger-narwhal-compact-certificate)
+[![Authors](https://img.shields.io/badge/authors-Aleo-orange.svg)](https://aleo.org)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE.md)
+
+The `snarkvm-ledger-narwhal-compact-certificate` crate provides a compact certificate for a Narwhal-style memory pool.

--- a/ledger/narwhal/compact-certificate/src/bytes.rs
+++ b/ledger/narwhal/compact-certificate/src/bytes.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for CompactCertificate<N> {
+    /// Reads the batch certificate from the buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid compact certificate version"));
+        }
+
+        // Read the batch header.
+        let batch_header = CompactHeader::read_le(&mut reader)?;
+        // Read the number of signatures.
+        let num_signatures = u16::read_le(&mut reader)?;
+        // Ensure the number of signatures is within bounds.
+        if num_signatures > N::LATEST_MAX_CERTIFICATES().unwrap() {
+            return Err(error(format!(
+                "Number of signatures ({num_signatures}) exceeds the maximum ({})",
+                N::LATEST_MAX_CERTIFICATES().unwrap()
+            )));
+        }
+        // Read the signature bytes.
+        let mut signature_bytes = vec![0u8; num_signatures as usize * Signature::<N>::size_in_bytes()];
+        reader.read_exact(&mut signature_bytes)?;
+        // Read the signatures.
+        let signatures = cfg_chunks!(signature_bytes, Signature::<N>::size_in_bytes())
+            .map(Signature::read_le)
+            .collect::<Result<IndexSet<_>, _>>()?;
+        // Return the batch certificate.
+        Self::from(batch_header, signatures).map_err(error)
+    }
+}
+
+impl<N: Network> ToBytes for CompactCertificate<N> {
+    /// Writes the batch certificate to the buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the version.
+        1u8.write_le(&mut writer)?;
+        // Write the batch header.
+        self.compact_header.write_le(&mut writer)?;
+        // Write the number of signatures.
+        u16::try_from(self.signatures.len()).map_err(error)?.write_le(&mut writer)?;
+        // Write the signatures.
+        for signature in self.signatures.iter() {
+            // Write the signature.
+            signature.write_le(&mut writer)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bytes() {
+        let rng = &mut TestRng::default();
+
+        for expected in crate::test_helpers::sample_compact_certificates(rng) {
+            // Check the byte representation.
+            let expected_bytes = expected.to_bytes_le().unwrap();
+            assert_eq!(expected, CompactCertificate::read_le(&expected_bytes[..]).unwrap());
+        }
+    }
+}

--- a/ledger/narwhal/compact-certificate/src/lib.rs
+++ b/ledger/narwhal/compact-certificate/src/lib.rs
@@ -1,0 +1,285 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::cast_possible_truncation)]
+
+mod bytes;
+mod serialize;
+mod string;
+
+use snarkvm_console::{
+    account::{Address, Signature},
+    prelude::*,
+    types::Field,
+};
+use snarkvm_ledger_narwhal_batch_certificate::BatchCertificate;
+use snarkvm_ledger_narwhal_compact_header::CompactHeader;
+use snarkvm_ledger_narwhal_traits::NarwhalCertificate;
+use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
+
+use core::hash::{Hash, Hasher};
+use indexmap::IndexSet;
+
+#[cfg(not(feature = "serial"))]
+use rayon::prelude::*;
+
+#[derive(Clone)]
+pub struct CompactCertificate<N: Network> {
+    /// The compact header.
+    compact_header: CompactHeader<N>,
+    /// The signatures for the batch ID from the committee.
+    signatures: IndexSet<Signature<N>>,
+}
+
+impl<N: Network> CompactCertificate<N> {
+    /// Initializes a new compact certificate.
+    pub fn from(compact_header: CompactHeader<N>, signatures: IndexSet<Signature<N>>) -> Result<Self> {
+        // Ensure that the number of signatures is within bounds.
+        ensure!(signatures.len() <= N::LATEST_MAX_CERTIFICATES().unwrap() as usize, "Invalid number of signatures");
+
+        // Verify the signatures are valid.
+        cfg_iter!(signatures).try_for_each(|signature| {
+            if !signature.verify(&signature.to_address(), &[compact_header.batch_id()]) {
+                bail!("Invalid compact certificate signature")
+            }
+            Ok(())
+        })?;
+        // Return the compact certificate.
+        Self::from_unchecked(compact_header, signatures)
+    }
+
+    /// Initializes a new compact certificate.
+    pub fn from_unchecked(compact_header: CompactHeader<N>, signatures: IndexSet<Signature<N>>) -> Result<Self> {
+        // Ensure the signatures are not empty.
+        ensure!(!signatures.is_empty(), "Compact certificate must contain signatures");
+        // Return the compact certificate.
+        Ok(Self { compact_header, signatures })
+    }
+
+    /// Initializes a new compact certificate from a batch certificate.
+    pub fn from_batch_certificate<'a>(
+        batch_certificate: BatchCertificate<N>,
+        solutions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        prior_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+    ) -> Result<Self> {
+        let compact_header = CompactHeader::new(
+            batch_certificate.batch_header(),
+            solutions,
+            prior_solutions,
+            aborted_solutions,
+            transactions,
+            prior_transactions,
+            aborted_transactions,
+        )?;
+        let BatchCertificate { signatures, .. } = batch_certificate;
+        // Return the compact certificate.
+        Self::from_unchecked(compact_header, signatures)
+    }
+
+    /// Convert compact certificate to batch certificate
+    pub fn into_batch_certificate<'a>(
+        self,
+        solutions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        prior_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+    ) -> Result<BatchCertificate<N>> {
+        let CompactCertificate { compact_header, signatures } = self;
+        let batch_header = compact_header.into_batch_header(
+            solutions,
+            prior_solutions,
+            aborted_solutions,
+            transactions,
+            prior_transactions,
+            aborted_transactions,
+        )?;
+        BatchCertificate::from(batch_header, signatures)
+    }
+}
+
+impl<N: Network> PartialEq for CompactCertificate<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.batch_id() == other.batch_id()
+    }
+}
+
+impl<N: Network> Eq for CompactCertificate<N> {}
+
+impl<N: Network> Hash for CompactCertificate<N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.compact_header.batch_id().hash(state);
+    }
+}
+
+impl<N: Network> CompactCertificate<N> {
+    /// Returns the compact header.
+    pub const fn compact_header(&self) -> &CompactHeader<N> {
+        &self.compact_header
+    }
+
+    /// Returns the transaction indices.
+    pub const fn transaction_indices(&self) -> &IndexSet<u32> {
+        self.compact_header().transaction_indices()
+    }
+
+    /// Returns the solution indices.
+    pub const fn solution_indices(&self) -> &IndexSet<u32> {
+        self.compact_header().solution_indices()
+    }
+
+    /// Returns the signature of the compact header.
+    pub const fn signature(&self) -> &Signature<N> {
+        self.compact_header.signature()
+    }
+}
+
+impl<N: Network> NarwhalCertificate<N> for CompactCertificate<N> {
+    /// Returns the certificate ID.
+    fn id(&self) -> Field<N> {
+        self.compact_header.batch_id()
+    }
+
+    /// Returns the batch ID.
+    fn batch_id(&self) -> Field<N> {
+        self.compact_header().batch_id()
+    }
+
+    /// Returns the author.
+    fn author(&self) -> Address<N> {
+        self.compact_header().author()
+    }
+
+    /// Returns the round.
+    fn round(&self) -> u64 {
+        self.compact_header().round()
+    }
+
+    /// Returns the certificate IDs for the previous round.
+    fn previous_certificate_ids(&self) -> &IndexSet<Field<N>> {
+        self.compact_header().previous_certificate_ids()
+    }
+
+    /// Returns the timestamp of the compact header.
+    fn timestamp(&self) -> i64 {
+        self.compact_header.timestamp()
+    }
+
+    /// Returns the committee ID.
+    fn committee_id(&self) -> Field<N> {
+        self.compact_header.committee_id()
+    }
+
+    /// Returns the signatures of the batch ID from the committee.
+    fn signatures(&self) -> Box<dyn '_ + ExactSizeIterator<Item = &Signature<N>>> {
+        Box::new(self.signatures.iter())
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers {
+    use super::*;
+    use snarkvm_console::{account::PrivateKey, network::MainnetV0, prelude::TestRng, types::Field};
+
+    use indexmap::IndexSet;
+
+    type CurrentNetwork = MainnetV0;
+
+    /// Returns a sample compact certificate, sampled at random.
+    pub fn sample_compact_certificate(rng: &mut TestRng) -> CompactCertificate<CurrentNetwork> {
+        sample_compact_certificate_for_round(rng.r#gen(), rng)
+    }
+
+    /// Returns a sample compact certificate with a given round; the rest is sampled at random.
+    pub fn sample_compact_certificate_for_round(round: u64, rng: &mut TestRng) -> CompactCertificate<CurrentNetwork> {
+        // Sample certificate IDs.
+        let certificate_ids = (0..10).map(|_| Field::<CurrentNetwork>::rand(rng)).collect::<IndexSet<_>>();
+        // Return the compact certificate.
+        sample_compact_certificate_for_round_with_previous_certificate_ids(round, certificate_ids, rng)
+    }
+
+    /// Returns a sample compact certificate with a given round; the rest is sampled at random.
+    pub fn sample_compact_certificate_for_round_with_previous_certificate_ids(
+        round: u64,
+        previous_certificate_ids: IndexSet<Field<CurrentNetwork>>,
+        rng: &mut TestRng,
+    ) -> CompactCertificate<CurrentNetwork> {
+        // Sample a compact header.
+        let compact_header =
+            snarkvm_ledger_narwhal_compact_header::test_helpers::sample_compact_header_for_round_with_previous_certificate_ids(
+                round,
+                previous_certificate_ids,
+                rng,
+            );
+        // Sample a list of signatures.
+        let mut signatures = IndexSet::with_capacity(5);
+        for _ in 0..5 {
+            let private_key = PrivateKey::new(rng).unwrap();
+            signatures.insert(private_key.sign(&[compact_header.batch_id()], rng).unwrap());
+        }
+        // Return the compact certificate.
+        CompactCertificate::from(compact_header, signatures).unwrap()
+    }
+
+    /// Returns a list of sample compact certificates, sampled at random.
+    pub fn sample_compact_certificates(rng: &mut TestRng) -> IndexSet<CompactCertificate<CurrentNetwork>> {
+        // Initialize a sample vector.
+        let mut sample = IndexSet::with_capacity(10);
+        // Append sample compact certificates.
+        for _ in 0..10 {
+            sample.insert(sample_compact_certificate(rng));
+        }
+        // Return the sample vector.
+        sample
+    }
+
+    /// Returns a sample compact certificate with previous certificates, sampled at random.
+    pub fn sample_compact_certificate_with_previous_certificates(
+        round: u64,
+        rng: &mut TestRng,
+    ) -> (CompactCertificate<CurrentNetwork>, Vec<CompactCertificate<CurrentNetwork>>) {
+        assert!(round > 1, "Round must be greater than 1");
+
+        // Initialize the round parameters.
+        let previous_round = round - 1; // <- This must be an even number, for `BFT::update_dag` to behave correctly below.
+        let current_round = round;
+
+        assert_eq!(previous_round % 2, 0, "Previous round must be even");
+
+        // Sample the previous certificates.
+        let previous_certificates = vec![
+            sample_compact_certificate_for_round(previous_round, rng),
+            sample_compact_certificate_for_round(previous_round, rng),
+            sample_compact_certificate_for_round(previous_round, rng),
+            sample_compact_certificate_for_round(previous_round, rng),
+        ];
+        // Construct the previous certificate IDs.
+        let previous_certificate_ids: IndexSet<_> = previous_certificates.iter().map(|c| c.id()).collect();
+        // Sample the leader certificate.
+        let certificate = sample_compact_certificate_for_round_with_previous_certificate_ids(
+            current_round,
+            previous_certificate_ids.clone(),
+            rng,
+        );
+
+        (certificate, previous_certificates)
+    }
+}

--- a/ledger/narwhal/compact-certificate/src/lib.rs
+++ b/ledger/narwhal/compact-certificate/src/lib.rs
@@ -79,8 +79,9 @@ impl<N: Network> CompactCertificate<N> {
         prior_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
         aborted_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
     ) -> Result<Self> {
+        let (batch_header, signatures) = batch_certificate.into_components();
         let compact_header = CompactHeader::new(
-            batch_certificate.batch_header(),
+            &batch_header,
             solutions,
             prior_solutions,
             aborted_solutions,
@@ -88,7 +89,6 @@ impl<N: Network> CompactCertificate<N> {
             prior_transactions,
             aborted_transactions,
         )?;
-        let BatchCertificate { signatures, .. } = batch_certificate;
         // Return the compact certificate.
         Self::from_unchecked(compact_header, signatures)
     }

--- a/ledger/narwhal/compact-certificate/src/serialize.rs
+++ b/ledger/narwhal/compact-certificate/src/serialize.rs
@@ -15,49 +15,36 @@
 
 use super::*;
 
-impl<N: Network> Serialize for Subdag<N> {
-    /// Serializes the subdag to a JSON-string or buffer.
+impl<N: Network> Serialize for CompactCertificate<N> {
+    /// Serializes the batch certificate to a JSON-string or buffer.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match serializer.is_human_readable() {
-            true => match self {
-                Self::Full { subdag } => {
-                    let mut full_subdag = serializer.serialize_struct("Subdag", 1)?;
-                    full_subdag.serialize_field("subdag", subdag)?;
-                    full_subdag.end()
-                }
-                Self::Compact { subdag } => {
-                    let mut compact_subdag = serializer.serialize_struct("Subdag", 1)?;
-                    compact_subdag.serialize_field("compact_subdag", subdag)?;
-                    compact_subdag.end()
-                }
-            },
+            true => {
+                let mut state = serializer.serialize_struct("CompactCertificate", 2)?;
+                state.serialize_field("compact_header", &self.compact_header)?;
+                state.serialize_field("signatures", &self.signatures)?;
+                state.end()
+            }
             false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
         }
     }
 }
 
-impl<'de, N: Network> Deserialize<'de> for Subdag<N> {
-    /// Deserializes the subdag from a JSON-string or buffer.
+impl<'de, N: Network> Deserialize<'de> for CompactCertificate<N> {
+    /// Deserializes the batch certificate from a JSON-string or buffer.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => {
                 let mut value = serde_json::Value::deserialize(deserializer)?;
 
-                // Check if a full Subdag field is present.
-                let subdag_is_full = match value.get("subdag") {
-                    Some(..) => true,
-                    None => false,
-                };
-                match subdag_is_full {
-                    true => Ok(Self::from_full(DeserializeExt::take_from_value::<D>(&mut value, "subdag")?)
-                        .map_err(de::Error::custom)?),
-                    false => {
-                        Ok(Self::from_compact(DeserializeExt::take_from_value::<D>(&mut value, "compact_subdag")?)
-                            .map_err(de::Error::custom)?)
-                    }
-                }
+                // Parse batch certificate.
+                Self::from(
+                    DeserializeExt::take_from_value::<D>(&mut value, "compact_header")?,
+                    DeserializeExt::take_from_value::<D>(&mut value, "signatures")?,
+                )
+                .map_err(de::Error::custom)
             }
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "subdag"),
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "compact certificate"),
         }
     }
 }
@@ -103,7 +90,7 @@ mod tests {
     fn test_serde_json() {
         let rng = &mut TestRng::default();
 
-        for expected in crate::test_helpers::sample_subdags(rng) {
+        for expected in crate::test_helpers::sample_compact_certificates(rng) {
             check_serde_json(expected);
         }
     }
@@ -112,7 +99,7 @@ mod tests {
     fn test_bincode() {
         let rng = &mut TestRng::default();
 
-        for expected in crate::test_helpers::sample_subdags(rng) {
+        for expected in crate::test_helpers::sample_compact_certificates(rng) {
             check_bincode(expected);
         }
     }

--- a/ledger/narwhal/compact-certificate/src/string.rs
+++ b/ledger/narwhal/compact-certificate/src/string.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromStr for CompactCertificate<N> {
+    type Err = Error;
+
+    /// Initializes the batch certificate from a JSON-string.
+    fn from_str(certificate: &str) -> Result<Self, Self::Err> {
+        Ok(serde_json::from_str(certificate)?)
+    }
+}
+
+impl<N: Network> Debug for CompactCertificate<N> {
+    /// Prints the batch certificate as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for CompactCertificate<N> {
+    /// Displays the batch certificate as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).map_err::<fmt::Error, _>(ser::Error::custom)?)
+    }
+}

--- a/ledger/narwhal/compact-header/Cargo.toml
+++ b/ledger/narwhal/compact-header/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "snarkvm-ledger-narwhal-subdag"
-version = "4.1.0"
+name = "snarkvm-ledger-narwhal-compact-header"
+version = "4.0.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
-description = "A subdag for a Narwhal-style memory pool in a decentralized virtual machine"
+description = "A compact header for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"
 repository = "https://github.com/ProvableHQ/snarkVM"
 keywords = [
@@ -24,29 +24,15 @@ license = "Apache-2.0"
 edition = "2024"
 
 [features]
-default = [ "indexmap/rayon", "rayon" ]
+default = [ ]
 serial = [ "snarkvm-console/serial" ]
 wasm = [ "snarkvm-console/wasm" ]
-test-helpers = [ "snarkvm-ledger-narwhal-batch-certificate/test-helpers" ]
+test-helpers = [ "snarkvm-ledger-narwhal-transmission-id/test-helpers", "snarkvm-ledger-narwhal-batch-header/test-helpers" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
-
-[dependencies.snarkvm-ledger-narwhal-batch-certificate]
-workspace = true
-
-[dependencies.snarkvm-ledger-narwhal-compact-certificate]
-workspace = true
 
 [dependencies.snarkvm-ledger-narwhal-batch-header]
-workspace = true
-
-[dependencies.snarkvm-ledger-committee]
-workspace = true
-features = [ "default" ]
-
-[dependencies.snarkvm-ledger-narwhal-traits]
 workspace = true
 
 [dependencies.snarkvm-ledger-narwhal-transmission-id]
@@ -56,20 +42,13 @@ workspace = true
 workspace = true
 features = [ "serde" ]
 
-[dependencies.rayon]
-workspace = true
-optional = true
-
 [dependencies.serde_json]
 workspace = true
 features = [ "preserve_order" ]
 
-[dependencies.tracing]
-workspace = true
-
 [dev-dependencies.bincode]
 workspace = true
 
-[dev-dependencies.snarkvm-ledger-narwhal-subdag]
+[dev-dependencies.snarkvm-ledger-narwhal-compact-header]
 path = "."
 features = [ "test-helpers" ]

--- a/ledger/narwhal/compact-header/Cargo.toml
+++ b/ledger/narwhal/compact-header/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-compact-header"
-version = "4.0.0"
+version = "4.1.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A compact header for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/compact-header/LICENSE.md
+++ b/ledger/narwhal/compact-header/LICENSE.md
@@ -1,0 +1,194 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/ledger/narwhal/compact-header/README.md
+++ b/ledger/narwhal/compact-header/README.md
@@ -1,0 +1,7 @@
+# snarkvm-ledger-narwhal-compact-header
+
+[![Crates.io](https://img.shields.io/crates/v/snarkvm-ledger-narwhal-compact-header.svg?color=neon)](https://crates.io/crates/snarkvm-ledger-narwhal-compact-header)
+[![Authors](https://img.shields.io/badge/authors-Aleo-orange.svg)](https://aleo.org)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE.md)
+
+The `snarkvm-ledger-narwhal-compact-header` crate provides a compact header for a Narwhal-style memory pool.

--- a/ledger/narwhal/compact-header/src/bytes.rs
+++ b/ledger/narwhal/compact-header/src/bytes.rs
@@ -15,8 +15,8 @@
 
 use super::*;
 
-impl<N: Network> FromBytes for BatchHeader<N> {
-    /// Reads the batch header from the buffer.
+impl<N: Network> FromBytes for CompactHeader<N> {
+    /// Reads the compact header from the buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
@@ -36,57 +36,64 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         // Read the committee ID.
         let committee_id = Field::read_le(&mut reader)?;
 
-        // Read the number of transmission IDs.
-        let num_transmission_ids = u32::read_le(&mut reader)?;
-        // Ensure the number of transmission IDs is within bounds.
-        if num_transmission_ids as usize > Self::MAX_TRANSMISSIONS_PER_BATCH {
-            return Err(error(format!(
-                "Number of transmission IDs ({num_transmission_ids}) exceeds the maximum ({})",
-                Self::MAX_TRANSMISSIONS_PER_BATCH,
-            )));
+        // Read the number of transaction indices.
+        let num_transaction_indices = u16::read_le(&mut reader)?;
+        let mut transaction_indices = IndexSet::with_capacity(num_transaction_indices as usize);
+        // Read the transaction indices.
+        for _ in 0..num_transaction_indices {
+            transaction_indices.insert(u32::read_le(&mut reader)?);
         }
-        // Read the transmission IDs.
-        let mut transmission_ids = IndexSet::new();
-        for _ in 0..num_transmission_ids {
-            // Insert the transmission ID.
-            transmission_ids.insert(TransmissionID::read_le(&mut reader)?);
+
+        // Read the number of solution indices.
+        let num_solution_indices = u16::read_le(&mut reader)?;
+        let mut solution_indices = IndexSet::with_capacity(num_solution_indices as usize);
+        // Read the transaction indices.
+        for _ in 0..num_solution_indices {
+            solution_indices.insert(u32::read_le(&mut reader)?);
         }
 
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u16::read_le(&mut reader)?;
         // Ensure the number of previous certificate IDs is within bounds.
-        if num_previous_certificate_ids > N::LATEST_MAX_CERTIFICATES().map_err(error)? {
+        if num_previous_certificate_ids > N::LATEST_MAX_CERTIFICATES().unwrap() {
             return Err(error(format!(
-                "Number of previous certificate IDs ({num_previous_certificate_ids}) exceeds the maximum.",
+                "Number of previous certificate IDs ({num_previous_certificate_ids}) exceeds the maximum ({})",
+                N::LATEST_MAX_CERTIFICATES().unwrap()
             )));
         }
-
-        // Read the previous certificate ID bytes.
-        let mut previous_certificate_id_bytes =
-            vec![0u8; num_previous_certificate_ids as usize * Field::<N>::size_in_bytes()];
-        reader.read_exact(&mut previous_certificate_id_bytes)?;
         // Read the previous certificate IDs.
-        let previous_certificate_ids = cfg_chunks!(previous_certificate_id_bytes, Field::<N>::size_in_bytes())
-            .map(Field::read_le)
-            .collect::<Result<IndexSet<_>, _>>()?;
+        let mut previous_certificate_ids = IndexSet::new();
+        for _ in 0..num_previous_certificate_ids {
+            // Read the certificate ID.
+            previous_certificate_ids.insert(Field::read_le(&mut reader)?);
+        }
 
         // Read the signature.
         let signature = Signature::read_le(&mut reader)?;
 
         // Construct the batch.
-        let batch =
-            Self::from(author, round, timestamp, committee_id, transmission_ids, previous_certificate_ids, signature)
-                .map_err(error)?;
+        let batch = Self::from(
+            batch_id,
+            author,
+            round,
+            timestamp,
+            committee_id,
+            transaction_indices,
+            solution_indices,
+            previous_certificate_ids,
+            signature,
+        )
+        .map_err(|e| error(e.to_string()))?;
 
         // Return the batch.
         match batch.batch_id == batch_id {
             true => Ok(batch),
-            false => Err(error("Invalid batch ID for batch header.")),
+            false => Err(error("Invalid batch ID")),
         }
     }
 }
 
-impl<N: Network> ToBytes for BatchHeader<N> {
+impl<N: Network> ToBytes for CompactHeader<N> {
     /// Writes the batch header to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the version.
@@ -101,13 +108,14 @@ impl<N: Network> ToBytes for BatchHeader<N> {
         self.timestamp.write_le(&mut writer)?;
         // Write the committee ID.
         self.committee_id.write_le(&mut writer)?;
-        // Write the number of transmission IDs.
-        u32::try_from(self.transmission_ids.len()).map_err(|e| error(e.to_string()))?.write_le(&mut writer)?;
-        // Write the transmission IDs.
-        for transmission_id in &self.transmission_ids {
-            // Write the transmission ID.
-            transmission_id.write_le(&mut writer)?;
-        }
+        // Write the number of transaction indices.
+        u16::try_from(self.transaction_indices.len()).map_err(error)?.write_le(&mut writer)?;
+        // Write the transaction indices.
+        self.transaction_indices.iter().try_for_each(|b| b.write_le(&mut writer))?;
+        // Write the number of solution indices.
+        u16::try_from(self.solution_indices.len()).map_err(error)?.write_le(&mut writer)?;
+        // Write the solution indices.
+        self.solution_indices.iter().try_for_each(|b| b.write_le(&mut writer))?;
         // Write the number of previous certificate IDs.
         u16::try_from(self.previous_certificate_ids.len()).map_err(|e| error(e.to_string()))?.write_le(&mut writer)?;
         // Write the previous certificate IDs.
@@ -128,10 +136,10 @@ mod tests {
     fn test_bytes() {
         let rng = &mut TestRng::default();
 
-        for expected in crate::test_helpers::sample_batch_headers(rng) {
+        for expected in crate::test_helpers::sample_compact_headers(rng) {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
-            assert_eq!(expected, BatchHeader::read_le(&expected_bytes[..]).unwrap());
+            assert_eq!(expected, CompactHeader::read_le(&expected_bytes[..]).unwrap());
         }
     }
 }

--- a/ledger/narwhal/compact-header/src/lib.rs
+++ b/ledger/narwhal/compact-header/src/lib.rs
@@ -226,6 +226,7 @@ impl<N: Network> CompactHeader<N> {
         &self.signature
     }
 
+    /// Returns the transmission IDs associated with the header.
     pub fn to_transmission_ids<'a>(
         &self,
         solutions: impl Iterator<Item = &'a TransmissionID<N>>,
@@ -268,7 +269,6 @@ impl<N: Network> CompactHeader<N> {
     }
 
     /// Convert compact header to batch header
-    /// NOTE: this also recomputes the batch_id and verifies the signature.
     pub fn into_batch_header<'a>(
         self,
         solutions: impl Iterator<Item = &'a TransmissionID<N>>,
@@ -287,7 +287,7 @@ impl<N: Network> CompactHeader<N> {
             aborted_transactions,
         )?;
 
-        BatchHeader::from(
+        BatchHeader::from_unchecked(
             self.author,
             self.round,
             self.timestamp,

--- a/ledger/narwhal/compact-header/src/lib.rs
+++ b/ledger/narwhal/compact-header/src/lib.rs
@@ -43,9 +43,11 @@ pub struct CompactHeader<N: Network> {
     timestamp: i64,
     /// The committee ID.
     committee_id: Field<N>,
-    /// The set of transaction indices in a block.
+    /// The transactions included in this batch, stored compactly as indices in the set of all
+    /// transactions of the associated block.
     transaction_indices: IndexSet<u32>,
-    /// The set of solution indices in a block.
+    /// The solutions included in this batch, stored compactly as indices in the set of all
+    /// solutions of the associated block.
     solution_indices: IndexSet<u32>,
     /// The batch certificate IDs of the previous round.
     previous_certificate_ids: IndexSet<Field<N>>,

--- a/ledger/narwhal/compact-header/src/lib.rs
+++ b/ledger/narwhal/compact-header/src/lib.rs
@@ -1,0 +1,435 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::cast_possible_truncation)]
+#![allow(clippy::too_many_arguments)]
+
+mod bytes;
+mod serialize;
+mod string;
+
+use indexmap::IndexSet;
+use snarkvm_console::{
+    account::{Address, Signature},
+    prelude::*,
+    types::Field,
+};
+use snarkvm_ledger_narwhal_batch_header::BatchHeader;
+use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct CompactHeader<N: Network> {
+    /// The batch ID, defined as the hash of the author, round number, timestamp, transmission IDs,
+    /// previous batch certificate IDs, and last election certificate IDs.
+    batch_id: Field<N>,
+    /// The author of the batch.
+    author: Address<N>,
+    /// The round number.
+    round: u64,
+    /// The timestamp.
+    timestamp: i64,
+    /// The committee ID.
+    committee_id: Field<N>,
+    /// The set of transaction indices in a block.
+    transaction_indices: IndexSet<u32>,
+    /// The set of solution indices in a block.
+    solution_indices: IndexSet<u32>,
+    /// The batch certificate IDs of the previous round.
+    previous_certificate_ids: IndexSet<Field<N>>,
+    /// The signature of the batch ID from the creator.
+    signature: Signature<N>,
+}
+
+impl<N: Network> CompactHeader<N> {
+    /// Initializes a new compact header.
+    /// This does not recompute the batch_id nor verify the signature.
+    pub fn new<'a>(
+        batch_header: &BatchHeader<N>,
+        solutions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        prior_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+    ) -> Result<Self> {
+        let transmission_ids = batch_header.transmission_ids();
+
+        // Check the number of transactions and solutions in the batch.
+        let mut num_transactions = 0;
+        let mut num_solutions = 0;
+        for id in transmission_ids.iter() {
+            match id {
+                TransmissionID::Solution(..) => num_solutions += 1,
+                TransmissionID::Transaction(..) => num_transactions += 1,
+                TransmissionID::Ratification => bail!("Invalid batch, contains ratifications"),
+            }
+        }
+
+        // Check which transaction_indices the certificate contains.
+        let mut transaction_indices = IndexSet::with_capacity(num_transactions);
+        for (i, transmission_id) in transactions.chain(aborted_transactions).chain(prior_transactions).enumerate() {
+            if transmission_ids.contains(transmission_id) {
+                transaction_indices.insert(u32::try_from(i)?);
+            }
+        }
+
+        // Check which solution_indices the certificate contains.
+        let solution_indices = Self::create_solution_indices(
+            solutions.chain(prior_solutions).chain(aborted_solutions),
+            transmission_ids,
+            num_solutions,
+        )?;
+
+        // Check if we found all Transmission IDs.
+        ensure!(
+            transaction_indices.len() + solution_indices.len() == transmission_ids.len(),
+            "Could not find all transmission_ids"
+        );
+
+        // Return the compact header.
+        Ok(Self {
+            author: batch_header.author(),
+            batch_id: batch_header.batch_id(),
+            round: batch_header.round(),
+            timestamp: batch_header.timestamp(),
+            committee_id: batch_header.committee_id(),
+            transaction_indices,
+            solution_indices,
+            previous_certificate_ids: batch_header.previous_certificate_ids().clone(),
+            signature: *batch_header.signature(),
+        })
+    }
+
+    /// Creates solution_indices from transmission_ids.
+    fn create_solution_indices<'a>(
+        block_solutions: impl Iterator<Item = &'a TransmissionID<N>>,
+        transmission_ids: &IndexSet<TransmissionID<N>>,
+        num_solutions_in_batch: usize,
+    ) -> Result<IndexSet<u32>> {
+        let mut solution_indices = IndexSet::with_capacity(num_solutions_in_batch);
+        for (i, transmission_id) in block_solutions.enumerate() {
+            if transmission_ids.contains(transmission_id) {
+                solution_indices.insert(u32::try_from(i)?);
+            }
+        }
+        Ok(solution_indices)
+    }
+
+    /// Initializes a new compact header.
+    /// This does not recompute the batch_id.
+    pub fn from(
+        batch_id: Field<N>,
+        author: Address<N>,
+        round: u64,
+        timestamp: i64,
+        committee_id: Field<N>,
+        transaction_indices: IndexSet<u32>,
+        solution_indices: IndexSet<u32>,
+        previous_certificate_ids: IndexSet<Field<N>>,
+        signature: Signature<N>,
+    ) -> Result<Self> {
+        match round {
+            0 | 1 => {
+                // If the round is zero or one, then there should be no previous certificate IDs.
+                ensure!(previous_certificate_ids.is_empty(), "Invalid round number, must not have certificates");
+            }
+            // If the round is not zero and not one, then there should be at least one previous certificate ID.
+            _ => ensure!(!previous_certificate_ids.is_empty(), "Invalid round number, must have certificates"),
+        }
+
+        // Ensure that the number of transmissions is within bounds.
+        ensure!(
+            transaction_indices.len() + solution_indices.len() <= BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH,
+            "Invalid number of transmission ids"
+        );
+        // Ensure that the number of previous certificate IDs is within bounds.
+        ensure!(
+            previous_certificate_ids.len() <= N::LATEST_MAX_CERTIFICATES().unwrap() as usize,
+            "Invalid number of previous certificate IDs"
+        );
+
+        // Verify the signature.
+        if !signature.verify(&author, &[batch_id]) {
+            bail!("Invalid signature for the batch header");
+        }
+        // Return the compact header.
+        Ok(Self {
+            author,
+            batch_id,
+            round,
+            timestamp,
+            committee_id,
+            transaction_indices,
+            solution_indices,
+            previous_certificate_ids,
+            signature,
+        })
+    }
+}
+
+impl<N: Network> CompactHeader<N> {
+    /// Returns the batch ID.
+    pub const fn batch_id(&self) -> Field<N> {
+        self.batch_id
+    }
+
+    /// Returns the author.
+    pub const fn author(&self) -> Address<N> {
+        self.author
+    }
+
+    /// Returns the round number.
+    pub const fn round(&self) -> u64 {
+        self.round
+    }
+
+    /// Returns the timestamp.
+    pub const fn timestamp(&self) -> i64 {
+        self.timestamp
+    }
+
+    /// Returns the committee ID.
+    pub const fn committee_id(&self) -> Field<N> {
+        self.committee_id
+    }
+
+    /// Returns the transaction indices.
+    pub const fn transaction_indices(&self) -> &IndexSet<u32> {
+        &self.transaction_indices
+    }
+
+    /// Returns the solution indices.
+    pub const fn solution_indices(&self) -> &IndexSet<u32> {
+        &self.solution_indices
+    }
+
+    /// Returns the batch certificate IDs for the previous round.
+    pub const fn previous_certificate_ids(&self) -> &IndexSet<Field<N>> {
+        &self.previous_certificate_ids
+    }
+
+    /// Returns the signature.
+    pub const fn signature(&self) -> &Signature<N> {
+        &self.signature
+    }
+
+    pub fn to_transmission_ids<'a>(
+        &self,
+        solutions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        transactions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_transactions: impl Iterator<Item = &'a TransmissionID<N>>,
+    ) -> Result<IndexSet<TransmissionID<N>>> {
+        // Insert the transactions into the transmission_ids.
+        let mut transmission_ids = IndexSet::new();
+        transactions.chain(aborted_transactions).chain(prior_transactions).enumerate().try_for_each(
+            |(index, transmission_id)| {
+                if self.transaction_indices.contains(&u32::try_from(index)?) {
+                    transmission_ids.insert(*transmission_id);
+                }
+                Ok::<(), Error>(())
+            },
+        )?;
+        // Define a closure to insert a solution into the transmission_ids.
+        let mut insert_solution = |(index, transmission_id): (usize, &TransmissionID<N>)| {
+            if self.solution_indices.contains(&u32::try_from(index)?) {
+                transmission_ids.insert(*transmission_id);
+            }
+            Ok::<(), Error>(())
+        };
+        // Insert the solutions into the transmission_ids.
+        solutions
+            .chain(prior_solutions)
+            .chain(aborted_solutions)
+            .enumerate()
+            .try_for_each(|(index, puzzle_commitment)| insert_solution((index, puzzle_commitment)))?;
+
+        ensure!(
+            transmission_ids.len() == self.transaction_indices.len() + self.solution_indices.len(),
+            "Internal logic error: could not find all transmission_ids."
+        );
+
+        Ok(transmission_ids)
+    }
+
+    /// Convert compact header to batch header
+    /// NOTE: this also recomputes the batch_id and verifies the signature.
+    pub fn into_batch_header<'a>(
+        self,
+        solutions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        transactions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_transactions: impl Iterator<Item = &'a TransmissionID<N>>,
+    ) -> Result<BatchHeader<N>> {
+        let transmission_ids = self.to_transmission_ids(
+            solutions,
+            prior_solutions,
+            aborted_solutions,
+            transactions,
+            prior_transactions,
+            aborted_transactions,
+        )?;
+
+        BatchHeader::from(
+            self.author,
+            self.round,
+            self.timestamp,
+            self.committee_id,
+            transmission_ids,
+            self.previous_certificate_ids,
+            self.signature,
+        )
+    }
+
+    /// Check the batch ID.
+    /// NOTE: to verify the batch ID, and thereby confirm the validity of batch
+    /// signatures, the full transmission ID set is required. Because this is an
+    /// expensive operation, this should only be called once, during block
+    /// verification.
+    pub fn check_batch_id<'a>(
+        &self,
+        solutions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_solutions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        transactions: impl Iterator<Item = &'a TransmissionID<N>>,
+        prior_transactions: impl ExactSizeIterator<Item = &'a TransmissionID<N>>,
+        aborted_transactions: impl Iterator<Item = &'a TransmissionID<N>>,
+    ) -> Result<()> {
+        let transmission_ids = self.to_transmission_ids(
+            solutions,
+            prior_solutions,
+            aborted_solutions,
+            transactions,
+            prior_transactions,
+            aborted_transactions,
+        )?;
+
+        let batch_id = BatchHeader::compute_batch_id(
+            self.author,
+            self.round,
+            self.timestamp,
+            self.committee_id,
+            &transmission_ids,
+            &self.previous_certificate_ids,
+        )?;
+
+        // Compare the batch_id.
+        if batch_id != self.batch_id {
+            bail!("Invalid batch_id for compact header.");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers {
+    use super::*;
+    use snarkvm_console::{network::MainnetV0, prelude::TestRng};
+
+    use snarkvm_ledger_narwhal_batch_header::test_helpers::sample_batch_header_for_round_with_previous_certificate_ids;
+
+    type CurrentNetwork = MainnetV0;
+
+    /// Returns a sample batch header, sampled at random.
+    pub fn sample_compact_header(rng: &mut TestRng) -> CompactHeader<CurrentNetwork> {
+        sample_compact_header_for_round(rng.r#gen(), rng)
+    }
+
+    /// Returns a sample compact header with a given round; the rest is sampled at random.
+    pub fn sample_compact_header_for_round(round: u64, rng: &mut TestRng) -> CompactHeader<CurrentNetwork> {
+        // Sample certificate IDs.
+        let certificate_ids = (0..10).map(|_| Field::<CurrentNetwork>::rand(rng)).collect::<IndexSet<_>>();
+        // Return the batch header.
+        sample_compact_header_for_round_with_previous_certificate_ids(round, certificate_ids, rng)
+    }
+
+    /// Returns a sample compact header with a given round and set of previous certificate IDs; the rest is sampled at random.
+    pub fn sample_compact_header_for_round_with_previous_certificate_ids(
+        round: u64,
+        previous_certificate_ids: IndexSet<Field<CurrentNetwork>>,
+        rng: &mut TestRng,
+    ) -> CompactHeader<CurrentNetwork> {
+        // Sample a batch header.
+        let batch_header =
+            sample_batch_header_for_round_with_previous_certificate_ids(round, previous_certificate_ids, rng);
+        // Construct appropriate sets to collect transmission IDs.
+        let mut solutions = IndexSet::new();
+        let mut prior_solutions = IndexSet::new();
+        let mut aborted_solutions = IndexSet::new();
+        let mut tx_ids = IndexSet::new();
+        let mut prior_tx_ids = IndexSet::new();
+        let mut aborted_tx_ids = IndexSet::new();
+        for (i, transmission_id) in batch_header.transmission_ids().iter().enumerate() {
+            match transmission_id {
+                TransmissionID::Solution(..) => match i % 3 {
+                    0 => {
+                        solutions.insert(transmission_id);
+                    }
+                    1 => {
+                        prior_solutions.insert(transmission_id);
+                    }
+                    2 => {
+                        aborted_solutions.insert(transmission_id);
+                    }
+                    _ => panic!("Invalid solution index"),
+                },
+                TransmissionID::Transaction(..) => match i % 3 {
+                    0 => {
+                        tx_ids.insert(transmission_id);
+                    }
+                    1 => {
+                        prior_tx_ids.insert(transmission_id);
+                    }
+                    2 => {
+                        aborted_tx_ids.insert(transmission_id);
+                    }
+                    _ => panic!("Invalid solution index"),
+                },
+                TransmissionID::Ratification => {}
+            }
+        }
+
+        // Return the compact header.
+        CompactHeader::new(
+            &batch_header,
+            solutions.into_iter(),
+            prior_solutions.into_iter(),
+            aborted_solutions.into_iter(),
+            tx_ids.into_iter(),
+            prior_tx_ids.into_iter(),
+            aborted_tx_ids.into_iter(),
+        )
+        .unwrap()
+    }
+
+    /// Returns a list of sample compact headers, sampled at random.
+    pub fn sample_compact_headers(rng: &mut TestRng) -> Vec<CompactHeader<CurrentNetwork>> {
+        // Initialize a sample vector.
+        let mut sample = Vec::with_capacity(10);
+        // Append sample batches.
+        for _ in 0..10 {
+            // Append the batch header.
+            sample.push(sample_compact_header(rng));
+        }
+        // Return the sample vector.
+        sample
+    }
+}

--- a/ledger/narwhal/compact-header/src/serialize.rs
+++ b/ledger/narwhal/compact-header/src/serialize.rs
@@ -1,0 +1,133 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Serialize for CompactHeader<N> {
+    #[inline]
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match serializer.is_human_readable() {
+            true => {
+                let mut header = serializer.serialize_struct("CompactHeader", 9)?;
+                header.serialize_field("batch_id", &self.batch_id)?;
+                header.serialize_field("author", &self.author)?;
+                header.serialize_field("round", &self.round)?;
+                header.serialize_field("timestamp", &self.timestamp)?;
+                header.serialize_field("committee_id", &self.committee_id)?;
+                header.serialize_field("transaction_indices", &self.transaction_indices.iter().collect_vec())?;
+                header.serialize_field("solution_indices", &self.solution_indices.iter().collect_vec())?;
+                header.serialize_field("previous_certificate_ids", &self.previous_certificate_ids)?;
+                header.serialize_field("signature", &self.signature)?;
+                header.end()
+            }
+            false => ToBytesSerializer::serialize_with_size_encoding(self, serializer),
+        }
+    }
+}
+
+impl<'de, N: Network> Deserialize<'de> for CompactHeader<N> {
+    #[inline]
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match deserializer.is_human_readable() {
+            true => {
+                let mut header = serde_json::Value::deserialize(deserializer)?;
+                let batch_id: Field<N> = DeserializeExt::take_from_value::<D>(&mut header, "batch_id")?;
+
+                // Parse the transaction indices.
+                let transaction_indices_vec: Vec<_> =
+                    DeserializeExt::take_from_value::<D>(&mut header, "transaction_indices")?;
+                let mut transaction_indices = IndexSet::with_capacity(transaction_indices_vec.len());
+                for index in transaction_indices_vec {
+                    transaction_indices.insert(index);
+                }
+                // Parse the solution indices.
+                let solution_indices_vec: Vec<_> =
+                    DeserializeExt::take_from_value::<D>(&mut header, "solution_indices")?;
+                let mut solution_indices = IndexSet::with_capacity(solution_indices_vec.len());
+                for index in solution_indices_vec {
+                    solution_indices.insert(index);
+                }
+
+                // Recover the header.
+                let batch_header = Self::from(
+                    batch_id,
+                    DeserializeExt::take_from_value::<D>(&mut header, "author")?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "round")?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "timestamp")?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "committee_id")?,
+                    transaction_indices,
+                    solution_indices,
+                    DeserializeExt::take_from_value::<D>(&mut header, "previous_certificate_ids")?,
+                    DeserializeExt::take_from_value::<D>(&mut header, "signature")?,
+                )
+                .map_err(de::Error::custom)?;
+
+                Ok(batch_header)
+            }
+            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "compact header"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check_serde_json<
+        T: Serialize + for<'a> Deserialize<'a> + Debug + Display + PartialEq + Eq + FromStr + ToBytes + FromBytes,
+    >(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_string = &expected.to_string();
+        let candidate_string = serde_json::to_string(&expected).unwrap();
+        assert_eq!(expected_string, &serde_json::Value::from_str(&candidate_string).unwrap().to_string());
+
+        // Deserialize
+        assert_eq!(expected, T::from_str(expected_string).unwrap_or_else(|_| panic!("FromStr: {expected_string}")));
+        assert_eq!(expected, serde_json::from_str(&candidate_string).unwrap());
+    }
+
+    fn check_bincode<T: Serialize + for<'a> Deserialize<'a> + Debug + PartialEq + Eq + ToBytes + FromBytes>(
+        expected: T,
+    ) {
+        // Serialize
+        let expected_bytes = expected.to_bytes_le().unwrap();
+        let expected_bytes_with_size_encoding = bincode::serialize(&expected).unwrap();
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(expected, T::read_le(&expected_bytes[..]).unwrap());
+        assert_eq!(expected, bincode::deserialize(&expected_bytes_with_size_encoding[..]).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json() {
+        let rng = &mut TestRng::default();
+
+        for expected in crate::test_helpers::sample_compact_headers(rng) {
+            check_serde_json(expected);
+        }
+    }
+
+    #[test]
+    fn test_bincode() {
+        let rng = &mut TestRng::default();
+
+        for expected in crate::test_helpers::sample_compact_headers(rng) {
+            check_bincode(expected);
+        }
+    }
+}

--- a/ledger/narwhal/compact-header/src/string.rs
+++ b/ledger/narwhal/compact-header/src/string.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromStr for CompactHeader<N> {
+    type Err = Error;
+
+    /// Initializes the batch header from a JSON-string.
+    fn from_str(header: &str) -> Result<Self, Self::Err> {
+        Ok(serde_json::from_str(header)?)
+    }
+}
+
+impl<N: Network> Debug for CompactHeader<N> {
+    /// Prints the batch header as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for CompactHeader<N> {
+    /// Displays the batch header as a JSON-string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).map_err::<fmt::Error, _>(ser::Error::custom)?)
+    }
+}

--- a/ledger/narwhal/src/lib.rs
+++ b/ledger/narwhal/src/lib.rs
@@ -26,6 +26,16 @@ pub use snarkvm_ledger_narwhal_batch_header as batch_header;
 #[cfg(feature = "batch-header")]
 pub use snarkvm_ledger_narwhal_batch_header::BatchHeader;
 
+#[cfg(feature = "compact-certificate")]
+pub use snarkvm_ledger_narwhal_compact_certificate as compact_certificate;
+#[cfg(feature = "compact-certificate")]
+pub use snarkvm_ledger_narwhal_compact_certificate::CompactCertificate;
+
+#[cfg(feature = "compact-header")]
+pub use snarkvm_ledger_narwhal_compact_header as compact_header;
+#[cfg(feature = "compact-header")]
+pub use snarkvm_ledger_narwhal_compact_header::CompactHeader;
+
 #[cfg(feature = "data")]
 pub use snarkvm_ledger_narwhal_data as data;
 #[cfg(feature = "data")]
@@ -34,7 +44,12 @@ pub use snarkvm_ledger_narwhal_data::Data;
 #[cfg(feature = "subdag")]
 pub use snarkvm_ledger_narwhal_subdag as subdag;
 #[cfg(feature = "subdag")]
-pub use snarkvm_ledger_narwhal_subdag::Subdag;
+pub use snarkvm_ledger_narwhal_subdag::{LeaderCertificate, Subdag};
+
+#[cfg(feature = "traits")]
+pub use snarkvm_ledger_narwhal_traits as traits;
+#[cfg(feature = "traits")]
+pub use snarkvm_ledger_narwhal_traits::NarwhalCertificate;
 
 #[cfg(feature = "transmission")]
 pub use snarkvm_ledger_narwhal_transmission as transmission;

--- a/ledger/narwhal/subdag/Cargo.toml
+++ b/ledger/narwhal/subdag/Cargo.toml
@@ -27,7 +27,10 @@ edition = "2024"
 default = [ "indexmap/rayon", "rayon" ]
 serial = [ "snarkvm-console/serial" ]
 wasm = [ "snarkvm-console/wasm" ]
-test-helpers = [ "snarkvm-ledger-narwhal-batch-certificate/test-helpers" ]
+test-helpers = [
+  "snarkvm-ledger-narwhal-batch-certificate/test-helpers",
+  "snarkvm-ledger-narwhal-compact-certificate/test-helpers",
+]
 
 [dependencies.snarkvm-console]
 workspace = true

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -21,9 +21,15 @@ impl<N: Network> FromBytes for Subdag<N> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
-        if version != 1 {
+        if ![1, 2].contains(&version) {
             return Err(error(format!("Invalid subdag version ({version})")));
         }
+
+        // Read the subdag type.
+        let subdag_type = match version {
+            1 => 1u8,
+            _ => u8::read_le(&mut reader)?,
+        };
 
         // Read the number of rounds.
         let num_rounds = u32::read_le(&mut reader)?;
@@ -32,7 +38,8 @@ impl<N: Network> FromBytes for Subdag<N> {
             return Err(error(format!("Number of rounds ({num_rounds}) exceeds the maximum ({})", Self::MAX_ROUNDS)));
         }
         // Read the round certificates.
-        let mut subdag = BTreeMap::new();
+        let mut batch_subdag = BTreeMap::new();
+        let mut compact_subdag = BTreeMap::new();
         for _ in 0..num_rounds {
             // Read the round.
             let round = u64::read_le(&mut reader)?;
@@ -43,17 +50,37 @@ impl<N: Network> FromBytes for Subdag<N> {
                 return Err(error(format!("Number of certificates ({num_certificates}) exceeds the maximum.",)));
             }
             // Read the certificates.
-            let mut certificates = IndexSet::new();
-            for _ in 0..num_certificates {
-                // Read the certificate.
-                certificates.insert(BatchCertificate::read_le(&mut reader)?);
+            match subdag_type {
+                1 => {
+                    let mut certificates = IndexSet::new();
+                    for _ in 0..num_certificates {
+                        // Read the certificate.
+                        certificates.insert(BatchCertificate::read_le(&mut reader)?);
+                    }
+                    // Insert the round and certificates.
+                    batch_subdag.insert(round, certificates);
+                }
+                2 => {
+                    let mut certificates = IndexSet::new();
+                    for _ in 0..num_certificates {
+                        // Read the certificate.
+                        certificates.insert(CompactCertificate::read_le(&mut reader)?);
+                    }
+                    // Insert the round and certificates.
+                    compact_subdag.insert(round, certificates);
+                }
+                _ => {
+                    return Err(error(format!("Found unexpected subdag type ({subdag_type})")));
+                }
             }
-            // Insert the round and certificates.
-            subdag.insert(round, certificates);
         }
 
         // Return the subdag.
-        Self::from(subdag).map_err(error)
+        match subdag_type {
+            1 => Self::from_full(batch_subdag).map_err(error),
+            2 => Self::from_compact(compact_subdag).map_err(error),
+            _ => Err(error(format!("Found unexpected subdag type ({subdag_type})"))),
+        }
     }
 }
 
@@ -61,19 +88,46 @@ impl<N: Network> ToBytes for Subdag<N> {
     /// Writes the subdag to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the version.
-        1u8.write_le(&mut writer)?;
+        let version = 1u8;
+        version.write_le(&mut writer)?;
+        // Get the subdag type
+        let (subdag_type, subdag_len) = match self {
+            Self::Full { subdag, .. } => (1u8, subdag.len()),
+            Self::Compact { subdag, .. } => (2u8, subdag.len()),
+        };
+        // Write the subdag type
+        if version >= 2 {
+            subdag_type.write_le(&mut writer)?;
+        }
         // Write the number of rounds.
-        u32::try_from(self.subdag.len()).map_err(error)?.write_le(&mut writer)?;
+        u32::try_from(subdag_len).map_err(error)?.write_le(&mut writer)?;
         // Write the round certificates.
-        for (round, certificates) in &self.subdag {
-            // Write the round.
-            round.write_le(&mut writer)?;
-            // Write the number of certificates.
-            u16::try_from(certificates.len()).map_err(error)?.write_le(&mut writer)?;
-            // Write the certificates.
-            for certificate in certificates {
-                // Write the certificate.
-                certificate.write_le(&mut writer)?;
+        match self {
+            Self::Full { subdag, .. } => {
+                for (round, certificates) in subdag {
+                    // Write the round.
+                    round.write_le(&mut writer)?;
+                    // Write the number of certificates.
+                    u16::try_from(certificates.len()).map_err(error)?.write_le(&mut writer)?;
+                    // Write the certificates.
+                    for certificate in certificates {
+                        // Write the certificate.
+                        certificate.write_le(&mut writer)?;
+                    }
+                }
+            }
+            Self::Compact { subdag, .. } => {
+                for (round, certificates) in subdag {
+                    // Write the round.
+                    round.write_le(&mut writer)?;
+                    // Write the number of certificates.
+                    u16::try_from(certificates.len()).map_err(error)?.write_le(&mut writer)?;
+                    // Write the certificates.
+                    for certificate in certificates {
+                        // Write the certificate.
+                        certificate.write_le(&mut writer)?;
+                    }
+                }
             }
         }
         Ok(())

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -25,12 +25,6 @@ impl<N: Network> FromBytes for Subdag<N> {
             return Err(error(format!("Invalid subdag version ({version})")));
         }
 
-        // Read the subdag type.
-        let subdag_type = match version {
-            1 => 1u8,
-            _ => u8::read_le(&mut reader)?,
-        };
-
         // Read the number of rounds.
         let num_rounds = u32::read_le(&mut reader)?;
         // Ensure the number of rounds is within bounds.
@@ -50,7 +44,7 @@ impl<N: Network> FromBytes for Subdag<N> {
                 return Err(error(format!("Number of certificates ({num_certificates}) exceeds the maximum.",)));
             }
             // Read the certificates.
-            match subdag_type {
+            match version {
                 1 => {
                     let mut certificates = IndexSet::new();
                     for _ in 0..num_certificates {
@@ -70,16 +64,16 @@ impl<N: Network> FromBytes for Subdag<N> {
                     compact_subdag.insert(round, certificates);
                 }
                 _ => {
-                    return Err(error(format!("Found unexpected subdag type ({subdag_type})")));
+                    return Err(error(format!("Found unexpected subdag version ({version})")));
                 }
             }
         }
 
         // Return the subdag.
-        match subdag_type {
+        match version {
             1 => Self::from_full(batch_subdag).map_err(error),
             2 => Self::from_compact(compact_subdag).map_err(error),
-            _ => Err(error(format!("Found unexpected subdag type ({subdag_type})"))),
+            _ => Err(error(format!("Found unexpected subdag version ({version})"))),
         }
     }
 }
@@ -87,18 +81,13 @@ impl<N: Network> FromBytes for Subdag<N> {
 impl<N: Network> ToBytes for Subdag<N> {
     /// Writes the subdag to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        // Write the version.
-        let version = 1u8;
-        version.write_le(&mut writer)?;
-        // Get the subdag type
-        let (subdag_type, subdag_len) = match self {
+        // Get the subdag version and length
+        let (version, subdag_len) = match self {
             Self::Full { subdag, .. } => (1u8, subdag.len()),
             Self::Compact { subdag, .. } => (2u8, subdag.len()),
         };
-        // Write the subdag type
-        if version >= 2 {
-            subdag_type.write_le(&mut writer)?;
-        }
+        // Write the version.
+        version.write_le(&mut writer)?;
         // Write the number of rounds.
         u32::try_from(subdag_len).map_err(error)?.write_le(&mut writer)?;
         // Write the round certificates.

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -131,7 +131,7 @@ mod tests {
     fn test_bytes() {
         let rng = &mut TestRng::default();
 
-        for expected in crate::test_helpers::sample_subdags(rng) {
+        for expected in crate::test_helpers::sample_any_subdags(rng) {
             // Check the byte representation.
             let expected_bytes = expected.to_bytes_le().unwrap();
             assert_eq!(expected, Subdag::read_le(&expected_bytes[..]).unwrap());

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -560,8 +560,61 @@ pub mod test_helpers {
 
     type CurrentNetwork = MainnetV0;
 
-    /// Returns a sample subdag, sampled at random.
-    pub fn sample_subdag(rng: &mut TestRng) -> Subdag<CurrentNetwork> {
+    /// Returns a sample compact subdag, sampled at random.
+    pub fn sample_compact_subdag(rng: &mut TestRng) -> Subdag<CurrentNetwork> {
+        const F: usize = 1;
+        const AVAILABILITY_THRESHOLD: usize = F + 1;
+        const QUORUM_THRESHOLD: usize = 2 * F + 1;
+
+        // Initialize the map for the subdag.
+        let mut subdag = BTreeMap::<u64, IndexSet<_>>::new();
+
+        // Initialize the starting round.
+        let starting_round = {
+            loop {
+                let round = rng.gen_range(2..u64::MAX);
+                if round % 2 == 0 {
+                    break round;
+                }
+            }
+        };
+
+        // Process the earliest round.
+        let mut previous_certificate_ids = IndexSet::new();
+        for _ in 0..AVAILABILITY_THRESHOLD {
+            let certificate =
+                snarkvm_ledger_narwhal_compact_certificate::test_helpers::sample_compact_certificate_for_round(
+                    starting_round,
+                    rng,
+                );
+            previous_certificate_ids.insert(certificate.id());
+            subdag.entry(starting_round).or_default().insert(certificate);
+        }
+
+        // Process the middle round.
+        let mut previous_certificate_ids_2 = IndexSet::new();
+        for _ in 0..QUORUM_THRESHOLD {
+            let certificate =
+                snarkvm_ledger_narwhal_compact_certificate::test_helpers::sample_compact_certificate_for_round_with_previous_certificate_ids(starting_round + 1, previous_certificate_ids.clone(), rng);
+            previous_certificate_ids_2.insert(certificate.id());
+            subdag.entry(starting_round + 1).or_default().insert(certificate);
+        }
+
+        // Process the latest round.
+        let certificate =
+            snarkvm_ledger_narwhal_compact_certificate::test_helpers::sample_compact_certificate_for_round_with_previous_certificate_ids(
+                starting_round + 2,
+                previous_certificate_ids_2,
+                rng,
+            );
+        subdag.insert(starting_round + 2, indexset![certificate]);
+
+        // Return the subdag.
+        Subdag::from_compact(subdag).unwrap()
+    }
+
+    /// Returns a sample full subdag, sampled at random.
+    pub fn sample_full_subdag(rng: &mut TestRng) -> Subdag<CurrentNetwork> {
         const F: usize = 1;
         const AVAILABILITY_THRESHOLD: usize = F + 1;
         const QUORUM_THRESHOLD: usize = 2 * F + 1;
@@ -613,13 +666,30 @@ pub mod test_helpers {
         Subdag::from_full(subdag).unwrap()
     }
 
-    /// Returns a list of sample subdags, sampled at random.
-    pub fn sample_subdags(rng: &mut TestRng) -> Vec<Subdag<CurrentNetwork>> {
+    /// Returns a list of sample full subdags, sampled at random.
+    pub fn sample_full_subdags(rng: &mut TestRng) -> Vec<Subdag<CurrentNetwork>> {
         // Initialize a sample vector.
         let mut sample = Vec::with_capacity(10);
         // Append sample subdags.
         for _ in 0..10 {
-            sample.push(sample_subdag(rng));
+            sample.push(sample_full_subdag(rng));
+        }
+        // Return the sample vector.
+        sample
+    }
+
+    /// Returns a list of sample subdags, both full and compact, sampled at random.
+    pub fn sample_any_subdags(rng: &mut TestRng) -> Vec<Subdag<CurrentNetwork>> {
+        // Initialize a sample vector.
+        let mut sample = Vec::with_capacity(10);
+        // Append sample subdags.
+        for _ in 0..10 {
+            // Flip a coin to decide if the subdag is going to be compact.
+            if rng.r#gen::<bool>() {
+                sample.push(sample_compact_subdag(rng));
+            } else {
+                sample.push(sample_full_subdag(rng));
+            }
         }
         // Return the sample vector.
         sample

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -372,11 +372,6 @@ impl<N: Network> Subdag<N> {
         }
     }
 
-    // /// Returns certificates in this subdag (from earliest round to latest round).
-    // pub fn certificates(&self) -> impl Iterator<Item = &BatchCertificate<N>> {
-    //     self.values().flatten()
-    // }
-
     /// Returns the leader certificate.
     pub fn leader_certificate(&self) -> LeaderCertificate<N> {
         match self {
@@ -442,10 +437,7 @@ impl<N: Network> Subdag<N> {
                 match subdag.get(&round) {
                     Some(certificates) => {
                         // Retrieve the certificate for the given certificate ID.
-                        match certificates.iter().find(|certificate| certificate.id() == *certificate_id) {
-                            Some(certificate) => Some(Cow::Borrowed(certificate)),
-                            None => None,
-                        }
+                        certificates.iter().find(|certificate| certificate.id() == *certificate_id).map(Cow::Borrowed)
                     }
                     None => None,
                 }

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -270,12 +270,12 @@ impl<N: Network> Subdag<N> {
     /// Returns the subdag with full batch certificates.
     pub fn into_full(
         self,
-        solutions: Vec<TransmissionID<N>>,
-        prior_solutions: Vec<TransmissionID<N>>,
-        aborted_solutions: Vec<TransmissionID<N>>,
-        transaction_ids: Vec<TransmissionID<N>>,
-        prior_transactions: Vec<TransmissionID<N>>,
-        aborted_transaction_ids: Vec<TransmissionID<N>>,
+        solutions: &[TransmissionID<N>],
+        prior_solutions: &[TransmissionID<N>],
+        aborted_solutions: &[TransmissionID<N>],
+        transaction_ids: &[TransmissionID<N>],
+        prior_transactions: &[TransmissionID<N>],
+        aborted_transaction_ids: &[TransmissionID<N>],
     ) -> Result<Subdag<N>> {
         let subdag = match self {
             Self::Compact { subdag } => subdag,

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -26,13 +26,71 @@ use console::{account::Address, prelude::*, program::SUBDAG_CERTIFICATES_DEPTH, 
 use snarkvm_ledger_committee::Committee;
 use snarkvm_ledger_narwhal_batch_certificate::BatchCertificate;
 use snarkvm_ledger_narwhal_batch_header::BatchHeader;
+use snarkvm_ledger_narwhal_compact_certificate::CompactCertificate;
+use snarkvm_ledger_narwhal_traits::NarwhalCertificate;
 use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
 
 use indexmap::IndexSet;
-use std::collections::BTreeMap;
+use std::{borrow::Cow, collections::BTreeMap};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
+
+/// Helper enum to wrap the leader certificate.
+#[derive(Clone, PartialEq, Eq)]
+pub enum LeaderCertificate<'a, N: Network> {
+    Full(&'a BatchCertificate<N>),
+    Compact(&'a CompactCertificate<N>),
+}
+
+impl<'a, N: Network> From<&'a BatchCertificate<N>> for LeaderCertificate<'a, N> {
+    fn from(cert: &'a BatchCertificate<N>) -> Self {
+        Self::Full(cert)
+    }
+}
+
+impl<'a, N: Network> From<&'a CompactCertificate<N>> for LeaderCertificate<'a, N> {
+    fn from(cert: &'a CompactCertificate<N>) -> Self {
+        Self::Compact(cert)
+    }
+}
+
+impl<'a, N: Network> LeaderCertificate<'a, N> {
+    pub fn id(&self) -> Field<N> {
+        match self {
+            Self::Full(cert) => cert.id(),
+            Self::Compact(cert) => cert.id(),
+        }
+    }
+
+    pub fn author(&self) -> Address<N> {
+        match self {
+            Self::Full(cert) => cert.author(),
+            Self::Compact(cert) => cert.author(),
+        }
+    }
+
+    pub fn committee_id(&self) -> Field<N> {
+        match self {
+            Self::Full(cert) => cert.committee_id(),
+            Self::Compact(cert) => cert.committee_id(),
+        }
+    }
+
+    pub fn previous_certificate_ids(&self) -> &IndexSet<Field<N>> {
+        match self {
+            Self::Full(cert) => cert.previous_certificate_ids(),
+            Self::Compact(cert) => cert.previous_certificate_ids(),
+        }
+    }
+
+    pub fn round(&self) -> u64 {
+        match self {
+            Self::Full(cert) => cert.round(),
+            Self::Compact(cert) => cert.round(),
+        }
+    }
+}
 
 /// Returns `true` if the rounds are sequential.
 fn is_sequential<T>(map: &BTreeMap<u64, T>) -> bool {
@@ -50,39 +108,64 @@ fn is_sequential<T>(map: &BTreeMap<u64, T>) -> bool {
 ///
 /// Returns `true` if the DFS traversal using the given subdag structure matches the commit.
 /// Note, this does not guarantee that the subDAG contains all batches it should, because this function has no knowledge of other blocks/subDAGs.
-fn sanity_check_subdag_with_dfs<N: Network>(subdag: &BTreeMap<u64, IndexSet<BatchCertificate<N>>>) -> bool {
-    use std::collections::HashSet;
+macro_rules! sanity_check_subdag_with_dfs {
+    ($subdag:expr) => {{
+        use std::collections::HashSet;
 
-    // Initialize a map for the certificates to commit.
-    let mut commit = BTreeMap::<u64, IndexSet<_>>::new();
-    // Initialize a set for the already ordered certificates.
-    let mut already_ordered = HashSet::new();
-    // Initialize a buffer for the certificates to order, starting with the leader certificate.
-    let mut buffer = subdag.iter().next_back().map_or(Default::default(), |(_, leader)| leader.clone());
-    // Iterate over the certificates to order.
-    while let Some(certificate) = buffer.pop() {
-        // Insert the certificate into the map.
-        commit.entry(certificate.round()).or_default().insert(certificate.clone());
-        // Iterate over the previous certificate IDs.
-        for previous_certificate_id in certificate.previous_certificate_ids() {
-            let Some(previous_certificate) = subdag
-                .get(&(certificate.round() - 1))
-                .and_then(|map| map.iter().find(|certificate| certificate.id() == *previous_certificate_id))
-            else {
-                // It is either ordered or below the GC round.
-                continue;
-            };
-            // Insert the previous certificate into the set of already ordered certificates.
-            if !already_ordered.insert(previous_certificate.id()) {
-                // If the previous certificate is already ordered, continue.
-                continue;
+        // Initialize a map for the certificates to commit.
+        let mut commit = BTreeMap::<u64, IndexSet<_>>::new();
+        // Initialize a set for the already ordered certificates.
+        let mut already_ordered = HashSet::new();
+        // Initialize a buffer for the certificates to order, starting with the leader certificate.
+        let mut buffer = $subdag.iter().next_back().map_or(Default::default(), |(_, leader)| leader.clone());
+        // Iterate over the certificates to order.
+        while let Some(certificate) = buffer.pop() {
+            // Insert the certificate into the map.
+            commit.entry(certificate.round()).or_default().insert(certificate.clone());
+            // Iterate over the previous certificate IDs.
+            for previous_certificate_id in certificate.previous_certificate_ids() {
+                let Some(previous_certificate) = $subdag
+                    .get(&(certificate.round() - 1))
+                    .and_then(|map| map.iter().find(|certificate| certificate.id() == *previous_certificate_id))
+                else {
+                    // It is either ordered or below the GC round.
+                    continue;
+                };
+                // Insert the previous certificate into the set of already ordered certificates.
+                if !already_ordered.insert(previous_certificate.id()) {
+                    // If the previous certificate is already ordered, continue.
+                    continue;
+                }
+                // Insert the previous certificate into the buffer.
+                buffer.insert(previous_certificate.clone());
             }
-            // Insert the previous certificate into the buffer.
-            buffer.insert(previous_certificate.clone());
         }
-    }
-    // Return `true` if the subdag matches the commit.
-    &commit == subdag
+        // Return `true` if the subdag matches the commit.
+        &commit == $subdag
+    }};
+}
+
+/// Performs sanity checks on the subdag.
+macro_rules! sanity_check_subdag {
+    ($subdag:expr) => {{
+        // Ensure the subdag is not empty.
+        ensure!(!$subdag.is_empty(), "Subdag cannot be empty");
+        // Ensure the subdag does not exceed the maximum number of rounds.
+        ensure!(
+            $subdag.len() <= usize::try_from(Self::MAX_ROUNDS)?,
+            "Subdag cannot exceed the maximum number of rounds"
+        );
+        // Ensure the anchor round is even.
+        ensure!($subdag.iter().next_back().map_or(0, |(r, _)| *r) % 2 == 0, "Anchor round must be even");
+        // Ensure there is only one leader certificate.
+        ensure!($subdag.iter().next_back().map_or(0, |(_, c)| c.len()) == 1, "Subdag cannot have multiple leaders");
+        // Ensure the rounds are sequential.
+        ensure!(is_sequential($subdag), "Subdag rounds must be sequential");
+        // Ensure the subdag structure matches the commit.
+        ensure!(sanity_check_subdag_with_dfs!($subdag), "Subdag structure does not match commit");
+        // Ensure the leader certificate is an even round.
+        Ok::<_, Error>(())
+    }};
 }
 
 /// Returns the weighted median timestamp of the given timestamps and stakes.
@@ -116,14 +199,27 @@ fn weighted_median(timestamps_and_stake: Vec<(i64, u64)>) -> i64 {
 }
 
 #[derive(Clone)]
-pub struct Subdag<N: Network> {
-    /// The subdag of round certificates.
-    subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>,
+pub enum Subdag<N: Network> {
+    Full {
+        /// The subdag of round certificates.
+        subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>,
+    },
+    Compact {
+        /// The subdag of round certificates.
+        subdag: BTreeMap<u64, IndexSet<CompactCertificate<N>>>,
+    },
 }
 
 impl<N: Network> PartialEq for Subdag<N> {
     fn eq(&self, other: &Self) -> bool {
-        self.subdag == other.subdag
+        match (self, other) {
+            (Self::Full { subdag }, Self::Full { subdag: other_subdag }) => subdag == other_subdag,
+            (Self::Compact { subdag }, Self::Compact { subdag: other_subdag }) => subdag == other_subdag,
+            _ => {
+                tracing::warn!("Subdag equality check failed - trying to compare a Full to a Compact subdag");
+                false
+            }
+        }
     }
 }
 
@@ -131,24 +227,83 @@ impl<N: Network> Eq for Subdag<N> {}
 
 impl<N: Network> Subdag<N> {
     /// Initializes a new subdag.
-    pub fn from(subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>) -> Result<Self> {
-        // Ensure the subdag is not empty.
-        ensure!(!subdag.is_empty(), "Subdag cannot be empty");
-        // Ensure the subdag does not exceed the maximum number of rounds.
-        ensure!(
-            subdag.len() <= usize::try_from(Self::MAX_ROUNDS)?,
-            "Subdag cannot exceed the maximum number of rounds"
-        );
-        // Ensure the anchor round is even.
-        ensure!(subdag.iter().next_back().map_or(0, |(r, _)| *r) % 2 == 0, "Anchor round must be even");
-        // Ensure there is only one leader certificate.
-        ensure!(subdag.iter().next_back().map_or(0, |(_, c)| c.len()) == 1, "Subdag cannot have multiple leaders");
-        // Ensure the rounds are sequential.
-        ensure!(is_sequential(&subdag), "Subdag rounds must be sequential");
-        // Ensure the subdag structure matches the commit.
-        ensure!(sanity_check_subdag_with_dfs(&subdag), "Subdag structure does not match commit");
-        // Ensure the leader certificate is an even round.
-        Ok(Self { subdag })
+    pub fn from_full(subdag: BTreeMap<u64, IndexSet<BatchCertificate<N>>>) -> Result<Self> {
+        // Perform sanity checks.
+        sanity_check_subdag!(&subdag)?;
+        // Construct the subdag.
+        Ok(Self::Full { subdag })
+    }
+
+    /// Initializes a new subdag.
+    pub fn from_compact(subdag: BTreeMap<u64, IndexSet<CompactCertificate<N>>>) -> Result<Self> {
+        // Perform sanity checks.
+        sanity_check_subdag!(&subdag)?;
+        // Construct the subdag.
+        Ok(Self::Compact { subdag })
+    }
+
+    pub fn check_committee_id_coherence(&self) -> Result<()> {
+        macro_rules! checker {
+            ($round:expr, $certificates:expr) => {{
+                // Check that every certificate for a given round shares the same committee ID.
+                let expected_committee_id = $certificates
+                    .first()
+                    .map(|certificate| certificate.committee_id())
+                    .ok_or(anyhow!("No certificates found for subdag round {}", $round))?;
+                ensure!(
+                    $certificates.iter().skip(1).all(|certificate| certificate.committee_id() == expected_committee_id),
+                    "Certificates on round {} do not all have the same committee ID",
+                    $round,
+                );
+                Ok(())
+            }};
+        }
+
+        match self {
+            Self::Full { subdag } => cfg_iter!(subdag).try_for_each(|(round, certs)| checker!(round, certs))?,
+            Self::Compact { subdag } => cfg_iter!(subdag).try_for_each(|(round, certs)| checker!(round, certs))?,
+        }
+
+        Ok(())
+    }
+
+    /// Returns the subdag with full batch certificates.
+    pub fn into_full(
+        self,
+        solutions: Vec<TransmissionID<N>>,
+        prior_solutions: Vec<TransmissionID<N>>,
+        aborted_solutions: Vec<TransmissionID<N>>,
+        transaction_ids: Vec<TransmissionID<N>>,
+        prior_transactions: Vec<TransmissionID<N>>,
+        aborted_transaction_ids: Vec<TransmissionID<N>>,
+    ) -> Result<Subdag<N>> {
+        let subdag = match self {
+            Self::Compact { subdag } => subdag,
+            subdag @ Self::Full { .. } => return Ok(subdag),
+        };
+        // Initialize the new subdag.
+        let mut batch_subdag = BTreeMap::new();
+
+        // Iterate over the subdag.
+        for (round, compact_certificates) in subdag.into_iter() {
+            let mut batch_certificates = IndexSet::with_capacity(compact_certificates.len());
+            for certificate in compact_certificates.into_iter() {
+                // Convert compact certificate to batch certificate.
+                let batch_certificate = certificate.into_batch_certificate(
+                    solutions.iter(),
+                    prior_solutions.iter(),
+                    aborted_solutions.iter(),
+                    transaction_ids.iter(),
+                    prior_transactions.iter(),
+                    aborted_transaction_ids.iter(),
+                )?;
+                batch_certificates.insert(batch_certificate);
+            }
+            batch_subdag.insert(round, batch_certificates);
+        }
+
+        // Return the batch certificates.
+        Ok(Self::Full { subdag: batch_subdag })
     }
 }
 
@@ -160,40 +315,167 @@ impl<N: Network> Subdag<N> {
 impl<N: Network> Subdag<N> {
     /// Returns the anchor round.
     pub fn anchor_round(&self) -> u64 {
-        self.subdag.iter().next_back().map_or(0, |(round, _)| *round)
+        match self {
+            Self::Full { subdag } => subdag.iter().next_back().map_or(0, |(round, _)| *round),
+            Self::Compact { subdag } => subdag.iter().next_back().map_or(0, |(round, _)| *round),
+        }
     }
 
     /// Returns the certificate IDs of the subdag (from earliest round to latest round).
-    pub fn certificate_ids(&self) -> impl Iterator<Item = Field<N>> + '_ {
-        self.values().flatten().map(BatchCertificate::id)
+    pub fn certificate_ids(&self) -> Vec<Field<N>> {
+        match self {
+            Self::Full { subdag } => subdag.values().flatten().map(BatchCertificate::id).collect_vec(),
+            Self::Compact { subdag } => subdag.values().flatten().map(CompactCertificate::id).collect_vec(),
+        }
     }
 
-    /// Returns certificates in this subdag (from earliest round to latest round).
-    pub fn certificates(&self) -> impl Iterator<Item = &BatchCertificate<N>> {
-        self.values().flatten()
+    /// Returns the certificates of the subdag (from earliest round to latest round).
+    pub fn into_iter_batch_certificates(self) -> Result<impl Iterator<Item = BatchCertificate<N>>> {
+        let Self::Full { subdag } = self else {
+            bail!("Can only iter over certificates of Full Subdag.");
+        };
+        Ok(subdag.into_values().flatten())
+    }
+
+    /// Returns the certificates of the subdag (from earliest round to latest round).
+    #[cfg(not(feature = "serial"))]
+    pub fn into_par_iter_batch_certificates(self) -> Result<impl ParallelIterator<Item = BatchCertificate<N>>> {
+        let Self::Full { subdag } = self else {
+            bail!("Can only iter over certificates of Full Subdag.");
+        };
+        Ok(subdag.into_par_iter().map(|(_k, v)| v).flatten())
+    }
+
+    /// Returns the certificate IDs and rounds of the subdag (from earliest round to latest round).
+    pub fn certificate_ids_rounds(&self) -> Vec<(Field<N>, u64)> {
+        match self {
+            Self::Full { subdag } => subdag
+                .iter()
+                .flat_map(|(round, certificates)| certificates.iter().map(|c| (c.id(), *round)))
+                .collect_vec(),
+            Self::Compact { subdag } => subdag
+                .iter()
+                .flat_map(|(round, certificates)| certificates.iter().map(|c| (c.id(), *round)))
+                .collect_vec(),
+        }
+    }
+
+    /// Returns the number of certificates and rounds of the subdag (from earliest round to latest round).
+    pub fn num_certificates_rounds(&self) -> Vec<(usize, u64)> {
+        match self {
+            Self::Full { subdag } => {
+                subdag.iter().map(|(round, certificates)| (certificates.len(), *round)).collect_vec()
+            }
+            Self::Compact { subdag } => {
+                subdag.iter().map(|(round, certificates)| (certificates.len(), *round)).collect_vec()
+            }
+        }
+    }
+
+    // /// Returns certificates in this subdag (from earliest round to latest round).
+    // pub fn certificates(&self) -> impl Iterator<Item = &BatchCertificate<N>> {
+    //     self.values().flatten()
+    // }
+
+    /// Returns the leader certificate.
+    pub fn leader_certificate(&self) -> LeaderCertificate<N> {
+        match self {
+            Self::Full { subdag } => {
+                // Retrieve entry for the anchor round.
+                let entry = subdag.iter().next_back();
+                debug_assert!(entry.is_some(), "There must be at least one round of certificates");
+                // Retrieve the certificates from the anchor round.
+                let certificates = entry.expect("There must be one round in the subdag").1;
+                debug_assert!(certificates.len() == 1, "There must be only one leader certificate, by definition");
+                // Note: There is guaranteed to be only one leader certificate.
+                let cert = certificates.iter().next().expect("There must be a leader certificate");
+                LeaderCertificate::Full(cert)
+            }
+            Self::Compact { subdag } => {
+                // Retrieve entry for the anchor round.
+                let entry = subdag.iter().next_back();
+                debug_assert!(entry.is_some(), "There must be at least one round of certificates");
+                // Retrieve the certificates from the anchor round.
+                let certificates = entry.expect("There must be one round in the subdag").1;
+                debug_assert!(certificates.len() == 1, "There must be only one leader certificate, by definition");
+                // Note: There is guaranteed to be only one leader certificate.
+                let cert = certificates.iter().next().expect("There must be a leader certificate");
+                LeaderCertificate::Compact(cert)
+            }
+        }
     }
 
     /// Returns the leader certificate.
-    pub fn leader_certificate(&self) -> &BatchCertificate<N> {
-        // Retrieve entry for the anchor round.
-        let entry = self.subdag.iter().next_back();
-        debug_assert!(entry.is_some(), "There must be at least one round of certificates");
-        // Retrieve the certificates from the anchor round.
-        let certificates = entry.expect("There must be one round in the subdag").1;
-        debug_assert!(certificates.len() == 1, "There must be only one leader certificate, by definition");
-        // Note: There is guaranteed to be only one leader certificate.
-        certificates.iter().next().expect("There must be a leader certificate")
+    pub fn leader_batch_certificate(&self) -> Result<&BatchCertificate<N>> {
+        match self.leader_certificate() {
+            LeaderCertificate::Full(cert) => Ok(cert),
+            LeaderCertificate::Compact(_) => {
+                bail!("We can only return the leader batch certificate of a full Subdag")
+            }
+        }
+    }
+
+    /// Returns the timestamp of the leader certificate.
+    pub fn leader_timestamp(&self) -> Result<i64> {
+        match self.leader_certificate() {
+            LeaderCertificate::Full(cert) => Ok(cert.timestamp()),
+            LeaderCertificate::Compact(cert) => Ok(cert.timestamp()),
+        }
+    }
+
+    /// Return the number of certificates
+    pub fn num_certificates(&self) -> usize {
+        match self {
+            Self::Full { subdag } => subdag.values().flatten().count(),
+            Self::Compact { subdag } => subdag.values().flatten().count(),
+        }
+    }
+
+    /// Return CompactCertificate for a given round
+    pub fn get_certificate_for_round(
+        &self,
+        round: u64,
+        certificate_id: &Field<N>,
+    ) -> Option<Cow<'_, CompactCertificate<N>>> {
+        match self {
+            Self::Compact { subdag } => {
+                match subdag.get(&round) {
+                    Some(certificates) => {
+                        // Retrieve the certificate for the given certificate ID.
+                        match certificates.iter().find(|certificate| certificate.id() == *certificate_id) {
+                            Some(certificate) => Some(Cow::Borrowed(certificate)),
+                            None => None,
+                        }
+                    }
+                    None => None,
+                }
+            }
+            Self::Full { subdag } => {
+                let Self::Compact { subdag } = Subdag::from_full(subdag.clone()).ok()? else {
+                    unreachable!();
+                };
+
+                match subdag.get(&round) {
+                    Some(certificates) => {
+                        // Retrieve the certificate for the given certificate ID.
+                        certificates
+                            .iter()
+                            .find(|certificate| certificate.id() == *certificate_id)
+                            .map(|certificate| Cow::Owned(certificate.clone()))
+                    }
+                    None => None,
+                }
+            }
+        }
     }
 
     /// Returns the address of the leader.
     pub fn leader_address(&self) -> Address<N> {
         // Retrieve the leader address from the leader certificate.
-        self.leader_certificate().author()
-    }
-
-    /// Returns the transmission IDs of the subdag (from earliest round to latest round).
-    pub fn transmission_ids(&self) -> impl Iterator<Item = &TransmissionID<N>> {
-        self.values().flatten().flat_map(BatchCertificate::transmission_ids)
+        match self.leader_certificate() {
+            LeaderCertificate::Full(cert) => cert.author(),
+            LeaderCertificate::Compact(cert) => cert.author(),
+        }
     }
 
     /// Returns the timestamp of the anchor round, defined as the weighted median timestamp of the subdag.
@@ -201,12 +483,20 @@ impl<N: Network> Subdag<N> {
         // Retrieve the anchor round.
         let anchor_round = self.anchor_round();
         // Retrieve the timestamps and stakes of the certificates for `anchor_round` - 1.
-        let timestamps_and_stakes = self
-            .values()
-            .flatten()
-            .filter(|certificate| certificate.round() == anchor_round.saturating_sub(1))
-            .map(|certificate| (certificate.timestamp(), committee.get_stake(certificate.author())))
-            .collect::<Vec<_>>();
+        let timestamps_and_stakes = match self {
+            Self::Compact { subdag } => subdag
+                .values()
+                .flatten()
+                .filter(|certificate| certificate.round() == anchor_round.saturating_sub(1))
+                .map(|cert| (cert.timestamp(), committee.get_stake(cert.author())))
+                .collect::<Vec<_>>(),
+            Self::Full { subdag } => subdag
+                .values()
+                .flatten()
+                .filter(|certificate| certificate.round() == anchor_round.saturating_sub(1))
+                .map(|cert| (cert.timestamp(), committee.get_stake(cert.author())))
+                .collect::<Vec<_>>(),
+        };
 
         // Return the weighted median timestamp.
         weighted_median(timestamps_and_stakes)
@@ -215,23 +505,57 @@ impl<N: Network> Subdag<N> {
     /// Returns the subdag root of the certificates.
     pub fn to_subdag_root(&self) -> Result<Field<N>> {
         // Prepare the leaves.
-        let leaves = cfg_iter!(self.subdag)
-            .map(|(_, certificates)| {
-                certificates.iter().flat_map(|certificate| certificate.id().to_bits_le()).collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-
+        let leaves = match self {
+            Self::Full { subdag } => cfg_iter!(subdag)
+                .map(|(_, certificates)| {
+                    certificates.iter().flat_map(|certificate| certificate.id().to_bits_le()).collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+            Self::Compact { subdag } => cfg_iter!(subdag)
+                .map(|(_, certificates)| {
+                    certificates.iter().flat_map(|certificate| certificate.id().to_bits_le()).collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+        };
         // Compute the subdag root.
         Ok(*N::merkle_tree_bhp::<SUBDAG_CERTIFICATES_DEPTH>(&leaves)?.root())
     }
-}
 
-impl<N: Network> Deref for Subdag<N> {
-    type Target = BTreeMap<u64, IndexSet<BatchCertificate<N>>>;
+    /// Returns the subdag with compact certificates
+    pub fn into_compact(
+        self,
+        solutions: Vec<TransmissionID<N>>,
+        prior_solutions: Vec<TransmissionID<N>>,
+        aborted_solutions: Vec<TransmissionID<N>>,
+        transaction_ids: Vec<TransmissionID<N>>,
+        prior_transactions: Vec<TransmissionID<N>>,
+        aborted_transactions: Vec<TransmissionID<N>>,
+    ) -> Result<Subdag<N>> {
+        let Self::Full { subdag } = self else { bail!("Can only turn a Full subdag into a Compact one.") };
 
-    /// Returns the batch certificates.
-    fn deref(&self) -> &Self::Target {
-        &self.subdag
+        // Initialize the new subdag.
+        let mut compact_subdag = BTreeMap::new();
+
+        // Iterate over the subdag.
+        for (round, batch_certificates) in subdag.into_iter() {
+            let certificates = cfg_into_iter!(batch_certificates)
+                .map(|batch_certificate| {
+                    CompactCertificate::from_batch_certificate(
+                        batch_certificate,
+                        solutions.iter(),
+                        prior_solutions.iter(),
+                        aborted_solutions.iter(),
+                        transaction_ids.iter(),
+                        prior_transactions.iter(),
+                        aborted_transactions.iter(),
+                    )
+                })
+                .collect::<Result<_>>()?;
+            compact_subdag.insert(round, certificates);
+        }
+
+        // Return the compact certificates.
+        Ok(Self::Compact { subdag: compact_subdag })
     }
 }
 
@@ -294,7 +618,7 @@ pub mod test_helpers {
         subdag.insert(starting_round + 2, indexset![certificate]);
 
         // Return the subdag.
-        Subdag::from(subdag).unwrap()
+        Subdag::from_full(subdag).unwrap()
     }
 
     /// Returns a list of sample subdags, sampled at random.

--- a/ledger/narwhal/subdag/src/serialize.rs
+++ b/ledger/narwhal/subdag/src/serialize.rs
@@ -103,7 +103,7 @@ mod tests {
     fn test_serde_json() {
         let rng = &mut TestRng::default();
 
-        for expected in crate::test_helpers::sample_subdags(rng) {
+        for expected in crate::test_helpers::sample_any_subdags(rng) {
             check_serde_json(expected);
         }
     }
@@ -112,7 +112,7 @@ mod tests {
     fn test_bincode() {
         let rng = &mut TestRng::default();
 
-        for expected in crate::test_helpers::sample_subdags(rng) {
+        for expected in crate::test_helpers::sample_any_subdags(rng) {
             check_bincode(expected);
         }
     }

--- a/ledger/narwhal/traits/Cargo.toml
+++ b/ledger/narwhal/traits/Cargo.toml
@@ -4,7 +4,7 @@ version = "4.1.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A batch certificate for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"
-repository = "https://github.com/AleoHQ/snarkVM"
+repository = "https://github.com/ProvableHQ/snarkVM"
 keywords = [
   "aleo",
   "cryptography",
@@ -27,4 +27,4 @@ edition = "2024"
 workspace = true
 
 [dependencies.indexmap]
-version = "2.0"
+workspace = true

--- a/ledger/narwhal/traits/Cargo.toml
+++ b/ledger/narwhal/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-traits"
-version = "4.0.0"
+version = "4.1.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A batch certificate for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/traits/Cargo.toml
+++ b/ledger/narwhal/traits/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "snarkvm-ledger-narwhal-traits"
+version = "4.0.0"
+authors = [ "The Aleo Team <hello@aleo.org>" ]
+description = "A batch certificate for a Narwhal-style memory pool in a decentralized virtual machine"
+homepage = "https://aleo.org"
+repository = "https://github.com/AleoHQ/snarkVM"
+keywords = [
+  "aleo",
+  "cryptography",
+  "blockchain",
+  "decentralized",
+  "zero-knowledge"
+]
+categories = [
+  "compilers",
+  "cryptography",
+  "mathematics",
+  "wasm",
+  "web-programming"
+]
+include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
+license = "Apache-2.0"
+edition = "2024"
+
+[dependencies.snarkvm-console]
+workspace = true
+
+[dependencies.indexmap]
+version = "2.0"

--- a/ledger/narwhal/traits/LICENSE.md
+++ b/ledger/narwhal/traits/LICENSE.md
@@ -1,0 +1,194 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/ledger/narwhal/traits/README.md
+++ b/ledger/narwhal/traits/README.md
@@ -1,0 +1,7 @@
+# snarkvm-ledger-narwhal-traits
+
+[![Crates.io](https://img.shields.io/crates/v/snarkvm-ledger-narwhal-data.svg?color=neon)](https://crates.io/crates/snarkvm-ledger-narwhal-data)
+[![Authors](https://img.shields.io/badge/authors-Aleo-orange.svg)](https://aleo.org)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE.md)
+
+The `snarkvm-ledger-narwhal-traits` crate provides traits for narwhal objects

--- a/ledger/narwhal/traits/src/lib.rs
+++ b/ledger/narwhal/traits/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use indexmap::IndexSet;
+use snarkvm_console::{
+    program::{Network, Signature},
+    types::{Address, Field},
+};
+
+pub trait NarwhalCertificate<N: Network>: Send + Sync {
+    /// Returns the certificate ID.
+    fn id(&self) -> Field<N>;
+
+    /// Returns the batch ID.
+    fn batch_id(&self) -> Field<N>;
+
+    /// Returns the author.
+    fn author(&self) -> Address<N>;
+
+    /// Returns the round.
+    fn round(&self) -> u64;
+
+    /// Returns the certificate IDs for the previous round.
+    fn previous_certificate_ids(&self) -> &IndexSet<Field<N>>;
+
+    /// Returns the timestamp of the compact header.
+    fn timestamp(&self) -> i64;
+
+    /// Returns the committee ID of the compact header.
+    fn committee_id(&self) -> Field<N>;
+
+    /// Returns the signatures of the batch ID from the committee.
+    fn signatures(&self) -> Box<dyn '_ + ExactSizeIterator<Item = &Signature<N>>>;
+}

--- a/ledger/narwhal/traits/src/lib.rs
+++ b/ledger/narwhal/traits/src/lib.rs
@@ -19,6 +19,8 @@ use snarkvm_console::{
     types::{Address, Field},
 };
 
+/// A trait exposing functionalities shared by both full and compact
+/// Narwhal certificates.
 pub trait NarwhalCertificate<N: Network>: Send + Sync {
     /// Returns the certificate ID.
     fn id(&self) -> Field<N>;

--- a/ledger/narwhal/transmission-id/src/lib.rs
+++ b/ledger/narwhal/transmission-id/src/lib.rs
@@ -77,6 +77,28 @@ impl<N: Network> TransmissionID<N> {
     }
 }
 
+impl<N: Network> Ord for TransmissionID<N> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        match (self, other) {
+            // If self and other are the same type, compare contents.
+            (Self::Ratification, Self::Ratification) => core::cmp::Ordering::Equal,
+            (Self::Solution(a, _), Self::Solution(b, _)) => a.cmp(b),
+            (Self::Transaction(a, _), Self::Transaction(b, _)) => a.cmp(b),
+            // If self and other are different types, order by type.
+            (Self::Ratification, _) => core::cmp::Ordering::Less,
+            (_, Self::Ratification) => core::cmp::Ordering::Greater,
+            (Self::Solution(..), Self::Transaction(..)) => core::cmp::Ordering::Less,
+            (Self::Transaction(..), Self::Solution(..)) => core::cmp::Ordering::Greater,
+        }
+    }
+}
+
+impl<N: Network> PartialOrd for TransmissionID<N> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers {
     use super::*;

--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -272,8 +272,12 @@ impl<N: Network> Puzzle<N> {
         Ok(())
     }
 
-    /// ATTENTION: This function will update the target if the solution target is different from the calculated one.
-    /// Returns `Ok(())` if the solution is valid.
+    /// ATTENTION: This function will update the target if the solution target
+    /// is different from the calculated one. This was needed before
+    /// ConsensusVersion::V10, because the lack of transmission checksums could
+    /// have allowed a malicious actor to create a fork when submitting
+    /// solutions with the same id but different targets. Returns `Ok(())` if
+    /// the solution is valid.
     pub fn check_solution_mut(
         &self,
         solution: &mut Solution<N>,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -19,7 +19,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns a candidate for the next block in the ledger, using a committed subdag and its transmissions.
     pub fn prepare_advance_to_next_quorum_block<R: Rng + CryptoRng>(
         &self,
-        mut subdag: Subdag<N>,
+        subdag: Subdag<N>,
         subdag_transmissions: SubdagTransmissions<N>,
         rng: &mut R,
     ) -> Result<Block<N>> {
@@ -160,16 +160,18 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         };
 
         // Construct the compact Subdag
-        if N::CONSENSUS_VERSION(self.latest_height()).unwrap() >= ConsensusVersion::V10 {
-            subdag = subdag.into_compact(
+        let subdag = if N::CONSENSUS_VERSION(self.latest_height()).unwrap() >= ConsensusVersion::V10 {
+            subdag.into_compact(
                 solution_transmission_ids,
                 prior_solution_transmission_ids.clone(),
                 aborted_solution_transmission_ids.clone(),
                 transaction_transmission_ids,
                 prior_transaction_transmission_ids.clone(),
                 aborted_transaction_transmission_ids.clone(),
-            )?;
-        }
+            )?
+        } else {
+            subdag
+        };
 
         let (
             prior_solution_transmission_ids,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -19,20 +19,161 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns a candidate for the next block in the ledger, using a committed subdag and its transmissions.
     pub fn prepare_advance_to_next_quorum_block<R: Rng + CryptoRng>(
         &self,
-        subdag: Subdag<N>,
-        transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+        mut subdag: Subdag<N>,
+        subdag_transmissions: SubdagTransmissions<N>,
         rng: &mut R,
     ) -> Result<Block<N>> {
         // Retrieve the latest block as the previous block (for the next block).
         let previous_block = self.latest_block();
 
+        // Obtain the subdag transmissions.
+        let SubdagTransmissions { prior_included_transmissions, aborted_transmissions, transmissions } =
+            subdag_transmissions;
+
         // Decouple the transmissions into ratifications, solutions, and transactions.
-        let (ratifications, solutions, transactions) = decouple_transmissions(transmissions.into_iter())?;
+        let (ratifications, solutions, solutions_with_id, transactions, transactions_with_id) =
+            decouple_transmissions(transmissions.into_iter())?;
+        // Decouple the prior_transmissions into ratifications, solutions, and transactions.
+        let (prior_ratifications, prior_solution_transmission_ids, prior_transaction_transmission_ids) =
+            decouple_transmission_ids(prior_included_transmissions)?;
+        // Decouple the aborted_transmissions into ratifications, solutions, and transactions.
+        let (
+            aborted_ratifications,
+            early_aborted_solution_transmission_ids,
+            early_aborted_transaction_transmission_ids,
+        ) = decouple_transmission_ids(aborted_transmissions)?;
         // Currently, we do not support ratifications from the memory pool.
-        ensure!(ratifications.is_empty(), "Ratifications are currently unsupported from the memory pool");
+        ensure!(
+            ratifications.is_empty() && prior_ratifications.is_empty() && aborted_ratifications.is_empty(),
+            "Ratifications are currently unsupported from the memory pool"
+        );
         // Construct the block template.
-        let (header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids) =
+        let (
+            header,
+            ratifications,
+            solutions,
+            aborted_solution_ids_from_finalization,
+            transactions,
+            aborted_transaction_ids_from_finalization,
+        ) =
             self.construct_block_template(&previous_block, Some(&subdag), ratifications, solutions, transactions, rng)?;
+
+        // --- Solutions ---
+        // Construct the solution transmission IDs.
+        let solution_transmission_ids = solutions
+            .solution_ids()
+            .filter_map(|target_id| {
+                solutions_with_id
+                    .iter()
+                    .find(|(id, _)| match id {
+                        TransmissionID::Solution(id, _) => *id == *target_id,
+                        _ => false,
+                    })
+                    .map(|(id, _)| *id)
+            })
+            .collect_vec();
+        ensure!(solution_transmission_ids.len() == solutions.len(), "Mismatching number of solution IDs");
+        // Construct the aborted solution transmission IDs.
+        let mut aborted_solution_transmission_ids = aborted_solution_ids_from_finalization
+            .iter()
+            .filter_map(|target_id| {
+                solutions_with_id
+                    .iter()
+                    .find(|(id, _)| match id {
+                        TransmissionID::Solution(id, _) => id == target_id,
+                        _ => false,
+                    })
+                    .map(|(id, _)| *id)
+            })
+            .collect_vec();
+        ensure!(
+            aborted_solution_transmission_ids.len() == aborted_solution_ids_from_finalization.len(),
+            "Mismatching number of aborted solution IDs"
+        );
+        aborted_solution_transmission_ids.extend(early_aborted_solution_transmission_ids);
+        // Construct the aborted solution IDs.
+        let aborted_solution_ids = aborted_solution_transmission_ids
+            .iter()
+            .filter_map(|id| match id {
+                TransmissionID::Solution(id, _) => Some(*id),
+                _ => None,
+            })
+            .collect_vec();
+
+        // --- Transactions ---
+        // Construct the transaction transmission IDs.
+        let unconfirmed_transaction_ids = transactions.unconfirmed_transaction_ids()?;
+        let unconfirmed_transactions_len = unconfirmed_transaction_ids.len();
+        let transaction_transmission_ids = unconfirmed_transaction_ids
+            .into_iter()
+            .filter_map(|target_id| {
+                transactions_with_id
+                    .iter()
+                    .find(|(id, _)| match id {
+                        TransmissionID::Transaction(id, _) => *id == target_id,
+                        _ => false,
+                    })
+                    .map(|(id, _)| *id)
+            })
+            .collect_vec();
+        ensure!(
+            transaction_transmission_ids.len() == unconfirmed_transactions_len,
+            "Mismatching number of transaction IDs"
+        );
+        // Construct the aborted Transaction transmission IDs.
+        let mut aborted_transaction_transmission_ids = aborted_transaction_ids_from_finalization
+            .iter()
+            .filter_map(|target_id| {
+                transactions_with_id
+                    .iter()
+                    .find(|(id, _)| match id {
+                        TransmissionID::Transaction(id, _) => id == target_id,
+                        _ => false,
+                    })
+                    .map(|(id, _)| *id)
+            })
+            .collect_vec();
+        ensure!(
+            aborted_transaction_transmission_ids.len() == aborted_transaction_ids_from_finalization.len(),
+            "Mismatching number of aborted transaction IDs"
+        );
+        aborted_transaction_transmission_ids.extend(early_aborted_transaction_transmission_ids);
+        // Construct the aborted transaction IDs.
+        let aborted_transaction_ids = aborted_transaction_transmission_ids
+            .iter()
+            .filter_map(|id| match id {
+                TransmissionID::Transaction(id, _) => Some(*id),
+                _ => None,
+            })
+            .collect_vec();
+
+        // Construct the compact Subdag
+        if N::CONSENSUS_VERSION(self.latest_height()).unwrap() >= ConsensusVersion::V10 {
+            subdag = subdag.into_compact(
+                solution_transmission_ids,
+                prior_solution_transmission_ids.clone(),
+                aborted_solution_transmission_ids.clone(),
+                transaction_transmission_ids,
+                prior_transaction_transmission_ids.clone(),
+                aborted_transaction_transmission_ids.clone(),
+            )?;
+        }
+
+        let (
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
+        ) = if N::CONSENSUS_VERSION(self.latest_height()).unwrap() >= ConsensusVersion::V10 {
+            (
+                Some(prior_solution_transmission_ids),
+                Some(aborted_solution_transmission_ids),
+                Some(prior_transaction_transmission_ids),
+                Some(aborted_transaction_transmission_ids),
+            )
+        } else {
+            (None, None, None, None)
+        };
 
         // Construct the new quorum block.
         Block::new_quorum(
@@ -41,13 +182,18 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             subdag,
             ratifications,
             solutions,
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
             aborted_solution_ids,
             transactions,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
             aborted_transaction_ids,
         )
     }
 
     /// Returns a candidate for the next block in the ledger.
+    #[allow(clippy::too_many_arguments)]
     pub fn prepare_advance_to_next_beacon_block<R: Rng + CryptoRng>(
         &self,
         private_key: &PrivateKey<N>,
@@ -237,8 +383,14 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                         if self.is_solution_limit_reached(&prover_address, num_accepted_solutions) {
                             return false;
                         }
+                        // From ConsensusVersion::V10 onwards, use `check_solution` instead of `check_solution_mut`.
+                        let res = if N::CONSENSUS_VERSION(self.latest_height()).unwrap() >= ConsensusVersion::V10 {
+                            self.puzzle().check_solution(solution, latest_epoch_hash, latest_proof_target)
+                        } else {
+                            self.puzzle().check_solution_mut(solution, latest_epoch_hash, latest_proof_target)
+                        };
                         // Check if the solution is valid and update the number of accepted solutions.
-                        match self.puzzle().check_solution_mut(solution, latest_epoch_hash, latest_proof_target) {
+                        match res {
                             // Increment the number of accepted solutions for the prover.
                             Ok(()) => {
                                 *accepted_solutions.entry(prover_address).or_insert(0) += 1;

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -92,13 +92,19 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         );
         aborted_solution_transmission_ids.extend(early_aborted_solution_transmission_ids);
         // Construct the aborted solution IDs.
-        let aborted_solution_ids = aborted_solution_transmission_ids
-            .iter()
-            .filter_map(|id| match id {
-                TransmissionID::Solution(id, _) => Some(*id),
-                _ => None,
-            })
-            .collect_vec();
+        let aborted_solution_ids = if N::CONSENSUS_VERSION(self.latest_height()).unwrap() < ConsensusVersion::V10 {
+            Some(
+                aborted_solution_transmission_ids
+                    .iter()
+                    .filter_map(|id| match id {
+                        TransmissionID::Solution(id, _) => Some(*id),
+                        _ => None,
+                    })
+                    .collect_vec(),
+            )
+        } else {
+            None
+        };
 
         // --- Transactions ---
         // Construct the transaction transmission IDs.
@@ -139,13 +145,19 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         );
         aborted_transaction_transmission_ids.extend(early_aborted_transaction_transmission_ids);
         // Construct the aborted transaction IDs.
-        let aborted_transaction_ids = aborted_transaction_transmission_ids
-            .iter()
-            .filter_map(|id| match id {
-                TransmissionID::Transaction(id, _) => Some(*id),
-                _ => None,
-            })
-            .collect_vec();
+        let aborted_transaction_ids = if N::CONSENSUS_VERSION(self.latest_height()).unwrap() < ConsensusVersion::V10 {
+            Some(
+                aborted_transaction_transmission_ids
+                    .iter()
+                    .filter_map(|id| match id {
+                        TransmissionID::Transaction(id, _) => Some(*id),
+                        _ => None,
+                    })
+                    .collect_vec(),
+            )
+        } else {
+            None
+        };
 
         // Construct the compact Subdag
         if N::CONSENSUS_VERSION(self.latest_height()).unwrap() >= ConsensusVersion::V10 {
@@ -226,9 +238,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             header,
             ratifications,
             solutions,
-            aborted_solution_ids,
+            Some(aborted_solution_ids),
             transactions,
-            aborted_transaction_ids,
+            Some(aborted_transaction_ids),
             rng,
         )
     }

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -13,9 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use snarkvm_ledger_narwhal::CompactCertificate;
+
 use super::*;
 
-use crate::narwhal::BatchHeader;
+use crate::narwhal::{BatchHeader, LeaderCertificate, NarwhalCertificate};
 
 /// Wrapper for a block that has a valid subDAG, but where the block header,
 /// solutions, and transmissions have not been verified yet.
@@ -243,16 +245,29 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Store the IDs of all certificates in this subDAG.
         // This allows determining which edges point to other subDAGs/blocks.
-        let subdag_certs: HashSet<_> = subdag.certificate_ids().collect();
+        let subdag_certs: HashSet<_> = subdag.certificate_ids().into_iter().collect();
 
         // Generate a set of all external certificates this subDAG references.
         // If multiple certificates reference the same external certificate, the id and round number will be
         // identical and the set will contain only one entry for the external certificate.
-        let leaf_edges: HashSet<_> = subdag
-            .certificates()
-            .flat_map(|cert| cert.previous_certificate_ids().iter().map(|prev_id| (cert.round() - 1, prev_id)))
-            .filter(|(_, prev_id)| !subdag_certs.contains(prev_id))
-            .collect();
+        let leaf_edges: HashSet<_> = match subdag {
+            Subdag::Full { subdag } => subdag
+                .values()
+                .flatten()
+                .flat_map(|cert: &BatchCertificate<N>| {
+                    cert.previous_certificate_ids().iter().map(|prev_id| (cert.round() - 1, prev_id))
+                })
+                .filter(|(_, prev_id)| !subdag_certs.contains(prev_id))
+                .collect(),
+            Subdag::Compact { subdag } => subdag
+                .values()
+                .flatten()
+                .flat_map(|cert: &CompactCertificate<N>| {
+                    cert.previous_certificate_ids().iter().map(|prev_id| (cert.round() - 1, prev_id))
+                })
+                .filter(|(_, prev_id)| !subdag_certs.contains(prev_id))
+                .collect(),
+        };
 
         cfg_iter!(leaf_edges).try_for_each(|(prev_round, prev_id)| {
             if prev_round + (BatchHeader::<N>::MAX_GC_ROUNDS as u64) - 1 <= block.round() {
@@ -277,19 +292,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// Called by [`Self::check_block_subdag`]
     fn check_block_subdag_quorum(&self, block: &Block<N>) -> Result<()> {
-        // Check if the block has a subdag.
-        let subdag = match block.authority() {
-            Authority::Quorum(subdag) => subdag,
-            _ => return Ok(()),
-        };
-
-        // Check that all certificates on each round have met quorum requirements.
-        cfg_iter!(subdag).try_for_each(|(round, certificates)| {
-            // Retrieve the committee lookback for the round.
-            let committee_lookback = self
-                .get_committee_lookback_for_round(*round)?
-                .ok_or_else(|| anyhow!("No committee lookback found for round {round}"))?;
-
+        fn check_quorum_requirements<N: Network, C: NarwhalCertificate<N>>(
+            round: u64,
+            certificates: &IndexSet<C>,
+            committee_lookback: Committee<N>,
+        ) -> Result<()> {
             // Check that each certificate for this round has met quorum requirements.
             // Note that we do not need to check the quorum requirement for the previous certificates
             // because that is done during construction in `BatchCertificate::new`.
@@ -308,12 +315,34 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 );
 
                 Ok::<_, Error>(())
-            })?;
+            })
+        }
 
-            Ok::<_, Error>(())
-        })?;
+        // Check if the block has a subdag.
+        let subdag = match block.authority() {
+            Authority::Quorum(subdag) => subdag,
+            _ => return Ok(()),
+        };
 
-        Ok(())
+        // Check that all certificates on each round have met quorum requirements.
+        match subdag {
+            Subdag::Full { subdag } => cfg_iter!(subdag).try_for_each(|(round, certificates)| {
+                // Retrieve the committee lookback for the round.
+                let committee_lookback = self
+                    .get_committee_lookback_for_round(*round)?
+                    .ok_or_else(|| anyhow!("No committee lookback found for round {round}"))?;
+
+                check_quorum_requirements(*round, certificates, committee_lookback)
+            }),
+            Subdag::Compact { subdag } => cfg_iter!(subdag).try_for_each(|(round, certificates)| {
+                // Retrieve the committee lookback for the round.
+                let committee_lookback = self
+                    .get_committee_lookback_for_round(*round)?
+                    .ok_or_else(|| anyhow!("No committee lookback found for round {round}"))?;
+
+                check_quorum_requirements(*round, certificates, committee_lookback)
+            }),
+        }
     }
 
     /// Checks that the block subdag can not be split into multiple valid subdags.
@@ -323,20 +352,31 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Returns `true` if there is a path from the previous certificate to the current certificate.
         fn is_linked<N: Network>(
             subdag: &Subdag<N>,
-            previous_certificate: &BatchCertificate<N>,
-            current_certificate: &BatchCertificate<N>,
+            previous_certificate: LeaderCertificate<N>,
+            current_certificate: LeaderCertificate<N>,
         ) -> Result<bool> {
+            // Obtain the current round.
+            let current_round = current_certificate.round();
             // Initialize the list containing the traversal.
             let mut traversal = vec![current_certificate];
             // Iterate over the rounds from the current certificate to the previous certificate.
-            for round in (previous_certificate.round()..current_certificate.round()).rev() {
+            for round in (previous_certificate.round()..current_round).rev() {
                 // Retrieve all of the certificates for this past round.
-                let certificates = subdag.get(&round).ok_or(anyhow!("No certificates found for round {round}"))?;
                 // Filter the certificates to only include those that are in the traversal.
-                traversal = certificates
-                    .into_iter()
-                    .filter(|p| traversal.iter().any(|c| c.previous_certificate_ids().contains(&p.id())))
-                    .collect();
+                traversal = match subdag {
+                    Subdag::Full { subdag } => subdag
+                        .get(&round)
+                        .map(|certs| certs.iter().map(LeaderCertificate::<N>::from))
+                        .ok_or(anyhow!("No certificates found for round {round}"))?
+                        .filter(|p| traversal.iter().any(|c| c.previous_certificate_ids().contains(&p.id())))
+                        .collect(),
+                    Subdag::Compact { subdag } => subdag
+                        .get(&round)
+                        .map(|certs| certs.iter().map(LeaderCertificate::<N>::from))
+                        .ok_or(anyhow!("No certificates found for round {round}"))?
+                        .filter(|p| traversal.iter().any(|c| c.previous_certificate_ids().contains(&p.id())))
+                        .collect(),
+                };
             }
             Ok(traversal.contains(&previous_certificate))
         }
@@ -361,11 +401,23 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 .map_err(|e| anyhow!("Failed to compute leader for round {round}: {e}"))?;
 
             // Retrieve the previous leader certificates.
-            let previous_certificate = match subdag.get(&round).and_then(|certificates| {
-                certificates.iter().find(|certificate| certificate.author() == computed_leader)
-            }) {
-                Some(cert) => cert,
-                None => continue,
+            let previous_certificate = match subdag {
+                Subdag::Full { subdag } => {
+                    match subdag.get(&round).map(|certs| certs.iter().map(LeaderCertificate::<N>::from)).and_then(
+                        |mut certificates| certificates.find(|certificate| computed_leader == certificate.author()),
+                    ) {
+                        Some(cert) => cert,
+                        None => continue,
+                    }
+                }
+                Subdag::Compact { subdag } => {
+                    match subdag.get(&round).map(|certs| certs.iter().map(LeaderCertificate::<N>::from)).and_then(
+                        |mut certificates| certificates.find(|certificate| computed_leader == certificate.author()),
+                    ) {
+                        Some(cert) => cert,
+                        None => continue,
+                    }
+                }
             };
 
             // Determine if there is a path between the previous certificate and the subdag's leader certificate.

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -293,11 +293,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
     }
 
-    /// Returns the batch certificate for the given `certificate ID`.
-    pub fn get_batch_certificate(&self, certificate_id: &Field<N>) -> Result<Option<BatchCertificate<N>>> {
-        self.vm.block_store().get_batch_certificate(certificate_id)
-    }
-
     /// Returns the delegators for the given validator.
     pub fn get_delegators_for_validator(&self, validator: &Address<N>) -> Result<Vec<Address<N>>> {
         // Construct the credits.aleo program ID.

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -191,7 +191,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     pub fn get_aborted_transaction_ids(&self, height: u32) -> Result<Vec<N::TransactionID>> {
         // If the height is 0, return the genesis block aborted transaction IDs.
         if height == 0 {
-            return Ok(self.genesis_block.aborted_transaction_ids().clone());
+            return Ok(self.genesis_block.aborted_transaction_ids().cloned().unwrap_or_default());
         }
         // Retrieve the block hash.
         let Some(block_hash) = self.vm.block_store().get_block_hash(height)? else {

--- a/ledger/src/helpers/bft.rs
+++ b/ledger/src/helpers/bft.rs
@@ -16,6 +16,7 @@
 #![allow(clippy::type_complexity)]
 
 use console::network::Network;
+use indexmap::IndexSet;
 use snarkvm_ledger_block::{Ratify, Transaction};
 use snarkvm_ledger_narwhal::{Transmission, TransmissionID};
 use snarkvm_ledger_puzzle::Solution;
@@ -29,13 +30,19 @@ use std::collections::HashSet;
 /// This method guarantees that the output is 1) order-preserving, and 2) unique.
 pub fn decouple_transmissions<N: Network>(
     transmissions: impl Iterator<Item = (TransmissionID<N>, Transmission<N>)>,
-) -> Result<(Vec<Ratify<N>>, Vec<Solution<N>>, Vec<Transaction<N>>)> {
-    // Initialize a list for the ratifications.
+) -> Result<(
+    Vec<Ratify<N>>,
+    Vec<Solution<N>>,
+    Vec<(TransmissionID<N>, Solution<N>)>,
+    Vec<Transaction<N>>,
+    Vec<(TransmissionID<N>, Transaction<N>)>,
+)> {
+    // Initialize a list for the objects to return.
     let ratifications = Vec::new();
-    // Initialize a list for the solutions.
     let mut solutions = Vec::new();
-    // Initialize a list for the transactions.
+    let mut solutions_with_id = Vec::new();
     let mut transactions = Vec::new();
+    let mut transactions_with_id = Vec::new();
 
     // Initialize a set to ensure the transmissions are unique.
     let mut unique = HashSet::new();
@@ -47,29 +54,63 @@ pub fn decouple_transmissions<N: Network>(
         // Deserialize and store the transmission.
         match (transmission_id, transmission) {
             (TransmissionID::Ratification, Transmission::Ratification) => (),
-            (TransmissionID::Solution(commitment, checksum), Transmission::Solution(solution)) => {
+            (id @ TransmissionID::Solution(commitment, checksum), Transmission::Solution(solution)) => {
                 // Ensure the transmission checksum corresponds to the solution.
                 ensure!(checksum == solution.to_checksum::<N>()?, "Mismatching transmission checksum (solution)");
                 // Deserialize the solution.
                 let solution = solution.deserialize_blocking()?;
                 // Ensure the transmission ID corresponds to the solution.
                 ensure!(commitment == solution.id(), "Mismatching transmission ID (solution)");
-                // Insert the solution into the list.
+                // Insert the solution into the lists.
                 solutions.push(solution);
+                solutions_with_id.push((id, solution));
             }
-            (TransmissionID::Transaction(transaction_id, checksum), Transmission::Transaction(transaction)) => {
+            (id @ TransmissionID::Transaction(transaction_id, checksum), Transmission::Transaction(transaction)) => {
                 // Ensure the transmission checksum corresponds to the transaction.
                 ensure!(checksum == transaction.to_checksum::<N>()?, "Mismatching transmission checksum (transaction)");
                 // Deserialize the transaction.
                 let transaction = transaction.deserialize_blocking()?;
                 // Ensure the transmission ID corresponds to the transaction.
                 ensure!(transaction_id == transaction.id(), "Mismatching transmission ID (transaction)");
-                // Insert the transaction into the list.
-                transactions.push(transaction);
+                // Insert the transaction into the lists.
+                transactions.push(transaction.clone());
+                transactions_with_id.push((id, transaction));
             }
             _ => bail!("Mismatching (transmission ID, transmission) entry"),
         }
     }
     // Return the ratifications, solutions, and transactions.
-    Ok((ratifications, solutions, transactions))
+    Ok((ratifications, solutions, solutions_with_id, transactions, transactions_with_id))
+}
+
+/// Takes in an iterator of transmission IDs and returns a tuple of ratifications, solutions, and transactions.
+///
+/// This method guarantees that the output is 1) order-preserving, and 2) unique.
+pub fn decouple_transmission_ids<N: Network>(
+    transmission_ids: IndexSet<TransmissionID<N>>,
+) -> Result<(Vec<TransmissionID<N>>, Vec<TransmissionID<N>>, Vec<TransmissionID<N>>)> {
+    // Initialize a list for the ratifications.
+    let ratifications = Vec::new();
+    // Initialize a list for the solutions.
+    let mut solution_ids = Vec::new();
+    // Initialize a list for the transactions.
+    let mut transaction_ids = Vec::new();
+
+    // Iterate over the transmissions.
+    for transmission_id in transmission_ids.into_iter() {
+        // Deserialize and store the transmission.
+        match transmission_id {
+            TransmissionID::Ratification => (),
+            TransmissionID::Solution(..) => {
+                // Insert the solution into the list.
+                solution_ids.push(transmission_id);
+            }
+            TransmissionID::Transaction(..) => {
+                // Insert the transaction into the list.
+                transaction_ids.push(transmission_id);
+            }
+        }
+    }
+    // Return the ratifications, solution_ids, and transaction_ids.
+    Ok((ratifications, solution_ids, transaction_ids))
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -74,7 +74,7 @@ use aleo_std::{
 };
 use anyhow::Result;
 use core::ops::Range;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::{Mutex, RwLock};
 use lru::LruCache;
@@ -104,6 +104,43 @@ pub enum RecordsFilter<N: Network> {
     SlowSpent(PrivateKey<N>),
     /// Returns all records associated with the account that are **not spent** with the given private key.
     SlowUnspent(PrivateKey<N>),
+}
+
+/// Helper struct to wrap transmissions in the Subdag.
+#[derive(Clone)]
+pub struct SubdagTransmissions<N: Network> {
+    /// The transmissions in a subdag ready to be included in the next block.
+    pub transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+    /// Transmission ids in a subdag which were already included in a prior block.
+    pub prior_included_transmissions: IndexSet<TransmissionID<N>>,
+    /// Novel transmission ids in a subdag which at the moment can't be included in a block.
+    pub aborted_transmissions: IndexSet<TransmissionID<N>>,
+}
+
+impl<N: Network> Default for SubdagTransmissions<N> {
+    fn default() -> Self {
+        Self {
+            transmissions: IndexMap::default(),
+            prior_included_transmissions: IndexSet::default(),
+            aborted_transmissions: IndexSet::default(),
+        }
+    }
+}
+
+impl<N: Network> SubdagTransmissions<N> {
+    /// Returns the total number of transmissions.
+    pub fn len(&self) -> usize {
+        self.transmissions
+            .len()
+            .saturating_add(self.prior_included_transmissions.len().saturating_add(self.aborted_transmissions.len()))
+    }
+
+    /// Returns `true` if the subdag is empty.
+    pub fn is_empty(&self) -> bool {
+        self.transmissions.is_empty()
+            && self.prior_included_transmissions.is_empty()
+            && self.aborted_transmissions.is_empty()
+    }
 }
 
 /// State of the entire chain.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -1045,7 +1045,7 @@ fn test_aborted_transaction_indexing() {
         .unwrap();
 
     // Check that the block contains the aborted transaction.
-    assert_eq!(block.aborted_transaction_ids(), &[aborted_transaction_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &[aborted_transaction_id]);
 
     // Check that the next block is valid.
     ledger.check_next_block(&block, rng).unwrap();
@@ -1098,7 +1098,7 @@ fn test_aborted_solution_ids() {
 
     // Enforce that the block solution was aborted properly.
     assert!(block.solutions().is_empty());
-    assert_eq!(block.aborted_solution_ids(), &vec![invalid_solution.id()]);
+    assert_eq!(block.aborted_solution_ids().unwrap(), &vec![invalid_solution.id()]);
 }
 
 #[test]
@@ -1261,7 +1261,7 @@ finalize foo:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&execution_ids[2], &deployment_ids[2]]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![
         execution_ids[5],
         execution_ids[4],
         execution_ids[3],
@@ -1309,7 +1309,7 @@ finalize foo:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_id]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![execution_ids[0], deployment_ids[0]]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![execution_ids[0], deployment_ids[0]]);
 
     // Ensure that verification was not run on transactions aborted in a previous block.
     let partially_verified_transaction = ledger.vm().partially_verified_transactions().read().clone();
@@ -1521,7 +1521,7 @@ function create_duplicate_record:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_1_id, &deployment_1_id]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![transfer_2_id, deployment_2_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![transfer_2_id, deployment_2_id]);
 
     // Ensure that verification was not run on aborted deployments.
     let partially_verified_transaction = ledger.vm().partially_verified_transactions().read().clone();
@@ -1559,7 +1559,7 @@ function create_duplicate_record:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_4_id]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![transfer_3_id, deployment_3_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![transfer_3_id, deployment_3_id]);
 
     // Ensure that verification was not run on transactions aborted in a previous block.
     let partially_verified_transaction = ledger.vm().partially_verified_transactions().read().clone();
@@ -1677,7 +1677,7 @@ function empty_function:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transaction_1_id]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![transaction_2_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![transaction_2_id]);
 
     // Ensure that verification was not run on aborted transactions.
     let partially_verified_transaction = ledger.vm().partially_verified_transactions().read().clone();
@@ -1713,7 +1713,7 @@ function empty_function:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_transaction_id]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![transaction_3_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![transaction_3_id]);
 
     // Ensure that verification was not run on transactions aborted in a previous block.
     let partially_verified_transaction = ledger.vm().partially_verified_transactions().read().clone();
@@ -1831,7 +1831,7 @@ function simple_output:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transaction_1_id]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![transaction_2_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![transaction_2_id]);
 
     // Ensure that verification was not run on aborted transactions.
     let partially_verified_transaction = ledger.vm().partially_verified_transactions().read().clone();
@@ -1867,7 +1867,7 @@ function simple_output:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().transaction_ids().collect::<Vec<_>>(), vec![&transfer_transaction_id]);
-    assert_eq!(block.aborted_transaction_ids(), &vec![transaction_3_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![transaction_3_id]);
 
     // Ensure that verification was not run on transactions aborted in a previous block.
     let partially_verified_transaction = ledger.vm().partially_verified_transactions().read().clone();
@@ -1924,7 +1924,7 @@ function empty_function:
 
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
-    assert_eq!(block.aborted_transaction_ids(), &vec![deployment_2_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![deployment_2_id]);
 
     // Enforce that the first program was deployed and the second was aborted.
     assert_eq!(ledger.get_program(*program_1.id()).unwrap(), program_1);
@@ -1966,7 +1966,7 @@ fn test_abort_fee_transaction() {
         .unwrap();
 
     // Check that the block aborts the invalid transaction.
-    assert_eq!(block.aborted_transaction_ids(), &vec![fee_transaction_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![fee_transaction_id]);
     assert_eq!(block.transaction_ids().collect::<Vec<_>>(), vec![&transaction_id]);
 
     // Check that the next block is valid.
@@ -2026,7 +2026,7 @@ fn test_abort_invalid_transaction() {
         .unwrap();
 
     // Check that the block aborts the invalid transaction.
-    assert_eq!(block.aborted_transaction_ids(), &vec![invalid_transaction_id]);
+    assert_eq!(block.aborted_transaction_ids().unwrap(), &vec![invalid_transaction_id]);
     assert_eq!(block.transaction_ids().collect::<Vec<_>>(), vec![&valid_transaction_id_1, &valid_transaction_id_2]);
 
     // Check that the next block is valid.
@@ -2118,7 +2118,7 @@ finalize foo2:
     // Enforce that the block transactions were correct.
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
 
     // Enforce that the first program was deployed and the second was rejected.
     assert_eq!(ledger.get_program(*program_1.id()).unwrap(), program_1);
@@ -2631,7 +2631,7 @@ finalize foo:
         assert_eq!(block_confirmed_transactions_ids, confirmed_transaction_ids);
 
         // Enforce that the aborted transactions is correct.
-        assert_eq!(block.aborted_transaction_ids(), &aborted_transaction_ids);
+        assert_eq!(block.aborted_transaction_ids().unwrap(), &aborted_transaction_ids);
     }
 }
 
@@ -2934,7 +2934,7 @@ mod valid_solutions {
 
         // Enforce that the block solution was accepted properly.
         assert_eq!(block.solutions().len(), 1);
-        assert_eq!(block.aborted_solution_ids().len(), 0)
+        assert_eq!(block.aborted_solution_ids().unwrap().len(), 0)
     }
 
     #[test]
@@ -3156,7 +3156,7 @@ mod valid_solutions {
         );
         // Check that the solution is aborted.
         assert!(next_block.solutions().is_empty());
-        assert_eq!(next_block.aborted_solution_ids().len(), 1);
+        assert_eq!(next_block.aborted_solution_ids().unwrap().len(), 1);
         // Advance to the next block.
         ledger.advance_to_next_block(&next_block).unwrap();
 
@@ -3206,7 +3206,7 @@ mod valid_solutions {
 
         // Check that the first solution is accepted and the second is aborted.
         assert!(next_block.solutions().solution_ids().contains(&valid_solution_1.id()));
-        assert_eq!(next_block.aborted_solution_ids(), &vec![valid_solution_2.id()]);
+        assert_eq!(next_block.aborted_solution_ids().unwrap(), &vec![valid_solution_2.id()]);
 
         // Advance to the next block.
         ledger.advance_to_next_block(&next_block).unwrap();
@@ -3295,14 +3295,14 @@ mod valid_solutions {
         ledger.advance_to_next_block(&block).unwrap();
 
         // Check that the block's solutions are well-formed.
-        assert_eq!(block.aborted_solution_ids().len(), NUM_INVALID_SOLUTIONS);
+        assert_eq!(block.aborted_solution_ids().unwrap().len(), NUM_INVALID_SOLUTIONS);
         assert_eq!(block.solutions().len(), NUM_VALID_SOLUTIONS);
 
         let block_solutions = block.solutions().solution_ids().cloned().collect::<HashSet<_>>();
         let valid_solutions = valid_solutions.iter().map(|s| s.id()).collect::<HashSet<_>>();
         assert_eq!(block_solutions, valid_solutions, "Valid solutions do not match");
 
-        let block_aborted_solution_ids = block.aborted_solution_ids().iter().cloned().collect::<HashSet<_>>();
+        let block_aborted_solution_ids = block.aborted_solution_ids().unwrap().iter().cloned().collect::<HashSet<_>>();
         let invalid_solutions = invalid_solutions.iter().map(|s| s.id()).collect::<HashSet<_>>();
         assert_eq!(block_aborted_solution_ids, invalid_solutions, "Invalid solutions do not match");
     }
@@ -3373,14 +3373,14 @@ mod valid_solutions {
 
         // Check that the block's solutions are well-formed.
         assert_eq!(block.solutions().len(), CurrentNetwork::MAX_SOLUTIONS);
-        assert_eq!(block.aborted_solution_ids().len(), NUM_VALID_SOLUTIONS - CurrentNetwork::MAX_SOLUTIONS);
+        assert_eq!(block.aborted_solution_ids().unwrap().len(), NUM_VALID_SOLUTIONS - CurrentNetwork::MAX_SOLUTIONS);
 
         let block_solutions = block.solutions().solution_ids().cloned().collect::<HashSet<_>>();
         let expected_accepted_solutions =
             candidate_solutions.iter().take(CurrentNetwork::MAX_SOLUTIONS).map(|s| s.id()).collect::<HashSet<_>>();
         assert_eq!(block_solutions, expected_accepted_solutions, "Accepted solutions do not match");
 
-        let block_aborted_solution_ids = block.aborted_solution_ids().iter().cloned().collect::<HashSet<_>>();
+        let block_aborted_solution_ids = block.aborted_solution_ids().unwrap().iter().cloned().collect::<HashSet<_>>();
         let expected_aborted_solutions =
             candidate_solutions.iter().skip(CurrentNetwork::MAX_SOLUTIONS).map(|s| s.id()).collect::<HashSet<_>>();
         assert_eq!(block_aborted_solution_ids, expected_aborted_solutions, "Aborted solutions do not match");
@@ -3457,7 +3457,7 @@ mod valid_solutions {
 
             // Check that the block's solutions are well-formed.
             assert_eq!(block.solutions().len(), 1);
-            assert_eq!(block.aborted_solution_ids().len(), 0);
+            assert_eq!(block.aborted_solution_ids().unwrap().len(), 0);
 
             // Fetch the solution from the block.
             let (solution_id, solution) = block.solutions().as_ref().unwrap().first().unwrap();
@@ -3529,10 +3529,10 @@ mod valid_solutions {
 
         // Check that the block's solutions are well-formed.
         assert_eq!(block.solutions().len(), 0);
-        assert_eq!(block.aborted_solution_ids().len(), 1);
+        assert_eq!(block.aborted_solution_ids().unwrap().len(), 1);
 
         // Check that the aborted solution is correct.
-        let block_aborted_solution_id = block.aborted_solution_ids().first().unwrap();
+        let block_aborted_solution_id = block.aborted_solution_ids().unwrap().first().unwrap();
         assert_eq!(*block_aborted_solution_id, invalid_solution.id(), "Aborted solutions do not match");
     }
 }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -16,6 +16,7 @@
 use crate::{
     Ledger,
     RecordsFilter,
+    SubdagTransmissions,
     advance::split_candidate_solutions,
     test_helpers::{CurrentAleo, CurrentConsensusStorage, CurrentLedger, CurrentNetwork},
 };
@@ -29,7 +30,15 @@ use console::{
 use snarkvm_ledger_authority::Authority;
 use snarkvm_ledger_block::{Block, ConfirmedTransaction, Execution, Ratify, Rejected, Transaction};
 use snarkvm_ledger_committee::{Committee, MIN_VALIDATOR_STAKE};
-use snarkvm_ledger_narwhal::{BatchCertificate, BatchHeader, Data, Subdag, Transmission, TransmissionID};
+use snarkvm_ledger_narwhal::{
+    BatchCertificate,
+    BatchHeader,
+    Data,
+    NarwhalCertificate,
+    Subdag,
+    Transmission,
+    TransmissionID,
+};
 use snarkvm_ledger_store::ConsensusStore;
 use snarkvm_synthesizer::{
     Stack,
@@ -286,8 +295,15 @@ impl TestChainBuilder {
         self.last_committed_batch.insert(leader_idx, commit_round);
 
         // Construct the block.
-        let subdag = Subdag::from(subdag_map).unwrap();
-        let block = self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions, rng).unwrap();
+        let subdag = Subdag::from_full(subdag_map).unwrap();
+        let block = self
+            .ledger
+            .prepare_advance_to_next_quorum_block(
+                subdag,
+                SubdagTransmissions { transmissions, ..Default::default() },
+                rng,
+            )
+            .unwrap();
         if !skip_verification {
             self.ledger.check_next_block(&block, rng).unwrap();
         }
@@ -3563,8 +3579,8 @@ fn test_forged_block_subdags() {
     ledger.check_next_block(&block_2, rng).expect("Unmodified block 2 must be accepted by the ledger");
 
     // Fetch the unmodified/correct subdags.
-    let Authority::Quorum(block_2_subdag) = block_2.authority() else { unreachable!("") };
-    let Authority::Quorum(block_3_subdag) = block_3.authority() else { unreachable!("") };
+    let Authority::Quorum(Subdag::Full { subdag: block_2_subdag }) = block_2.authority() else { unreachable!("") };
+    let Authority::Quorum(Subdag::Full { subdag: block_3_subdag }) = block_3.authority() else { unreachable!("") };
 
     // Fetch the transmissions.
     let block_2_transmissions = extract_transmissions(&block_2);
@@ -3577,8 +3593,8 @@ fn test_forged_block_subdags() {
         // Forge the block.
         let forged_block_2 = ledger
             .prepare_advance_to_next_quorum_block(
-                block_3_subdag.clone(),
-                block_3_transmissions.clone(),
+                Subdag::Full { subdag: block_3_subdag.clone() },
+                SubdagTransmissions { transmissions: block_3_transmissions.clone(), ..Default::default() },
                 &mut rand::thread_rng(),
             )
             .unwrap();
@@ -3594,7 +3610,7 @@ fn test_forged_block_subdags() {
     ////////////////////////////////////////////////////////////////////////////
     {
         // Combined the subdags.
-        let mut combined_subdag = block_2_subdag.deref().clone();
+        let mut combined_subdag = block_2_subdag.clone();
         for (round, certificates) in block_3_subdag.iter() {
             combined_subdag
                 .entry(*round)
@@ -3609,8 +3625,8 @@ fn test_forged_block_subdags() {
         // Forge the block.
         let forged_block_2_from_both_subdags = ledger
             .prepare_advance_to_next_quorum_block(
-                Subdag::from(combined_subdag).unwrap(),
-                combined_transmissions,
+                Subdag::from_full(combined_subdag).unwrap(),
+                SubdagTransmissions { transmissions: combined_transmissions, ..Default::default() },
                 &mut rand::thread_rng(),
             )
             .unwrap();
@@ -3625,7 +3641,7 @@ fn test_forged_block_subdags() {
     // Attack 3:  Forge block 2' that misses some batches.
     ////////////////////////////////////////////////////////////////////////////
     {
-        let mut subdag = block_2_subdag.deref().clone();
+        let mut subdag = block_2_subdag.clone();
 
         // Get the lowest round which contains batches pointing to the previous
         // block's DAG
@@ -3645,7 +3661,11 @@ fn test_forged_block_subdags() {
 
         // Forge the block.
         let forged_block_2 = ledger
-            .prepare_advance_to_next_quorum_block(Subdag::from(subdag).unwrap(), transmissions, &mut rand::thread_rng())
+            .prepare_advance_to_next_quorum_block(
+                Subdag::from_full(subdag).unwrap(),
+                SubdagTransmissions { transmissions, ..Default::default() },
+                &mut rand::thread_rng(),
+            )
             .unwrap();
 
         assert_ne!(forged_block_2, block_1);
@@ -3746,8 +3766,9 @@ fn test_subdag_with_gc_length() {
 
     {
         // First, let us ensure that the leaf check still works by removing the lowest round and trying to reinsert.
-        let Authority::Quorum(block_subdag) = block.authority() else { unreachable!("") };
-        let mut forged_subdag = block_subdag.deref().clone();
+        let subdag = block.to_full_subdag().unwrap();
+        let Subdag::Full { subdag } = subdag else { unreachable!("") };
+        let mut forged_subdag = subdag.clone();
         let transmissions = extract_transmissions(&block);
 
         // Remove one round from the subDAG.
@@ -3765,8 +3786,8 @@ fn test_subdag_with_gc_length() {
         // Forge the block.
         let forged_block = ledger
             .prepare_advance_to_next_quorum_block(
-                Subdag::from(forged_subdag).unwrap(),
-                transmissions,
+                Subdag::from_full(forged_subdag).unwrap(),
+                SubdagTransmissions { transmissions, ..Default::default() },
                 &mut rand::thread_rng(),
             )
             .unwrap();

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -34,7 +34,6 @@ wasm = [
   "snarkvm-ledger-block/wasm",
   "snarkvm-ledger-puzzle/wasm",
   "snarkvm-ledger-committee/wasm",
-  "snarkvm-ledger-narwhal-batch-certificate/wasm",
   "snarkvm-synthesizer-program/wasm",
   "snarkvm-synthesizer-snark/wasm"
 ]
@@ -54,7 +53,7 @@ workspace = true
 workspace = true
 features = [ "default" ]
 
-[dependencies.snarkvm-ledger-narwhal-batch-certificate]
+[dependencies.snarkvm-ledger-narwhal-transmission-id]
 workspace = true
 
 [dependencies.snarkvm-ledger-puzzle]

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -40,7 +40,7 @@ use snarkvm_ledger_block::{
     Transaction,
     Transactions,
 };
-use snarkvm_ledger_narwhal_batch_certificate::BatchCertificate;
+use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
 use snarkvm_ledger_puzzle::{Solution, SolutionID};
 use snarkvm_synthesizer_program::{FinalizeOperation, Program};
 
@@ -125,6 +125,10 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     type RatificationsMap: for<'a> Map<'a, N::BlockHash, Ratifications<N>>;
     /// The mapping of `block hash` to `block solutions`.
     type SolutionsMap: for<'a> Map<'a, N::BlockHash, Solutions<N>>;
+    /// The mapping of `block hash` to `[prior solution transmission ID]`.
+    type PriorSolutionTransmissionIDsMap: for<'a> Map<'a, N::BlockHash, Vec<TransmissionID<N>>>;
+    /// The mapping of `block hash` to `[aborted solution transmission ID]`.
+    type AbortedSolutionTransmissionIDsMap: for<'a> Map<'a, N::BlockHash, Vec<TransmissionID<N>>>;
     /// The mapping of `solution ID` to `block height`.
     type SolutionIDsMap: for<'a> Map<'a, SolutionID<N>, u32>;
     /// The mapping of `block hash` to `[aborted solution ID]`.
@@ -135,6 +139,10 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     type TransactionsMap: for<'a> Map<'a, N::BlockHash, Vec<N::TransactionID>>;
     /// The mapping of `block hash` to `[aborted transaction ID]`.
     type AbortedTransactionIDsMap: for<'a> Map<'a, N::BlockHash, Vec<N::TransactionID>>;
+    /// The mapping of `block hash` to `[prior transaction transmission ID]`.
+    type PriorTransactionTransmissionIDsMap: for<'a> Map<'a, N::BlockHash, Vec<TransmissionID<N>>>;
+    /// The mapping of `block hash` to `[aborted transaction transmission ID]`.
+    type AbortedTransactionTransmissionIDsMap: for<'a> Map<'a, N::BlockHash, Vec<TransmissionID<N>>>;
     /// The mapping of rejected or aborted `transaction ID` to `block hash`.
     type RejectedOrAbortedTransactionIDMap: for<'a> Map<'a, N::TransactionID, N::BlockHash>;
     /// The mapping of `transaction ID` to `(block hash, confirmed tx type, finalize operations)`.
@@ -167,6 +175,10 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     fn ratifications_map(&self) -> &Self::RatificationsMap;
     /// Returns the solutions map.
     fn solutions_map(&self) -> &Self::SolutionsMap;
+    /// Returns the prior solution transmission IDs map.
+    fn prior_solution_transmission_ids_map(&self) -> &Self::PriorSolutionTransmissionIDsMap;
+    /// Returns the aborted solution transmission IDs map.
+    fn aborted_solution_transmission_ids_map(&self) -> &Self::AbortedSolutionTransmissionIDsMap;
     /// Returns the solution IDs map.
     fn solution_ids_map(&self) -> &Self::SolutionIDsMap;
     /// Returns the aborted solution IDs map.
@@ -177,6 +189,10 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     fn transactions_map(&self) -> &Self::TransactionsMap;
     /// Returns the aborted transaction IDs map.
     fn aborted_transaction_ids_map(&self) -> &Self::AbortedTransactionIDsMap;
+    /// Returns the prior transaction transmission IDs map.
+    fn prior_transaction_transmission_ids_map(&self) -> &Self::PriorTransactionTransmissionIDsMap;
+    /// Returns the aborted transaction transmission IDs map.
+    fn aborted_transaction_transmission_ids_map(&self) -> &Self::AbortedTransactionTransmissionIDsMap;
     /// Returns the rejected or aborted transaction ID map.
     fn rejected_or_aborted_transaction_id_map(&self) -> &Self::RejectedOrAbortedTransactionIDMap;
     /// Returns the confirmed transactions map.
@@ -207,11 +223,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.certificate_map().start_atomic();
         self.ratifications_map().start_atomic();
         self.solutions_map().start_atomic();
+        self.prior_solution_transmission_ids_map().start_atomic();
+        self.aborted_solution_transmission_ids_map().start_atomic();
         self.solution_ids_map().start_atomic();
         self.aborted_solution_ids_map().start_atomic();
         self.aborted_solution_heights_map().start_atomic();
         self.transactions_map().start_atomic();
         self.aborted_transaction_ids_map().start_atomic();
+        self.prior_transaction_transmission_ids_map().start_atomic();
+        self.aborted_transaction_transmission_ids_map().start_atomic();
         self.rejected_or_aborted_transaction_id_map().start_atomic();
         self.confirmed_transactions_map().start_atomic();
         self.rejected_deployment_or_execution_map().start_atomic();
@@ -229,11 +249,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             || self.certificate_map().is_atomic_in_progress()
             || self.ratifications_map().is_atomic_in_progress()
             || self.solutions_map().is_atomic_in_progress()
+            || self.prior_solution_transmission_ids_map().is_atomic_in_progress()
+            || self.aborted_solution_transmission_ids_map().is_atomic_in_progress()
             || self.solution_ids_map().is_atomic_in_progress()
             || self.aborted_solution_ids_map().is_atomic_in_progress()
             || self.aborted_solution_heights_map().is_atomic_in_progress()
             || self.transactions_map().is_atomic_in_progress()
             || self.aborted_transaction_ids_map().is_atomic_in_progress()
+            || self.prior_transaction_transmission_ids_map().is_atomic_in_progress()
+            || self.aborted_transaction_transmission_ids_map().is_atomic_in_progress()
             || self.rejected_or_aborted_transaction_id_map().is_atomic_in_progress()
             || self.confirmed_transactions_map().is_atomic_in_progress()
             || self.rejected_deployment_or_execution_map().is_atomic_in_progress()
@@ -251,11 +275,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.certificate_map().atomic_checkpoint();
         self.ratifications_map().atomic_checkpoint();
         self.solutions_map().atomic_checkpoint();
+        self.prior_solution_transmission_ids_map().atomic_checkpoint();
+        self.aborted_solution_transmission_ids_map().atomic_checkpoint();
         self.solution_ids_map().atomic_checkpoint();
         self.aborted_solution_ids_map().atomic_checkpoint();
         self.aborted_solution_heights_map().atomic_checkpoint();
         self.transactions_map().atomic_checkpoint();
         self.aborted_transaction_ids_map().atomic_checkpoint();
+        self.prior_transaction_transmission_ids_map().atomic_checkpoint();
+        self.aborted_transaction_transmission_ids_map().atomic_checkpoint();
         self.rejected_or_aborted_transaction_id_map().atomic_checkpoint();
         self.confirmed_transactions_map().atomic_checkpoint();
         self.rejected_deployment_or_execution_map().atomic_checkpoint();
@@ -273,11 +301,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.certificate_map().clear_latest_checkpoint();
         self.ratifications_map().clear_latest_checkpoint();
         self.solutions_map().clear_latest_checkpoint();
+        self.prior_solution_transmission_ids_map().clear_latest_checkpoint();
+        self.aborted_solution_transmission_ids_map().clear_latest_checkpoint();
         self.solution_ids_map().clear_latest_checkpoint();
         self.aborted_solution_ids_map().clear_latest_checkpoint();
         self.aborted_solution_heights_map().clear_latest_checkpoint();
         self.transactions_map().clear_latest_checkpoint();
         self.aborted_transaction_ids_map().clear_latest_checkpoint();
+        self.prior_transaction_transmission_ids_map().clear_latest_checkpoint();
+        self.aborted_transaction_transmission_ids_map().clear_latest_checkpoint();
         self.rejected_or_aborted_transaction_id_map().clear_latest_checkpoint();
         self.confirmed_transactions_map().clear_latest_checkpoint();
         self.rejected_deployment_or_execution_map().clear_latest_checkpoint();
@@ -295,11 +327,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.certificate_map().atomic_rewind();
         self.ratifications_map().atomic_rewind();
         self.solutions_map().atomic_rewind();
+        self.prior_solution_transmission_ids_map().atomic_rewind();
+        self.aborted_solution_transmission_ids_map().atomic_rewind();
         self.solution_ids_map().atomic_rewind();
         self.aborted_solution_ids_map().atomic_rewind();
         self.aborted_solution_heights_map().atomic_rewind();
         self.transactions_map().atomic_rewind();
         self.aborted_transaction_ids_map().atomic_rewind();
+        self.prior_transaction_transmission_ids_map().atomic_rewind();
+        self.aborted_transaction_transmission_ids_map().atomic_rewind();
         self.rejected_or_aborted_transaction_id_map().atomic_rewind();
         self.confirmed_transactions_map().atomic_rewind();
         self.rejected_deployment_or_execution_map().atomic_rewind();
@@ -317,11 +353,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.certificate_map().abort_atomic();
         self.ratifications_map().abort_atomic();
         self.solutions_map().abort_atomic();
+        self.prior_solution_transmission_ids_map().abort_atomic();
+        self.aborted_solution_transmission_ids_map().abort_atomic();
         self.solution_ids_map().abort_atomic();
         self.aborted_solution_ids_map().abort_atomic();
         self.aborted_solution_heights_map().abort_atomic();
         self.transactions_map().abort_atomic();
         self.aborted_transaction_ids_map().abort_atomic();
+        self.prior_transaction_transmission_ids_map().abort_atomic();
+        self.aborted_transaction_transmission_ids_map().abort_atomic();
         self.rejected_or_aborted_transaction_id_map().abort_atomic();
         self.confirmed_transactions_map().abort_atomic();
         self.rejected_deployment_or_execution_map().abort_atomic();
@@ -339,11 +379,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.certificate_map().finish_atomic()?;
         self.ratifications_map().finish_atomic()?;
         self.solutions_map().finish_atomic()?;
+        self.prior_solution_transmission_ids_map().finish_atomic()?;
+        self.aborted_solution_transmission_ids_map().finish_atomic()?;
         self.solution_ids_map().finish_atomic()?;
         self.aborted_solution_ids_map().finish_atomic()?;
         self.aborted_solution_heights_map().finish_atomic()?;
         self.transactions_map().finish_atomic()?;
         self.aborted_transaction_ids_map().finish_atomic()?;
+        self.prior_transaction_transmission_ids_map().finish_atomic()?;
+        self.aborted_transaction_transmission_ids_map().finish_atomic()?;
         self.rejected_or_aborted_transaction_id_map().finish_atomic()?;
         self.confirmed_transactions_map().finish_atomic()?;
         self.rejected_deployment_or_execution_map().finish_atomic()?;
@@ -377,9 +421,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         // Retrieve the certificate IDs to store.
         let certificates_to_store = match block.authority() {
             Authority::Beacon(_) => Vec::new(),
-            Authority::Quorum(subdag) => {
-                subdag.iter().flat_map(|(round, certificates)| certificates.iter().map(|c| (c.id(), *round))).collect()
-            }
+            Authority::Quorum(subdag) => subdag.certificate_ids_rounds(),
         };
 
         // Prepare the rejected transaction IDs and their corresponding unconfirmed transaction IDs.
@@ -422,9 +464,17 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
                 self.solution_ids_map().insert(*solution_id, block.height())?;
             }
 
+            if N::CONSENSUS_VERSION(block.height()).unwrap() >= ConsensusVersion::V10 {
+                // Store the prior solution transmission IDs.
+                self.prior_solution_transmission_ids_map()
+                    .insert(block.hash(), block.prior_solution_transmission_ids().clone().unwrap_or_default())?;
+
+                // Store the aborted solution transmission ids.
+                self.aborted_solution_transmission_ids_map()
+                    .insert(block.hash(), block.aborted_solution_transmission_ids().clone().unwrap_or_default())?;
+            }
             // Store the aborted solution IDs.
             self.aborted_solution_ids_map().insert(block.hash(), block.aborted_solution_ids().clone())?;
-
             // Store the block aborted solution heights.
             for solution_id in block.aborted_solution_ids() {
                 self.aborted_solution_heights_map().insert(*solution_id, block.height())?;
@@ -433,6 +483,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             // Store the transaction IDs.
             self.transactions_map().insert(block.hash(), block.transaction_ids().copied().collect())?;
 
+            if N::CONSENSUS_VERSION(block.height()).unwrap() >= ConsensusVersion::V10 {
+                // Store the prior transaction IDs.
+                self.prior_transaction_transmission_ids_map()
+                    .insert(block.hash(), block.prior_transaction_transmission_ids().clone().unwrap_or_default())?;
+
+                // Store the aborted transaction transmission ids.
+                self.aborted_transaction_transmission_ids_map()
+                    .insert(block.hash(), block.aborted_transaction_transmission_ids().clone().unwrap_or_default())?;
+            }
             // Store the aborted transaction IDs.
             self.aborted_transaction_ids_map().insert(block.hash(), block.aborted_transaction_ids().clone())?;
             for aborted_transaction_id in block.aborted_transaction_ids() {
@@ -501,9 +560,9 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         // Determine the certificate IDs to remove.
         let certificate_ids_to_remove = match self.authority_map().get_confirmed(block_hash)? {
             Some(authority) => match &authority {
-                Cow::Owned(Authority::Beacon(_)) | Cow::Borrowed(Authority::Beacon(_)) => Vec::new(),
+                Cow::Owned(Authority::Beacon(_)) | Cow::Borrowed(Authority::Beacon(_)) => None,
                 Cow::Owned(Authority::Quorum(subdag)) | Cow::Borrowed(Authority::Quorum(subdag)) => {
-                    subdag.values().flatten().map(|c| c.id()).collect()
+                    Some(subdag.certificate_ids())
                 }
             },
             None => bail!("Failed to remove block: missing authority for block '{block_height}' ('{block_hash}')"),
@@ -526,8 +585,10 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             self.authority_map().remove(block_hash)?;
 
             // Remove the block certificates.
-            for certificate_id in certificate_ids_to_remove.iter() {
-                self.certificate_map().remove(certificate_id)?;
+            if let Some(certificate_ids_to_remove) = certificate_ids_to_remove {
+                for certificate_id in certificate_ids_to_remove {
+                    self.certificate_map().remove(&certificate_id)?;
+                }
             }
 
             // Remove the block ratifications.
@@ -742,40 +803,6 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         self.certificate_map().contains_key_confirmed(certificate_id)
     }
 
-    /// Returns the batch certificate for the given `certificate ID`.
-    fn get_batch_certificate(&self, certificate_id: &Field<N>) -> Result<Option<BatchCertificate<N>>> {
-        // Retrieve the height and round for the given certificate ID.
-        let Some((block_height, round)) = self.certificate_map().get_confirmed(certificate_id)?.map(|x| *x) else {
-            return Ok(None);
-        };
-        // Retrieve the block hash.
-        let Some(block_hash) = self.get_block_hash(block_height)? else {
-            bail!("The block hash for block '{block_height}' is missing in block storage")
-        };
-        // Retrieve the authority for the given block hash.
-        let Some(authority) = self.authority_map().get_confirmed(&block_hash)? else {
-            bail!("The authority for '{block_hash}' is missing in block storage")
-        };
-        // Retrieve the certificate for the given certificate ID.
-        match &authority {
-            Cow::Owned(Authority::Quorum(subdag)) | Cow::Borrowed(Authority::Quorum(subdag)) => {
-                match subdag.get(&round) {
-                    Some(certificates) => {
-                        // Retrieve the certificate for the given certificate ID.
-                        match certificates.iter().find(|certificate| &certificate.id() == certificate_id) {
-                            Some(certificate) => Ok(Some(certificate.clone())),
-                            None => bail!("The certificate '{certificate_id}' is missing in block storage"),
-                        }
-                    }
-                    None => bail!("The certificates for round '{round}' is missing in block storage"),
-                }
-            }
-            _ => bail!(
-                "Cannot fetch batch certificate '{certificate_id}' - The authority for block '{block_height}' is not a subdag"
-            ),
-        }
-    }
-
     /// Returns the block ratifications for the given `block hash`.
     fn get_block_ratifications(&self, block_hash: &N::BlockHash) -> Result<Option<Ratifications<N>>> {
         Ok(self.ratifications_map().get_confirmed(block_hash)?.map(|x| x.into_owned()))
@@ -812,6 +839,28 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         }
     }
 
+    /// Returns the block prior solution transmission IDs for the given `block hash`.
+    fn get_block_prior_solution_transmission_ids(
+        &self,
+        block_hash: &N::BlockHash,
+    ) -> Result<Option<Vec<TransmissionID<N>>>> {
+        match self.prior_solution_transmission_ids_map().get_confirmed(block_hash)? {
+            Some(ids) => Ok(Some(ids.to_vec())),
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the block aborted solution transmission IDs for the given `block hash`.
+    fn get_block_aborted_solution_transmission_ids(
+        &self,
+        block_hash: &N::BlockHash,
+    ) -> Result<Option<Vec<TransmissionID<N>>>> {
+        match self.aborted_solution_transmission_ids_map().get_confirmed(block_hash)? {
+            Some(ids) => Ok(Some(ids.to_vec())),
+            None => Ok(None),
+        }
+    }
+
     /// Returns the block aborted solution IDs for the given `block hash`.
     fn get_block_aborted_solution_ids(&self, block_hash: &N::BlockHash) -> Result<Option<Vec<SolutionID<N>>>> {
         Ok(self.aborted_solution_ids_map().get_confirmed(block_hash)?.map(|x| x.into_owned()))
@@ -833,6 +882,28 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     /// Returns the block aborted transaction IDs for the given `block hash`.
     fn get_block_aborted_transaction_ids(&self, block_hash: &N::BlockHash) -> Result<Option<Vec<N::TransactionID>>> {
         Ok(self.aborted_transaction_ids_map().get_confirmed(block_hash)?.map(|x| x.into_owned()))
+    }
+
+    /// Returns the block prior transaction transmission IDs for the given `block hash`.
+    fn get_block_prior_transaction_transmission_ids(
+        &self,
+        block_hash: &N::BlockHash,
+    ) -> Result<Option<Vec<TransmissionID<N>>>> {
+        match self.prior_transaction_transmission_ids_map().get_confirmed(block_hash)? {
+            Some(ids) => Ok(Some(ids.to_vec())),
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the block aborted transaction transmission IDs for the given `block hash`.
+    fn get_block_aborted_transaction_transmission_ids(
+        &self,
+        block_hash: &N::BlockHash,
+    ) -> Result<Option<Vec<TransmissionID<N>>>> {
+        match self.aborted_transaction_transmission_ids_map().get_confirmed(block_hash)? {
+            Some(ids) => Ok(Some(ids.to_vec())),
+            None => Ok(None),
+        }
     }
 
     /// Returns the transaction for the given `TransactionID`.
@@ -945,6 +1016,14 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         let Ok(solutions) = self.get_block_solutions(block_hash) else {
             bail!("Missing solutions for block {height} ('{block_hash}')");
         };
+        // Retrieve the block prior solution transmission IDs.
+        let Ok(prior_solution_transmission_ids) = self.get_block_prior_solution_transmission_ids(block_hash) else {
+            bail!("Missing prior solution transmission IDs for block {height} ('{block_hash}')");
+        };
+        // Retrieve the block prior solution transmission IDs.
+        let Ok(aborted_solution_transmission_ids) = self.get_block_aborted_solution_transmission_ids(block_hash) else {
+            bail!("Missing aborted solution transmission IDs for block {height} ('{block_hash}')");
+        };
         // Retrieve the block aborted solution IDs.
         let Some(aborted_solution_ids) = self.get_block_aborted_solution_ids(block_hash)? else {
             bail!("Missing aborted solutions IDs for block {height} ('{block_hash}')");
@@ -953,20 +1032,33 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         let Some(transactions) = self.get_block_transactions(block_hash)? else {
             bail!("Missing transactions for block {height} ('{block_hash}')");
         };
+        // Retrieve the block prior solution transmission IDs.
+        let Ok(prior_transaction_transmission_ids) = self.get_block_prior_transaction_transmission_ids(block_hash)
+        else {
+            bail!("Missing prior transaction transmission IDs for block {height} ('{block_hash}')");
+        };
+        // Retrieve the block prior solution transmission IDs.
+        let Ok(aborted_transaction_transmission_ids) = self.get_block_aborted_transaction_transmission_ids(block_hash)
+        else {
+            bail!("Missing aborted transaction transmission IDs for block {height} ('{block_hash}')");
+        };
         // Retrieve the block aborted transaction IDs.
         let Some(aborted_transaction_ids) = self.get_block_aborted_transaction_ids(block_hash)? else {
             bail!("Missing aborted transaction IDs for block {height} ('{block_hash}')");
         };
 
-        // Return the block.
         Ok(Some(Block::from(
             previous_hash,
             header,
             authority,
             ratifications,
             solutions,
+            prior_solution_transmission_ids,
+            aborted_solution_transmission_ids,
             aborted_solution_ids,
             transactions,
+            prior_transaction_transmission_ids,
+            aborted_transaction_transmission_ids,
             aborted_transaction_ids,
         )?))
     }
@@ -1288,11 +1380,6 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     /// Returns true if there is a block for the given certificate.
     pub fn contains_block_for_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         self.storage.contains_block_for_certificate(certificate_id)
-    }
-
-    /// Returns the batch certificate for the given `certificate ID`.
-    pub fn get_batch_certificate(&self, certificate_id: &Field<N>) -> Result<Option<BatchCertificate<N>>> {
-        self.storage.get_batch_certificate(certificate_id)
     }
 }
 

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -472,12 +472,14 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
                 // Store the aborted solution transmission ids.
                 self.aborted_solution_transmission_ids_map()
                     .insert(block.hash(), block.aborted_solution_transmission_ids().clone().unwrap_or_default())?;
-            }
-            // Store the aborted solution IDs.
-            self.aborted_solution_ids_map().insert(block.hash(), block.aborted_solution_ids().clone())?;
-            // Store the block aborted solution heights.
-            for solution_id in block.aborted_solution_ids() {
-                self.aborted_solution_heights_map().insert(*solution_id, block.height())?;
+            } else {
+                // Store the aborted solution IDs.
+                self.aborted_solution_ids_map()
+                    .insert(block.hash(), block.aborted_solution_ids().cloned().unwrap_or_default())?;
+                // Store the block aborted solution heights.
+                for solution_id in block.aborted_solution_ids().into_iter().flatten() {
+                    self.aborted_solution_heights_map().insert(*solution_id, block.height())?;
+                }
             }
 
             // Store the transaction IDs.
@@ -491,11 +493,13 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
                 // Store the aborted transaction transmission ids.
                 self.aborted_transaction_transmission_ids_map()
                     .insert(block.hash(), block.aborted_transaction_transmission_ids().clone().unwrap_or_default())?;
-            }
-            // Store the aborted transaction IDs.
-            self.aborted_transaction_ids_map().insert(block.hash(), block.aborted_transaction_ids().clone())?;
-            for aborted_transaction_id in block.aborted_transaction_ids() {
-                self.rejected_or_aborted_transaction_id_map().insert(*aborted_transaction_id, block.hash())?;
+            } else {
+                // Store the aborted transaction IDs.
+                self.aborted_transaction_ids_map()
+                    .insert(block.hash(), block.aborted_transaction_ids().cloned().unwrap_or_default())?;
+                for aborted_transaction_id in block.aborted_transaction_ids().into_iter().flatten() {
+                    self.rejected_or_aborted_transaction_id_map().insert(*aborted_transaction_id, block.hash())?;
+                }
             }
 
             // Store the rejected transactions IDs.
@@ -1025,7 +1029,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             bail!("Missing aborted solution transmission IDs for block {height} ('{block_hash}')");
         };
         // Retrieve the block aborted solution IDs.
-        let Some(aborted_solution_ids) = self.get_block_aborted_solution_ids(block_hash)? else {
+        let Ok(aborted_solution_ids) = self.get_block_aborted_solution_ids(block_hash) else {
             bail!("Missing aborted solutions IDs for block {height} ('{block_hash}')");
         };
         // Retrieve the block transactions.
@@ -1043,7 +1047,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
             bail!("Missing aborted transaction transmission IDs for block {height} ('{block_hash}')");
         };
         // Retrieve the block aborted transaction IDs.
-        let Some(aborted_transaction_ids) = self.get_block_aborted_transaction_ids(block_hash)? else {
+        let Ok(aborted_transaction_ids) = self.get_block_aborted_transaction_ids(block_hash) else {
             bail!("Missing aborted transaction IDs for block {height} ('{block_hash}')");
         };
 
@@ -1638,9 +1642,9 @@ mod tests {
             header,
             ratifications,
             None.into(),
-            vec![],
+            Some(vec![]),
             transactions,
-            vec![unconfirmed_id],
+            Some(vec![unconfirmed_id]),
             rng,
         )
         .unwrap();

--- a/ledger/store/src/helpers/memory/block.rs
+++ b/ledger/store/src/helpers/memory/block.rs
@@ -23,6 +23,7 @@ use crate::{
 use console::{prelude::*, types::Field};
 use snarkvm_ledger_authority::Authority;
 use snarkvm_ledger_block::{Header, Ratifications, Rejected, Solutions};
+use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
 use snarkvm_ledger_puzzle::SolutionID;
 use snarkvm_synthesizer_program::FinalizeOperation;
 
@@ -50,6 +51,10 @@ pub struct BlockMemory<N: Network> {
     ratifications_map: MemoryMap<N::BlockHash, Ratifications<N>>,
     /// The solutions map.
     solutions_map: MemoryMap<N::BlockHash, Solutions<N>>,
+    /// The prior solution transmission IDs map.
+    prior_solution_transmission_ids_map: MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>,
+    /// The aborted solution transmission IDs map.
+    aborted_solution_transmission_ids_map: MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>,
     /// The solution IDs map.
     solution_ids_map: MemoryMap<SolutionID<N>, u32>,
     /// The aborted solution IDs map.
@@ -58,6 +63,10 @@ pub struct BlockMemory<N: Network> {
     aborted_solution_heights_map: MemoryMap<SolutionID<N>, u32>,
     /// The transactions map.
     transactions_map: MemoryMap<N::BlockHash, Vec<N::TransactionID>>,
+    /// The prior transaction transmission ids map.
+    prior_transaction_transmission_ids_map: MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>,
+    /// The aborted transaction transmission ids map.
+    aborted_transaction_transmission_ids_map: MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>,
     /// The aborted transaction IDs map.
     aborted_transaction_ids_map: MemoryMap<N::BlockHash, Vec<N::TransactionID>>,
     /// The rejected transaction ID or aborted transaction ID map.
@@ -82,10 +91,14 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     type CertificateMap = MemoryMap<Field<N>, (u32, u64)>;
     type RatificationsMap = MemoryMap<N::BlockHash, Ratifications<N>>;
     type SolutionsMap = MemoryMap<N::BlockHash, Solutions<N>>;
+    type PriorSolutionTransmissionIDsMap = MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>;
+    type AbortedSolutionTransmissionIDsMap = MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>;
     type SolutionIDsMap = MemoryMap<SolutionID<N>, u32>;
     type AbortedSolutionIDsMap = MemoryMap<N::BlockHash, Vec<SolutionID<N>>>;
     type AbortedSolutionHeightsMap = MemoryMap<SolutionID<N>, u32>;
     type TransactionsMap = MemoryMap<N::BlockHash, Vec<N::TransactionID>>;
+    type PriorTransactionTransmissionIDsMap = MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>;
+    type AbortedTransactionTransmissionIDsMap = MemoryMap<N::BlockHash, Vec<TransmissionID<N>>>;
     type AbortedTransactionIDsMap = MemoryMap<N::BlockHash, Vec<N::TransactionID>>;
     type RejectedOrAbortedTransactionIDMap = MemoryMap<N::TransactionID, N::BlockHash>;
     type ConfirmedTransactionsMap = MemoryMap<N::TransactionID, (N::BlockHash, ConfirmedTxType<N>, Vec<FinalizeOperation<N>>)>;
@@ -110,10 +123,14 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
             certificate_map: MemoryMap::default(),
             ratifications_map: MemoryMap::default(),
             solutions_map: MemoryMap::default(),
+            prior_solution_transmission_ids_map: MemoryMap::default(),
+            aborted_solution_transmission_ids_map: MemoryMap::default(),
             solution_ids_map: MemoryMap::default(),
             aborted_solution_ids_map: MemoryMap::default(),
             aborted_solution_heights_map: MemoryMap::default(),
             transactions_map: MemoryMap::default(),
+            prior_transaction_transmission_ids_map: MemoryMap::default(),
+            aborted_transaction_transmission_ids_map: MemoryMap::default(),
             aborted_transaction_ids_map: MemoryMap::default(),
             rejected_or_aborted_transaction_id_map: MemoryMap::default(),
             confirmed_transactions_map: MemoryMap::default(),
@@ -167,6 +184,16 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
         &self.solutions_map
     }
 
+    /// Returns the prior solution transmission ids map.
+    fn prior_solution_transmission_ids_map(&self) -> &Self::PriorSolutionTransmissionIDsMap {
+        &self.prior_solution_transmission_ids_map
+    }
+
+    /// Returns the aborted solution transmission ids map.
+    fn aborted_solution_transmission_ids_map(&self) -> &Self::PriorSolutionTransmissionIDsMap {
+        &self.aborted_solution_transmission_ids_map
+    }
+
     /// Returns the solution IDs map.
     fn solution_ids_map(&self) -> &Self::SolutionIDsMap {
         &self.solution_ids_map
@@ -185,6 +212,16 @@ impl<N: Network> BlockStorage<N> for BlockMemory<N> {
     /// Returns the transactions map.
     fn transactions_map(&self) -> &Self::TransactionsMap {
         &self.transactions_map
+    }
+
+    /// Returns the prior transaction transmission ids map.
+    fn prior_transaction_transmission_ids_map(&self) -> &Self::PriorTransactionTransmissionIDsMap {
+        &self.prior_transaction_transmission_ids_map
+    }
+
+    /// Returns the aborted transaction transmission ids map.
+    fn aborted_transaction_transmission_ids_map(&self) -> &Self::AbortedTransactionTransmissionIDsMap {
+        &self.aborted_transaction_transmission_ids_map
     }
 
     /// Returns the aborted transaction IDs map.

--- a/ledger/store/src/helpers/rocksdb/block.rs
+++ b/ledger/store/src/helpers/rocksdb/block.rs
@@ -29,6 +29,7 @@ use crate::{
 use console::{prelude::*, types::Field};
 use snarkvm_ledger_authority::Authority;
 use snarkvm_ledger_block::{Header, Ratifications, Rejected, Solutions};
+use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
 use snarkvm_ledger_puzzle::SolutionID;
 use snarkvm_synthesizer_program::FinalizeOperation;
 
@@ -56,6 +57,10 @@ pub struct BlockDB<N: Network> {
     ratifications_map: DataMap<N::BlockHash, Ratifications<N>>,
     /// The solutions map.
     solutions_map: DataMap<N::BlockHash, Solutions<N>>,
+    /// The prior solution transmission ids map.
+    prior_solution_transmission_ids_map: DataMap<N::BlockHash, Vec<TransmissionID<N>>>,
+    /// The aborted solution transmission ids map.
+    aborted_solution_transmission_ids_map: DataMap<N::BlockHash, Vec<TransmissionID<N>>>,
     /// The solution IDs map.
     solution_ids_map: DataMap<SolutionID<N>, u32>,
     /// The aborted solution IDs map.
@@ -64,6 +69,10 @@ pub struct BlockDB<N: Network> {
     aborted_solution_heights_map: DataMap<SolutionID<N>, u32>,
     /// The transactions map.
     transactions_map: DataMap<N::BlockHash, Vec<N::TransactionID>>,
+    /// The prior transaction transmission ids map.
+    prior_transaction_transmission_ids_map: DataMap<N::BlockHash, Vec<TransmissionID<N>>>,
+    /// The aborted transaction transmission ids map.
+    aborted_transaction_transmission_ids_map: DataMap<N::BlockHash, Vec<TransmissionID<N>>>,
     /// The aborted transaction IDs map.
     aborted_transaction_ids_map: DataMap<N::BlockHash, Vec<N::TransactionID>>,
     /// The rejected or aborted transaction ID map.
@@ -88,10 +97,14 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
     type CertificateMap = DataMap<Field<N>, (u32, u64)>;
     type RatificationsMap = DataMap<N::BlockHash, Ratifications<N>>;
     type SolutionsMap = DataMap<N::BlockHash, Solutions<N>>;
+    type PriorSolutionTransmissionIDsMap = DataMap<N::BlockHash, Vec<TransmissionID<N>>>;
+    type AbortedSolutionTransmissionIDsMap = DataMap<N::BlockHash, Vec<TransmissionID<N>>>;
     type SolutionIDsMap = DataMap<SolutionID<N>, u32>;
     type AbortedSolutionIDsMap = DataMap<N::BlockHash, Vec<SolutionID<N>>>;
     type AbortedSolutionHeightsMap = DataMap<SolutionID<N>, u32>;
     type TransactionsMap = DataMap<N::BlockHash, Vec<N::TransactionID>>;
+    type PriorTransactionTransmissionIDsMap = DataMap<N::BlockHash, Vec<TransmissionID<N>>>;
+    type AbortedTransactionTransmissionIDsMap = DataMap<N::BlockHash, Vec<TransmissionID<N>>>;
     type AbortedTransactionIDsMap = DataMap<N::BlockHash, Vec<N::TransactionID>>;
     type RejectedOrAbortedTransactionIDMap = DataMap<N::TransactionID, N::BlockHash>;
     type ConfirmedTransactionsMap = DataMap<N::TransactionID, (N::BlockHash, ConfirmedTxType<N>, Vec<FinalizeOperation<N>>)>;
@@ -117,11 +130,15 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
             certificate_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::Certificate))?,
             ratifications_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::Ratifications))?,
             solutions_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::Solutions))?,
+            prior_solution_transmission_ids_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::PriorSolutionTransmissionIDs))?,
+            aborted_solution_transmission_ids_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::AbortedSolutionTransmissionIDs))?,
             solution_ids_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::PuzzleCommitments))?,
             aborted_solution_ids_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::AbortedSolutionIDs))?,
             aborted_solution_heights_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::AbortedSolutionHeights))?,
             transactions_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::Transactions))?,
             aborted_transaction_ids_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::AbortedTransactionIDs))?,
+            prior_transaction_transmission_ids_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::PriorTransactionTransmissionIDs))?,
+            aborted_transaction_transmission_ids_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::AbortedTransactionTransmissionIDs))?,
             rejected_or_aborted_transaction_id_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::RejectedOrAbortedTransactionID))?,
             confirmed_transactions_map: internal::RocksDB::open_map(N::ID, storage.clone(), MapID::Block(BlockMap::ConfirmedTransactions))?,
             rejected_deployment_or_execution_map: internal::RocksDB::open_map(N::ID, storage, MapID::Block(BlockMap::RejectedDeploymentOrExecution))?,
@@ -174,6 +191,16 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
         &self.solutions_map
     }
 
+    /// Returns the prior solution transmission ids map.
+    fn prior_solution_transmission_ids_map(&self) -> &Self::PriorSolutionTransmissionIDsMap {
+        &self.prior_solution_transmission_ids_map
+    }
+
+    /// Returns the aborted solution transmission ids map.
+    fn aborted_solution_transmission_ids_map(&self) -> &Self::AbortedSolutionTransmissionIDsMap {
+        &self.aborted_solution_transmission_ids_map
+    }
+
     /// Returns the solution IDs map.
     fn solution_ids_map(&self) -> &Self::SolutionIDsMap {
         &self.solution_ids_map
@@ -192,6 +219,16 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
     /// Returns the transactions map.
     fn transactions_map(&self) -> &Self::TransactionsMap {
         &self.transactions_map
+    }
+
+    /// Returns the prior transaction transmission ids map.
+    fn prior_transaction_transmission_ids_map(&self) -> &Self::PriorTransactionTransmissionIDsMap {
+        &self.prior_transaction_transmission_ids_map
+    }
+
+    /// Returns the aborted transaction transmission ids map.
+    fn aborted_transaction_transmission_ids_map(&self) -> &Self::AbortedTransactionTransmissionIDsMap {
+        &self.aborted_transaction_transmission_ids_map
     }
 
     /// Returns the aborted transaction IDs map.

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -78,10 +78,14 @@ pub enum BlockMap {
     Certificate = DataID::BlockCertificateMap as u16,
     Ratifications = DataID::BlockRatificationsMap as u16,
     Solutions = DataID::BlockSolutionsMap as u16,
+    PriorSolutionTransmissionIDs = DataID::BlockPriorSolutionTransmissionIDsMap as u16,
+    AbortedSolutionTransmissionIDs = DataID::BlockAbortedSolutionTransmissionIDsMap as u16,
     PuzzleCommitments = DataID::BlockSolutionIDsMap as u16,
     AbortedSolutionIDs = DataID::BlockAbortedSolutionIDsMap as u16,
     AbortedSolutionHeights = DataID::BlockAbortedSolutionHeightsMap as u16,
     Transactions = DataID::BlockTransactionsMap as u16,
+    PriorTransactionTransmissionIDs = DataID::BlockPriorTransactionTransmissionIDsMap as u16,
+    AbortedTransactionTransmissionIDs = DataID::BlockAbortedTransactionTransmissionIDsMap as u16,
     AbortedTransactionIDs = DataID::BlockAbortedTransactionIDsMap as u16,
     RejectedOrAbortedTransactionID = DataID::BlockRejectedOrAbortedTransactionIDMap as u16,
     ConfirmedTransactions = DataID::BlockConfirmedTransactionsMap as u16,
@@ -303,6 +307,12 @@ enum DataID {
     IDEditionMap,
     // Track deployments that contain an optional checksum
     DeploymentChecksumMap,
+
+    // Compact Subdag support
+    BlockPriorSolutionTransmissionIDsMap,
+    BlockAbortedSolutionTransmissionIDsMap,
+    BlockPriorTransactionTransmissionIDsMap,
+    BlockAbortedTransactionTransmissionIDsMap,
 
     // Testing
     #[cfg(test)]

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -664,9 +664,9 @@ fn sample_genesis_block_and_components_raw(
         header,
         ratifications,
         None.into(),
-        vec![],
+        Some(vec![]),
         transactions.clone(),
-        vec![],
+        Some(vec![]),
         rng,
     )
     .unwrap();

--- a/ledger/tests/helpers/mod.rs
+++ b/ledger/tests/helpers/mod.rs
@@ -20,7 +20,7 @@ use snarkvm_console::{
     prelude::*,
 };
 use snarkvm_ledger::{Block, Ledger};
-use snarkvm_ledger_narwhal::{BatchCertificate, BatchHeader, Subdag};
+use snarkvm_ledger_narwhal::{BatchCertificate, BatchHeader, NarwhalCertificate, Subdag};
 use snarkvm_ledger_store::ConsensusStore;
 use snarkvm_synthesizer::vm::VM;
 
@@ -282,7 +282,7 @@ impl TestChainBuilder {
         self.last_committed_batch_round.insert(leader_idx, commit_round);
 
         // Construct the block.
-        let subdag = Subdag::from(subdag_map).unwrap();
+        let subdag = Subdag::from_full(subdag_map).unwrap();
         let block = self.ledger.prepare_advance_to_next_quorum_block(subdag, Default::default(), rng).unwrap();
         self.ledger.check_next_block(&block, rng).unwrap();
 

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1571,9 +1571,9 @@ finalize transfer_public:
             header,
             ratifications,
             None.into(),
-            vec![],
+            Some(vec![]),
             transactions,
-            aborted_transaction_ids,
+            Some(aborted_transaction_ids),
             rng,
         )?;
 
@@ -2608,7 +2608,7 @@ finalize compute:
                 .unwrap();
 
         // Ensure that the excess transactions were aborted.
-        assert_eq!(next_block.aborted_transaction_ids(), &excess_transaction_ids);
+        assert_eq!(next_block.aborted_transaction_ids().unwrap(), &excess_transaction_ids);
         assert_eq!(next_block.transactions().len(), VM::<CurrentNetwork, LedgerType>::MAXIMUM_CONFIRMED_TRANSACTIONS);
     }
 

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -399,9 +399,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             header,
             ratifications,
             solutions,
-            aborted_solution_ids,
+            Some(aborted_solution_ids),
             transactions,
-            aborted_transaction_ids,
+            Some(aborted_transaction_ids),
             rng,
         )?;
         // Ensure the block is valid genesis block.
@@ -893,9 +893,9 @@ function compute:
             header,
             ratifications,
             None.into(),
-            vec![],
+            Some(vec![]),
             transactions,
-            aborted_transaction_ids,
+            Some(aborted_transaction_ids),
             rng,
         )
     }
@@ -1639,7 +1639,7 @@ function do:
         let block = sample_next_block(&vm, &private_key, &[transaction, adjusted_transaction.clone()], rng).unwrap();
 
         // Check that the block aborts the deployment transaction.
-        assert_eq!(block.aborted_transaction_ids(), &vec![adjusted_transaction.id()]);
+        assert_eq!(block.aborted_transaction_ids(), Some(&vec![adjusted_transaction.id()]));
 
         // Update the VM.
         vm.add_next_block(&block).unwrap();
@@ -1720,7 +1720,7 @@ function do:
         let block = sample_next_block(&vm, &private_key, &[transaction, adjusted_transaction.clone()], rng).unwrap();
 
         // Check that the block aborts the deployment transaction.
-        assert_eq!(block.aborted_transaction_ids(), &vec![adjusted_transaction.id()]);
+        assert_eq!(block.aborted_transaction_ids(), Some(&vec![adjusted_transaction.id()]));
 
         // Update the VM.
         vm.add_next_block(&block).unwrap();
@@ -2993,7 +2993,7 @@ function add_thrice:
         let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
 
         // Check that the transaction was aborted.
-        assert_eq!(block.aborted_transaction_ids().len(), 1);
+        assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
 
         // Update the VM.
         vm.add_next_block(&block).unwrap();
@@ -3227,7 +3227,7 @@ function check:
         let block = sample_next_block(&vm, &caller_private_key, &[tx_1, tx_2], rng).unwrap();
         assert_eq!(block.transactions().num_accepted(), 2);
         assert_eq!(block.transactions().num_rejected(), 0);
-        assert_eq!(block.aborted_transaction_ids().len(), 0);
+        assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
         vm.add_next_block(&block).unwrap();
 
         // Deploy two programs that depend on each other.
@@ -3279,7 +3279,7 @@ function adder:
         let block = sample_next_block(&vm, &caller_private_key, &[deployment_1, deployment_2], rng).unwrap();
         assert_eq!(block.transactions().num_accepted(), 1);
         assert_eq!(block.transactions().num_rejected(), 0);
-        assert_eq!(block.aborted_transaction_ids().len(), 1);
+        assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
         vm.add_next_block(&block).unwrap();
 
         // Check that only `child_program.aleo` is in the VM.
@@ -3320,7 +3320,7 @@ function adder:
             let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
             assert_eq!(block.transactions().num_accepted(), 1);
             assert_eq!(block.transactions().num_rejected(), 0);
-            assert_eq!(block.aborted_transaction_ids().len(), 0);
+            assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
             vm.add_next_block(&block).unwrap();
         }
 
@@ -3409,7 +3409,7 @@ function adder:
         let block = sample_next_block(&vm, &caller_private_key, &[deployment, transaction], rng).unwrap();
         assert_eq!(block.transactions().num_accepted(), 1);
         assert_eq!(block.transactions().num_rejected(), 0);
-        assert_eq!(block.aborted_transaction_ids().len(), 1);
+        assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
         vm.add_next_block(&block).unwrap();
 
         // Check that the program was deployed.

--- a/synthesizer/src/vm/tests/test_v8.rs
+++ b/synthesizer/src/vm/tests/test_v8.rs
@@ -86,7 +86,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Execute the program.
@@ -102,7 +102,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to redeploy the program before `ConsensusVersion::V8`.
@@ -110,7 +110,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Check that the consensus version is `V8`.
@@ -131,7 +131,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Attempt to redeploy the program with different code after `ConsensusVersion::V8`.
@@ -143,7 +143,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Verify that the program can be executed after redeployment.
@@ -159,7 +159,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to redeploy the program again after `ConsensusVersion::V8`.
@@ -167,7 +167,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Drop the VM.
@@ -193,7 +193,7 @@ function dummy2:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -262,7 +262,7 @@ finalize run:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Extract a record from the genesis block and `split` it into two smaller records.
@@ -287,7 +287,7 @@ finalize run:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Extract the split record.
@@ -306,7 +306,7 @@ finalize run:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Check that the consensus version is `V8`.
@@ -319,7 +319,7 @@ finalize run:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Execute the `upgrade` function directly.
@@ -335,7 +335,7 @@ finalize run:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
 
     Ok(())
 }
@@ -372,7 +372,7 @@ fn test_deploy_and_redeploy() -> Result<()> {
     let block = sample_next_block(&vm, &caller_private_key, &[transfer], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Initialize the program.
@@ -409,7 +409,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction_0.clone(), transaction_1], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Check the edition of the deployed program.
@@ -429,7 +429,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Redeploy the program with the other private key, using the original deployment.
@@ -455,7 +455,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the program can now be executed.
@@ -471,7 +471,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[execute], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Verify that the program cannot be redeployed further.
@@ -479,7 +479,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
 
     Ok(())
 }

--- a/synthesizer/src/vm/tests/test_v9.rs
+++ b/synthesizer/src/vm/tests/test_v9.rs
@@ -65,7 +65,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Initialize the program.
@@ -82,7 +82,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Verify that the VM is at the V9 height.
@@ -105,7 +105,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Initialize the program.
@@ -122,7 +122,7 @@ function dummy:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -164,7 +164,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the program is deployed.
@@ -208,7 +208,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Upgrade the program.
@@ -233,7 +233,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the program is upgraded.
@@ -250,7 +250,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Execute the upgraded program.
@@ -351,14 +351,14 @@ constructor:
     let block = sample_next_block(&on_chain_vm, &caller_private_key, &[deployment_v1_fail], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     on_chain_vm.add_next_block(&block)?;
 
     // This deployment should pass.
     let block = sample_next_block(&on_chain_vm, &caller_private_key, &[deployment_v0_pass], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     on_chain_vm.add_next_block(&block)?;
     let stack = on_chain_vm.process().read().get_stack("basic.aleo")?;
     assert_eq!(*stack.program_edition(), 0);
@@ -367,14 +367,14 @@ constructor:
     let block = sample_next_block(&on_chain_vm, &caller_private_key, &[deployment_v2_fail], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     on_chain_vm.add_next_block(&block)?;
 
     // This deployment should pass.
     let block = sample_next_block(&on_chain_vm, &caller_private_key, &[deployment_v1_pass], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     on_chain_vm.add_next_block(&block)?;
     let stack = on_chain_vm.process().read().get_stack("basic.aleo")?;
     assert_eq!(*stack.program_edition(), 1);
@@ -383,14 +383,14 @@ constructor:
     let block = sample_next_block(&on_chain_vm, &caller_private_key, &[deployment_v2_as_v1_fail], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     on_chain_vm.add_next_block(&block)?;
 
     // This deployment should pass.
     let block = sample_next_block(&on_chain_vm, &caller_private_key, &[deployment_v2_pass], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     on_chain_vm.add_next_block(&block)?;
     let stack = on_chain_vm.process().read().get_stack("basic.aleo")?;
     assert_eq!(*stack.program_edition(), 2);
@@ -469,7 +469,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Execute the mint function twice.
@@ -494,7 +494,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[mint_execution_0, mint_execution_1], rng)?;
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     let mut v1_records = block
         .records()
         .map(|(_, record)| record.decrypt(&caller_view_key))
@@ -507,7 +507,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to execute the mint function.
@@ -538,7 +538,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[convert_execution], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     let mut v2_records = block
         .records()
         .map(|(_, record)| record.decrypt(&caller_view_key))
@@ -560,7 +560,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[burn_execution], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to execute the burn function with the remaining v1 record.
@@ -671,7 +671,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Execute the store_data_v1 function.
@@ -687,7 +687,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[store_data_v1_execution], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the value was stored correctly.
@@ -706,7 +706,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to execute the store_data_v1 function.
@@ -722,7 +722,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Execute the migrate_data_v1_to_v2 function.
@@ -738,7 +738,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[migrate_data_v1_to_v2_execution], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the value was migrated correctly.
@@ -776,7 +776,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[store_data_v2_execution], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the value was stored correctly.
@@ -949,7 +949,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Deploy the v0 dependent.
@@ -957,7 +957,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Execute the functions.
@@ -982,7 +982,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[tx_1, tx_2], rng)?;
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Verify that the sum function fails on overflow.
@@ -1016,7 +1016,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Verify that the original sum transaction fails after the dependency upgrade.
@@ -1024,7 +1024,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[sum_unchecked], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Verify that the sum function fails on edition check.
@@ -1049,7 +1049,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[tx_1, tx_2], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 2);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Update the dependent to v1.
@@ -1057,7 +1057,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Verify that the sum function passes.
@@ -1082,7 +1082,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[tx_1, tx_2], rng)?;
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -1131,7 +1131,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Deploy the failing program.
@@ -1139,7 +1139,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -1186,7 +1186,7 @@ fn test_anyone_can_upgrade() -> Result<()> {
     let block = sample_next_block(&vm, &caller_private_key, &[transfer_1, transfer_2], rng)?;
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Define the programs.
@@ -1225,7 +1225,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Deploy the second version of the program.
@@ -1233,7 +1233,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Deploy the third version of the program.
@@ -1241,7 +1241,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -1282,14 +1282,14 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     let transaction = vm.deploy(&caller_private_key, &program_1_v1, None, 0, None, rng)?;
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -1369,7 +1369,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Deploy the second version of the program.
@@ -1377,7 +1377,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Set the lock.
@@ -1393,7 +1393,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to deploy the third version of the program.
@@ -1401,7 +1401,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -1518,7 +1518,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the caller is the admin.
@@ -1538,7 +1538,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to set the expected checksum with the wrong admin.
@@ -1563,7 +1563,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block)?;
 
     // Check that there is no expected checksum set.
@@ -1591,7 +1591,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Check that the expected checksum is set.
@@ -1610,7 +1610,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Update with the expected checksum set.
@@ -1618,7 +1618,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -1662,7 +1662,7 @@ function dummy:",
     let block = sample_next_block(&vm, &caller_private_key, &[transaction_first], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Deploy the program again without changing its contents.
@@ -1672,7 +1672,7 @@ function dummy:",
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Deploy the program with an extra mapping as an upgrade.
@@ -1682,7 +1682,7 @@ function dummy:",
     let block = sample_next_block(&vm, &caller_private_key, &[transaction_third], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
 
     Ok(())
 }
@@ -1779,14 +1779,14 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     let transaction = vm.deploy(&caller_private_key, &program_1_v0, None, 0, None, rng)?;
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Assert that the VM is after the V9 height.
@@ -1850,7 +1850,7 @@ fn test_simple_admin_upgrade() {
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Define the programs.
@@ -1880,7 +1880,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Deploy the first version of the program with the correct admin.
@@ -1888,7 +1888,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Attempt to upgrade the program with the wrong admin.
@@ -1896,7 +1896,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Upgrade the program with the correct admin.
@@ -1904,7 +1904,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 }
 
@@ -1949,7 +1949,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Execute a transaction with the first version of the program.
@@ -1978,7 +1978,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify the transaction again and check the cache size.
@@ -2029,7 +2029,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Deploy the second program.
@@ -2041,7 +2041,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Check the owners of the programs.
@@ -2091,7 +2091,7 @@ function dummy2:",
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Pre-generate 3 executions of the dummy function.
@@ -2116,7 +2116,7 @@ function dummy2:",
         let block = sample_next_block(&vm, &caller_private_key, &[execution.clone()], rng).unwrap();
         assert_eq!(block.transactions().num_accepted(), 1);
         assert_eq!(block.transactions().num_rejected(), 0);
-        assert_eq!(block.aborted_transaction_ids().len(), 0);
+        assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
         vm.add_next_block(&block).unwrap();
     }
 
@@ -2125,7 +2125,7 @@ function dummy2:",
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Add the third transaction to a block.
@@ -2133,7 +2133,7 @@ function dummy2:",
     let block = sample_next_block(&vm, &caller_private_key, &[executions[2].clone()], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block).unwrap();
 }
 
@@ -2181,7 +2181,7 @@ fn test_credits_executions() {
     let block = sample_next_block(&vm, &caller_private_key, &[transfer_1], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Skip to consensus height V9.
@@ -2194,7 +2194,7 @@ fn test_credits_executions() {
     let block = sample_next_block(&vm, &caller_private_key, &[transfer_2], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
 }
 
 // This tests verifies that:
@@ -2289,7 +2289,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Deploy the first version of program B.
@@ -2297,7 +2297,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Execute `foo` and `bar`.
@@ -2326,7 +2326,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution_foo, execution_bar], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Upgrade program A to version 1.
@@ -2334,7 +2334,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Execute `foo` and `bar`.
@@ -2363,7 +2363,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution_foo, execution_bar], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Attempt to upgrade program A to version 2.
@@ -2406,7 +2406,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution_foo, execution_bar], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Drop the VM.
@@ -2443,7 +2443,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution_foo, execution_bar], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 }
 
@@ -2491,7 +2491,7 @@ constructor:
     assert_eq!(block.height(), 18);
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to deploy the second version of the program before block height 20.
@@ -2500,7 +2500,7 @@ constructor:
     assert_eq!(block.height(), 19);
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     // Attempt to deploy the second version of the program at block height 20.
@@ -2509,7 +2509,7 @@ constructor:
     assert_eq!(block.height(), 20);
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block)?;
 
     Ok(())
@@ -2588,7 +2588,7 @@ finalize set_first:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment_v0], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Execute the program.
@@ -2606,7 +2606,7 @@ finalize set_first:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify that the entry exists in the mapping.
@@ -2649,7 +2649,7 @@ finalize set_first:
     .unwrap();
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block).unwrap();
 
     // Check that the program was upgraded.
@@ -2676,7 +2676,7 @@ finalize set_first:
     let block = sample_next_block(&vm, &caller_private_key, &[executions[2].clone()], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify that the entry exists in the first mapping.
@@ -2698,7 +2698,7 @@ finalize set_first:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment_v1], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Check that the program was upgraded.
@@ -2711,7 +2711,7 @@ finalize set_first:
     let block = sample_next_block(&vm, &caller_private_key, &[executions[3].clone()], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block).unwrap();
 
     // Execute the new program with the new mapping.
@@ -2729,7 +2729,7 @@ finalize set_first:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify that the entry exists in the second mapping.
@@ -2775,7 +2775,7 @@ function foo:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment_v0], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Fund two accounts to pay for the two upgrades.
@@ -2811,7 +2811,7 @@ function foo:
     let block = sample_next_block(&vm, &caller_private_key, &[tx_1, tx_2], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 2);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Upgrade the program twice.
@@ -2892,7 +2892,7 @@ function baz:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction_1, transaction_2], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block).unwrap();
 
     // Attempt to upgrade twice using the same edition.
@@ -2973,7 +2973,7 @@ function fly:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction_1, transaction_2], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 1);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
 }
 
 // This test checks that:
@@ -3025,7 +3025,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Deploy the upgradable program.
@@ -3033,7 +3033,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Attempt to execute the upgradable program.
@@ -3051,7 +3051,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block).unwrap();
 
     let execution = vm
@@ -3068,7 +3068,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Upgrade the pre-V9 program.
@@ -3076,7 +3076,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Now execute the upgradable program.
@@ -3094,7 +3094,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 }
 
@@ -3165,7 +3165,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Deploy child programs up to the maximum transition depth.
@@ -3175,7 +3175,7 @@ constructor:
         let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
         assert_eq!(block.transactions().num_accepted(), 1);
         assert_eq!(block.transactions().num_rejected(), 0);
-        assert_eq!(block.aborted_transaction_ids().len(), 0);
+        assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
         vm.add_next_block(&block).unwrap();
     }
 
@@ -3194,7 +3194,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Deploy a program lower than the lowest program.
@@ -3214,7 +3214,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Upgrade the zero program to call the lower program.
@@ -3236,7 +3236,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify that the zero program can be executed.
@@ -3254,7 +3254,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify the uppermost parent cannot be executed.
@@ -3284,7 +3284,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Drop the VM.
@@ -3330,7 +3330,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 }
 
@@ -3429,7 +3429,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[child_deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Deploy the parent program.
@@ -3437,7 +3437,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[parent_deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Execute the parent program.
@@ -3455,7 +3455,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Upgrade the child program with a more expensive finalize body.
@@ -3481,7 +3481,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[upgraded_child_deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Execute the child program.
@@ -3499,7 +3499,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify that the parent program cannot be executed after the upgrade.
@@ -3517,7 +3517,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block).unwrap();
 
     // Drop the VM.
@@ -3549,7 +3549,7 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 0);
     vm.add_next_block(&block).unwrap();
 
     // Verify that the parent program still cannot be executed.
@@ -3567,6 +3567,6 @@ constructor:
     let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 0);
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    assert_eq!(block.aborted_transaction_ids().unwrap().len(), 1);
     vm.add_next_block(&block).unwrap();
 }

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -900,9 +900,9 @@ mod tests {
             deployment_header,
             ratifications,
             None.into(),
-            vec![],
+            Some(vec![]),
             transactions,
-            aborted_transaction_ids,
+            Some(aborted_transaction_ids),
             rng,
         )
         .unwrap();
@@ -1252,7 +1252,7 @@ function compute:
             rng,
         )
         .unwrap();
-        assert_eq!(next_block.aborted_transaction_ids(), &vec![
+        assert_eq!(next_block.aborted_transaction_ids().unwrap(), &vec![
             deploy_1_tx_id,
             deploy_2_tx_id,
             deploy_3_tx_id,
@@ -1546,7 +1546,7 @@ mod credits_migration_tests {
         println!("\n\n TOTAL UPGRADED: {total_upgraded}\n\n");
         let num_aborted = usize::try_from((total_upgraded - TOTAL_UPGRADE_LIMIT) / RECORD_UPGRADE_LIMIT).unwrap();
         assert_eq!(next_block.transactions().len() + num_aborted, combined_upgrades.len());
-        assert_eq!(next_block.aborted_transaction_ids().len(), num_aborted);
+        assert_eq!(next_block.aborted_transaction_ids().unwrap().len(), num_aborted);
         assert!(num_aborted > 0);
     }
 
@@ -1715,7 +1715,7 @@ function local_transfer:
         let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &[local_transfer], rng).unwrap();
         assert_eq!(next_block.transactions().num_accepted(), 0);
         assert_eq!(next_block.transactions().num_rejected(), 0);
-        assert_eq!(next_block.aborted_transaction_ids().len(), 1);
+        assert_eq!(next_block.aborted_transaction_ids().unwrap().len(), 1);
         vm.add_next_block(&next_block).unwrap();
 
         // Re-deploy the program.
@@ -1723,7 +1723,7 @@ function local_transfer:
         let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &[deployment], rng).unwrap();
         assert_eq!(next_block.transactions().num_accepted(), 1);
         assert_eq!(next_block.transactions().num_rejected(), 0);
-        assert_eq!(next_block.aborted_transaction_ids().len(), 0);
+        assert_eq!(next_block.aborted_transaction_ids().unwrap().len(), 0);
         vm.add_next_block(&next_block).unwrap();
 
         // Execute the local transfer again.
@@ -1734,7 +1734,7 @@ function local_transfer:
         let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &[local_transfer], rng).unwrap();
         assert_eq!(next_block.transactions().num_accepted(), 1);
         assert_eq!(next_block.transactions().num_rejected(), 0);
-        assert_eq!(next_block.aborted_transaction_ids().len(), 0);
+        assert_eq!(next_block.aborted_transaction_ids().unwrap().len(), 0);
     }
 
     #[cfg(feature = "test")]
@@ -1854,7 +1854,7 @@ function transfer:
         let next_block = crate::vm::test_helpers::sample_next_block(&vm, &private_key, &[deployment], rng).unwrap();
         assert_eq!(next_block.transactions().num_accepted(), 1);
         assert_eq!(next_block.transactions().num_rejected(), 0);
-        assert_eq!(next_block.aborted_transaction_ids().len(), 0);
+        assert_eq!(next_block.aborted_transaction_ids().unwrap().len(), 0);
         vm.add_next_block(&next_block).unwrap();
 
         let transfer_2 = {

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -549,9 +549,9 @@ fn construct_next_block<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>
         header,
         ratifications,
         None.into(),
-        vec![],
+        Some(vec![]),
         transactions,
-        aborted_transaction_ids,
+        Some(aborted_transaction_ids),
         rng,
     )
 }


### PR DESCRIPTION
A revival of https://github.com/ProvableHQ/snarkVM/pull/2304.

Filing as a draft for now, as due to the age of the aforelinked PR it was a challenging rebase, and further adjustments may be needed.

# Design
The goal of this PR is to decrease the bandwidth usage during block sync. If we scale to large amounts of validators (e.g. 100), besides signatures, duplicate transmissions may take up a significant amount of space.

To achieve this:
- Prior transmission IDs and new transmissions are stored in a Block just once.
- CompactHeaders, CompactCertificates and Compact Subdags reference these with ordered u32 indices
- New Quorum blocks are created, stored and broadcasted as Compact.
- Recipients must convert back to full transmissions on the ocassions:
  - For every received block to recompute the batch_id, which in turn ensures the signatures are actually valid.
  - For validators who do at-tip Sync with full certificates or who boot up with full certificates. This is not needed in theory, but require a large refactor to change. Conversion to full certificates can be unchecked.

## TODOs
- [x] Replace bitset by index vec to retain ordering
- [x] Make sure Block contains Optional `{prior, aborted}_{transaction,solution}_transmission_ids`, and stores/retrieves them from disk appropriately
- [ ] Out of Scope: Consider re-use the `SubdagTransmissions` object (or something similar) to unify passing in transmissions for all the conversions to-from compact subdag. This should not stand in the way of passing iterators, we must avoid Cloning these large amounts of data wherever we can...

## Related past PRs
https://github.com/ProvableHQ/snarkVM/pull/1999, https://github.com/ProvableHQ/snarkOS/pull/3000.