### PR TITLE
[Fix] Always return version 0 for credits.aleo

### DIFF
--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -260,6 +260,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
     }
 
+    /// Returns the program for the given `program ID` and `edition`,
+    /// or `None` if no program of this ID and edition exists.
+    pub fn try_get_program_for_edition(&self, program_id: ProgramID<N>, edition: u16) -> Result<Option<Program<N>>> {
+        self.vm.block_store().get_program_for_edition(&program_id, edition)
+    }
+
     /// Returns the block solutions for the given block height.
     pub fn get_solutions(&self, height: u32) -> Result<Solutions<N>> {
         // If the height is 0, return the genesis block solutions.

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -254,7 +254,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the program for the given `program ID` and `edition`.
     pub fn get_program_for_edition(&self, program_id: ProgramID<N>, edition: u16) -> Result<Program<N>> {
-        match self.vm.block_store().get_program_for_edition(&program_id, edition)? {
+        match self.try_get_program_for_edition(&program_id, edition)? {
             Some(program) => Ok(program),
             None => bail!("Missing program for ID {program_id} and edition {edition}"),
         }
@@ -262,8 +262,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the program for the given `program ID` and `edition`,
     /// or `None` if no program of this ID and edition exists.
-    pub fn try_get_program_for_edition(&self, program_id: ProgramID<N>, edition: u16) -> Result<Option<Program<N>>> {
-        self.vm.block_store().get_program_for_edition(&program_id, edition)
+    pub fn try_get_program_for_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<Option<Program<N>>> {
+        self.vm.block_store().get_program_for_edition(program_id, edition)
     }
 
     /// Returns the block solutions for the given block height.

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -428,11 +428,7 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Returns the program for the given `program ID` and `edition`.
     fn get_program_for_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<Option<Program<N>>> {
-        // Retrieve the program.
-        match self.program_map().get_confirmed(&(*program_id, edition))? {
-            Some(program) => Ok(Some(program.into_owned())),
-            None => bail!("Failed to get program '{program_id}' (edition {edition})"),
-        }
+        self.program_map().get_confirmed(&(*program_id, edition)).map(|p| p.map(|p| p.into_owned()))
     }
 
     /// Returns the latest verifying key for the given `program ID` and `function name`.

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -392,13 +392,6 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Returns the latest edition for the given `program ID`.
     fn get_latest_edition_for_program(&self, program_id: &ProgramID<N>) -> Result<Option<u16>> {
-        // Check if the program ID is for 'credits.aleo'.
-        // This case is handled separately, as it is a default program of the VM.
-        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
-        if program_id == &ProgramID::from_str("credits.aleo")? {
-            return Ok(None);
-        }
-
         Ok(self.edition_map().get_confirmed(program_id)?.map(|x| *x))
     }
 
@@ -421,13 +414,6 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Returns the latest program for the given `program ID`.
     fn get_latest_program(&self, program_id: &ProgramID<N>) -> Result<Option<Program<N>>> {
-        // Check if the program ID is for 'credits.aleo'.
-        // This case is handled separately, as it is a default program of the VM.
-        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
-        if program_id == &ProgramID::from_str("credits.aleo")? {
-            return Ok(Some(Program::credits()?));
-        }
-
         // Retrieve the latest edition.
         let edition = match self.get_latest_edition_for_program(program_id)? {
             Some(edition) => edition,
@@ -442,13 +428,6 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
 
     /// Returns the program for the given `program ID` and `edition`.
     fn get_program_for_edition(&self, program_id: &ProgramID<N>, edition: u16) -> Result<Option<Program<N>>> {
-        // Check if the program ID is for 'credits.aleo'.
-        // This case is handled separately, as it is a default program of the VM.
-        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
-        if program_id == &ProgramID::from_str("credits.aleo")? {
-            return Ok(Some(Program::credits()?));
-        }
-
         // Retrieve the program.
         match self.program_map().get_confirmed(&(*program_id, edition))? {
             Some(program) => Ok(Some(program.into_owned())),
@@ -697,6 +676,12 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     pub fn open(fee_store: FeeStore<N, D::FeeStorage>) -> Result<Self> {
         // Initialize the deployment storage.
         let storage = D::open(fee_store)?;
+
+        // Insert `credits.aleo`, which is the default program.
+        let credits_id = ProgramID::from_str("credits.aleo")?;
+        storage.edition_map().insert(credits_id, 0)?;
+        storage.program_map().insert((credits_id, 0), Program::credits()?)?;
+
         // Return the deployment store.
         Ok(Self { storage, _phantom: PhantomData })
     }


### PR DESCRIPTION
Aims to fix [snarkOS #3804](https://github.com/ProvableHQ/snarkOS/issues/3804).

**Side note:** I am not sure if I understand the TODO left by Howard, but it would be great if we did not have to construct the `ProgramID` for `credits.aleo` on every call to these functions.