### PR TITLE
[Tests] deduplicate TestRngs in snarkvm-algorithms

### DIFF
--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -91,8 +91,9 @@ mod tests {
     #[test]
     fn test_msm() {
         use snarkvm_curves::ProjectiveCurve;
+
+        let mut rng = TestRng::default();
         for msm_size in [1, 5, 10, 50, 100, 500, 1000] {
-            let mut rng = TestRng::default();
             let (bases, scalars) = create_scalar_bases::<G1Affine, Fr>(&mut rng, msm_size);
 
             let naive_a = VariableBase::msm_naive(bases.as_slice(), scalars.as_slice()).to_affine();

--- a/algorithms/src/snark/varuna/tests.rs
+++ b/algorithms/src/snark/varuna/tests.rs
@@ -48,8 +48,7 @@ mod varuna {
         ($test_struct: ident, $snark_inst: tt, $snark_mode: tt) => {
             struct $test_struct {}
             impl $test_struct {
-                pub(crate) fn test_circuit(num_constraints: usize, num_variables: usize, pk_size_expectation: usize, varuna_version: VarunaVersion) {
-                    let rng = &mut snarkvm_utilities::rand::TestRng::default();
+                pub(crate) fn test_circuit(num_constraints: usize, num_variables: usize, pk_size_expectation: usize, varuna_version: VarunaVersion, rng: &mut snarkvm_utilities::rand::TestRng) {
                     let random = Fr::rand(rng);
 
                     let max_degree = AHPForR1CS::<Fr, $snark_mode>::max_degree(100, 25, 300).unwrap();
@@ -187,10 +186,8 @@ mod varuna {
                     }
                 }
 
-                pub(crate) fn test_serde_json(num_constraints: usize, num_variables: usize) {
+                pub(crate) fn test_serde_json(num_constraints: usize, num_variables: usize, rng: &mut TestRng) {
                     use std::str::FromStr;
-
-                    let rng = &mut TestRng::default();
 
                     let max_degree = AHPForR1CS::<Fr, $snark_mode>::max_degree(100, 25, 300).unwrap();
                     let universal_srs = $snark_inst::universal_setup(max_degree).unwrap();
@@ -214,10 +211,8 @@ mod varuna {
                     assert_eq!(index_vk, serde_json::from_str(&candidate_string).unwrap());
                 }
 
-                pub(crate) fn test_bincode(num_constraints: usize, num_variables: usize) {
+                pub(crate) fn test_bincode(num_constraints: usize, num_variables: usize, rng: &mut TestRng) {
                     use snarkvm_utilities::{FromBytes, ToBytes};
-
-                    let rng = &mut TestRng::default();
 
                     let max_degree = AHPForR1CS::<Fr, $snark_mode>::max_degree(100, 25, 300).unwrap();
                     let universal_srs = $snark_inst::universal_setup(max_degree).unwrap();
@@ -251,18 +246,19 @@ mod varuna {
         let num_variables = 25;
         let pk_size_zk = 91971;
         let pk_size_posw = 91633;
+        let mut rng = TestRng::default();
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1, &mut rng);
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2, &mut rng);
 
-        SonicPCTest::test_serde_json(num_constraints, num_variables);
-        SonicPCPoswTest::test_serde_json(num_constraints, num_variables);
+        SonicPCTest::test_serde_json(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_serde_json(num_constraints, num_variables, &mut rng);
 
-        SonicPCTest::test_bincode(num_constraints, num_variables);
-        SonicPCPoswTest::test_bincode(num_constraints, num_variables);
+        SonicPCTest::test_bincode(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
@@ -271,18 +267,19 @@ mod varuna {
         let num_variables = 25;
         let pk_size_zk = 25428;
         let pk_size_posw = 25090;
+        let mut rng = TestRng::default();
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1, &mut rng);
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2, &mut rng);
 
-        SonicPCTest::test_serde_json(num_constraints, num_variables);
-        SonicPCPoswTest::test_serde_json(num_constraints, num_variables);
+        SonicPCTest::test_serde_json(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_serde_json(num_constraints, num_variables, &mut rng);
 
-        SonicPCTest::test_bincode(num_constraints, num_variables);
-        SonicPCPoswTest::test_bincode(num_constraints, num_variables);
+        SonicPCTest::test_bincode(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
@@ -291,18 +288,19 @@ mod varuna {
         let num_variables = 100;
         let pk_size_zk = 53523;
         let pk_size_posw = 53185;
+        let mut rng = TestRng::default();
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1, &mut rng);
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2, &mut rng);
 
-        SonicPCTest::test_serde_json(num_constraints, num_variables);
-        SonicPCPoswTest::test_serde_json(num_constraints, num_variables);
+        SonicPCTest::test_serde_json(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_serde_json(num_constraints, num_variables, &mut rng);
 
-        SonicPCTest::test_bincode(num_constraints, num_variables);
-        SonicPCPoswTest::test_bincode(num_constraints, num_variables);
+        SonicPCTest::test_bincode(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
@@ -311,18 +309,19 @@ mod varuna {
         let num_variables = 26;
         let pk_size_zk = 25284;
         let pk_size_posw = 24946;
+        let mut rng = TestRng::default();
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1, &mut rng);
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2, &mut rng);
 
-        SonicPCTest::test_serde_json(num_constraints, num_variables);
-        SonicPCPoswTest::test_serde_json(num_constraints, num_variables);
+        SonicPCTest::test_serde_json(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_serde_json(num_constraints, num_variables, &mut rng);
 
-        SonicPCTest::test_bincode(num_constraints, num_variables);
-        SonicPCPoswTest::test_bincode(num_constraints, num_variables);
+        SonicPCTest::test_bincode(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
@@ -331,18 +330,19 @@ mod varuna {
         let num_variables = 25;
         let pk_size_zk = 25284;
         let pk_size_posw = 24946;
+        let mut rng = TestRng::default();
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V1, &mut rng);
 
-        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2);
-        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2);
+        SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V2, &mut rng);
+        SonicPCPoswTest::test_circuit(num_constraints, num_variables, pk_size_posw, VarunaVersion::V2, &mut rng);
 
-        SonicPCTest::test_serde_json(num_constraints, num_variables);
-        SonicPCPoswTest::test_serde_json(num_constraints, num_variables);
+        SonicPCTest::test_serde_json(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_serde_json(num_constraints, num_variables, &mut rng);
 
-        SonicPCTest::test_bincode(num_constraints, num_variables);
-        SonicPCPoswTest::test_bincode(num_constraints, num_variables);
+        SonicPCTest::test_bincode(num_constraints, num_variables, &mut rng);
+        SonicPCPoswTest::test_bincode(num_constraints, num_variables, &mut rng);
     }
 }
 
@@ -377,9 +377,8 @@ mod varuna_hiding {
         num_variables: usize,
         num_times: usize,
         varuna_version: VarunaVersion,
+        rng: &mut TestRng,
     ) {
-        let rng = &mut TestRng::default();
-
         let max_degree = AHPForR1CS::<Fr, VarunaHidingMode>::max_degree(100, 25, 300).unwrap();
         let universal_srs = VarunaInst::universal_setup(max_degree).unwrap();
         let universal_prover = &universal_srs.to_universal_prover().unwrap();
@@ -443,13 +442,11 @@ mod varuna_hiding {
         }
     }
 
-    fn test_circuit(num_constraints: usize, num_variables: usize, varuna_version: VarunaVersion) {
-        test_circuit_n_times(num_constraints, num_variables, 100, varuna_version)
+    fn test_circuit(num_constraints: usize, num_variables: usize, varuna_version: VarunaVersion, rng: &mut TestRng) {
+        test_circuit_n_times(num_constraints, num_variables, 100, varuna_version, rng)
     }
 
-    fn test_serde_json(num_constraints: usize, num_variables: usize) {
-        let rng = &mut TestRng::default();
-
+    fn test_serde_json(num_constraints: usize, num_variables: usize, rng: &mut TestRng) {
         let max_degree = AHPForR1CS::<Fr, VarunaHidingMode>::max_degree(100, 25, 300).unwrap();
         let universal_srs = VarunaInst::universal_setup(max_degree).unwrap();
 
@@ -469,9 +466,7 @@ mod varuna_hiding {
         assert_eq!(index_vk, serde_json::from_str(&candidate_string).unwrap());
     }
 
-    fn test_bincode(num_constraints: usize, num_variables: usize) {
-        let rng = &mut TestRng::default();
-
+    fn test_bincode(num_constraints: usize, num_variables: usize, rng: &mut TestRng) {
         let max_degree = AHPForR1CS::<Fr, VarunaHidingMode>::max_degree(100, 25, 300).unwrap();
         let universal_srs = VarunaInst::universal_setup(max_degree).unwrap();
 
@@ -497,64 +492,70 @@ mod varuna_hiding {
     fn prove_and_verify_with_tall_matrix_big() {
         let num_constraints = 100;
         let num_variables = 25;
+        let mut rng = TestRng::default();
 
-        test_circuit(num_constraints, num_variables, VarunaVersion::V1);
-        test_circuit(num_constraints, num_variables, VarunaVersion::V2);
-        test_serde_json(num_constraints, num_variables);
-        test_bincode(num_constraints, num_variables);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V1, &mut rng);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V2, &mut rng);
+        test_serde_json(num_constraints, num_variables, &mut rng);
+        test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
     fn prove_and_verify_with_tall_matrix_small() {
         let num_constraints = 26;
         let num_variables = 25;
+        let mut rng = TestRng::default();
 
-        test_circuit(num_constraints, num_variables, VarunaVersion::V1);
-        test_circuit(num_constraints, num_variables, VarunaVersion::V2);
-        test_serde_json(num_constraints, num_variables);
-        test_bincode(num_constraints, num_variables);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V1, &mut rng);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V2, &mut rng);
+        test_serde_json(num_constraints, num_variables, &mut rng);
+        test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
     fn prove_and_verify_with_squat_matrix_big() {
         let num_constraints = 25;
         let num_variables = 100;
+        let mut rng = TestRng::default();
 
-        test_circuit(num_constraints, num_variables, VarunaVersion::V1);
-        test_circuit(num_constraints, num_variables, VarunaVersion::V2);
-        test_serde_json(num_constraints, num_variables);
-        test_bincode(num_constraints, num_variables);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V1, &mut rng);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V2, &mut rng);
+        test_serde_json(num_constraints, num_variables, &mut rng);
+        test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
     fn prove_and_verify_with_squat_matrix_small() {
         let num_constraints = 25;
         let num_variables = 26;
+        let mut rng = TestRng::default();
 
-        test_circuit(num_constraints, num_variables, VarunaVersion::V1);
-        test_circuit(num_constraints, num_variables, VarunaVersion::V2);
-        test_serde_json(num_constraints, num_variables);
-        test_bincode(num_constraints, num_variables);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V1, &mut rng);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V2, &mut rng);
+        test_serde_json(num_constraints, num_variables, &mut rng);
+        test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
     fn prove_and_verify_with_square_matrix() {
         let num_constraints = 25;
         let num_variables = 25;
+        let mut rng = TestRng::default();
 
-        test_circuit(num_constraints, num_variables, VarunaVersion::V1);
-        test_circuit(num_constraints, num_variables, VarunaVersion::V2);
-        test_serde_json(num_constraints, num_variables);
-        test_bincode(num_constraints, num_variables);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V1, &mut rng);
+        test_circuit(num_constraints, num_variables, VarunaVersion::V2, &mut rng);
+        test_serde_json(num_constraints, num_variables, &mut rng);
+        test_bincode(num_constraints, num_variables, &mut rng);
     }
 
     #[test]
     fn prove_and_verify_with_large_matrix() {
         let num_constraints = 1 << 16;
         let num_variables = 1 << 16;
+        let mut rng = TestRng::default();
 
-        test_circuit_n_times(num_constraints, num_variables, 1, VarunaVersion::V1);
-        test_circuit_n_times(num_constraints, num_variables, 1, VarunaVersion::V2);
+        test_circuit_n_times(num_constraints, num_variables, 1, VarunaVersion::V1, &mut rng);
+        test_circuit_n_times(num_constraints, num_variables, 1, VarunaVersion::V2, &mut rng);
     }
 
     #[test]


### PR DESCRIPTION
This is an introductory PR tackling https://github.com/ProvableHQ/snarkVM/issues/2988.

Example test (`cargo test test_msm -- --nocapture`) output before these changes:
```
Initializing 'TestRng' with seed '13116800673470553581'

Called TestRng with seed 13116800673470553581 11 times

Initializing 'TestRng' with seed '16725893785308069827'

Called TestRng with seed 16725893785308069827 117 times

Initializing 'TestRng' with seed '3052667834104038088'

Called TestRng with seed 3052667834104038088 275 times

Initializing 'TestRng' with seed '2746784853373982725'

Called TestRng with seed 2746784853373982725 1127 times

Initializing 'TestRng' with seed '12554276280561960951'

Called TestRng with seed 12554276280561960951 2428 times

Initializing 'TestRng' with seed '15676505785869565031'

Called TestRng with seed 15676505785869565031 11591 times

Initializing 'TestRng' with seed '15185598707828020553'

Called TestRng with seed 15185598707828020553 23102 times
```

And after:
```
Called TestRng with seed 14131538015430052738 37718 times
```