### PR TITLE
Revise error logging

### DIFF
--- a/ledger/src/find.rs
+++ b/ledger/src/find.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 
-use snarkvm_utilities::LoggableError;
+use snarkvm_utilities::elog_warning;
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the block height that contains the given `state root`.
@@ -131,7 +131,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 Ok(Some(commitment)) => Some((commitment, record)),
                 Ok(None) => None,
                 Err(err) => {
-                    err.log_warning(format!("Failed to process 'find_record_ciphertexts({filter:?})'"));
+                    elog_warning!(err, "Failed to process 'find_record_ciphertexts({filter:?})'");
                     None
                 }
             }
@@ -149,7 +149,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             iter.flat_map(|(commitment, record)| match record.decrypt(view_key) {
                 Ok(record) => Some((commitment, record)),
                 Err(err) => {
-                    err.log_warning("Failed to decrypt record");
+                    elog_warning!(err, "Failed to decrypt record");
                     None
                 }
             })

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -109,6 +109,9 @@ workspace = true
 features = [ "write" ]
 optional = true
 
+[dependencies.tracing]
+workspace = true
+
 [dev-dependencies.aleo-std]
 workspace = true
 

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -18,7 +18,7 @@
 use super::*;
 use crate::helpers::{Map, MapRead};
 
-use snarkvm_utilities::{LoggableError, bytes::unchecked_deserialize};
+use snarkvm_utilities::{bytes::unchecked_deserialize, elog_error};
 
 use core::{fmt, fmt::Debug, hash::Hash, mem};
 use indexmap::IndexMap;
@@ -455,10 +455,11 @@ impl<
 
         // Deserialize the key and value.
         let key = unchecked_deserialize(&key[PREFIX_LEN..])
-            .map_err(|err| err.log_error("RocksDB Iter deserialize(key) error"))
+            .map_err(|err| elog_error!(err, "RocksDB Iter deserialize(key) error"))
             .ok()?;
-        let value =
-            unchecked_deserialize(value).map_err(|err| err.log_error("RocksDB Iter deserialize(value) error")).ok()?;
+        let value = unchecked_deserialize(value)
+            .map_err(|err| elog_error!(err, "RocksDB Iter deserialize(value) error"))
+            .ok()?;
 
         self.db_iter.next();
 
@@ -488,7 +489,7 @@ impl<'a, K: 'a + Clone + Debug + PartialEq + Eq + Hash + Serialize + Deserialize
 
         // Deserialize the key.
         let key = unchecked_deserialize(&self.db_iter.key()?[PREFIX_LEN..])
-            .map_err(|err| err.log_error("RocksDB Keys deserialize(key) error"))
+            .map_err(|err| elog_error!(err, "RocksDB Keys deserialize(key) error"))
             .ok()?;
 
         self.db_iter.next();
@@ -519,7 +520,7 @@ impl<'a, V: 'a + Clone + Serialize + DeserializeOwned> Iterator for Values<'a, V
 
         // Deserialize the value.
         let value = unchecked_deserialize(self.db_iter.value()?)
-            .map_err(|err| err.log_error("RocksDB Values deserialize(value) error"))
+            .map_err(|err| elog_error!(err, "RocksDB Values deserialize(value) error"))
             .ok()?;
 
         self.db_iter.next();

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -18,7 +18,7 @@
 use super::*;
 use crate::helpers::{NestedMap, NestedMapRead};
 use console::prelude::{FromBytes, anyhow, cfg_into_iter};
-use snarkvm_utilities::{LoggableError, bytes::unchecked_deserialize};
+use snarkvm_utilities::{bytes::unchecked_deserialize, elog_error};
 
 use anyhow::Context;
 use core::{fmt, fmt::Debug, hash::Hash, mem};
@@ -647,19 +647,20 @@ impl<
         let (map_key, value) = self.db_iter.item()?;
 
         // Extract the bytes belonging to the map and the key.
-        let (entry_map, entry_key) =
-            get_map_and_key(map_key).map_err(|err| err.log_error("RocksDB NestedIter get_map_and_key error")).ok()?;
+        let (entry_map, entry_key) = get_map_and_key(map_key)
+            .map_err(|err| elog_error!(err, "RocksDB NestedIter get_map_and_key error"))
+            .ok()?;
 
         // Deserialize the map, key, and value.
         let map = unchecked_deserialize(entry_map)
-            .map_err(|err| err.log_error("RocksDB NestedIter deserialize(map) error"))
+            .map_err(|err| elog_error!(err, "RocksDB NestedIter deserialize(map) error"))
             .ok()?;
         let key = unchecked_deserialize(entry_key)
-            .map_err(|err| err.log_error("RocksDB NestedIter deserialize(key) error"))
+            .map_err(|err| elog_error!(err, "RocksDB NestedIter deserialize(key) error"))
             .ok()?;
         // Deserialize the value.
         let value = unchecked_deserialize(value)
-            .map_err(|err| err.log_error("RocksDB NestedIter deserialize(value) error"))
+            .map_err(|err| elog_error!(err, "RocksDB NestedIter deserialize(value) error"))
             .ok()?;
 
         self.db_iter.next();
@@ -705,15 +706,16 @@ impl<
         let map_key = self.db_iter.key()?;
 
         // Extract the bytes belonging to the map and the key.
-        let (entry_map, entry_key) =
-            get_map_and_key(map_key).map_err(|err| err.log_error("RocksDB NestedKeys get_map_and_key error")).ok()?;
+        let (entry_map, entry_key) = get_map_and_key(map_key)
+            .map_err(|err| elog_error!(err, "RocksDB NestedKeys get_map_and_key error"))
+            .ok()?;
 
         // Deserialize the map and key.
         let map = unchecked_deserialize(entry_map)
-            .map_err(|err| err.log_error("RocksDB NestedKeys deserialize(map) error"))
+            .map_err(|err| elog_error!(err, "RocksDB NestedKeys deserialize(map) error"))
             .ok()?;
         let key = unchecked_deserialize(entry_key)
-            .map_err(|err| err.log_error("RocksDB NestedKeys deserialize(key) error"))
+            .map_err(|err| elog_error!(err, "RocksDB NestedKeys deserialize(key) error"))
             .ok()?;
 
         self.db_iter.next();
@@ -747,7 +749,7 @@ impl<'a, V: 'a + Clone + Serialize + DeserializeOwned> Iterator for NestedValues
         // Deserialize the value.
         let value = unchecked_deserialize(value)
             .map_err(|err| {
-                err.log_error("RocksDB NestedValues deserialize(value) error");
+                elog_error!(err, "RocksDB NestedValues deserialize(value) error");
             })
             .ok()?;
 

--- a/utilities/src/errors.rs
+++ b/utilities/src/errors.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{borrow::Borrow, fmt::Display};
+use std::borrow::Borrow;
 
 /// Generates an `io::Error` from the given string.
 #[inline]
@@ -32,7 +32,7 @@ pub fn into_io_error<E: Into<anyhow::Error>>(err: E) -> std::io::Error {
 
 /// Helper function for `log_error` and `log_warning`.
 #[inline]
-fn flatten_anyhow_error<E: Borrow<anyhow::Error>>(error: E) -> String {
+pub fn flatten_anyhow_error<E: Borrow<anyhow::Error>>(error: E) -> String {
     let error = error.borrow();
     let mut output = error.to_string();
     for next in error.chain().skip(1) {
@@ -41,26 +41,118 @@ fn flatten_anyhow_error<E: Borrow<anyhow::Error>>(error: E) -> String {
     output
 }
 
-/// Logs `anyhow::Error`'s its error chain using the `ERROR` log level.
+/// Logs an `anyhow::Error`'s error chain at the `ERROR` level.
 ///
 /// This follows the existing convention in the codebase that joins errors using em dashes.
 /// For example, an error "Invalid transaction" with a cause "Proof failed" would be logged
 /// as "Invalid transaction — Proof failed".
-#[inline]
-#[track_caller]
-pub fn log_error<E: Borrow<anyhow::Error>>(error: E) {
-    tracing::error!("{}", flatten_anyhow_error(error));
+///
+/// # Usage
+/// ```rust
+/// use snarkvm_utilities::elog_error;
+/// use anyhow::anyhow;
+///
+/// let my_error = anyhow!("Something went wrong");
+/// let user_id = 123;
+///
+/// // Log error without context
+/// elog_error!(my_error);
+///
+/// // Log error with formatted context  
+/// elog_error!(anyhow!("Database error"), "Failed to process transaction for user {}", user_id);
+/// ```
+#[macro_export]
+macro_rules! elog_error {
+    ($error:expr) => {
+        {
+            tracing::error!("{}", $crate::errors::flatten_anyhow_error($error));
+        }
+    };
+    ($err:expr, $($arg:expr),*) => {
+        {
+            #[allow(unused_imports)]
+            use anyhow::Context;
+            let err: anyhow::Error = $err.into();
+            let err = err.context(format!($($arg,)*));
+            tracing::error!("{}", $crate::errors::flatten_anyhow_error(&err));
+        }
+    };
 }
 
-/// Logs `anyhow::Error`'s its error chain using the `WARN` log level.
+/// Logs an `anyhow::Error`'s error chain at the `WARN` level.
 ///
 /// This follows the existing convention in the codebase that joins errors using em dashes.
 /// For example, an error "Invalid transaction" with a cause "Proof failed" would be logged
 /// as "Invalid transaction — Proof failed".
-#[inline]
-#[track_caller]
-pub fn log_warning<E: Borrow<anyhow::Error>>(error: E) {
-    tracing::warn!("{}", flatten_anyhow_error(error));
+///
+/// # Usage
+/// ```rust
+/// use snarkvm_utilities::elog_warning;
+/// use anyhow::anyhow;
+///
+/// let my_error = anyhow!("Validation failed");
+/// let height = 42;
+///
+/// // Log warning without context
+/// elog_warning!(my_error);
+///
+/// // Log warning with formatted context
+/// elog_warning!(anyhow!("Block validation error"), "Failed to validate block at height {}", height);
+/// ```
+#[macro_export]
+macro_rules! elog_warning {
+    ($error:expr) => {
+        {
+            tracing::warn!("{}", $crate::errors::flatten_anyhow_error($error));
+        }
+    };
+    ($err:expr, $($arg:expr),*) => {
+        {
+
+            #[allow(unused_imports)]
+            use anyhow::Context;
+            let err: anyhow::Error = $err.into();
+            let err = err.context(format!($($arg,)*));
+             tracing::warn!("{}", $crate::errors::flatten_anyhow_error(&err));
+        }
+    };
+}
+
+/// Logs an `anyhow::Error`'s error chain at the `DEBUG` level.
+///
+/// This follows the existing convention in the codebase that joins errors using em dashes.
+/// For example, an error "Invalid transaction" with a cause "Proof failed" would be logged
+/// as "Invalid transaction — Proof failed".
+///
+/// # Usage
+/// ```rust
+/// use snarkvm_utilities::elog_debug;
+/// use anyhow::anyhow;
+///
+/// let my_error = anyhow!("Processing failed");
+/// let step_name = "validation";
+///
+/// // Log debug without context
+/// elog_debug!(my_error);
+///
+/// // Log debug with formatted context
+/// elog_debug!(anyhow!("Step failed"), "Processing step {} failed", step_name);
+/// ```
+#[macro_export]
+macro_rules! elog_debug {
+    ($error:expr) => {
+        {
+            tracing::debug!("{}", $crate::errors::flatten_anyhow_error($error));
+        }
+    };
+  ($err:expr, $($arg:expr),*) => {
+        {
+            #[allow(unused_imports)]
+            let err: anyhow::Error = $err.into();
+            let err = err.context(format!($($arg,)*));
+            tracing::debug!("{}", $crate::errors::flatten_anyhow_error(&err));
+        }
+    };
 }
 
 /// Displays an `anyhow::Error`'s main error and its error chain to stderr.
@@ -86,55 +178,6 @@ macro_rules! ensure_equals {
             anyhow::bail!("{}: Was {} but expected {}.", $message, $actual, $expected);
         }
     };
-}
-
-/// A trait that allows printing the entire error chain of an Error (it is implemented for [`anyhow::Error`]) along with a custom context message.
-///
-/// This reduces the need for custom error printing code and ensures consistency across log messages.
-///
-/// # Example
-/// The following code will log `user-facing message - low level error` as an error.
-///
-/// ```rust
-/// use anyhow::anyhow;
-/// use snarkvm_utilities::LoggableError;
-///
-/// let my_error = anyhow!("low level problem");
-/// my_error.log_error("user-facing message");
-/// ```
-pub trait LoggableError {
-    /// Log the error with the given context and log level `ERROR`.
-    fn log_error<S: Send + Sync + Display + 'static>(self, context: S);
-    /// Log the error with the given context and log level `WARNING`.
-    fn log_warning<S: Send + Sync + Display + 'static>(self, context: S);
-    /// Log the error with the given context and log level `DEBUG`.
-    fn log_debug<S: Send + Sync + Display + 'static>(self, context: S);
-}
-
-impl<E: Into<anyhow::Error>> LoggableError for E {
-    /// Log the error with the given context and log level `ERROR`.
-    #[track_caller]
-    #[inline]
-    fn log_error<S: Send + Sync + Display + 'static>(self, context: S) {
-        let err: anyhow::Error = self.into();
-        log_error(err.context(context));
-    }
-
-    /// Log the error with the given context and log level `WARNING`.
-    #[track_caller]
-    #[inline]
-    fn log_warning<S: Send + Sync + Display + 'static>(self, context: S) {
-        let err: anyhow::Error = self.into();
-        log_warning(err.context(context));
-    }
-
-    /// Log the error with the given context and log level `DEBUG`.
-    #[track_caller]
-    #[inline]
-    fn log_debug<S: Send + Sync + Display + 'static>(self, context: S) {
-        let err: anyhow::Error = self.into();
-        log_warning(err.context(context));
-    }
 }
 
 /// A trait to provide a nicer way to unwarp `anyhow::Result`.
@@ -262,5 +305,25 @@ mod tests {
 
         assert!(result.is_ok(), "Should handle VM error gracefully");
         assert_eq!(result.unwrap(), "handled_vm_error");
+    }
+
+    #[test]
+    fn test_elog_context_formatting() {
+        use anyhow::anyhow;
+
+        let user_id = 12345;
+        let operation = "transaction";
+
+        // Test that context formatting works correctly
+        // We can't easily test the actual logging output, but we can verify the macro compiles
+        // and runs without panicking
+        crate::elog_error!(anyhow!("Database connection failed"), "Failed {} for user {}", operation, user_id);
+        crate::elog_warning!(anyhow!("Database connection failed"), "Retrying {} for user {}", operation, user_id);
+        crate::elog_debug!(anyhow!("Database connection failed"), "Debug info for {} user {}", operation, user_id);
+
+        // Test without context
+        crate::elog_error!(anyhow!("Simple error"));
+        crate::elog_warning!(anyhow!("Simple warning"));
+        crate::elog_debug!(anyhow!("Simple debug"));
     }
 }


### PR DESCRIPTION
This PR removes `LoggableError` and then `log_and replaces it with simpler macros: `elog_error`, `elog_warning`, and `elog_debug`.

### Details
The current approach has a significant limitation in that it does not log the affected module correctly. The `track_caller` macro does indeed forward the caller's location (filename and line), but there is no way to access the module name.
The only way to implement this properly is through a macro.

The new `elog_` macros also replace the previous `log_*` functions.

You can either invoke them with an error directly.
```
elog_warning!(myerror); //logs the error at the WARN level
```

Or you can add a context, as with `LoggableError`.
```
elog_debug!(myerror, "Sync error at height {height}");
```
### Changed Behavior
Before these changes. Certain log messages incorrectly listed `errors` module as their source if they used the `LoggableError` trait. The message below is an example.
```
2025-10-30T21:13:40.693297Z  WARN snarkvm_utilities::errors: Cannot sign a batch at round 297 from '127.0.0.1:5139' - Certificate for round 296 already exists in storage (gc = 194)
```

After the changes, the macro will correctly print the module where the error was thrown.
```
2025-10-30T21:13:40.693297Z  WARN snarkos_node_bft::primary: Cannot sign a batch at round 297 from '127.0.0.1:5139' - Certificate for round 296 already exists in storage (gc = 194)
```

This is a needed fix as the module is often used to filter or search for log messages.

### Testing
There is a [companion PR in snarkOS](https://github.com/ProvableHQ/snarkOS/pull/3981) that uses these changes, and that I am testing the PR with.

The PR also includes a new unit tests that verifies the log output using `tracing_test`.