### PR TITLE
Add test to prevent regression of ConsensusVersion::read_le

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -391,6 +391,11 @@ mod tests {
         let result = ConsensusVersion::from_bytes_le(&bytes).unwrap();
         assert_eq!(result, version);
 
+        let version = ConsensusVersion::latest();
+        let bytes = version.to_bytes_le().unwrap();
+        let result = ConsensusVersion::from_bytes_le(&bytes).unwrap();
+        assert_eq!(result, version);
+
         let invalid_bytes = u16::MAX.to_bytes_le().unwrap();
         let result = ConsensusVersion::from_bytes_le(&invalid_bytes);
         assert!(result.is_err());


### PR DESCRIPTION
# Motivation

We have to manually extend the logic in ConsensusVersion::read_le

This adds a test that we don't forget to add new versions in there