### PR TITLE
[Perf] Add option to cache the most recent blocks in the ledger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -631,7 +631,7 @@ jobs:
           # test_vm_execute_and_finalize can take over 10 minutes in the current setup
           no_output_timeout: 20m
           workspace_member: snarkvm-synthesizer
-          flags: --test '*' --features test
+          flags: --test '*' --features test -- --test-threads=4 
           cache_key_suffix: -integration
 
   synthesizer-process:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,11 +441,11 @@ jobs:
 
   ledger-with-rocksdb:
     executor: rust-docker
-    resource_class: << pipeline.parameters.large >>
+    resource_class: << pipeline.parameters.xlarge >>
     steps:
       - run_test:
           workspace_member: snarkvm-ledger
-          flags: --release --features=rocks -- --test-threads=2
+          flags: --release --features=rocks -- --test-threads=4
           timeout: 20m
 
   ledger-with-valid-solutions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,8 +1585,6 @@ dependencies = [
 [[package]]
 name = "locktick"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307f02aff720d58003290879abe635b818b2176488c5ba2855ab9c11b4e0c04e"
 dependencies = [
  "backtrace",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "locktick"
-version = "0.3.0"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a4a7c4b9459e549968abf200cb77c6faf0bdedc87df5065f73ca95031795050"
 dependencies = [
  "backtrace",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,6 @@ license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.88.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
 
-[package.metadata.cargo-semver-checks.lints]
-workspace = true
-# We ignore removed features as `cli` is now missing
-# TODO remove this exception on the next release
-feature_missing = "allow"
-
 [workspace]
 members = [
   "algorithms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,7 +464,8 @@ version = "0.14"
 version = "1.4"
 
 [workspace.dependencies.locktick]
-version = "0.3"
+#version = "0.3"
+path = "../locktick"
 
 [workspace.dependencies.lru]
 version = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,6 @@ locktick = [
 ]
 noconfig = [ ]
 rocks = [ "snarkvm-ledger/rocks", "snarkvm-synthesizer/rocks" ]
-test = [ "snarkvm-ledger/test" ]
 test-helpers = [ "snarkvm-ledger/test-helpers" ]
 timer = [ "snarkvm-ledger/timer" ]
 algorithms = [ "snarkvm-algorithms" ]
@@ -159,9 +158,19 @@ parameters = [ "snarkvm-parameters" ]
 synthesizer = [ "snarkvm-synthesizer" ]
 utilities = [ "snarkvm-utilities" ]
 wasm = [ "snarkvm-wasm" ]
+test = [
+  "snarkvm-console/test",
+  "snarkvm-ledger/test"
+]
 test_exports = [ "snarkvm-algorithms/test_exports" ]
-test_targets = [ "snarkvm-console/test_targets" ]
-test_consensus_heights = [ "snarkvm-console/test_consensus_heights" ]
+test_targets = [
+  "snarkvm-ledger/test_targets",
+  "snarkvm-console/test_targets"
+]
+test_consensus_heights = [
+  "snarkvm-ledger/test_consensus_heights",
+  "snarkvm-console/test_consensus_heights"
+]
 serial = [
   "snarkvm-algorithms?/serial",
   "snarkvm-console?/serial",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,8 +464,7 @@ version = "0.14"
 version = "1.4"
 
 [workspace.dependencies.locktick]
-#version = "0.3"
-path = "../locktick"
+version = "0.4"
 
 [workspace.dependencies.lru]
 version = "0.16"

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -13,9 +13,13 @@ filesystem = [ "snarkvm-parameters/filesystem" ]
 wasm = [
   "snarkvm-parameters/wasm"
 ]
-test = [ ]
+test = [ "test_targets", "test_consensus_heights", "test_max_certificates" ]
+# Lowers the target for solutions
 test_targets = [ ]
+# Lowers the height at which consensus version upgrades happen
 test_consensus_heights = [ ]
+# Lowers the value for MAX_CERTIFICATES
+test_max_certificates = [ ]
 
 [dependencies.snarkvm-algorithms]
 workspace = true

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -163,7 +163,7 @@ impl Network for CanaryV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::canary::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test, feature = "test_max_certificates")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
@@ -172,7 +172,7 @@ impl Network for CanaryV0 {
         (ConsensusVersion::V9, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(any(test, feature = "test_max_certificates"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -247,14 +247,14 @@ pub trait Network:
 
     /// Returns the list of consensus versions.
     #[allow(non_snake_case)]
-    #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
+    #[cfg(not(any(test, feature = "test_consensus_heights")))]
     fn CONSENSUS_VERSION_HEIGHTS() -> &'static [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
         // Initialize the consensus version heights directly from the constant.
         CONSENSUS_VERSION_HEIGHTS.get_or_init(|| Self::_CONSENSUS_VERSION_HEIGHTS)
     }
     /// Returns the list of test consensus versions.
     #[allow(non_snake_case)]
-    #[cfg(any(test, feature = "test", feature = "test_consensus_heights"))]
+    #[cfg(any(test, feature = "test_consensus_heights"))]
     fn CONSENSUS_VERSION_HEIGHTS() -> &'static [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
         CONSENSUS_VERSION_HEIGHTS.get_or_init(load_test_consensus_heights)
     }

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -148,18 +148,18 @@ impl Network for MainnetV0 {
     type TransmissionChecksum = u128;
 
     /// The genesis block coinbase target.
-    #[cfg(not(feature = "test"))]
+    #[cfg(not(feature = "test_targets"))]
     const GENESIS_COINBASE_TARGET: u64 = (1u64 << 29).saturating_sub(1);
     /// The genesis block coinbase target.
     /// This is deliberately set to a low value (32) for testing purposes only.
-    #[cfg(feature = "test")]
+    #[cfg(feature = "test_targets")]
     const GENESIS_COINBASE_TARGET: u64 = (1u64 << 5).saturating_sub(1);
     /// The genesis block proof target.
-    #[cfg(not(feature = "test"))]
+    #[cfg(not(feature = "test_targets"))]
     const GENESIS_PROOF_TARGET: u64 = 1u64 << 27;
     /// The genesis block proof target.
     /// This is deliberately set to a low value (8) for testing purposes only.
-    #[cfg(feature = "test")]
+    #[cfg(feature = "test_targets")]
     const GENESIS_PROOF_TARGET: u64 = 1u64 << 3;
     /// The fixed timestamp of the genesis block.
     const GENESIS_TIMESTAMP: i64 = 1725462000 /* 2024-09-04 11:00:00 UTC */;
@@ -168,7 +168,7 @@ impl Network for MainnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test, feature = "test_max_certificates")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 16),
         (ConsensusVersion::V3, 25),
@@ -177,7 +177,7 @@ impl Network for MainnetV0 {
         (ConsensusVersion::V9, 40),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(any(test, feature = "test_max_certificates"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 101),

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -163,7 +163,7 @@ impl Network for TestnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::testnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test, feature = "test_max_certificates")))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
@@ -172,7 +172,7 @@ impl Network for TestnetV0 {
         (ConsensusVersion::V9, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(any(test, feature = "test_max_certificates"))]
     const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -16,6 +16,11 @@ categories = [ "cryptography", "web-programming" ]
 license = "Apache-2.0"
 edition = "2024"
 
+[[test]]
+name = "block-cache"
+path = "tests/block_cache.rs"
+required-features = [ "rocks" ]
+
 [[bench]]
 name = "block"
 path = "benches/block.rs"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -87,6 +87,9 @@ test-helpers = [
   "snarkvm-ledger-narwhal/test-helpers",
   "dep:snarkvm-circuit"
 ]
+test_consensus_heights = [
+  "snarkvm-console/test_consensus_heights",
+]
 test_targets = [
   "snarkvm-console/test_targets",
 ]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -34,6 +34,12 @@ harness = false
 required-features = [ "test-helpers", "rocks" ]
 
 [[bench]]
+name = "advance"
+path = "benches/advance.rs"
+harness = false
+required-features = [ "test-helpers", "rocks" ]
+
+[[bench]]
 name = "dag"
 path = "benches/dag.rs"
 harness = false

--- a/ledger/benches/advance.rs
+++ b/ledger/benches/advance.rs
@@ -1,0 +1,187 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm_console::prelude::*;
+use snarkvm_ledger::{
+    Block,
+    Ledger,
+    LedgerOptions,
+    store::{
+        ConsensusStorage,
+        helpers::{memory::ConsensusMemory, rocksdb::ConsensusDB},
+    },
+    test_helpers::TestChainBuilder,
+};
+use snarkvm_utilities::PrettyUnwrap;
+
+use aleo_std_storage::StorageMode;
+
+use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime};
+use std::time::Instant;
+
+type Network = snarkvm_console::network::MainnetV0;
+
+/// Helper to initialize the `Ledger`.
+fn create_ledger<S: ConsensusStorage<Network>>(
+    genesis_block: Block<Network>,
+    enable_cache: bool,
+) -> Ledger<Network, S> {
+    let options = if enable_cache { LedgerOptions::default().enable_block_cache() } else { LedgerOptions::default() };
+
+    Ledger::load_with_opts(genesis_block, StorageMode::new_test(None), options).unwrap()
+}
+
+/// Measures block advancement.
+fn bench_ledger_advancement<S: ConsensusStorage<Network>>(
+    name: &str,
+    group: &mut BenchmarkGroup<WallTime>,
+    genesis_block: &Block<Network>,
+    blocks: &[Block<Network>],
+    enable_cache: bool,
+    check_next_block: bool,
+    rng: &mut TestRng,
+) {
+    let name = if check_next_block {
+        format!("Ledger<{name}>::check_and_advance")
+    } else {
+        format!("Ledger<{name}>::advance_without_checks")
+    };
+
+    group.bench_function(name, |b| {
+        b.iter_custom(|num_ops| {
+            let ledger = create_ledger::<S>(genesis_block.clone(), enable_cache);
+            let mut blocks_iter = blocks.iter();
+
+            let start = Instant::now();
+            for _ in 0..num_ops {
+                let block = blocks_iter.next().expect("Not enough blocks");
+                if check_next_block {
+                    ledger.check_next_block(block, rng).unwrap();
+                }
+                ledger.advance_to_next_block(block).unwrap();
+            }
+
+            start.elapsed()
+        })
+    });
+}
+
+/// Measures block checks.
+fn bench_ledger_checks<S: ConsensusStorage<Network>>(
+    name: &str,
+    group: &mut BenchmarkGroup<WallTime>,
+    genesis_block: &Block<Network>,
+    blocks: &[Block<Network>],
+    enable_cache: bool,
+    rng: &mut TestRng,
+) {
+    group.bench_function(format!("Ledger<{name}>::check_next_block"), |b| {
+        b.iter_custom(|num_ops| {
+            let ledger = create_ledger::<S>(genesis_block.clone(), enable_cache);
+            let mut blocks_iter = blocks.iter();
+
+            // Pre-load the ledger with blocks.
+            let num_preloaded_blocks = blocks.len() - 1;
+            while (ledger.latest_height() as usize) < num_preloaded_blocks {
+                ledger.advance_to_next_block(blocks_iter.next().unwrap()).unwrap();
+            }
+
+            let last_block = blocks_iter.next().unwrap();
+
+            let start = Instant::now();
+            for _ in 0..num_ops {
+                ledger.check_next_block(last_block, rng).unwrap();
+            }
+            start.elapsed()
+        })
+    });
+}
+
+fn ledger_advance(c: &mut Criterion) {
+    // The number of pre generated blocks.
+    const NUM_BLOCKS: usize = 1000;
+
+    let mut group = c.benchmark_group("ledger_advance");
+    group.sample_size(10);
+
+    // Pre-generate enough blocks for all benchmarks.
+    println!("Generating test chain of {NUM_BLOCKS} blocks");
+    let rng = &mut TestRng::default();
+    let mut builder = TestChainBuilder::new(rng).pretty_unwrap();
+    let blocks = builder.generate_blocks(NUM_BLOCKS, rng).unwrap();
+
+    println!("Done generating blocks. Starting benchmark.");
+
+    for check_next_block in [false, true] {
+        /* memory-backed is too fast for the small number of blocks
+        bench_ledger_advancement::<ConsensusMemory<Network>>(
+            "BlockMemory",
+            &mut group,
+            builder.genesis_block(),
+            &blocks,
+            false, // disable cache
+            check_next_block,
+            rng,
+        );*/
+        bench_ledger_advancement::<ConsensusDB<Network>>(
+            "BlockDB",
+            &mut group,
+            builder.genesis_block(),
+            &blocks,
+            false, // disable cache
+            check_next_block,
+            rng,
+        );
+        bench_ledger_advancement::<ConsensusDB<Network>>(
+            "CachedBlockDB",
+            &mut group,
+            builder.genesis_block(),
+            &blocks,
+            true, // enable cache
+            check_next_block,
+            rng,
+        );
+    }
+
+    bench_ledger_checks::<ConsensusMemory<Network>>(
+        "BlockMemory",
+        &mut group,
+        builder.genesis_block(),
+        &blocks,
+        false, // disable cache
+        rng,
+    );
+    bench_ledger_checks::<ConsensusDB<Network>>(
+        "BlockDB",
+        &mut group,
+        builder.genesis_block(),
+        &blocks,
+        false, // disable cache
+        rng,
+    );
+    bench_ledger_checks::<ConsensusDB<Network>>(
+        "CachedBlockDB",
+        &mut group,
+        builder.genesis_block(),
+        &blocks,
+        true, // enable cache
+        rng,
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, ledger_advance);
+criterion_main!(benches);

--- a/ledger/benches/store.rs
+++ b/ledger/benches/store.rs
@@ -15,11 +15,8 @@
 
 use snarkvm_console::prelude::*;
 use snarkvm_ledger::{
-    store::{
-        BlockStorage,
-        BlockStore,
-        helpers::{memory::BlockMemory, rocksdb::BlockDB},
-    },
+    Block,
+    store::{BlockStorage, BlockStore, helpers::rocksdb::BlockDB},
     test_helpers::TestChainBuilder,
 };
 use snarkvm_utilities::PrettyUnwrap;
@@ -32,53 +29,58 @@ use std::time::Instant;
 
 type Network = snarkvm_console::network::MainnetV0;
 
-/// The number of blocks in the store for get/search operations.
-/// Also, the number of pre-generated blocks.
-const NUM_BLOCKS: usize = 1000;
+/// Helper to initialize the `BlockStorage`.
+fn create_storage<S: BlockStorage<Network>>(
+    genesis_block: &Block<Network>,
+    enable_caching: bool,
+) -> BlockStore<Network, S> {
+    let store = if enable_caching {
+        BlockStore::<Network, S>::open_with_cache(StorageMode::new_test(None))
+    } else {
+        BlockStore::<Network, S>::open(StorageMode::new_test(None))
+    }
+    .expect("Failed to create storage");
 
-// Helper method to benchmark serialization.
+    store.insert(genesis_block).unwrap();
+    store
+}
+
+/// Runs the benchmark for the given implementation of `BlockStorage`.
 fn bench_block_store<S: BlockStorage<Network>>(
     name: &str,
     group: &mut BenchmarkGroup<WallTime>,
+    genesis_block: &Block<Network>,
+    blocks: &[Block<Network>],
     num_validators: usize,
+    enable_caching: bool,
 ) {
     let rng = &mut TestRng::default();
 
-    // Pre-generate enough blocks for all benchmarks.
-    println!("Generating test chain of {NUM_BLOCKS} blocks with {num_validators} validators");
-    let mut builder = TestChainBuilder::new_with_quorum_size(num_validators, rng).pretty_unwrap();
-    let blocks = builder.generate_blocks(NUM_BLOCKS, rng).unwrap();
-
-    println!("Done generating blocks. Starting benchmark.");
-
-    // TODO(kaimast): Figure out a way to pre-generate a large number of blocks or reduce the number of iterations.
-    /*   group.bench_function(format!("{name}::insert/{num_validators}validators"), |b| {
+    group.bench_function(format!("{name}::insert/{num_validators}validators"), |b| {
         b.iter_custom(|num_inserts| {
             let num_inserts = num_inserts as usize;
-            let store = BlockStore::<Network, S>::open(StorageMode::new_test(None)).unwrap();
-            store.insert(builder.genesis_block()).unwrap();
+            let store = create_storage::<S>(genesis_block, enable_caching);
 
-            assert!(num_inserts < NUM_BLOCKS);
+            assert!(num_inserts < blocks.len());
 
             let start = Instant::now();
             for block in &blocks[..num_inserts] {
-                if let Err(err) = store.insert(&block) {
+                if let Err(err) = store.insert(block) {
                     panic!("Failed to insert block at height {}: {err}", block.height());
                 }
             }
 
             start.elapsed()
         })
-    });*/
+    });
 
     group.bench_function(format!("{name}::get_block/{num_validators}validators"), |b| {
         let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
 
         b.iter_custom(|num_gets| {
-            let store = BlockStore::<Network, S>::open(StorageMode::new_test(None)).unwrap();
-            store.insert(builder.genesis_block()).unwrap();
+            let store = create_storage::<S>(genesis_block, enable_caching);
 
-            for block in &blocks {
+            for block in blocks {
                 if let Err(err) = store.insert(block) {
                     panic!("Failed to insert block at height {}: {err}", block.height());
                 }
@@ -98,10 +100,9 @@ fn bench_block_store<S: BlockStorage<Network>>(
         let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
 
         b.iter_custom(|num_gets| {
-            let store = BlockStore::<Network, S>::open(StorageMode::new_test(None)).unwrap();
-            store.insert(builder.genesis_block()).unwrap();
+            let store = create_storage::<S>(genesis_block, enable_caching);
 
-            for block in &blocks {
+            for block in blocks {
                 if let Err(err) = store.insert(block) {
                     panic!("Failed to insert block at height {}: {err}", block.height());
                 }
@@ -119,16 +120,49 @@ fn bench_block_store<S: BlockStorage<Network>>(
 }
 
 fn block_store(c: &mut Criterion) {
+    // The number of pre-generated blocks.
+    //TODO(kaimast) find a way to cache these
+    const NUM_BLOCKS: usize = 2000;
+
     let mut group = c.benchmark_group("block_store");
     group.sample_size(10);
 
-    //TODO(kaimast) find a way to speed this up
-    //for f in 1..=4 {
+    // TODO this takes too long
+    // for f in 1..=3 {
     for f in 1..=1 {
         let num_validators = 3 * f + 1;
 
-        bench_block_store::<BlockMemory<Network>>("BlockMemory", &mut group, num_validators);
-        bench_block_store::<BlockDB<Network>>("BlockDB", &mut group, num_validators);
+        // Pre-generate enough blocks for all benchmarks.
+        println!("Generating test chain of {NUM_BLOCKS} blocks with {num_validators} validators");
+        let rng = &mut TestRng::default();
+        let mut builder = TestChainBuilder::new_with_quorum_size(num_validators, rng).pretty_unwrap();
+        let blocks = builder.generate_blocks(NUM_BLOCKS, rng).unwrap();
+        println!("Done generating blocks. Starting benchmark.");
+
+        /*bench_block_store::<BlockMemory<Network>>(
+            "BlockMemory",
+            &mut group,
+            builder.genesis_block(),
+            &blocks,
+            num_validators,
+            false, // disable block cache
+        );*/
+        bench_block_store::<BlockDB<Network>>(
+            "BlockDB",
+            &mut group,
+            builder.genesis_block(),
+            &blocks,
+            num_validators,
+            false, // disable block cache
+        );
+        bench_block_store::<BlockDB<Network>>(
+            "CachedBlockDB",
+            &mut group,
+            builder.genesis_block(),
+            &blocks,
+            num_validators,
+            true, // enable block cache
+        );
     }
 
     group.finish();

--- a/ledger/bins/testchain_generator.rs
+++ b/ledger/bins/testchain_generator.rs
@@ -88,8 +88,8 @@ fn main() -> Result<()> {
         let batch_size = (num_blocks - blocks.len()).min(100);
         let mut batch = builder.generate_blocks(batch_size, &mut rng).with_context(|| "Failed to generate blocks")?;
 
-        println!("Generated {pos} of {num_blocks} blocks");
         pos += batch_size;
+        println!("Generated {pos} of {num_blocks} blocks");
         blocks.append(&mut batch);
     }
 

--- a/ledger/block/src/header/bytes.rs
+++ b/ledger/block/src/header/bytes.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> FromBytes for Header<N> {
     /// Reads the block header from the buffer.
     #[inline]
-    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le_with_unchecked<R: Read>(mut reader: R, unchecked: bool) -> IoResult<Self> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
@@ -27,25 +27,49 @@ impl<N: Network> FromBytes for Header<N> {
         }
 
         // Read from the buffer.
-        let previous_state_root = N::StateRoot::read_le(&mut reader)?;
-        let transactions_root = Field::<N>::read_le(&mut reader)?;
-        let finalize_root = Field::<N>::read_le(&mut reader)?;
-        let ratifications_root = Field::<N>::read_le(&mut reader)?;
-        let solutions_root = Field::<N>::read_le(&mut reader)?;
-        let subdag_root = Field::<N>::read_le(&mut reader)?;
-        let metadata = Metadata::read_le(&mut reader)?;
+        let previous_state_root = N::StateRoot::read_le_with_unchecked(&mut reader, unchecked)?;
+        let transactions_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let finalize_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let ratifications_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let solutions_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let subdag_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let metadata = Metadata::read_le_with_unchecked(&mut reader, unchecked)?;
 
         // Construct the block header.
-        Self::from(
-            previous_state_root,
-            transactions_root,
-            finalize_root,
-            ratifications_root,
-            solutions_root,
-            subdag_root,
-            metadata,
-        )
-        .map_err(|e| error(format!("{e:#?}")))
+        if unchecked {
+            Self::from_unchecked(
+                previous_state_root,
+                transactions_root,
+                finalize_root,
+                ratifications_root,
+                solutions_root,
+                subdag_root,
+                metadata,
+            )
+        } else {
+            Self::from(
+                previous_state_root,
+                transactions_root,
+                finalize_root,
+                ratifications_root,
+                solutions_root,
+                subdag_root,
+                metadata,
+            )
+        }
+        .map_err(into_io_error)
+    }
+
+    /// Reads the block header from the buffer.
+    #[inline]
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, false)
+    }
+
+    /// Reads the block header from the buffer without performing any validity checks.
+    #[inline]
+    fn read_le_unchecked<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, true)
     }
 }
 

--- a/ledger/block/src/header/metadata/bytes.rs
+++ b/ledger/block/src/header/metadata/bytes.rs
@@ -18,12 +18,12 @@ use super::*;
 impl<N: Network> FromBytes for Metadata<N> {
     /// Reads the metadata from the buffer.
     #[inline]
-    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le_with_unchecked<R: Read>(mut reader: R, unchecked: bool) -> IoResult<Self> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
         if version != 1 {
-            return Err(error("Invalid metadata version"));
+            return Err(io_error("Invalid metadata version"));
         }
 
         // Read from the buffer.
@@ -39,19 +39,42 @@ impl<N: Network> FromBytes for Metadata<N> {
         let timestamp = i64::read_le(&mut reader)?;
 
         // Construct the metadata.
-        Self::new(
-            network,
-            round,
-            height,
-            cumulative_weight,
-            cumulative_proof_target,
-            coinbase_target,
-            proof_target,
-            last_coinbase_target,
-            last_coinbase_timestamp,
-            timestamp,
-        )
+        if unchecked {
+            Self::from_unchecked(
+                network,
+                round,
+                height,
+                cumulative_weight,
+                cumulative_proof_target,
+                coinbase_target,
+                proof_target,
+                last_coinbase_target,
+                last_coinbase_timestamp,
+                timestamp,
+            )
+        } else {
+            Self::from(
+                network,
+                round,
+                height,
+                cumulative_weight,
+                cumulative_proof_target,
+                coinbase_target,
+                proof_target,
+                last_coinbase_target,
+                last_coinbase_timestamp,
+                timestamp,
+            )
+        }
         .map_err(into_io_error)
+    }
+
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, false)
+    }
+
+    fn read_le_unchecked<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, true)
     }
 }
 

--- a/ledger/block/src/header/metadata/genesis.rs
+++ b/ledger/block/src/header/metadata/genesis.rs
@@ -63,11 +63,7 @@ impl<N: Network> Metadata<N> {
         );
         ensure_equals!(self.timestamp, N::GENESIS_TIMESTAMP, "Invalid timestamp");
         ensure_equals!(self.last_coinbase_timestamp, N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
-        ensure_equals!(
-            self.coinbase_target,
-            N::GENESIS_COINBASE_TARGET,
-            "Invalid coinsbase target for genesis block expected {expected}."
-        );
+        ensure_equals!(self.coinbase_target, N::GENESIS_COINBASE_TARGET, "Invalid coinbase target for genesis block");
         ensure_equals!(
             self.last_coinbase_target,
             N::GENESIS_COINBASE_TARGET,

--- a/ledger/block/src/header/metadata/mod.rs
+++ b/ledger/block/src/header/metadata/mod.rs
@@ -54,6 +54,8 @@ pub struct Metadata<N: Network> {
 
 impl<N: Network> Metadata<N> {
     /// Initializes a new metadata with the given inputs.
+    ///
+    /// This is identitcal to calling [`Self::from`].
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         network: u16,
@@ -67,8 +69,69 @@ impl<N: Network> Metadata<N> {
         last_coinbase_timestamp: i64,
         timestamp: i64,
     ) -> Result<Self> {
+        Self::from(
+            network,
+            round,
+            height,
+            cumulative_weight,
+            cumulative_proof_target,
+            coinbase_target,
+            proof_target,
+            last_coinbase_target,
+            last_coinbase_timestamp,
+            timestamp,
+        )
+    }
+
+    /// Initializes a new metadata with the given inputs.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from(
+        network: u16,
+        round: u64,
+        height: u32,
+        cumulative_weight: u128,
+        cumulative_proof_target: u128,
+        coinbase_target: u64,
+        proof_target: u64,
+        last_coinbase_target: u64,
+        last_coinbase_timestamp: i64,
+        timestamp: i64,
+    ) -> Result<Self> {
         // Construct a new metadata.
-        let metadata = Self {
+        let metadata = Self::from_unchecked(
+            network,
+            round,
+            height,
+            cumulative_weight,
+            cumulative_proof_target,
+            coinbase_target,
+            proof_target,
+            last_coinbase_target,
+            last_coinbase_timestamp,
+            timestamp,
+        )?;
+
+        // Ensure the header is valid.
+        metadata.check_validity().with_context(|| "Invalid block metadata")?;
+
+        Ok(metadata)
+    }
+
+    /// Initializes a new metadata with the given inputs, and without performing any validity checks.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_unchecked(
+        network: u16,
+        round: u64,
+        height: u32,
+        cumulative_weight: u128,
+        cumulative_proof_target: u128,
+        coinbase_target: u64,
+        proof_target: u64,
+        last_coinbase_target: u64,
+        last_coinbase_timestamp: i64,
+        timestamp: i64,
+    ) -> Result<Self> {
+        Ok(Self {
             network,
             round,
             height,
@@ -80,12 +143,7 @@ impl<N: Network> Metadata<N> {
             last_coinbase_timestamp,
             timestamp,
             _phantom: PhantomData,
-        };
-
-        // Ensure the header is valid.
-        metadata.check_validity().with_context(|| "Invalid block metadata")?;
-
-        Ok(metadata)
+        })
     }
 
     /// Returns `true` if the block metadata is well-formed.

--- a/ledger/block/src/header/mod.rs
+++ b/ledger/block/src/header/mod.rs
@@ -63,8 +63,7 @@ impl<N: Network> Header<N> {
         subdag_root: Field<N>,
         metadata: Metadata<N>,
     ) -> Result<Self> {
-        // Construct a new block header.
-        let header = Self {
+        let header = Self::from_unchecked(
             previous_state_root,
             transactions_root,
             finalize_root,
@@ -72,10 +71,33 @@ impl<N: Network> Header<N> {
             solutions_root,
             subdag_root,
             metadata,
-        };
+        )?;
+
         // Ensure the header is valid.
         header.check_validity().with_context(|| "Invalid block header")?;
         Ok(header)
+    }
+
+    /// Initializes a new block header with the given inputs,
+    /// and without performing any validity checks.
+    pub fn from_unchecked(
+        previous_state_root: N::StateRoot,
+        transactions_root: Field<N>,
+        finalize_root: Field<N>,
+        ratifications_root: Field<N>,
+        solutions_root: Field<N>,
+        subdag_root: Field<N>,
+        metadata: Metadata<N>,
+    ) -> Result<Self> {
+        Ok(Self {
+            previous_state_root,
+            transactions_root,
+            finalize_root,
+            ratifications_root,
+            solutions_root,
+            subdag_root,
+            metadata,
+        })
     }
 
     /// Returns `true` if the block header is well-formed.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -385,7 +385,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             next_last_coinbase_target,
             next_last_coinbase_timestamp,
             next_timestamp,
-        )?;
+        )
+        .with_context(|| "Failed to construct the block metadata")?;
 
         // Construct the header.
         let header = Header::from(
@@ -396,7 +397,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             solutions_root,
             subdag_root,
             metadata,
-        )?;
+        )
+        .with_context(|| "Failed to construct the block header")?;
 
         // Return the block template.
         Ok((header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids))

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -70,7 +70,7 @@ use aleo_std::{
     StorageMode,
     prelude::{finish, lap, timer},
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use core::ops::Range;
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
@@ -195,7 +195,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         let ledger = Self::initialize(genesis_block, storage_mode, options.block_cache)?;
         if options.startup_checks {
-            ledger.check_integrity(genesis_hash)?;
+            ledger.check_integrity(genesis_hash).with_context(|| "Startup integrity checks failed")?;
         }
 
         finish!(timer);
@@ -208,16 +208,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         info!("Loading the ledger from storage...");
         // Initialize the consensus store
-        let result = if enable_block_cache {
+        let store = if enable_block_cache {
             ConsensusStore::<N, C>::open_with_cache(storage_mode)
         } else {
             ConsensusStore::<N, C>::open(storage_mode)
-        };
+        }?;
 
-        let store = match result {
-            Ok(store) => store,
-            Err(e) => bail!("Failed to load ledger (run 'snarkos clean' and try again)\n\n{e}\n"),
-        };
         lap!(timer, "Load consensus store");
 
         // Initialize a new VM.
@@ -250,11 +246,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Retrieve the latest height.
         let latest_height =
-            ledger.vm.block_store().max_height().ok_or_else(|| anyhow!("Failed to load blocks from the ledger"))?;
+            ledger.vm.block_store().max_height().with_context(|| "Failed to load blocks from the ledger")?;
         // Fetch the latest block.
         let block = ledger
             .get_block(latest_height)
-            .map_err(|err| err.context("Failed to load block {latest_height} from the ledger"))?;
+            .with_context(|| format!("Failed to load block {latest_height} from the ledger"))?;
 
         // Set the current block.
         ledger.current_block = Arc::new(RwLock::new(block));

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -90,6 +90,33 @@ pub type RecordMap<N> = IndexMap<Field<N>, Record<N, Plaintext<N>>>;
 /// The capacity of the LRU cache holding the recently queried committees.
 const COMMITTEE_CACHE_SIZE: usize = 16;
 
+/// Options
+pub struct LedgerOptions {
+    startup_checks: bool,
+    block_cache: bool,
+}
+
+impl Default for LedgerOptions {
+    /// Creates the default ledger option, with a checked startup and no block cache.
+    fn default() -> Self {
+        Self { startup_checks: false, block_cache: false }
+    }
+}
+
+impl LedgerOptions {
+    /// Disables checks at startup.
+    /// This can increase performance, but is less safe.
+    pub fn disable_startup_checks(self) -> Self {
+        Self { startup_checks: false, block_cache: self.block_cache }
+    }
+
+    /// Enables caching of the most recent blocks.
+    /// This can increase performance, but consumes more memory.
+    pub fn enable_block_cache(self) -> Self {
+        Self { startup_checks: self.startup_checks, block_cache: true }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub enum RecordsFilter<N: Network> {
     /// Returns all records associated with the account.
@@ -152,43 +179,42 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Loads the ledger from storage.
     pub fn load(genesis_block: Block<N>, storage_mode: StorageMode) -> Result<Self> {
-        let timer = timer!("Ledger::load");
+        Self::load_with_opts(genesis_block, storage_mode, LedgerOptions::default())
+    }
+
+    /// Loads the ledger from storage, without performing integrity checks.
+    pub fn load_unchecked(genesis_block: Block<N>, storage_mode: StorageMode) -> Result<Self> {
+        Self::load_with_opts(genesis_block, storage_mode, LedgerOptions::default().disable_startup_checks())
+    }
+
+    pub fn load_with_opts(genesis_block: Block<N>, storage_mode: StorageMode, options: LedgerOptions) -> Result<Self> {
+        let timer = timer!("Ledger::load_with_opts");
 
         // Retrieve the genesis hash.
         let genesis_hash = genesis_block.hash();
-        // Initialize the ledger.
-        let ledger = Self::load_unchecked(genesis_block, storage_mode)?;
 
-        // Ensure the ledger contains the correct genesis block.
-        if !ledger.contains_block_hash(&genesis_hash)? {
-            bail!("Incorrect genesis block (run 'snarkos clean' and try again)")
+        let ledger = Self::initialize(genesis_block, storage_mode, options.block_cache)?;
+        if options.startup_checks {
+            ledger.check_integrity(genesis_hash)?;
         }
-
-        // Spot check the integrity of `NUM_BLOCKS` random blocks upon bootup.
-        const NUM_BLOCKS: usize = 10;
-        // Retrieve the latest height.
-        let latest_height = ledger.current_block.read().height();
-        debug_assert_eq!(latest_height, ledger.vm.block_store().max_height().unwrap(), "Mismatch in latest height");
-        // Sample random block heights.
-        let block_heights: Vec<u32> =
-            (0..=latest_height).choose_multiple(&mut OsRng, (latest_height as usize).min(NUM_BLOCKS));
-        cfg_into_iter!(block_heights).try_for_each(|height| {
-            ledger.get_block(height)?;
-            Ok::<_, Error>(())
-        })?;
-        lap!(timer, "Check existence of {NUM_BLOCKS} random blocks");
 
         finish!(timer);
         Ok(ledger)
     }
 
-    /// Loads the ledger from storage, without performing integrity checks.
-    pub fn load_unchecked(genesis_block: Block<N>, storage_mode: StorageMode) -> Result<Self> {
-        let timer = timer!("Ledger::load_unchecked");
+    /// Sets up the consensus store and ledger.
+    fn initialize(genesis_block: Block<N>, storage_mode: StorageMode, enable_block_cache: bool) -> Result<Self> {
+        let timer = timer!("Ledger::initialize");
 
         info!("Loading the ledger from storage...");
-        // Initialize the consensus store.
-        let store = match ConsensusStore::<N, C>::open(storage_mode) {
+        // Initialize the consensus store
+        let result = if enable_block_cache {
+            ConsensusStore::<N, C>::open_with_cache(storage_mode)
+        } else {
+            ConsensusStore::<N, C>::open(storage_mode)
+        };
+
+        let store = match result {
             Ok(store) => store,
             Err(e) => bail!("Failed to load ledger (run 'snarkos clean' and try again)\n\n{e}\n"),
         };
@@ -239,8 +265,34 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Set the epoch prover cache.
         ledger.epoch_provers_cache = Arc::new(RwLock::new(ledger.load_epoch_provers()));
 
-        finish!(timer, "Initialize ledger");
+        finish!(timer);
         Ok(ledger)
+    }
+
+    /// Spot check the integrity of `NUM_BLOCKS` random blocks upon bootup.
+    fn check_integrity(&self, genesis_hash: N::BlockHash) -> Result<()> {
+        let timer = timer!("Ledger::check_integrity");
+
+        // Ensure the ledger contains the correct genesis block.
+        if !self.contains_block_hash(&genesis_hash)? {
+            bail!("Incorrect genesis block (run 'snarkos clean' and try again)")
+        }
+
+        const NUM_BLOCKS: usize = 10;
+        // Retrieve the latest height.
+        let latest_height = self.current_block.read().height();
+        debug_assert_eq!(latest_height, self.vm.block_store().max_height().unwrap(), "Mismatch in latest height");
+        // Sample random block heights.
+        let block_heights: Vec<u32> =
+            (0..=latest_height).choose_multiple(&mut OsRng, (latest_height as usize).min(NUM_BLOCKS));
+        cfg_into_iter!(block_heights).try_for_each(|height| {
+            self.get_block(height)?;
+            Ok::<_, Error>(())
+        })?;
+        lap!(timer, "Check existence of {NUM_BLOCKS} random blocks");
+
+        finish!(timer);
+        Ok(())
     }
 
     /// Creates a rocksdb checkpoint in the specified directory, which needs to not exist at the
@@ -468,5 +520,17 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 }
 
 pub mod prelude {
-    pub use crate::{Ledger, authority, block, block::*, committee, helpers::*, narwhal, puzzle, query, store};
+    pub use crate::{
+        Ledger,
+        LedgerOptions,
+        authority,
+        block,
+        block::*,
+        committee,
+        helpers::*,
+        narwhal,
+        puzzle,
+        query,
+        store,
+    };
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -337,6 +337,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.vm.puzzle()
     }
 
+    /// Returns the size of the block cache (or `None` if the block cache is not enabled).
+    pub fn block_cache_size(&self) -> Option<u32> {
+        self.vm.block_store().cache_size()
+    }
+
     /// Returns the provers and the number of solutions they have submitted for the current epoch.
     pub fn epoch_provers(&self) -> Arc<RwLock<IndexMap<Address<N>, u32>>> {
         self.epoch_provers_cache.clone()

--- a/ledger/store/src/block/cache.rs
+++ b/ledger/store/src/block/cache.rs
@@ -19,7 +19,7 @@ use snarkvm_utilities::ensure_equals;
 
 use std::collections::VecDeque;
 
-use anyhow::{Result, bail, ensure};
+use anyhow::Result;
 
 /// Helper struct for caching the most recent blocks.
 pub(super) struct BlockCache<N: Network> {
@@ -29,12 +29,11 @@ pub(super) struct BlockCache<N: Network> {
 }
 
 impl<N: Network> BlockCache<N> {
-    /// Cache the 10 most recent blocks.
+    /// The maximum size of the cache in blocks.
     pub(super) const BLOCK_CACHE_SIZE: u32 = 10;
 
     /// Initialize the cache with the given blocks.
     pub fn new(blocks: Vec<Block<N>>) -> Result<Self> {
-        ensure!(!blocks.is_empty(), "Block cache cannot be empty");
         Ok(Self { blocks: VecDeque::from(blocks) })
     }
 
@@ -42,15 +41,13 @@ impl<N: Network> BlockCache<N> {
     /// Must be the successor of the last block inserted into the cache.
     #[inline]
     pub fn insert(&mut self, block: Block<N>) -> Result<()> {
-        let Some(prev) = self.blocks.back() else {
-            bail!("Block cache cannot be empty");
-        };
-
-        ensure_equals!(
-            prev.height() + 1,
-            block.height(),
-            "Block is not the successor of the last block inserted into the cache"
-        );
+        if let Some(prev) = self.blocks.back() {
+            ensure_equals!(
+                prev.height() + 1,
+                block.height(),
+                "Block is not the successor of the last block inserted into the cache"
+            );
+        }
 
         self.blocks.push_back(block.clone());
         if self.blocks.len() > (Self::BLOCK_CACHE_SIZE as usize) {
@@ -64,7 +61,10 @@ impl<N: Network> BlockCache<N> {
     #[inline]
     pub fn get_block(&self, block_height: u32) -> Option<&Block<N>> {
         // Is the block height in the range of the cache?
-        let first_block = self.blocks.front().expect("Block cache cannot be empty");
+        let Some(first_block) = self.blocks.front() else {
+            // Cache is empty
+            return None;
+        };
 
         let offset = block_height.checked_sub(first_block.height())?;
         self.blocks.get(offset as usize)

--- a/ledger/store/src/block/cache.rs
+++ b/ledger/store/src/block/cache.rs
@@ -1,0 +1,89 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::block::{Block, Network};
+
+use snarkvm_utilities::ensure_equals;
+
+use std::collections::VecDeque;
+
+use anyhow::{Result, bail, ensure};
+
+/// Helper struct for caching the most recent blocks.
+pub(super) struct BlockCache<N: Network> {
+    /// Contains the most recent blocks ordered by height.
+    /// We do not use a BTreeMap here as the cache is small and updates to a vector are more efficient
+    blocks: VecDeque<Block<N>>,
+}
+
+impl<N: Network> BlockCache<N> {
+    /// Cache the 10 most recent blocks.
+    pub(super) const BLOCK_CACHE_SIZE: u32 = 10;
+
+    /// Initialize the cache with the given blocks.
+    pub fn new(blocks: Vec<Block<N>>) -> Result<Self> {
+        ensure!(!blocks.is_empty(), "Block cache cannot be empty");
+        Ok(Self { blocks: VecDeque::from(blocks) })
+    }
+
+    /// Insert a new block into the cache.
+    /// Must be the successor of the last block inserted into the cache.
+    #[inline]
+    pub fn insert(&mut self, block: Block<N>) -> Result<()> {
+        let Some(prev) = self.blocks.back() else {
+            bail!("Block cache cannot be empty");
+        };
+
+        ensure_equals!(
+            prev.height() + 1,
+            block.height(),
+            "Block is not the successor of the last block inserted into the cache"
+        );
+
+        self.blocks.push_back(block.clone());
+        if self.blocks.len() > (Self::BLOCK_CACHE_SIZE as usize) {
+            self.blocks.pop_front();
+        }
+
+        Ok(())
+    }
+
+    /// Return the block at the given height if it is in the cache.i
+    #[inline]
+    pub fn get_block(&self, block_height: u32) -> Option<&Block<N>> {
+        // Is the block height in the range of the cache?
+        let first_block = self.blocks.front().expect("Block cache cannot be empty");
+
+        let offset = block_height.checked_sub(first_block.height())?;
+        self.blocks.get(offset as usize)
+    }
+
+    /// Return the block with the given hash if it is in the cache.
+    #[inline]
+    pub fn get_block_by_hash(&self, block_hash: &N::BlockHash) -> Option<&Block<N>> {
+        // Perform a linear search through the cache.
+        // This is cheap, as the cache is very small.
+        self.blocks.iter().find(|block| &block.hash() == block_hash)
+    }
+
+    /// Remove the last `n` blocks from the cache.
+    #[inline]
+    pub fn remove_last_n(&mut self, n: u32) -> Result<()> {
+        for _ in 0..n {
+            self.blocks.pop_back();
+        }
+        Ok(())
+    }
+}

--- a/ledger/store/src/block/cache.rs
+++ b/ledger/store/src/block/cache.rs
@@ -19,12 +19,14 @@ use snarkvm_utilities::ensure_equals;
 
 use std::collections::VecDeque;
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 
 /// Helper struct for caching the most recent blocks.
 pub(super) struct BlockCache<N: Network> {
     /// Contains the most recent blocks ordered by height.
     /// We do not use a BTreeMap here as the cache is small and updates to a vector are more efficient
+    ///
+    /// Invariant: all entries in this vector (except the first) a height equal to h+1 (where h` is the previous block entry)
     blocks: VecDeque<Block<N>>,
 }
 
@@ -34,6 +36,13 @@ impl<N: Network> BlockCache<N> {
 
     /// Initialize the cache with the given blocks.
     pub fn new(blocks: Vec<Block<N>>) -> Result<Self> {
+        if let Some(block) = blocks.first() {
+            ensure!(block.height() != 0, "Cannot cache the genesis block");
+        }
+        for idx in 1..blocks.len() {
+            ensure!(blocks[idx - 1].height() + 1 == blocks[idx].height(), "Not a continuous chain of blocks");
+        }
+
         Ok(Self { blocks: VecDeque::from(blocks) })
     }
 
@@ -41,6 +50,8 @@ impl<N: Network> BlockCache<N> {
     /// Must be the successor of the last block inserted into the cache.
     #[inline]
     pub fn insert(&mut self, block: Block<N>) -> Result<()> {
+        ensure!(block.height() != 0, "Cannot cache the genesis block");
+
         if let Some(prev) = self.blocks.back() {
             ensure_equals!(
                 prev.height() + 1,
@@ -60,13 +71,12 @@ impl<N: Network> BlockCache<N> {
     /// Return the block at the given height if it is in the cache.i
     #[inline]
     pub fn get_block(&self, block_height: u32) -> Option<&Block<N>> {
-        // Is the block height in the range of the cache?
-        let Some(first_block) = self.blocks.front() else {
-            // Cache is empty
-            return None;
-        };
+        let first_block = self.blocks.front()?;
 
+        // Determine to location of the cached block (if any).
+        // This returns `None` if `block_height` is lower than the height of the first cached block.
         let offset = block_height.checked_sub(first_block.height())?;
+
         self.blocks.get(offset as usize)
     }
 
@@ -85,5 +95,128 @@ impl<N: Network> BlockCache<N> {
             self.blocks.pop_back();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_helpers::CurrentNetwork;
+
+    use snarkvm_console::{
+        account::{Field, PrivateKey},
+        prelude::{Rng, TestRng},
+    };
+    use snarkvm_ledger_authority::Authority;
+    use snarkvm_ledger_block::{Header, Metadata, Ratifications, Transactions};
+
+    type BlockCache = super::BlockCache<CurrentNetwork>;
+
+    #[test]
+    fn eviction() {
+        // The number of blocks to insert during the test
+        // (must be more than the cache size)
+        const NUM_BLOCKS: u32 = 15;
+        const { assert!(NUM_BLOCKS > BlockCache::BLOCK_CACHE_SIZE) };
+
+        let rng = &mut TestRng::default();
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+
+        // Construct a chain of blocks.
+        let mut previous_hash = None;
+        let blocks: Vec<_> = (0..NUM_BLOCKS)
+            .map(|h| {
+                let transactions = Transactions::from(&[]);
+                let ratifications = Ratifications::try_from(vec![]).unwrap();
+                let header = if h == 0 {
+                    Header::genesis(&ratifications, &transactions, vec![]).unwrap()
+                } else {
+                    // Use mock metadata to save compute time.
+                    let metadata = Metadata::new(
+                        CurrentNetwork::ID,
+                        (h * 2) as u64,
+                        h,
+                        0,
+                        (h * 1000) as u128,
+                        CurrentNetwork::GENESIS_COINBASE_TARGET,
+                        CurrentNetwork::GENESIS_PROOF_TARGET + 1,
+                        CurrentNetwork::GENESIS_COINBASE_TARGET,
+                        CurrentNetwork::GENESIS_TIMESTAMP + ((h - 1) * 100) as i64,
+                        CurrentNetwork::GENESIS_TIMESTAMP + (h * 100) as i64,
+                    )
+                    .unwrap();
+
+                    let previous_state_root: <CurrentNetwork as Network>::StateRoot = rng.r#gen();
+                    Header::<CurrentNetwork>::from(
+                        previous_state_root,
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        metadata,
+                    )
+                    .unwrap()
+                };
+                let block_hash = rng.r#gen();
+                let authority = Authority::<CurrentNetwork>::new_beacon(&private_key, block_hash, rng).unwrap();
+
+                let block = Block::from_unchecked(
+                    block_hash.into(),
+                    previous_hash.unwrap_or_default(),
+                    header,
+                    authority,
+                    ratifications,
+                    None.into(),
+                    vec![],
+                    transactions,
+                    vec![],
+                )
+                .unwrap();
+
+                previous_hash = Some(block.hash());
+                block
+            })
+            .collect();
+
+        let mut cache = BlockCache::new(vec![]).unwrap();
+        let mut blocks = blocks.into_iter().skip(1);
+
+        // First, fill up the cache.
+        while cache.blocks.len() < (BlockCache::BLOCK_CACHE_SIZE as usize) {
+            cache.insert(blocks.next().unwrap()).unwrap();
+        }
+
+        // Then, continue insertions and check that old blocks are evicted.
+        for block in blocks {
+            let hash = block.hash();
+            let height = block.height();
+
+            cache.insert(block).unwrap();
+
+            // Ensure eviction work.
+            assert_eq!(cache.blocks.len(), BlockCache::BLOCK_CACHE_SIZE as usize);
+
+            // Ensure the correct block is returned.
+            let ret1 = cache.get_block(height).unwrap();
+            let ret2 = cache.get_block_by_hash(&hash).unwrap();
+
+            assert_eq!(ret1.hash(), hash);
+            assert_eq!(ret2.hash(), hash);
+            assert_eq!(ret1.height(), height);
+            assert_eq!(ret2.height(), height);
+
+            assert_eq!(cache.blocks[0].height(), height - BlockCache::BLOCK_CACHE_SIZE + 1);
+        }
+
+        // Fetch something that isn't the last block.
+        let block = cache.get_block(10).unwrap();
+        assert_eq!(block.height(), 10);
+
+        // Fetch the last thing that must be in the cache.
+        assert!(cache.get_block(NUM_BLOCKS - BlockCache::BLOCK_CACHE_SIZE).is_some());
+        // Fetch something that must not be in the cache.
+        assert!(cache.get_block(NUM_BLOCKS - BlockCache::BLOCK_CACHE_SIZE - 1).is_none());
     }
 }

--- a/ledger/store/src/block/confirmed_tx_type/mod.rs
+++ b/ledger/store/src/block/confirmed_tx_type/mod.rs
@@ -36,7 +36,7 @@ pub mod test_helpers {
     use super::*;
     use console::network::MainnetV0;
 
-    type CurrentNetwork = MainnetV0;
+    pub(crate) type CurrentNetwork = MainnetV0;
 
     /// Samples an accepted deploy.
     pub(crate) fn sample_accepted_deploy(rng: &mut TestRng) -> ConfirmedTxType<CurrentNetwork> {

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1019,8 +1019,13 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
         let mut initial_cache = Vec::new();
         let cache_end_height = u32::try_from(tree.number_of_leaves())?;
-        let cache_start_height = cache_end_height - BlockCache::<N>::BLOCK_CACHE_SIZE + 1;
+        let cache_start_height = cache_end_height.saturating_sub(BlockCache::<N>::BLOCK_CACHE_SIZE - 1);
         for height in cache_start_height..=cache_end_height {
+            // Ignore genesis block.
+            if height == 0 {
+                continue;
+            }
+
             // Get the hash for the next block to add to the cache.
             let hash = storage
                 .id_map()
@@ -1073,6 +1078,11 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         }
         // Return success.
         Ok(())
+    }
+
+    /// Returns the size of the block cache (or `None` if the block cache is not enabled).
+    pub fn cache_size(&self) -> Option<u32> {
+        if self.block_cache.is_none() { None } else { Some(BlockCache::<N>::BLOCK_CACHE_SIZE) }
     }
 
     /// Reverts the Merkle tree to its shape before the insertion of the last 'n' blocks.

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -16,6 +16,9 @@
 pub mod confirmed_tx_type;
 pub use confirmed_tx_type::*;
 
+mod cache;
+use cache::BlockCache;
+
 use crate::{
     TransactionStorage,
     TransactionStore,
@@ -45,9 +48,9 @@ use snarkvm_ledger_puzzle::{Solution, SolutionID};
 use snarkvm_synthesizer_program::{FinalizeOperation, Program};
 
 use aleo_std_storage::StorageMode;
-use anyhow::Result;
+use anyhow::{Context, Result};
 #[cfg(feature = "locktick")]
-use locktick::parking_lot::RwLock;
+use locktick::{LockGuard, parking_lot::RwLock};
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
 use std::{borrow::Cow, sync::Arc};
@@ -989,36 +992,63 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     fn backup_database<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), String>;
 }
 
-/// The block store.
+/// The `BlockStore` is the user facing API that either uses `BlockMemory` or `BlockDB` as its storae backend.
 #[derive(Clone)]
 pub struct BlockStore<N: Network, B: BlockStorage<N>> {
     /// The block storage.
     storage: B,
     /// The block tree.
     tree: Arc<RwLock<BlockTree<N>>>,
+    /// Cache of the most recent blocks.
+    block_cache: Arc<Option<RwLock<BlockCache<N>>>>,
 }
 
 impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
-    /// Initializes the block store.
+    /// Initializes the block storage without a block cache..
     pub fn open<S: Into<StorageMode>>(storage: S) -> Result<Self> {
-        // Initialize the block storage.
         let storage = B::open(storage)?;
+        let tree = Self::generate_block_tree(&storage)?;
 
-        // Compute the block tree.
-        let tree = {
-            // Prepare an iterator over the block heights and prepare the leaves of the block tree.
-            let hashes = storage
+        Ok(Self { storage, tree: Arc::new(RwLock::new(tree)), block_cache: Arc::new(None) })
+    }
+
+    /// Initializes the block storage with a cache for the most recent blocks.
+    pub fn open_with_cache<S: Into<StorageMode>>(storage: S) -> Result<Self> {
+        let storage = B::open(storage)?;
+        let tree = Self::generate_block_tree(&storage)?;
+
+        let mut initial_cache = Vec::new();
+        let cache_end_height = u32::try_from(tree.number_of_leaves())?;
+        let cache_start_height = cache_end_height - BlockCache::<N>::BLOCK_CACHE_SIZE + 1;
+        for height in cache_start_height..=cache_end_height {
+            // Get the hash for the next block to add to the cache.
+            let hash = storage
                 .id_map()
-                .iter_confirmed()
-                .sorted_unstable_by(|(h1, _), (h2, _)| h1.cmp(h2))
-                .map(|(_, hash)| hash.to_bits_le())
-                .collect::<Vec<Vec<bool>>>();
-            // Construct the block tree.
-            Arc::new(RwLock::new(N::merkle_tree_bhp(&hashes)?))
-        };
+                .get_confirmed(&height)?
+                .with_context(|| format!("Block {height} exists in tree but not in storage"))?;
 
-        // Return the block store.
-        Ok(Self { storage, tree })
+            initial_cache.push(
+                storage.get_block(&hash)?.with_context(|| format!("Block {hash} exists in tree but not in storage"))?,
+            );
+        }
+
+        let block_cache = RwLock::new(BlockCache::new(initial_cache)?);
+        Ok(Self { storage, tree: Arc::new(RwLock::new(tree)), block_cache: Arc::new(Some(block_cache)) })
+    }
+
+    /// Helper function for [`Self::open`] and [`Self::open_with_cache`].
+    ///
+    /// Builds a merkle tree from the set of all block hashes.
+    fn generate_block_tree(storage: &B) -> Result<BlockTree<N>> {
+        // Prepare an iterator over the block heights and prepare the leaves of the block tree.
+        let hashes = storage
+            .id_map()
+            .iter_confirmed()
+            .sorted_unstable_by(|(h1, _), (h2, _)| h1.cmp(h2))
+            .map(|(_, hash)| hash.to_bits_le())
+            .collect::<Vec<Vec<bool>>>();
+        // Construct the block tree.
+        N::merkle_tree_bhp(&hashes)
     }
 
     /// Stores the given block into storage.
@@ -1035,6 +1065,12 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.insert((*updated_tree.root()).into(), block)?;
         // Update the block tree.
         *tree = updated_tree;
+        // Add the block to the block cache (unless it is a genesis block).
+        if block.height() != 0
+            && let Some(block_cache) = &*self.block_cache
+        {
+            block_cache.write().insert(block.clone())?;
+        }
         // Return success.
         Ok(())
     }
@@ -1053,7 +1089,7 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         Ok(())
     }
 
-    /// Removes the last 'n' blocks from storage.
+    /// Removes the last (most recent) `n`` blocks from storage.
     pub fn remove_last_n(&self, n: u32) -> Result<()> {
         // Ensure 'n' is non-zero.
         ensure!(n > 0, "Cannot remove zero blocks");
@@ -1096,6 +1132,10 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
         // Update the block tree.
         *tree = updated_tree;
+        // Also remove the last n blocks from the cache.
+        if let Some(block_cache) = &*self.block_cache {
+            block_cache.write().remove_last_n(n)?;
+        }
         // Return success.
         Ok(())
     }
@@ -1184,6 +1224,23 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 }
 
 impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
+    /// Returns the read-locked `BlockCache`.
+    ///
+    /// This may return `None` due to lock contention, even if the cache is enabled.
+    #[inline]
+    #[cfg(feature = "locktick")]
+    fn get_block_cache(&self) -> Option<LockGuard<parking_lot::RwLockReadGuard<'_, BlockCache<N>>>> {
+        // This uses `try_read` to avoid deadlocks or prologned blocking of a thread in rayon: https://github.com/rayon-rs/rayon/issues/1205
+        if let Some(cache) = &*self.block_cache { cache.try_read() } else { None }
+    }
+
+    #[inline]
+    #[cfg(not(feature = "locktick"))]
+    fn get_block_cache(&self) -> Option<parking_lot::RwLockReadGuard<'_, BlockCache<N>>> {
+        // This uses `try_read` to avoid deadlocks or prologned blocking of a thread in rayon: https://github.com/rayon-rs/rayon/issues/1205
+        if let Some(cache) = &*self.block_cache { cache.try_read() } else { None }
+    }
+
     /// Returns the current state root.
     pub fn current_state_root(&self) -> N::StateRoot {
         (*self.tree.read().root()).into()
@@ -1211,11 +1268,23 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
     /// Returns the previous block hash of the given `block height`.
     pub fn get_previous_block_hash(&self, height: u32) -> Result<Option<N::BlockHash>> {
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block(height)
+        {
+            return Ok(Some(block.previous_hash()));
+        }
+
         self.storage.get_previous_block_hash(height)
     }
 
     /// Returns the block hash for the given `block height`.
     pub fn get_block_hash(&self, height: u32) -> Result<Option<N::BlockHash>> {
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block(height)
+        {
+            return Ok(Some(block.hash()));
+        }
+
         self.storage.get_block_hash(height)
     }
 
@@ -1226,22 +1295,46 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
     /// Returns the block header for the given `block hash`.
     pub fn get_block_header(&self, block_hash: &N::BlockHash) -> Result<Option<Header<N>>> {
-        self.storage.get_block_header(block_hash)
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block_by_hash(block_hash)
+        {
+            Ok(Some(*block.header()))
+        } else {
+            self.storage.get_block_header(block_hash)
+        }
     }
 
     /// Returns the block authority for the given `block hash`.
     pub fn get_block_authority(&self, block_hash: &N::BlockHash) -> Result<Option<Authority<N>>> {
-        self.storage.get_block_authority(block_hash)
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block_by_hash(block_hash)
+        {
+            Ok(Some(block.authority().clone()))
+        } else {
+            self.storage.get_block_authority(block_hash)
+        }
     }
 
     /// Returns the block ratifications for the given `block hash`.
     pub fn get_block_ratifications(&self, block_hash: &N::BlockHash) -> Result<Option<Ratifications<N>>> {
-        self.storage.get_block_ratifications(block_hash)
+        if let Some(block_cache) = self.get_block_cache()
+            && let Some(block) = block_cache.get_block_by_hash(block_hash)
+        {
+            Ok(Some(block.ratifications().clone()))
+        } else {
+            self.storage.get_block_ratifications(block_hash)
+        }
     }
 
     /// Returns the block solutions for the given `block hash`.
     pub fn get_block_solutions(&self, block_hash: &N::BlockHash) -> Result<Solutions<N>> {
-        self.storage.get_block_solutions(block_hash)
+        if let Some(block_cache) = self.get_block_cache()
+            && let Some(block) = block_cache.get_block_by_hash(block_hash)
+        {
+            Ok(block.solutions().clone())
+        } else {
+            self.storage.get_block_solutions(block_hash)
+        }
     }
 
     /// Returns the prover solution for the given solution ID.

--- a/ledger/store/src/consensus/mod.rs
+++ b/ledger/store/src/consensus/mod.rs
@@ -43,6 +43,9 @@ pub trait ConsensusStorage<N: Network>: 'static + Clone + Send + Sync {
     /// Initializes the consensus storage.
     fn open<S: Into<StorageMode>>(storage: S) -> Result<Self>;
 
+    /// Initializes the consensus storage with the block cache enabled.
+    fn open_with_cache<S: Into<StorageMode>>(storage: S) -> Result<Self>;
+
     /// Returns the finalize storage.
     fn finalize_store(&self) -> &FinalizeStore<N, Self::FinalizeStorage>;
     /// Returns the block storage.
@@ -104,7 +107,7 @@ pub trait ConsensusStorage<N: Network>: 'static + Clone + Send + Sync {
     }
 }
 
-/// The consensus store.
+/// Consensus store that either uses memory or rocksdb as a backend.
 #[derive(Clone)]
 pub struct ConsensusStore<N: Network, C: ConsensusStorage<N>> {
     /// The consensus storage.
@@ -116,9 +119,15 @@ pub struct ConsensusStore<N: Network, C: ConsensusStorage<N>> {
 impl<N: Network, C: ConsensusStorage<N>> ConsensusStore<N, C> {
     /// Initializes the consensus store.
     pub fn open<S: Into<StorageMode>>(storage: S) -> Result<Self> {
-        // Initialize the consensus storage.
         let storage = C::open(storage.into())?;
-        // Return the consensus store.
+        Ok(Self { storage, _phantom: PhantomData })
+    }
+
+    /// Initializes the consensus store with the block cache enabled.
+    ///
+    /// Note: This is identical to [`Self::open`] for memory-backed storage.
+    pub fn open_with_cache<S: Into<StorageMode>>(storage: S) -> Result<Self> {
+        let storage = C::open_with_cache(storage.into())?;
         Ok(Self { storage, _phantom: PhantomData })
     }
 

--- a/ledger/store/src/helpers/memory/consensus.rs
+++ b/ledger/store/src/helpers/memory/consensus.rs
@@ -32,10 +32,9 @@ pub struct ConsensusMemory<N: Network> {
     block_store: BlockStore<N, BlockMemory<N>>,
 }
 
-#[rustfmt::skip]
 impl<N: Network> ConsensusStorage<N> for ConsensusMemory<N> {
-    type FinalizeStorage = FinalizeMemory<N>;
     type BlockStorage = BlockMemory<N>;
+    type FinalizeStorage = FinalizeMemory<N>;
     type TransactionStorage = TransactionMemory<N>;
     type TransitionStorage = TransitionMemory<N>;
 
@@ -47,10 +46,7 @@ impl<N: Network> ConsensusStorage<N> for ConsensusMemory<N> {
         // Initialize the block store.
         let block_store = BlockStore::<N, BlockMemory<N>>::open(storage)?;
         // Return the consensus storage.
-        Ok(Self {
-            finalize_store,
-            block_store,
-        })
+        Ok(Self { finalize_store, block_store })
     }
 
     /// Initializes the consensus storage with the block cache enabled.

--- a/ledger/store/src/helpers/memory/consensus.rs
+++ b/ledger/store/src/helpers/memory/consensus.rs
@@ -53,6 +53,12 @@ impl<N: Network> ConsensusStorage<N> for ConsensusMemory<N> {
         })
     }
 
+    /// Initializes the consensus storage with the block cache enabled.
+    fn open_with_cache<S: Into<StorageMode>>(storage: S) -> Result<Self> {
+        // Blocks are already in memory, so no cache is needed.
+        Self::open(storage)
+    }
+
     /// Returns the finalize store.
     fn finalize_store(&self) -> &FinalizeStore<N, Self::FinalizeStorage> {
         &self.finalize_store

--- a/ledger/store/src/helpers/rocksdb/consensus.rs
+++ b/ledger/store/src/helpers/rocksdb/consensus.rs
@@ -42,11 +42,21 @@ impl<N: Network> ConsensusStorage<N> for ConsensusDB<N> {
     /// Initializes the consensus storage.
     fn open<S: Into<StorageMode>>(storage: S) -> Result<Self> {
         let storage = storage.into();
-        // Initialize the finalize store.
         let finalize_store = FinalizeStore::<N, FinalizeDB<N>>::open(storage.clone())?;
-        // Initialize the block store.
         let block_store = BlockStore::<N, BlockDB<N>>::open(storage)?;
-        // Return the consensus storage.
+
+        Ok(Self {
+            finalize_store,
+            block_store,
+        })
+    }
+
+    /// Initializes the consensus storage with the block cache enabled.
+    fn open_with_cache<S: Into<StorageMode>>(storage: S) -> Result<Self> {
+        let storage = storage.into();
+        let finalize_store = FinalizeStore::<N, FinalizeDB<N>>::open(storage.clone())?;
+        let block_store = BlockStore::<N, BlockDB<N>>::open_with_cache(storage)?;
+
         Ok(Self {
             finalize_store,
             block_store,

--- a/ledger/store/src/helpers/rocksdb/consensus.rs
+++ b/ledger/store/src/helpers/rocksdb/consensus.rs
@@ -32,10 +32,9 @@ pub struct ConsensusDB<N: Network> {
     block_store: BlockStore<N, BlockDB<N>>,
 }
 
-#[rustfmt::skip]
 impl<N: Network> ConsensusStorage<N> for ConsensusDB<N> {
-    type FinalizeStorage = FinalizeDB<N>;
     type BlockStorage = BlockDB<N>;
+    type FinalizeStorage = FinalizeDB<N>;
     type TransactionStorage = TransactionDB<N>;
     type TransitionStorage = TransitionDB<N>;
 
@@ -45,10 +44,7 @@ impl<N: Network> ConsensusStorage<N> for ConsensusDB<N> {
         let finalize_store = FinalizeStore::<N, FinalizeDB<N>>::open(storage.clone())?;
         let block_store = BlockStore::<N, BlockDB<N>>::open(storage)?;
 
-        Ok(Self {
-            finalize_store,
-            block_store,
-        })
+        Ok(Self { finalize_store, block_store })
     }
 
     /// Initializes the consensus storage with the block cache enabled.
@@ -57,10 +53,7 @@ impl<N: Network> ConsensusStorage<N> for ConsensusDB<N> {
         let finalize_store = FinalizeStore::<N, FinalizeDB<N>>::open(storage.clone())?;
         let block_store = BlockStore::<N, BlockDB<N>>::open_with_cache(storage)?;
 
-        Ok(Self {
-            finalize_store,
-            block_store,
-        })
+        Ok(Self { finalize_store, block_store })
     }
 
     /// Returns the finalize store.

--- a/ledger/tests/block_cache.rs
+++ b/ledger/tests/block_cache.rs
@@ -211,24 +211,17 @@ fn test_block_cache_performance_comparison() {
 
     // Add the same blocks to both ledgers.
     const NUM_BLOCKS: u32 = 20;
-    for i in 1..=NUM_BLOCKS {
+    for _ in 1..=NUM_BLOCKS {
         let transactions = vec![];
 
         // Add to non-cached ledger.
-        let block_no_cache = ledger_no_cache
+        let block = ledger_no_cache
             .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions.clone(), rng)
             .unwrap();
-        ledger_no_cache.advance_to_next_block(&block_no_cache).unwrap();
+        ledger_no_cache.advance_to_next_block(&block).unwrap();
 
-        // Add to cached ledger.
-        let block_with_cache = ledger_with_cache
-            .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng)
-            .unwrap();
-        ledger_with_cache.advance_to_next_block(&block_with_cache).unwrap();
-
-        // Verify both ledgers have the same state.
-        assert_eq!(ledger_no_cache.latest_height(), i);
-        assert_eq!(ledger_with_cache.latest_height(), i);
+        // Add the same block to cached ledger.
+        ledger_with_cache.advance_to_next_block(&block).unwrap();
     }
 
     // Test retrieval performance for recent blocks (should be cached).
@@ -257,7 +250,7 @@ fn test_block_cache_performance_comparison() {
     for height in 0..=latest_height {
         let block_no_cache = ledger_no_cache.get_block(height).unwrap();
         let block_with_cache = ledger_with_cache.get_block(height).unwrap();
-        assert_eq!(block_no_cache.hash(), block_with_cache.hash());
+        assert_eq!(block_no_cache.hash(), block_with_cache.hash(), "different block hashes at height {height}");
         assert_eq!(block_no_cache.height(), block_with_cache.height());
     }
 }

--- a/ledger/tests/block_cache.rs
+++ b/ledger/tests/block_cache.rs
@@ -1,0 +1,339 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the ledger block cache functionality.
+
+use snarkvm_ledger::{
+    Ledger,
+    test_helpers::{CurrentConsensusStore, CurrentLedger, CurrentNetwork, LedgerType},
+};
+
+use aleo_std::StorageMode;
+use snarkvm_console::{account::PrivateKey, prelude::*};
+use snarkvm_synthesizer::vm::VM;
+
+/// Tests that the block cache is properly initialized with existing blocks from storage.
+#[test]
+fn test_block_cache_initialization() {
+    let rng = &mut TestRng::default();
+
+    // Initialize a ledger without block cache and add some blocks.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    // Create ledger without cache initially.
+    let temp_ledger = CurrentLedger::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    // Add several blocks to storage.
+    const NUM_BLOCKS: u32 = 15; // More than cache size (10) to test initialization logic
+    for _ in 1..=NUM_BLOCKS {
+        let transactions = vec![];
+        let block =
+            temp_ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        temp_ledger.advance_to_next_block(&block).unwrap();
+    }
+
+    // Now load a new ledger with block cache enabled using the same storage type.
+    let ledger_with_cache = Ledger::<CurrentNetwork, LedgerType>::load_with_opts(
+        genesis.clone(),
+        StorageMode::new_test(None),
+        snarkvm_ledger::LedgerOptions::default().enable_block_cache(),
+    )
+    .unwrap();
+
+    // Verify that recent blocks can be retrieved quickly (should be in cache).
+    let latest_height = ledger_with_cache.latest_height();
+
+    // Test retrieval of the 10 most recent blocks (should be in cache).
+    for height in (latest_height.saturating_sub(9))..=latest_height {
+        let block = ledger_with_cache.get_block(height).unwrap();
+        assert_eq!(block.height(), height);
+    }
+
+    // Test retrieval of older blocks (should not be in cache but still accessible).
+    for height in 0..=(latest_height.saturating_sub(10)) {
+        let block = ledger_with_cache.get_block(height).unwrap();
+        assert_eq!(block.height(), height);
+    }
+}
+
+/// Tests cache hit and miss behavior when retrieving blocks.
+#[test]
+fn test_block_cache_hit_miss_behavior() {
+    let rng = &mut TestRng::default();
+
+    // Create a ledger with block cache enabled.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open_with_cache(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load_with_opts(
+        genesis.clone(),
+        StorageMode::new_test(None),
+        snarkvm_ledger::LedgerOptions::default().enable_block_cache(),
+    )
+    .unwrap();
+
+    let cache_size = ledger.block_cache_size().expect("No cache size found");
+
+    // Add blocks to fill and exceed the cache.
+    let mut block_hashes = vec![genesis.hash()];
+
+    for _ in 1..=(cache_size + 5) {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        let block_hash = block.hash();
+        ledger.advance_to_next_block(&block).unwrap();
+        block_hashes.push(block_hash);
+    }
+
+    let latest_height = ledger.latest_height();
+
+    // Test cache hits: Recent blocks should be fast to retrieve.
+    for height in (latest_height.saturating_sub(9))..=latest_height {
+        let start = std::time::Instant::now();
+        let block = ledger.get_block(height).unwrap();
+        let duration = start.elapsed();
+
+        assert_eq!(block.height(), height);
+        assert_eq!(block.hash(), block_hashes[height as usize]);
+
+        // Recent blocks should be retrieved quickly from cache.
+        // This is a rough performance check - exact timing depends on system.
+        assert!(duration.as_micros() < 1000, "Block {height} retrieval took too long: {duration:?}");
+    }
+
+    // Test cache misses: Older blocks should still be accessible but may be slower.
+    for height in 0..=(latest_height.saturating_sub(10)) {
+        let block = ledger.get_block(height).unwrap();
+        assert_eq!(block.height(), height);
+        assert_eq!(block.hash(), block_hashes[height as usize]);
+    }
+}
+
+/// Tests that the cache properly evicts old blocks when new ones are added.
+#[test]
+fn test_block_cache_eviction() {
+    let rng = &mut TestRng::default();
+
+    // Create a ledger with block cache enabled.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open_with_cache(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load_with_opts(
+        genesis.clone(),
+        StorageMode::new_test(None),
+        snarkvm_ledger::LedgerOptions::default().enable_block_cache(),
+    )
+    .unwrap();
+
+    // Add exactly 10 blocks to fill the cache.
+    for i in 1..=10 {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+
+        // Verify the block was added correctly.
+        assert_eq!(ledger.latest_height(), i);
+    }
+
+    // At this point, cache should contain blocks 1-10 (genesis block 0 may or may not be cached).
+    let initial_height = ledger.latest_height();
+
+    // Add 5 more blocks, which should cause eviction of the oldest cached blocks.
+    for i in 1..=5 {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+
+        assert_eq!(ledger.latest_height(), initial_height + i);
+    }
+
+    let final_height = ledger.latest_height();
+
+    // Verify that all blocks are still accessible, regardless of cache state.
+    for height in 0..=final_height {
+        let block = ledger.get_block(height).unwrap();
+        assert_eq!(block.height(), height);
+    }
+
+    // Verify that the most recent 10 blocks should be the fastest to access.
+    let cache_start = final_height.saturating_sub(9);
+    for height in cache_start..=final_height {
+        let start = std::time::Instant::now();
+        let _block = ledger.get_block(height).unwrap();
+        let duration = start.elapsed();
+
+        // Recent blocks should be retrieved quickly from cache.
+        assert!(duration.as_micros() < 1000, "Cached block {height} retrieval took too long: {duration:?}");
+    }
+}
+
+/// Tests performance comparison between ledgers with and without block cache.
+#[test]
+fn test_block_cache_performance_comparison() {
+    let rng = &mut TestRng::default();
+
+    // Create two identical ledgers: one with cache, one without.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+
+    // Create a common genesis block for both ledgers.
+    let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    // Ledger without cache.
+    let ledger_no_cache = CurrentLedger::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    // Ledger with cache.
+    let ledger_with_cache = Ledger::<CurrentNetwork, LedgerType>::load_with_opts(
+        genesis.clone(),
+        StorageMode::new_test(None),
+        snarkvm_ledger::LedgerOptions::default().enable_block_cache(),
+    )
+    .unwrap();
+
+    // Add the same blocks to both ledgers.
+    const NUM_BLOCKS: u32 = 20;
+    for i in 1..=NUM_BLOCKS {
+        let transactions = vec![];
+
+        // Add to non-cached ledger.
+        let block_no_cache = ledger_no_cache
+            .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions.clone(), rng)
+            .unwrap();
+        ledger_no_cache.advance_to_next_block(&block_no_cache).unwrap();
+
+        // Add to cached ledger.
+        let block_with_cache = ledger_with_cache
+            .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng)
+            .unwrap();
+        ledger_with_cache.advance_to_next_block(&block_with_cache).unwrap();
+
+        // Verify both ledgers have the same state.
+        assert_eq!(ledger_no_cache.latest_height(), i);
+        assert_eq!(ledger_with_cache.latest_height(), i);
+    }
+
+    // Test retrieval performance for recent blocks (should be cached).
+    let latest_height = ledger_with_cache.latest_height();
+    let test_heights: Vec<u32> = (latest_height.saturating_sub(9)..=latest_height).collect();
+
+    // Measure performance without cache.
+    let start_no_cache = std::time::Instant::now();
+    for &height in &test_heights {
+        let _block = ledger_no_cache.get_block(height).unwrap();
+    }
+    let duration_no_cache = start_no_cache.elapsed();
+
+    // Measure performance with cache.
+    let start_with_cache = std::time::Instant::now();
+    for &height in &test_heights {
+        let _block = ledger_with_cache.get_block(height).unwrap();
+    }
+    let duration_with_cache = start_with_cache.elapsed();
+
+    // Cache should provide some performance benefit for recent blocks.
+    // Note: In memory storage, the difference might be minimal, but with RocksDB it should be more significant.
+    println!("No cache: {duration_no_cache:?}, With cache: {duration_with_cache:?}");
+
+    // Verify both ledgers return the same blocks.
+    for height in 0..=latest_height {
+        let block_no_cache = ledger_no_cache.get_block(height).unwrap();
+        let block_with_cache = ledger_with_cache.get_block(height).unwrap();
+        assert_eq!(block_no_cache.hash(), block_with_cache.hash());
+        assert_eq!(block_no_cache.height(), block_with_cache.height());
+    }
+}
+
+/// Tests cache behavior during block advancement operations.
+#[test]
+fn test_block_cache_during_advancement() {
+    let rng = &mut TestRng::default();
+
+    // Create a ledger with block cache enabled.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open_with_cache(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load_with_opts(
+        genesis.clone(),
+        StorageMode::new_test(None),
+        snarkvm_ledger::LedgerOptions::default().enable_block_cache(),
+    )
+    .unwrap();
+
+    // Test cache behavior during sequential block additions.
+    const NUM_BLOCKS: u32 = 25; // Exceeds cache size to test eviction
+    let mut added_blocks = vec![genesis];
+
+    for i in 1..=NUM_BLOCKS {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+
+        // Test that we can retrieve the current latest block before advancement.
+        let current_latest = ledger.get_block(ledger.latest_height()).unwrap();
+        assert_eq!(current_latest.height(), i - 1);
+
+        // Advance to the next block.
+        ledger.advance_to_next_block(&block).unwrap();
+        added_blocks.push(block.clone());
+
+        // Test that the new block is immediately available.
+        let new_latest = ledger.get_block(ledger.latest_height()).unwrap();
+        assert_eq!(new_latest.height(), i);
+        assert_eq!(new_latest.hash(), block.hash());
+
+        // Test that previous blocks are still accessible.
+        if i >= 10 {
+            // Test both cached and potentially non-cached blocks.
+            let recent_block = ledger.get_block(i - 5).unwrap();
+            assert_eq!(recent_block.height(), i - 5);
+
+            if i >= 15 {
+                let older_block = ledger.get_block(i - 15).unwrap();
+                assert_eq!(older_block.height(), i - 15);
+            }
+        }
+    }
+
+    // Final verification: all blocks should be accessible.
+    for (expected_height, expected_block) in added_blocks.iter().enumerate() {
+        let retrieved_block = ledger.get_block(expected_height as u32).unwrap();
+        assert_eq!(retrieved_block.hash(), expected_block.hash());
+        assert_eq!(retrieved_block.height(), expected_height as u32);
+    }
+
+    // Test batch retrieval of recent blocks (should leverage cache).
+    let latest_height = ledger.latest_height();
+    let recent_heights: Vec<u32> = (latest_height.saturating_sub(9)..=latest_height).collect();
+
+    let start = std::time::Instant::now();
+    let recent_blocks = ledger.get_blocks(recent_heights[0]..recent_heights[recent_heights.len() - 1] + 1).unwrap();
+    let duration = start.elapsed();
+
+    assert_eq!(recent_blocks.len(), recent_heights.len());
+    for (block, &expected_height) in recent_blocks.iter().zip(&recent_heights) {
+        assert_eq!(block.height(), expected_height);
+    }
+
+    // Recent block retrieval should be fast.
+    assert!(duration.as_millis() < 100, "Batch retrieval of recent blocks took too long: {duration:?}");
+}


### PR DESCRIPTION
Fixes #2934. This PR relies on the changes in #2945 and #2946. There is a [companion PR](https://github.com/ProvableHQ/snarkOS/pull/3923) in snarkOS that uses this new feature.

### API Change
There is now a new way to create a ledger object, namely `Ledger::load_with_opts`. This function is the same as `Ledger::load` but also takes a `LedgerOptions` struct.
The idea is that we can add new options in the future without introducing more constructors for `Ledger`.
This struct currently has two settings; `disable_startup_checks` and `enable_block_caching`. The former is equivalent to `Ledger::load_unchecked`.

An alternative to this new option would be a feature flag, but there are already many features in snarkVM. 

### Minor Changes
* Uses the `test_consensus_heights` feature more consistently across the code base ([9547150](https://github.com/ProvableHQ/snarkVM/pull/2937/commits/9547150e5d16e4f7c491e8f0ef73066ff1cba4aa)) and adds a `test_max_certificates` flag ([eac0376](https://github.com/ProvableHQ/snarkVM/pull/2937/commits/eac0376516561e298df2758eacacdac6d224e619)). 
My hope is that we can eventually move away from the nondescript `test` feature, but it is still there for compatibility.
* Removed `#[rustfmt(skip)]` in ledger ([7e5a2a4](https://github.com/ProvableHQ/snarkVM/pull/2937/commits/7e5a2a4b0336938b3e52d2093b40a461b15c7c1e)). I assume this is a remnant from a previous version of the ledger storage, but does not seem to be needed anymore.
* Adds a new benchmark that measures block advancement ([919c9b4](https://github.com/ProvableHQ/snarkVM/pull/2937/commits/919c9b417ec6b201c432b8aff1f9fedac819647a)).

### Notes
* This is considered a breaking change as it introduces a new method, `new_with_cache` to the `ConsensusStorage` trait. However, I am not aware of anyone implementing this trait outside snarkVM.