### PR TITLE
[CI] Fix semver errors due to CLI removal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -610,7 +610,8 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --test '*' --features test -- --test-threads=4
+          flags: --test '*' --features test
+          timeout: 30
           cache_key_suffix: -integration
 
   synthesizer-process:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -797,7 +797,7 @@ jobs:
 
   check-cargo-semver-checks:
     executor: rust-docker
-    resource_class: << pipeline.parameters.large >>
+    resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - checkout
       - setup_environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,9 +805,8 @@ jobs:
           name: Check for semver violations
           no_output_timeout: 15m
           command: |
-            cargo install cargo-semver-checks@0.43.0 --locked
-            BASELINE_REV=eff84712b # UPDATE ME ON NECESSARY BREAKING CHANGES
-            cargo semver-checks --workspace --default-features --baseline-rev $BASELINE_REV
+            bash ./semver-checks.sh
+
       - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-cargo-semver-checks-cache
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 dependencies = [
  "backtrace",
 ]
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
@@ -341,9 +341,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -483,7 +483,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "log",
  "serde",
  "serde_derive",
@@ -880,9 +880,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flate2"
@@ -1063,7 +1063,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.6+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1090,7 +1090,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -1129,6 +1129,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hermit-abi"
@@ -1390,14 +1396,15 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "rayon",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1472,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2303,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "log",
  "once_cell",
@@ -2436,9 +2443,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2446,18 +2453,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -2470,7 +2477,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -2496,7 +2503,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itoa",
  "ryu",
  "serde",
@@ -2625,7 +2632,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -2708,7 +2715,7 @@ name = "snarkvm-circuit-environment"
 version = "4.2.1"
 dependencies = [
  "criterion",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -2899,7 +2906,7 @@ version = "4.2.1"
 dependencies = [
  "aleo-std",
  "criterion",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "rayon",
  "snarkvm-console-algorithms",
  "snarkvm-console-network",
@@ -2912,7 +2919,7 @@ version = "4.2.1"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "lazy_static",
  "paste",
  "serde",
@@ -2950,7 +2957,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "num-derive",
  "num-traits",
  "serde_json",
@@ -3099,7 +3106,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "locktick",
  "lru",
  "parking_lot",
@@ -3142,7 +3149,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -3169,7 +3176,7 @@ version = "4.2.1"
 dependencies = [
  "anyhow",
  "bincode",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3202,7 +3209,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.2.1"
 dependencies = [
  "bincode",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3216,7 +3223,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.2.1"
 dependencies = [
  "bincode",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3242,7 +3249,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.2.1"
 dependencies = [
  "bincode",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3284,7 +3291,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "locktick",
  "lru",
  "parking_lot",
@@ -3304,7 +3311,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "locktick",
  "lru",
  "parking_lot",
@@ -3343,7 +3350,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3429,7 +3436,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itertools 0.14.0",
  "locktick",
  "lru",
@@ -3468,7 +3475,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "criterion",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3495,7 +3502,7 @@ version = "4.2.1"
 dependencies = [
  "bincode",
  "criterion",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3790,11 +3797,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -3891,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
  "rustls",
  "tokio",
@@ -4207,9 +4215,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.6+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f71243a3f320c00a8459e455c046ce571229c2f31fd11645d9dc095e3068ca0"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
@@ -4225,9 +4233,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4238,9 +4246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -4252,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.51"
+version = "0.4.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4265,9 +4273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote 1.0.40",
  "wasm-bindgen-macro-support",
@@ -4275,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4288,18 +4296,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cc7f8a4114fdaa0c58383caf973fc126cf004eba25c9dc639bccd3880d55ad"
+checksum = "aee0a0f5343de9221a0d233b04520ed8dc2e6728dce180b1dcd9288ec9d9fa3c"
 dependencies = [
  "js-sys",
  "minicov",
@@ -4310,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ada2ab788d46d4bda04c9d567702a79c8ced14f51f221646a16ed39d0e6a5d"
+checksum = "a369369e4360c2884c3168d22bded735c43cccae97bbc147586d4b480edd138d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4321,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.88.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
 
+[package.metadata.cargo-semver-checks.lints]
+workspace = true
+# We ignore removed features as `cli` is now missing
+# TODO remove this exception on the next release
+feature_missing = "allow"
+
 [workspace]
 members = [
   "algorithms",

--- a/console/account/src/graph_key/string.rs
+++ b/console/account/src/graph_key/string.rs
@@ -23,7 +23,7 @@ impl<N: Network> FromStr for GraphKey<N> {
     /// Reads in an account graph key from a base58 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Encode the string into base58.
-        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{:?}", err))?;
+        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{err:?}"))?;
         if data.len() != 41 {
             bail!("Invalid account graph key length: found {}, expected 41", data.len())
         } else if data[0..9] != GRAPH_KEY_PREFIX {

--- a/console/account/src/private_key/string.rs
+++ b/console/account/src/private_key/string.rs
@@ -23,7 +23,7 @@ impl<N: Network> FromStr for PrivateKey<N> {
     /// Reads in an account private key from a base58 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Encode the string into base58.
-        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{:?}", err))?;
+        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{err:?}"))?;
         if data.len() != 43 {
             bail!("Invalid account private key length: found {}, expected 43", data.len())
         } else if data[0..11] != PRIVATE_KEY_PREFIX {

--- a/console/account/src/view_key/string.rs
+++ b/console/account/src/view_key/string.rs
@@ -23,7 +23,7 @@ impl<N: Network> FromStr for ViewKey<N> {
     /// Reads in an account view key from a base58 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Encode the string into base58.
-        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{:?}", err))?;
+        let data = bs58::decode(s).into_vec().map_err(|err| anyhow!("{err:?}"))?;
         if data.len() != 39 {
             bail!("Invalid account view key length: found {}, expected 39", data.len())
         } else if data[0..7] != VIEW_KEY_PREFIX {

--- a/console/program/src/data/literal/from_bits.rs
+++ b/console/program/src/data/literal/from_bits.rs
@@ -49,7 +49,7 @@ impl<N: Network> Literal<N> {
                     false => bail!("String literal exceeds maximum length of {} bytes.", N::MAX_STRING_BYTES),
                 }
             }
-            17.. => bail!("Failed to initialize literal variant {} from bits (LE)", variant),
+            17.. => bail!("Failed to initialize literal variant {variant} from bits (LE)"),
         };
         Ok(literal)
     }
@@ -87,7 +87,7 @@ impl<N: Network> Literal<N> {
                     false => bail!("String literal exceeds maximum length of {} bytes.", N::MAX_STRING_BYTES),
                 }
             }
-            17.. => bail!("Failed to initialize literal variant {} from bits (BE)", variant),
+            17.. => bail!("Failed to initialize literal variant {variant} from bits (BE)"),
         };
         Ok(literal)
     }

--- a/console/program/src/data/record/decrypt.rs
+++ b/console/program/src/data/record/decrypt.rs
@@ -81,7 +81,7 @@ impl<N: Network> Record<N, Ciphertext<N>> {
             };
             // Insert the decrypted entry.
             if decrypted_data.insert(*id, entry).is_some() {
-                bail!("Duplicate identifier in record: {}", id);
+                bail!("Duplicate identifier in record: {id}");
             }
             // Increment the index.
             index += num_randomizers;

--- a/console/program/src/data/record/encrypt.rs
+++ b/console/program/src/data/record/encrypt.rs
@@ -92,7 +92,7 @@ impl<N: Network> Record<N, Plaintext<N>> {
             };
             // Insert the encrypted entry.
             if encrypted_data.insert(*id, entry).is_some() {
-                bail!("Duplicate identifier in record: {}", id);
+                bail!("Duplicate identifier in record: {id}");
             }
             // Increment the index.
             index += num_randomizers;

--- a/ledger/block/src/transition/mod.rs
+++ b/ledger/block/src/transition/mod.rs
@@ -145,7 +145,7 @@ impl<N: Network> Transition<N> {
                         Ok(Input::Record(*serial_number, *tag))
                     }
                     (InputID::ExternalRecord(input_hash), Value::Record(..)) => Ok(Input::ExternalRecord(*input_hash)),
-                    _ => bail!("Malformed request input: {:?}, {input}", input_id),
+                    _ => bail!("Malformed request input: {input_id:?}, {input}"),
                 }
             })
             .collect::<Result<Vec<_>>>()?;

--- a/semver-checks.sh
+++ b/semver-checks.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+# Ensure that the command is installed.
+cargo install cargo-semver-checks@0.43.0 --locked
+
+BASELINE_REV=eff84712b # UPDATE ME ON NECESSARY BREAKING CHANGES
+
+# Exclude CLI as it has been removed
+cargo semver-checks --workspace --default-features \
+  --exclude=snarkvm-cli --baseline-rev $BASELINE_REV

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -344,8 +344,7 @@ impl<N: Network> Stack<N> {
         // Check that the constructor cost does not exceed the maximum.
         ensure!(
             constructor_cost <= transaction_spend_limit,
-            "Constructor has a cost '{constructor_cost}' which exceeds the transaction spend limit '{}'",
-            transaction_spend_limit
+            "Constructor has a cost '{constructor_cost}' which exceeds the transaction spend limit '{transaction_spend_limit}'"
         );
 
         // Check that the functions are valid.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -563,7 +563,7 @@ impl<N: Network> ProgramCore<N> {
                 PlaintextType::Struct(member_identifier) => {
                     // Ensure the member struct name exists in the program.
                     if !self.structs.contains_key(member_identifier) {
-                        bail!("'{member_identifier}' in struct '{}' is not defined.", struct_name)
+                        bail!("'{member_identifier}' in struct '{struct_name}' is not defined.")
                     }
                 }
                 PlaintextType::Array(array_type) => {
@@ -579,11 +579,11 @@ impl<N: Network> ProgramCore<N> {
 
         // Add the struct name to the identifiers.
         if self.components.insert(ProgramLabel::Identifier(struct_name), ProgramDefinition::Struct).is_some() {
-            bail!("'{}' already exists in the program.", struct_name)
+            bail!("'{struct_name}' already exists in the program.")
         }
         // Add the struct to the program.
         if self.structs.insert(struct_name, struct_).is_some() {
-            bail!("'{}' already exists in the program.", struct_name)
+            bail!("'{struct_name}' already exists in the program.")
         }
         Ok(())
     }
@@ -877,7 +877,7 @@ impl<N: Network> ProgramCore<N> {
             if let Some(CallOperator::Locator(locator)) = instruction.call_operator() {
                 // Check if the locator is restricted.
                 if locator.to_string() == "credits.aleo/upgrade" {
-                    bail!("External call to restricted locator '{}'", locator)
+                    bail!("External call to restricted locator '{locator}'")
                 }
             }
             Ok(())

--- a/synthesizer/src/vm/tests/test_v9.rs
+++ b/synthesizer/src/vm/tests/test_v9.rs
@@ -697,7 +697,7 @@ constructor:
         &Plaintext::from_str("0u8")?,
     )? {
         Some(Value::Plaintext(Plaintext::Literal(Literal::U8(value), _))) => *value,
-        value => bail!(format!("Unexpected value: {:?}", value)),
+        value => bail!(format!("Unexpected value: {value:?}")),
     };
     assert_eq!(value, 0u8);
 
@@ -748,7 +748,7 @@ constructor:
         &Plaintext::from_str("0u8")?,
     )? {
         Some(Value::Plaintext(Plaintext::Literal(Literal::U8(value), _))) => *value,
-        value => bail!(format!("Unexpected value: {:?}", value)),
+        value => bail!(format!("Unexpected value: {value:?}")),
     };
     assert_eq!(value, 0u8);
 
@@ -786,7 +786,7 @@ constructor:
         &Plaintext::from_str("1u8")?,
     )? {
         Some(Value::Plaintext(Plaintext::Literal(Literal::U8(value), _))) => *value,
-        value => bail!(format!("Unexpected value: {:?}", value)),
+        value => bail!(format!("Unexpected value: {value:?}")),
     };
     assert_eq!(value, 1u8);
 

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -446,8 +446,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         // Ensure the transaction spend does not exceed the transaction spend limit.
                         ensure!(
                             transaction_spend <= transaction_spend_limit,
-                            "Transaction '{id}' exceeds the transaction spend limit '{}'",
-                            transaction_spend_limit
+                            "Transaction '{id}' exceeds the transaction spend limit '{transaction_spend_limit}'"
                         );
                         // Ensure the fee is sufficient to cover the cost.
                         if *fee.base_amount()? < cost {

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -40,7 +40,7 @@ impl<N: Network> ProverFile<N> {
         // Ensure the directory path exists.
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
         // Ensure the function name is valid.
-        ensure!(!Program::is_reserved_keyword(function_name), "Function name is invalid (reserved): {}", function_name);
+        ensure!(!Program::is_reserved_keyword(function_name), "Function name is invalid (reserved): {function_name}");
 
         // Create the candidate prover file.
         let prover_file = Self { function_name: *function_name, proving_key };

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -40,7 +40,7 @@ impl<N: Network> VerifierFile<N> {
         // Ensure the directory path exists.
         ensure!(directory.exists(), "The build directory does not exist: '{}'", directory.display());
         // Ensure the function name is valid.
-        ensure!(!Program::is_reserved_keyword(function_name), "Function name is invalid (reserved): {}", function_name);
+        ensure!(!Program::is_reserved_keyword(function_name), "Function name is invalid (reserved): {function_name}");
 
         // Create the candidate verifier file.
         let verifier_file = Self { function_name: *function_name, verifying_key };


### PR DESCRIPTION
`cargo semver-checks` will complain about the CLI crate and feature missing. This PR ignores those warnings. It also fixes some clippy warnings in a separate commit (I am unclear why I get those, but they need to be resolved eventually anyway).

I also added a `semver-check.sh` script, so that you can easily run the command with the same arguments as CI will. It would be better to set the baseline revision and features for the semver checks in `Cargo.toml`, but I am not sure if is possible.