### PR TITLE
Migrate from encoding crate to encoding_rs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,6 +3,4 @@ ignore = [
   # As the rust community considers the paste crate 'done', we can safely ignore this warning.
   # see https://users.rust-lang.org/t/paste-alternatives/126787/2
   "RUSTSEC-2024-0436",
-  # TODO replace encoding crate with encoding_rs
-  "RUSTSEC-2021-0153",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,70 +808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
-dependencies = [
- "encoding-index-japanese",
- "encoding-index-korean",
- "encoding-index-simpchinese",
- "encoding-index-singlebyte",
- "encoding-index-tradchinese",
-]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +2784,7 @@ dependencies = [
  "clap",
  "colored 3.0.0",
  "dotenvy",
+ "encoding_rs",
  "num-format",
  "rand 0.8.5",
  "rusty-hook",
@@ -3654,7 +3591,7 @@ dependencies = [
  "cfg-if",
  "colored 3.0.0",
  "curl",
- "encoding",
+ "encoding_rs",
  "hex",
  "js-sys",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,9 @@ serial = [
   "snarkvm-ledger?/serial"
 ]
 
+[dependencies]
+encoding_rs = "0.8.35"
+
 [workspace.dependencies.snarkvm-algorithms]
 path = "algorithms"
 version = "=4.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,9 +186,6 @@ serial = [
   "snarkvm-ledger?/serial"
 ]
 
-[dependencies]
-encoding_rs = "0.8.35"
-
 [workspace.dependencies.snarkvm-algorithms]
 path = "algorithms"
 version = "=4.1.0"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -29,7 +29,7 @@ large_params = [ ]
 locktick = [ "dep:locktick" ]
 no_std_out = [ ]
 rocks = [ "snarkvm-ledger-store/rocks" ]
-wasm = [ "encoding", "js-sys", "web-sys" ]
+wasm = [ "encoding_rs", "js-sys", "web-sys" ]
 dev-print = [ "snarkvm-utilities/dev-print" ]
 
 [dependencies.snarkvm-curves]
@@ -50,8 +50,8 @@ workspace = true
 [dependencies.colored]
 workspace = true
 
-[dependencies.encoding]
-version = "0.2"
+[dependencies.encoding_rs]
+version = "0.8"
 optional = true
 
 [dependencies.hex]

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -135,10 +135,10 @@ macro_rules! impl_store_and_remote_fetch {
                     ))?;
 
                 // Re-encode the text back into bytes using the chosen encoding.
-                use encoding::Encoding;
-                encoding::all::ISO_8859_5
-                    .encode(&rust_text, encoding::EncoderTrap::Strict)
-                    .map_err(|_| $crate::errors::ParameterError::Wasm("Parameter decoding failed".to_string()))
+                match encoding_rs::ISO_8859_5.encode(&rust_text) {
+                    (bytes, _, false) => Ok(bytes.into_owned()),
+                    (_, _, true) => Err($crate::errors::ParameterError::Wasm("Parameter decoding failed".to_string())),
+                }
             } else {
                 Err($crate::errors::ParameterError::Wasm("Download failed - XMLHttpRequest failed".to_string()))
             }


### PR DESCRIPTION
## Motivation

encoding crate is not supported anymore, migrating to encoding_rs

## Test Plan

Relying on `cargo test` and CI runs

## Related PRs
