### PR TITLE
[Fix] Re-enable `wasm` proving

### DIFF
--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -167,7 +167,7 @@ macro_rules! impl_load_bytes_logic_local {
 macro_rules! impl_load_bytes_logic_remote {
     ($remote_url: expr, $local_dir: expr, $filename: expr, $metadata: expr, $expected_checksum: expr, $expected_size: expr) => {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "filesystem")] {
+            if #[cfg(all(feature = "filesystem", not(feature="wasm")))] {
                 // Compose the correct file path for the parameter file.
                 let mut file_path = aleo_std::aleo_dir();
                 file_path.push($local_dir);
@@ -188,12 +188,10 @@ macro_rules! impl_load_bytes_logic_remote {
                         );
                     }
 
-                    // Construct the URL.
-                    let url = format!("{}/{}", $remote_url, $filename);
-
                     // Load remote file
                     cfg_if::cfg_if!{
                         if #[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))] {
+                            let url = format!("{}/{}", $remote_url, $filename);
                             let mut buffer = vec![];
                             Self::remote_fetch(&mut buffer, &url)?;
 
@@ -213,16 +211,6 @@ macro_rules! impl_load_bytes_logic_remote {
                                     buffer
                                 }
                             }
-                        } else if #[cfg(feature = "wasm")] {
-                            let buffer = Self::remote_fetch(&url)?;
-
-                            // Ensure the checksum matches.
-                            let candidate_checksum = checksum!(&buffer);
-                            if $expected_checksum != candidate_checksum {
-                                return checksum_error!($expected_checksum, candidate_checksum)
-                            }
-
-                            buffer
                         } else {
                             return Err($crate::errors::ParameterError::RemoteFetchDisabled);
                         }
@@ -241,9 +229,29 @@ macro_rules! impl_load_bytes_logic_remote {
                     return checksum_error!($expected_checksum, candidate_checksum)
                 }
                 return Ok(buffer);
-            }
-            else {
-                return Err($crate::errors::ParameterError::FilesystemDisabled);
+            } else {
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "wasm")] {
+                        let url = format!("{}/{}", $remote_url, $filename);
+                        let buffer = Self::remote_fetch(&url)?;
+
+                        // Ensure the size matches.
+                        if $expected_size != buffer.len() {
+                            remove_file!(file_path);
+                            return Err($crate::errors::ParameterError::SizeMismatch($expected_size, buffer.len()));
+                        }
+
+                        // Ensure the checksum matches.
+                        let candidate_checksum = checksum!(&buffer);
+                        if $expected_checksum != candidate_checksum {
+                            return checksum_error!($expected_checksum, candidate_checksum)
+                        }
+
+                        return Ok(buffer)
+                    } else {
+                        return Err($crate::errors::ParameterError::FilesystemDisabled);
+                    }
+                }
             }
         }
     }

--- a/synthesizer/snark/src/certificate/mod.rs
+++ b/synthesizer/snark/src/certificate/mod.rs
@@ -37,6 +37,7 @@ impl<N: Network> Certificate<N> {
         proving_key: &ProvingKey<N>,
         verifying_key: &VerifyingKey<N>,
     ) -> Result<Certificate<N>> {
+        #[cfg(feature = "dev-print")]
         let timer = std::time::Instant::now();
 
         // Retrieve the proving parameters.
@@ -46,8 +47,11 @@ impl<N: Network> Certificate<N> {
         // Compute the certificate.
         let certificate = Varuna::<N>::prove_vk(universal_prover, fiat_shamir, verifying_key, proving_key)?;
 
-        let _elapsed = timer.elapsed().as_millis();
-        dev_println!(" • Certified '{_function_name}' (in {_elapsed} ms)");
+        #[cfg(feature = "dev-print")]
+        {
+            let _elapsed = timer.elapsed().as_millis();
+            dev_println!(" • Certified '{_function_name}' (in {_elapsed} ms)")
+        };
 
         Ok(Self::new(certificate))
     }
@@ -59,6 +63,7 @@ impl<N: Network> Certificate<N> {
         assignment: &circuit::Assignment<N::Field>,
         verifying_key: &VerifyingKey<N>,
     ) -> bool {
+        #[cfg(feature = "dev-print")]
         let timer = std::time::Instant::now();
 
         // Retrieve the verification parameters.
@@ -69,8 +74,11 @@ impl<N: Network> Certificate<N> {
         #[allow(clippy::manual_unwrap_or_default)]
         match Varuna::<N>::verify_vk(universal_verifier, fiat_shamir, assignment, verifying_key, self) {
             Ok(is_valid) => {
-                let _elapsed = timer.elapsed().as_millis();
-                dev_println!(" • Verified certificate for '{_function_name}' (in {_elapsed} ms)");
+                #[cfg(feature = "dev-print")]
+                {
+                    let _elapsed = timer.elapsed().as_millis();
+                    dev_println!(" • Verified certificate for '{_function_name}' (in {_elapsed} ms)");
+                }
                 is_valid
             }
             Err(_error) => {

--- a/synthesizer/snark/src/certificate/mod.rs
+++ b/synthesizer/snark/src/certificate/mod.rs
@@ -50,8 +50,8 @@ impl<N: Network> Certificate<N> {
         #[cfg(feature = "dev-print")]
         {
             let _elapsed = timer.elapsed().as_millis();
-            dev_println!(" • Certified '{_function_name}' (in {_elapsed} ms)")
-        };
+            dev_println!(" • Certified '{_function_name}' (in {_elapsed} ms)");
+        }
 
         Ok(Self::new(certificate))
     }

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -41,6 +41,7 @@ impl<N: Network> ProvingKey<N> {
         assignment: &circuit::Assignment<N::Field>,
         rng: &mut R,
     ) -> Result<Proof<N>> {
+        #[cfg(feature = "dev-print")]
         let timer = std::time::Instant::now();
 
         // Retrieve the proving parameters.
@@ -51,8 +52,12 @@ impl<N: Network> ProvingKey<N> {
         let proof =
             Proof::new(Varuna::<N>::prove(universal_prover, fiat_shamir, self, varuna_version, assignment, rng)?);
 
-        let _elapsed = timer.elapsed().as_millis();
-        dev_println!(" • Executed '{_function_name}' (in {_elapsed} ms)");
+        #[cfg(feature = "dev-print")]
+        {
+            let _elapsed = timer.elapsed().as_millis();
+            dev_println!(" • Executed '{_function_name}' (in {_elapsed} ms)");
+        }
+
         Ok(proof)
     }
 
@@ -64,6 +69,7 @@ impl<N: Network> ProvingKey<N> {
         assignments: &[(ProvingKey<N>, Vec<circuit::Assignment<N::Field>>)],
         rng: &mut R,
     ) -> Result<Proof<N>> {
+        #[cfg(feature = "dev-print")]
         let timer = std::time::Instant::now();
 
         // Prepare the instances.
@@ -82,8 +88,11 @@ impl<N: Network> ProvingKey<N> {
         let batch_proof =
             Proof::new(Varuna::<N>::prove_batch(universal_prover, fiat_shamir, varuna_version, &instances, rng)?);
 
-        let _elapsed = timer.elapsed().as_millis();
-        dev_println!(" • Executed '{_locator}' (in {_elapsed} ms)");
+        #[cfg(feature = "dev-print")]
+        {
+            let _elapsed = timer.elapsed().as_millis();
+            dev_println!(" • Executed '{_locator}' (in {_elapsed} ms)");
+        }
 
         Ok(batch_proof)
     }

--- a/synthesizer/snark/src/universal_srs.rs
+++ b/synthesizer/snark/src/universal_srs.rs
@@ -33,12 +33,16 @@ impl<N: Network> UniversalSRS<N> {
         _function_name: &str,
         assignment: &circuit::Assignment<N::Field>,
     ) -> Result<(ProvingKey<N>, VerifyingKey<N>)> {
+        #[cfg(feature = "dev-print")]
         let timer = std::time::Instant::now();
 
         let (proving_key, verifying_key) = Varuna::<N>::circuit_setup(self, assignment)?;
 
-        let _elapsed = timer.elapsed().as_millis();
-        dev_println!(" • Built '{_function_name}' (in {_elapsed} ms)");
+        #[cfg(feature = "dev-print")]
+        {
+            let _elapsed = timer.elapsed().as_millis();
+            dev_println!(" • Built '{_function_name}' (in {_elapsed} ms)");
+        }
 
         Ok((
             ProvingKey::new(Arc::new(proving_key)),
@@ -69,13 +73,17 @@ impl<N: Network> Deref for UniversalSRS<N> {
     #[allow(clippy::let_and_return)]
     fn deref(&self) -> &Self::Target {
         self.srs.get_or_init(|| {
+            #[cfg(feature = "dev-print")]
             let timer = std::time::Instant::now();
 
             // Load the universal SRS.
             let universal_srs = varuna::UniversalSRS::load().expect("Failed to load the universal SRS");
 
-            let _elapsed = timer.elapsed().as_millis();
-            dev_println!(" • Loaded universal setup (in {_elapsed} ms)");
+            #[cfg(feature = "dev-print")]
+            {
+                let _elapsed = timer.elapsed().as_millis();
+                dev_println!(" • Loaded universal setup (in {_elapsed} ms)");
+            }
 
             universal_srs
         })

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -49,6 +49,7 @@ impl<N: Network> VerifyingKey<N> {
         inputs: &[N::Field],
         proof: &Proof<N>,
     ) -> bool {
+        #[cfg(feature = "dev-print")]
         let timer = std::time::Instant::now();
 
         // Retrieve the verification parameters.
@@ -59,8 +60,11 @@ impl<N: Network> VerifyingKey<N> {
         #[allow(clippy::manual_unwrap_or_default)]
         match Varuna::<N>::verify(universal_verifier, fiat_shamir, self, varuna_version, inputs, proof) {
             Ok(is_valid) => {
-                let _elapsed = timer.elapsed().as_millis();
-                dev_println!(" • Verified '{_function_name}' (in {_elapsed} ms)");
+                #[cfg(feature = "dev-print")]
+                {
+                    let _elapsed = timer.elapsed().as_millis();
+                    dev_println!(" • Verified '{_function_name}' (in {_elapsed} ms)");
+                }
                 is_valid
             }
             Err(_error) => {
@@ -78,6 +82,7 @@ impl<N: Network> VerifyingKey<N> {
         inputs: Vec<(VerifyingKey<N>, Vec<Vec<N::Field>>)>,
         proof: &Proof<N>,
     ) -> Result<()> {
+        #[cfg(feature = "dev-print")]
         let timer = std::time::Instant::now();
 
         // Convert the instances.
@@ -93,8 +98,11 @@ impl<N: Network> VerifyingKey<N> {
         // Verify the batch proof.
         match Varuna::<N>::verify_batch(universal_verifier, fiat_shamir, varuna_version, &keys_to_inputs, proof) {
             Ok(is_valid) => {
-                let _elapsed = timer.elapsed().as_millis();
-                dev_println!(" • Verified '{_locator}': {is_valid} (in {_elapsed} ms)");
+                #[cfg(feature = "dev-print")]
+                {
+                    let _elapsed = timer.elapsed().as_millis();
+                    dev_println!(" • Verified '{_locator}': {is_valid} (in {_elapsed} ms)");
+                }
                 if is_valid { Ok(()) } else { bail!("'verify_batch' failed") }
             }
             Err(error) => {


### PR DESCRIPTION
## Motivation

SnarkVM tag [Canary-v4.2.1](https://github.com/ProvableHQ/snarkVM/releases/tag/canary-v4.2.1) ended up introducing several issues for wasm + other environments that don't assume availability of filesystems.

These issues were as follows:
1. Feature flags were structured such that one was unable to disable the new `filesystem` feature.
2. When the `filesystem` feature was turned disabled, `wasm` [parameter fetching was disabled in parameter macros](https://github.com/ProvableHQ/snarkVM/compare/c885fb8551aa8027a88e066c04f1e87c49947bc2...7bc4c2867c6d1ba52d084907d161cc034fdf5822?utm_source=chatgpt.com#diff-6258319405e4f00f17bfa92ba4d83fb1dc841fbb985f3ed01537be03927b8bf6R169-R246).
3. `std::time::Instant::now` [was directly exposed](https://github.com/ProvableHQ/snarkVM/compare/c885fb8551aa8027a88e066c04f1e87c49947bc2...7bc4c2867c6d1ba52d084907d161cc034fdf5822?utm_source=chatgpt.com) to the main proving and verifying subroutines in the synthesizer crate. For environments like `wasm` and `sgx` which do not have access to this particular `std` library, this caused panics.

The `chore/no-default` fixed issue #1, this PR does the following to fix issues 2 & 3.
1. It re-enables `wasm` parameter fetching in the parameter macros.
2. It gates std::time invocations behind the `dev-print` feature.

## Test Plan

* Testing across SnarkVM dependent products should be added to ensure the `chore/no-default` branch does not affect any other major products. 
* Wasm tests should be added that execute program executions and parameter downloads directly in wasm should be developed and run in ci to ensure these pathways aren't broken in the future.

## Related PRs

#2900 

