### PR TITLE
Add support for passing in a custom genesis block to testchain_generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "serde_json",
  "snarkvm-circuit",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -153,6 +153,9 @@ workspace = true
 [dependencies.rand]
 workspace = true
 
+[dependencies.rand_chacha]
+workspace = true
+
 [dependencies.rayon]
 workspace = true
 

--- a/ledger/bins/testchain_generator.rs
+++ b/ledger/bins/testchain_generator.rs
@@ -23,18 +23,19 @@ use anyhow::{Context, Result, ensure};
 type Network = snarkvm_console::prelude::TestnetV0;
 
 /// Simple argument parsing to avoid pulling in all of `clap`.
-fn parse_args() -> Result<(usize, usize)> {
+fn parse_args() -> Result<(usize, usize, Option<String>)> {
     let mut args = std::env::args().skip(1);
-    ensure!(args.len() == 2, "Need exactly two arguments");
+    ensure!(args.len() >= 2 && args.len() <= 3, "Need exactly two or three arguments");
 
     let num_validators: usize =
         args.next().unwrap().parse().with_context(|| "Failed to parse `num_validators` argument")?;
     let num_blocks: usize = args.next().unwrap().parse().with_context(|| "Failed to parse `num_blocks` argument")?;
+    let genesis_path: Option<String> = args.next();
 
     ensure!(num_validators >= 4, "Need at least four validators");
     ensure!(num_blocks > 0, "Need to generate at least one block");
 
-    Ok((num_validators, num_blocks))
+    Ok((num_validators, num_blocks, genesis_path))
 }
 
 /// Removes an existing ledger (if any) from the filesystem.
@@ -54,12 +55,12 @@ fn main() -> Result<()> {
     // Uncomment this to enable logging.
     // tracing_subscriber::fmt::init();
 
-    let (num_validators, num_blocks) = match parse_args() {
+    let (num_validators, num_blocks, genesis_path) = match parse_args() {
         Ok(args) => args,
         Err(err) => {
             eprintln!("{err:?}");
             eprintln!();
-            eprintln!("Usage: `snarkvm-testchain-generator <NUM_VALIDATORS> <NUM_BLOCKS>`");
+            eprintln!("Usage: `snarkvm-testchain-generator <NUM_VALIDATORS> <NUM_BLOCKS> [<GENESIS_PATH>]`");
             std::process::exit(1);
         }
     };
@@ -69,8 +70,14 @@ fn main() -> Result<()> {
     remove_ledger(Network::ID)?;
 
     println!("Initializing test chain builder with {num_validators} validators");
-    let mut builder = TestChainBuilder::<Network>::new_with_quorum_size(num_validators, &mut rng)
-        .with_context(|| "Failed to set up test chain builder")?;
+    let mut builder = match genesis_path {
+        Some(genesis_path) => {
+            TestChainBuilder::<Network>::new_with_quorum_size_and_genesis_block(num_validators, genesis_path)
+                .with_context(|| "Failed to set up test chain builder")?
+        }
+        None => TestChainBuilder::<Network>::new_with_quorum_size(num_validators, &mut rng)
+            .with_context(|| "Failed to set up test chain builder")?,
+    };
 
     println!("Generating {num_blocks} blocks");
 

--- a/ledger/src/test_helpers/chain_builder.rs
+++ b/ledger/src/test_helpers/chain_builder.rs
@@ -34,6 +34,8 @@ use aleo_std::StorageMode;
 
 use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
 use std::collections::{BTreeMap, HashMap};
 use time::OffsetDateTime;
 
@@ -132,6 +134,23 @@ impl<N: Network> TestChainBuilder<N> {
     /// Initialize the builder with the specified quorum size.
     pub fn new_with_quorum_size(num_validators: usize, rng: &mut TestRng) -> Result<Self> {
         let (private_keys, genesis) = Self::initialize_components(num_validators, rng)?;
+        Self::from_components(private_keys, genesis)
+    }
+
+    /// Initialize the builder with the specified genesis block..
+    /// Note: this function mirrors the way the private keys are sampled in snarkOS `fn parse_genesis`.
+    pub fn new_with_quorum_size_and_genesis_block(num_validators: usize, genesis_path: String) -> Result<Self> {
+        // Attempts to load the genesis block file.
+        let buffer = std::fs::read(genesis_path)?;
+        // Return the genesis block.
+        let genesis = Block::from_bytes_le(&buffer)?;
+        /// The development mode RNG seed.
+        pub const DEVELOPMENT_MODE_RNG_SEED: u64 = 1234567890u64;
+        // Initialize the (fixed) RNG.
+        let mut rng = ChaChaRng::seed_from_u64(DEVELOPMENT_MODE_RNG_SEED);
+        // Initialize the development private keys.
+        let private_keys = (0..num_validators).map(|_| PrivateKey::new(&mut rng).unwrap()).collect();
+        // Initialize the builder with the specified committee and genesis block.
         Self::from_components(private_keys, genesis)
     }
 


### PR DESCRIPTION
## Motivation

In order to generate test chains with pregenerated transactions, it'll be useful to use a deterministic genesis block, i.e. the one generated by `snarkos start --dev-num-validators X`.

In the future, we could consider moving the logic from snarkOS `fn parse_genesis` into snarkVM, but it's a lot of extra work.
