### PR TITLE
[Build] Do not enable default features for snarkvm crates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - run_test: # This runs a single test with profiler enabled
           workspace_member: snarkvm-algorithms
           flags: varuna::prove_and_verify_with_square_matrix --features profiler
-          cache_key_suffix: -profiler
+          cache_key_suffix: -profiler-test
   
   circuit:
     executor: rust-docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4868,9 +4868,6 @@ name = "wit-bindgen"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
-dependencies = [
- "bitflags 2.9.3",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1613,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2217,7 +2217,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2532,7 +2532,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3976,7 +3976,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4657,7 +4657,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "blake2"
@@ -382,9 +382,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -563,7 +563,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "log",
  "serde",
  "serde_derive",
@@ -691,7 +691,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.6.0",
+ "socket2",
  "windows-sys 0.59.0",
 ]
 
@@ -1003,9 +1003,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1144,7 +1144,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1172,7 +1172,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1352,7 +1352,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1504,11 +1504,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -1570,9 +1570,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -1628,7 +1628,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
 ]
 
@@ -1950,7 +1950,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2031,9 +2031,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2089,9 +2089,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -2138,13 +2138,13 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2178,8 +2178,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
- "thiserror 2.0.15",
+ "socket2",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -2200,7 +2200,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2208,16 +2208,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2354,7 +2354,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -2370,14 +2370,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2391,13 +2391,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2408,9 +2408,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -2515,7 +2515,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2528,7 +2528,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2646,7 +2646,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2725,7 +2725,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2750,7 +2750,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "ryu",
  "serde",
@@ -2866,7 +2866,7 @@ dependencies = [
  "snarkvm-utilities",
  "snarkvm-wasm",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "ureq",
  "walkdir",
 ]
@@ -2885,7 +2885,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -2900,7 +2900,7 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2968,7 +2968,7 @@ name = "snarkvm-circuit-environment"
 version = "4.1.0"
 dependencies = [
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -3159,7 +3159,7 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "snarkvm-console-algorithms",
  "snarkvm-console-network",
@@ -3172,7 +3172,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "lazy_static",
  "paste",
  "serde",
@@ -3210,7 +3210,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "num-derive",
  "num-traits",
  "serde_json",
@@ -3330,7 +3330,7 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3347,7 +3347,7 @@ dependencies = [
  "serde",
  "snarkvm-curves",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -3359,7 +3359,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3401,7 +3401,7 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -3427,7 +3427,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3460,7 +3460,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3474,7 +3474,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3500,7 +3500,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
 dependencies = [
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3542,7 +3542,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3562,7 +3562,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3601,7 +3601,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3672,7 +3672,7 @@ dependencies = [
  "snarkvm-ledger-store",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "wasm-bindgen-test",
  "web-sys",
 ]
@@ -3685,7 +3685,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "locktick",
  "lru",
@@ -3724,7 +3724,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3751,7 +3751,7 @@ version = "4.1.0"
 dependencies = [
  "bincode",
  "criterion",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3793,7 +3793,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "snarkvm-utilities-derives",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "zeroize",
 ]
 
@@ -3820,16 +3820,6 @@ dependencies = [
  "snarkvm-synthesizer",
  "snarkvm-utilities",
  "wasm-bindgen-test",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3961,7 +3951,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4012,11 +4002,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.15",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -4032,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4147,7 +4137,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "windows-sys 0.59.0",
 ]
 
@@ -4214,7 +4204,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytes",
  "futures-util",
  "http",
@@ -4403,13 +4393,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4490,11 +4481,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4873,13 +4864,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.2",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,6 +437,10 @@ version = "=4.1.0"
 [workspace.dependencies.aleo-std]
 version = "1.0.1"
 
+[workspace.dependencies.aleo-std-storage]
+default-features=false
+version = "1.0.1"
+
 [workspace.dependencies.anyhow]
 version = "1.0.73"
 
@@ -543,7 +547,6 @@ optional = true
 [dependencies.snarkvm-console]
 workspace = true
 optional = true
-features = [ "default" ]
 
 [dependencies.snarkvm-curves]
 workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ package = [
   "circuit",
   "file",
   "ledger",
+  "snarkvm-console/filesystem",
   "dep:ureq",
   "dep:dotenvy"
 ]

--- a/circuit/types/Cargo.toml
+++ b/circuit/types/Cargo.toml
@@ -34,4 +34,3 @@ workspace = true
 
 [dev-dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -258,7 +258,7 @@ mod tests {
 
     /// Ensure that `MAX_CERTIFICATES` increases and is correctly defined.
     /// See the constant declaration for an explanation why.
-    fn max_certificates_and_transaction_spend_limit_increasing<N: Network>() {
+    fn max_certificates_increasing<N: Network>() {
         let mut previous_value = N::MAX_CERTIFICATES.first().unwrap().1;
         for (_, value) in N::MAX_CERTIFICATES.iter().skip(1) {
             assert!(*value >= previous_value);
@@ -297,9 +297,9 @@ mod tests {
         consensus_config_returns_some::<TestnetV0>();
         consensus_config_returns_some::<CanaryV0>();
 
-        max_certificates_and_transaction_spend_limit_increasing::<MainnetV0>();
-        max_certificates_and_transaction_spend_limit_increasing::<TestnetV0>();
-        max_certificates_and_transaction_spend_limit_increasing::<CanaryV0>();
+        max_certificates_increasing::<MainnetV0>();
+        max_certificates_increasing::<TestnetV0>();
+        max_certificates_increasing::<CanaryV0>();
 
         constants_equal_length::<MainnetV0, TestnetV0, CanaryV0>();
     }

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -39,3 +39,6 @@ pub mod prelude {
     #[cfg(feature = "network")]
     pub use crate::network::prelude::*;
 }
+
+#[cfg(all(feature = "filesystem", target_arch = "wasm32"))]
+compile_error!("Filesystem feature is not supported on wasm32");

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -99,6 +99,7 @@ workspace = true
 
 [dependencies.aleo-std]
 workspace = true
+features = [ "storage" ]
 
 [dependencies.anyhow]
 workspace = true

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -67,7 +67,6 @@ timer = [ "aleo-std/timer" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-authority]
 workspace = true
@@ -77,7 +76,6 @@ workspace = true
 
 [dependencies.snarkvm-ledger-committee]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal]
 workspace = true
@@ -137,6 +135,10 @@ workspace = true
 
 [dev-dependencies.criterion]
 workspace = true
+
+[dev-dependencies.snarkvm-console]
+workspace = true
+features = [ "filesystem" ]
 
 [dev-dependencies.snarkvm-ledger-block]
 workspace = true

--- a/ledger/authority/Cargo.toml
+++ b/ledger/authority/Cargo.toml
@@ -31,7 +31,6 @@ test-helpers = [ "snarkvm-ledger-narwhal-subdag/test-helpers" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-subdag]
 workspace = true

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -38,14 +38,12 @@ test = [ "snarkvm-synthesizer-process/test" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-authority]
 workspace = true
 
 [dependencies.snarkvm-ledger-committee]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-batch-header]
 workspace = true

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -90,6 +90,10 @@ workspace = true
 [dev-dependencies.snarkvm-circuit]
 workspace = true
 
+[dev-dependencies.snarkvm-console]
+workspace = true
+features = [ "filesystem" ]
+
 [dev-dependencies.snarkvm-ledger-committee]
 workspace = true
 features = [ "test-helpers" ]

--- a/ledger/committee/Cargo.toml
+++ b/ledger/committee/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 edition = "2024"
 
 [features]
-default = [ "rayon" ]
+default = [ ]
 serial = [ "snarkvm-console/serial" ]
 wasm = [ "snarkvm-console/wasm" ]
 metrics = [ "dep:snarkvm-metrics" ]
@@ -33,7 +33,6 @@ test-helpers = [ "prop-tests", "rand_distr" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-batch-header]
 workspace = true
@@ -72,7 +71,6 @@ optional = true
 
 [dependencies.rayon]
 workspace = true
-optional = true
 
 [dependencies.test-strategy]
 version = "0.3.1"

--- a/ledger/committee/Cargo.toml
+++ b/ledger/committee/Cargo.toml
@@ -33,6 +33,7 @@ test-helpers = [ "prop-tests", "rand_distr" ]
 
 [dependencies.snarkvm-console]
 workspace = true
+features = [ "program" ]
 
 [dependencies.snarkvm-ledger-narwhal-batch-header]
 workspace = true

--- a/ledger/narwhal/batch-certificate/Cargo.toml
+++ b/ledger/narwhal/batch-certificate/Cargo.toml
@@ -31,7 +31,6 @@ test-helpers = [ "snarkvm-ledger-narwhal-batch-header/test-helpers" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-batch-header]
 workspace = true

--- a/ledger/narwhal/batch-header/Cargo.toml
+++ b/ledger/narwhal/batch-header/Cargo.toml
@@ -31,7 +31,6 @@ test-helpers = [ "snarkvm-ledger-narwhal-transmission-id/test-helpers", "time" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-transmission-id]
 workspace = true

--- a/ledger/narwhal/data/Cargo.toml
+++ b/ledger/narwhal/data/Cargo.toml
@@ -28,7 +28,6 @@ async = [ "tokio" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.bytes]
 workspace = true

--- a/ledger/narwhal/subdag/Cargo.toml
+++ b/ledger/narwhal/subdag/Cargo.toml
@@ -31,7 +31,6 @@ test-helpers = [ "snarkvm-ledger-narwhal-batch-certificate/test-helpers" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-batch-certificate]
 workspace = true
@@ -41,7 +40,6 @@ workspace = true
 
 [dependencies.snarkvm-ledger-committee]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-transmission-id]
 workspace = true

--- a/ledger/narwhal/transmission-id/Cargo.toml
+++ b/ledger/narwhal/transmission-id/Cargo.toml
@@ -31,7 +31,6 @@ test-helpers = [ ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-puzzle]
 workspace = true

--- a/ledger/narwhal/transmission/Cargo.toml
+++ b/ledger/narwhal/transmission/Cargo.toml
@@ -31,7 +31,6 @@ test-helpers = [ ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-block]
 workspace = true

--- a/ledger/puzzle/Cargo.toml
+++ b/ledger/puzzle/Cargo.toml
@@ -40,7 +40,6 @@ wasm = [ "snarkvm-console/wasm" ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-algorithms]
 workspace = true

--- a/ledger/puzzle/Cargo.toml
+++ b/ledger/puzzle/Cargo.toml
@@ -40,6 +40,7 @@ wasm = [ "snarkvm-console/wasm" ]
 
 [dependencies.snarkvm-console]
 workspace = true
+features = [ "account", "network", "types" ]
 
 [dependencies.snarkvm-algorithms]
 workspace = true

--- a/ledger/puzzle/epoch/Cargo.toml
+++ b/ledger/puzzle/epoch/Cargo.toml
@@ -50,7 +50,6 @@ optional = true
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-puzzle]
 workspace = true
@@ -105,4 +104,4 @@ optional = true
 
 [dev-dependencies.snarkvm-console]
 workspace = true
-features = [ "test", "default" ]
+features = [ "test" ]

--- a/ledger/query/Cargo.toml
+++ b/ledger/query/Cargo.toml
@@ -38,7 +38,6 @@ query = [
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-block]
 workspace = true

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -42,7 +42,6 @@ test = [ ]
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-authority]
 workspace = true
@@ -52,7 +51,6 @@ workspace = true
 
 [dependencies.snarkvm-ledger-committee]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-batch-certificate]
 workspace = true
@@ -67,8 +65,7 @@ workspace = true
 workspace = true
 
 [dependencies.aleo-std-storage]
-version = "1.0.1"
-default-features = false
+workspace = true
 
 [dependencies.anyhow]
 workspace = true

--- a/ledger/test-helpers/Cargo.toml
+++ b/ledger/test-helpers/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 
 [dependencies.snarkvm-console]
 workspace = true
+features = ["filesystem"]
 
 [dependencies.snarkvm-circuit]
 workspace = true

--- a/ledger/test-helpers/Cargo.toml
+++ b/ledger/test-helpers/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-circuit]
 workspace = true

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -73,14 +73,12 @@ workspace = true
 
 [dependencies.snarkvm-console]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-block]
 workspace = true
 
 [dependencies.snarkvm-ledger-committee]
 workspace = true
-features = [ "default" ]
 
 [dependencies.snarkvm-ledger-narwhal-data]
 workspace = true

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -159,6 +159,10 @@ workspace = true
 [dev-dependencies.criterion]
 workspace = true
 
+[dev-dependencies.snarkvm-console]
+workspace = true
+features = [ "filesystem" ]
+
 [dev-dependencies.snarkvm-ledger-committee]
 workspace = true
 features = [ "test-helpers" ]

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -33,7 +33,6 @@ workspace = true
 
 [dependencies.snarkvm-console]
 workspace = true
-default-features = false
 features = [ "account", "network", "program", "types" ]
 
 [dependencies.snarkvm-utilities]
@@ -73,7 +72,7 @@ workspace = true
 
 [dev-dependencies.snarkvm-console]
 workspace = true
-features = [ "test", "default" ]
+features = [ "test" ]
 
 [dev-dependencies.criterion]
 workspace = true

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -440,12 +440,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         // Get the transaction spend limit.
                         let transaction_spend_limit =
                             consensus_config_value!(N, TRANSACTION_SPEND_LIMIT, current_height).unwrap();
-                        // Determine the cost to check.
-                        let cost_to_check =
+                        // Determine the transaction spend to prevent DoS attacks. From V10 onwards, we only compare the finalize (compute) cost.
+                        let transaction_spend =
                             if consensus_version >= ConsensusVersion::V10 { finalize_cost } else { cost };
-                        // Ensure the finalize cost does not exceed the transaction spend limit.
+                        // Ensure the transaction spend does not exceed the transaction spend limit.
                         ensure!(
-                            cost_to_check <= transaction_spend_limit,
+                            transaction_spend <= transaction_spend_limit,
                             "Transaction '{id}' exceeds the transaction spend limit '{}'",
                             transaction_spend_limit
                         );


### PR DESCRIPTION
A recent PR (#2783) explicitly enables `default` on snarkVM crates in many places. We should not do this to reduce bloat and compile times. 

The `filesystem` feature also causes issues on WASM. I added a check to ensure it is not enabled when compiling to the wasm32 arch. That way, the issue can be detected at compile time, not run time.