### PR TITLE
[Feat] Implement batched state path fetching

### DIFF
--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -161,6 +161,11 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
 
     /// Returns a list of state paths for the given list of `commitment`s.
     fn get_state_paths_for_commitments(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
+        // Return an empty vector if there are no commitments.
+        if commitments.is_empty() {
+            return Ok(vec![]);
+        }
+
         match self {
             Self::VM(block_store) => block_store.get_state_paths_for_commitments(commitments),
             Self::REST(url) => {

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -159,6 +159,70 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
         }
     }
 
+    /// Returns a list of state paths for the given list of `commitment`s.
+    fn get_state_paths_for_commitments(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
+        match self {
+            Self::VM(block_store) => block_store.get_state_paths_for_commitments(commitments),
+            Self::REST(url) => {
+                // Construct the comma separated string of commitments.
+                let commitments_string = commitments.iter().map(|cm| cm.to_string()).collect::<Vec<_>>().join(",");
+                match N::ID {
+                    console::network::MainnetV0::ID => {
+                        Ok(Self::get_request(&format!("{url}/mainnet/statePaths?commitments={commitments_string}"))?
+                            .body_mut()
+                            .read_json()?)
+                    }
+                    console::network::TestnetV0::ID => {
+                        Ok(Self::get_request(&format!("{url}/testnet/statePaths?commitments={commitments_string}"))?
+                            .body_mut()
+                            .read_json()?)
+                    }
+                    console::network::CanaryV0::ID => {
+                        Ok(Self::get_request(&format!("{url}/canary/statePaths?commitments={commitments_string}"))?
+                            .body_mut()
+                            .read_json()?)
+                    }
+                    _ => bail!("Unsupported network ID in inclusion query"),
+                }
+            }
+            Self::STATIC(query) => query.get_state_paths_for_commitments(commitments),
+        }
+    }
+
+    /// Returns a list of state paths for the given list of `commitment`s.
+    #[cfg(feature = "async")]
+    async fn get_state_paths_for_commitments_async(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
+        match self {
+            Self::VM(block_store) => block_store.get_state_paths_for_commitments(commitments),
+            Self::REST(url) => {
+                // Construct the comma separated string of commitments.
+                let commitments_string = commitments.iter().map(|cm| cm.to_string()).collect::<Vec<_>>().join(",");
+                match N::ID {
+                    console::network::MainnetV0::ID => Ok(Self::get_request_async(&format!(
+                        "{url}/mainnet/statePaths?commitments={commitments_string}"
+                    ))
+                    .await?
+                    .json()
+                    .await?),
+                    console::network::TestnetV0::ID => Ok(Self::get_request_async(&format!(
+                        "{url}/testnet/statePaths?commitments={commitments_string}"
+                    ))
+                    .await?
+                    .json()
+                    .await?),
+                    console::network::CanaryV0::ID => Ok(Self::get_request_async(&format!(
+                        "{url}/canary/statePaths?commitments={commitments_string}"
+                    ))
+                    .await?
+                    .json()
+                    .await?),
+                    _ => bail!("Unsupported network ID in inclusion query"),
+                }
+            }
+            Self::STATIC(query) => query.get_state_paths_for_commitments(commitments),
+        }
+    }
+
     /// Returns a state path for the given `commitment`.
     fn current_block_height(&self) -> Result<u32> {
         match self {

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -176,24 +176,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
             Self::REST(url) => {
                 // Construct the comma separated string of commitments.
                 let commitments_string = commitments.iter().map(|cm| cm.to_string()).collect::<Vec<_>>().join(",");
-                match N::ID {
-                    console::network::MainnetV0::ID => {
-                        Ok(Self::get_request(&format!("{url}/mainnet/statePaths?commitments={commitments_string}"))?
-                            .body_mut()
-                            .read_json()?)
-                    }
-                    console::network::TestnetV0::ID => {
-                        Ok(Self::get_request(&format!("{url}/testnet/statePaths?commitments={commitments_string}"))?
-                            .body_mut()
-                            .read_json()?)
-                    }
-                    console::network::CanaryV0::ID => {
-                        Ok(Self::get_request(&format!("{url}/canary/statePaths?commitments={commitments_string}"))?
-                            .body_mut()
-                            .read_json()?)
-                    }
-                    _ => bail!("Unsupported network ID in inclusion query"),
-                }
+                Self::get_request(&format!("{url}{}/statePaths?commitments={commitments_string}", N::SHORT_NAME))
             }
             Self::STATIC(query) => query.get_state_paths_for_commitments(commitments),
         }
@@ -207,27 +190,8 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
             Self::REST(url) => {
                 // Construct the comma separated string of commitments.
                 let commitments_string = commitments.iter().map(|cm| cm.to_string()).collect::<Vec<_>>().join(",");
-                match N::ID {
-                    console::network::MainnetV0::ID => Ok(Self::get_request_async(&format!(
-                        "{url}/mainnet/statePaths?commitments={commitments_string}"
-                    ))
-                    .await?
-                    .json()
-                    .await?),
-                    console::network::TestnetV0::ID => Ok(Self::get_request_async(&format!(
-                        "{url}/testnet/statePaths?commitments={commitments_string}"
-                    ))
-                    .await?
-                    .json()
-                    .await?),
-                    console::network::CanaryV0::ID => Ok(Self::get_request_async(&format!(
-                        "{url}/canary/statePaths?commitments={commitments_string}"
-                    ))
-                    .await?
-                    .json()
-                    .await?),
-                    _ => bail!("Unsupported network ID in inclusion query"),
-                }
+                Self::get_request_async(&format!("{url}{}/statePaths?commitments={commitments_string}", N::SHORT_NAME))
+                    .await
             }
             Self::STATIC(query) => query.get_state_paths_for_commitments(commitments),
         }

--- a/ledger/query/src/static_query.rs
+++ b/ledger/query/src/static_query.rs
@@ -72,7 +72,7 @@ impl<N: Network> QueryTrait<N> for StaticQuery<N> {
     fn get_state_path_for_commitment(&self, commitment: &Field<N>) -> Result<StatePath<N>> {
         match self.state_paths.get(commitment) {
             Some(state_path) => Ok(state_path.clone()),
-            None => bail!("could not find state path for commitment '{commitment}'"),
+            None => bail!("Could not find state path for commitment '{commitment}'"),
         }
     }
 
@@ -80,6 +80,20 @@ impl<N: Network> QueryTrait<N> for StaticQuery<N> {
     #[cfg(feature = "async")]
     async fn get_state_path_for_commitment_async(&self, _commitment: &Field<N>) -> Result<StatePath<N>> {
         unimplemented!("Async calls are not supported by StaticQuery");
+    }
+
+    /// Returns a list of state paths for the given list of `commitment`s.
+    fn get_state_paths_for_commitments(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
+        commitments
+            .iter()
+            .map(|commitment| self.get_state_path_for_commitment(commitment))
+            .collect::<Result<Vec<StatePath<N>>>>()
+    }
+
+    /// Returns a list of state paths for the given list of `commitment`s.
+    #[cfg(feature = "async")]
+    async fn get_state_paths_for_commitments_async(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
+        self.get_state_paths_for_commitments(commitments)
     }
 
     /// Returns the current block height

--- a/ledger/query/src/traits.rs
+++ b/ledger/query/src/traits.rs
@@ -31,6 +31,13 @@ pub trait QueryTrait<N: Network> {
     #[cfg(feature = "async")]
     async fn get_state_path_for_commitment_async(&self, commitment: &Field<N>) -> Result<StatePath<N>>;
 
+    /// Returns a list of state paths for the given list of `commitment`s.
+    fn get_state_paths_for_commitments(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>>;
+
+    /// Returns a list of state paths for the given list of `commitment`s.
+    #[cfg(feature = "async")]
+    async fn get_state_paths_for_commitments_async(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>>;
+
     /// Returns the current block height
     fn current_block_height(&self) -> Result<u32>;
 

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -75,6 +75,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.vm.block_store().get_state_path_for_commitment(commitment)
     }
 
+    /// Returns a list of state paths for the given list of `commitment`s.
+    pub fn get_state_paths_for_commitments(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
+        self.vm.block_store().get_state_paths_for_commitments(commitments)
+    }
+
     /// Returns the epoch hash for the given block height.
     pub fn get_epoch_hash(&self, block_height: u32) -> Result<N::BlockHash> {
         // Compute the epoch number from the current block height.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -418,6 +418,21 @@ fn test_state_path() {
 }
 
 #[test]
+fn test_state_paths() {
+    let rng = &mut TestRng::default();
+
+    // Initialize the ledger.
+    let ledger = crate::test_helpers::sample_ledger(PrivateKey::<CurrentNetwork>::new(rng).unwrap(), rng);
+    // Retrieve the genesis block.
+    let block = ledger.get_block(0).unwrap();
+
+    // Construct the state path.
+    let commitments = block.transactions().commitments().copied().collect::<Vec<_>>();
+
+    let _state_paths = ledger.get_state_paths_for_commitments(&commitments).unwrap();
+}
+
+#[test]
 fn test_insufficient_private_fees() {
     let rng = &mut TestRng::default();
 

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -714,6 +714,10 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         commitments: &[Field<N>],
         block_tree: &BlockTree<N>,
     ) -> Result<Vec<StatePath<N>>> {
+        // Restrict the number of commitments requested to the maximum number of inputs in a transition.
+        if commitments.len() > N::MAX_INPUTS {
+            bail!("Too many commitments provided: expected at most {}, got {}", N::MAX_INPUTS, commitments.len());
+        }
         commitments.iter().map(|commitment| self.get_state_path_for_commitment(commitment, block_tree)).collect()
     }
 

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -708,6 +708,15 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         ))
     }
 
+    /// Returns a list of state paths for the given list of `commitment`s.
+    fn get_state_paths_for_commitments(
+        &self,
+        commitments: &[Field<N>],
+        block_tree: &BlockTree<N>,
+    ) -> Result<Vec<StatePath<N>>> {
+        commitments.iter().map(|commitment| self.get_state_path_for_commitment(commitment, block_tree)).collect()
+    }
+
     /// Returns the previous block hash of the given `block height`.
     fn get_previous_block_hash(&self, height: u32) -> Result<Option<N::BlockHash>> {
         if height.is_zero() {
@@ -1188,6 +1197,11 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     /// Returns a state path for the given `commitment`.
     pub fn get_state_path_for_commitment(&self, commitment: &Field<N>) -> Result<StatePath<N>> {
         self.storage.get_state_path_for_commitment(commitment, &self.tree.read())
+    }
+
+    /// Returns a list of state paths for the given list of `commitment`s.
+    pub fn get_state_paths_for_commitments(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
+        self.storage.get_state_paths_for_commitments(commitments, &self.tree.read())
     }
 
     /// Returns the previous block hash of the given `block height`.

--- a/synthesizer/process/src/trace/inclusion/mod.rs
+++ b/synthesizer/process/src/trace/inclusion/mod.rs
@@ -35,7 +35,7 @@ use console::{
 use snarkvm_ledger_block::{Input, Output, Transaction, Transition};
 use snarkvm_ledger_query::QueryTrait;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 #[derive(Clone, Copy, Debug)]
 pub enum InclusionVersion {

--- a/synthesizer/process/src/trace/inclusion/prepare.rs
+++ b/synthesizer/process/src/trace/inclusion/prepare.rs
@@ -16,7 +16,7 @@
 use super::*;
 
 macro_rules! prepare_impl {
-    ($self:ident, $transitions:ident, $query:ident, $current_state_root:ident, $current_block_height:ident, $get_state_path_for_commitment:ident $(, $await:ident)?) => {{
+    ($self:ident, $transitions:ident, $query:ident, $current_state_root:ident, $current_block_height:ident, $get_state_paths_for_commitments:ident $(, $await:ident)?) => {{
         // Ensure the number of leaves is within the Merkle tree size.
         Transaction::<N>::check_execution_size($transitions.len())?;
 
@@ -24,12 +24,6 @@ macro_rules! prepare_impl {
         let mut transaction_tree = N::merkle_tree_bhp::<TRANSACTION_DEPTH>(&[])?;
         // Initialize a vector for the assignments.
         let mut assignments = vec![];
-
-        // Retrieve the global state root.
-        let global_state_root = {
-            $query.$current_state_root()
-            $(.$await)?
-        }?;
 
         // Retrieve the current block height.
         let current_block_height = {
@@ -39,6 +33,26 @@ macro_rules! prepare_impl {
 
         // Determine which consensus version is being used.
         let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
+
+        // Fetch all the record commitments for the transitions.
+        let commitments: Vec<_> = $transitions
+            .iter()
+            .flat_map(|t| $self.input_tasks.get(t.id()).into_iter().flatten())
+            .filter_map(|task| task.local.is_none().then_some(task.commitment))
+            .collect();
+
+        // Fetch all the state paths for the commitments.
+        let mut state_paths: VecDeque<_> = $query.$get_state_paths_for_commitments(&commitments)
+                                $(.$await)??.into();
+
+        // Retrieve the global state root.
+        let global_state_root = match state_paths.front() {
+            Some(path) => path.global_state_root(),
+            None => {
+                $query.$current_state_root()
+                $(.$await)?
+            }?
+        };
 
         // Ensure the global state root is not zero.
         if *global_state_root == Field::zero() {
@@ -75,9 +89,10 @@ macro_rules! prepare_impl {
                                 )?
                             }
                             None => {
-                                $query.$get_state_path_for_commitment(&task.commitment)
-                                $(.$await)?
-                            }?
+                                // Use the next state path from the batched state paths.
+                                state_paths.pop_front()
+                                    .ok_or(anyhow!("Missing state path for commitment {}", task.commitment))?
+                            }
                         };
 
                         // Ensure the global state root is the same across iterations.
@@ -150,7 +165,14 @@ impl<N: Network> Inclusion<N> {
         transitions: &[Transition<N>],
         query: &dyn QueryTrait<N>,
     ) -> Result<(Vec<InclusionAssignmentWrapper<N>>, N::StateRoot)> {
-        prepare_impl!(self, transitions, query, current_state_root, current_block_height, get_state_path_for_commitment)
+        prepare_impl!(
+            self,
+            transitions,
+            query,
+            current_state_root,
+            current_block_height,
+            get_state_paths_for_commitments
+        )
     }
 
     /// Returns the inclusion assignments for the given transitions.
@@ -166,7 +188,7 @@ impl<N: Network> Inclusion<N> {
             query,
             current_state_root_async,
             current_block_height_async,
-            get_state_path_for_commitment_async,
+            get_state_paths_for_commitments_async,
             await
         )
     }

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -734,6 +734,9 @@ finalize test:
         let transaction =
             vm.execute(&caller_private_key, ("credits.aleo", "join"), inputs, None, 0, None, rng).unwrap();
 
+        // Verify the transaction.
+        vm.check_transaction(&transaction, None, rng).unwrap();
+
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
         assert_eq!(3571, transaction_size_in_bytes, "Update me if serialization has changed");


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR implements `get_state_paths_for_commitments` to retrieve a batch of state paths rather than one at a time in the query. This will help mitigate the `global state root to be the same across iterations` issues seen when users/provers are querying for state. 

### Testing
Existing tests should ensure that new batched approach works as intended since we have a variety of tests for record spending.

## Related PRs

Sister snarkOS PR - https://github.com/ProvableHQ/snarkOS/pull/3794
