### PR TITLE
[CI] Update baseline revision for semver checks

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -3,7 +3,7 @@
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=eff84712b # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=65a079a87 # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Exclude CLI as it has been removed
 cargo semver-checks --workspace --default-features \


### PR DESCRIPTION
This PR updates the baseline revision for semver checks, as there are some new errors that break its CI job right now.

The following three errors pop up right now:
* Variants were added to non-exhaustive enums and I made an issue about it (#2966)
* The `cli` feature was removed, which happened a while ago
* Some cost-related functions (e.g., `execution_cost_v2`) are not public anymore, which I assume is on purpose.