### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/sync-snarkvm-documentation.yml
+++ b/.github/workflows/sync-snarkvm-documentation.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fetch branch name
         run: echo Running on branch ${GITHUB_REF#refs/heads/}

--- a/.github/workflows/sync-snarkvm-to-welcome-documentation.yml
+++ b/.github/workflows/sync-snarkvm-to-welcome-documentation.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fetch branch name
         run: echo Running on branch ${GITHUB_REF#refs/heads/}


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0