### PR TITLE
[Perf] Only calculate the hash of circuit commitments once for the VK

### DIFF
--- a/algorithms/benches/snark/varuna.rs
+++ b/algorithms/benches/snark/varuna.rs
@@ -107,6 +107,7 @@ fn snark_batch_prove(c: &mut Criterion) {
 
         let mut pks = Vec::with_capacity(circuit_batch_size);
         let mut all_circuits = Vec::with_capacity(circuit_batch_size);
+        #[allow(clippy::mutable_key_type)]
         let mut keys_to_constraints = BTreeMap::new();
 
         for i in 0..circuit_batch_size {
@@ -191,7 +192,9 @@ fn snark_batch_verify(c: &mut Criterion) {
         let mut vks = Vec::with_capacity(circuit_batch_size);
         let mut all_circuits = Vec::with_capacity(circuit_batch_size);
         let mut all_inputs = Vec::with_capacity(circuit_batch_size);
+        #[allow(clippy::mutable_key_type)]
         let mut keys_to_constraints = BTreeMap::new();
+        #[allow(clippy::mutable_key_type)]
         let mut keys_to_inputs = BTreeMap::new();
         for i in 0..circuit_batch_size {
             let num_constraints = num_constraints_base + i;

--- a/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{polycommit::sonic_pc, snark::varuna::ahp::indexer::*};
+use crate::{AlgebraicSponge, polycommit::sonic_pc, snark::varuna::ahp::indexer::*};
 use snarkvm_curves::PairingEngine;
 use snarkvm_utilities::{FromBytes, FromBytesDeserializer, ToBytes, ToBytesSerializer, into_io_error, serialize::*};
 
@@ -25,10 +25,11 @@ use std::{
     io::{self, Read, Write},
     str::FromStr,
     string::String,
+    sync::OnceLock,
 };
 
 /// Verification key for a specific index (i.e., R1CS matrices).
-#[derive(Debug, Clone, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CircuitVerifyingKey<E: PairingEngine> {
     /// Stores information about the size of the circuit, as well as its defined
     /// field.
@@ -36,6 +37,21 @@ pub struct CircuitVerifyingKey<E: PairingEngine> {
     /// Commitments to the indexed polynomials.
     pub circuit_commitments: Vec<sonic_pc::Commitment<E>>,
     pub id: CircuitId,
+    pub circuit_commitments_hash: OnceLock<E::Fq>,
+}
+
+impl<E: PairingEngine> CircuitVerifyingKey<E> {
+    pub fn get_or_calculate_circuit_commitments_hash<FS: AlgebraicSponge<E::Fq, 2>>(
+        &self,
+        fs_parameters: &FS::Parameters,
+    ) -> &E::Fq {
+        self.circuit_commitments_hash.get_or_init(|| {
+            let mut sponge = FS::new_with_parameters(fs_parameters);
+            sponge.absorb_native_field_elements(&self.circuit_commitments);
+
+            sponge.squeeze_native_field_elements(1)[0]
+        })
+    }
 }
 
 impl<E: PairingEngine> FromBytes for CircuitVerifyingKey<E> {
@@ -96,6 +112,58 @@ impl<'de, E: PairingEngine> Deserialize<'de> for CircuitVerifyingKey<E> {
             }
             false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "verifying key"),
         }
+    }
+}
+
+impl<E: PairingEngine> CanonicalSerialize for CircuitVerifyingKey<E> {
+    fn serialize_with_mode<W: Write>(&self, mut writer: W, compress: Compress) -> Result<(), SerializationError> {
+        self.circuit_info.serialize_with_mode(&mut writer, compress)?;
+        self.circuit_commitments.serialize_with_mode(&mut writer, compress)?;
+        self.id.serialize_with_mode(&mut writer, compress)?;
+        // The hash is omitted.
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        self.circuit_info.serialized_size(compress)
+            + self.circuit_commitments.serialized_size(compress)
+            + self.id.serialized_size(compress)
+        // The hash is omitted.
+    }
+}
+
+impl<E: PairingEngine> CanonicalDeserialize for CircuitVerifyingKey<E> {
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let circuit_info = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let circuit_commitments = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let id = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        Ok(Self { circuit_info, circuit_commitments, id, circuit_commitments_hash: Default::default() })
+    }
+}
+
+impl<E: PairingEngine> Valid for CircuitVerifyingKey<E> {
+    fn check(&self) -> Result<(), SerializationError> {
+        Valid::check(&self.circuit_info)?;
+        Valid::check(&self.circuit_commitments)?;
+        Valid::check(&self.id)?;
+        // The hash is omitted.
+        Ok(())
+    }
+
+    fn batch_check<'a>(batch: impl Iterator<Item = &'a Self> + Send) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        let batch: Vec<_> = batch.collect();
+        Valid::batch_check(batch.iter().map(|v| &v.circuit_info))?;
+        Valid::batch_check(batch.iter().map(|v| &v.circuit_commitments))?;
+        Valid::batch_check(batch.iter().map(|v| &v.id))?;
+        // The hash is omitted.
+        Ok(())
     }
 }
 

--- a/algorithms/src/snark/varuna/tests.rs
+++ b/algorithms/src/snark/varuna/tests.rs
@@ -115,7 +115,9 @@ mod varuna {
                                 $snark_inst::batch_circuit_setup(&universal_srs, unique_instances.as_slice()).unwrap();
                             println!("Called circuit setup");
 
+                            #[allow(clippy::mutable_key_type)]
                             let mut pks_to_constraints = BTreeMap::new();
+                            #[allow(clippy::mutable_key_type)]
                             let mut vks_to_inputs = BTreeMap::new();
 
                             for (index_pk, index_vk) in index_keys.iter() {
@@ -147,6 +149,7 @@ mod varuna {
                                 }
                                 fake_instance_inputs.push(fake_instance_input);
                             }
+                            #[allow(clippy::mutable_key_type)]
                             let mut vks_to_fake_inputs = BTreeMap::new();
                             for (i, vk) in vks_to_inputs.keys().enumerate() {
                                 vks_to_fake_inputs.insert(*vk, fake_instance_inputs[i].as_slice());

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -46,12 +46,13 @@ use crate::{
 use rand::RngCore;
 use snarkvm_curves::PairingEngine;
 use snarkvm_fields::{One, PrimeField, ToConstraintField, Zero};
-use snarkvm_utilities::{ToBytes, dev_eprintln, dev_println, to_bytes_le};
+use snarkvm_utilities::{CanonicalSerialize, ToBytes, dev_eprintln, dev_println, to_bytes_le};
 
 use anyhow::{Result, anyhow, bail, ensure};
 use core::marker::PhantomData;
 use itertools::Itertools;
 use rand::{CryptoRng, Rng};
+use sha2::Digest;
 use std::{borrow::Borrow, collections::BTreeMap, ops::Deref, sync::Arc};
 
 use crate::srs::UniversalProver;
@@ -66,6 +67,20 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
     /// The personalization string for this protocol.
     /// Used to personalize the Fiat-Shamir RNG.
     pub const PROTOCOL_NAME: &'static [u8] = b"VARUNA-2023";
+
+    /// Hash batches in advance for the purposes of `Self::init_sponge`.
+    fn hash_batches(inputs_and_batch_sizes: &BTreeMap<CircuitId, (usize, &[Vec<E::Fr>])>) -> Result<[u8; 32]> {
+        let mut hash = blake2::Blake2s256::new();
+
+        for (batch_size, inputs) in inputs_and_batch_sizes.values() {
+            (*batch_size as u64).serialize_uncompressed(&mut hash)?;
+            for input in *inputs {
+                input.serialize_uncompressed(&mut hash)?;
+            }
+        }
+
+        Ok(hash.finalize().into())
+    }
 
     // TODO: implement optimizations resulting from batching
     //       (e.g. computing a common set of Lagrange powers, FFT precomputations,
@@ -137,17 +152,12 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
 
     fn init_sponge(
         fs_parameters: &FS::Parameters,
-        inputs_and_batch_sizes: &BTreeMap<CircuitId, (usize, &[Vec<E::Fr>])>,
+        hashed_batches: [u8; 32],
         circuit_commitments_hashes: Vec<E::Fq>,
     ) -> FS {
         let mut sponge = FS::new_with_parameters(fs_parameters);
         sponge.absorb_bytes(Self::PROTOCOL_NAME);
-        for (batch_size, inputs) in inputs_and_batch_sizes.values() {
-            sponge.absorb_bytes(&(*batch_size as u64).to_le_bytes());
-            for input in inputs.iter() {
-                sponge.absorb_nonnative_field_elements(input.iter().copied());
-            }
-        }
+        sponge.absorb_bytes(&hashed_batches);
         sponge.absorb_native_field_elements(&circuit_commitments_hashes);
         sponge
     }
@@ -398,7 +408,8 @@ where
             .copied()
             .collect();
 
-        let mut sponge = Self::init_sponge(fs_parameters, &inputs_and_batch_sizes, circuit_commitments_hashes);
+        let hashed_batches = Self::hash_batches(&inputs_and_batch_sizes)?;
+        let mut sponge = Self::init_sponge(fs_parameters, hashed_batches, circuit_commitments_hashes);
 
         // --------------------------------------------------------------------
         // First round
@@ -867,7 +878,9 @@ where
             .map(|vk| vk.get_or_calculate_circuit_commitments_hash::<FS>(fs_parameters))
             .copied()
             .collect();
-        let mut sponge = Self::init_sponge(fs_parameters, &inputs_and_batch_sizes, circuit_commitments_hashes);
+
+        let hashed_batches = Self::hash_batches(&inputs_and_batch_sizes)?;
+        let mut sponge = Self::init_sponge(fs_parameters, hashed_batches, circuit_commitments_hashes);
 
         // --------------------------------------------------------------------
         // First round

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -120,6 +120,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
             let circuit_verifying_key = CircuitVerifyingKey {
                 circuit_info: indexed_circuit.index_info,
                 circuit_commitments,
+                circuit_commitments_hash: Default::default(),
                 id: indexed_circuit.id,
             };
             let circuit_proving_key = CircuitProvingKey {
@@ -134,10 +135,10 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
         Ok(circuit_keys)
     }
 
-    fn init_sponge<'a>(
+    fn init_sponge(
         fs_parameters: &FS::Parameters,
         inputs_and_batch_sizes: &BTreeMap<CircuitId, (usize, &[Vec<E::Fr>])>,
-        circuit_commitments: impl Iterator<Item = &'a [crate::polycommit::sonic_pc::Commitment<E>]>,
+        circuit_commitments_hashes: Vec<E::Fq>,
     ) -> FS {
         let mut sponge = FS::new_with_parameters(fs_parameters);
         sponge.absorb_bytes(Self::PROTOCOL_NAME);
@@ -147,9 +148,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
                 sponge.absorb_nonnative_field_elements(input.iter().copied());
             }
         }
-        for circuit_specific_commitments in circuit_commitments {
-            sponge.absorb_native_field_elements(circuit_specific_commitments);
-        }
+        sponge.absorb_native_field_elements(&circuit_commitments_hashes);
         sponge
     }
 
@@ -393,10 +392,13 @@ where
 
         let committer_key = CommitterUnionKey::union(keys_to_constraints.keys().map(|pk| pk.committer_key.deref()));
 
-        let circuit_commitments =
-            keys_to_constraints.keys().map(|pk| pk.circuit_verifying_key.circuit_commitments.as_slice());
+        let circuit_commitments_hashes = keys_to_constraints
+            .keys()
+            .map(|pk| pk.circuit_verifying_key.get_or_calculate_circuit_commitments_hash::<FS>(fs_parameters))
+            .copied()
+            .collect();
 
-        let mut sponge = Self::init_sponge(fs_parameters, &inputs_and_batch_sizes, circuit_commitments.clone());
+        let mut sponge = Self::init_sponge(fs_parameters, &inputs_and_batch_sizes, circuit_commitments_hashes);
 
         // --------------------------------------------------------------------
         // First round
@@ -860,7 +862,12 @@ where
         let fifth_commitments = [LabeledCommitment::new_with_info(&fifth_round_info["h_2"], comms.h_2)];
 
         let circuit_commitments = keys_to_inputs.keys().map(|vk| vk.circuit_commitments.as_slice());
-        let mut sponge = Self::init_sponge(fs_parameters, &inputs_and_batch_sizes, circuit_commitments.clone());
+        let circuit_commitments_hashes = keys_to_inputs
+            .keys()
+            .map(|vk| vk.get_or_calculate_circuit_commitments_hash::<FS>(fs_parameters))
+            .copied()
+            .collect();
+        let mut sponge = Self::init_sponge(fs_parameters, &inputs_and_batch_sizes, circuit_commitments_hashes);
 
         // --------------------------------------------------------------------
         // First round

--- a/synthesizer/snark/src/proving_key/mod.rs
+++ b/synthesizer/snark/src/proving_key/mod.rs
@@ -74,6 +74,7 @@ impl<N: Network> ProvingKey<N> {
 
         // Prepare the instances.
         let num_expected_instances = assignments.len();
+        #[allow(clippy::mutable_key_type)]
         let instances: BTreeMap<_, _> = assignments
             .iter()
             .map(|(proving_key, assignments)| (proving_key.deref(), assignments.as_slice()))

--- a/synthesizer/snark/src/verifying_key/mod.rs
+++ b/synthesizer/snark/src/verifying_key/mod.rs
@@ -87,6 +87,7 @@ impl<N: Network> VerifyingKey<N> {
 
         // Convert the instances.
         let num_expected_keys = inputs.len();
+        #[allow(clippy::mutable_key_type)]
         let keys_to_inputs: BTreeMap<_, _> =
             inputs.iter().map(|(verifying_key, inputs)| (verifying_key.deref(), inputs.as_slice())).collect();
         ensure!(keys_to_inputs.len() == num_expected_keys, "Incorrect number of verifying keys for batch proof");


### PR DESCRIPTION
This addresses the 1st part of [this comment](https://github.com/ProvableHQ/snarkVM/issues/2871#issuecomment-3302769764) on the linked issue.

CC https://github.com/ProvableHQ/snarkVM/issues/2871.