### PR TITLE
[Feat]: Add an 'in' instruction in the VM.

### DIFF
--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -747,6 +747,7 @@ pub fn cost_per_command<N: Network>(
         Command::Instruction(Instruction::HashManyPSD8(_)) => {
             bail!("`hash_many.psd8` is not supported in finalize")
         }
+        Command::Instruction(Instruction::In(_)) => Ok(500),
         Command::Instruction(Instruction::Inv(_)) => Ok(2_500),
         Command::Instruction(Instruction::IsEq(_)) => Ok(500),
         Command::Instruction(Instruction::IsNeq(_)) => Ok(500),

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -739,6 +739,13 @@ impl<N: Network> FinalizeTypes<N> {
             Opcode::ECDSA(opcode) => RegisterTypes::check_ecdsa_opcode(opcode, instruction)?,
             Opcode::Serialize(opcode) => RegisterTypes::check_serialize_opcode(opcode, instruction)?,
             Opcode::Deserialize(opcode) => RegisterTypes::check_deserialize_opcode(opcode, instruction)?,
+            Opcode::In => {
+                // Ensure the instruction has one destination register.
+                ensure!(
+                    instruction.destinations().len() == 1,
+                    "Instruction '{instruction}' has multiple destinations."
+                );
+            }
         }
         Ok(())
     }

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -594,6 +594,13 @@ impl<N: Network> RegisterTypes<N> {
             }
             Opcode::Serialize(opcode) => Self::check_serialize_opcode(opcode, instruction)?,
             Opcode::Deserialize(opcode) => Self::check_deserialize_opcode(opcode, instruction)?,
+            Opcode::In => {
+                // Ensure the instruction has one destination register.
+                ensure!(
+                    instruction.destinations().len() == 1,
+                    "Instruction '{instruction}' has multiple destinations."
+                );
+            }
         }
         Ok(())
     }

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -234,6 +234,8 @@ pub enum Instruction<N: Network> {
     HashManyPSD4(HashManyPSD4<N>),
     /// Performs a Poseidon hash with an input rate of 8.
     HashManyPSD8(HashManyPSD8<N>),
+    /// Returns true if the second i.e. the array contains the `first`, else returns false, storing the outcome in `destination`.
+    In(In<N>),
     /// Computes the multiplicative inverse of `first`, storing the outcome in `destination`.
     Inv(Inv<N>),
     /// Computes whether `first` equals `second` as a boolean, storing the outcome in `destination`.
@@ -365,6 +367,7 @@ macro_rules! instruction {
             HashManyPSD2,
             HashManyPSD4,
             HashManyPSD8,
+            In,
             Inv,
             IsEq,
             IsNeq,

--- a/synthesizer/program/src/logic/instruction/opcode/mod.rs
+++ b/synthesizer/program/src/logic/instruction/opcode/mod.rs
@@ -34,6 +34,8 @@ pub enum Opcode {
     Deserialize(&'static str),
     /// The opcode is for a hash operation (i.e. `hash.psd4`).
     Hash(&'static str),
+    /// The opcode is for an 'in' operation (i.e. `in`).
+    In,
     /// The opcode is for an 'is' operation (i.e. `is.eq`).
     Is(&'static str),
     /// The opcode is for a literal operation (i.e. `add`).
@@ -61,6 +63,7 @@ impl Deref for Opcode {
             Opcode::Deserialize(opcode) => opcode,
             Opcode::Hash(opcode) => opcode,
             Opcode::Is(opcode) => opcode,
+            Opcode::In => &"in",
             Opcode::Literal(opcode) => opcode,
             Opcode::Serialize(opcode) => opcode,
             Opcode::Sign(opcode) => opcode,
@@ -88,6 +91,7 @@ impl Display for Opcode {
             Self::Commit(opcode) => write!(f, "{opcode}"),
             Self::Deserialize(opcode) => write!(f, "{opcode}"),
             Self::Hash(opcode) => write!(f, "{opcode}"),
+            Self::In => write!(f, "{}", self.deref()),
             Self::Is(opcode) => write!(f, "{opcode}"),
             Self::Literal(opcode) => write!(f, "{opcode}"),
             Self::Serialize(opcode) => write!(f, "{opcode}"),

--- a/synthesizer/program/src/logic/instruction/operation/in_instruction.rs
+++ b/synthesizer/program/src/logic/instruction/operation/in_instruction.rs
@@ -1,0 +1,255 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use circuit::{Eject, Inject};
+use console::{
+    network::prelude::*,
+    program::{Literal, LiteralType, Plaintext, PlaintextType, Register, RegisterType, Value},
+    types::Boolean,
+};
+
+use crate::{Opcode, Operand, RegistersCircuit, RegistersTrait, StackTrait};
+
+/// Computes an equality operation on two operands, and stores the outcome in `destination`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct In<N: Network> {
+    /// The operands.
+    operands: [Operand<N>; 2],
+    /// The destination register.
+    destination: Register<N>,
+}
+
+impl<N: Network> In<N> {
+    /// Initializes a new `in` instruction.
+    #[inline]
+    pub fn new(operands: [Operand<N>; 2], destination: Register<N>) -> Result<Self> {
+        // Return the instruction.
+        Ok(Self { operands, destination })
+    }
+
+    /// Returns the opcode.s
+    #[inline]
+    pub const fn opcode() -> Opcode {
+        Opcode::In
+    }
+
+    /// Returns the operands in the operation.
+    #[inline]
+    pub fn operands(&self) -> &[Operand<N>] {
+        // Return the operands.
+        &self.operands
+    }
+
+    /// Returns the destination register.
+    #[inline]
+    pub fn destinations(&self) -> Vec<Register<N>> {
+        vec![self.destination.clone()]
+    }
+}
+
+impl<N: Network> In<N> {
+    /// Evaluates the instruction.
+    pub fn evaluate(&self, stack: &impl StackTrait<N>, registers: &mut impl RegistersTrait<N>) -> Result<()> {
+        // Retrieve the inputs.
+        let input_a = registers.load(stack, &self.operands[0])?;
+        let input_b = registers.load(stack, &self.operands[1])?;
+
+        // Make sure the second operand is an array.
+        let Value::Plaintext(Plaintext::Array(array, _)) = &input_b else {
+            bail!("Instruction '{}' requires second operand to be an array but found {}", Self::opcode(), input_b)
+        };
+
+        // Make sure the first operand is not an illegal type for this case.
+        let Value::Plaintext(val) = &input_a else { bail!("Array cannot have records or futures as its elements.") };
+
+        // Check if the array contains the value.
+        let output = Literal::Boolean(Boolean::new(array.contains(val)));
+
+        // Store the output.
+        registers.store(stack, &self.destination, Value::Plaintext(Plaintext::from(output)))
+    }
+
+    /// Executes the instruction.
+    pub fn execute<A: circuit::Aleo<Network = N>>(
+        &self,
+        stack: &impl StackTrait<N>,
+        registers: &mut impl RegistersCircuit<N, A>,
+    ) -> Result<()> {
+        // Retrieve the inputs.
+        let input_a = registers.load_circuit(stack, &self.operands[0])?;
+        let input_b = registers.load_circuit(stack, &self.operands[1])?;
+
+        // Make sure the second operand is an array.
+        let circuit::Value::Plaintext(circuit::Plaintext::Array(array, _)) = &input_b else {
+            bail!(
+                "Instruction '{}' requires second operand to be an array but found {}",
+                Self::opcode(),
+                input_b.eject_value()
+            )
+        };
+
+        // Make sure the first operand is not an illegal type for this case.
+        let circuit::Value::Plaintext(val) = &input_a else {
+            bail!("Array cannot have records or futures as its elements.")
+        };
+
+        // Check if the array contains the value.
+        let mut output = circuit::Boolean::constant(false);
+        for element in array {
+            output = val.is_equal(element).bitor(output)
+        }
+
+        // Store the output.
+        registers.store_literal_circuit(stack, &self.destination, circuit::Literal::from(output))
+    }
+
+    /// Finalizes the instruction.
+    #[inline]
+    pub fn finalize(&self, stack: &impl StackTrait<N>, registers: &mut impl RegistersTrait<N>) -> Result<()> {
+        self.evaluate(stack, registers)
+    }
+
+    /// Returns the output type from the given program and input types.
+    pub fn output_types(
+        &self,
+        _stack: &impl StackTrait<N>,
+        input_types: &[RegisterType<N>],
+    ) -> Result<Vec<RegisterType<N>>> {
+        // Ensure the number of input types is correct.
+        if input_types.len() != 2 {
+            bail!("Instruction '{}' expects 2 inputs, found {} inputs", Self::opcode(), input_types.len())
+        }
+
+        let RegisterType::Plaintext(PlaintextType::Array(arr_type)) = &input_types[1] else {
+            bail!("Instruction {} expects the second input to be an array got {}", Self::opcode(), input_types[1])
+        };
+
+        let element_type = RegisterType::Plaintext(arr_type.next_element_type().clone());
+
+        // Ensure the operand are of the same type.
+        if input_types[0] != element_type {
+            bail!(
+                "Instruction '{}' expects first input and element type of array to be of the same type. Found inputs of type '{}' and '{}'",
+                Self::opcode(),
+                input_types[0],
+                element_type
+            )
+        }
+
+        Ok(vec![RegisterType::Plaintext(PlaintextType::Literal(LiteralType::Boolean))])
+    }
+}
+
+impl<N: Network> Parser for In<N> {
+    /// Parses a string into an operation.
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the opcode from the string.
+        let (string, _) = tag(*Self::opcode())(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the first operand from the string.
+        let (string, first) = Operand::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the second operand from the string.
+        let (string, second) = Operand::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "into" from the string.
+        let (string, _) = tag("into")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the destination register from the string.
+        let (string, destination) = Register::parse(string)?;
+
+        Ok((string, Self { operands: [first, second], destination }))
+    }
+}
+
+impl<N: Network> FromStr for In<N> {
+    type Err = Error;
+
+    /// Parses a string into an operation.
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                // Ensure the remainder is empty.
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                // Return the object.
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for In<N> {
+    /// Prints the operation as a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for In<N> {
+    /// Prints the operation to a string.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Print the operation.
+        write!(f, "{} ", Self::opcode())?;
+        self.operands.iter().try_for_each(|operand| write!(f, "{operand} "))?;
+        write!(f, "into {}", self.destination)
+    }
+}
+
+impl<N: Network> FromBytes for In<N> {
+    /// Reads the operation from a buffer.
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Initialize the array and read the operands.
+        let operands = [Operand::read_le(&mut reader)?, Operand::read_le(&mut reader)?];
+
+        // Read the destination register.
+        let destination = Register::read_le(&mut reader)?;
+
+        // Return the operation.
+        Ok(Self { operands, destination })
+    }
+}
+
+impl<N: Network> ToBytes for In<N> {
+    /// Writes the operation to a buffer.
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the operands.
+        self.operands.iter().try_for_each(|operand| operand.write_le(&mut writer))?;
+        // Write the destination register.
+        self.destination.write_le(&mut writer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::network::MainnetV0;
+
+    type CurrentNetwork = MainnetV0;
+
+    #[test]
+    fn test_parse() {
+        let (string, in_) = In::<CurrentNetwork>::parse("in r0 r1 into r2").unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+        assert_eq!(in_.operands.len(), 2, "The number of operands is incorrect");
+        assert_eq!(in_.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+        assert_eq!(in_.operands[1], Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+        assert_eq!(in_.destination, Register::Locator(2), "The destination register is incorrect");
+    }
+}

--- a/synthesizer/program/src/logic/instruction/operation/mod.rs
+++ b/synthesizer/program/src/logic/instruction/operation/mod.rs
@@ -37,6 +37,9 @@ pub use ecdsa_verify::*;
 mod hash;
 pub use hash::*;
 
+mod in_instruction;
+pub use in_instruction::*;
+
 mod is;
 pub use is::*;
 

--- a/synthesizer/program/tests/helpers/sample.rs
+++ b/synthesizer/program/tests/helpers/sample.rs
@@ -17,7 +17,7 @@ use circuit::AleoV0;
 use console::{
     network::MainnetV0,
     prelude::*,
-    program::{Identifier, Plaintext, Register, Value},
+    program::{Identifier, Register, Value},
 };
 use snarkvm_synthesizer_process::{Authorization, CallStack, FinalizeRegisters, Registers, Stack};
 use snarkvm_synthesizer_program::{FinalizeGlobalState, RegistersCircuit as _, RegistersTrait as _};
@@ -29,7 +29,7 @@ type CurrentAleo = AleoV0;
 pub fn sample_registers(
     stack: &Stack<CurrentNetwork>,
     function_name: &Identifier<CurrentNetwork>,
-    values: &[(Value<CurrentNetwork>, Option<circuit::Mode>)],
+    values: &[(&Value<CurrentNetwork>, Option<circuit::Mode>)],
 ) -> Result<Registers<CurrentNetwork, CurrentAleo>> {
     // Initialize the registers.
     let mut registers = Registers::<CurrentNetwork, CurrentAleo>::new(
@@ -41,6 +41,8 @@ pub fn sample_registers(
     for (index, (value, mode)) in values.iter().enumerate() {
         // Initialize the register.
         let register = Register::Locator(index as u64);
+        // Initialize the console value.
+        let value = (*value).clone();
         // Store the value in the console registers.
         registers.store(stack, &register, value.clone())?;
         // If the mode is not `None`,
@@ -60,7 +62,7 @@ pub fn sample_registers(
 pub fn sample_finalize_registers(
     stack: &Stack<CurrentNetwork>,
     function_name: &Identifier<CurrentNetwork>,
-    plaintexts: &[Plaintext<CurrentNetwork>],
+    literals: &[&Value<CurrentNetwork>],
 ) -> Result<FinalizeRegisters<CurrentNetwork>> {
     // Initialize the registers.
     let mut finalize_registers = FinalizeRegisters::<CurrentNetwork>::new(
@@ -72,11 +74,13 @@ pub fn sample_finalize_registers(
     );
 
     // For each literal,
-    for (index, plaintext) in plaintexts.iter().enumerate() {
+    for (index, val) in literals.iter().enumerate() {
         // Initialize the register
         let register = Register::Locator(index as u64);
+        // Initialize the console value.
+        let value = (*val).clone();
         // Store the value in the console registers.
-        finalize_registers.store(stack, &register, Value::Plaintext(plaintext.clone()))?;
+        finalize_registers.store(stack, &register, value)?;
     }
 
     Ok(finalize_registers)

--- a/synthesizer/program/tests/instruction/assert.rs
+++ b/synthesizer/program/tests/instruction/assert.rs
@@ -99,13 +99,14 @@ fn check_assert<const VARIANT: u8>(
     // Initialize the function name.
     let function_name = Identifier::from_str("run").unwrap();
 
+    // Create values from literals.
+    let value_a = Value::Plaintext(Plaintext::from(literal_a.clone()));
+    let value_b = Value::Plaintext(Plaintext::from(literal_b.clone()));
+
     /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
     {
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), None),
-            (Value::Plaintext(Plaintext::from(literal_a)), None),
-        ];
+        let values = [(&value_a, None), (&value_a, None)];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         let result_a = operation.evaluate(&stack, &mut registers);
 
@@ -120,10 +121,7 @@ fn check_assert<const VARIANT: u8>(
         }
 
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), Some(*mode_a)),
-            (Value::Plaintext(Plaintext::from(literal_a)), Some(*mode_a)),
-        ];
+        let values = [(&value_a, Some(*mode_a)), (&value_a, Some(*mode_a))];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut registers);
 
@@ -157,11 +155,7 @@ fn check_assert<const VARIANT: u8>(
         <CurrentAleo as circuit::Environment>::reset();
 
         // Attempt to finalize the valid operand case.
-        let mut registers = sample_finalize_registers(&stack, &function_name, &[
-            Plaintext::from(literal_a),
-            Plaintext::from(literal_a),
-        ])
-        .unwrap();
+        let mut registers = sample_finalize_registers(&stack, &function_name, &[&value_a, &value_a]).unwrap();
         let result_c = operation.finalize(&stack, &mut registers);
 
         // Ensure the result is correct.
@@ -177,10 +171,7 @@ fn check_assert<const VARIANT: u8>(
     /* Next, check the mismatching literals *fail*. */
     if literal_a != literal_b {
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), None),
-            (Value::Plaintext(Plaintext::from(literal_b)), None),
-        ];
+        let values = [(&value_a, None), (&value_b, None)];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         let result_a = operation.evaluate(&stack, &mut registers);
 
@@ -195,10 +186,7 @@ fn check_assert<const VARIANT: u8>(
         }
 
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), Some(*mode_a)),
-            (Value::Plaintext(Plaintext::from(literal_b)), Some(*mode_b)),
-        ];
+        let values = [(&value_a, Some(*mode_a)), (&value_b, Some(*mode_b))];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut registers);
 
@@ -232,11 +220,7 @@ fn check_assert<const VARIANT: u8>(
         <CurrentAleo as circuit::Environment>::reset();
 
         // Attempt to finalize the valid operand case.
-        let mut registers = sample_finalize_registers(&stack, &function_name, &[
-            Plaintext::from(literal_a),
-            Plaintext::from(literal_b),
-        ])
-        .unwrap();
+        let mut registers = sample_finalize_registers(&stack, &function_name, &[&value_a, &value_b]).unwrap();
         let result_c = operation.finalize(&stack, &mut registers);
 
         // Ensure the result is correct.

--- a/synthesizer/program/tests/instruction/commit.rs
+++ b/synthesizer/program/tests/instruction/commit.rs
@@ -127,24 +127,22 @@ fn check_commit<const VARIANT: u8>(
     // Initialize a destination operand.
     let destination_operand = Operand::Register(destination);
 
+    // Create values from literals.
+    let value_a = Value::Plaintext(Plaintext::from(literal_a.clone()));
+    let value_b = Value::Plaintext(Plaintext::from(literal_b.clone()));
+
     // Attempt to evaluate the valid operand case.
-    let values =
-        [(Value::Plaintext(Plaintext::from(literal_a)), None), (Value::Plaintext(Plaintext::from(literal_b)), None)];
+    let values = [(&value_a, None), (&value_b, None)];
     let mut evaluate_registers = sample_registers(&stack, &function_name, &values).unwrap();
     let result_a = operation.evaluate(&stack, &mut evaluate_registers);
 
     // Attempt to execute the valid operand case.
-    let values = [
-        (Value::Plaintext(Plaintext::from(literal_a)), Some(*mode_a)),
-        (Value::Plaintext(Plaintext::from(literal_b)), Some(*mode_b)),
-    ];
+    let values = [(&value_a, Some(*mode_a)), (&value_b, Some(*mode_b))];
     let mut execute_registers = sample_registers(&stack, &function_name, &values).unwrap();
     let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
     // Attempt to finalize the valid operand case.
-    let mut finalize_registers =
-        sample_finalize_registers(&stack, &function_name, &[Plaintext::from(literal_a), Plaintext::from(literal_b)])
-            .unwrap();
+    let mut finalize_registers = sample_finalize_registers(&stack, &function_name, &[&value_a, &value_a]).unwrap();
     let result_c = operation.finalize(&stack, &mut finalize_registers);
 
     // Check that either all operations failed, or all operations succeeded.

--- a/synthesizer/program/tests/instruction/deserialize.rs
+++ b/synthesizer/program/tests/instruction/deserialize.rs
@@ -141,16 +141,17 @@ fn check_deserialize<const VARIANT: u8>(
 
         // Attempt to evaluate the valid operand case.
         let mut evaluate_registers =
-            sample_registers(&stack, &function_name, &[(Value::Plaintext(bit_array.clone()), None)]).unwrap();
+            sample_registers(&stack, &function_name, &[(&Value::Plaintext(bit_array.clone()), None)]).unwrap();
         let result_a = operation.evaluate(&stack, &mut evaluate_registers);
 
         // Attempt to execute the valid operand case.
         let mut execute_registers =
-            sample_registers(&stack, &function_name, &[(Value::Plaintext(bit_array.clone()), Some(*mode))]).unwrap();
+            sample_registers(&stack, &function_name, &[(&Value::Plaintext(bit_array.clone()), Some(*mode))]).unwrap();
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
         // Attempt to finalize the valid operand case.
-        let mut finalize_registers = sample_finalize_registers(&stack, &function_name, &[bit_array]).unwrap();
+        let mut finalize_registers =
+            sample_finalize_registers(&stack, &function_name, &[&Value::Plaintext(bit_array)]).unwrap();
         let result_c = operation.finalize(&stack, &mut finalize_registers);
 
         // Check that either all operations failed, or all operations succeeded.

--- a/synthesizer/program/tests/instruction/hash.rs
+++ b/synthesizer/program/tests/instruction/hash.rs
@@ -261,18 +261,19 @@ fn check_hash<const VARIANT: u8>(
     // Initialize a destination operand.
     let destination_operand = Operand::Register(destination);
 
+    // Create value from input.
+    let value = Value::Plaintext(input);
+
     // Attempt to evaluate the valid operand case.
-    let mut evaluate_registers =
-        sample_registers(&stack, &function_name, &[(Value::Plaintext(input.clone()), None)]).unwrap();
+    let mut evaluate_registers = sample_registers(&stack, &function_name, &[(&value, None)]).unwrap();
     let result_a = operation.evaluate(&stack, &mut evaluate_registers);
 
     // Attempt to execute the valid operand case.
-    let mut execute_registers =
-        sample_registers(&stack, &function_name, &[(Value::Plaintext(input.clone()), Some(*mode))]).unwrap();
+    let mut execute_registers = sample_registers(&stack, &function_name, &[(&value, Some(*mode))]).unwrap();
     let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
     // Attempt to finalize the valid operand case.
-    let mut finalize_registers = sample_finalize_registers(&stack, &function_name, &[input]).unwrap();
+    let mut finalize_registers = sample_finalize_registers(&stack, &function_name, &[&value]).unwrap();
     let result_c = operation.finalize(&stack, &mut finalize_registers);
 
     // Check that either all operations failed, or all operations succeeded.

--- a/synthesizer/program/tests/instruction/in_.rs
+++ b/synthesizer/program/tests/instruction/in_.rs
@@ -1,0 +1,428 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WinnerANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include!("../helpers/macros.rs");
+
+use std::sync::OnceLock;
+
+use circuit::AleoV0;
+use console::{
+    network::MainnetV0,
+    prelude::*,
+    program::{ArrayType, Identifier, Literal, LiteralType, Plaintext, PlaintextType, Register, Value},
+    types::U32,
+};
+use snarkvm_synthesizer_process::{Process, Stack};
+use snarkvm_synthesizer_program::{In, Opcode, Operand, Program, RegistersCircuit as _, RegistersTrait as _};
+
+use crate::helpers::sample::{sample_finalize_registers, sample_registers};
+
+type CurrentNetwork = MainnetV0;
+type CurrentAleo = AleoV0;
+
+const ITERATIONS: usize = 25;
+
+/// Samples the stack. Note: Do not replicate this for real program use, it is insecure.
+#[allow(clippy::type_complexity)]
+fn sample_stack(
+    opcode: Opcode,
+    type_a: LiteralType,
+    type_b: ArrayType<CurrentNetwork>,
+    mode_a: circuit::Mode,
+    mode_b: circuit::Mode,
+) -> Result<(Stack<CurrentNetwork>, [Operand<CurrentNetwork>; 2], Register<CurrentNetwork>)> {
+    // Initialize the opcode.
+    let opcode = opcode.to_string();
+
+    // Initialize the function name.
+    let function_name = Identifier::<CurrentNetwork>::from_str("run")?;
+
+    // Initialize the registers.
+    let r0 = Register::Locator(0);
+    let r1 = Register::Locator(1);
+    let r2 = Register::Locator(2);
+
+    // Initialize the program.
+    let program = Program::from_str(&format!(
+        "program testing.aleo;
+            function {function_name}:
+                input {r0} as {type_a}.{mode_a};
+                input {r1} as {type_b}.{mode_b};
+                {opcode} {r0} {r1} into {r2};
+                async {function_name} {r0} {r1} into r3;
+                output r3 as testing.aleo/{function_name}.future;
+
+            finalize {function_name}:
+                input {r0} as {type_a}.public;
+                input {r1} as {type_b}.public;
+                {opcode} {r0} {r1} into {r2};
+        "
+    ))?;
+
+    // Initialize the operands.
+    let operand_a = Operand::Register(r0);
+    let operand_b = Operand::Register(r1);
+    let operands = [operand_a, operand_b];
+
+    // Initialize the stack.
+    let stack = Stack::new(&Process::load()?, &program)?;
+
+    Ok((stack, operands, r2))
+}
+
+fn check_in(
+    operation: impl FnOnce([Operand<CurrentNetwork>; 2], Register<CurrentNetwork>) -> In<CurrentNetwork>,
+    opcode: Opcode,
+    literal: &Literal<CurrentNetwork>,
+    array: &[Literal<CurrentNetwork>],
+    mode_a: &circuit::Mode,
+    mode_b: &circuit::Mode,
+) {
+    use circuit::Eject;
+
+    println!("Checking '{opcode}' for '{literal}.{mode_a}' and '{array:?}.{mode_b}'");
+
+    // Initialize the types.
+    let type_a = literal.to_type();
+    let type_b = ArrayType::<CurrentNetwork>::new(array.last().unwrap().to_type().into(), vec![U32::new(
+        array.len().try_into().unwrap(),
+    )])
+    .unwrap();
+
+    // Initialize the stack.
+    let (stack, operands, destination) = sample_stack(opcode, type_a, type_b, *mode_a, *mode_b).unwrap();
+    // Initialize the operation.
+    let operation = operation(operands, destination.clone());
+    // Initialize the function name.
+    let function_name = Identifier::from_str("run").unwrap();
+    // Initialize a destination operand.
+    let destination_operand = Operand::Register(destination);
+
+    // Create values from literals.
+    let value_a = Value::Plaintext(Plaintext::from(literal.clone()));
+    let value_b =
+        Value::Plaintext(Plaintext::Array(array.iter().cloned().map(Plaintext::from).collect(), OnceLock::new()));
+
+    /* Check the operation *succeeds* when the array contains the operand. */
+    if array.contains(literal) {
+        // Attempt to compute the valid operand case.
+        let values = [(&value_a, None), (&value_b, None)];
+        let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
+        operation.evaluate(&stack, &mut registers).unwrap();
+
+        // Retrieve the output.
+        let output_a = registers.load_literal(&stack, &destination_operand).unwrap();
+
+        // Ensure the output is correct.
+        if let Literal::Boolean(output_a) = output_a {
+            assert!(*output_a, "Instruction '{operation}' failed (console): {literal} {array:?}")
+        } else {
+            panic!("The output must be a boolean (console)");
+        }
+
+        // Attempt to compute the valid operand case.
+        let values = [(&value_a, Some(*mode_a)), (&value_b, Some(*mode_a))];
+        let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
+        operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
+
+        // Retrieve the output.
+        let output_b = registers.load_literal_circuit(&stack, &destination_operand).unwrap();
+
+        // Ensure the output is correct.
+        if let circuit::Literal::Boolean(output_b) = output_b {
+            assert!(
+                output_b.eject_value(),
+                "Instruction '{operation}' failed (circuit): {literal}.{mode_a} {array:?}.{mode_b}"
+            )
+        } else {
+            panic!("The output must be a boolean (circuit)");
+        }
+
+        // Ensure the circuit is satisfied.
+        assert!(
+            <CurrentAleo as circuit::Environment>::is_satisfied(),
+            "Instruction '{operation}' should be satisfied (circuit): {literal}.{mode_a} {array:?}.{mode_b}"
+        );
+
+        // Reset the circuit.
+        <CurrentAleo as circuit::Environment>::reset();
+
+        // Attempt to finalize the valid operand case.
+        let mut registers = sample_finalize_registers(&stack, &function_name, &[&value_a, &value_b]).unwrap();
+        operation.finalize(&stack, &mut registers).unwrap();
+
+        // Retrieve the output.
+        let output_c = registers.load_literal(&stack, &destination_operand).unwrap();
+
+        // Ensure the output is correct.
+        if let Literal::Boolean(output_c) = output_c {
+            assert!(*output_c, "Instruction '{operation}' failed (finalize): {literal} {array:?}")
+        } else {
+            panic!("The output must be a boolean (finalize)");
+        }
+    }
+    /* Check the operation *fails* when the array does not contains the operand. */
+    else {
+        // Attempt to compute the valid operand case.
+        let values = [(&value_a, None), (&value_b, None)];
+        let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
+        operation.evaluate(&stack, &mut registers).unwrap();
+
+        // Retrieve the output.
+        let output_a = registers.load_literal(&stack, &destination_operand).unwrap();
+
+        // Ensure the output is correct.
+        if let Literal::Boolean(output_a) = output_a {
+            assert!(!*output_a, "Instruction '{operation}' should have failed (console): {literal} {array:?}")
+        } else {
+            panic!("The output must be a boolean (console)");
+        }
+
+        // Attempt to compute the valid operand case.
+        let values = [(&value_a, Some(*mode_a)), (&value_b, Some(*mode_a))];
+        let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
+        operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
+
+        // Retrieve the output.
+        let output_b = registers.load_literal_circuit(&stack, &destination_operand).unwrap();
+
+        // Ensure the output is correct.
+        if let circuit::Literal::Boolean(output_b) = output_b {
+            assert!(
+                !output_b.eject_value(),
+                "Instruction '{operation}' should have failed (circuit): {literal}.{mode_a} {array:?}.{mode_b}"
+            )
+        } else {
+            panic!("The output must be a boolean (circuit)");
+        }
+
+        // Ensure the circuit is satisfied.
+        assert!(
+            <CurrentAleo as circuit::Environment>::is_satisfied(),
+            "Instruction '{operation}' should be satisfied (circuit): {literal}.{mode_a} {array:?}.{mode_b}"
+        );
+
+        // Reset the circuit.
+        <CurrentAleo as circuit::Environment>::reset();
+
+        // Attempt to finalize the valid operand case.
+        let mut registers = sample_finalize_registers(&stack, &function_name, &[&value_a, &value_b]).unwrap();
+        operation.finalize(&stack, &mut registers).unwrap();
+
+        // Retrieve the output.
+        let output_c = registers.load_literal(&stack, &destination_operand).unwrap();
+
+        // Ensure the output is correct.
+        if let Literal::Boolean(output_c) = output_c {
+            assert!(!*output_c, "Instruction '{operation}' should have failed (finalize): {literal} {array:?}")
+        } else {
+            panic!("The output must be a boolean (finalize)");
+        }
+    }
+}
+
+fn check_in_fails(
+    opcode: Opcode,
+    literal: &Literal<CurrentNetwork>,
+    array: &[Literal<CurrentNetwork>],
+    mode_a: &circuit::Mode,
+    mode_b: &circuit::Mode,
+) {
+    // Initialize the types.
+    // Initialize the types.
+    let type_a = literal.to_type();
+    let type_b = ArrayType::<CurrentNetwork>::new(array.last().unwrap().to_type().into(), vec![U32::new(
+        array.len().try_into().unwrap(),
+    )])
+    .unwrap();
+    assert_ne!(
+        &PlaintextType::Literal(type_a),
+        type_b.next_element_type(),
+        "The literal and array elements must be *different* types for this test"
+    );
+
+    // If the types mismatch, ensure the stack fails to initialize.
+    let result = sample_stack(opcode, type_a, type_b.clone(), *mode_a, *mode_b);
+    assert!(
+        result.is_err(),
+        "Stack should have failed to initialize for: {opcode} {type_a}.{mode_a} {type_b}.{mode_b}"
+    );
+}
+
+#[test]
+fn test_in_succeeds() {
+    // Initialize the operation.
+    let operation = |operands, destination| In::<CurrentNetwork>::new(operands, destination).unwrap();
+    // Initialize the opcode.
+    let opcode = In::<CurrentNetwork>::opcode();
+
+    // Prepare the rng.
+    let mut rng = TestRng::default();
+
+    // Prepare the test.
+    let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+    let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
+
+    for _ in 0..ITERATIONS {
+        let literals = sample_literals!(CurrentNetwork, &mut rng);
+        let arrays = sample_arrays(&mut rng);
+        for (literal, array) in literals.iter().zip_eq(arrays.iter()) {
+            for mode_a in &modes_a {
+                for mode_b in &modes_b {
+                    // Check the operation.
+                    check_in(operation, opcode, literal, array, mode_a, mode_b);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_in_fails() {
+    // Initialize the opcode.
+    let opcode = In::<CurrentNetwork>::opcode();
+
+    // Prepare the rng.
+    let mut rng = TestRng::default();
+
+    // Prepare the test.
+    let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+    let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
+
+    for _ in 0..ITERATIONS {
+        let literals = sample_literals!(CurrentNetwork, &mut rng);
+        let arrays = sample_arrays(&mut rng);
+        for array in &arrays {
+            let type_array = ArrayType::<CurrentNetwork>::new(array.last().unwrap().to_type().into(), vec![U32::new(
+                array.len().try_into().unwrap(),
+            )])
+            .unwrap();
+            for literal in &literals {
+                if PlaintextType::from(literal.to_type()) != *type_array.next_element_type() {
+                    for mode_a in &modes_a {
+                        for mode_b in &modes_b {
+                            // Check the operation fails.
+                            check_in_fails(opcode, literal, array, mode_a, mode_b);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Samples a random array of a random length for each literal type.
+fn sample_arrays(rng: &mut TestRng) -> Vec<Vec<Literal<CurrentNetwork>>> {
+    use rand::Rng;
+
+    let len = rng.gen_range(1..32);
+    let mut outer = Vec::with_capacity(17);
+
+    for choice in 0..17 {
+        let mut inner = Vec::with_capacity(len);
+        match choice {
+            0 => {
+                for _ in 0..len {
+                    inner
+                        .push(console::program::Literal::<CurrentNetwork>::Address(console::types::Address::rand(rng)));
+                }
+            }
+            1 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::Boolean(console::types::Boolean::rand(rng)));
+                }
+            }
+            2 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::Field(console::types::Field::rand(rng)));
+                }
+            }
+            3 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::Group(console::types::Group::rand(rng)));
+                }
+            }
+            4 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::I8(console::types::I8::rand(rng)));
+                }
+            }
+            5 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::I16(console::types::I16::rand(rng)));
+                }
+            }
+            6 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::I32(console::types::I32::rand(rng)));
+                }
+            }
+            7 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::I64(console::types::I64::rand(rng)));
+                }
+            }
+            8 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::I128(console::types::I128::rand(rng)));
+                }
+            }
+            9 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::U8(console::types::U8::rand(rng)));
+                }
+            }
+            10 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::U16(console::types::U16::rand(rng)));
+                }
+            }
+            11 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::U32(console::types::U32::rand(rng)));
+                }
+            }
+            12 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::U64(console::types::U64::rand(rng)));
+                }
+            }
+            13 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::U128(console::types::U128::rand(rng)));
+                }
+            }
+            14 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::Scalar(console::types::Scalar::rand(rng)));
+                }
+            }
+            15 => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::sample(console::program::LiteralType::Signature, rng));
+                }
+            }
+            _ => {
+                for _ in 0..len {
+                    inner.push(console::program::Literal::String(console::types::StringType::rand(rng)));
+                }
+            }
+        }
+
+        outer.push(inner);
+    }
+
+    outer
+}

--- a/synthesizer/program/tests/instruction/is.rs
+++ b/synthesizer/program/tests/instruction/is.rs
@@ -114,13 +114,14 @@ fn check_is<const VARIANT: u8>(
     // Initialize a destination operand.
     let destination_operand = Operand::Register(destination);
 
+    // Create values from literals.
+    let value_a = Value::Plaintext(Plaintext::from(literal_a.clone()));
+    let value_b = Value::Plaintext(Plaintext::from(literal_b.clone()));
+
     /* First, check the operation *succeeds* when both operands are `literal_a.mode_a`. */
     {
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), None),
-            (Value::Plaintext(Plaintext::from(literal_a)), None),
-        ];
+        let values = [(&value_a, None), (&value_a, None)];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         operation.evaluate(&stack, &mut registers).unwrap();
 
@@ -142,10 +143,7 @@ fn check_is<const VARIANT: u8>(
         }
 
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), Some(*mode_a)),
-            (Value::Plaintext(Plaintext::from(literal_a)), Some(*mode_a)),
-        ];
+        let values = [(&value_a, Some(*mode_a)), (&value_a, Some(*mode_a))];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
@@ -186,11 +184,7 @@ fn check_is<const VARIANT: u8>(
         <CurrentAleo as circuit::Environment>::reset();
 
         // Attempt to finalize the valid operand case.
-        let mut registers = sample_finalize_registers(&stack, &function_name, &[
-            Plaintext::from(literal_a),
-            Plaintext::from(literal_a),
-        ])
-        .unwrap();
+        let mut registers = sample_finalize_registers(&stack, &function_name, &[&value_a, &value_a]).unwrap();
         operation.finalize(&stack, &mut registers).unwrap();
 
         // Retrieve the output.
@@ -213,10 +207,7 @@ fn check_is<const VARIANT: u8>(
     /* Next, check the mismatching literals *fail*. */
     if literal_a != literal_b {
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), None),
-            (Value::Plaintext(Plaintext::from(literal_b)), None),
-        ];
+        let values = [(&value_a, None), (&value_b, None)];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         operation.evaluate(&stack, &mut registers).unwrap();
 
@@ -238,10 +229,7 @@ fn check_is<const VARIANT: u8>(
         }
 
         // Attempt to compute the valid operand case.
-        let values = [
-            (Value::Plaintext(Plaintext::from(literal_a)), Some(*mode_a)),
-            (Value::Plaintext(Plaintext::from(literal_b)), Some(*mode_b)),
-        ];
+        let values = [(&value_a, Some(*mode_a)), (&value_b, Some(*mode_b))];
         let mut registers = sample_registers(&stack, &function_name, &values).unwrap();
         operation.execute::<CurrentAleo>(&stack, &mut registers).unwrap();
 
@@ -282,11 +270,7 @@ fn check_is<const VARIANT: u8>(
         <CurrentAleo as circuit::Environment>::reset();
 
         // Attempt to finalize the valid operand case.
-        let mut registers = sample_finalize_registers(&stack, &function_name, &[
-            Plaintext::from(literal_a),
-            Plaintext::from(literal_b),
-        ])
-        .unwrap();
+        let mut registers = sample_finalize_registers(&stack, &function_name, &[&value_a, &value_b]).unwrap();
         operation.finalize(&stack, &mut registers).unwrap();
 
         // Retrieve the output.

--- a/synthesizer/program/tests/instruction/mod.rs
+++ b/synthesizer/program/tests/instruction/mod.rs
@@ -18,5 +18,6 @@ mod commit;
 mod deserialize;
 mod ecdsa;
 mod hash;
+mod in_;
 mod is;
 mod serialize;

--- a/synthesizer/program/tests/instruction/serialize.rs
+++ b/synthesizer/program/tests/instruction/serialize.rs
@@ -138,16 +138,17 @@ fn check_serialize<const VARIANT: u8>(
 
         // Attempt to evaluate the valid operand case.
         let mut evaluate_registers =
-            sample_registers(&stack, &function_name, &[(Value::Plaintext(plaintext.clone()), None)]).unwrap();
+            sample_registers(&stack, &function_name, &[(&Value::Plaintext(plaintext.clone()), None)]).unwrap();
         let result_a = operation.evaluate(&stack, &mut evaluate_registers);
 
         // Attempt to execute the valid operand case.
         let mut execute_registers =
-            sample_registers(&stack, &function_name, &[(Value::Plaintext(plaintext.clone()), Some(*mode))]).unwrap();
+            sample_registers(&stack, &function_name, &[(&Value::Plaintext(plaintext.clone()), Some(*mode))]).unwrap();
         let result_b = operation.execute::<CurrentAleo>(&stack, &mut execute_registers);
 
         // Attempt to finalize the valid operand case.
-        let mut finalize_registers = sample_finalize_registers(&stack, &function_name, &[plaintext]).unwrap();
+        let mut finalize_registers =
+            sample_finalize_registers(&stack, &function_name, &[&Value::Plaintext(plaintext)]).unwrap();
         let result_c = operation.finalize(&stack, &mut finalize_registers);
 
         // Check that either all operations failed, or all operations succeeded.


### PR DESCRIPTION

## Motivation

for this issue in leo https://github.com/ProvableHQ/leo/issues/28721

This PR adds a new 'in' instruction support at the synthesizer level. Without this developers would have to do a verbose unroll of the entire array and also instruction costs would increase for contracts for multiple checks, so this saves that.

Some notes: 
- The tests currently only checks for single dimensional literal arrays as for multi dimensional arrays and struct struct arrays, it would require a slight different infrastructure then the rest of the tests. But also there's no reason implementation won't work for all kinds of arrays.
- Maybe the cost function can be optimized more, for e.g. rather than a constant, some heuristic approximation or maybe even linear multiple of the recursive array length, considering all the the inner members in structs etc.

If this PR is approved, I would also add the support in leo as well.

## Test Plan
Added new tests

