### PR TITLE
Re-enable default console features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -548,6 +548,7 @@ optional = true
 [dependencies.snarkvm-console]
 workspace = true
 optional = true
+features = [ "default" ]
 
 [dependencies.snarkvm-curves]
 workspace = true


### PR DESCRIPTION
## Motivation

While https://github.com/ProvableHQ/snarkVM/pull/2900 fixed wasm compilation, it broke snarkOS compilation, which requires the top-level console import to enable default features:

```
56 |     pub use crate::console::{account::*, network::*, program::*};
   |                              ^^^^^^^     ^^^^^^^     ^^^^^^^ could not find `program` in `console`
   |                              |           |
   |                              |           could not find `network` in `console`
   |                              could not find `account` in `console`
```

## Test Plan

- [x] snarkOS compiles
- [x] I believe this PR will not break wasm because wasm doesn't import entire snarkVM. Here is a test PR with succeeding CI to prove it: https://github.com/ProvableHQ/sdk/pull/1086
