### PR TITLE
Update ConsensusVersion::V11 heights

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -64,7 +64,7 @@ pub const CANARY_V0_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); NUM_CON
     (ConsensusVersion::V8, 7_565_000),
     (ConsensusVersion::V9, 8_028_000),
     (ConsensusVersion::V10, 8_600_000),
-    (ConsensusVersion::V11, 10_235_000),
+    (ConsensusVersion::V11, 9_510_000),
 ];
 
 /// The consensus version height for `MainnetV0`.
@@ -79,7 +79,7 @@ pub const MAINNET_V0_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); NUM_CO
     (ConsensusVersion::V8, 9_430_000),
     (ConsensusVersion::V9, 10_272_000),
     (ConsensusVersion::V10, 11_205_000),
-    (ConsensusVersion::V11, 13_575_000),
+    (ConsensusVersion::V11, 12_155_500),
 ];
 
 /// The consensus version heights for `TestnetV0`.
@@ -94,7 +94,7 @@ pub const TESTNET_V0_CONSENSUS_VERSION_HEIGHTS: [(ConsensusVersion, u32); NUM_CO
     (ConsensusVersion::V8, 9_173_000),
     (ConsensusVersion::V9, 9_800_000),
     (ConsensusVersion::V10, 10_525_000),
-    (ConsensusVersion::V11, 12_660_000),
+    (ConsensusVersion::V11, 11_680_720),
 ];
 
 /// The consensus version heights when the `test_consensus_heights` feature is enabled.


### PR DESCRIPTION
## Motivation

Based on the current height and last 7 days network speed

