### PR TITLE
[Feature] Enable consensus heights to be set in `wasm`

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -106,8 +106,13 @@ pub const TEST_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); NUM_CONSENSU
     (ConsensusVersion::V10, 18),
 ];
 
-#[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
-pub fn load_test_consensus_heights() -> [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
+#[cfg(any(test, feature = "test", feature = "test_consensus_heights", feature = "wasm"))]
+pub fn load_test_consensus_heights(
+    #[cfg(feature = "wasm")] consensus_version_heights: Option<String>,
+) -> [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
+    #[cfg(not(feature = "wasm"))]
+    let consensus_version_heights = std::env::var("CONSENSUS_VERSION_HEIGHTS").ok();
+
     // Define a closure to verify the consensus heights.
     let verify_consensus_heights = |heights: &[(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS]| {
         // Assert that the genesis height is 0.
@@ -124,8 +129,8 @@ pub fn load_test_consensus_heights() -> [(ConsensusVersion, u32); NUM_CONSENSUS_
     let mut test_consensus_heights = TEST_CONSENSUS_VERSION_HEIGHTS;
 
     // Check if we can read the heights from an environment variable.
-    match std::env::var("CONSENSUS_VERSION_HEIGHTS") {
-        Ok(height_string) => {
+    match consensus_version_heights {
+        Some(height_string) => {
             let parsing_error = format!("Expected exactly {NUM_CONSENSUS_VERSIONS} ConsensusVersion heights.");
             // Parse the heights from the environment variable.
             let parsed_test_consensus_heights: [u32; NUM_CONSENSUS_VERSIONS] = height_string
@@ -143,7 +148,7 @@ pub fn load_test_consensus_heights() -> [(ConsensusVersion, u32); NUM_CONSENSUS_
             verify_consensus_heights(&test_consensus_heights);
             test_consensus_heights
         }
-        Err(_) => {
+        None => {
             // Verify and return the default test consensus heights.
             verify_consensus_heights(&test_consensus_heights);
             test_consensus_heights

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -106,13 +106,16 @@ pub const TEST_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); NUM_CONSENSU
     (ConsensusVersion::V10, 18),
 ];
 
-#[cfg(any(test, feature = "test", feature = "test_consensus_heights", feature = "wasm"))]
-pub fn load_test_consensus_heights(
-    #[cfg(feature = "wasm")] consensus_version_heights: Option<String>,
-) -> [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
-    #[cfg(not(feature = "wasm"))]
-    let consensus_version_heights = std::env::var("CONSENSUS_VERSION_HEIGHTS").ok();
+#[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
+pub fn load_test_consensus_heights() -> [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
+    // Attempt to read the test consensus heights from the environment variable.
+    load_test_consensus_heights_inner(std::env::var("CONSENSUS_VERSION_HEIGHTS").ok())
+}
 
+#[cfg(any(test, feature = "test", feature = "test_consensus_heights", feature = "wasm"))]
+pub(crate) fn load_test_consensus_heights_inner(
+    consensus_version_heights: Option<String>,
+) -> [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
     // Define a closure to verify the consensus heights.
     let verify_consensus_heights = |heights: &[(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS]| {
         // Assert that the genesis height is 0.
@@ -128,7 +131,7 @@ pub fn load_test_consensus_heights(
     // Define consensus version heights container used for testing.
     let mut test_consensus_heights = TEST_CONSENSUS_VERSION_HEIGHTS;
 
-    // Check if we can read the heights from an environment variable.
+    // If version heights have been specified, validate and then return them.
     match consensus_version_heights {
         Some(height_string) => {
             let parsing_error = format!("Expected exactly {NUM_CONSENSUS_VERSIONS} ConsensusVersion heights.");

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -131,7 +131,7 @@ pub(crate) fn load_test_consensus_heights_inner(
     // Define consensus version heights container used for testing.
     let mut test_consensus_heights = TEST_CONSENSUS_VERSION_HEIGHTS;
 
-    // If version heights have been specified, validate and then return them.
+    // If version heights have been specified, verify and return them.
     match consensus_version_heights {
         Some(height_string) => {
             let parsing_error = format!("Expected exactly {NUM_CONSENSUS_VERSIONS} ConsensusVersion heights.");

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -41,7 +41,7 @@ pub use testnet_v0::*;
 
 pub mod prelude {
     #[cfg(feature = "wasm")]
-    pub use crate::set_test_consensus_version_heights;
+    pub use crate::set_consensus_version_test_heights;
     pub use crate::{
         CANARY_V0_CONSENSUS_VERSION_HEIGHTS,
         ConsensusVersion,
@@ -504,7 +504,7 @@ pub trait Network:
 }
 
 #[cfg(feature = "wasm")]
-pub fn set_test_consensus_version_heights(heights: Option<String>) -> Result<()> {
+pub fn set_consensus_version_test_heights(heights: Option<String>) -> Result<()> {
     let heights = load_test_consensus_heights(heights);
     CONSENSUS_VERSION_HEIGHTS
         .set(heights)

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -41,7 +41,7 @@ pub use testnet_v0::*;
 
 pub mod prelude {
     #[cfg(feature = "wasm")]
-    pub use crate::set_consensus_version_heights;
+    pub use crate::set_test_consensus_version_heights;
     pub use crate::{
         CANARY_V0_CONSENSUS_VERSION_HEIGHTS,
         ConsensusVersion,
@@ -504,8 +504,8 @@ pub trait Network:
 }
 
 #[cfg(feature = "wasm")]
-pub fn set_consensus_version_heights(heights: String) -> Result<()> {
-    let heights = load_test_consensus_heights(Some(heights));
+pub fn set_test_consensus_version_heights(heights: Option<String>) -> Result<()> {
+    let heights = load_test_consensus_heights(heights);
     CONSENSUS_VERSION_HEIGHTS
         .set(heights)
         .map_err(|_| anyhow!("Consensus version heights have already been initialized and cannot be set twice."))

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -40,6 +40,8 @@ mod testnet_v0;
 pub use testnet_v0::*;
 
 pub mod prelude {
+    #[cfg(feature = "wasm")]
+    pub use crate::set_consensus_version_heights;
     pub use crate::{
         CANARY_V0_CONSENSUS_VERSION_HEIGHTS,
         ConsensusVersion,
@@ -251,7 +253,11 @@ pub trait Network:
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
     fn CONSENSUS_VERSION_HEIGHTS() -> &'static [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
         // NOTE: this function may panic, as it is only called during startup.
-        CONSENSUS_VERSION_HEIGHTS.get_or_init(load_test_consensus_heights)
+        #[cfg(not(feature = "wasm"))]
+        let consensus_version_heights = CONSENSUS_VERSION_HEIGHTS.get_or_init(load_test_consensus_heights);
+        #[cfg(feature = "wasm")]
+        let consensus_version_heights = CONSENSUS_VERSION_HEIGHTS.get_or_init(|| load_test_consensus_heights(None));
+        consensus_version_heights
     }
 
     /// A set of incrementing consensus version heights used for tests.
@@ -495,4 +501,12 @@ pub trait Network:
         root: &Field<Self>,
         leaf: &Vec<Field<Self>>,
     ) -> bool;
+}
+
+#[cfg(feature = "wasm")]
+pub fn set_consensus_version_heights(heights: String) -> Result<()> {
+    let heights = load_test_consensus_heights(Some(heights));
+    CONSENSUS_VERSION_HEIGHTS
+        .set(heights)
+        .map_err(|_| anyhow!("Consensus version heights have already been initialized and cannot be set twice."))
 }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -504,9 +504,9 @@ pub trait Network:
 }
 
 #[cfg(feature = "wasm")]
-pub fn set_consensus_version_test_heights(heights: Option<String>) -> Result<()> {
+pub fn set_consensus_version_test_heights(
+    heights: Option<String>,
+) -> [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
     let heights = load_test_consensus_heights(heights);
-    CONSENSUS_VERSION_HEIGHTS
-        .set(heights)
-        .map_err(|_| anyhow!("Consensus version heights have already been initialized and cannot be set twice."))
+    *CONSENSUS_VERSION_HEIGHTS.get_or_init(|| heights)
 }

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -500,15 +500,19 @@ pub trait Network:
 
 /// Returns the consensus version heights, initializing them if necessary.
 ///
-/// If `heights` is provided, it must be a comma-separated list of ascending block heights
-/// starting from zero (e.g., `"0,2,3,4,..."`) with exactly `NUM_CONSENSUS_VERSIONS` entries.  
-/// These heights correspond to the activation block of each `ConsensusVersion`.
+/// If a `heights` string is provided, it must be a comma-separated list of ascending block heights
+/// starting from zero (e.g., `"0,2,3,4,..."`) with a number of heights exactly equal to the value
+/// of the Network trait's `NUM_CONSENSUS_VERSIONS` constant. These heights correspond to the
+/// activation block of each `ConsensusVersion`.
 ///
-/// If `heights` is `None`, the function uses SnarkVM's default test consensus heights.
+/// If `heights` is `None`, the function will use SnarkVM's default test consensus heights.
 ///
-/// This function caches the initialized heights, so subsequent calls return the same values.  
-/// It should be called first by `wasm` users who need to work with test consensus heights,
-/// immediately after the wasm module is initialized.
+/// This function caches the initialized heights, and can be set only once. Further calls will
+/// return the cached heights.
+///
+/// This method should be called by `wasm` users who need to set test values for consensus heights
+/// for purposes such as testing on a local devnet. If this method needs to be used, it should be
+/// called immediately after the wasm module is initialized.
 #[cfg(feature = "wasm")]
 pub fn get_or_init_consensus_version_heights(
     heights: Option<String>,

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -41,7 +41,7 @@ pub use testnet_v0::*;
 
 pub mod prelude {
     #[cfg(feature = "wasm")]
-    pub use crate::set_consensus_version_test_heights;
+    pub use crate::get_or_init_consensus_version_heights;
     pub use crate::{
         CANARY_V0_CONSENSUS_VERSION_HEIGHTS,
         ConsensusVersion,
@@ -252,12 +252,7 @@ pub trait Network:
     #[allow(non_snake_case)]
     #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
     fn CONSENSUS_VERSION_HEIGHTS() -> &'static [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
-        // NOTE: this function may panic, as it is only called during startup.
-        #[cfg(not(feature = "wasm"))]
-        let consensus_version_heights = CONSENSUS_VERSION_HEIGHTS.get_or_init(load_test_consensus_heights);
-        #[cfg(feature = "wasm")]
-        let consensus_version_heights = CONSENSUS_VERSION_HEIGHTS.get_or_init(|| load_test_consensus_heights(None));
-        consensus_version_heights
+        CONSENSUS_VERSION_HEIGHTS.get_or_init(load_test_consensus_heights)
     }
 
     /// A set of incrementing consensus version heights used for tests.
@@ -503,10 +498,21 @@ pub trait Network:
     ) -> bool;
 }
 
+/// Returns the consensus version heights, initializing them if necessary.
+///
+/// If `heights` is provided, it must be a comma-separated list of ascending block heights
+/// starting from zero (e.g., `"0,2,3,4,..."`) with exactly `NUM_CONSENSUS_VERSIONS` entries.  
+/// These heights correspond to the activation block of each `ConsensusVersion`.
+///
+/// If `heights` is `None`, the function uses SnarkVM's default test consensus heights.
+///
+/// This function caches the initialized heights, so subsequent calls return the same values.  
+/// It should be called first by `wasm` users who need to work with test consensus heights,
+/// immediately after the wasm module is initialized.
 #[cfg(feature = "wasm")]
-pub fn set_consensus_version_test_heights(
+pub fn get_or_init_consensus_version_heights(
     heights: Option<String>,
 ) -> [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
-    let heights = load_test_consensus_heights(heights);
+    let heights = load_test_consensus_heights_inner(heights);
     *CONSENSUS_VERSION_HEIGHTS.get_or_init(|| heights)
 }


### PR DESCRIPTION
## Motivation

Wasm has no access to its host system's userspace and thus any calls to `std::env` fail. This makes it such that any testing being done with the SDK against user devnets fails which seriously restricts the ability of nodejs and web apps to test against devnets.  This PR adds the ability for wasm environment to set the consensus heights manually.

## Related PRs

SDK [PR 1093](https://github.com/ProvableHQ/sdk/pull/1093) enables the SDK to set `ConsensusVersion` test heights through the same `CONSENSUS_VERSION_HEIGHTS` environment variable as SnarkVM. But it requires the change present within this PR.
