### PR TITLE
[Feat] Announce new blocks via IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
+name = "doctest-file"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1589,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2344,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -3669,6 +3694,7 @@ dependencies = [
  "criterion",
  "hex",
  "indexmap 2.12.0",
+ "interprocess",
  "itertools 0.14.0",
  "k256",
  "locktick",
@@ -4604,6 +4630,12 @@ dependencies = [
  "rustix 1.1.2",
  "winsafe",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ package = [
   "dep:dotenvy"
 ]
 
+announce-blocks = [ "snarkvm-synthesizer/announce-blocks" ]
 async = [ "snarkvm-ledger/async", "snarkvm-synthesizer/async" ]
 cuda = [ "snarkvm-algorithms/cuda" ]
 history = [ "snarkvm-synthesizer/history" ]

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -24,6 +24,7 @@ license = "Apache-2.0"
 edition = "2024"
 
 [features]
+announce-blocks = [ "dep:bincode", "dep:interprocess" ]
 locktick = [
   "dep:locktick",
   "snarkvm-ledger-puzzle/locktick",
@@ -116,9 +117,17 @@ workspace = true
 [dependencies.anyhow]
 workspace = true
 
+[dependencies.bincode]
+workspace = true
+optional = true
+
 [dependencies.indexmap]
 workspace = true
 features = [ "serde", "rayon" ]
+
+[dependencies.interprocess]
+version = "2.2.3"
+optional = true
 
 [dependencies.itertools]
 workspace = true

--- a/synthesizer/src/vm/helpers/sequential_op.rs
+++ b/synthesizer/src/vm/helpers/sequential_op.rs
@@ -49,7 +49,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         let ret = vm.add_next_block_inner(block);
                         #[cfg(feature = "announce-blocks")]
                         if ret.is_ok() {
-                            let _ = announce_block(&mut stream, ipc_payload);
+                            if let Err(e) = announce_block(&mut stream, ipc_payload) {
+                                error!("IPC error: {e}");
+                                // Attempt to restart the stream.
+                                stream = start_block_announcement_stream();
+                            }
                         }
                         SequentialOperationResult::AddNextBlock(ret)
                     }
@@ -164,11 +168,11 @@ fn start_block_announcement_stream() -> Option<Stream> {
 
     match Stream::connect(path) {
         Ok(stream) => {
-            debug!("Successfully started the IPC stream for block announcements");
+            debug!("Successfully (re)started the IPC stream for block announcements");
             Some(stream)
         }
         Err(e) => {
-            warn!("Couldn't start the IPC stream for block announcements: {e}");
+            warn!("Couldn't (re)start the IPC stream for block announcements: {e}");
             None
         }
     }

--- a/synthesizer/src/vm/helpers/sequential_op.rs
+++ b/synthesizer/src/vm/helpers/sequential_op.rs
@@ -45,7 +45,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 let ret = match op {
                     SequentialOperation::AddNextBlock(block) => {
                         #[cfg(feature = "announce-blocks")]
-                        let ipc_payload = (block.height(), bincode::serialize(&block).unwrap()); // Infallible.
+                        let ipc_payload = (block.height(), bincode::serialize(&block));
                         let ret = vm.add_next_block_inner(block);
                         #[cfg(feature = "announce-blocks")]
                         if ret.is_ok() {
@@ -179,9 +179,13 @@ fn start_block_announcement_stream() -> Option<Stream> {
 }
 
 #[cfg(feature = "announce-blocks")]
-fn announce_block(stream: &mut Option<Stream>, payload: (u32, Vec<u8>)) -> Result<bool> {
+fn announce_block(
+    stream: &mut Option<Stream>,
+    payload: (u32, Result<Vec<u8>, Box<bincode::ErrorKind>>),
+) -> Result<bool> {
     if let Some(stream) = stream {
-        let (block_height, block_bytes) = payload;
+        let (block_height, serialized_block) = payload;
+        let block_bytes = serialized_block?;
         debug!("Announcing block {block_height} to the IPC stream");
         let payload_size = u32::try_from(4 + block_bytes.len()).unwrap(); // Safe - blocks are smaller than 4GiB.
         stream.write_all(&payload_size.to_le_bytes())?;

--- a/synthesizer/src/vm/helpers/sequential_op.rs
+++ b/synthesizer/src/vm/helpers/sequential_op.rs
@@ -187,7 +187,7 @@ fn announce_block(
         let (block_height, serialized_block) = payload;
         let block_bytes = serialized_block?;
         debug!("Announcing block {block_height} to the IPC stream");
-        let payload_size = u32::try_from(std::mem::size_of::<u32>() + block_bytes.len()).unwrap()); // Safe - blocks are smaller than 4GiB.
+        let payload_size = u32::try_from(std::mem::size_of::<u32>() + block_bytes.len()).unwrap(); // Safe - blocks are smaller than 4GiB.
         stream.write_all(&payload_size.to_le_bytes())?;
         stream.write_all(&block_height.to_le_bytes())?;
         stream.write_all(&block_bytes)?;

--- a/synthesizer/src/vm/helpers/sequential_op.rs
+++ b/synthesizer/src/vm/helpers/sequential_op.rs
@@ -16,8 +16,12 @@
 use crate::vm::*;
 use console::network::prelude::Network;
 
+#[cfg(feature = "announce-blocks")]
+use interprocess::local_socket::{self, Stream, prelude::*};
 use std::{fmt, thread};
 use tokio::sync::oneshot;
+#[cfg(feature = "announce-blocks")]
+use tracing::*;
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Launches a thread dedicated to the sequential processing of storage-related
@@ -26,6 +30,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         &self,
         request_rx: mpsc::Receiver<SequentialOperationRequest<N>>,
     ) -> thread::JoinHandle<()> {
+        #[cfg(feature = "announce-blocks")]
+        let mut stream = start_block_announcement_stream();
+
         // Spawn a dedicated thread.
         let vm = self.clone();
         thread::spawn(move || {
@@ -37,7 +44,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Perform the queued operation.
                 let ret = match op {
                     SequentialOperation::AddNextBlock(block) => {
+                        #[cfg(feature = "announce-blocks")]
+                        let ipc_payload = (block.height(), bincode::serialize(&block).unwrap()); // Infallible.
                         let ret = vm.add_next_block_inner(block);
+                        #[cfg(feature = "announce-blocks")]
+                        if ret.is_ok() {
+                            let _ = announce_block(&mut stream, ipc_payload);
+                        }
                         SequentialOperationResult::AddNextBlock(ret)
                     }
                     SequentialOperation::AtomicSpeculate(a, b, c, d, e, f) => {
@@ -137,4 +150,43 @@ pub enum SequentialOperationResult<N: Network> {
             Vec<FinalizeOperation<N>>,
         )>,
     ),
+}
+
+#[cfg(feature = "announce-blocks")]
+fn start_block_announcement_stream() -> Option<Stream> {
+    let path = std::env::var("BLOCK_ANNOUNCE_PATH")
+        .map_err(|_| {
+            warn!("BLOCK_ANNOUNCE_PATH env variable must be set in order to publish blocks via IPC");
+        })
+        .ok()?
+        .to_fs_name::<local_socket::GenericFilePath>()
+        .expect("Invalid path provided as the BLOCK_ANNOUNCE_PATH");
+
+    match Stream::connect(path) {
+        Ok(stream) => {
+            debug!("Successfully started the IPC stream for block announcements");
+            Some(stream)
+        }
+        Err(e) => {
+            warn!("Couldn't start the IPC stream for block announcements: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(feature = "announce-blocks")]
+fn announce_block(stream: &mut Option<Stream>, payload: (u32, Vec<u8>)) -> Result<bool> {
+    if let Some(stream) = stream {
+        let (block_height, block_bytes) = payload;
+        debug!("Announcing block {block_height} to the IPC stream");
+        let payload_size = u32::try_from(4 + block_bytes.len()).unwrap(); // Safe - blocks are smaller than 4GiB.
+        stream.write_all(&payload_size.to_le_bytes())?;
+        stream.write_all(&block_height.to_le_bytes())?;
+        stream.write_all(&block_bytes)?;
+
+        Ok(true)
+    } else {
+        *stream = start_block_announcement_stream();
+        if stream.is_some() { announce_block(stream, payload) } else { Ok(false) }
+    }
 }

--- a/synthesizer/src/vm/helpers/sequential_op.rs
+++ b/synthesizer/src/vm/helpers/sequential_op.rs
@@ -187,7 +187,7 @@ fn announce_block(
         let (block_height, serialized_block) = payload;
         let block_bytes = serialized_block?;
         debug!("Announcing block {block_height} to the IPC stream");
-        let payload_size = u32::try_from(4 + block_bytes.len()).unwrap(); // Safe - blocks are smaller than 4GiB.
+        let payload_size = u32::try_from(std::mem::size_of::<u32>() + block_bytes.len()).unwrap()); // Safe - blocks are smaller than 4GiB.
         stream.write_all(&payload_size.to_le_bytes())?;
         stream.write_all(&block_height.to_le_bytes())?;
         stream.write_all(&block_bytes)?;


### PR DESCRIPTION
**Introduction**

This is a proposal for a new feature which would allow freshly inserted blocks to be streamed via an IPC socket.

**Use cases**

The expected users are those who seek to receive information on new blocks as soon as possible (e.g. block explorers), and potentially (if only transmitting further, or with some manual deserialization) without even having to depend on snarkVM. This feature can also be used in test-related tools which produce blocks, e.g. in tandem with the `testchain-generator`, for immediate consumption by other tools.

**Why not implement this in snarkOS?**

1. This feature could be used by tools which don't depend on snarkOS, custom nodes, etc.
2. Having this operation in the context of the sequential processing thread guarantees that an aggressively syncing node won't cause the block stream to become unordered.
3. This also ensures that the blocks can be streamed while syncing **via any means** (CDN, other peers), ensuring maximum stream performance after a potential downtime. This is _the_ ultimate point where block insertion happens (other than directly in the `Ledger` itself) so no other place requires the announcement code to be attached.
4. In snarkOS, blocks are normally inserted via `try_advance_to_next_block`, which then notifies other nodes via the `BlockLocators` mechanism, which means attaching this setup there would incur additional database queries and cloning (as the `Block` is not readily available).
5. snarkVM already implements the entire persistent storage, so introducing a feature-gated IPC doesn't "break the paradigm" - we're already well into I/O.

**Additional considerations**

- the blocks could be announced even before their insertion into the ledger - they could be streamed optimistically, with a tiny confirmation message being sent to the IPC once they are fully accepted
- `bincode` could be changed to some more common `serde-compatible` serialization format
- the stream currently also receives information on the baked block's height, in order to avoid having to deserialize the block; would any additional information (e.g. the hash) be practical by default?