### PR TITLE
[Chore] Migrate benchmarks to newer rust-toolchain action

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'staging'
+      - 'bench/rust-toolchain'
+  workflow_dispatch:
 
 jobs:
   # Run benchmarks and stores the output to a file
@@ -17,11 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install required Debian pacakges
         run: sudo apt install -y lld


### PR DESCRIPTION
`actions-rs/toolchain` has been unmaintained for at least three years. See [this issue](https://github.com/actions-rs/toolchain/issues/216). 

This PR also adds `workflow_dispatch` as a trigger for this workflow, so we can run it, if needed, on branches like this.