### PR TITLE
[Fix] Restore PendingBlocks API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,16 @@ commands:
       - restore_cache:
           key: cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
-          name: "Install Rust and run cargo check"
+          name: "Install Rust"
+          timeout: 10m
           command: |
             $ProgressPreference = "SilentlyContinue"
             # Remove the circleci installed rustc.
-            choco uninstall -y rust
+            choco uninstall -y --force rust
             # Install rust with rustup.
             Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile "C:\rustup-init.exe"
             & C:\rustup-init.exe -y --default-toolchain "1.88.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+            # Add cargo to the PATH.
             $Env:Path += ";$Env:USERPROFILE\.cargo\bin"
             # Verify the installation.
             cargo --version --verbose
@@ -52,7 +54,13 @@ commands:
             if (!(Test-Path "Cargo.lock" -PathType Leaf)) {
                 cargo generate-lockfile
             }
-            cd << parameters.workspace_member >>
+      - run:
+          name: "Run cargo check"
+          command: |
+            # Add cargo to the PATH.
+            $Env:Path += ";$Env:USERPROFILE\.cargo\bin"
+            # Run cargo check for the given crate.
+             cd << parameters.workspace_member >>
             cargo check --examples --benches --tests
       - save_cache:
           paths:

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -64,6 +64,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             randomizing_assignments.push(circuit_assignments);
         }
 
+        #[allow(clippy::unused_enumerate_index)]
         let indices_and_assignments = circuits_to_constraints
             .iter()
             .zip_eq(randomizing_assignments.into_iter())

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -264,6 +264,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         state: &mut prover::State<F, SM>,
     ) -> Result<BTreeMap<CircuitId, Vec<DensePolynomial<F>>>> {
         let assignments_time = start_timer!(|| "Calculate assignments");
+
+        #[allow(clippy::unused_enumerate_index)]
         let assignments: BTreeMap<_, _> = state
             .circuit_specific_states
             .iter()

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -123,6 +123,9 @@ optional = true
 [dependencies.snarkvm-synthesizer]
 workspace = true
 
+[dependencies.snarkvm-utilities]
+workspace = true
+
 [dependencies.aleo-std]
 workspace = true
 features = [ "storage" ]

--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -361,6 +361,7 @@ impl<N: Network> Puzzle<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use console::{
         account::{Address, PrivateKey},
         network::Network,
@@ -373,7 +374,7 @@ mod tests {
     use rand::{CryptoRng, Rng, RngCore, SeedableRng};
     use rand_chacha::ChaChaRng;
 
-    type CurrentNetwork = console::network::MainnetV0;
+    pub type CurrentNetwork = console::network::MainnetV0;
 
     const ITERATIONS: u64 = 100;
 

--- a/ledger/puzzle/src/solutions/mod.rs
+++ b/ledger/puzzle/src/solutions/mod.rs
@@ -87,35 +87,45 @@ impl<N: Network> Deref for PuzzleSolutions<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::PartialSolution;
+
     use console::account::{Address, PrivateKey};
+
+    pub type CurrentNetwork = console::network::MainnetV0;
 
     use std::collections::HashSet;
 
-    type CurrentNetwork = console::network::MainnetV0;
+    /// Generates a single solution.
+    pub fn sample_solution(rng: &mut TestRng) -> Solution<CurrentNetwork> {
+        let address = Address::try_from(PrivateKey::new(rng).unwrap()).unwrap();
+        let partial_solution = PartialSolution::new(rng.r#gen(), address, u64::rand(rng)).unwrap();
+        Solution::new(partial_solution, u64::rand(rng))
+    }
 
-    /// Returns the solutions for the given number of solutions.
-    pub(crate) fn sample_solutions_with_count(
-        num_solutions: usize,
-        rng: &mut TestRng,
-    ) -> PuzzleSolutions<CurrentNetwork> {
-        // Sample a new solutions.
-        let mut solutions = vec![];
-        for _ in 0..num_solutions {
-            let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
-            let address = Address::try_from(private_key).unwrap();
-
-            let partial_solution = PartialSolution::new(rng.r#gen(), address, u64::rand(rng)).unwrap();
-            let solution = Solution::new(partial_solution, u64::rand(rng));
-            solutions.push(solution);
-        }
+    /// Generates a given number of solutions.
+    pub fn sample_solutions_with_count(num_solutions: usize, rng: &mut TestRng) -> PuzzleSolutions<CurrentNetwork> {
+        let solutions = (0..num_solutions).map(|_| sample_solution(rng)).collect();
         PuzzleSolutions::new(solutions).unwrap()
     }
 
+    // Test that empty puzzle solutions are rejected
     #[test]
     fn test_new_is_not_empty() {
         // Ensure the solutions are not empty.
         assert!(PuzzleSolutions::<CurrentNetwork>::new(vec![]).is_err());
+    }
+
+    #[test]
+    fn test_duplicate_solutions_in_puzzle() {
+        let mut rng = TestRng::default();
+
+        // Create a solution and try to use it twice
+        let solution = sample_solution(&mut rng);
+        let duplicate_solution = solution;
+
+        let result = PuzzleSolutions::new(vec![solution, duplicate_solution]);
+        assert!(result.is_err(), "Duplicate solutions in puzzle solutions should be rejected");
     }
 
     #[test]

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -92,7 +92,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Adds the given block as the next block in the ledger.
+    ///
+    /// Note: This may block if another thread is concurrently calling `check_block`, `check_block_content`,or `advance_to_next_block`.
     pub fn advance_to_next_block(&self, block: &Block<N>) -> Result<()> {
+        // Ensure only one task performs block advacement or speculation.
+        let _lock = self.block_advancement_lock.lock();
+
         // Acquire the write lock on the current block.
         let mut current_block = self.current_block.write();
         // Check again for any possible race conditions.

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -81,6 +81,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             bail!("Block has invalid height. Expected {expected_height}, but got {}.", block.height());
         }
 
+        // Ensure solution IDs are unique
+        self.check_block_solution_ids(block, pending_blocks)?;
+
         // Ensure the certificates in the block subdag have met quorum requirements.
         self.check_block_subdag_quorum(block)?;
 
@@ -116,13 +119,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     fn check_block_content_inner<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
         let latest_block = self.latest_block();
-
-        // Ensure the solutions do not already exist.
-        for solution_id in block.solutions().solution_ids() {
-            if self.contains_solution_id(solution_id)? {
-                bail!("Solution ID {solution_id} already exists in the ledger");
-            }
-        }
 
         // TODO (howardwu): Remove this after moving the total supply into credits.aleo.
         {
@@ -276,9 +272,31 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         })
     }
 
+    /// Ensure solutions IDs are unique and did not already appear in previous blocks.
+    /// Called by [`Self::check_block_subdag_inner`]
+    fn check_block_solution_ids(&self, block: &Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<()> {
+        let mut pending_ids = HashSet::new();
+
+        for pending_block in pending_blocks {
+            for solution_id in pending_block.solutions().solution_ids() {
+                if !pending_ids.insert(solution_id) || self.contains_solution_id(solution_id)? {
+                    bail!("Solution ID {solution_id} already exists in the ledger");
+                }
+            }
+        }
+
+        for solution_id in block.solutions().solution_ids() {
+            if !pending_ids.insert(solution_id) || self.contains_solution_id(solution_id)? {
+                bail!("Solution ID {solution_id} already exists in the ledger");
+            }
+        }
+
+        Ok(())
+    }
+
     /// Check that the certificates in the block subdag have met quorum requirements.
     ///
-    /// Called by [`Self::check_block_subdag`]
+    /// Called by [`Self::check_block_subdag_inner`]
     fn check_block_subdag_quorum(&self, block: &Block<N>) -> Result<()> {
         // Check if the block has a subdag.
         let subdag = match block.authority() {
@@ -321,7 +339,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Checks that the block subdag can not be split into multiple valid subdags.
     ///
-    /// Called by [`Self::check_block_subdag`]
+    /// Called by [`Self::check_block_subdag_inner`]
     fn check_block_subdag_atomicity(&self, block: &Block<N>) -> Result<()> {
         // Returns `true` if there is a path from the previous certificate to the current certificate.
         fn is_linked<N: Network>(

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -108,6 +108,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     fn check_block_content_inner<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
+        // Ensure only one task performs block advacement or speculation.
+        let _lock = self.block_advancement_lock.lock();
+
         let latest_block = self.latest_block();
 
         // Construct the finalize state.

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use snarkvm_utilities::ensure_equals;
+
 use crate::narwhal::BatchHeader;
 
 use anyhow::bail;
@@ -58,27 +60,15 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // First check that the heights and hashes of the pending block sequence and of the new block are correct.
         // The hash checks should be redundant, but we perform them out of extra caution.
         let mut expected_height = self.latest_height() + 1;
-        for pending in pending_blocks {
-            if pending.height() != expected_height {
-                bail!(
-                    "Pending block has invalid height. Expected {expected_height}, but got {actual}.",
-                    actual = pending.height()
-                );
-            }
 
-            if self.contains_block_hash(&pending.hash())? {
-                bail!("Hash for pending block '{}' already exists in the ledger", block.hash())
+        for block in pending_blocks.iter().map(|b| b.deref()).chain([block]) {
+            ensure_equals!(block.height(), expected_height, "Block has invalid height");
+
+            if self.contains_block_hash(&block.hash())? {
+                bail!("Hash '{}' for block at height {} already exists in the ledger", block.height(), block.hash())
             }
 
             expected_height += 1;
-        }
-
-        if self.contains_block_hash(&block.hash())? {
-            bail!("Block hash '{}' already exists in the ledger", block.hash())
-        }
-
-        if block.height() != expected_height {
-            bail!("Block has invalid height. Expected {expected_height}, but got {}.", block.height());
         }
 
         // Ensure solution IDs are unique
@@ -254,17 +244,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     fn check_block_solution_ids(&self, block: &Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<()> {
         let mut pending_ids = HashSet::new();
 
-        for pending_block in pending_blocks {
-            for solution_id in pending_block.solutions().solution_ids() {
+        for block in pending_blocks.iter().map(|b| b.deref()).chain([block]) {
+            for solution_id in block.solutions().solution_ids() {
                 if !pending_ids.insert(solution_id) || self.contains_solution_id(solution_id)? {
                     bail!("Solution ID {solution_id} already exists in the ledger");
                 }
-            }
-        }
-
-        for solution_id in block.solutions().solution_ids() {
-            if !pending_ids.insert(solution_id) || self.contains_solution_id(solution_id)? {
-                bail!("Solution ID {solution_id} already exists in the ledger");
             }
         }
 

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -120,29 +120,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     fn check_block_content_inner<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
         let latest_block = self.latest_block();
 
-        // TODO (howardwu): Remove this after moving the total supply into credits.aleo.
-        {
-            // // Retrieve the latest total supply.
-            // let latest_total_supply = self.latest_total_supply_in_microcredits();
-            // // Retrieve the block reward from the first block ratification.
-            // let block_reward = match block.ratifications()[0] {
-            //     Ratify::BlockReward(block_reward) => block_reward,
-            //     _ => bail!("Block {height} is invalid - the first ratification must be a block reward"),
-            // };
-            // // Retrieve the puzzle reward from the second block ratification.
-            // let puzzle_reward = match block.ratifications()[1] {
-            //     Ratify::PuzzleReward(puzzle_reward) => puzzle_reward,
-            //     _ => bail!("Block {height} is invalid - the second ratification must be a puzzle reward"),
-            // };
-            // // Compute the next total supply in microcredits.
-            // let next_total_supply_in_microcredits =
-            //     update_total_supply(latest_total_supply, block_reward, puzzle_reward, block.transactions())?;
-            // // Ensure the total supply in microcredits is correct.
-            // if next_total_supply_in_microcredits != block.total_supply_in_microcredits() {
-            //     bail!("Invalid total supply in microcredits")
-            // }
-        }
-
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(
             block.round(),

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -17,21 +17,105 @@ use super::*;
 
 use crate::narwhal::BatchHeader;
 
-impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
-    /// Checks the given block is valid next block.
-    pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
-        let height = block.height();
-        let latest_block = self.latest_block();
+use anyhow::bail;
 
-        // Check that this is actually the next block.
-        if height != latest_block.height() + 1 {
-            bail!("Block height is {height}, but expected {}", latest_block.height() + 1);
+/// Wrapper for a block that has a valid subDAG, but where the block header,
+/// solutions, and transmissions have not been verified yet.
+///
+/// This type is created by `Ledger::check_block_subdag` and consumed by `Ledger::check_block_content`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PendingBlock<N: Network>(Block<N>);
+
+impl<N: Network> Deref for PendingBlock<N> {
+    type Target = Block<N>;
+
+    fn deref(&self) -> &Block<N> {
+        &self.0
+    }
+}
+
+impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
+    /// Checks that the subDAG in a given block is valid, but does not fully verify the block.
+    ///
+    /// # Arguments
+    /// * `block` - The block to check.
+    /// * `pending_block` - A sequence of blocks between the block to check and the current height of the ledger.
+    ///
+    /// # Notes
+    /// * This does *not* check that the header of the block is correct or execute/verify any of the transmissions contained within it.
+    ///
+    /// * In most cases, you want to use [`Self::check_next_block`] instead to perform a full verification.
+    ///
+    /// * This will reject any blocks with a height <= the current height and any blocks with a height >= the current height + GC.
+    ///   For the former, a valid block already exists and,
+    ///   for the latter, the comittte is still unknown.
+    pub fn check_block_subdag(&self, block: Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        self.check_block_subdag_inner(&block, pending_blocks)?;
+        Ok(PendingBlock(block))
+    }
+
+    fn check_block_subdag_inner(&self, block: &Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<()> {
+        // First check that the heights and hashes of the pending block sequence and of the new block are correct.
+        // The hash checks should be redundant, but we perform them out of extra caution.
+        let mut expected_height = self.latest_height() + 1;
+        for pending in pending_blocks {
+            if pending.height() != expected_height {
+                bail!(
+                    "Pending block has invalid height. Expected {expected_height}, but got {actual}.",
+                    actual = pending.height()
+                );
+            }
+
+            if self.contains_block_hash(&pending.hash())? {
+                bail!("Hash for pending block '{}' already exists in the ledger", block.hash())
+            }
+
+            expected_height += 1;
         }
 
-        // Ensure the block hash does not already exist.
         if self.contains_block_hash(&block.hash())? {
             bail!("Block hash '{}' already exists in the ledger", block.hash())
         }
+
+        if block.height() != expected_height {
+            bail!("Block has invalid height. Expected {expected_height}, but got {}.", block.height());
+        }
+
+        // Ensure the certificates in the block subdag have met quorum requirements.
+        self.check_block_subdag_quorum(block)?;
+
+        // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
+        self.check_block_subdag_atomicity(block)?;
+
+        // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
+        self.check_block_subdag_leaves(block, pending_blocks)?;
+
+        Ok(())
+    }
+
+    /// Checks the given block is a valid next block with regard to the current state/height of the Ledger.
+    pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
+        self.check_block_subdag_inner(block, &[])?;
+        self.check_block_content_inner(block, rng)?;
+
+        Ok(())
+    }
+
+    /// Takes a pending block and performs the remaining checks to full verify it.
+    ///
+    /// # Arguments
+    /// This takes a [`PendingBlock`] as input, which is the output of a successful call to [`Self::check_block_subdag`].
+    /// The latter already verified the block's DAG and certificate signatures.
+    ///
+    /// # Return Value
+    /// This returns a [`Block`] on success representing the fully verified block.
+    pub fn check_block_content<R: CryptoRng + Rng>(&self, block: PendingBlock<N>, rng: &mut R) -> Result<Block<N>> {
+        self.check_block_content_inner(&block.0, rng)?;
+        Ok(block.0)
+    }
+
+    fn check_block_content_inner<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
+        let latest_block = self.latest_block();
 
         // Ensure the solutions do not already exist.
         for solution_id in block.solutions().solution_ids() {
@@ -124,15 +208,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
         }
 
-        // Ensure the certificates in the block subdag have met quorum requirements.
-        self.check_block_subdag_quorum(block)?;
-
-        // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
-        self.check_block_subdag_atomicity(block)?;
-
-        // Ensure that all leafs of the subdag point to valid batches in other subdags/blocks.
-        self.check_block_subdag_leaves(block)?;
-
         // Ensure that each existing solution ID from the block exists in the ledger.
         for existing_solution_id in expected_existing_solution_ids {
             if !self.contains_solution_id(&existing_solution_id)? {
@@ -154,11 +229,20 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// This does not verify that the batches are signed correctly or that the edges are valid
     /// (only point to the previous round), as those checks already happened when the node received the batch.
-    fn check_block_subdag_leaves(&self, block: &Block<N>) -> Result<()> {
+    fn check_block_subdag_leaves(&self, block: &Block<N>, previous_blocks: &[PendingBlock<N>]) -> Result<()> {
         // Check if the block has a subdag.
         let Authority::Quorum(subdag) = block.authority() else {
             return Ok(());
         };
+
+        let previous_certs: HashSet<_> = previous_blocks
+            .iter()
+            .filter_map(|block| match block.authority() {
+                Authority::Quorum(subdag) => Some(subdag.certificate_ids()),
+                Authority::Beacon(_) => None,
+            })
+            .flatten()
+            .collect();
 
         // Store the IDs of all certificates in this subDAG.
         // This allows determining which edges point to other subDAGs/blocks.
@@ -182,7 +266,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
 
             // Ensure that the certificate is associated with a previous block.
-            if !self.vm.block_store().contains_block_for_certificate(prev_id)? {
+            if !previous_certs.contains(prev_id) && !self.vm.block_store().contains_block_for_certificate(prev_id)? {
                 bail!(
                     "Batch(es) in the block point(s) to a certificate {prev_id} in round {prev_round} that is not associated with a previous block"
                 )
@@ -193,6 +277,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Check that the certificates in the block subdag have met quorum requirements.
+    ///
+    /// Called by [`Self::check_block_subdag`]
     fn check_block_subdag_quorum(&self, block: &Block<N>) -> Result<()> {
         // Check if the block has a subdag.
         let subdag = match block.authority() {
@@ -234,6 +320,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Checks that the block subdag can not be split into multiple valid subdags.
+    ///
+    /// Called by [`Self::check_block_subdag`]
     fn check_block_subdag_atomicity(&self, block: &Block<N>) -> Result<()> {
         // Returns `true` if there is a path from the previous certificate to the current certificate.
         fn is_linked<N: Network>(

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -25,7 +25,7 @@ use anyhow::bail;
 /// solutions, and transmissions have not been verified yet.
 ///
 /// This type is created by `Ledger::check_block_subdag` and consumed by `Ledger::check_block_content`.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PendingBlock<N: Network>(Block<N>);
 
 impl<N: Network> Deref for PendingBlock<N> {
@@ -360,5 +360,80 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        check_next_block::PendingBlock,
+        test_helpers::{sample_genesis_block, sample_test_env},
+    };
+
+    use console::prelude::*;
+
+    #[test]
+    fn test_check_block_subdag_inner_duplicate_hash() {
+        let mut rng = TestRng::default();
+        let test_env = sample_test_env(&mut rng);
+        let ledger = test_env.ledger;
+
+        // Get the existing genesis block
+        let genesis_block = ledger.latest_block().clone();
+
+        // Try to check a block with the same hash as genesis (already exists)
+        let result = ledger.check_block_subdag_inner(&genesis_block, &[]);
+        assert!(result.is_err(), "check_block_subdag_inner should fail for duplicate block hash");
+
+        // The error could be either about duplicate hash or invalid height
+        let error_message = result.unwrap_err().to_string();
+        assert!(
+            error_message.contains("already exists in the ledger")
+                || error_message.contains("Block has invalid height"),
+        );
+    }
+
+    #[test]
+    fn test_check_block_subdag_with_empty_pending_blocks() {
+        let mut rng = TestRng::default();
+        let test_env = sample_test_env(&mut rng);
+        let ledger = test_env.ledger;
+
+        let genesis_block = ledger.latest_block().clone();
+
+        // Test all individual functions with empty pending blocks.
+        //TODO(kaimast): test with blocks other than the genesis.
+
+        let result1 = ledger.check_block_solution_ids(&genesis_block, &[]);
+        assert!(result1.is_ok(), "check_block_solution_ids should succeed with empty pending blocks");
+
+        let result2 = ledger.check_block_subdag_quorum(&genesis_block);
+        assert!(result2.is_ok(), "check_block_subdag_quorum should succeed");
+
+        let result3 = ledger.check_block_subdag_atomicity(&genesis_block);
+        assert!(result3.is_ok(), "check_block_subdag_atomicity should succeed");
+
+        let result4 = ledger.check_block_subdag_leaves(&genesis_block, &[]);
+        assert!(result4.is_ok(), "check_block_subdag_leaves should succeed with empty pending blocks");
+    }
+
+    #[test]
+    fn test_pending_block_properties() {
+        let mut rng = TestRng::default();
+
+        //TODO(kaimast): test with blocks other than the genesis.
+        let genesis_block = sample_genesis_block(&mut rng);
+        let pending_block = PendingBlock(genesis_block.clone());
+
+        // Test all properties accessible through Deref
+        assert_eq!(pending_block.height(), genesis_block.height());
+        assert_eq!(pending_block.hash(), genesis_block.hash());
+        assert_eq!(pending_block.round(), genesis_block.round());
+        assert_eq!(pending_block.timestamp(), genesis_block.timestamp());
+        assert_eq!(pending_block.previous_hash(), genesis_block.previous_hash());
+
+        // Test Clone and PartialEq
+        let pending_block2 = pending_block.clone();
+        assert_eq!(pending_block, pending_block2, "PendingBlock should be cloneable and equal");
     }
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -37,8 +37,10 @@ pub use helpers::*;
 
 pub use crate::block::*;
 
-mod advance;
 mod check_next_block;
+pub use check_next_block::PendingBlock;
+
+mod advance;
 mod check_transaction_basic;
 mod contains;
 mod find;

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -149,6 +149,10 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
     committee_cache: Arc<Mutex<LruCache<u64, Committee<N>>>>,
     /// The cache that holds the provers and the number of solutions they have submitted for the current epoch.
     epoch_provers_cache: Arc<RwLock<IndexMap<Address<N>, u32>>>,
+    /// This lock ensures only one task modifies the ledger at a time.
+    ///
+    /// Note: this also applies to speculation, as that mechanism uses atomic batches.
+    block_advancement_lock: Arc<Mutex<()>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
@@ -215,6 +219,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             current_block: Arc::new(RwLock::new(genesis_block.clone())),
             committee_cache,
             epoch_provers_cache: Default::default(),
+            block_advancement_lock: Default::default(),
         };
 
         // If the block store is empty, add the genesis block.

--- a/ledger/store/src/helpers/memory/internal/map.rs
+++ b/ledger/store/src/helpers/memory/internal/map.rs
@@ -137,7 +137,10 @@ impl<
         // Set the atomic batch flag to `true`.
         self.batch_in_progress.store(true, Ordering::SeqCst);
         // Ensure that the atomic batch is empty.
-        assert!(self.atomic_batch.lock().is_empty());
+        assert!(
+            self.atomic_batch.lock().is_empty(),
+            "Cannot start an atomic operation when the atomic batch is not empty"
+        );
     }
 
     ///

--- a/ledger/store/src/helpers/memory/internal/nested_map.rs
+++ b/ledger/store/src/helpers/memory/internal/nested_map.rs
@@ -152,7 +152,10 @@ impl<
         // Set the atomic batch flag to `true`.
         self.batch_in_progress.store(true, Ordering::SeqCst);
         // Ensure that the atomic batch is empty.
-        assert!(self.atomic_batch.lock().is_empty());
+        assert!(
+            self.atomic_batch.lock().is_empty(),
+            "Cannot start an atomic operation when the atomic batch is not empty"
+        );
     }
 
     ///

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -117,11 +117,17 @@ impl<
         self.database.atomic_depth.fetch_add(1, Ordering::SeqCst);
 
         // Ensure that the atomic batch is empty.
-        assert!(self.atomic_batch.lock().is_empty());
+        assert!(
+            self.atomic_batch.lock().is_empty(),
+            "Cannot start an atomic operation when the atomic batch is not empty"
+        );
         // Ensure that the database atomic batch is empty; skip this check if the atomic
         // writes are paused, as there may be pending operations.
         if !self.database.are_atomic_writes_paused() {
-            assert!(self.database.atomic_batch.lock().is_empty());
+            assert!(
+                self.database.atomic_batch.lock().is_empty(),
+                "Cannot start an atomic operation when the database atomic batch is not empty"
+            );
         }
     }
 
@@ -229,7 +235,10 @@ impl<
 
         // Ensure that the value of `atomic_depth` doesn't overflow, meaning that all the
         // calls to `start_atomic` have corresponding calls to `finish_atomic`.
-        assert!(previous_atomic_depth != 0);
+        assert_ne!(
+            previous_atomic_depth, 0,
+            "Atomic depth underflow: finish_atomic called without corresponding start_atomic"
+        );
 
         // If we're at depth 0, it is the final call to `finish_atomic` and the
         // atomic write batch can be physically executed. This is skipped if the
@@ -240,7 +249,10 @@ impl<
             // Execute all the operations atomically.
             self.database.rocksdb.write(batch)?;
             // Ensure that the database atomic batch is empty.
-            assert!(self.database.atomic_batch.lock().is_empty());
+            assert!(
+                self.database.atomic_batch.lock().is_empty(),
+                "Database atomic batch must empty after write operation"
+            );
         }
 
         Ok(())

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -202,11 +202,17 @@ impl<
         self.database.atomic_depth.fetch_add(1, Ordering::SeqCst);
 
         // Ensure that the atomic batch is empty.
-        assert!(self.atomic_batch.lock().is_empty());
+        assert!(
+            self.atomic_batch.lock().is_empty(),
+            "Cannot start an atomic operation when the atomic batch is not empty"
+        );
         // Ensure that the database atomic batch is empty; skip this check if the atomic
         // writes are paused, as there may be pending operations.
         if !self.database.are_atomic_writes_paused() {
-            assert!(self.database.atomic_batch.lock().is_empty());
+            assert!(
+                self.database.atomic_batch.lock().is_empty(),
+                "Cannot start an atomic operation when the database atomic batch is not empty"
+            );
         }
     }
 
@@ -325,7 +331,10 @@ impl<
 
         // Ensure that the value of `atomic_depth` doesn't overflow, meaning that all the
         // calls to `start_atomic` have corresponding calls to `finish_atomic`.
-        assert!(previous_atomic_depth != 0);
+        assert_ne!(
+            previous_atomic_depth, 0,
+            "Atomic depth underflow: finish_atomic called without corresponding start_atomic"
+        );
 
         // If we're at depth 0, it is the final call to `finish_atomic` and the
         // atomic write batch can be physically executed. This is skipped if the
@@ -336,7 +345,10 @@ impl<
             // Execute all the operations atomically.
             self.database.rocksdb.write(batch)?;
             // Ensure that the database atomic batch is empty.
-            assert!(self.database.atomic_batch.lock().is_empty());
+            assert!(
+                self.database.atomic_batch.lock().is_empty(),
+                "Database atomic batch should be empty after write operation"
+            );
         }
 
         Ok(())

--- a/ledger/tests/helpers/mod.rs
+++ b/ledger/tests/helpers/mod.rs
@@ -1,0 +1,300 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use aleo_std::StorageMode;
+use snarkvm_console::{
+    account::{Address, PrivateKey},
+    network::MainnetV0,
+    prelude::*,
+};
+use snarkvm_ledger::{Block, Ledger};
+use snarkvm_ledger_narwhal::{BatchCertificate, BatchHeader, Subdag};
+use snarkvm_ledger_store::ConsensusStore;
+use snarkvm_synthesizer::vm::VM;
+
+use indexmap::{IndexMap, IndexSet};
+use std::collections::{BTreeMap, HashMap};
+use time::OffsetDateTime;
+
+pub type CurrentNetwork = MainnetV0;
+
+#[cfg(not(feature = "rocks"))]
+pub type LedgerType<N> = snarkvm_ledger_store::helpers::memory::ConsensusMemory<N>;
+#[cfg(feature = "rocks")]
+pub type LedgerType<N> = snarkvm_ledger_store::helpers::rocksdb::ConsensusDB<N>;
+
+/// Helper to build chains with custom structures for testing.
+pub struct TestChainBuilder {
+    /// The keys of all validators.
+    private_keys: Vec<PrivateKey<CurrentNetwork>>,
+    /// The underlying ledger.
+    ledger: Ledger<CurrentNetwork, LedgerType<CurrentNetwork>>,
+    /// The round containing the leader certificate for the most recent block we generated.
+    last_block_round: u64,
+    /// The batch certificates of the last round we generated.
+    round_to_certificates: HashMap<u64, IndexMap<usize, BatchCertificate<CurrentNetwork>>>,
+    /// The batch certificate of the last leader (if any).
+    previous_leader_certificate: Option<BatchCertificate<CurrentNetwork>>,
+    /// The last round for each committee member where they created a batch.
+    /// Invariant: for any validator i, last_batch[i] <= last_committed_batch[i]
+    last_batch_round: HashMap<usize, u64>,
+    /// The last batch of a validator that was included in a block.
+    last_committed_batch_round: HashMap<usize, u64>,
+    /// The start of the test chain.
+    genesis_block: Block<CurrentNetwork>,
+}
+
+/// Additional options you can pass to the builder when generating blocks.
+#[derive(Default)]
+pub struct BlockOptions {
+    /// Do not include votes to the previous leader certificate
+    pub skip_votes: bool,
+    /// Do not generate certificates for the specific node indices (to simulate a partition).
+    pub skip_nodes: Vec<usize>,
+}
+
+impl TestChainBuilder {
+    pub fn new(committee_size: usize, rng: &mut TestRng) -> Self {
+        // Sample the genesis private key.
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        // Initialize the store.
+        let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+        // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
+        let seed: u64 = rng.r#gen();
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let genesis_block = VM::from(store).unwrap().genesis_beacon(&private_key, genesis_rng).unwrap();
+
+        // Extract the private keys from the genesis committee by using the same RNG to sample private keys.
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let private_keys = (0..committee_size).map(|_| PrivateKey::new(genesis_rng).unwrap()).collect();
+
+        Self::from_genesis(private_keys, genesis_block)
+    }
+
+    /// Initialize the builder with the specified committee and gensis block
+    pub fn from_genesis(private_keys: Vec<PrivateKey<CurrentNetwork>>, genesis_block: Block<CurrentNetwork>) -> Self {
+        // Initialize the ledger with the genesis block.
+        let ledger = Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(
+            genesis_block.clone(),
+            StorageMode::new_test(None),
+        )
+        .unwrap();
+
+        Self {
+            private_keys,
+            ledger,
+
+            genesis_block,
+            last_batch_round: Default::default(),
+            last_committed_batch_round: Default::default(),
+            last_block_round: 0,
+            round_to_certificates: Default::default(),
+            previous_leader_certificate: Default::default(),
+        }
+    }
+
+    /// Create multiple blocks, with fully-connected DAGs.
+    #[allow(dead_code)]
+    pub fn generate_blocks(&mut self, num_blocks: usize, rng: &mut TestRng) -> Vec<Block<CurrentNetwork>> {
+        self.generate_blocks_with_opts(num_blocks, &BlockOptions::default(), rng)
+    }
+
+    /// Create multiple blocks, with additional parameters.
+    pub fn generate_blocks_with_opts(
+        &mut self,
+        num_blocks: usize,
+        options: &BlockOptions,
+        rng: &mut TestRng,
+    ) -> Vec<Block<CurrentNetwork>> {
+        assert!(num_blocks > 0, "Need to build at least one block");
+
+        (0..num_blocks).map(|_| self.generate_block_with_opts(options, rng)).collect()
+    }
+
+    /// Create a new block, with a fully-connected DAG.
+    ///
+    /// This will "fill in" any gaps left in earlier rounds from non participating nodes.
+    pub fn generate_block(&mut self, rng: &mut TestRng) -> Block<CurrentNetwork> {
+        self.generate_block_with_opts(&BlockOptions::default(), rng)
+    }
+
+    /// Same as `generate_block` but with additional options/parameters.
+    pub fn generate_block_with_opts(&mut self, options: &BlockOptions, rng: &mut TestRng) -> Block<CurrentNetwork> {
+        assert!(
+            options.skip_nodes.len() * 3 < self.private_keys.len(),
+            "Cannot mark more than f nodes as unavailable/skipped"
+        );
+
+        let next_block_round = self.last_block_round + 2;
+
+        // SubDAGs can be at most GC rounds long.
+        let mut round = if next_block_round < BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64 {
+            // Batches from genesis round cannot be included in any block that isn't genesis
+            1
+        } else {
+            next_block_round - BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64
+        };
+
+        // =======================================
+        // Create certificates for the new block.
+        // =======================================
+        loop {
+            let mut created_anchor = false;
+
+            let previous_certificate_ids = if round == 1 {
+                IndexSet::default()
+            } else {
+                self.round_to_certificates
+                    .get(&(round - 1))
+                    .unwrap()
+                    .iter()
+                    .filter_map(|(_, cert)| {
+                        // If votes are skipped, remove previous leader cert from the set.
+                        let skip = if let Some(leader) = &self.previous_leader_certificate {
+                            options.skip_votes && leader.id() == cert.id()
+                        } else {
+                            false
+                        };
+
+                        if skip { None } else { Some(cert.id()) }
+                    })
+                    .collect()
+            };
+
+            let committee = self.ledger.get_committee_lookback_for_round(round).unwrap().unwrap_or_else(|| {
+                panic!("No committee for round {round}");
+            });
+
+            for (key1_idx, private_key_1) in self.private_keys.iter().enumerate() {
+                if options.skip_nodes.contains(&key1_idx) {
+                    continue;
+                }
+                // Don't recreate batches that already exist.
+                if self.last_batch_round.get(&key1_idx).unwrap_or(&0) >= &round {
+                    continue;
+                }
+
+                let batch_header = BatchHeader::new(
+                    private_key_1,
+                    round,
+                    OffsetDateTime::now_utc().unix_timestamp(),
+                    committee.id(),
+                    Default::default(),
+                    previous_certificate_ids.clone(),
+                    rng,
+                )
+                .unwrap();
+
+                // Add signatures for the batch header.
+                let signatures = self
+                    .private_keys
+                    .iter()
+                    .enumerate()
+                    .filter(|&(key2_idx, _)| key1_idx != key2_idx)
+                    .map(|(_, private_key_2)| private_key_2.sign(&[batch_header.batch_id()], rng).unwrap())
+                    .collect();
+
+                // Update the round at which this validator last created a batch.
+                self.last_batch_round.insert(key1_idx, round);
+
+                // Insert certificate into the round_to_certificates mapping.
+                self.round_to_certificates
+                    .entry(round)
+                    .or_default()
+                    .insert(key1_idx, BatchCertificate::from(batch_header, signatures).unwrap());
+
+                // Check if this batch was an anchor.
+                if round % 2 == 0 {
+                    let leader = committee.get_leader(round).unwrap();
+                    if leader == Address::try_from(private_key_1).unwrap() {
+                        created_anchor = true;
+                    }
+                }
+            }
+
+            // Anchor was confirmed by more than a third of the validators.
+            if created_anchor && round % 2 == 0 && self.last_block_round < round {
+                self.last_block_round = round;
+                break;
+            }
+
+            round += 1;
+        }
+
+        // ==============================================================
+        // Build a subdag from the new certificates and create the block.
+        // ==============================================================
+        let commit_round = round;
+
+        let leader_committee = self.ledger.get_committee_lookback_for_round(round).unwrap().unwrap();
+        let leader = leader_committee.get_leader(commit_round).unwrap();
+        let (leader_idx, leader_certificate) =
+            self.round_to_certificates.get(&commit_round).unwrap().iter().find(|(_, c)| c.author() == leader).unwrap();
+        let leader_idx = *leader_idx;
+        let leader_certificate = leader_certificate.clone();
+
+        // Construct the subdag for the new block.
+        let mut subdag_map = BTreeMap::new();
+
+        // Figure out what the earliest round for the subDAG could be.
+        let start_round = if commit_round < BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64 {
+            1
+        } else {
+            commit_round - BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64 + 2
+        };
+
+        for round in start_round..commit_round {
+            let mut to_insert = IndexSet::new();
+            for idx in 0..self.private_keys.len() {
+                // Some of the batches we in previous rounds might not be new,
+                // and already included in a previous block.
+                let cround = self.last_committed_batch_round.entry(idx).or_default();
+                // Batch already included in another block
+                if *cround >= round {
+                    continue;
+                }
+
+                if let Some(cert) = self.round_to_certificates.entry(round).or_default().get(&idx) {
+                    to_insert.insert(cert.clone());
+                    *cround = round;
+                }
+            }
+            if !to_insert.is_empty() {
+                subdag_map.insert(round, to_insert);
+            }
+        }
+
+        // Add the leader certificate.
+        // (special case, because it is the only cert included from the commit round)
+        subdag_map.insert(commit_round, [leader_certificate.clone()].into());
+        self.last_committed_batch_round.insert(leader_idx, commit_round);
+
+        // Construct the block.
+        let subdag = Subdag::from(subdag_map).unwrap();
+        let block = self.ledger.prepare_advance_to_next_quorum_block(subdag, Default::default(), rng).unwrap();
+        self.ledger.check_next_block(&block, rng).unwrap();
+
+        // Update th ledger state.
+        self.ledger.advance_to_next_block(&block).unwrap();
+        self.previous_leader_certificate = Some(leader_certificate.clone());
+
+        block
+    }
+
+    /// Return the genesis block associated with the test chain
+    pub fn genesis_block(&self) -> &Block<CurrentNetwork> {
+        &self.genesis_block
+    }
+}

--- a/ledger/tests/pending_blocks.rs
+++ b/ledger/tests/pending_blocks.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod helpers;
+use helpers::{BlockOptions, CurrentNetwork, LedgerType, TestChainBuilder};
+
+use snarkvm_ledger::Ledger;
+
+use aleo_std::StorageMode;
+use snarkvm_utilities::TestRng;
+
+#[test]
+fn test_preprocess_block() {
+    let rng = &mut TestRng::default();
+
+    let mut builder = TestChainBuilder::new(4, rng);
+
+    // Construct the ledger.
+    let ledger = Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(
+        builder.genesis_block().clone(),
+        StorageMode::new_test(None),
+    )
+    .unwrap();
+
+    // Generate a bunch of blocks that do not contain votes
+    let mut pending_blocks = vec![];
+
+    for block in builder.generate_blocks_with_opts(5, &BlockOptions { skip_votes: true, ..Default::default() }, rng) {
+        if !pending_blocks.is_empty() {
+            // We shoud only be able to pre-process a pending block if the previous
+            // blocks are applied to the ledger or in the pending set
+            assert!(ledger.check_block_subdag(block.clone(), &[]).is_err());
+        }
+
+        let pending_block = ledger.check_block_subdag(block, &pending_blocks).unwrap();
+        pending_blocks.push(pending_block);
+    }
+
+    // Now, create a "vote block" that contains sufficient votes to the previous leader block
+    let vote_block = builder.generate_block(rng);
+    assert!(ledger.check_next_block(&vote_block, rng).is_err());
+
+    for pending in pending_blocks.into_iter() {
+        let block = ledger.check_block_content(pending, rng).expect("Pending block should be accepted");
+        assert!(ledger.advance_to_next_block(&block).is_ok());
+    }
+
+    // Now the commit block should be accepted
+    assert!(ledger.check_next_block(&vote_block, rng).is_ok());
+    assert!(ledger.advance_to_next_block(&vote_block).is_ok());
+}


### PR DESCRIPTION
This PR restores the changes from #2745. 

The PR is mostly unchanged except for a few changes to reduce the reordering of checks, most notably the solution ID checks are now performed earlier (see [be754f1](https://github.com/ProvableHQ/snarkVM/pull/2932/commits/be754f1b299003a5ed1b696913c4d4411ef713d8)).

Finally, the PR adds a `--force` argument to `choco uninstall rust`. It seems to help with the flakiness of windows CI ([1f43c5d](https://github.com/ProvableHQ/snarkVM/pull/2932/commits/1f43c5dabd2b9e3c3228a8576723f6409ed4ada8)). 