### PR TITLE
Implement reporting unit test timings in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,7 +786,7 @@ jobs:
           flags: >
             --lib --bins --features test
             --partition count:1/2
-            -- --test-threads 8
+            -- --test-threads 16
           cache_key_suffix: -test1
           timeout: 25m
 
@@ -799,7 +799,7 @@ jobs:
           flags: >
             --lib --bins --features test
             --partition count:2/2
-            -- --test-threads 8
+            -- --test-threads 16
           cache_key_suffix: -test2
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ commands:
               fi
             fi
 
-            DEFAULT_JOBS=16
+            DEFAULT_JOBS=12
 
             # Default JOBS, overridden by TEST_THREADS if set
             JOBS="${NEXTEST_JOBS:-$DEFAULT_JOBS}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,17 @@ commands:
               fi
             fi
 
+            # Detect special "cargo-style" nextest mode: run like cargo test, but via nextest.
+            # This is a pseudo-flag for the CI script and must NOT be passed to cargo/nextest.
+            NEXTEST_CARGO_STYLE=0
+            if printf '%s\n' "$BUILD_FLAGS" | grep -q -- '--nextest-cargo-style'; then
+              NEXTEST_CARGO_STYLE=1
+              # Strip the pseudo-flag from BUILD_FLAGS so cargo/nextest never see it.
+              BUILD_FLAGS="$(printf '%s\n' "$BUILD_FLAGS" \
+                | sed -E 's/(^|[[:space:]])--nextest-cargo-style([[:space:]]|$)/ /g' \
+                | tr -s ' ' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+            fi
+
             # Detect and extract --test-threads value (used to set JOBS)
             TEST_THREADS=""
             if [ -n "$RIGHT_OF_SEP" ]; then
@@ -258,6 +269,22 @@ commands:
               JOBS="$TEST_THREADS"
             elif [ -n "${NEXTEST_JOBS:-}" ]; then
               JOBS="$NEXTEST_JOBS"
+            fi
+
+            # If --nextest-cargo-style was requested, force nextest to a single job.
+            # This mimics cargo test in terms of "only one big test binary active at a time".
+            if [ "$NEXTEST_CARGO_STYLE" -eq 1 ]; then
+              JOBS=1
+
+              # Auto-detect cores for --test-threads, fall back to 1.
+              if command -v nproc >/dev/null 2>&1; then
+                CORES="$(nproc)"
+              else
+                CORES=1
+              fi
+
+              TEST_THREADS="$CORES"       # for logging
+              LIBTEST_ARGS+=(--test-threads "$CORES")
             fi
 
             # Create nextest config (disable fail-fast, add slow-timeout + JUnit output)
@@ -296,13 +323,24 @@ commands:
               cargo test --package="<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED | tee "$OUT"
               : > "$CSV"; : > "$TOP"
             else
-              cargo nextest run \
-                -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
-                --profile ci "${NEXT_JOBS_ARGS[@]}" "${CFG_ARGS[@]}" \
-                --status-level fail --hide-progress-bar \
-                --no-tests=pass \
-                ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \
-                2>&1 | tee "$OUT"
+              if [ "${#LIBTEST_ARGS[@]}" -gt 0 ]; then
+                cargo nextest run \
+                  -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
+                  --profile ci "${NEXT_JOBS_ARGS[@]}" "${CFG_ARGS[@]}" \
+                  --status-level fail --hide-progress-bar \
+                  --no-tests=pass \
+                  ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \
+                  -- "${LIBTEST_ARGS[@]}" \
+                  2>&1 | tee "$OUT"
+              else
+                cargo nextest run \
+                  -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
+                  --profile ci "${NEXT_JOBS_ARGS[@]}" "${CFG_ARGS[@]}" \
+                  --status-level fail --hide-progress-bar \
+                  --no-tests=pass \
+                  ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \
+                  2>&1 | tee "$OUT"
+              fi
 
               # Parse junit.xml to extract test timings
               if [ -f "$JUNIT" ]; then
@@ -792,7 +830,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test
+          flags: --lib --bins --features test --nextest-cargo-style
           cache_key_suffix: -test
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,7 +785,7 @@ jobs:
           # nextest args before `--`, libtest args after `--`
           flags: >
             --lib --bins --features test
-            --partition count:2:1
+            --partition count:2/1
             -- --test-threads 4
           cache_key_suffix: -test1
           timeout: 25m
@@ -798,7 +798,7 @@ jobs:
           workspace_member: snarkvm-synthesizer
           flags: >
             --lib --bins --features test
-            --partition count:2:2
+            --partition count:2/2
             -- --test-threads 4
           cache_key_suffix: -test2
           timeout: 25m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,13 +149,180 @@ commands:
       - checkout
       - setup_environment:
           cache_key: v4.2.0-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+
+      - run:
+          name: Install cargo-nextest
+          command: |
+            cargo install cargo-nextest --locked || true
+
       - run:
           name: "Run Tests"
           timeout: << parameters.timeout >>
           no_output_timeout: << parameters.no_output_timeout >>
-          command: RUST_MIN_STACK=67108864 cargo test --package=<< parameters.workspace_member >> << parameters.flags >>
+          command: |
+            set -euo pipefail
+            export CARGO_TERM_COLOR=never
+
+            # Create artifact + nextest output directories
+            mkdir -p artifacts target/nextest/ci
+
+            # Create artifact + nextest output directories
+            OUT="artifacts/<< parameters.workspace_member >>-nextest.txt"
+            CSV="artifacts/<< parameters.workspace_member >>-test-times.csv"
+            TOP="artifacts/<< parameters.workspace_member >>-slow-tests-top30.csv"
+            JUNIT="target/nextest/ci/junit.xml"
+
+            # Extract and trim flags from parameters
+            FLAGS_FULL="<< parameters.flags >>"
+            FLAGS_TRIM="$(printf '%s' "$FLAGS_FULL" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+            # Split flags into cargo build flags (before --) and libtest args (after --)
+            RIGHT_OF_SEP=""
+            if printf '%s' "$FLAGS_TRIM" | grep -q ' -- '; then
+              BUILD_FLAGS="${FLAGS_TRIM%% -- *}"
+              RIGHT_OF_SEP="${FLAGS_TRIM#* -- }"
+            elif printf '%s' "$FLAGS_TRIM" | grep -Eq '^--[[:space:]]'; then
+              BUILD_FLAGS=""
+              RIGHT_OF_SEP="${FLAGS_TRIM#-- }"
+            else
+              BUILD_FLAGS="$FLAGS_TRIM"
+            fi
+
+            # Remove any --test target flags,they cause nextest build errors
+            BUILD_FLAGS_SANITIZED="$(printf '%s' "$BUILD_FLAGS" \
+              | sed -E "s/(^|[[:space:]])--test[[:space:]]+'[^']*'([[:space:]]|$)/ /g" \
+              | sed -E 's/(^|[[:space:]])--test[[:space:]]+\"[^\"]*\"([[:space:]]|$)/ /g' \
+              | sed -E 's/(^|[[:space:]])--test[[:space:]]+[^[:space:]]+([[:space:]]|$)/ /g' \
+              | tr -s ' ' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+            )"
+
+            # Detect wildcard integration selection: `--test '*'` (with or without quotes)
+            HAS_TEST_WILDCARD=0
+            if printf '%s\n' "$BUILD_FLAGS" | grep -Eq -- '--test[[:space:]]+("\*"|'\''\*'\''|\*)'; then
+              HAS_TEST_WILDCARD=1
+            fi
+
+            # Build nextest filter expression from any --skip <pattern> arguments
+            FILTER_EXPR=""
+
+            WSM="<< parameters.workspace_member >>"
+            if [ "$WSM" = "snarkvm-synthesizer" ] && [ "$HAS_TEST_WILDCARD" -eq 1 ]; then
+              FILTER_EXPR='test(/test_command_parse/)+test(/test_instruction_parse/)+test(/test_process_execute/)+test(/test_program_parse/)+test(/test_vm_execute_and_finalize/)'
+            fi
+
+            # Build nextest filter expression from any --skip <pattern> arguments
+            if [ -z "$FILTER_EXPR" ] && [ -n "$RIGHT_OF_SEP" ]; then
+              SKIPS="$(printf '%s\n' "$RIGHT_OF_SEP" \
+                | sed -E 's/[[:space:]]+/ /g' \
+                | grep -oE -- '--skip[[:space:]]+(\"[^\"]+\"|'\''[^'\'']+'\''|[^[:space:]]+)' || true)"
+              if [ -n "$SKIPS" ]; then
+                EXPRS=""
+                tmpf="$(mktemp)"
+                printf '%s\n' "$SKIPS" > "$tmpf"
+                while IFS= read -r line; do
+                  pat="${line#--skip }"
+                  pat="${pat%\"}"; pat="${pat#\"}"
+                  pat="${pat%\'}"; pat="${pat#\'}"
+                  pat_rx="${pat//\//\\/}"  # escape forward slashes for regex
+                  if [ -z "$EXPRS" ]; then
+                    EXPRS="test(/$pat_rx/)"
+                  else
+                    EXPRS="$EXPRS or test(/$pat_rx/)"
+                  fi
+                done < "$tmpf"
+                rm -f "$tmpf"
+                if [ -n "$EXPRS" ]; then
+                  FILTER_EXPR="not ($EXPRS)"
+                fi
+              fi
+            fi
+
+            # Detect and extract --test-threads value (used to set JOBS)
+            TEST_THREADS=""
+            if [ -n "$RIGHT_OF_SEP" ]; then
+              # form: --test-threads=8
+              TEST_THREADS="$(printf '%s\n' "$RIGHT_OF_SEP" | sed -nE 's/.*--test-threads=([0-9]+).*/\1/p' | head -n1)"
+              if [ -z "$TEST_THREADS" ]; then
+                # form: --test-threads 8
+                TEST_THREADS="$(printf '%s\n' "$RIGHT_OF_SEP" | sed -nE 's/.*--test-threads[[:space:]]+([0-9]+).*/\1/p' | head -n1)"
+              fi
+            fi
+
+            DEFAULT_JOBS=8
+
+            # Default JOBS, overridden by TEST_THREADS if set
+            JOBS="${NEXTEST_JOBS:-$DEFAULT_JOBS}"
+            if [ -n "$TEST_THREADS" ]; then
+              JOBS="$TEST_THREADS"
+            fi
+
+            # Create nextest config (disable fail-fast, add slow-timeout + JUnit output)
+            SLOW_PERIOD="${NEXTEST_SLOW_PERIOD:-60s}"
+            CFG_ARGS=()
+            TMPD="$(mktemp -d)"
+            if [ -f ".config/nextest.toml" ]; then
+              CFG_ARGS+=(--config-file ".config/nextest.toml")
+            fi
+            {
+              printf '%s\n' '[profile.ci]'
+              printf '%s\n' 'fail-fast = false'
+              printf '%s\n' "slow-timeout = \"${SLOW_PERIOD}\""
+              printf '%s\n' ''
+              printf '%s\n' '[profile.ci.junit]'
+              printf '%s\n' 'path = "junit.xml"'
+            } > "$TMPD/nextest-override.toml"
+            CFG_ARGS+=(--config-file "$TMPD/nextest-override.toml")
+
+            # Print configuration summary for debugging
+            echo "==> nextest package: << parameters.workspace_member >>"
+            echo "==> build flags (sanitized): '${BUILD_FLAGS_SANITIZED}'"
+            echo "==> filter-expr: ${FILTER_EXPR:-<none>}  (right-of-sep: ${RIGHT_OF_SEP:-<none>})"
+            echo "==> test-threads override: ${TEST_THREADS:-<none>}"
+            echo "==> jobs: ${JOBS}"
+
+            # Use plain cargo test if --no-run was requested
+            # Otherwise, run tests with cargo nextest
+            if printf '%s' " $BUILD_FLAGS_SANITIZED " | grep -q ' --no-run '; then
+              cargo test --package="<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED | tee "$OUT"
+              : > "$CSV"; : > "$TOP"
+            else
+              cargo nextest run \
+                -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
+                --profile ci -j "${JOBS}" "${CFG_ARGS[@]}" \
+                --status-level fail --hide-progress-bar \
+                --no-tests=pass \
+                ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \
+                2>&1 | tee "$OUT"
+
+              # Parse junit.xml to extract test timings
+              if [ -f "$JUNIT" ]; then
+                awk -v RS='<testcase ' '
+                  NR>1 {
+                    name=""; classname=""; time="";
+                    start=index($0,"classname=\""); if(start>0){ start+=11; rest=substr($0,start); end=index(rest,"\""); if(end>0) classname=substr(rest,1,end-1) }
+                    start=index($0,"name=\"");      if(start>0){ start+=6;  rest=substr($0,start); end=index(rest,"\""); if(end>0) name=substr(rest,1,end-1) }
+                    start=index($0,"time=\"");      if(start>0){ start+=6;  rest=substr($0,start); end=index(rest,"\""); if(end>0) time=substr(rest,1,end-1) }
+                    if(name!="" && time!=""){ full=(classname!=""?classname"::"name:name); printf "%s,%s\n", full, time }
+                  }
+                ' "$JUNIT" > "$CSV" || true
+
+                # Sort and store top 30 slowest tests
+                sort -t, -k2,2nr "$CSV" | head -n 30 > "$TOP" || true
+              else
+                echo "WARN: $JUNIT not found; no timings extracted." >&2
+                : > "$CSV"; : > "$TOP"
+              fi
+            fi
+
+      - store_artifacts:
+          path: artifacts
+          destination: test-timings/<< parameters.workspace_member >>
+      - store_test_results:
+          path: target/nextest/ci
+
       - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+
 
   install_rust_nightly:
     description: "Install Rust nightly toolchain"
@@ -446,7 +613,8 @@ jobs:
       - run_test:
           workspace_member: snarkvm-ledger
           flags: --release --features=rocks -- --test-threads=2
-          timeout: 20m
+          no_output_timeout: 20m
+          timeout: 30m
 
   ledger-with-valid-solutions:
     executor: rust-docker
@@ -470,6 +638,8 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-ledger-block
+          no_output_timeout: 20m
+          timeout: 30m
 
   ledger-committee:
     executor: rust-docker
@@ -593,6 +763,8 @@ jobs:
           workspace_member: snarkvm-parameters
           flags: -- --test-threads=2 --ignored test_load_bytes_mini
           cache_key_suffix: -v-{{ epoch }}
+          no_output_timeout: 20m
+          timeout: 30m
 
   synthesizer:
     executor: rust-docker
@@ -601,7 +773,8 @@ jobs:
       - run_test:
           workspace_member: snarkvm-synthesizer
           flags: --lib --bins
-          timeout: 20m
+          no_output_timeout: 20m
+          timeout: 30m
 
   synthesizer-test:
     executor: rust-docker
@@ -631,7 +804,7 @@ jobs:
           # test_vm_execute_and_finalize can take over 10 minutes in the current setup
           no_output_timeout: 20m
           workspace_member: snarkvm-synthesizer
-          flags: --test '*' --features test -- --test-threads=4 
+          flags: --test '*' --features test -- --test-threads=4
           cache_key_suffix: -integration
 
   synthesizer-process:
@@ -640,7 +813,6 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer-process
-          flags: -- --test-threads=8
 
   synthesizer-process-with-rocksdb:
     executor: rust-docker
@@ -648,7 +820,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer-process
-          flags: --features=rocks
+          flags: --features=rocks -- --test-threads=4
           cache_key_suffix: -with-rocksdb
 
   synthesizer-program:
@@ -665,7 +837,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer-program
-          flags: -- --skip keccak --skip psd --skip sha --skip instruction::is --skip instruction::equal --skip instruction::commit
+          flags: -- --skip keccak --skip psd --skip sha --skip instruction::is --skip instruction::equal --skip instruction::commit --test-threads=8
           cache_key_suffix: -integration
 
   synthesizer-program-integration-keccak:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -782,7 +782,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test -- --test-threads 16
+          flags: --lib --bins --features test -- --test-threads 32
           cache_key_suffix: -test
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1121,26 +1121,26 @@ workflows:
   #    - console-types-scalar
   #    - console-types-string
 
-  #ledger-workflow:
-  #  jobs:
-  #    - ledger
-  #    - ledger-with-rocksdb
-  #    - ledger-with-valid-solutions
-  #    - ledger-authority
-  #    - ledger-block
-  #    - ledger-committee
-  #    - ledger-narwhal
-  #    - ledger-narwhal-batch-certificate
-  #    - ledger-narwhal-batch-header
-  #    - ledger-narwhal-data
-  #    - ledger-narwhal-subdag
-  #    - ledger-narwhal-transmission
-  #    - ledger-narwhal-transmission-id
-  #    - ledger-puzzle
-  #    - ledger-puzzle-epoch
-  #    - ledger-query
-  #    - ledger-store
-  #    - ledger-test-helpers
+  ledger-workflow:
+    jobs:
+      - ledger
+      - ledger-with-rocksdb
+      - ledger-with-valid-solutions
+      - ledger-authority
+      - ledger-block
+      - ledger-committee
+      - ledger-narwhal
+      - ledger-narwhal-batch-certificate
+      - ledger-narwhal-batch-header
+      - ledger-narwhal-data
+      - ledger-narwhal-subdag
+      - ledger-narwhal-transmission
+      - ledger-narwhal-transmission-id
+      - ledger-puzzle
+      - ledger-puzzle-epoch
+      - ledger-query
+      - ledger-store
+      - ledger-test-helpers
 
   synthesizer-workflow:
     jobs:
@@ -1161,33 +1161,33 @@ workflows:
       - synthesizer-program-integration-instruction-commit
       - synthesizer-snark
 
-  #snarkvm-workflow:
-  #  jobs:
-  #    - snarkvm
-  #    - algorithms
-  #    - algorithms-profiler
-  #    - curves
-  #    - fields
-  #    - parameters
-  #    - parameters-large
-  #    - parameters-uncached
-  #    - utilities
-  #    - utilities-derives
-  #    - wasm
+  snarkvm-workflow:
+    jobs:
+      - snarkvm
+      - algorithms
+      - algorithms-profiler
+      - curves
+      - fields
+      - parameters
+      - parameters-large
+      - parameters-uncached
+      - utilities
+      - utilities-derives
+      - wasm
 
-  #windows-workflow:
-  #  jobs:
-  #    - verify-windows:
-  #        matrix:
-  #          parameters:
-  #            workspace_member: [
-  #              algorithms,
-  #              circuit,
-  #              console,
-  #              curves,
-  #              fields,
-  #              ledger,
-  #              parameters,
-  #              synthesizer,
-  #              utilities,
-  #            ]
+  windows-workflow:
+    jobs:
+      - verify-windows:
+          matrix:
+            parameters:
+              workspace_member: [
+                algorithms,
+                circuit,
+                console,
+                curves,
+                fields,
+                ledger,
+                parameters,
+                synthesizer,
+                utilities,
+              ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,7 +772,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins
+          flags: --lib --bins -- --test-threads 16
           no_output_timeout: 20m
           timeout: 30m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,10 +283,10 @@ commands:
             # Use plain cargo test if --no-run was requested
             # Otherwise, run tests with cargo nextest
             if printf '%s' " $BUILD_FLAGS_SANITIZED " | grep -q ' --no-run '; then
-              cargo test --package="<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED | tee "$OUT"
+              RUST_MIN_STACK=67108864 cargo test --package="<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED | tee "$OUT"
               : > "$CSV"; : > "$TOP"
             else
-              cargo nextest run \
+              RUST_MIN_STACK=67108864 cargo nextest run \
                 -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
                 --profile ci -j "${JOBS}" "${CFG_ARGS[@]}" \
                 --status-level fail --hide-progress-bar \
@@ -782,7 +782,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test -- --test-threads 10
+          flags: --lib --bins --features test -- --test-threads 16
           cache_key_suffix: -test
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -782,7 +782,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test -- --test-threads 32
+          flags: --lib --bins --features test -- --test-threads 8
           cache_key_suffix: -test
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,15 +776,32 @@ jobs:
           no_output_timeout: 20m
           timeout: 30m
 
-  synthesizer-test:
-    executor: rust-docker
-    resource_class: << pipeline.parameters.twoxlarge >>
-    steps:
-      - run_test:
-          workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test -- --test-threads 8
-          cache_key_suffix: -test
-          timeout: 25m
+synthesizer-test-partition1:
+  executor: rust-docker
+  resource_class: << pipeline.parameters.twoxlarge >>
+  steps:
+    - run_test:
+        workspace_member: snarkvm-synthesizer
+        # nextest args before `--`, libtest args after `--`
+        flags: >
+          --lib --bins --features test
+          --partition count:2:1
+          -- --test-threads 4
+        cache_key_suffix: -test1
+        timeout: 25m
+
+synthesizer-test-partition2:
+  executor: rust-docker
+  resource_class: << pipeline.parameters.twoxlarge >>
+  steps:
+    - run_test:
+        workspace_member: snarkvm-synthesizer
+        flags: >
+          --lib --bins --features test
+          --partition count:2:2
+          -- --test-threads 4
+        cache_key_suffix: -test2
+        timeout: 25m
 
 #  synthesizer-mem-heavy:
 #    executor: rust-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,18 @@ commands:
               BUILD_FLAGS="$FLAGS_TRIM"
             fi
 
-            # Remove any --test target flags,they cause nextest build errors
+            # Detect special "cargo-style" nextest mode: run like cargo test, but via nextest.
+            # This is a pseudo-flag for the CI script and must NOT be passed to cargo/nextest.
+            NEXTEST_CARGO_STYLE=0
+            if printf '%s\n' "$BUILD_FLAGS" | grep -q -- '--nextest-cargo-style'; then
+              NEXTEST_CARGO_STYLE=1
+              # Strip the pseudo-flag from BUILD_FLAGS so cargo/nextest never see it.
+              BUILD_FLAGS="$(printf '%s\n' "$BUILD_FLAGS" \
+                | sed -E 's/(^|[[:space:]])--nextest-cargo-style([[:space:]]|$)/ /g' \
+                | tr -s ' ' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+            fi
+
+            # Remove any --test target flags, they cause nextest build errors
             BUILD_FLAGS_SANITIZED="$(printf '%s' "$BUILD_FLAGS" \
               | sed -E "s/(^|[[:space:]])--test[[:space:]]+'[^']*'([[:space:]]|$)/ /g" \
               | sed -E 's/(^|[[:space:]])--test[[:space:]]+\"[^\"]*\"([[:space:]]|$)/ /g' \
@@ -235,17 +246,6 @@ commands:
                   FILTER_EXPR="not ($EXPRS)"
                 fi
               fi
-            fi
-
-            # Detect special "cargo-style" nextest mode: run like cargo test, but via nextest.
-            # This is a pseudo-flag for the CI script and must NOT be passed to cargo/nextest.
-            NEXTEST_CARGO_STYLE=0
-            if printf '%s\n' "$BUILD_FLAGS" | grep -q -- '--nextest-cargo-style'; then
-              NEXTEST_CARGO_STYLE=1
-              # Strip the pseudo-flag from BUILD_FLAGS so cargo/nextest never see it.
-              BUILD_FLAGS="$(printf '%s\n' "$BUILD_FLAGS" \
-                | sed -E 's/(^|[[:space:]])--nextest-cargo-style([[:space:]]|$)/ /g' \
-                | tr -s ' ' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
             fi
 
             # Detect and extract --test-threads value (used to set JOBS)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,12 +248,16 @@ commands:
               fi
             fi
 
-            DEFAULT_JOBS=8
-
-            # Default JOBS, overridden by TEST_THREADS if set
-            JOBS="${NEXTEST_JOBS:-$DEFAULT_JOBS}"
+            # Decide whether to pass an explicit -j to nextest.
+            # Priority:
+            #   1) --test-threads N  → JOBS=N
+            #   2) NEXTEST_JOBS      → JOBS=$NEXTEST_JOBS
+            #   3) otherwise         → JOBS empty, let nextest choose default
+            JOBS=""
             if [ -n "$TEST_THREADS" ]; then
               JOBS="$TEST_THREADS"
+            elif [ -n "${NEXTEST_JOBS:-}" ]; then
+              JOBS="$NEXTEST_JOBS"
             fi
 
             # Create nextest config (disable fail-fast, add slow-timeout + JUnit output)
@@ -273,12 +277,18 @@ commands:
             } > "$TMPD/nextest-override.toml"
             CFG_ARGS+=(--config-file "$TMPD/nextest-override.toml")
 
+            # Build -j argument array for nextest (only if JOBS is set)
+            NEXT_JOBS_ARGS=()
+            if [ -n "$JOBS" ]; then
+              NEXT_JOBS_ARGS=(-j "$JOBS")
+            fi
+
             # Print configuration summary for debugging
             echo "==> nextest package: << parameters.workspace_member >>"
             echo "==> build flags (sanitized): '${BUILD_FLAGS_SANITIZED}'"
             echo "==> filter-expr: ${FILTER_EXPR:-<none>}  (right-of-sep: ${RIGHT_OF_SEP:-<none>})"
             echo "==> test-threads override: ${TEST_THREADS:-<none>}"
-            echo "==> jobs: ${JOBS}"
+            echo "==> jobs: ${JOBS:-<auto>}"
 
             # Use plain cargo test if --no-run was requested
             # Otherwise, run tests with cargo nextest
@@ -288,7 +298,7 @@ commands:
             else
               cargo nextest run \
                 -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
-                --profile ci -j "${JOBS}" "${CFG_ARGS[@]}" \
+                --profile ci "${NEXT_JOBS_ARGS[@]}" "${CFG_ARGS[@]}" \
                 --status-level fail --hide-progress-bar \
                 --no-tests=pass \
                 ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ commands:
               fi
             fi
 
-            DEFAULT_JOBS=12
+            DEFAULT_JOBS=16
 
             # Default JOBS, overridden by TEST_THREADS if set
             JOBS="${NEXTEST_JOBS:-$DEFAULT_JOBS}"
@@ -782,7 +782,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test -- --test-threads 1
+          flags: --lib --bins --features test -- --test-threads 10
           cache_key_suffix: -test
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,7 +785,7 @@ jobs:
           # nextest args before `--`, libtest args after `--`
           flags: >
             --lib --bins --features test
-            --partition count:2/1
+            --partition count:1/2
             -- --test-threads 4
           cache_key_suffix: -test1
           timeout: 25m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,32 +776,32 @@ jobs:
           no_output_timeout: 20m
           timeout: 30m
 
-synthesizer-test-partition1:
-  executor: rust-docker
-  resource_class: << pipeline.parameters.twoxlarge >>
-  steps:
-    - run_test:
-        workspace_member: snarkvm-synthesizer
-        # nextest args before `--`, libtest args after `--`
-        flags: >
-          --lib --bins --features test
-          --partition count:2:1
-          -- --test-threads 4
-        cache_key_suffix: -test1
-        timeout: 25m
+  synthesizer-test-partition1:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.twoxlarge >>
+    steps:
+      - run_test:
+          workspace_member: snarkvm-synthesizer
+          # nextest args before `--`, libtest args after `--`
+          flags: >
+            --lib --bins --features test
+            --partition count:2:1
+            -- --test-threads 4
+          cache_key_suffix: -test1
+          timeout: 25m
 
-synthesizer-test-partition2:
-  executor: rust-docker
-  resource_class: << pipeline.parameters.twoxlarge >>
-  steps:
-    - run_test:
-        workspace_member: snarkvm-synthesizer
-        flags: >
-          --lib --bins --features test
-          --partition count:2:2
-          -- --test-threads 4
-        cache_key_suffix: -test2
-        timeout: 25m
+  synthesizer-test-partition2:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.twoxlarge >>
+    steps:
+      - run_test:
+          workspace_member: snarkvm-synthesizer
+          flags: >
+            --lib --bins --features test
+            --partition count:2:2
+            -- --test-threads 4
+          cache_key_suffix: -test2
+          timeout: 25m
 
 #  synthesizer-mem-heavy:
 #    executor: rust-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -782,7 +782,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test
+          flags: --lib --bins --features test -- --test-threads 1
           cache_key_suffix: -test
           timeout: 25m
 
@@ -1057,73 +1057,73 @@ jobs:
 workflows:
   version: 2
 
-  cargo-workflow:
-    jobs:
-      - check-fmt
-      - check-clippy
-      - check-unused-dependencies
-      - check-cargo-audit
-      - check-cargo-semver-checks
-      - check-all-targets
+  #cargo-workflow:
+  #  jobs:
+  #    - check-fmt
+  #    - check-clippy
+  #    - check-unused-dependencies
+  #    - check-cargo-audit
+  #    - check-cargo-semver-checks
+  #    - check-all-targets
 
-  circuit-workflow:
-    jobs:
-      - circuit
-      - circuit-account
-      - circuit-account-noconsole
-      - circuit-algorithms
-      - circuit-collections
-      - circuit-collections-noconsole
-      - circuit-environment
-      - circuit-network
-      - circuit-program
-      - circuit-types
-      - circuit-types-address
-      - circuit-types-boolean
-      - circuit-types-field
-      - circuit-types-group
-      - circuit-types-integers
-      - circuit-types-scalar
-      - circuit-types-string
+  #circuit-workflow:
+  #  jobs:
+  #    - circuit
+  #    - circuit-account
+  #    - circuit-account-noconsole
+  #    - circuit-algorithms
+  #    - circuit-collections
+  #    - circuit-collections-noconsole
+  #    - circuit-environment
+  #    - circuit-network
+  #    - circuit-program
+  #    - circuit-types
+  #    - circuit-types-address
+  #    - circuit-types-boolean
+  #    - circuit-types-field
+  #    - circuit-types-group
+  #    - circuit-types-integers
+  #    - circuit-types-scalar
+  #    - circuit-types-string
 
-  console-workflow:
-    jobs:
-      - console
-      - console-account
-      - console-algorithms
-      - console-collections
-      - console-network
-      - console-network-environment
-      - console-program
-      - console-types
-      - console-types-address
-      - console-types-boolean
-      - console-types-field
-      - console-types-group
-      - console-types-integers
-      - console-types-scalar
-      - console-types-string
+  #console-workflow:
+  #  jobs:
+  #    - console
+  #    - console-account
+  #    - console-algorithms
+  #    - console-collections
+  #    - console-network
+  #    - console-network-environment
+  #    - console-program
+  #    - console-types
+  #    - console-types-address
+  #    - console-types-boolean
+  #    - console-types-field
+  #    - console-types-group
+  #    - console-types-integers
+  #    - console-types-scalar
+  #    - console-types-string
 
-  ledger-workflow:
-    jobs:
-      - ledger
-      - ledger-with-rocksdb
-      - ledger-with-valid-solutions
-      - ledger-authority
-      - ledger-block
-      - ledger-committee
-      - ledger-narwhal
-      - ledger-narwhal-batch-certificate
-      - ledger-narwhal-batch-header
-      - ledger-narwhal-data
-      - ledger-narwhal-subdag
-      - ledger-narwhal-transmission
-      - ledger-narwhal-transmission-id
-      - ledger-puzzle
-      - ledger-puzzle-epoch
-      - ledger-query
-      - ledger-store
-      - ledger-test-helpers
+  #ledger-workflow:
+  #  jobs:
+  #    - ledger
+  #    - ledger-with-rocksdb
+  #    - ledger-with-valid-solutions
+  #    - ledger-authority
+  #    - ledger-block
+  #    - ledger-committee
+  #    - ledger-narwhal
+  #    - ledger-narwhal-batch-certificate
+  #    - ledger-narwhal-batch-header
+  #    - ledger-narwhal-data
+  #    - ledger-narwhal-subdag
+  #    - ledger-narwhal-transmission
+  #    - ledger-narwhal-transmission-id
+  #    - ledger-puzzle
+  #    - ledger-puzzle-epoch
+  #    - ledger-query
+  #    - ledger-store
+  #    - ledger-test-helpers
 
   synthesizer-workflow:
     jobs:
@@ -1143,33 +1143,33 @@ workflows:
       - synthesizer-program-integration-instruction-commit
       - synthesizer-snark
 
-  snarkvm-workflow:
-    jobs:
-      - snarkvm
-      - algorithms
-      - algorithms-profiler
-      - curves
-      - fields
-      - parameters
-      - parameters-large
-      - parameters-uncached
-      - utilities
-      - utilities-derives
-      - wasm
+  #snarkvm-workflow:
+  #  jobs:
+  #    - snarkvm
+  #    - algorithms
+  #    - algorithms-profiler
+  #    - curves
+  #    - fields
+  #    - parameters
+  #    - parameters-large
+  #    - parameters-uncached
+  #    - utilities
+  #    - utilities-derives
+  #    - wasm
 
-  windows-workflow:
-    jobs:
-      - verify-windows:
-          matrix:
-            parameters:
-              workspace_member: [
-                algorithms,
-                circuit,
-                console,
-                curves,
-                fields,
-                ledger,
-                parameters,
-                synthesizer,
-                utilities,
-              ]
+  #windows-workflow:
+  #  jobs:
+  #    - verify-windows:
+  #        matrix:
+  #          parameters:
+  #            workspace_member: [
+  #              algorithms,
+  #              circuit,
+  #              console,
+  #              curves,
+  #              fields,
+  #              ledger,
+  #              parameters,
+  #              synthesizer,
+  #              utilities,
+  #            ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,7 @@ commands:
 
             # If --nextest-cargo-style was requested, force nextest to a single job.
             # This mimics cargo test in terms of "only one big test binary active at a time".
+            LIBTEST_ARGS=()
             if [ "$NEXTEST_CARGO_STYLE" -eq 1 ]; then
               JOBS=1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1145,7 +1145,8 @@ workflows:
   synthesizer-workflow:
     jobs:
       - synthesizer
-      - synthesizer-test
+      - synthesizer-test-partition1
+      - synthesizer-test-partition2
       # - synthesizer-mem-heavy
       - synthesizer-integration
       - synthesizer-process

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,7 +612,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-ledger
-          flags: --release --features=rocks -- --test-threads=2
+          flags: --release --features=rocks -- --test-threads=4
           no_output_timeout: 20m
           timeout: 30m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,13 +606,23 @@ jobs:
       - run_test:
           workspace_member: snarkvm-ledger
 
-  ledger-with-rocksdb:
+  ledger-with-rocksdb-partition1:
     executor: rust-docker
     resource_class: << pipeline.parameters.large >>
     steps:
       - run_test:
           workspace_member: snarkvm-ledger
-          flags: --release --features=rocks -- --test-threads=4
+          flags: --release --features=rocks --partition count:1/2 -- --test-threads=8
+          no_output_timeout: 20m
+          timeout: 30m
+
+  ledger-with-rocksdb-partition2:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.large >>
+    steps:
+      - run_test:
+          workspace_member: snarkvm-ledger
+          flags: --release --features=rocks --partition count:2/2 -- --test-threads=8
           no_output_timeout: 20m
           timeout: 30m
 
@@ -1124,7 +1134,8 @@ workflows:
   ledger-workflow:
     jobs:
       - ledger
-      - ledger-with-rocksdb
+      - ledger-with-rocksdb-partition1
+      - ledger-with-rocksdb-partition2
       - ledger-with-valid-solutions
       - ledger-authority
       - ledger-block

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,18 +188,7 @@ commands:
               BUILD_FLAGS="$FLAGS_TRIM"
             fi
 
-            # Detect special "cargo-style" nextest mode: run like cargo test, but via nextest.
-            # This is a pseudo-flag for the CI script and must NOT be passed to cargo/nextest.
-            NEXTEST_CARGO_STYLE=0
-            if printf '%s\n' "$BUILD_FLAGS" | grep -q -- '--nextest-cargo-style'; then
-              NEXTEST_CARGO_STYLE=1
-              # Strip the pseudo-flag from BUILD_FLAGS so cargo/nextest never see it.
-              BUILD_FLAGS="$(printf '%s\n' "$BUILD_FLAGS" \
-                | sed -E 's/(^|[[:space:]])--nextest-cargo-style([[:space:]]|$)/ /g' \
-                | tr -s ' ' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
-            fi
-
-            # Remove any --test target flags, they cause nextest build errors
+            # Remove any --test target flags,they cause nextest build errors
             BUILD_FLAGS_SANITIZED="$(printf '%s' "$BUILD_FLAGS" \
               | sed -E "s/(^|[[:space:]])--test[[:space:]]+'[^']*'([[:space:]]|$)/ /g" \
               | sed -E 's/(^|[[:space:]])--test[[:space:]]+\"[^\"]*\"([[:space:]]|$)/ /g' \
@@ -259,33 +248,12 @@ commands:
               fi
             fi
 
-            # Decide whether to pass an explicit -j to nextest.
-            # Priority:
-            #   1) --test-threads N  → JOBS=N
-            #   2) NEXTEST_JOBS      → JOBS=$NEXTEST_JOBS
-            #   3) otherwise         → JOBS empty, let nextest choose default
-            JOBS=""
+            DEFAULT_JOBS=12
+
+            # Default JOBS, overridden by TEST_THREADS if set
+            JOBS="${NEXTEST_JOBS:-$DEFAULT_JOBS}"
             if [ -n "$TEST_THREADS" ]; then
               JOBS="$TEST_THREADS"
-            elif [ -n "${NEXTEST_JOBS:-}" ]; then
-              JOBS="$NEXTEST_JOBS"
-            fi
-
-            # If --nextest-cargo-style was requested, force nextest to a single job.
-            # This mimics cargo test in terms of "only one big test binary active at a time".
-            LIBTEST_ARGS=()
-            if [ "$NEXTEST_CARGO_STYLE" -eq 1 ]; then
-              JOBS=1
-
-              # Auto-detect cores for --test-threads, fall back to 1.
-              if command -v nproc >/dev/null 2>&1; then
-                CORES="$(nproc)"
-              else
-                CORES=1
-              fi
-
-              TEST_THREADS="$CORES"       # for logging
-              LIBTEST_ARGS+=(--test-threads "$CORES")
             fi
 
             # Create nextest config (disable fail-fast, add slow-timeout + JUnit output)
@@ -305,18 +273,12 @@ commands:
             } > "$TMPD/nextest-override.toml"
             CFG_ARGS+=(--config-file "$TMPD/nextest-override.toml")
 
-            # Build -j argument array for nextest (only if JOBS is set)
-            NEXT_JOBS_ARGS=()
-            if [ -n "$JOBS" ]; then
-              NEXT_JOBS_ARGS=(-j "$JOBS")
-            fi
-
             # Print configuration summary for debugging
             echo "==> nextest package: << parameters.workspace_member >>"
             echo "==> build flags (sanitized): '${BUILD_FLAGS_SANITIZED}'"
             echo "==> filter-expr: ${FILTER_EXPR:-<none>}  (right-of-sep: ${RIGHT_OF_SEP:-<none>})"
             echo "==> test-threads override: ${TEST_THREADS:-<none>}"
-            echo "==> jobs: ${JOBS:-<auto>}"
+            echo "==> jobs: ${JOBS}"
 
             # Use plain cargo test if --no-run was requested
             # Otherwise, run tests with cargo nextest
@@ -324,24 +286,13 @@ commands:
               cargo test --package="<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED | tee "$OUT"
               : > "$CSV"; : > "$TOP"
             else
-              if [ "${#LIBTEST_ARGS[@]}" -gt 0 ]; then
-                cargo nextest run \
-                  -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
-                  --profile ci "${NEXT_JOBS_ARGS[@]}" "${CFG_ARGS[@]}" \
-                  --status-level fail --hide-progress-bar \
-                  --no-tests=pass \
-                  ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \
-                  -- "${LIBTEST_ARGS[@]}" \
-                  2>&1 | tee "$OUT"
-              else
-                cargo nextest run \
-                  -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
-                  --profile ci "${NEXT_JOBS_ARGS[@]}" "${CFG_ARGS[@]}" \
-                  --status-level fail --hide-progress-bar \
-                  --no-tests=pass \
-                  ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \
-                  2>&1 | tee "$OUT"
-              fi
+              cargo nextest run \
+                -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \
+                --profile ci -j "${JOBS}" "${CFG_ARGS[@]}" \
+                --status-level fail --hide-progress-bar \
+                --no-tests=pass \
+                ${FILTER_EXPR:+--filter-expr "$FILTER_EXPR"} \
+                2>&1 | tee "$OUT"
 
               # Parse junit.xml to extract test timings
               if [ -f "$JUNIT" ]; then
@@ -831,7 +782,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
-          flags: --lib --bins --features test --nextest-cargo-style
+          flags: --lib --bins --features test
           cache_key_suffix: -test
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,7 +786,7 @@ jobs:
           flags: >
             --lib --bins --features test
             --partition count:1/2
-            -- --test-threads 4
+            -- --test-threads 8
           cache_key_suffix: -test1
           timeout: 25m
 
@@ -799,7 +799,7 @@ jobs:
           flags: >
             --lib --bins --features test
             --partition count:2/2
-            -- --test-threads 4
+            -- --test-threads 8
           cache_key_suffix: -test2
           timeout: 25m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1084,52 +1084,52 @@ jobs:
 workflows:
   version: 2
 
-  #cargo-workflow:
-  #  jobs:
-  #    - check-fmt
-  #    - check-clippy
-  #    - check-unused-dependencies
-  #    - check-cargo-audit
-  #    - check-cargo-semver-checks
-  #    - check-all-targets
+  cargo-workflow:
+    jobs:
+      - check-fmt
+      - check-clippy
+      - check-unused-dependencies
+      - check-cargo-audit
+      - check-cargo-semver-checks
+      - check-all-targets
 
-  #circuit-workflow:
-  #  jobs:
-  #    - circuit
-  #    - circuit-account
-  #    - circuit-account-noconsole
-  #    - circuit-algorithms
-  #    - circuit-collections
-  #    - circuit-collections-noconsole
-  #    - circuit-environment
-  #    - circuit-network
-  #    - circuit-program
-  #    - circuit-types
-  #    - circuit-types-address
-  #    - circuit-types-boolean
-  #    - circuit-types-field
-  #    - circuit-types-group
-  #    - circuit-types-integers
-  #    - circuit-types-scalar
-  #    - circuit-types-string
+  circuit-workflow:
+    jobs:
+      - circuit
+      - circuit-account
+      - circuit-account-noconsole
+      - circuit-algorithms
+      - circuit-collections
+      - circuit-collections-noconsole
+      - circuit-environment
+      - circuit-network
+      - circuit-program
+      - circuit-types
+      - circuit-types-address
+      - circuit-types-boolean
+      - circuit-types-field
+      - circuit-types-group
+      - circuit-types-integers
+      - circuit-types-scalar
+      - circuit-types-string
 
-  #console-workflow:
-  #  jobs:
-  #    - console
-  #    - console-account
-  #    - console-algorithms
-  #    - console-collections
-  #    - console-network
-  #    - console-network-environment
-  #    - console-program
-  #    - console-types
-  #    - console-types-address
-  #    - console-types-boolean
-  #    - console-types-field
-  #    - console-types-group
-  #    - console-types-integers
-  #    - console-types-scalar
-  #    - console-types-string
+  console-workflow:
+    jobs:
+      - console
+      - console-account
+      - console-algorithms
+      - console-collections
+      - console-network
+      - console-network-environment
+      - console-program
+      - console-types
+      - console-types-address
+      - console-types-boolean
+      - console-types-field
+      - console-types-group
+      - console-types-integers
+      - console-types-scalar
+      - console-types-string
 
   ledger-workflow:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 !**/beta-h.usrs
 !**/neg-powers-of-beta.usrs
 **/proptest-regressions/
+artifacts


### PR DESCRIPTION

## Motivation

Implements https://github.com/ProvableHQ/snarkVM/issues/2981 and also stores the timing reports as CSVs so they can be analysed.

## Test Plan

The CI passes and the timings of the different tests could be viewed.

## Documentation

The PR updates the CI configuration and modifies how tests are ran.

## Backwards compatibility

Backwards compatible.
