### PR TITLE
[Perf] Block advancement benchmarks

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -3,7 +3,7 @@
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=8970619a # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=70d441f4c # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Exclude CLI as it has been removed
 cargo semver-checks --workspace --default-features \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -301,9 +301,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blake2"
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -494,7 +494,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -560,7 +560,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "log",
  "serde",
  "serde_derive",
@@ -791,7 +791,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -942,7 +942,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1249,7 +1249,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1705,7 +1705,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -1939,7 +1939,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1988,9 +1988,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2004,7 +2004,7 @@ version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2021,7 +2021,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2166,14 +2166,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2186,7 +2186,7 @@ checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -2338,7 +2338,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2482,7 +2482,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2495,7 +2495,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2504,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.33"
+version = "0.23.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
 dependencies = [
  "log",
  "once_cell",
@@ -2625,7 +2625,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2681,7 +2681,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2690,7 +2690,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2716,7 +2716,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itoa",
  "ryu",
  "serde",
@@ -2745,7 +2745,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2861,7 +2861,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -2944,7 +2944,7 @@ name = "snarkvm-circuit-environment"
 version = "4.3.0"
 dependencies = [
  "criterion",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -3137,7 +3137,7 @@ version = "4.3.0"
 dependencies = [
  "aleo-std",
  "criterion",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "rayon",
  "snarkvm-console-algorithms",
  "snarkvm-console-network",
@@ -3150,7 +3150,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "lazy_static",
  "paste",
  "serde",
@@ -3188,7 +3188,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "num-derive",
  "num-traits",
  "seq-macro",
@@ -3339,7 +3339,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3384,7 +3384,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -3411,7 +3411,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3444,7 +3444,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.3.0"
 dependencies = [
  "bincode",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3458,7 +3458,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.3.0"
 dependencies = [
  "bincode",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3484,7 +3484,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.3.0"
 dependencies = [
  "bincode",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3526,7 +3526,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3546,7 +3546,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3585,7 +3585,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3673,7 +3673,7 @@ dependencies = [
  "bincode",
  "criterion",
  "hex",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itertools 0.14.0",
  "k256",
  "locktick",
@@ -3713,7 +3713,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "criterion",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3741,7 +3741,7 @@ dependencies = [
  "bincode",
  "criterion",
  "enum-iterator",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "k256",
  "paste",
  "rand 0.8.5",
@@ -3807,7 +3807,7 @@ version = "4.3.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3867,7 +3867,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.41",
  "structmeta-derive",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3878,7 +3878,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3911,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
@@ -3946,7 +3946,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3955,7 +3955,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3992,7 +3992,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.41",
  "structmeta",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4021,7 +4021,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4032,7 +4032,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4205,7 +4205,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -4248,7 +4248,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4308,7 +4308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4331,9 +4331,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "unicode-width"
@@ -4506,7 +4506,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
  "wasm-bindgen-shared",
 ]
 
@@ -4541,7 +4541,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4576,7 +4576,7 @@ checksum = "b673bca3298fe582aeef8352330ecbad91849f85090805582400850f8270a2e8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4896,7 +4896,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -4917,7 +4917,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4937,7 +4937,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -4958,7 +4958,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4991,5 +4991,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "snarkvm-utilities",
  "time",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -34,6 +34,12 @@ harness = false
 required-features = [ "test-helpers", "rocks" ]
 
 [[bench]]
+name = "advance"
+path = "benches/advance.rs"
+harness = false
+required-features = [ "test-helpers", "rocks" ]
+
+[[bench]]
 name = "dag"
 path = "benches/dag.rs"
 harness = false
@@ -197,3 +203,7 @@ workspace = true
 [dev-dependencies.snarkvm-synthesizer]
 workspace = true
 features = [ "test" ]
+
+[dev-dependencies.tracing-subscriber]
+version = "0.3"
+features = [ "env-filter", "std" ]

--- a/ledger/benches/advance.rs
+++ b/ledger/benches/advance.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm_console::prelude::*;
+use snarkvm_ledger::{
+    Block,
+    store::{
+        ConsensusStorage,
+        helpers::{memory::ConsensusMemory, rocksdb::ConsensusDB},
+    },
+};
+use snarkvm_utilities::PrettyUnwrap;
+
+use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime};
+use std::time::Instant;
+
+mod common;
+use common::{CurrentNetwork, create_ledger, initialize_logging, load_blocks};
+
+/// Measures block advancement.
+fn bench_ledger_advancement<S: ConsensusStorage<CurrentNetwork>>(
+    name: &str,
+    group: &mut BenchmarkGroup<WallTime>,
+    genesis_block: &Block<CurrentNetwork>,
+    blocks: &[Block<CurrentNetwork>],
+    check_next_block: bool,
+    rng: &mut TestRng,
+) {
+    let name = if check_next_block {
+        format!("Ledger<{name}>::check_and_advance")
+    } else {
+        format!("Ledger<{name}>::advance_without_checks")
+    };
+
+    group.bench_function(name, |b| {
+        b.iter_custom(|num_ops| {
+            let ledger = create_ledger::<S>(genesis_block.clone());
+            let mut blocks_iter = blocks.iter();
+
+            let start = Instant::now();
+            for _ in 0..num_ops {
+                let block = blocks_iter.next().expect("Not enough blocks");
+                if check_next_block {
+                    ledger.check_next_block(block, rng).pretty_expect("Check for next block failed");
+                }
+                ledger.advance_to_next_block(block).pretty_expect("Advancement to next block failed");
+            }
+
+            start.elapsed()
+        })
+    });
+}
+
+/// Measures block checks.
+fn bench_ledger_checks<S: ConsensusStorage<CurrentNetwork>>(
+    name: &str,
+    group: &mut BenchmarkGroup<WallTime>,
+    genesis_block: &Block<CurrentNetwork>,
+    blocks: &[Block<CurrentNetwork>],
+    rng: &mut TestRng,
+) {
+    group.bench_function(format!("Ledger<{name}>::check_next_block"), |b| {
+        b.iter_custom(|num_ops| {
+            let ledger = create_ledger::<S>(genesis_block.clone());
+            let mut blocks_iter = blocks.iter();
+
+            // Pre-load the ledger with blocks.
+            let num_preloaded_blocks = blocks.len() - 1;
+            while (ledger.latest_height() as usize) < num_preloaded_blocks {
+                ledger.advance_to_next_block(blocks_iter.next().unwrap()).unwrap();
+            }
+
+            let last_block = blocks_iter.next().unwrap();
+
+            let start = Instant::now();
+            for _ in 0..num_ops {
+                ledger.check_next_block(last_block, rng).unwrap();
+            }
+            start.elapsed()
+        })
+    });
+}
+
+fn ledger_advance(c: &mut Criterion) {
+    initialize_logging();
+
+    let (genesis_block, blocks) = load_blocks("test-ledger").pretty_expect("Failed to load blocks from disk");
+
+    let mut rng = TestRng::default();
+
+    let mut group = c.benchmark_group("ledger_advance");
+    group.sample_size(10);
+
+    for check_next_block in [false, true] {
+        bench_ledger_advancement::<ConsensusMemory<CurrentNetwork>>(
+            "BlockMemory",
+            &mut group,
+            &genesis_block,
+            &blocks,
+            check_next_block,
+            &mut rng,
+        );
+        bench_ledger_advancement::<ConsensusDB<CurrentNetwork>>(
+            "BlockDB",
+            &mut group,
+            &genesis_block,
+            &blocks,
+            check_next_block,
+            &mut rng,
+        );
+    }
+
+    bench_ledger_checks::<ConsensusMemory<CurrentNetwork>>(
+        "BlockMemory",
+        &mut group,
+        &genesis_block,
+        &blocks,
+        &mut rng,
+    );
+    bench_ledger_checks::<ConsensusDB<CurrentNetwork>>("BlockDB", &mut group, &genesis_block, &blocks, &mut rng);
+    group.finish();
+}
+
+criterion_group!(benches, ledger_advance);
+criterion_main!(benches);

--- a/ledger/benches/common/mod.rs
+++ b/ledger/benches/common/mod.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm_ledger::{Block, Ledger};
+use snarkvm_ledger_store::{BlockStorage, BlockStore, ConsensusStorage};
+use snarkvm_utilities::{FromBytes, PrettyUnwrap};
+
+use aleo_std::StorageMode;
+use anyhow::{Result, ensure};
+use std::{fs, path::PathBuf};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+pub type CurrentNetwork = snarkvm_console::network::MainnetV0;
+
+/// Helper to initialize the `BlockStorage`.
+#[allow(dead_code)]
+pub fn create_storage<S: BlockStorage<CurrentNetwork>>(
+    genesis_block: &Block<CurrentNetwork>,
+) -> BlockStore<CurrentNetwork, S> {
+    let store = BlockStore::<CurrentNetwork, S>::open(StorageMode::new_test(None)).expect("Failed to create storage");
+
+    store.insert(genesis_block).unwrap();
+    store
+}
+
+/// Helper to initialize the `Ledger`.
+#[allow(dead_code)]
+pub fn create_ledger<S: ConsensusStorage<CurrentNetwork>>(
+    genesis_block: Block<CurrentNetwork>,
+) -> Ledger<CurrentNetwork, S> {
+    Ledger::load(genesis_block, StorageMode::new_test(None)).pretty_expect("Failed to create empty test ledger")
+}
+
+/// Load blocks, which were generated using `snarkvm-testchain-generator --no-ledger [..]` from the given path.
+#[allow(dead_code)]
+pub fn load_blocks(path: &str) -> Result<(Block<CurrentNetwork>, Vec<Block<CurrentNetwork>>)> {
+    let mut current_height = 1;
+    let mut blocks = vec![];
+
+    let genesis_block = {
+        let path: PathBuf = format!("{path}/genesis.data").into();
+
+        let data = fs::read(path)?;
+        Block::from_bytes_le_unchecked(&data)?
+    };
+
+    loop {
+        let path: PathBuf = format!("{path}/block{current_height}.data").into();
+        if !path.is_file() {
+            break;
+        }
+
+        let data = fs::read(path)?;
+        let block = Block::from_bytes_le_unchecked(&data)?;
+
+        blocks.push(block);
+        current_height += 1;
+    }
+
+    ensure!(!blocks.is_empty(), "found no blocks");
+
+    println!("Loaded {num} blocks from disk", num = blocks.len());
+
+    Ok((genesis_block, blocks))
+}
+
+pub fn initialize_logging() {
+    tracing_subscriber::registry().with(fmt::layer()).with(EnvFilter::from_default_env()).init();
+}

--- a/ledger/benches/store.rs
+++ b/ledger/benches/store.rs
@@ -15,73 +15,61 @@
 
 use snarkvm_console::prelude::*;
 use snarkvm_ledger::{
+    Block,
     store::{
         BlockStorage,
-        BlockStore,
         helpers::{memory::BlockMemory, rocksdb::BlockDB},
     },
-    test_helpers::TestChainBuilder,
 };
 use snarkvm_utilities::PrettyUnwrap;
-
-use aleo_std_storage::StorageMode;
 
 use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime};
 use rand::seq::SliceRandom;
 use std::time::Instant;
 
-type Network = snarkvm_console::network::MainnetV0;
+mod common;
+use common::{CurrentNetwork, create_storage, initialize_logging, load_blocks};
 
-/// The number of blocks in the store for get/search operations.
-/// Also, the number of pre-generated blocks.
-const NUM_BLOCKS: usize = 1000;
-
-// Helper method to benchmark serialization.
-fn bench_block_store<S: BlockStorage<Network>>(
+/// Runs the benchmark for the given implementation of `BlockStorage`.
+fn bench_block_store<S: BlockStorage<CurrentNetwork>>(
     name: &str,
     group: &mut BenchmarkGroup<WallTime>,
+    genesis_block: &Block<CurrentNetwork>,
+    blocks: &[Block<CurrentNetwork>],
     num_validators: usize,
 ) {
     let rng = &mut TestRng::default();
 
-    // Pre-generate enough blocks for all benchmarks.
-    println!("Generating test chain of {NUM_BLOCKS} blocks with {num_validators} validators");
-    let mut builder = TestChainBuilder::new_with_quorum_size(num_validators, rng).pretty_unwrap();
-    let blocks = builder.generate_blocks(NUM_BLOCKS, rng).unwrap();
-
-    println!("Done generating blocks. Starting benchmark.");
-
-    // TODO(kaimast): Figure out a way to pre-generate a large number of blocks or reduce the number of iterations.
-    /*   group.bench_function(format!("{name}::insert/{num_validators}validators"), |b| {
+    group.bench_function(format!("{name}::insert/{num_validators}validators"), |b| {
         b.iter_custom(|num_inserts| {
             let num_inserts = num_inserts as usize;
-            let store = BlockStore::<Network, S>::open(StorageMode::new_test(None)).unwrap();
-            store.insert(builder.genesis_block()).unwrap();
+            let store = create_storage::<S>(genesis_block);
 
-            assert!(num_inserts < NUM_BLOCKS);
+            assert!(num_inserts < blocks.len());
 
             let start = Instant::now();
             for block in &blocks[..num_inserts] {
-                if let Err(err) = store.insert(&block) {
-                    panic!("Failed to insert block at height {}: {err}", block.height());
-                }
+                store
+                    .insert(block)
+                    .map_err(|err| err.context(format!("Failed to insert block at height {}", block.height())))
+                    .pretty_unwrap();
             }
 
             start.elapsed()
         })
-    });*/
+    });
 
     group.bench_function(format!("{name}::get_block/{num_validators}validators"), |b| {
         let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
 
         b.iter_custom(|num_gets| {
-            let store = BlockStore::<Network, S>::open(StorageMode::new_test(None)).unwrap();
-            store.insert(builder.genesis_block()).unwrap();
+            let store = create_storage::<S>(genesis_block);
 
-            for block in &blocks {
-                if let Err(err) = store.insert(block) {
-                    panic!("Failed to insert block at height {}: {err}", block.height());
-                }
+            for block in blocks {
+                store
+                    .insert(block)
+                    .map_err(|err| err.context(format!("Failed to insert block at height {}", block.height())))
+                    .pretty_unwrap();
             }
 
             let start = Instant::now();
@@ -98,10 +86,9 @@ fn bench_block_store<S: BlockStorage<Network>>(
         let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
 
         b.iter_custom(|num_gets| {
-            let store = BlockStore::<Network, S>::open(StorageMode::new_test(None)).unwrap();
-            store.insert(builder.genesis_block()).unwrap();
+            let store = create_storage::<S>(genesis_block);
 
-            for block in &blocks {
+            for block in blocks {
                 if let Err(err) = store.insert(block) {
                     panic!("Failed to insert block at height {}: {err}", block.height());
                 }
@@ -119,17 +106,23 @@ fn bench_block_store<S: BlockStorage<Network>>(
 }
 
 fn block_store(c: &mut Criterion) {
+    initialize_logging();
+
+    const NUM_VALIDATORS: usize = 4;
+
+    let (genesis_block, blocks) = load_blocks("test-ledger").pretty_expect("Failed to load blocks from disk");
+
     let mut group = c.benchmark_group("block_store");
     group.sample_size(10);
 
-    //TODO(kaimast) find a way to speed this up
-    //for f in 1..=4 {
-    for f in 1..=1 {
-        let num_validators = 3 * f + 1;
-
-        bench_block_store::<BlockMemory<Network>>("BlockMemory", &mut group, num_validators);
-        bench_block_store::<BlockDB<Network>>("BlockDB", &mut group, num_validators);
-    }
+    bench_block_store::<BlockMemory<CurrentNetwork>>(
+        "BlockMemory",
+        &mut group,
+        &genesis_block,
+        &blocks,
+        NUM_VALIDATORS,
+    );
+    bench_block_store::<BlockDB<CurrentNetwork>>("BlockDB", &mut group, &genesis_block, &blocks, NUM_VALIDATORS);
 
     group.finish();
 }

--- a/ledger/block/src/header/metadata/genesis.rs
+++ b/ledger/block/src/header/metadata/genesis.rs
@@ -63,11 +63,7 @@ impl<N: Network> Metadata<N> {
         );
         ensure_equals!(self.timestamp, N::GENESIS_TIMESTAMP, "Invalid timestamp");
         ensure_equals!(self.last_coinbase_timestamp, N::GENESIS_TIMESTAMP, "Invalid last coinbase timestamp");
-        ensure_equals!(
-            self.coinbase_target,
-            N::GENESIS_COINBASE_TARGET,
-            "Invalid coinsbase target for genesis block expected {expected}."
-        );
+        ensure_equals!(self.coinbase_target, N::GENESIS_COINBASE_TARGET, "Invalid coinbase target for genesis block");
         ensure_equals!(
             self.last_coinbase_target,
             N::GENESIS_COINBASE_TARGET,

--- a/ledger/src/test_helpers/chain_builder.rs
+++ b/ledger/src/test_helpers/chain_builder.rs
@@ -114,6 +114,7 @@ impl<N: Network> TestChainBuilder<N> {
             .with_context(|| "Failed to initialize consensus store")?;
         // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
         let seed: u64 = rng.r#gen();
+        trace!("Using seed {seed} and key {} for genesis RNG", private_key);
         let genesis_rng = &mut TestRng::from_seed(seed);
         let genesis_block = VM::from(store).unwrap().genesis_beacon(&private_key, genesis_rng)?;
 
@@ -121,7 +122,10 @@ impl<N: Network> TestChainBuilder<N> {
         let genesis_rng = &mut TestRng::from_seed(seed);
         let private_keys = (0..committee_size).map(|_| PrivateKey::new(genesis_rng).unwrap()).collect();
 
-        trace!("Generated private keys for all {committee_size} committee members");
+        trace!(
+            "Generated genesis block ({}) and private keys for all {committee_size} committee members",
+            genesis_block.hash()
+        );
 
         Ok((private_keys, genesis_block))
     }

--- a/ledger/store/src/block/confirmed_tx_type/mod.rs
+++ b/ledger/store/src/block/confirmed_tx_type/mod.rs
@@ -36,7 +36,7 @@ pub mod test_helpers {
     use super::*;
     use console::network::MainnetV0;
 
-    type CurrentNetwork = MainnetV0;
+    pub(crate) type CurrentNetwork = MainnetV0;
 
     /// Samples an accepted deploy.
     pub(crate) fn sample_accepted_deploy(rng: &mut TestRng) -> ConfirmedTxType<CurrentNetwork> {

--- a/ledger/testchain-generator/Cargo.toml
+++ b/ledger/testchain-generator/Cargo.toml
@@ -17,6 +17,11 @@ license = "Apache-2.0"
 edition = "2024"
 include = ["../../LICENSE.md"]
 
+[features]
+default = [ ]
+test_targets = [ "snarkvm-ledger/test_targets"]
+test = [ "snarkvm-ledger/test" ]
+
 [dependencies.aleo-std]
 workspace = true
 

--- a/ledger/testchain-generator/src/main.rs
+++ b/ledger/testchain-generator/src/main.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkvm_console::prelude::{CanaryV0, MainnetV0, Network, TestRng, TestnetV0};
+use snarkvm_console::prelude::{CanaryV0, MainnetV0, Network, TestRng, TestnetV0, ToBytes};
 use snarkvm_ledger::{Ledger, store::helpers::rocksdb::ConsensusDB, test_helpers::TestChainBuilder};
 
 use aleo_std::StorageMode;
-
 use anyhow::{Context, Result, bail};
 use clap::{Parser, builder::PossibleValuesParser};
+use std::fs;
 
 #[derive(Parser)]
 struct Args {
@@ -41,6 +41,12 @@ struct Args {
     /// The name of the network to generate the chain for.
     #[clap(long, value_parser=PossibleValuesParser::new(vec![CanaryV0::SHORT_NAME, TestnetV0::SHORT_NAME, MainnetV0::SHORT_NAME]), default_value=TestnetV0::SHORT_NAME)]
     network: String,
+    /// Set the seed to used to generate the chain.
+    #[clap(long)]
+    seed: Option<u64>,
+    /// Store serialized blocks directly on disk instead of going through ledger storage.
+    #[clap(long, requires = "storage_path")]
+    no_ledger: bool,
 }
 
 /// Removes an existing ledger (if any) from the filesystem.
@@ -74,16 +80,25 @@ fn main() -> Result<()> {
 }
 
 fn generate_testchain<N: Network>(args: Args) -> Result<()> {
-    let mut rng = TestRng::default();
-    let storage_mode =
-        if let Some(path) = args.storage_path { StorageMode::Custom(path.into()) } else { StorageMode::Development(0) };
+    let mut rng = if let Some(seed) = args.seed {
+        println!("Using seed of {seed}");
+        TestRng::from_seed(seed)
+    } else {
+        TestRng::default()
+    };
+
+    let storage_mode = if let Some(path) = args.storage_path.clone() {
+        StorageMode::Custom(path.into())
+    } else {
+        StorageMode::Development(0)
+    };
 
     remove_ledger(N::ID, &storage_mode, args.force)?;
 
     let num_validators = args.num_validators;
     let num_blocks = args.num_blocks;
 
-    println!("Initializing test chain builder with {num_validators} validators");
+    println!("Initializing test chain builder for {} with {num_validators} validators", N::SHORT_NAME);
     let mut builder: TestChainBuilder<N> = match args.genesis_path {
         Some(genesis_path) => TestChainBuilder::new_with_quorum_size_and_genesis_block(num_validators, genesis_path),
         None => TestChainBuilder::new_with_quorum_size(num_validators, &mut rng),
@@ -99,20 +114,46 @@ fn generate_testchain<N: Network>(args: Args) -> Result<()> {
         let batch_size = (num_blocks - blocks.len()).min(100);
         let mut batch = builder.generate_blocks(batch_size, &mut rng).with_context(|| "Failed to generate blocks")?;
 
-        println!("Generated {pos} of {num_blocks} blocks");
         pos += batch_size;
+        println!("Generated {pos} of {num_blocks} blocks");
         blocks.append(&mut batch);
     }
 
-    println!("Done. Storing blocks to disk.");
-    let ledger = Ledger::<N, ConsensusDB<N>>::load(builder.genesis_block().clone(), storage_mode)
-        .with_context(|| "Failed to initialize ledger")?;
+    if args.no_ledger {
+        let base_path = args.storage_path.unwrap();
+        fs::create_dir(base_path.clone())?;
 
-    // Ensure there is only one active ledger at a time.
-    drop(builder);
+        println!("Storing blocks as {base_path}/block{{height}}.data");
 
-    for block in &blocks {
-        ledger.advance_to_next_block(block)?;
+        // Store genesis block.
+        {
+            let path = format!("{base_path}/genesis.data");
+            let data = builder.genesis_block().to_bytes_le()?;
+            fs::write(path, data)?;
+        }
+
+        // Store remaining blocks.
+        for block in blocks.into_iter() {
+            let path = format!("{base_path}/block{}.data", block.height());
+            let data = block.to_bytes_le()?;
+            fs::write(path, data)?;
+        }
+    } else {
+        println!("Done. Storing blocks to on-disk ledger.");
+
+        let ledger = Ledger::<N, ConsensusDB<N>>::load_unchecked(builder.genesis_block().clone(), storage_mode)
+            .with_context(|| "Failed to initialize ledger")?;
+
+        // Ensure there is only one active ledger at a time.
+        drop(builder);
+
+        for block in blocks.into_iter() {
+            ledger.advance_to_next_block(&block)?;
+
+            if block.height().is_multiple_of(100) {
+                println!("Stored {} blocks out of {num_blocks} to disk", block.height());
+            }
+        }
     }
 
     Ok(())

--- a/utilities/src/errors.rs
+++ b/utilities/src/errors.rs
@@ -143,6 +143,9 @@ pub trait PrettyUnwrap {
 
     /// Behaves like [`std::result::Result::unwrap`] but will print the entire anyhow chain to stderr.
     fn pretty_unwrap(self) -> Self::Inner;
+
+    /// Behaves like [`std::result::Result::expect`] but will print the entire anyhow chain to stderr.
+    fn pretty_expect<S: ToString>(self, context: S) -> Self::Inner;
 }
 
 /// Helper for `PrettyUnwrap`, which creates a panic with the `anyhow::Error` nicely formatted and also logs the panic.
@@ -167,6 +170,16 @@ impl<T> PrettyUnwrap for anyhow::Result<T> {
             Ok(result) => result,
             Err(error) => {
                 pretty_panic(&error);
+            }
+        }
+    }
+
+    #[track_caller]
+    fn pretty_expect<S: ToString>(self, context: S) -> Self::Inner {
+        match self {
+            Ok(result) => result,
+            Err(error) => {
+                pretty_panic(&error.context(context.to_string()));
             }
         }
     }


### PR DESCRIPTION
This PR serves a basis for the block caching and other future performance improvements and has two parts.

* It introduces a new block advancement benchmark and improves the existing storage benchmark
* It adds a new feature to testchain generator that allows storing blocks directly on disk. These generated blocks are then used in the benchmark to allow for much shorter runtimes

### Testchain block storage
When running the testchain generator with the `--no-ledger` flag, it will create a folder at the given `--storage-path` containing the genesis block as `genesis.data` and blocks as `block{{height}}.data`. In both cases, the data is binary encoded using `to_bytes_le`.

The block advancement and storage benchmarks then load the ledger using a new helper function `load_blocks` in `ledger/benches/common/mod.rs`. This avoids costly chain generation when running the benchmark, and also makes the benchmarks more consistent as they use the same ledger for every run.

### Notes
* This PR does not add a CI workflow for those new benchmarks yet, but that is something I would like to add in the future.
* I added a commit that bumps the baseline revision for semver checks, as this PR modifies the `PrettyUnwrap` trait.