### PR TITLE
[Feature] Add `Header::from_bytes_le_unchecked`

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -298,6 +298,9 @@ pub trait Network:
     fn INCLUSION_UPGRADE_HEIGHT() -> Result<u32>;
 
     /// Returns the genesis block bytes.
+    ///
+    /// Note, that this always returns the bytes of the production genesis block.
+    /// As a result, this may not match the bytes of the genesis block with the `test_targets` feature enabled.
     fn genesis_bytes() -> &'static [u8];
 
     /// Returns the restrictions list as a JSON-compatible string.

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -84,6 +84,7 @@ test-helpers = [
 ]
 test_targets = [
   "snarkvm-console/test_targets",
+  "snarkvm-ledger-block/test_targets",
 ]
 timer = [ "aleo-std/timer" ]
 

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -36,6 +36,7 @@ wasm = [
 ]
 test = [ "snarkvm-synthesizer-process/test" ]
 test-helpers = [ ]
+test_targets = [ "snarkvm-console/test_targets" ]
 
 [dependencies.snarkvm-console]
 workspace = true

--- a/ledger/block/src/bytes.rs
+++ b/ledger/block/src/bytes.rs
@@ -152,9 +152,7 @@ impl<N: Network> ToBytes for Block<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use console::network::MainnetV0;
-
-    type CurrentNetwork = MainnetV0;
+    use console::network::{MainnetV0, TestnetV0};
 
     #[test]
     fn test_bytes() -> Result<()> {
@@ -170,9 +168,33 @@ mod tests {
     }
 
     #[test]
-    fn test_genesis_bytes() -> Result<()> {
+    fn test_genesis_bytes_mainnet_unchecked() -> Result<()> {
         // Load the genesis block.
-        let genesis_block = Block::<CurrentNetwork>::read_le(CurrentNetwork::genesis_bytes()).unwrap();
+        let genesis_block = Block::<MainnetV0>::read_le_unchecked(MainnetV0::genesis_bytes()).unwrap();
+
+        // Check the byte representation.
+        let expected_bytes = genesis_block.to_bytes_le()?;
+        assert_eq!(genesis_block, Block::read_le_unchecked(&expected_bytes[..])?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_genesis_bytes_testnet_unchecked() -> Result<()> {
+        // Load the genesis block.
+        let genesis_block = Block::<TestnetV0>::read_le_unchecked(TestnetV0::genesis_bytes()).unwrap();
+
+        // Check the byte representation.
+        let expected_bytes = genesis_block.to_bytes_le()?;
+        assert_eq!(genesis_block, Block::read_le_unchecked(&expected_bytes[..])?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_genesis_bytes_mainnet() -> Result<()> {
+        // Load the genesis block.
+        let genesis_block = Block::<MainnetV0>::read_le(MainnetV0::genesis_bytes()).unwrap();
 
         // Check the byte representation.
         let expected_bytes = genesis_block.to_bytes_le()?;
@@ -182,16 +204,22 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_bincode() -> Result<()> {
-        // Load the genesis block.
-        let genesis_block = Block::<CurrentNetwork>::read_le(CurrentNetwork::genesis_bytes()).unwrap();
+    // When `test_targets` is enabled, the gensis bytes do not match the expected coinbase target.
+    // (except for Mainnet which ignores this feature)
+    #[cfg(not(feature = "test_targets"))]
+    mod production {
+        use super::*;
+        #[test]
+        fn test_genesis_bytes_testnet() -> Result<()> {
+            // Load the genesis block.
+            let genesis_block = Block::<TestnetV0>::read_le(TestnetV0::genesis_bytes()).unwrap();
 
-        let bincode_data = bincode::serialize(&genesis_block)?;
-        let block = bincode::deserialize(&bincode_data)?;
+            // Check the byte representation.
+            let expected_bytes = genesis_block.to_bytes_le()?;
+            assert_eq!(genesis_block, Block::read_le(&expected_bytes[..])?);
+            assert_eq!(genesis_block, Block::read_le_unchecked(&expected_bytes[..])?);
 
-        assert_eq!(genesis_block, block);
-
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/ledger/block/src/header/bytes.rs
+++ b/ledger/block/src/header/bytes.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> FromBytes for Header<N> {
     /// Reads the block header from the buffer.
     #[inline]
-    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le_with_unchecked<R: Read>(mut reader: R, unchecked: bool) -> IoResult<Self> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
@@ -27,25 +27,49 @@ impl<N: Network> FromBytes for Header<N> {
         }
 
         // Read from the buffer.
-        let previous_state_root = N::StateRoot::read_le(&mut reader)?;
-        let transactions_root = Field::<N>::read_le(&mut reader)?;
-        let finalize_root = Field::<N>::read_le(&mut reader)?;
-        let ratifications_root = Field::<N>::read_le(&mut reader)?;
-        let solutions_root = Field::<N>::read_le(&mut reader)?;
-        let subdag_root = Field::<N>::read_le(&mut reader)?;
-        let metadata = Metadata::read_le(&mut reader)?;
+        let previous_state_root = N::StateRoot::read_le_with_unchecked(&mut reader, unchecked)?;
+        let transactions_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let finalize_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let ratifications_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let solutions_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let subdag_root = Field::<N>::read_le_with_unchecked(&mut reader, unchecked)?;
+        let metadata = Metadata::read_le_with_unchecked(&mut reader, unchecked)?;
 
         // Construct the block header.
-        Self::from(
-            previous_state_root,
-            transactions_root,
-            finalize_root,
-            ratifications_root,
-            solutions_root,
-            subdag_root,
-            metadata,
-        )
-        .map_err(|e| error(format!("{e:#?}")))
+        if unchecked {
+            Self::from_unchecked(
+                previous_state_root,
+                transactions_root,
+                finalize_root,
+                ratifications_root,
+                solutions_root,
+                subdag_root,
+                metadata,
+            )
+        } else {
+            Self::from(
+                previous_state_root,
+                transactions_root,
+                finalize_root,
+                ratifications_root,
+                solutions_root,
+                subdag_root,
+                metadata,
+            )
+        }
+        .map_err(into_io_error)
+    }
+
+    /// Reads the block header from the buffer.
+    #[inline]
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, false)
+    }
+
+    /// Reads the block header from the buffer without performing any validity checks.
+    #[inline]
+    fn read_le_unchecked<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, true)
     }
 }
 

--- a/ledger/block/src/header/metadata/bytes.rs
+++ b/ledger/block/src/header/metadata/bytes.rs
@@ -18,12 +18,12 @@ use super::*;
 impl<N: Network> FromBytes for Metadata<N> {
     /// Reads the metadata from the buffer.
     #[inline]
-    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+    fn read_le_with_unchecked<R: Read>(mut reader: R, unchecked: bool) -> IoResult<Self> {
         // Read the version.
         let version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
         if version != 1 {
-            return Err(error("Invalid metadata version"));
+            return Err(io_error("Invalid metadata version"));
         }
 
         // Read from the buffer.
@@ -39,19 +39,42 @@ impl<N: Network> FromBytes for Metadata<N> {
         let timestamp = i64::read_le(&mut reader)?;
 
         // Construct the metadata.
-        Self::new(
-            network,
-            round,
-            height,
-            cumulative_weight,
-            cumulative_proof_target,
-            coinbase_target,
-            proof_target,
-            last_coinbase_target,
-            last_coinbase_timestamp,
-            timestamp,
-        )
+        if unchecked {
+            Self::from_unchecked(
+                network,
+                round,
+                height,
+                cumulative_weight,
+                cumulative_proof_target,
+                coinbase_target,
+                proof_target,
+                last_coinbase_target,
+                last_coinbase_timestamp,
+                timestamp,
+            )
+        } else {
+            Self::from(
+                network,
+                round,
+                height,
+                cumulative_weight,
+                cumulative_proof_target,
+                coinbase_target,
+                proof_target,
+                last_coinbase_target,
+                last_coinbase_timestamp,
+                timestamp,
+            )
+        }
         .map_err(into_io_error)
+    }
+
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, false)
+    }
+
+    fn read_le_unchecked<R: Read>(reader: R) -> IoResult<Self> {
+        Self::read_le_with_unchecked(reader, true)
     }
 }
 

--- a/ledger/block/src/header/metadata/mod.rs
+++ b/ledger/block/src/header/metadata/mod.rs
@@ -54,6 +54,8 @@ pub struct Metadata<N: Network> {
 
 impl<N: Network> Metadata<N> {
     /// Initializes a new metadata with the given inputs.
+    ///
+    /// This is identitcal to calling [`Self::from`].
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         network: u16,
@@ -67,8 +69,69 @@ impl<N: Network> Metadata<N> {
         last_coinbase_timestamp: i64,
         timestamp: i64,
     ) -> Result<Self> {
+        Self::from(
+            network,
+            round,
+            height,
+            cumulative_weight,
+            cumulative_proof_target,
+            coinbase_target,
+            proof_target,
+            last_coinbase_target,
+            last_coinbase_timestamp,
+            timestamp,
+        )
+    }
+
+    /// Initializes a new metadata with the given inputs.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from(
+        network: u16,
+        round: u64,
+        height: u32,
+        cumulative_weight: u128,
+        cumulative_proof_target: u128,
+        coinbase_target: u64,
+        proof_target: u64,
+        last_coinbase_target: u64,
+        last_coinbase_timestamp: i64,
+        timestamp: i64,
+    ) -> Result<Self> {
         // Construct a new metadata.
-        let metadata = Self {
+        let metadata = Self::from_unchecked(
+            network,
+            round,
+            height,
+            cumulative_weight,
+            cumulative_proof_target,
+            coinbase_target,
+            proof_target,
+            last_coinbase_target,
+            last_coinbase_timestamp,
+            timestamp,
+        )?;
+
+        // Ensure the header is valid.
+        metadata.check_validity().with_context(|| "Invalid block metadata")?;
+
+        Ok(metadata)
+    }
+
+    /// Initializes a new metadata with the given inputs, and without performing any validity checks.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_unchecked(
+        network: u16,
+        round: u64,
+        height: u32,
+        cumulative_weight: u128,
+        cumulative_proof_target: u128,
+        coinbase_target: u64,
+        proof_target: u64,
+        last_coinbase_target: u64,
+        last_coinbase_timestamp: i64,
+        timestamp: i64,
+    ) -> Result<Self> {
+        Ok(Self {
             network,
             round,
             height,
@@ -80,12 +143,7 @@ impl<N: Network> Metadata<N> {
             last_coinbase_timestamp,
             timestamp,
             _phantom: PhantomData,
-        };
-
-        // Ensure the header is valid.
-        metadata.check_validity().with_context(|| "Invalid block metadata")?;
-
-        Ok(metadata)
+        })
     }
 
     /// Returns `true` if the block metadata is well-formed.

--- a/ledger/block/src/header/mod.rs
+++ b/ledger/block/src/header/mod.rs
@@ -63,8 +63,7 @@ impl<N: Network> Header<N> {
         subdag_root: Field<N>,
         metadata: Metadata<N>,
     ) -> Result<Self> {
-        // Construct a new block header.
-        let header = Self {
+        let header = Self::from_unchecked(
             previous_state_root,
             transactions_root,
             finalize_root,
@@ -72,10 +71,33 @@ impl<N: Network> Header<N> {
             solutions_root,
             subdag_root,
             metadata,
-        };
+        )?;
+
         // Ensure the header is valid.
         header.check_validity().with_context(|| "Invalid block header")?;
         Ok(header)
+    }
+
+    /// Initializes a new block header with the given inputs,
+    /// and without performing any validity checks.
+    pub fn from_unchecked(
+        previous_state_root: N::StateRoot,
+        transactions_root: Field<N>,
+        finalize_root: Field<N>,
+        ratifications_root: Field<N>,
+        solutions_root: Field<N>,
+        subdag_root: Field<N>,
+        metadata: Metadata<N>,
+    ) -> Result<Self> {
+        Ok(Self {
+            previous_state_root,
+            transactions_root,
+            finalize_root,
+            ratifications_root,
+            solutions_root,
+            subdag_root,
+            metadata,
+        })
     }
 
     /// Returns `true` if the block header is well-formed.

--- a/ledger/block/src/serialize.rs
+++ b/ledger/block/src/serialize.rs
@@ -125,9 +125,47 @@ mod tests {
     }
 
     #[test]
-    fn test_genesis_bincode() -> Result<()> {
+    fn test_genesis_bincode_unchecked_mainnet() -> Result<()> {
+        let genesis_block = Block::<MainnetV0>::read_le_unchecked(MainnetV0::genesis_bytes()).unwrap();
+
+        // Serialize
+        let expected_bytes = genesis_block.to_bytes_le()?;
+        let expected_bytes_with_size_encoding = bincode::serialize(&genesis_block)?;
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(genesis_block, Block::read_le_unchecked(&expected_bytes[..])?);
+        assert_eq!(
+            genesis_block,
+            snarkvm_utilities::bytes::unchecked_deserialize(&expected_bytes_with_size_encoding[..])?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_genesis_bincode_unchecked_testnet() -> Result<()> {
+        let genesis_block = Block::<TestnetV0>::read_le_unchecked(TestnetV0::genesis_bytes()).unwrap();
+
+        // Serialize
+        let expected_bytes = genesis_block.to_bytes_le()?;
+        let expected_bytes_with_size_encoding = bincode::serialize(&genesis_block)?;
+        assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+        // Deserialize
+        assert_eq!(genesis_block, Block::read_le_unchecked(&expected_bytes[..])?);
+        assert_eq!(
+            genesis_block,
+            snarkvm_utilities::bytes::unchecked_deserialize(&expected_bytes_with_size_encoding[..])?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_genesis_bincode_mainnet() -> Result<()> {
         // Load the genesis block.
-        let genesis_block = Block::<CurrentNetwork>::read_le(CurrentNetwork::genesis_bytes()).unwrap();
+        let genesis_block = Block::<MainnetV0>::read_le(MainnetV0::genesis_bytes()).unwrap();
 
         // Serialize
         let expected_bytes = genesis_block.to_bytes_le()?;
@@ -139,5 +177,29 @@ mod tests {
         assert_eq!(genesis_block, bincode::deserialize(&expected_bytes_with_size_encoding[..])?);
 
         Ok(())
+    }
+
+    // When `test_targets` is enabled, the gensis bytes do not match the expected coinbase target.
+    // (except for Mainnet which ignores this feature)
+    #[cfg(not(feature = "test_targets"))]
+    mod production {
+        use super::*;
+
+        #[test]
+        fn test_genesis_bincode_testnet() -> Result<()> {
+            // Load the genesis block.
+            let genesis_block = Block::<TestnetV0>::read_le(TestnetV0::genesis_bytes()).unwrap();
+
+            // Serialize
+            let expected_bytes = genesis_block.to_bytes_le()?;
+            let expected_bytes_with_size_encoding = bincode::serialize(&genesis_block)?;
+            assert_eq!(&expected_bytes[..], &expected_bytes_with_size_encoding[8..]);
+
+            // Deserialize
+            assert_eq!(genesis_block, Block::read_le(&expected_bytes[..])?);
+            assert_eq!(genesis_block, bincode::deserialize(&expected_bytes_with_size_encoding[..])?);
+
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
This PR adds `Header::from_byts_le_unchecked` and `Metadata::from_bytes_le_unchecked`. These variants skip any validity checks for data. This is needed for [snarkOS PR #3925](https://github.com/ProvableHQ/snarkOS/pull/3925).

All functionality changes of the PR are contained in the [first commit](https://github.com/ProvableHQ/snarkVM/commit/822a6d9677d20eabe14225e1caa52d468d726c64). The [second commit](https://github.com/ProvableHQ/snarkVM/commit/d48915ef457445182871b7c315bb4b17bbb78de3) only adds tests.

The tests were changes to also tests testnet deserialization, and not just mainnet. Some tests are skipped when the `test_targets` features is disabled.
