### PR TITLE
[Feat] Allow the testchain-generator to be fed with pregenerated txs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,21 +684,21 @@ jobs:
 
   ledger-with-rocksdb-partition1:
     executor: rust-docker
-    resource_class: << pipeline.parameters.large >>
+    resource_class: << pipeline.parameters.xlarge >>
     steps:
       - run_test:
           workspace_member: snarkvm-ledger
-          flags: --release --features=rocks --partition count:1/2 -- --test-threads=8
+          flags: --release --features=rocks --partition count:1/2 -- --test-threads=10
           no_output_timeout: 20m
           timeout: 30m
 
   ledger-with-rocksdb-partition2:
     executor: rust-docker
-    resource_class: << pipeline.parameters.large >>
+    resource_class: << pipeline.parameters.xlarge >>
     steps:
       - run_test:
           workspace_member: snarkvm-ledger
-          flags: --release --features=rocks --partition count:2/2 -- --test-threads=8
+          flags: --release --features=rocks --partition count:2/2 -- --test-threads=10
           no_output_timeout: 20m
           timeout: 30m
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3764,6 +3764,7 @@ dependencies = [
  "clap",
  "snarkvm-console",
  "snarkvm-ledger",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/ledger/benches/block.rs
+++ b/ledger/benches/block.rs
@@ -77,7 +77,7 @@ fn bench_serialization<T: Serialize + DeserializeOwned + ToBytes + FromBytes + C
 fn block_serialization(c: &mut Criterion) {
     let mut rng = TestRng::default();
 
-    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng).unwrap();
+    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng, vec![]).unwrap();
     let block = builder.generate_block(&mut rng).unwrap();
 
     bench_serialization(c, "Block", block);
@@ -86,7 +86,7 @@ fn block_serialization(c: &mut Criterion) {
 fn block_header_serialization(c: &mut Criterion) {
     let mut rng = TestRng::default();
 
-    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng).unwrap();
+    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng, vec![]).unwrap();
     let block = builder.generate_block(&mut rng).unwrap();
 
     bench_serialization(c, "Header", *block.header());

--- a/ledger/benches/block.rs
+++ b/ledger/benches/block.rs
@@ -77,7 +77,7 @@ fn bench_serialization<T: Serialize + DeserializeOwned + ToBytes + FromBytes + C
 fn block_serialization(c: &mut Criterion) {
     let mut rng = TestRng::default();
 
-    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng, vec![]).unwrap();
+    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng).unwrap();
     let block = builder.generate_block(&mut rng).unwrap();
 
     bench_serialization(c, "Block", block);
@@ -86,7 +86,7 @@ fn block_serialization(c: &mut Criterion) {
 fn block_header_serialization(c: &mut Criterion) {
     let mut rng = TestRng::default();
 
-    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng, vec![]).unwrap();
+    let mut builder = TestChainBuilder::<CurrentNetwork>::new(&mut rng).unwrap();
     let block = builder.generate_block(&mut rng).unwrap();
 
     bench_serialization(c, "Header", *block.header());

--- a/ledger/src/test_helpers/chain_builder.rs
+++ b/ledger/src/test_helpers/chain_builder.rs
@@ -36,7 +36,11 @@ use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    cmp,
+    collections::{BTreeMap, HashMap},
+    mem,
+};
 use time::OffsetDateTime;
 
 pub type CurrentNetwork = MainnetV0;
@@ -65,15 +69,36 @@ pub struct TestChainBuilder<N: Network> {
     last_committed_batch_round: HashMap<usize, u64>,
     /// The start of the test chain.
     genesis_block: Block<N>,
+    /// Preloaded transactions to populate the blocks with.
+    transactions: Vec<Transaction<N>>,
 }
 
 /// Additional options you can pass to the builder when generating a set of blocks.
-#[derive(Clone, Default)]
-pub struct GenerateBlocksOptions {
+#[derive(Clone)]
+pub struct GenerateBlocksOptions<N: Network> {
     /// Do not include votes to the previous leader certificate
     pub skip_votes: bool,
     /// Do not generate certificates for the specific node indices (to simulate a partition).
     pub skip_nodes: Vec<usize>,
+    /// A flag indicating that a number of initial "placeholder blocks" should be baked
+    /// wthout transactions in order to skip to the latest version of consensus.
+    pub skip_to_current_version: bool,
+    /// The number of validators.
+    pub num_validators: usize,
+    /// Preloaded transactions to populate the blocks with.
+    pub transactions: Vec<Transaction<N>>,
+}
+
+impl<N: Network> Default for GenerateBlocksOptions<N> {
+    fn default() -> Self {
+        Self {
+            skip_votes: false,
+            skip_nodes: Default::default(),
+            skip_to_current_version: false,
+            num_validators: 0,
+            transactions: Default::default(),
+        }
+    }
 }
 
 /// Additional options you can pass to the builder when generating a single block.
@@ -131,19 +156,27 @@ impl<N: Network> TestChainBuilder<N> {
     }
 
     /// Initialize the builder with the default quorum size.
-    pub fn new(rng: &mut TestRng) -> Result<Self> {
-        Self::new_with_quorum_size(4, rng)
+    pub fn new(rng: &mut TestRng, transactions: Vec<Transaction<N>>) -> Result<Self> {
+        Self::new_with_quorum_size(4, rng, transactions)
     }
 
     /// Initialize the builder with the specified quorum size.
-    pub fn new_with_quorum_size(num_validators: usize, rng: &mut TestRng) -> Result<Self> {
+    pub fn new_with_quorum_size(
+        num_validators: usize,
+        rng: &mut TestRng,
+        transactions: Vec<Transaction<N>>,
+    ) -> Result<Self> {
         let (private_keys, genesis) = Self::initialize_components(num_validators, rng)?;
-        Self::from_components(private_keys, genesis)
+        Self::from_components(private_keys, genesis, transactions)
     }
 
     /// Initialize the builder with the specified genesis block..
     /// Note: this function mirrors the way the private keys are sampled in snarkOS `fn parse_genesis`.
-    pub fn new_with_quorum_size_and_genesis_block(num_validators: usize, genesis_path: String) -> Result<Self> {
+    pub fn new_with_quorum_size_and_genesis_block(
+        num_validators: usize,
+        genesis_path: String,
+        transactions: Vec<Transaction<N>>,
+    ) -> Result<Self> {
         // Attempts to load the genesis block file.
         let buffer = std::fs::read(genesis_path)?;
         // Return the genesis block.
@@ -155,22 +188,30 @@ impl<N: Network> TestChainBuilder<N> {
         // Initialize the development private keys.
         let private_keys = (0..num_validators).map(|_| PrivateKey::new(&mut rng).unwrap()).collect();
         // Initialize the builder with the specified committee and genesis block.
-        Self::from_components(private_keys, genesis)
+        Self::from_components(private_keys, genesis, transactions)
     }
 
     /// Initialize the builder with the specified committee and genesis block
-    pub fn from_components(private_keys: Vec<PrivateKey<N>>, genesis_block: Block<N>) -> Result<Self> {
+    pub fn from_components(
+        private_keys: Vec<PrivateKey<N>>,
+        genesis_block: Block<N>,
+        transactions: Vec<Transaction<N>>,
+    ) -> Result<Self> {
         // Initialize the ledger with the genesis block.
         let ledger = Ledger::<N, ConsensusMemory<N>>::load(genesis_block.clone(), StorageMode::new_test(None))
             .with_context(|| "Failed to set up ledger for test chain")?;
 
         ensure!(ledger.genesis_block == genesis_block);
 
-        Self::from_genesis(private_keys, genesis_block)
+        Self::from_genesis(private_keys, genesis_block, transactions)
     }
 
     /// Initialize the builder with the specified committee and gensis block
-    pub fn from_genesis(private_keys: Vec<PrivateKey<N>>, genesis_block: Block<N>) -> Result<Self> {
+    pub fn from_genesis(
+        private_keys: Vec<PrivateKey<N>>,
+        genesis_block: Block<N>,
+        transactions: Vec<Transaction<N>>,
+    ) -> Result<Self> {
         // Initialize the ledger with the genesis block.
         let ledger = Ledger::<N, ConsensusMemory<N>>::load(genesis_block.clone(), StorageMode::new_test(None))
             .with_context(|| "Failed to set up ledger for test chain")?;
@@ -185,12 +226,20 @@ impl<N: Network> TestChainBuilder<N> {
             last_block_round: 0,
             round_to_certificates: Default::default(),
             previous_leader_certificate: Default::default(),
+            transactions,
         })
     }
 
     /// Create multiple blocks, with fully-connected DAGs.
     pub fn generate_blocks(&mut self, num_blocks: usize, rng: &mut TestRng) -> Result<Vec<Block<N>>> {
-        self.generate_blocks_with_opts(num_blocks, GenerateBlocksOptions::default(), rng)
+        let num_validators = self.private_keys.len();
+        let transactions = mem::take(&mut self.transactions);
+
+        self.generate_blocks_with_opts(
+            num_blocks,
+            GenerateBlocksOptions { num_validators, transactions, ..Default::default() },
+            rng,
+        )
     }
 
     /// Create multiple blocks, with additional parameters.
@@ -199,21 +248,50 @@ impl<N: Network> TestChainBuilder<N> {
     /// This function panics if called from an async context.
     pub fn generate_blocks_with_opts(
         &mut self,
-        num_blocks: usize,
-        options: GenerateBlocksOptions,
+        mut num_blocks: usize,
+        mut options: GenerateBlocksOptions<N>,
         rng: &mut TestRng,
     ) -> Result<Vec<Block<N>>> {
         assert!(num_blocks > 0, "Need to build at least one block");
 
-        let options = GenerateBlockOptions {
-            skip_votes: options.skip_votes,
-            skip_nodes: options.skip_nodes,
-            ..Default::default()
-        };
-
         let mut result = vec![];
+
+        // If configured, skip enough blocks to reach the current consensus version.
+        if options.skip_to_current_version {
+            let (version, height) = TEST_CONSENSUS_VERSION_HEIGHTS.last().unwrap();
+            println!("Skipping {height} blocks to reach {version}");
+
+            for _ in 0..*height {
+                let options = GenerateBlockOptions {
+                    skip_votes: options.skip_votes,
+                    skip_nodes: options.skip_nodes.clone(),
+                    ..Default::default()
+                };
+
+                let block = self.generate_block_with_opts(options, rng)?;
+                result.push(block);
+            }
+
+            // Subtract the number of placeholder blocks from the number of blocks to generate.
+            num_blocks -= *height as usize;
+
+            println!("Advanced to the current consensus version");
+        }
+
         for _ in 0..num_blocks {
-            let block = self.generate_block_with_opts(options.clone(), rng)?;
+            let num_txs = cmp::min(
+                BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * options.num_validators,
+                options.transactions.len(),
+            );
+
+            let options = GenerateBlockOptions {
+                skip_votes: options.skip_votes,
+                skip_nodes: options.skip_nodes.clone(),
+                transactions: options.transactions.drain(..num_txs).collect(),
+                ..Default::default()
+            };
+
+            let block = self.generate_block_with_opts(options, rng)?;
             result.push(block);
         }
 
@@ -262,8 +340,6 @@ impl<N: Network> TestChainBuilder<N> {
             transmissions.insert(transmission_id, transmission);
         }
 
-        let transmission_ids: IndexSet<_> = transmissions.keys().copied().collect();
-
         // =======================================
         // Create certificates for the new block.
         // =======================================
@@ -302,6 +378,13 @@ impl<N: Network> TestChainBuilder<N> {
                 if self.last_batch_round.get(&key1_idx).unwrap_or(&0) >= &round {
                     continue;
                 }
+
+                let transmission_ids: IndexSet<_> = transmissions
+                    .keys()
+                    .skip(key1_idx * BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH)
+                    .take(BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH)
+                    .copied()
+                    .collect();
 
                 let batch_header = BatchHeader::new(
                     private_key_1,
@@ -404,6 +487,7 @@ impl<N: Network> TestChainBuilder<N> {
 
         // Construct the block.
         let subdag = Subdag::from(subdag_map).unwrap();
+
         let block = self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions, rng)?;
 
         // Skip to increase performance.

--- a/ledger/src/test_helpers/chain_builder.rs
+++ b/ledger/src/test_helpers/chain_builder.rs
@@ -39,7 +39,6 @@ use rand_chacha::ChaChaRng;
 use std::{
     cmp,
     collections::{BTreeMap, HashMap},
-    mem,
 };
 use time::OffsetDateTime;
 
@@ -69,8 +68,6 @@ pub struct TestChainBuilder<N: Network> {
     last_committed_batch_round: HashMap<usize, u64>,
     /// The start of the test chain.
     genesis_block: Block<N>,
-    /// Preloaded transactions to populate the blocks with.
-    transactions: Vec<Transaction<N>>,
 }
 
 /// Additional options you can pass to the builder when generating a set of blocks.
@@ -156,27 +153,19 @@ impl<N: Network> TestChainBuilder<N> {
     }
 
     /// Initialize the builder with the default quorum size.
-    pub fn new(rng: &mut TestRng, transactions: Vec<Transaction<N>>) -> Result<Self> {
-        Self::new_with_quorum_size(4, rng, transactions)
+    pub fn new(rng: &mut TestRng) -> Result<Self> {
+        Self::new_with_quorum_size(4, rng)
     }
 
     /// Initialize the builder with the specified quorum size.
-    pub fn new_with_quorum_size(
-        num_validators: usize,
-        rng: &mut TestRng,
-        transactions: Vec<Transaction<N>>,
-    ) -> Result<Self> {
+    pub fn new_with_quorum_size(num_validators: usize, rng: &mut TestRng) -> Result<Self> {
         let (private_keys, genesis) = Self::initialize_components(num_validators, rng)?;
-        Self::from_components(private_keys, genesis, transactions)
+        Self::from_components(private_keys, genesis)
     }
 
     /// Initialize the builder with the specified genesis block..
     /// Note: this function mirrors the way the private keys are sampled in snarkOS `fn parse_genesis`.
-    pub fn new_with_quorum_size_and_genesis_block(
-        num_validators: usize,
-        genesis_path: String,
-        transactions: Vec<Transaction<N>>,
-    ) -> Result<Self> {
+    pub fn new_with_quorum_size_and_genesis_block(num_validators: usize, genesis_path: String) -> Result<Self> {
         // Attempts to load the genesis block file.
         let buffer = std::fs::read(genesis_path)?;
         // Return the genesis block.
@@ -188,30 +177,22 @@ impl<N: Network> TestChainBuilder<N> {
         // Initialize the development private keys.
         let private_keys = (0..num_validators).map(|_| PrivateKey::new(&mut rng).unwrap()).collect();
         // Initialize the builder with the specified committee and genesis block.
-        Self::from_components(private_keys, genesis, transactions)
+        Self::from_components(private_keys, genesis)
     }
 
     /// Initialize the builder with the specified committee and genesis block
-    pub fn from_components(
-        private_keys: Vec<PrivateKey<N>>,
-        genesis_block: Block<N>,
-        transactions: Vec<Transaction<N>>,
-    ) -> Result<Self> {
+    pub fn from_components(private_keys: Vec<PrivateKey<N>>, genesis_block: Block<N>) -> Result<Self> {
         // Initialize the ledger with the genesis block.
         let ledger = Ledger::<N, ConsensusMemory<N>>::load(genesis_block.clone(), StorageMode::new_test(None))
             .with_context(|| "Failed to set up ledger for test chain")?;
 
         ensure!(ledger.genesis_block == genesis_block);
 
-        Self::from_genesis(private_keys, genesis_block, transactions)
+        Self::from_genesis(private_keys, genesis_block)
     }
 
     /// Initialize the builder with the specified committee and gensis block
-    pub fn from_genesis(
-        private_keys: Vec<PrivateKey<N>>,
-        genesis_block: Block<N>,
-        transactions: Vec<Transaction<N>>,
-    ) -> Result<Self> {
+    pub fn from_genesis(private_keys: Vec<PrivateKey<N>>, genesis_block: Block<N>) -> Result<Self> {
         // Initialize the ledger with the genesis block.
         let ledger = Ledger::<N, ConsensusMemory<N>>::load(genesis_block.clone(), StorageMode::new_test(None))
             .with_context(|| "Failed to set up ledger for test chain")?;
@@ -219,27 +200,20 @@ impl<N: Network> TestChainBuilder<N> {
         Ok(Self {
             private_keys,
             ledger,
-
             genesis_block,
             last_batch_round: Default::default(),
             last_committed_batch_round: Default::default(),
             last_block_round: 0,
             round_to_certificates: Default::default(),
             previous_leader_certificate: Default::default(),
-            transactions,
         })
     }
 
     /// Create multiple blocks, with fully-connected DAGs.
     pub fn generate_blocks(&mut self, num_blocks: usize, rng: &mut TestRng) -> Result<Vec<Block<N>>> {
         let num_validators = self.private_keys.len();
-        let transactions = mem::take(&mut self.transactions);
 
-        self.generate_blocks_with_opts(
-            num_blocks,
-            GenerateBlocksOptions { num_validators, transactions, ..Default::default() },
-            rng,
-        )
+        self.generate_blocks_with_opts(num_blocks, GenerateBlocksOptions { num_validators, ..Default::default() }, rng)
     }
 
     /// Create multiple blocks, with additional parameters.
@@ -259,9 +233,10 @@ impl<N: Network> TestChainBuilder<N> {
         // If configured, skip enough blocks to reach the current consensus version.
         if options.skip_to_current_version {
             let (version, height) = TEST_CONSENSUS_VERSION_HEIGHTS.last().unwrap();
+            let mut current_height = self.ledger.latest_height();
             println!("Skipping {height} blocks to reach {version}");
 
-            for _ in 0..*height {
+            while current_height < *height && result.len() < num_blocks {
                 let options = GenerateBlockOptions {
                     skip_votes: options.skip_votes,
                     skip_nodes: options.skip_nodes.clone(),
@@ -269,11 +244,13 @@ impl<N: Network> TestChainBuilder<N> {
                 };
 
                 let block = self.generate_block_with_opts(options, rng)?;
+                current_height = block.height();
                 result.push(block);
             }
 
             // Subtract the number of placeholder blocks from the number of blocks to generate.
-            num_blocks -= *height as usize;
+            assert!(result.len() <= num_blocks);
+            num_blocks -= result.len();
 
             println!("Advanced to the current consensus version");
         }

--- a/ledger/src/test_helpers/chain_builder.rs
+++ b/ledger/src/test_helpers/chain_builder.rs
@@ -36,10 +36,7 @@ use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
-use std::{
-    cmp,
-    collections::{BTreeMap, HashMap},
-};
+use std::collections::{BTreeMap, HashMap};
 use time::OffsetDateTime;
 
 pub type CurrentNetwork = MainnetV0;
@@ -222,7 +219,7 @@ impl<N: Network> TestChainBuilder<N> {
     /// This function panics if called from an async context.
     pub fn generate_blocks_with_opts(
         &mut self,
-        mut num_blocks: usize,
+        num_blocks: usize,
         mut options: GenerateBlocksOptions<N>,
         rng: &mut TestRng,
     ) -> Result<Vec<Block<N>>> {
@@ -232,34 +229,35 @@ impl<N: Network> TestChainBuilder<N> {
 
         // If configured, skip enough blocks to reach the current consensus version.
         if options.skip_to_current_version {
-            let (version, height) = TEST_CONSENSUS_VERSION_HEIGHTS.last().unwrap();
+            let (version, target_height) = TEST_CONSENSUS_VERSION_HEIGHTS.last().unwrap();
             let mut current_height = self.ledger.latest_height();
-            println!("Skipping {height} blocks to reach {version}");
 
-            while current_height < *height && result.len() < num_blocks {
-                let options = GenerateBlockOptions {
-                    skip_votes: options.skip_votes,
-                    skip_nodes: options.skip_nodes.clone(),
-                    ..Default::default()
-                };
+            let diff = target_height.saturating_sub(current_height);
 
-                let block = self.generate_block_with_opts(options, rng)?;
-                current_height = block.height();
-                result.push(block);
+            if diff > 0 {
+                println!("Skipping {diff} blocks to reach {version}");
+
+                while current_height < *target_height && result.len() < num_blocks {
+                    let options = GenerateBlockOptions {
+                        skip_votes: options.skip_votes,
+                        skip_nodes: options.skip_nodes.clone(),
+                        ..Default::default()
+                    };
+
+                    let block = self.generate_block_with_opts(options, rng)?;
+                    current_height = block.height();
+                    result.push(block);
+                }
+
+                println!("Advanced to the current consensus version at height {target_height}");
+            } else {
+                debug!("Already at the current consensus version. No blocks to skip.");
             }
-
-            // Subtract the number of placeholder blocks from the number of blocks to generate.
-            assert!(result.len() <= num_blocks);
-            num_blocks -= result.len();
-
-            println!("Advanced to the current consensus version");
         }
 
-        for _ in 0..num_blocks {
-            let num_txs = cmp::min(
-                BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * options.num_validators,
-                options.transactions.len(),
-            );
+        while result.len() < num_blocks {
+            let num_txs = (BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * options.num_validators)
+                .min(options.transactions.len());
 
             let options = GenerateBlockOptions {
                 skip_votes: options.skip_votes,

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -828,7 +828,7 @@ fn test_aborted_transaction_indexing() {
 #[test]
 fn test_aborted_solution_ids() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut builder = TestChainBuilder::<CurrentNetwork>::new(rng, vec![])?;
+    let mut builder = TestChainBuilder::<CurrentNetwork>::new(rng)?;
     let ledger = builder.instantiate_ledger();
     let private_key = builder.validator_key(0);
     let address = builder.validator_address(0);
@@ -1710,7 +1710,7 @@ function empty_function:
 #[test]
 fn test_abort_fee_transaction() {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new(rng, vec![]).unwrap();
+    let mut chain_builder = TestChainBuilder::new(rng).unwrap();
 
     let private_key = chain_builder.private_keys()[0];
     let address = Address::try_from(&private_key).unwrap();
@@ -2766,7 +2766,7 @@ mod valid_solutions {
     fn test_solution_limits() -> Result<()> {
         let rng = &mut TestRng::default();
         let stake_requirements = stake_requirements_per_solution::<CurrentNetwork>();
-        let mut chain_builder = TestChainBuilder::new(rng, vec![])?;
+        let mut chain_builder = TestChainBuilder::new(rng)?;
 
         let private_key = chain_builder.private_keys()[0];
         let validator_address = Address::try_from(&private_key).unwrap();
@@ -3242,7 +3242,7 @@ mod valid_solutions {
 #[test]
 fn test_forged_block_subdags() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new_with_quorum_size(10, rng, vec![])?;
+    let mut chain_builder = TestChainBuilder::new_with_quorum_size(10, rng)?;
     // Construct 3 quorum blocks.
     let mut quorum_blocks = chain_builder.generate_blocks(3, rng)?;
 
@@ -3361,7 +3361,7 @@ fn test_forged_block_subdags() -> Result<()> {
 #[test]
 fn test_subdag_with_long_branch() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new(rng, vec![])?;
+    let mut chain_builder = TestChainBuilder::new(rng)?;
 
     let blocks = chain_builder.generate_blocks_with_opts(
         BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS / 4,
@@ -3390,7 +3390,7 @@ fn test_subdag_with_long_branch() -> Result<()> {
 #[test]
 fn test_subdag_with_gc_length() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new(rng, vec![])?;
+    let mut chain_builder = TestChainBuilder::new(rng).unwrap();
 
     let blocks = chain_builder.generate_blocks_with_opts(
         BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS / 2,

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -828,7 +828,7 @@ fn test_aborted_transaction_indexing() {
 #[test]
 fn test_aborted_solution_ids() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut builder = TestChainBuilder::<CurrentNetwork>::new(rng)?;
+    let mut builder = TestChainBuilder::<CurrentNetwork>::new(rng, vec![])?;
     let ledger = builder.instantiate_ledger();
     let private_key = builder.validator_key(0);
     let address = builder.validator_address(0);
@@ -1710,7 +1710,7 @@ function empty_function:
 #[test]
 fn test_abort_fee_transaction() {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new(rng).unwrap();
+    let mut chain_builder = TestChainBuilder::new(rng, vec![]).unwrap();
 
     let private_key = chain_builder.private_keys()[0];
     let address = Address::try_from(&private_key).unwrap();
@@ -2766,7 +2766,7 @@ mod valid_solutions {
     fn test_solution_limits() -> Result<()> {
         let rng = &mut TestRng::default();
         let stake_requirements = stake_requirements_per_solution::<CurrentNetwork>();
-        let mut chain_builder = TestChainBuilder::new(rng)?;
+        let mut chain_builder = TestChainBuilder::new(rng, vec![])?;
 
         let private_key = chain_builder.private_keys()[0];
         let validator_address = Address::try_from(&private_key).unwrap();
@@ -3242,7 +3242,7 @@ mod valid_solutions {
 #[test]
 fn test_forged_block_subdags() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new_with_quorum_size(10, rng)?;
+    let mut chain_builder = TestChainBuilder::new_with_quorum_size(10, rng, vec![])?;
     // Construct 3 quorum blocks.
     let mut quorum_blocks = chain_builder.generate_blocks(3, rng)?;
 
@@ -3361,7 +3361,7 @@ fn test_forged_block_subdags() -> Result<()> {
 #[test]
 fn test_subdag_with_long_branch() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new(rng)?;
+    let mut chain_builder = TestChainBuilder::new(rng, vec![])?;
 
     let blocks = chain_builder.generate_blocks_with_opts(
         BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS / 4,
@@ -3390,7 +3390,7 @@ fn test_subdag_with_long_branch() -> Result<()> {
 #[test]
 fn test_subdag_with_gc_length() -> Result<()> {
     let rng = &mut TestRng::default();
-    let mut chain_builder = TestChainBuilder::new(rng)?;
+    let mut chain_builder = TestChainBuilder::new(rng, vec![])?;
 
     let blocks = chain_builder.generate_blocks_with_opts(
         BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS / 2,

--- a/ledger/testchain-generator/Cargo.toml
+++ b/ledger/testchain-generator/Cargo.toml
@@ -27,6 +27,7 @@ workspace = true
 
 [dependencies.snarkvm-console]
 workspace = true
+features = [ "test_consensus_heights" ]
 
 [dependencies.snarkvm-ledger]
 workspace = true

--- a/ledger/testchain-generator/Cargo.toml
+++ b/ledger/testchain-generator/Cargo.toml
@@ -36,6 +36,9 @@ features = [ "test-helpers", "rocks" ]
 [dependencies.anyhow]
 workspace = true
 
+[dependencies.tracing]
+workspace = true
+
 [dependencies.tracing-subscriber]
 version = "0.3"
 

--- a/ledger/testchain-generator/src/main.rs
+++ b/ledger/testchain-generator/src/main.rs
@@ -14,12 +14,17 @@
 // limitations under the License.
 
 use snarkvm_console::prelude::{CanaryV0, MainnetV0, Network, TestRng, TestnetV0, ToBytes};
-use snarkvm_ledger::{Ledger, store::helpers::rocksdb::ConsensusDB, test_helpers::TestChainBuilder};
+use snarkvm_ledger::{Ledger, Transaction, store::helpers::rocksdb::ConsensusDB, test_helpers::TestChainBuilder};
 
 use aleo_std::StorageMode;
 use anyhow::{Context, Result, bail};
 use clap::{Parser, builder::PossibleValuesParser};
-use std::fs;
+use std::{
+    fs::{self, File},
+    io::Read,
+    path::Path,
+    str::FromStr,
+};
 
 #[derive(Parser)]
 struct Args {
@@ -38,6 +43,10 @@ struct Args {
     /// Remove existing ledger if it already exists.
     #[clap(long, short = 'f')]
     force: bool,
+    /// Load the transactions to be used with the generated blocks. They are expected to be
+    /// stored in a JSON-encoded format.
+    #[clap(long)]
+    txs_path: Option<String>,
     /// The name of the network to generate the chain for.
     #[clap(long, value_parser=PossibleValuesParser::new(vec![CanaryV0::SHORT_NAME, TestnetV0::SHORT_NAME, MainnetV0::SHORT_NAME]), default_value=TestnetV0::SHORT_NAME)]
     network: String,
@@ -95,13 +104,40 @@ fn generate_testchain<N: Network>(args: Args) -> Result<()> {
 
     remove_ledger(N::ID, &storage_mode, args.force)?;
 
+    let txs = if let Some(path) = args.txs_path {
+        let path = Path::new(&path);
+        println!("Attempting to load txs from {}", path.display());
+
+        let mut txs = Vec::new();
+        if path.is_dir() {
+            let mut buffer = String::new();
+            for entry in fs::read_dir(path)? {
+                let entry = entry?;
+                let path = entry.path();
+
+                let mut file = File::open(path)?;
+                let _ = file.read_to_string(&mut buffer)?;
+                let tx = Transaction::<N>::from_str(&buffer)?;
+                txs.push(tx);
+                buffer.clear();
+            }
+        }
+
+        println!("Loaded {} txs from {}", txs.len(), path.display());
+        txs
+    } else {
+        Default::default()
+    };
+
     let num_validators = args.num_validators;
     let num_blocks = args.num_blocks;
 
     println!("Initializing test chain builder for {} with {num_validators} validators", N::SHORT_NAME);
     let mut builder: TestChainBuilder<N> = match args.genesis_path {
-        Some(genesis_path) => TestChainBuilder::new_with_quorum_size_and_genesis_block(num_validators, genesis_path),
-        None => TestChainBuilder::new_with_quorum_size(num_validators, &mut rng),
+        Some(genesis_path) => {
+            TestChainBuilder::new_with_quorum_size_and_genesis_block(num_validators, genesis_path, txs)
+        }
+        None => TestChainBuilder::new_with_quorum_size(num_validators, &mut rng, txs),
     }
     .with_context(|| "Failed to set up test chain builder")?;
 

--- a/ledger/testchain-generator/src/main.rs
+++ b/ledger/testchain-generator/src/main.rs
@@ -13,8 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkvm_console::prelude::{CanaryV0, MainnetV0, Network, TestRng, TestnetV0, ToBytes};
-use snarkvm_ledger::{Ledger, Transaction, store::helpers::rocksdb::ConsensusDB, test_helpers::TestChainBuilder};
+use snarkvm_console::prelude::{
+    CanaryV0,
+    MainnetV0,
+    Network,
+    TEST_CONSENSUS_VERSION_HEIGHTS,
+    TestRng,
+    TestnetV0,
+    ToBytes,
+};
+use snarkvm_ledger::{
+    Ledger,
+    Transaction,
+    store::helpers::rocksdb::ConsensusDB,
+    test_helpers::{TestChainBuilder, chain_builder::GenerateBlocksOptions},
+};
 
 use aleo_std::StorageMode;
 use anyhow::{Context, Result, bail};
@@ -25,6 +38,7 @@ use std::{
     path::Path,
     str::FromStr,
 };
+use tracing::debug;
 
 #[derive(Parser)]
 struct Args {
@@ -104,7 +118,7 @@ fn generate_testchain<N: Network>(args: Args) -> Result<()> {
 
     remove_ledger(N::ID, &storage_mode, args.force)?;
 
-    let txs = if let Some(path) = args.txs_path {
+    let mut txs = if let Some(path) = args.txs_path {
         let path = Path::new(&path);
         println!("Attempting to load txs from {}", path.display());
 
@@ -134,10 +148,8 @@ fn generate_testchain<N: Network>(args: Args) -> Result<()> {
 
     println!("Initializing test chain builder for {} with {num_validators} validators", N::SHORT_NAME);
     let mut builder: TestChainBuilder<N> = match args.genesis_path {
-        Some(genesis_path) => {
-            TestChainBuilder::new_with_quorum_size_and_genesis_block(num_validators, genesis_path, txs)
-        }
-        None => TestChainBuilder::new_with_quorum_size(num_validators, &mut rng, txs),
+        Some(genesis_path) => TestChainBuilder::new_with_quorum_size_and_genesis_block(num_validators, genesis_path),
+        None => TestChainBuilder::new_with_quorum_size(num_validators, &mut rng),
     }
     .with_context(|| "Failed to set up test chain builder")?;
 
@@ -146,9 +158,31 @@ fn generate_testchain<N: Network>(args: Args) -> Result<()> {
     let mut pos = 0;
     let mut blocks = vec![];
 
+    // How many blocks to generate in a single batch.
+    const BATCH_SIZE: usize = 100;
+
+    // How many transactions to insert per block.
+    let latest_consensus_height = TEST_CONSENSUS_VERSION_HEIGHTS.last().unwrap().1 as usize;
+    let num_txn_blocks = num_blocks.saturating_sub(latest_consensus_height);
+    let txns_per_block = txs.len().div_ceil(num_txn_blocks);
+
     while blocks.len() < num_blocks {
-        let batch_size = (num_blocks - blocks.len()).min(100);
-        let mut batch = builder.generate_blocks(batch_size, &mut rng).with_context(|| "Failed to generate blocks")?;
+        let current_height = blocks.len();
+        // How many blocks to generate in this batch.
+        let batch_size = (num_blocks - current_height).min(BATCH_SIZE);
+        // Generate set of transactions to insert in this batch.
+        let num_empty_blocks = latest_consensus_height.saturating_sub(current_height);
+        let num_txns = (batch_size.saturating_sub(num_empty_blocks)) * txns_per_block;
+        let transactions = txs.drain(..num_txns).collect();
+
+        debug!("Generating next batch with {batch_size} blocks and {num_txns} transactions");
+        let mut batch = builder
+            .generate_blocks_with_opts(
+                batch_size,
+                GenerateBlocksOptions { transactions, skip_to_current_version: true, ..Default::default() },
+                &mut rng,
+            )
+            .with_context(|| "Failed to generate blocks")?;
 
         pos += batch_size;
         println!("Generated {pos} of {num_blocks} blocks");

--- a/ledger/testchain-generator/src/main.rs
+++ b/ledger/testchain-generator/src/main.rs
@@ -32,12 +32,7 @@ use snarkvm_ledger::{
 use aleo_std::StorageMode;
 use anyhow::{Context, Result, bail};
 use clap::{Parser, builder::PossibleValuesParser};
-use std::{
-    fs::{self, File},
-    io::Read,
-    path::Path,
-    str::FromStr,
-};
+use std::{fs, path::Path, str::FromStr};
 use tracing::debug;
 
 #[derive(Parser)]
@@ -120,24 +115,25 @@ fn generate_testchain<N: Network>(args: Args) -> Result<()> {
 
     let mut txs = if let Some(path) = args.txs_path {
         let path = Path::new(&path);
-        println!("Attempting to load txs from {}", path.display());
 
-        let mut txs = Vec::new();
         if path.is_dir() {
-            let mut buffer = String::new();
-            for entry in fs::read_dir(path)? {
-                let entry = entry?;
-                let path = entry.path();
-
-                let mut file = File::open(path)?;
-                let _ = file.read_to_string(&mut buffer)?;
-                let tx = Transaction::<N>::from_str(&buffer)?;
-                txs.push(tx);
-                buffer.clear();
-            }
+            println!("Attempting to load transactions from \"{}\"", path.display());
+        } else {
+            bail!("Cannot load transactions from \"{}\": not a valid directory", path.display());
         }
 
-        println!("Loaded {} txs from {}", txs.len(), path.display());
+        let mut txs = Vec::new();
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            let buffer = fs::read_to_string(path)?;
+            let tx = Transaction::<N>::from_str(&buffer)?;
+
+            txs.push(tx);
+        }
+
+        println!("Loaded {} tranactionss from \"{}\"", txs.len(), path.display());
         txs
     } else {
         Default::default()


### PR DESCRIPTION
This PR addresses [this request](https://github.com/ProvableHQ/snarkVM/issues/2943#issuecomment-3432746311); it allows the `testchain-generator` to:
1. introduce pre-generated transactions to the baked blocks
2. "skip" the first blocks in order to apply the transactions under the latest conensus version

The blocks are fed with the maximum number of possible transactions per block, and each validator produces the maximum number of transmissions per batch (as long as the number of txs and solutions is sufficient).

This extension feels a little bit "duct-tapey" to me, and perhaps some of the affected objects need a bit more adjustment in order for the overall setup to feel more "natural". @kaimast happy to hear your thoughts on this.