### PR TITLE
[Perf] Block Caching

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -3,7 +3,7 @@
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=7a6475c36 # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=dec54170ce # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Exclude CLI as it has been removed
 cargo semver-checks --workspace --default-features \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "libc",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -16,6 +16,11 @@ categories = [ "cryptography", "web-programming" ]
 license = "Apache-2.0"
 edition = "2024"
 
+[[test]]
+name = "block-cache"
+path = "tests/block_cache.rs"
+required-features = [ "rocks" ]
+
 [[bench]]
 name = "block"
 path = "benches/block.rs"

--- a/ledger/benches/store.rs
+++ b/ledger/benches/store.rs
@@ -36,11 +36,10 @@ fn bench_block_store<S: BlockStorage<CurrentNetwork>>(
     group: &mut BenchmarkGroup<WallTime>,
     genesis_block: &Block<CurrentNetwork>,
     blocks: &[Block<CurrentNetwork>],
-    num_validators: usize,
 ) {
     let rng = &mut TestRng::default();
 
-    group.bench_function(format!("{name}::insert/{num_validators}validators"), |b| {
+    group.bench_function(format!("{name}::insert"), |b| {
         b.iter_custom(|num_inserts| {
             let num_inserts = num_inserts as usize;
             let store = create_storage::<S>(genesis_block);
@@ -59,7 +58,7 @@ fn bench_block_store<S: BlockStorage<CurrentNetwork>>(
         })
     });
 
-    group.bench_function(format!("{name}::get_block/{num_validators}validators"), |b| {
+    group.bench_function(format!("{name}::get_block"), |b| {
         let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
 
         b.iter_custom(|num_gets| {
@@ -82,7 +81,7 @@ fn bench_block_store<S: BlockStorage<CurrentNetwork>>(
         })
     });
 
-    group.bench_function(format!("{name}::get_block_height/{num_validators}validators"), |b| {
+    group.bench_function(format!("{name}::get_block_height"), |b| {
         let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
 
         b.iter_custom(|num_gets| {
@@ -108,21 +107,13 @@ fn bench_block_store<S: BlockStorage<CurrentNetwork>>(
 fn block_store(c: &mut Criterion) {
     initialize_logging();
 
-    const NUM_VALIDATORS: usize = 4;
-
     let (genesis_block, blocks) = load_blocks("test-ledger").pretty_expect("Failed to load blocks from disk");
 
     let mut group = c.benchmark_group("block_store");
     group.sample_size(10);
 
-    bench_block_store::<BlockMemory<CurrentNetwork>>(
-        "BlockMemory",
-        &mut group,
-        &genesis_block,
-        &blocks,
-        NUM_VALIDATORS,
-    );
-    bench_block_store::<BlockDB<CurrentNetwork>>("BlockDB", &mut group, &genesis_block, &blocks, NUM_VALIDATORS);
+    bench_block_store::<BlockMemory<CurrentNetwork>>("BlockMemory", &mut group, &genesis_block, &blocks);
+    bench_block_store::<BlockDB<CurrentNetwork>>("BlockDB", &mut group, &genesis_block, &blocks);
 
     group.finish();
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -70,7 +70,7 @@ use aleo_std::{
     StorageMode,
     prelude::{finish, lap, timer},
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use core::ops::Range;
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
@@ -224,11 +224,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Retrieve the latest height.
         let latest_height =
-            ledger.vm.block_store().max_height().ok_or_else(|| anyhow!("Failed to load blocks from the ledger"))?;
+            ledger.vm.block_store().max_height().with_context(|| "Failed to load blocks from the ledger")?;
         // Fetch the latest block.
         let block = ledger
             .get_block(latest_height)
-            .map_err(|err| err.context("Failed to load block {latest_height} from the ledger"))?;
+            .with_context(|| format!("Failed to load block {latest_height} from the ledger"))?;
 
         // Set the current block.
         ledger.current_block = Arc::new(RwLock::new(block));
@@ -283,6 +283,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the puzzle.
     pub const fn puzzle(&self) -> &Puzzle<N> {
         self.vm.puzzle()
+    }
+
+    /// Returns the size of the block cache (or `None` if the block cache is not enabled).
+    pub fn block_cache_size(&self) -> Option<u32> {
+        self.vm.block_store().cache_size()
     }
 
     /// Returns the provers and the number of solutions they have submitted for the current epoch.

--- a/ledger/store/src/block/cache.rs
+++ b/ledger/store/src/block/cache.rs
@@ -36,6 +36,8 @@ impl<N: Network> BlockCache<N> {
 
     /// Initialize the cache with the given blocks.
     pub fn new(blocks: Vec<Block<N>>) -> Result<Self> {
+        ensure!(blocks.len() <= Self::BLOCK_CACHE_SIZE as usize, "Too many blocks to fit in the cache");
+
         if let Some(block) = blocks.first() {
             ensure!(block.height() != 0, "Cannot cache the genesis block");
         }

--- a/ledger/store/src/block/cache.rs
+++ b/ledger/store/src/block/cache.rs
@@ -1,0 +1,222 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::block::{Block, Network};
+
+use snarkvm_utilities::ensure_equals;
+
+use std::collections::VecDeque;
+
+use anyhow::{Result, ensure};
+
+/// Helper struct for caching the most recent blocks.
+pub(super) struct BlockCache<N: Network> {
+    /// Contains the most recent blocks ordered by height.
+    /// We do not use a BTreeMap here as the cache is small and updates to a vector are more efficient
+    ///
+    /// Invariant: all entries in this vector (except the first) a height equal to h+1 (where h` is the previous block entry)
+    blocks: VecDeque<Block<N>>,
+}
+
+impl<N: Network> BlockCache<N> {
+    /// The maximum size of the cache in blocks.
+    pub(super) const BLOCK_CACHE_SIZE: u32 = 10;
+
+    /// Initialize the cache with the given blocks.
+    pub fn new(blocks: Vec<Block<N>>) -> Result<Self> {
+        if let Some(block) = blocks.first() {
+            ensure!(block.height() != 0, "Cannot cache the genesis block");
+        }
+        for idx in 1..blocks.len() {
+            ensure!(blocks[idx - 1].height() + 1 == blocks[idx].height(), "Not a continuous chain of blocks");
+        }
+
+        Ok(Self { blocks: VecDeque::from(blocks) })
+    }
+
+    /// Insert a new block into the cache.
+    /// Must be the successor of the last block inserted into the cache.
+    #[inline]
+    pub fn insert(&mut self, block: Block<N>) -> Result<()> {
+        ensure!(block.height() != 0, "Cannot cache the genesis block");
+
+        if let Some(prev) = self.blocks.back() {
+            ensure_equals!(
+                prev.height() + 1,
+                block.height(),
+                "Block is not the successor of the last block inserted into the cache"
+            );
+        }
+
+        self.blocks.push_back(block.clone());
+        if self.blocks.len() > (Self::BLOCK_CACHE_SIZE as usize) {
+            self.blocks.pop_front();
+        }
+
+        Ok(())
+    }
+
+    /// Return the block at the given height if it is in the cache.i
+    #[inline]
+    pub fn get_block(&self, block_height: u32) -> Option<&Block<N>> {
+        let first_block = self.blocks.front()?;
+
+        // Determine to location of the cached block (if any).
+        // This returns `None` if `block_height` is lower than the height of the first cached block.
+        let offset = block_height.checked_sub(first_block.height())?;
+
+        self.blocks.get(offset as usize)
+    }
+
+    /// Return the block with the given hash if it is in the cache.
+    #[inline]
+    pub fn get_block_by_hash(&self, block_hash: &N::BlockHash) -> Option<&Block<N>> {
+        // Perform a linear search through the cache.
+        // This is cheap, as the cache is very small.
+        self.blocks.iter().find(|block| &block.hash() == block_hash)
+    }
+
+    /// Remove the last `n` blocks from the cache.
+    #[inline]
+    pub fn remove_last_n(&mut self, n: u32) -> Result<()> {
+        for _ in 0..n {
+            self.blocks.pop_back();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_helpers::CurrentNetwork;
+
+    use snarkvm_console::{
+        account::{Field, PrivateKey},
+        prelude::{Rng, TestRng},
+    };
+    use snarkvm_ledger_authority::Authority;
+    use snarkvm_ledger_block::{Header, Metadata, Ratifications, Transactions};
+
+    type BlockCache = super::BlockCache<CurrentNetwork>;
+
+    #[test]
+    fn eviction() {
+        // The number of blocks to insert during the test
+        // (must be more than the cache size)
+        const NUM_BLOCKS: u32 = 15;
+        const { assert!(NUM_BLOCKS > BlockCache::BLOCK_CACHE_SIZE) };
+
+        let rng = &mut TestRng::default();
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+
+        // Construct a chain of blocks.
+        let mut previous_hash = None;
+        let blocks: Vec<_> = (0..NUM_BLOCKS)
+            .map(|h| {
+                let transactions = Transactions::from(&[]);
+                let ratifications = Ratifications::try_from(vec![]).unwrap();
+                let header = if h == 0 {
+                    Header::genesis(&ratifications, &transactions, vec![]).unwrap()
+                } else {
+                    // Use mock metadata to save compute time.
+                    let metadata = Metadata::new(
+                        CurrentNetwork::ID,
+                        (h * 2) as u64,
+                        h,
+                        0,
+                        (h * 1000) as u128,
+                        CurrentNetwork::GENESIS_COINBASE_TARGET,
+                        CurrentNetwork::GENESIS_PROOF_TARGET + 1,
+                        CurrentNetwork::GENESIS_COINBASE_TARGET,
+                        CurrentNetwork::GENESIS_TIMESTAMP + ((h - 1) * 100) as i64,
+                        CurrentNetwork::GENESIS_TIMESTAMP + (h * 100) as i64,
+                    )
+                    .unwrap();
+
+                    let previous_state_root: <CurrentNetwork as Network>::StateRoot = rng.r#gen();
+                    Header::<CurrentNetwork>::from(
+                        previous_state_root,
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        Field::from_u32(1),
+                        metadata,
+                    )
+                    .unwrap()
+                };
+                let block_hash = rng.r#gen();
+                let authority = Authority::<CurrentNetwork>::new_beacon(&private_key, block_hash, rng).unwrap();
+
+                let block = Block::from_unchecked(
+                    block_hash.into(),
+                    previous_hash.unwrap_or_default(),
+                    header,
+                    authority,
+                    ratifications,
+                    None.into(),
+                    vec![],
+                    transactions,
+                    vec![],
+                )
+                .unwrap();
+
+                previous_hash = Some(block.hash());
+                block
+            })
+            .collect();
+
+        let mut cache = BlockCache::new(vec![]).unwrap();
+        let mut blocks = blocks.into_iter().skip(1);
+
+        // First, fill up the cache.
+        while cache.blocks.len() < (BlockCache::BLOCK_CACHE_SIZE as usize) {
+            cache.insert(blocks.next().unwrap()).unwrap();
+        }
+
+        // Then, continue insertions and check that old blocks are evicted.
+        for block in blocks {
+            let hash = block.hash();
+            let height = block.height();
+
+            cache.insert(block).unwrap();
+
+            // Ensure eviction work.
+            assert_eq!(cache.blocks.len(), BlockCache::BLOCK_CACHE_SIZE as usize);
+
+            // Ensure the correct block is returned.
+            let ret1 = cache.get_block(height).unwrap();
+            let ret2 = cache.get_block_by_hash(&hash).unwrap();
+
+            assert_eq!(ret1.hash(), hash);
+            assert_eq!(ret2.hash(), hash);
+            assert_eq!(ret1.height(), height);
+            assert_eq!(ret2.height(), height);
+
+            assert_eq!(cache.blocks[0].height(), height - BlockCache::BLOCK_CACHE_SIZE + 1);
+        }
+
+        // Fetch something that isn't the last block.
+        let block = cache.get_block(10).unwrap();
+        assert_eq!(block.height(), 10);
+
+        // Fetch the last thing that must be in the cache.
+        assert!(cache.get_block(NUM_BLOCKS - BlockCache::BLOCK_CACHE_SIZE).is_some());
+        // Fetch something that must not be in the cache.
+        assert!(cache.get_block(NUM_BLOCKS - BlockCache::BLOCK_CACHE_SIZE - 1).is_none());
+    }
+}

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -16,6 +16,9 @@
 pub mod confirmed_tx_type;
 pub use confirmed_tx_type::*;
 
+mod cache;
+use cache::BlockCache;
+
 use crate::{
     TransactionStorage,
     TransactionStore,
@@ -45,12 +48,13 @@ use snarkvm_ledger_puzzle::{Solution, SolutionID};
 use snarkvm_synthesizer_program::{FinalizeOperation, Program};
 
 use aleo_std_storage::StorageMode;
-use anyhow::Result;
+use anyhow::{Context, Result};
 #[cfg(feature = "locktick")]
-use locktick::parking_lot::RwLock;
+use locktick::{LockGuard, parking_lot::RwLock};
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
 use std::{borrow::Cow, sync::Arc};
+use tracing::debug;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -989,36 +993,57 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
     fn backup_database<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), String>;
 }
 
-/// The block store.
+/// The `BlockStore` is the user facing API that either uses `BlockMemory` or `BlockDB` as its storae backend.
 #[derive(Clone)]
 pub struct BlockStore<N: Network, B: BlockStorage<N>> {
     /// The block storage.
     storage: B,
     /// The block tree.
     tree: Arc<RwLock<BlockTree<N>>>,
+    /// Cache of the most recent blocks.
+    block_cache: Arc<Option<RwLock<BlockCache<N>>>>,
 }
 
 impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
-    /// Initializes the block store.
+    /// Initializes the block storage and its cache.
     pub fn open<S: Into<StorageMode>>(storage: S) -> Result<Self> {
-        // Initialize the block storage.
         let storage = B::open(storage)?;
 
-        // Compute the block tree.
-        let tree = {
-            // Prepare an iterator over the block heights and prepare the leaves of the block tree.
-            let hashes = storage
-                .id_map()
-                .iter_confirmed()
-                .sorted_unstable_by(|(h1, _), (h2, _)| h1.cmp(h2))
-                .map(|(_, hash)| hash.to_bits_le())
-                .collect::<Vec<Vec<bool>>>();
-            // Construct the block tree.
-            Arc::new(RwLock::new(N::merkle_tree_bhp(&hashes)?))
-        };
+        // Prepare an iterator over the block heights and prepare the leaves of the block tree.
+        let hashes = storage
+            .id_map()
+            .iter_confirmed()
+            .sorted_unstable_by(|(h1, _), (h2, _)| h1.cmp(h2))
+            .map(|(_, hash)| hash.to_bits_le())
+            .collect::<Vec<Vec<bool>>>();
 
-        // Return the block store.
-        Ok(Self { storage, tree })
+        // Construct the block tree.
+        debug!("Found {} blocks on disk", hashes.len());
+        let tree = N::merkle_tree_bhp(&hashes)?;
+
+        let mut initial_cache = Vec::new();
+        let cache_end_height = u32::try_from(tree.number_of_leaves())?;
+        let cache_start_height = cache_end_height.saturating_sub(BlockCache::<N>::BLOCK_CACHE_SIZE);
+
+        for height in cache_start_height..cache_end_height {
+            // Ignore genesis block.
+            if height == 0 {
+                continue;
+            }
+
+            // Get the hash for the next block to add to the cache.
+            let hash = storage
+                .id_map()
+                .get_confirmed(&height)?
+                .with_context(|| format!("Block {height} exists in tree but not in storage"))?;
+
+            initial_cache.push(
+                storage.get_block(&hash)?.with_context(|| format!("Block {hash} exists in tree but not in storage"))?,
+            );
+        }
+
+        let block_cache = RwLock::new(BlockCache::new(initial_cache)?);
+        Ok(Self { storage, tree: Arc::new(RwLock::new(tree)), block_cache: Arc::new(Some(block_cache)) })
     }
 
     /// Stores the given block into storage.
@@ -1035,8 +1060,19 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         self.storage.insert((*updated_tree.root()).into(), block)?;
         // Update the block tree.
         *tree = updated_tree;
+        // Add the block to the block cache (unless it is a genesis block).
+        if block.height() != 0
+            && let Some(block_cache) = &*self.block_cache
+        {
+            block_cache.write().insert(block.clone())?;
+        }
         // Return success.
         Ok(())
+    }
+
+    /// Returns the size of the block cache (or `None` if the block cache is not enabled).
+    pub fn cache_size(&self) -> Option<u32> {
+        if self.block_cache.is_none() { None } else { Some(BlockCache::<N>::BLOCK_CACHE_SIZE) }
     }
 
     /// Reverts the Merkle tree to its shape before the insertion of the last 'n' blocks.
@@ -1053,7 +1089,7 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         Ok(())
     }
 
-    /// Removes the last 'n' blocks from storage.
+    /// Removes the last (most recent) `n` blocks from storage.
     pub fn remove_last_n(&self, n: u32) -> Result<()> {
         // Ensure 'n' is non-zero.
         ensure!(n > 0, "Cannot remove zero blocks");
@@ -1096,6 +1132,10 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
         // Update the block tree.
         *tree = updated_tree;
+        // Also remove the last n blocks from the cache.
+        if let Some(block_cache) = &*self.block_cache {
+            block_cache.write().remove_last_n(n)?;
+        }
         // Return success.
         Ok(())
     }
@@ -1184,6 +1224,23 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 }
 
 impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
+    /// Returns the read-locked `BlockCache`.
+    ///
+    /// This may return `None` due to lock contention, even if the cache is enabled.
+    #[inline]
+    #[cfg(feature = "locktick")]
+    fn get_block_cache(&self) -> Option<LockGuard<parking_lot::RwLockReadGuard<'_, BlockCache<N>>>> {
+        // This uses `try_read` to avoid deadlocks or prologned blocking of a thread in rayon: https://github.com/rayon-rs/rayon/issues/1205
+        if let Some(cache) = &*self.block_cache { cache.try_read() } else { None }
+    }
+
+    #[inline]
+    #[cfg(not(feature = "locktick"))]
+    fn get_block_cache(&self) -> Option<parking_lot::RwLockReadGuard<'_, BlockCache<N>>> {
+        // This uses `try_read` to avoid deadlocks or prologned blocking of a thread in rayon: https://github.com/rayon-rs/rayon/issues/1205
+        if let Some(cache) = &*self.block_cache { cache.try_read() } else { None }
+    }
+
     /// Returns the current state root.
     pub fn current_state_root(&self) -> N::StateRoot {
         (*self.tree.read().root()).into()
@@ -1211,11 +1268,23 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
     /// Returns the previous block hash of the given `block height`.
     pub fn get_previous_block_hash(&self, height: u32) -> Result<Option<N::BlockHash>> {
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block(height)
+        {
+            return Ok(Some(block.previous_hash()));
+        }
+
         self.storage.get_previous_block_hash(height)
     }
 
     /// Returns the block hash for the given `block height`.
     pub fn get_block_hash(&self, height: u32) -> Result<Option<N::BlockHash>> {
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block(height)
+        {
+            return Ok(Some(block.hash()));
+        }
+
         self.storage.get_block_hash(height)
     }
 
@@ -1226,22 +1295,46 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
     /// Returns the block header for the given `block hash`.
     pub fn get_block_header(&self, block_hash: &N::BlockHash) -> Result<Option<Header<N>>> {
-        self.storage.get_block_header(block_hash)
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block_by_hash(block_hash)
+        {
+            Ok(Some(*block.header()))
+        } else {
+            self.storage.get_block_header(block_hash)
+        }
     }
 
     /// Returns the block authority for the given `block hash`.
     pub fn get_block_authority(&self, block_hash: &N::BlockHash) -> Result<Option<Authority<N>>> {
-        self.storage.get_block_authority(block_hash)
+        if let Some(cache) = self.get_block_cache()
+            && let Some(block) = cache.get_block_by_hash(block_hash)
+        {
+            Ok(Some(block.authority().clone()))
+        } else {
+            self.storage.get_block_authority(block_hash)
+        }
     }
 
     /// Returns the block ratifications for the given `block hash`.
     pub fn get_block_ratifications(&self, block_hash: &N::BlockHash) -> Result<Option<Ratifications<N>>> {
-        self.storage.get_block_ratifications(block_hash)
+        if let Some(block_cache) = self.get_block_cache()
+            && let Some(block) = block_cache.get_block_by_hash(block_hash)
+        {
+            Ok(Some(block.ratifications().clone()))
+        } else {
+            self.storage.get_block_ratifications(block_hash)
+        }
     }
 
     /// Returns the block solutions for the given `block hash`.
     pub fn get_block_solutions(&self, block_hash: &N::BlockHash) -> Result<Solutions<N>> {
-        self.storage.get_block_solutions(block_hash)
+        if let Some(block_cache) = self.get_block_cache()
+            && let Some(block) = block_cache.get_block_by_hash(block_hash)
+        {
+            Ok(block.solutions().clone())
+        } else {
+            self.storage.get_block_solutions(block_hash)
+        }
     }
 
     /// Returns the prover solution for the given solution ID.
@@ -1286,7 +1379,13 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
 
     /// Returns the block for the given `block hash`.
     pub fn get_block(&self, block_hash: &N::BlockHash) -> Result<Option<Block<N>>> {
-        self.storage.get_block(block_hash)
+        if let Some(cache) = self.block_cache.as_ref()
+            && let Some(block) = cache.read().get_block_by_hash(block_hash)
+        {
+            Ok(Some(block.clone()))
+        } else {
+            self.storage.get_block(block_hash)
+        }
     }
 
     /// Returns the latest edition for the given `program ID`.

--- a/ledger/tests/block_cache.rs
+++ b/ledger/tests/block_cache.rs
@@ -1,0 +1,309 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the ledger block cache functionality.
+
+use snarkvm_ledger::{
+    Ledger,
+    test_helpers::{CurrentConsensusStore, CurrentLedger, CurrentNetwork, LedgerType},
+};
+
+use aleo_std::StorageMode;
+use snarkvm_console::{account::PrivateKey, prelude::*};
+use snarkvm_synthesizer::vm::VM;
+
+/// Tests that the block cache is properly initialized with existing blocks from storage.
+#[test]
+fn test_block_cache_initialization() {
+    let rng = &mut TestRng::default();
+
+    // Initialize a ledger without block cache and add some blocks.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    const NUM_BLOCKS: u32 = 15; // More than cache size (10) to test initialization logic
+
+    // Generate some block in the storage.
+    let temp_ledger = CurrentLedger::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+    for _ in 1..=NUM_BLOCKS {
+        let transactions = vec![];
+        let block =
+            temp_ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        temp_ledger.advance_to_next_block(&block).unwrap();
+    }
+
+    // Now load a new ledger and ensure that the block cache is correclty populated.
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    // Verify that recent blocks can be retrieved quickly (should be in cache).
+    let latest_height = ledger.latest_height();
+
+    // Test retrieval of the 10 most recent blocks (should be in cache).
+    for height in (latest_height.saturating_sub(9))..=latest_height {
+        let block = ledger.get_block(height).unwrap();
+        assert_eq!(block.height(), height);
+    }
+
+    // Test retrieval of older blocks (should not be in cache but still accessible).
+    for height in 0..=(latest_height.saturating_sub(10)) {
+        let block = ledger.get_block(height).unwrap();
+        assert_eq!(block.height(), height);
+    }
+}
+
+/// Tests cache hit and miss behavior when retrieving blocks.
+#[test]
+fn test_block_cache_hit_miss_behavior() {
+    let rng = &mut TestRng::default();
+
+    // Create a ledger with block cache enabled.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    let cache_size = ledger.block_cache_size().expect("No cache size found");
+    assert!(cache_size > 0, "Cache size is 0");
+
+    // Add blocks to fill and exceed the cache.
+    let mut block_hashes = vec![genesis.hash()];
+
+    for _ in 1..=(cache_size + 5) {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        let block_hash = block.hash();
+        ledger.advance_to_next_block(&block).unwrap();
+        block_hashes.push(block_hash);
+    }
+
+    let latest_height = ledger.latest_height();
+
+    // Test cache hits: Recent blocks should be fast to retrieve.
+    for height in (latest_height.saturating_sub(cache_size - 1))..=latest_height {
+        let start = std::time::Instant::now();
+        let block = ledger.get_block(height).unwrap();
+        let duration = start.elapsed();
+
+        assert_eq!(block.height(), height);
+        assert_eq!(block.hash(), block_hashes[height as usize]);
+
+        // Recent blocks should be retrieved quickly from cache.
+        // This is a rough performance check - exact timing depends on system.
+        assert!(duration.as_micros() < 1000, "Block {height} retrieval took too long: {duration:?}");
+    }
+
+    // Test cache misses: Older blocks should still be accessible but may be slower.
+    for height in 0..=(latest_height.saturating_sub(cache_size)) {
+        let block = ledger.get_block(height).unwrap();
+
+        assert_eq!(block.height(), height);
+        assert_eq!(block.hash(), block_hashes[height as usize]);
+    }
+}
+
+/// Tests that the cache properly evicts old blocks when new ones are added.
+#[test]
+fn test_block_cache_eviction() {
+    let rng = &mut TestRng::default();
+
+    // Create a ledger with block cache enabled.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    // Add exactly 10 blocks to fill the cache.
+    for i in 1..=10 {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+
+        // Verify the block was added correctly.
+        assert_eq!(ledger.latest_height(), i);
+    }
+
+    // At this point, cache should contain blocks 1-10 (genesis block 0 may or may not be cached).
+    let initial_height = ledger.latest_height();
+
+    // Add 5 more blocks, which should cause eviction of the oldest cached blocks.
+    for i in 1..=5 {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+
+        assert_eq!(ledger.latest_height(), initial_height + i);
+    }
+
+    let final_height = ledger.latest_height();
+
+    // Verify that all blocks are still accessible, regardless of cache state.
+    for height in 0..=final_height {
+        let block = ledger.get_block(height).unwrap();
+        assert_eq!(block.height(), height);
+    }
+
+    // Verify that the most recent 10 blocks should be the fastest to access.
+    let cache_start = final_height.saturating_sub(9);
+    for height in cache_start..=final_height {
+        let start = std::time::Instant::now();
+        let _block = ledger.get_block(height).unwrap();
+        let duration = start.elapsed();
+
+        // Recent blocks should be retrieved quickly from cache.
+        assert!(duration.as_micros() < 1000, "Cached block {height} retrieval took too long: {duration:?}");
+    }
+}
+
+/// Tests performance comparison between ledgers with and without block cache.
+#[test]
+fn test_block_cache_performance_comparison() {
+    let rng = &mut TestRng::default();
+
+    // Create two identical ledgers: one with cache, one without.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+
+    // Create a common genesis block for both ledgers.
+    let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    // Ledger without cache.
+    let ledger_no_cache = CurrentLedger::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    // Ledger with cache.
+    let ledger_with_cache =
+        Ledger::<CurrentNetwork, LedgerType>::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    // Add the same blocks to both ledgers.
+    const NUM_BLOCKS: u32 = 20;
+    for _ in 1..=NUM_BLOCKS {
+        let transactions = vec![];
+
+        // Add to non-cached ledger.
+        let block = ledger_no_cache
+            .prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions.clone(), rng)
+            .unwrap();
+        ledger_no_cache.advance_to_next_block(&block).unwrap();
+
+        // Add the same block to cached ledger.
+        ledger_with_cache.advance_to_next_block(&block).unwrap();
+    }
+
+    // Test retrieval performance for recent blocks (should be cached).
+    let latest_height = ledger_with_cache.latest_height();
+    let test_heights: Vec<u32> = (latest_height.saturating_sub(9)..=latest_height).collect();
+
+    // Measure performance without cache.
+    let start_no_cache = std::time::Instant::now();
+    for &height in &test_heights {
+        let _block = ledger_no_cache.get_block(height).unwrap();
+    }
+    let duration_no_cache = start_no_cache.elapsed();
+
+    // Measure performance with cache.
+    let start_with_cache = std::time::Instant::now();
+    for &height in &test_heights {
+        let _block = ledger_with_cache.get_block(height).unwrap();
+    }
+    let duration_with_cache = start_with_cache.elapsed();
+
+    // Cache should provide some performance benefit for recent blocks.
+    // Note: In memory storage, the difference might be minimal, but with RocksDB it should be more significant.
+    println!("No cache: {duration_no_cache:?}, With cache: {duration_with_cache:?}");
+
+    // Verify both ledgers return the same blocks.
+    for height in 0..=latest_height {
+        let block_no_cache = ledger_no_cache.get_block(height).unwrap();
+        let block_with_cache = ledger_with_cache.get_block(height).unwrap();
+        assert_eq!(block_no_cache.hash(), block_with_cache.hash(), "different block hashes at height {height}");
+        assert_eq!(block_no_cache.height(), block_with_cache.height());
+    }
+}
+
+/// Tests cache behavior during block advancement operations.
+#[test]
+fn test_block_cache_during_advancement() {
+    let rng = &mut TestRng::default();
+
+    // Create a ledger with block cache enabled.
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    let ledger = Ledger::<CurrentNetwork, LedgerType>::load(genesis.clone(), StorageMode::new_test(None)).unwrap();
+
+    // Test cache behavior during sequential block additions.
+    const NUM_BLOCKS: u32 = 25; // Exceeds cache size to test eviction
+    let mut added_blocks = vec![genesis];
+
+    for i in 1..=NUM_BLOCKS {
+        let transactions = vec![];
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], transactions, rng).unwrap();
+
+        // Test that we can retrieve the current latest block before advancement.
+        let current_latest = ledger.get_block(ledger.latest_height()).unwrap();
+        assert_eq!(current_latest.height(), i - 1);
+
+        // Advance to the next block.
+        ledger.advance_to_next_block(&block).unwrap();
+        added_blocks.push(block.clone());
+
+        // Test that the new block is immediately available.
+        let new_latest = ledger.get_block(ledger.latest_height()).unwrap();
+        assert_eq!(new_latest.height(), i);
+        assert_eq!(new_latest.hash(), block.hash());
+
+        // Test that previous blocks are still accessible.
+        if i >= 10 {
+            // Test both cached and potentially non-cached blocks.
+            let recent_block = ledger.get_block(i - 5).unwrap();
+            assert_eq!(recent_block.height(), i - 5);
+
+            if i >= 15 {
+                let older_block = ledger.get_block(i - 15).unwrap();
+                assert_eq!(older_block.height(), i - 15);
+            }
+        }
+    }
+
+    // Final verification: all blocks should be accessible.
+    for (expected_height, expected_block) in added_blocks.iter().enumerate() {
+        let retrieved_block = ledger.get_block(expected_height as u32).unwrap();
+        assert_eq!(retrieved_block.hash(), expected_block.hash());
+        assert_eq!(retrieved_block.height(), expected_height as u32);
+    }
+
+    // Test batch retrieval of recent blocks (should leverage cache).
+    let latest_height = ledger.latest_height();
+    let recent_heights: Vec<u32> = (latest_height.saturating_sub(9)..=latest_height).collect();
+
+    let start = std::time::Instant::now();
+    let recent_blocks = ledger.get_blocks(recent_heights[0]..recent_heights[recent_heights.len() - 1] + 1).unwrap();
+    let duration = start.elapsed();
+
+    assert_eq!(recent_blocks.len(), recent_heights.len());
+    for (block, &expected_height) in recent_blocks.iter().zip(&recent_heights) {
+        assert_eq!(block.height(), expected_height);
+    }
+
+    // Recent block retrieval should be fast.
+    assert!(duration.as_millis() < 100, "Batch retrieval of recent blocks took too long: {duration:?}");
+}


### PR DESCRIPTION
Cleaned up version of #2937 to address #2934. There is a https://github.com/ProvableHQ/snarkOS/pull/3923 in snarkOS that uses this new feature.

### Overview
The new block cache is part of the `BlockStore` and caches the 10 most recent blocks. It is always enabled and there is no API change, except for the addition of `Ledger::get_cache_size`. 

