### PR TITLE
[CI] Update baseline revision for semver checks

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -3,7 +3,7 @@
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=65a079a87 # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=8970619a # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Exclude CLI as it has been removed
 cargo semver-checks --workspace --default-features \


### PR DESCRIPTION
This PR (once again) bumps the baseline revision for semver checks.

The current errors were:
* enum variant added for `ConsensusVersion::V12`
* changes in `log_warning`/`log_error`: not used outside snarkOS/VM AFAIK
* removal of the `tracing` feature in `ledger/store`: that dependency is now always enabled