### PR TITLE
[Feature] Enable offline proving of public functions in `wasm`

### DIFF
--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -25,10 +25,7 @@ pub const RESTRICTIONS_LIST: &str = include_str!("./resources/restrictions.json"
 const REMOTE_URL: &str = "https://parameters.provable.com/mainnet";
 
 // Degrees
-#[cfg(not(feature = "wasm"))]
 impl_local!(Degree15, "resources/", "powers-of-beta-15", "usrs");
-#[cfg(feature = "wasm")]
-impl_remote!(Degree15, REMOTE_URL, "resources/", "powers-of-beta-15", "usrs");
 impl_remote!(Degree16, REMOTE_URL, "resources/", "powers-of-beta-16", "usrs");
 impl_remote!(Degree17, REMOTE_URL, "resources/", "powers-of-beta-17", "usrs");
 impl_remote!(Degree18, REMOTE_URL, "resources/", "powers-of-beta-18", "usrs");
@@ -52,14 +49,8 @@ impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
 impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
-#[cfg(not(feature = "wasm"))]
 impl_local!(ShiftedDegree15, "resources/", "shifted-powers-of-beta-15", "usrs");
-#[cfg(feature = "wasm")]
-impl_remote!(ShiftedDegree15, REMOTE_URL, "resources/", "shifted-powers-of-beta-15", "usrs");
-#[cfg(not(feature = "wasm"))]
 impl_local!(ShiftedDegree16, "resources/", "shifted-powers-of-beta-16", "usrs");
-#[cfg(feature = "wasm")]
-impl_remote!(ShiftedDegree16, REMOTE_URL, "resources/", "shifted-powers-of-beta-16", "usrs");
 impl_remote!(ShiftedDegree17, REMOTE_URL, "resources/", "shifted-powers-of-beta-17", "usrs");
 impl_remote!(ShiftedDegree18, REMOTE_URL, "resources/", "shifted-powers-of-beta-18", "usrs");
 impl_remote!(ShiftedDegree19, REMOTE_URL, "resources/", "shifted-powers-of-beta-19", "usrs");


### PR DESCRIPTION
## Motivation

If building transactions without an internet connection in `wasm`, the `CommiterKey` can't be initialized without powers of 15 and shifted powers of 16 being included in `wasm` binary. This PR ensures these powers are included with `wasm` binaries so that `wasm` provers can operate offline.