### PR TITLE
Correct `Option::serialized_size`

### DIFF
--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -197,7 +197,8 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Option<T> {
 
     #[inline]
     fn serialized_size(&self, compress: Compress) -> usize {
-        8 + self.as_ref().map(|s| s.serialized_size(compress)).unwrap_or(0)
+        bool::serialized_size(&self.is_some(), compress)
+            + self.as_ref().map(|s| s.serialized_size(compress)).unwrap_or(0)
     }
 }
 

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -637,10 +637,12 @@ mod test {
             (Compress::Yes, Validate::Yes),
         ];
         for (compress, validate) in combinations {
-            let mut serialized = vec![0; data.serialized_size(compress)];
-            data.serialize_with_mode(&mut serialized[..], compress).unwrap();
+            let mut serialized = vec![];
+            data.serialize_with_mode(&mut serialized, compress).unwrap();
             let de = T::deserialize_with_mode(&serialized[..], compress, validate).unwrap();
             assert_eq!(data, de);
+
+            assert_eq!(data.serialized_size(compress), serialized.len());
         }
     }
 


### PR DESCRIPTION
The current implementation of `CanonicalSerialize`'s `serialize_with_mode` (and therefore also `serialize_compressed` and `serialize_uncompressed`) for `Option<T>` serialises a `bool` indicating whether the option is `Some` or `None`. In the former case, it then serialises its contents (cf. [here](https://github.com/ProvableHQ/snarkVM/blob/staging/utilities/src/serialize/impls.rs#L190)). However, its `serialized_size` method reports 8 bytes for the boolean part ([here](https://github.com/ProvableHQ/snarkVM/blob/staging/utilities/src/serialize/impls.rs#L200)) where in actuality a `bool`'s serialised size is 1 byte ([here](https://github.com/ProvableHQ/snarkVM/blob/staging/utilities/src/serialize/impls.rs#L38)).

I have modified the preexisting test `test_serialise` to only allocate the necessary number of bytes and check that number matches the value reported by `serialized_size`. The updated version fails exactly for `Option` (concretely, [this test and commit](https://github.com/ProvableHQ/snarkVM/blob/aa9541e38e484014f96002580cceb0e43390844d/utilities/src/serialize/impls.rs#L37) - the first commit of this PR). The second commit fixes `Option`'s `serialized_size` and makes the check pass.

**On breaking changes**

@vicsn and I have gone over snarkVM to make sure this doesn't break anything or have unintended consequences, which we are relatively confident about (NB: `serialized_size`,  `compressed_size` and `uncompressed_size` aren't used in snarkOS). Here are some notes on our observations:
- `serialized_size` is used 
   - recursively (in implementations of `serialized_size` for composite types) and in tests, neither of which pose an issue by themselves.
   - in the macro `impl_serialize_field`, which is in turn used in `impl_canonical_serialize` whose code is used every time `CanonicalSerialize` is `derive`d. We have dug into the types that do derive the trait and concluded that, in all cases, either the type is only serialised to/deserialised from memory (in which case modifying the `serialized_size` function should not cause any issues) or was serialised/deserialised using other methods that don't rely on the `CanonicalSerialized` machinery (and therefore won't get broken if shared over a network where the sending and receiving parties have different version of `serialised_size`).
- `compressed_size` (a `CanonicalSerialize` method that has a default implementation relying on `serialized_size`) is used 
   - recursively and in tests, which do not need to be checked separately.
   - In the line `G::prime_subgroup_generator().compressed_size()`, where `G::prime_subgroup_generator()` is a generic implementor of `AffineCurve` and neither of the two implementors  (`twisted_edwards_extended::Affine` and `short_weierstrass_jacobian::Affine`) contains `Option`s.
- `uncompressed_size` (same default-implementation comment as in the previous point) is used recursively and in tests, which are again not an issue.
- `serialized_size_with_flags` and `serialized_vec_size_without_len` both only use and are used in other implementation of `serialized_size` and therefore do not need to be checked separately.
- One place where serialised sizes are very relevant is when computing storage costs for `Execution`s, but that is calculated using a method which is unaffected by the `serialized_size` change (cf. [here](https://github.com/ProvableHQ/snarkVM/blob/619464c8edf75636809d0bfb8e8404de78a62c97/ledger/block/src/transaction/execution/mod.rs#L58) and [here](https://github.com/ProvableHQ/snarkVM/blob/619464c8edf75636809d0bfb8e8404de78a62c97/synthesizer/process/src/cost.rs#L144)). This was also checked empirically.

Nonetheless, this change should be kept in mind in the near future if any unexpected (de)serialisation issues arise.