### PR TITLE
[Feature] Add `tracing::instrument` to allow generating flame graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,22 +153,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -227,7 +227,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -369,9 +369,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bzip2-sys"
@@ -391,9 +391,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -494,7 +494,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -560,7 +560,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "log",
  "serde",
  "serde_derive",
@@ -791,7 +791,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -942,7 +942,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
@@ -1249,7 +1249,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1339,12 +1339,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1379,9 +1378,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1433,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64",
  "bytes",
@@ -1571,12 +1570,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "rayon",
  "serde",
  "serde_core",
@@ -1640,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1685,7 +1684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1787,7 +1786,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1934,7 +1933,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2016,7 +2015,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2057,7 +2056,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2161,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2513,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "zeroize",
 ]
@@ -2666,7 +2665,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2675,7 +2674,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "memchr",
  "ryu",
@@ -2701,7 +2700,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "ryu",
  "serde",
@@ -2730,7 +2729,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2846,7 +2845,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -2929,7 +2928,7 @@ name = "snarkvm-circuit-environment"
 version = "4.4.0"
 dependencies = [
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -3122,7 +3121,7 @@ version = "4.4.0"
 dependencies = [
  "aleo-std",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "snarkvm-console-algorithms",
  "snarkvm-console-network",
@@ -3135,7 +3134,7 @@ version = "4.4.0"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "lazy_static",
  "paste",
  "serde",
@@ -3173,7 +3172,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "num-derive",
  "num-traits",
  "seq-macro",
@@ -3324,7 +3323,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru",
  "parking_lot",
@@ -3370,7 +3369,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -3389,6 +3388,7 @@ dependencies = [
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "tracing",
 ]
 
 [[package]]
@@ -3397,7 +3397,7 @@ version = "4.4.0"
 dependencies = [
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3430,7 +3430,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.4.0"
 dependencies = [
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3444,7 +3444,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.4.0"
 dependencies = [
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3470,7 +3470,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.4.0"
 dependencies = [
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3512,7 +3512,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru",
  "parking_lot",
@@ -3532,7 +3532,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru",
  "parking_lot",
@@ -3571,7 +3571,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3659,7 +3659,7 @@ dependencies = [
  "bincode",
  "criterion",
  "hex",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "k256",
  "locktick",
@@ -3700,7 +3700,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3728,7 +3728,7 @@ dependencies = [
  "bincode",
  "criterion",
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "k256",
  "paste",
  "rand 0.8.5",
@@ -3741,6 +3741,7 @@ dependencies = [
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
  "tiny-keccak",
+ "tracing",
 ]
 
 [[package]]
@@ -3797,7 +3798,7 @@ version = "4.4.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3857,7 +3858,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3868,7 +3869,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3901,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -3936,7 +3937,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3982,7 +3983,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4011,7 +4012,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4022,7 +4023,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4191,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -4221,9 +4222,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4232,20 +4233,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4264,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4298,7 +4299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4371,9 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64",
  "http",
@@ -4474,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4487,9 +4488,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4500,9 +4501,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote 1.0.42",
  "wasm-bindgen-macro-support",
@@ -4510,34 +4511,42 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -4545,20 +4554,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4629,43 +4638,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4701,7 +4704,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4726,7 +4729,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4870,28 +4873,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4911,7 +4914,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -4932,7 +4935,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4965,5 +4968,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ locktick = [
   "snarkvm-parameters?/locktick",
   "snarkvm-synthesizer?/locktick"
 ]
+instrumentation = [ "snarkvm-ledger/instrumentation" ]
 noconfig = [ ]
 rocks = [ "snarkvm-ledger/rocks", "snarkvm-synthesizer/rocks" ]
 test = [ "snarkvm-ledger/test" ]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following is an (incomplete) list of features flags in the snarkVM crate.
 * **instrumentation** -
   Adds `tracing::instrument` statements to (some) functions. This is useful for profiling, but should not be used in production.
 * **serial** -
-  *Disables* paralle processing using `rayon`.
+  *Disables* parallel processing using `rayon`. This is useful for specialized profiling, but should not be used in production.
 * **algorithms** -
   Adds the `algorithms` crate to `snarkvm` (as `snarkvm::algorithms`)
 * **circuit** -
@@ -78,7 +78,7 @@ The following is an (incomplete) list of features flags in the snarkVM crate.
 
 ### 3. Building Guide
 
-You can also build snarkVM from source. Because snarkVM is a library, this follwing guide is only useful if you plan to make modifications to its source code.
+You can also build snarkVM from source. Because snarkVM is a library, this following guide is only useful if you plan to make modifications to its source code.
 
 ### 3.1 Install Rust
 
@@ -98,7 +98,7 @@ We recommend installing Rust using [rustup](https://www.rustup.rs/). You can ins
 - Windows (64-bit):
 
   Download the [Windows 64-bit executable](https://win.rustup.rs/x86_64) or
-  [Windows 32-bit executable](https://win.rustup.rs/i686) and follow the on-screen instructions.i
+  [Windows 32-bit executable](https://win.rustup.rs/i686) and follow the on-screen instructions.
 
 ### 3.2 Additional Dependencies
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 ## Table of Contents
 
 * [1. Overview](#1-overview)
-* [2. Build Guide](#2-build-guide)
-* [3. Contributors](#3-contributors)
-* [4. License](#4-license)
+* [2. Usage Guide](#2-usage-guide)
+* [3. Build Guide](#3-build-guide)
+* [4. Contributors](#4-contributors)
+* [5. License](#5-license)
 
 ## 1. Overview
 
@@ -35,9 +36,51 @@
   
 For more information, visit [Welcome to Aleo](https://github.com/AleoNet/welcome) to get started.
 
-## 2. Build Guide
+## 2. Usage Guide
 
-### 2.1 Install Rust
+snarkVM is primarily designed to be used as a library in Rust projects. Add it to your `Cargo.toml` with your favourite published version:
+
+```toml
+[dependencies]
+snarkvm = "<major>.<minor>.<patch>"
+```
+
+### 2.1 Feature Flags
+
+The following is an (incomplete) list of features flags in the snarkVM crate.
+
+* **cuda** -
+  Allows some operations to run on the (NVidia) GPU, instead of on the CPU.
+* **cli** -
+  Enables the command-line interface. Needed when installing the `snarkvm` binary.
+* **locktick** -
+  This feature turns on code for detecting deadlocks.
+* **test_targets** -
+  This feature allows the lowering of coinbase and proof targets for testing.
+* **instrumentation** -
+  Adds `tracing::instrument` statements to (some) functions. This is useful for profiling, but should not be used in production.
+* **serial** -
+  *Disables* paralle processing using `rayon`.
+* **algorithms** -
+  Adds the `algorithms` crate to `snarkvm` (as `snarkvm::algorithms`)
+* **circuit** -
+  Adds the `circuit` crate to `snarkvm` (as `snarkvm::circuit`)
+* **fields** -
+  Adds the `fields` crate to `snarkvm` (as `snarkvm::fields`)
+* **ledger** -
+  Adds the `ledger` crate to `snarkvm` (as `snarkvm::ledger`)
+* **synthesizer** -
+  Adds the `synthesizer` crate to `snarkvm` (as `snarkvm::synthesizer`)
+* **parameters** -
+  Adds the `parameters` crate to `snarkvm` (as `snarkvm::parameters`)
+* **wasm** -
+  Enables behavior specific for WebAssembly. This feature should only be enabled when compiling to the `wasm32` architecture.
+
+### 3. Building Guide
+
+You can also build snarkVM from source. Because snarkVM is a library, this follwing guide is only useful if you plan to make modifications to its source code.
+
+### 3.1 Install Rust
 
 We recommend installing Rust using [rustup](https://www.rustup.rs/). You can install `rustup` as follows:
 
@@ -55,30 +98,34 @@ We recommend installing Rust using [rustup](https://www.rustup.rs/). You can ins
 - Windows (64-bit):
 
   Download the [Windows 64-bit executable](https://win.rustup.rs/x86_64) or
-  [Windows 32-bit executable](https://win.rustup.rs/i686) and follow the on-screen instructions.
+  [Windows 32-bit executable](https://win.rustup.rs/i686) and follow the on-screen instructions.i
 
-### 2.2 Using snarkVM as a Library
+### 3.2 Additional Dependencies
 
-snarkVM is primarily designed to be used as a library in Rust projects. Add it to your `Cargo.toml` with your favourite published version:
+On Linux, you also need the `lld` linker. For example, on a Debian system you would run the following to install it.
 
-```toml
-[dependencies]
-snarkvm = "<major>.<minor>.<patch>"
+```
+sudo apt install lld
 ```
 
-### 2.3 Build from Source Code
+### 3.3 Fetch Source Code
 
-You can also build snarkVM from source:
+The following snippet clones the `staging` branch of snarkVM. 
 
 ```bash
-# Fetch the repository's development (staging) branch
 git clone --branch staging --single-branch https://github.com/ProvableHQ/snarkVM.git 
 cd snarkVM
-# Build the library
+```
+
+### 3.4 Compiling snarkVM
+
+The following compiles the snarkVM crate.
+
+```
 cargo build --release
 ```
 
-## 3. Contributors
+## 4. Contributors
 
 Thank you for helping make snarkVM better!  
 [🧐 What do the emojis mean?](https://allcontributors.org/docs/en/emoji-key)
@@ -160,6 +207,6 @@ Thank you for helping make snarkVM better!
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
-## 4. License
+## 5. License
 
 [![License: GPL v3](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE.md)

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -81,6 +81,11 @@ serial = [
   "snarkvm-ledger-store/serial",
   "snarkvm-synthesizer/serial"
 ]
+instrumentation = [
+  "snarkvm-synthesizer/instrumentation",
+  "snarkvm-ledger-block/instrumentation",
+  "snarkvm-ledger-store/instrumentation"
+]
 test = [
   "snarkvm-console/test",
   "snarkvm-ledger-block/test",

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -34,6 +34,7 @@ wasm = [
   "snarkvm-synthesizer-program/wasm",
   "snarkvm-synthesizer-snark/wasm"
 ]
+instrumentation = [ "dep:tracing" ]
 test = [ "snarkvm-synthesizer-process/test" ]
 test-helpers = [ ]
 
@@ -76,6 +77,10 @@ version = "1"
 [dependencies.indexmap]
 workspace = true
 features = [ "serde" ]
+
+[dependencies.tracing]
+workspace = true
+optional = true
 
 [dependencies.rayon]
 workspace = true

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -27,7 +27,7 @@ use rayon::prelude::*;
 
 impl<N: Network> Block<N> {
     /// Ensures the block is correct.
-    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all, fields(height=self.height())))]
     pub fn verify(
         &self,
         previous_block: &Block<N>,

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -27,6 +27,7 @@ use rayon::prelude::*;
 
 impl<N: Network> Block<N> {
     /// Ensures the block is correct.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
     pub fn verify(
         &self,
         previous_block: &Block<N>,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -101,7 +101,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// # Panics
     /// This function panics if called from an async context.
-    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all, fields(height=block.height())))]
     pub fn advance_to_next_block(&self, block: &Block<N>) -> Result<()> {
         // Acquire the write lock on the current block.
         let mut current_block = self.current_block.write();

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -101,6 +101,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// # Panics
     /// This function panics if called from an async context.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
     pub fn advance_to_next_block(&self, block: &Block<N>) -> Result<()> {
         // Acquire the write lock on the current block.
         let mut current_block = self.current_block.write();

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -24,7 +24,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// # Panics
     /// This function panics if called from an async context.
-    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all, fields(height=block.height())))]
     pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
         let height = block.height();
         let latest_block = self.latest_block();
@@ -146,7 +146,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// This does not verify that the batches are signed correctly or that the edges are valid
     /// (only point to the previous round), as those checks already happened when the node received the batch.
-    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all, fields(height=block.height())))]
     fn check_block_subdag_leaves(&self, block: &Block<N>) -> Result<()> {
         // Check if the block has a subdag.
         let Authority::Quorum(subdag) = block.authority() else {
@@ -188,7 +188,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Check that the certificates in the block subdag have met quorum requirements.
     ///
     /// Called by [`Self::check_block_subdag`]
-    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all, fields(height=block.height())))]
     fn check_block_subdag_quorum(&self, block: &Block<N>) -> Result<()> {
         // Check if the block has a subdag.
         let subdag = match block.authority() {

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -24,6 +24,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// # Panics
     /// This function panics if called from an async context.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
     pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
         let height = block.height();
         let latest_block = self.latest_block();
@@ -145,6 +146,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// This does not verify that the batches are signed correctly or that the edges are valid
     /// (only point to the previous round), as those checks already happened when the node received the batch.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
     fn check_block_subdag_leaves(&self, block: &Block<N>) -> Result<()> {
         // Check if the block has a subdag.
         let Authority::Quorum(subdag) = block.authority() else {
@@ -184,6 +186,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Check that the certificates in the block subdag have met quorum requirements.
+    ///
+    /// Called by [`Self::check_block_subdag`]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
     fn check_block_subdag_quorum(&self, block: &Block<N>) -> Result<()> {
         // Check if the block has a subdag.
         let subdag = match block.authority() {

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -50,6 +50,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns the committee lookback for the given round.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     pub fn get_committee_lookback_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 [features]
 default = [ "indexmap/rayon" ]
 locktick = [ "dep:locktick", "snarkvm-ledger-puzzle/locktick" ]
-rocks = [ "rocksdb", "smallvec" ]
+rocks = [ "dep:rocksdb", "dep:smallvec" ]
 serial = [
   "snarkvm-console/serial",
   "snarkvm-ledger-block/serial",
@@ -39,6 +39,7 @@ wasm = [
   "snarkvm-synthesizer-snark/wasm"
 ]
 test = [ ]
+instrumentation = [ ]
 
 [dependencies.snarkvm-console]
 workspace = true

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -726,6 +726,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     }
 
     /// Returns the previous block hash of the given `block height`.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     fn get_previous_block_hash(&self, height: u32) -> Result<Option<N::BlockHash>> {
         if height.is_zero() {
             Ok(Some(N::BlockHash::default()))
@@ -735,11 +736,13 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     }
 
     /// Returns the block hash for the given `block height`.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     fn get_block_hash(&self, height: u32) -> Result<Option<N::BlockHash>> {
         Ok(self.id_map().get_confirmed(&height)?.map(|x| *x))
     }
 
     /// Returns the block height for the given `block hash`.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     fn get_block_height(&self, block_hash: &N::BlockHash) -> Result<Option<u32>> {
         Ok(self.reverse_id_map().get_confirmed(block_hash)?.map(|x| *x))
     }
@@ -760,6 +763,8 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     }
 
     /// Returns the batch certificate for the given `certificate ID`.
+    ///
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     fn get_batch_certificate(&self, certificate_id: &Field<N>) -> Result<Option<BatchCertificate<N>>> {
         // Retrieve the height and round for the given certificate ID.
         let Some((block_height, round)) = self.certificate_map().get_confirmed(certificate_id)?.map(|x| *x) else {
@@ -853,6 +858,7 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     }
 
     /// Returns the transaction for the given `TransactionID`.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     fn get_transaction(&self, transaction_id: &N::TransactionID) -> Result<Option<Transaction<N>>> {
         // Check if the transaction was rejected or aborted.
         // Note: We can only retrieve accepted or rejected transactions. We cannot retrieve aborted transactions.
@@ -932,7 +938,8 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
         }
     }
 
-    /// Returns the block for the given `block hash`.
+    /// Returns the block for the given `block_hash`.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     fn get_block(&self, block_hash: &N::BlockHash) -> Result<Option<Block<N>>> {
         // Retrieve the block height.
         let Some(height) = self.get_block_height(block_hash)? else { return Ok(None) };

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -46,6 +46,7 @@ serial = [
   "snarkvm-synthesizer-snark/serial"
 ]
 setup = [ ]
+instrumentation = [ "snarkvm-synthesizer-program/instrumentation" ]
 test = [ "snarkvm-console/test", "snarkvm-synthesizer-process/test" ]
 timer = [ "aleo-std/timer" ]
 wasm = [

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -25,6 +25,7 @@ edition = "2024"
 
 [features]
 default = [ ]
+instrumentation = [ "dep:tracing" ]
 serial = [ "snarkvm-console/serial" ]
 wasm = [ "snarkvm-console/wasm" ]
 
@@ -58,6 +59,10 @@ workspace = true
 
 [dependencies.rayon]
 version = "1"
+
+[dependencies.tracing]
+workspace = true
+optional = true
 
 [dependencies.serde_json]
 workspace = true

--- a/synthesizer/program/src/logic/finalize_global_state/mod.rs
+++ b/synthesizer/program/src/logic/finalize_global_state/mod.rs
@@ -50,6 +50,7 @@ impl FinalizeGlobalState {
 
     /// Initializes a new global state from the given inputs.
     #[inline]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
     pub fn new<N: Network>(
         block_round: u64,
         block_height: u32,


### PR DESCRIPTION
## Motivation
Generating flamegraphs using stack-based profilers, such as `perftools` or `cargo flamegraph` is great to measure CPU-bound synchronous workloads. For asynchronous or I/O bound-code `tracing` allows emitting information ("spans") about when a certain async function was started and finished, even if that function started/stopped multiple times, was waiting for a system call, or moved between threads.

The tracing spans can then be passed to different backends. I am particular interested in flamegraph/flamechart generation for my use case, but it also works with, for example, real-time profilers, such as [`tracy`](https://docs.rs/tracing-tracy/latest/tracing_tracy/).

## Proposed Changes
This PR adds `tracing::instrument` to various performance-critical functions when the `instrumentation` feature is enabled.

This allows, for example, generating flame graphs as is done in [snarkOS PR #3916](https://github.com/ProvableHQ/snarkOS/pull/3916)