### PR TITLE
[Fix] Ensure endpoint base URLs that end on slashes work as expected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "blake2"
@@ -382,9 +382,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -563,7 +563,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "log",
  "serde",
  "serde_derive",
@@ -1003,9 +1003,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1172,7 +1172,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1504,11 +1504,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -1570,9 +1570,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -1628,7 +1628,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
 ]
 
@@ -1950,7 +1950,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2031,9 +2031,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2138,13 +2138,13 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2179,7 +2179,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -2200,7 +2200,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2354,7 +2354,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -2370,14 +2370,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2391,13 +2391,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2408,9 +2408,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -2515,7 +2515,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2528,7 +2528,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2646,7 +2646,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2725,7 +2725,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2750,7 +2750,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "ryu",
  "serde",
@@ -2866,7 +2866,7 @@ dependencies = [
  "snarkvm-utilities",
  "snarkvm-wasm",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "ureq",
  "walkdir",
 ]
@@ -2885,7 +2885,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -2900,7 +2900,7 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2968,7 +2968,7 @@ name = "snarkvm-circuit-environment"
 version = "4.1.0"
 dependencies = [
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -3159,7 +3159,7 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "snarkvm-console-algorithms",
  "snarkvm-console-network",
@@ -3172,7 +3172,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "lazy_static",
  "paste",
  "serde",
@@ -3210,7 +3210,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "num-derive",
  "num-traits",
  "serde_json",
@@ -3330,7 +3330,7 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3347,7 +3347,7 @@ dependencies = [
  "serde",
  "snarkvm-curves",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -3359,7 +3359,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3401,7 +3401,7 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -3427,7 +3427,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3460,7 +3460,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3474,7 +3474,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3500,7 +3500,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3542,7 +3542,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3562,7 +3562,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3601,7 +3601,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3672,7 +3672,7 @@ dependencies = [
  "snarkvm-ledger-store",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "wasm-bindgen-test",
  "web-sys",
 ]
@@ -3685,7 +3685,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "locktick",
  "lru",
@@ -3724,7 +3724,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3751,7 +3751,7 @@ version = "4.1.0"
 dependencies = [
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3793,7 +3793,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "snarkvm-utilities-derives",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -3961,7 +3961,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4012,11 +4012,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.15",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -4032,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4214,7 +4214,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytes",
  "futures-util",
  "http",
@@ -4403,13 +4403,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4878,7 +4879,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -129,8 +129,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     fn current_state_root(&self) -> Result<N::StateRoot> {
         match self {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
-            Self::REST(url) => Self::get_request(&format!("{url}{}/stateRoot/latest", N::SHORT_NAME)),
-
+            Self::REST(base_url) => Self::get_request(base_url, "stateRoot/latest"),
             Self::STATIC(query) => query.current_state_root(),
         }
     }
@@ -140,7 +139,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     async fn current_state_root_async(&self) -> Result<N::StateRoot> {
         match self {
             Self::VM(block_store) => Ok(block_store.current_state_root()),
-            Self::REST(url) => Self::get_request_async(&format!("{url}{}/stateRoot/latest", N::SHORT_NAME)).await,
+            Self::REST(base_url) => Self::get_request_async(base_url, "stateRoot/latest").await,
             Self::STATIC(_query) => bail!("Async calls are not supported by StaticQuery"),
         }
     }
@@ -149,7 +148,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     fn get_state_path_for_commitment(&self, commitment: &Field<N>) -> Result<StatePath<N>> {
         match self {
             Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
-            Self::REST(url) => Self::get_request(&format!("{url}{}/statePath/{commitment}", N::SHORT_NAME)),
+            Self::REST(base_url) => Self::get_request(base_url, &format!("statePath/{commitment}")),
             Self::STATIC(query) => query.get_state_path_for_commitment(commitment),
         }
     }
@@ -159,7 +158,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     async fn get_state_path_for_commitment_async(&self, commitment: &Field<N>) -> Result<StatePath<N>> {
         match self {
             Self::VM(block_store) => block_store.get_state_path_for_commitment(commitment),
-            Self::REST(url) => Self::get_request_async(&format!("{url}{}/statePath/{commitment}", N::SHORT_NAME)).await,
+            Self::REST(base_url) => Self::get_request_async(base_url, &format!("statePath/{commitment}")).await,
             Self::STATIC(_query) => bail!("Async calls are not supported by StaticQuery"),
         }
     }
@@ -173,10 +172,10 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
 
         match self {
             Self::VM(block_store) => block_store.get_state_paths_for_commitments(commitments),
-            Self::REST(url) => {
+            Self::REST(base_url) => {
                 // Construct the comma separated string of commitments.
                 let commitments_string = commitments.iter().map(|cm| cm.to_string()).collect::<Vec<_>>().join(",");
-                Self::get_request(&format!("{url}{}/statePaths?commitments={commitments_string}", N::SHORT_NAME))
+                Self::get_request(base_url, &format!("statePaths?commitments={commitments_string}"))
             }
             Self::STATIC(query) => query.get_state_paths_for_commitments(commitments),
         }
@@ -187,11 +186,10 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     async fn get_state_paths_for_commitments_async(&self, commitments: &[Field<N>]) -> Result<Vec<StatePath<N>>> {
         match self {
             Self::VM(block_store) => block_store.get_state_paths_for_commitments(commitments),
-            Self::REST(url) => {
+            Self::REST(base_url) => {
                 // Construct the comma separated string of commitments.
                 let commitments_string = commitments.iter().map(|cm| cm.to_string()).collect::<Vec<_>>().join(",");
-                Self::get_request_async(&format!("{url}{}/statePaths?commitments={commitments_string}", N::SHORT_NAME))
-                    .await
+                Self::get_request_async(base_url, &format!("statePaths?commitments={commitments_string}")).await
             }
             Self::STATIC(query) => query.get_state_paths_for_commitments(commitments),
         }
@@ -201,7 +199,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     fn current_block_height(&self) -> Result<u32> {
         match self {
             Self::VM(block_store) => Ok(block_store.max_height().unwrap_or_default()),
-            Self::REST(url) => Self::get_request(&format!("{url}{}/block/height/latest", N::SHORT_NAME)),
+            Self::REST(base_url) => Self::get_request(base_url, "block/height/latest"),
             Self::STATIC(query) => query.current_block_height(),
         }
     }
@@ -211,7 +209,7 @@ impl<N: Network, B: BlockStorage<N>> QueryTrait<N> for Query<N, B> {
     async fn current_block_height_async(&self) -> Result<u32> {
         match self {
             Self::VM(block_store) => Ok(block_store.max_height().unwrap_or_default()),
-            Self::REST(url) => Self::get_request_async(&format!("{url}{}/block/height/latest", N::SHORT_NAME)).await,
+            Self::REST(base_url) => Self::get_request_async(base_url, "block/height/latest").await,
             Self::STATIC(_query) => bail!("Async calls are not supported by StaticQuery"),
         }
     }
@@ -225,7 +223,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 let txn = block_store.get_transaction(transaction_id)?;
                 txn.ok_or_else(|| anyhow!("Transaction {transaction_id} not in local storage"))
             }
-            Self::REST(url) => Self::get_request(&format!("{url}{}/transaction/{transaction_id}", N::SHORT_NAME)),
+            Self::REST(base_url) => Self::get_request(base_url, &format!("transaction/{transaction_id}")),
             Self::STATIC(_query) => bail!("get_transaction is not supported by StaticQuery"),
         }
     }
@@ -238,9 +236,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
                 let txn = block_store.get_transaction(transaction_id)?;
                 txn.ok_or_else(|| anyhow!("Transaction {transaction_id} not in local storage"))
             }
-            Self::REST(url) => {
-                Self::get_request_async(&format!("{url}{}/transaction/{transaction_id}", N::SHORT_NAME)).await
-            }
+            Self::REST(base_url) => Self::get_request_async(base_url, &format!("transaction/{transaction_id}")).await,
             Self::STATIC(_query) => bail!("get_transaction is not supported by StaticQuery"),
         }
     }
@@ -251,7 +247,7 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
             Self::VM(block_store) => block_store
                 .get_latest_program(program_id)?
                 .ok_or_else(|| anyhow!("Program {program_id} not found in storage")),
-            Self::REST(url) => Self::get_request(&format!("{url}{}/program/{program_id}", N::SHORT_NAME)),
+            Self::REST(base_url) => Self::get_request(base_url, &format!("program/{program_id}")),
             Self::STATIC(_query) => bail!("get_program is not supported by StaticQuery"),
         }
     }
@@ -263,17 +259,39 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
             Self::VM(block_store) => block_store
                 .get_latest_program(program_id)?
                 .with_context(|| format!("Program {program_id} not found in storage")),
-            Self::REST(url) => Self::get_request_async(&format!("{url}{}/program/{program_id}", N::SHORT_NAME)).await,
+            Self::REST(base_url) => Self::get_request_async(base_url, &format!("program/{program_id}")).await,
             Self::STATIC(_query) => bail!("get_program_async is not supported by StaticQuery"),
         }
     }
 
+    /// Builds the full endpoint Uri from the base and path. Used internally
+    /// for all REST API calls.
+    ///
+    /// # Arguments
+    ///  - `base_url`: the hostname (and path prefix) of the node to query. this must exclude the network name.
+    ///  - `route`: the route to the endpoint (e.g., `stateRoot/latest`). This cannot start with a slash.
+    fn build_endpoint(base_url: &http::Uri, route: &str) -> Result<String> {
+        // This function is only called internally but check for additional sanity.
+        ensure!(!route.starts_with('/'), "path cannot start with a slash");
+
+        // Work around a bug in the `http` crate where empty paths will be set to '/' but other paths are not appended with a slash.
+        // See [this issue](https://github.com/hyperium/http/issues/507).
+        let path = if base_url.path().ends_with('/') {
+            format!("{base_url}{network}/{route}", network = N::SHORT_NAME)
+        } else {
+            format!("{base_url}/{network}/{route}", network = N::SHORT_NAME)
+        };
+
+        Ok(path)
+    }
+
     /// Performs a GET request to the given URL and deserializes returned JSON.
-    fn get_request<T: DeserializeOwned>(url: &str) -> Result<T> {
-        let mut response = ureq::get(url).call().with_context(|| format!("Failed to fetch from {url}"))?;
+    fn get_request<T: DeserializeOwned>(base_url: &http::Uri, path: &str) -> Result<T> {
+        let endpoint = Self::build_endpoint(base_url, path)?;
+        let mut response = ureq::get(&endpoint).call().with_context(|| format!("Failed to fetch from {endpoint}"))?;
         if response.status() != http::StatusCode::OK {
             // NOTE: ureq will return an error in this case, but we are keeping the check just in case.
-            bail!("Failed to fetch from {url}: Server returned status {}", response.status());
+            bail!("Failed to fetch from {endpoint}: Server returned status {}", response.status());
         }
 
         response.body_mut().read_json().with_context(|| "Failed to parse JSON response")
@@ -281,10 +299,11 @@ impl<N: Network, B: BlockStorage<N>> Query<N, B> {
 
     /// Performs a GET request to the given URL and deserializes returned JSON (async version).
     #[cfg(feature = "async")]
-    async fn get_request_async<T: DeserializeOwned>(url: &str) -> Result<T> {
-        let response = reqwest::get(url).await.with_context(|| format!("Failed to fetch from {url}"))?;
+    async fn get_request_async<T: DeserializeOwned>(base_url: &http::Uri, path: &str) -> Result<T> {
+        let endpoint = Self::build_endpoint(base_url, path)?;
+        let response = reqwest::get(&endpoint).await.with_context(|| format!("Failed to fetch from {endpoint}"))?;
         if response.status() != http::StatusCode::OK {
-            bail!("Failed to fetch from {url}: Server returned status {}", response.status());
+            bail!("Failed to fetch from {endpoint}: Server returned status {}", response.status());
         }
 
         response.json().await.with_context(|| "Failed to parse JSON response")
@@ -324,7 +343,27 @@ mod tests {
         let str = "http://localhost:3030";
         let query = str.parse::<CurrentQuery>().unwrap();
 
-        assert!(matches!(query, Query::REST(_)));
+        let Query::REST(base_uri) = query else { panic!() };
+
+        assert_eq!(base_uri.to_string(), format!("{str}/"));
+    }
+
+    #[test]
+    fn test_rest_url_parse_with_suffix() -> Result<()> {
+        let base = "http://localhost:3030/a/prefix";
+        let route = "a/route";
+        let query = base.parse::<CurrentQuery>().unwrap();
+
+        // Test without trailing slash.
+        let Query::REST(base_uri) = query else { panic!() };
+        assert_eq!(CurrentQuery::build_endpoint(&base_uri, route)?, format!("{base}/testnet/{route}"));
+
+        // Set again with trailing slash.
+        let query = format!("{base}/").parse::<CurrentQuery>().unwrap();
+        let Query::REST(base_uri) = query else { panic!() };
+        assert_eq!(CurrentQuery::build_endpoint(&base_uri, route)?, format!("{base}/testnet/{route}"));
+
+        Ok(())
     }
 
     #[test]

--- a/ledger/query/src/query.rs
+++ b/ledger/query/src/query.rs
@@ -338,14 +338,36 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Tests HTTP's behavior of printing an empty path `/`
+    ///
+    /// `generate_endpoint` can handle base_urls with and without a trailing slash.
+    /// However, this test is still useful to see if the behavior changes in the future and a second slash is not
+    /// appended to a URL with an existing trailing slash.
     #[test]
     fn test_rest_url_parse() {
-        let str = "http://localhost:3030";
+        let noslash = "http://localhost:3030";
+        let withslash = format!("{noslash}/");
+
+        let query = noslash.parse::<CurrentQuery>().unwrap();
+        let Query::REST(base_uri) = query else { panic!() };
+        assert_eq!(base_uri.path_and_query().unwrap().to_string(), "/");
+        assert_eq!(base_uri.to_string(), withslash);
+
+        let query = withslash.parse::<CurrentQuery>().unwrap();
+        let Query::REST(base_uri) = query else { panic!() };
+        assert_eq!(base_uri.path_and_query().unwrap().to_string(), "/");
+        assert_eq!(base_uri.to_string(), withslash);
+    }
+
+    #[test]
+    fn test_rest_url_with_colon_parse() {
+        let str = "http://myendpoint.addr/:var/foo/bar";
         let query = str.parse::<CurrentQuery>().unwrap();
 
         let Query::REST(base_uri) = query else { panic!() };
 
-        assert_eq!(base_uri.to_string(), format!("{str}/"));
+        assert_eq!(base_uri.to_string(), format!("{str}"));
+        assert_eq!(base_uri.path_and_query().unwrap().to_string(), "/:var/foo/bar");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation
`http::Uri` adds a slash if there is no path after the authority (hostname+port) but does not append a slash to non-empty paths. For example, `test.com` gets converted into `test.com/`, but `test.com/foo` will remain unchanged.
All our tests assumed a simple hostname (+port) for the Query URL, but nodes might use a URL that includes some prefix, e.g. `example.com/mynode`. 

This PR changes `Query` to handle both cases as expected. It also adds a new `Query::build_endpoint` helper function that can be unit tested easier.

## Test Plan
In addition to the unit tests, I will also test manually using `snarkos developer`.