### PR TITLE
[Fix] Remove LoggableError trait

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -3,7 +3,7 @@
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=70d441f4c # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=d25622e60 # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Exclude CLI as it has been removed
 cargo semver-checks --workspace --default-features \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -391,9 +391,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.50"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.50"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -802,9 +802,9 @@ checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -1027,9 +1027,9 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flate2"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1330,11 +1330,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1472,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1485,11 +1485,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1500,42 +1499,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1645,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1750,15 +1745,15 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2137,9 +2132,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2171,23 +2166,22 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags 2.10.0",
- "lazy_static",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2528,18 +2522,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3789,6 +3783,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
+ "colored 3.0.0",
  "num-bigint",
  "num_cpus",
  "rand 0.8.5",
@@ -3800,6 +3795,7 @@ dependencies = [
  "snarkvm-utilities-derives",
  "thiserror 2.0.17",
  "tracing",
+ "tracing-test",
  "zeroize",
 ]
 
@@ -4097,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4333,9 +4329,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
@@ -4487,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4499,24 +4495,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote 1.0.41",
- "syn 2.0.108",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4527,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote 1.0.41",
  "wasm-bindgen-macro-support",
@@ -4537,31 +4519,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote 1.0.41",
  "syn 2.0.108",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e381134e148c1062f965a42ed1f5ee933eef2927c3f70d1812158f711d39865"
+checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
 dependencies = [
  "js-sys",
  "minicov",
@@ -4572,9 +4554,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b673bca3298fe582aeef8352330ecbad91849f85090805582400850f8270a2e8"
+checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
@@ -4583,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4874,17 +4856,16 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4892,9 +4873,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
@@ -4965,9 +4946,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4976,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4987,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -527,6 +527,9 @@ version = "0.3"
 [workspace.dependencies.tracing]
 version = "0.1"
 
+[workspace.dependencies.tracing-test]
+version = "0.2.5"
+
 [workspace.dependencies.ureq]
 version = "3"
 default-features = false

--- a/ledger/src/find.rs
+++ b/ledger/src/find.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 
-use snarkvm_utilities::LoggableError;
+use snarkvm_utilities::flatten_error;
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the block height that contains the given `state root`.
@@ -131,7 +131,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 Ok(Some(commitment)) => Some((commitment, record)),
                 Ok(None) => None,
                 Err(err) => {
-                    err.log_warning(format!("Failed to process 'find_record_ciphertexts({filter:?})'"));
+                    warn!("{}", &flatten_error(err.context("Failed to process 'find_record_ciphertexts({filter:?})'")));
                     None
                 }
             }
@@ -149,7 +149,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             iter.flat_map(|(commitment, record)| match record.decrypt(view_key) {
                 Ok(record) => Some((commitment, record)),
                 Err(err) => {
-                    err.log_warning("Failed to decrypt record");
+                    warn!("{}", &flatten_error(err.context("Failed to decrypt record")));
                     None
                 }
             })

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -109,6 +109,9 @@ workspace = true
 features = [ "write" ]
 optional = true
 
+[dependencies.tracing]
+workspace = true
+
 [dev-dependencies.aleo-std]
 workspace = true
 
@@ -126,7 +129,7 @@ path = "../../ledger/test-helpers"
 workspace = true
 
 [dev-dependencies.tracing-test]
-version = "0.2.5"
+workspace = true
 
 [dev-dependencies.tracing]
 workspace = true

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -18,12 +18,13 @@
 use super::*;
 use crate::helpers::{Map, MapRead};
 
-use snarkvm_utilities::{LoggableError, bytes::unchecked_deserialize};
+use snarkvm_utilities::{bytes::unchecked_deserialize, flatten_error};
 
 use core::{fmt, fmt::Debug, hash::Hash, mem};
 use indexmap::IndexMap;
 use smallvec::SmallVec;
 use std::{borrow::Cow, ops::Deref, path::Path, sync::atomic::Ordering};
+use tracing::error;
 
 #[derive(Clone)]
 pub struct DataMap<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned>(
@@ -455,10 +456,17 @@ impl<
 
         // Deserialize the key and value.
         let key = unchecked_deserialize(&key[PREFIX_LEN..])
-            .map_err(|err| err.log_error("RocksDB Iter deserialize(key) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB Iter deserialize(key) error")));
+            })
             .ok()?;
-        let value =
-            unchecked_deserialize(value).map_err(|err| err.log_error("RocksDB Iter deserialize(value) error")).ok()?;
+        let value = unchecked_deserialize(value)
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB Iter deserialize(value) error")));
+            })
+            .ok()?;
 
         self.db_iter.next();
 
@@ -488,7 +496,10 @@ impl<'a, K: 'a + Clone + Debug + PartialEq + Eq + Hash + Serialize + Deserialize
 
         // Deserialize the key.
         let key = unchecked_deserialize(&self.db_iter.key()?[PREFIX_LEN..])
-            .map_err(|err| err.log_error("RocksDB Keys deserialize(key) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB Keys deserialize(key) error")));
+            })
             .ok()?;
 
         self.db_iter.next();
@@ -519,7 +530,10 @@ impl<'a, V: 'a + Clone + Serialize + DeserializeOwned> Iterator for Values<'a, V
 
         // Deserialize the value.
         let value = unchecked_deserialize(self.db_iter.value()?)
-            .map_err(|err| err.log_error("RocksDB Values deserialize(value) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB Values deserialize(value) error")));
+            })
             .ok()?;
 
         self.db_iter.next();

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -18,11 +18,12 @@
 use super::*;
 use crate::helpers::{NestedMap, NestedMapRead};
 use console::prelude::{FromBytes, anyhow, cfg_into_iter};
-use snarkvm_utilities::{LoggableError, bytes::unchecked_deserialize};
+use snarkvm_utilities::{bytes::unchecked_deserialize, flatten_error};
 
 use anyhow::Context;
 use core::{fmt, fmt::Debug, hash::Hash, mem};
 use std::{borrow::Cow, sync::atomic::Ordering};
+use tracing::error;
 
 #[cfg(not(feature = "serial"))]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -647,19 +648,31 @@ impl<
         let (map_key, value) = self.db_iter.item()?;
 
         // Extract the bytes belonging to the map and the key.
-        let (entry_map, entry_key) =
-            get_map_and_key(map_key).map_err(|err| err.log_error("RocksDB NestedIter get_map_and_key error")).ok()?;
+        let (entry_map, entry_key) = get_map_and_key(map_key)
+            .map_err(|err| {
+                error!("{}", &flatten_error(err.context("RocksDB Iter deserialize(key) error")));
+            })
+            .ok()?;
 
         // Deserialize the map, key, and value.
         let map = unchecked_deserialize(entry_map)
-            .map_err(|err| err.log_error("RocksDB NestedIter deserialize(map) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB NestedIter deserialize(map) error")));
+            })
             .ok()?;
         let key = unchecked_deserialize(entry_key)
-            .map_err(|err| err.log_error("RocksDB NestedIter deserialize(key) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB NestedIter deserialize(key) error")));
+            })
             .ok()?;
         // Deserialize the value.
         let value = unchecked_deserialize(value)
-            .map_err(|err| err.log_error("RocksDB NestedIter deserialize(value) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB NestedIter deserialize(value) error")));
+            })
             .ok()?;
 
         self.db_iter.next();
@@ -705,15 +718,24 @@ impl<
         let map_key = self.db_iter.key()?;
 
         // Extract the bytes belonging to the map and the key.
-        let (entry_map, entry_key) =
-            get_map_and_key(map_key).map_err(|err| err.log_error("RocksDB NestedKeys get_map_and_key error")).ok()?;
+        let (entry_map, entry_key) = get_map_and_key(map_key)
+            .map_err(|err| {
+                error!("{}", &flatten_error(err.context("RocksDB  NestedKeys get_map_and_key error")));
+            })
+            .ok()?;
 
         // Deserialize the map and key.
         let map = unchecked_deserialize(entry_map)
-            .map_err(|err| err.log_error("RocksDB NestedKeys deserialize(map) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB  NestedKeys deserialize(map) error")));
+            })
             .ok()?;
         let key = unchecked_deserialize(entry_key)
-            .map_err(|err| err.log_error("RocksDB NestedKeys deserialize(key) error"))
+            .map_err(|err| {
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB  NestedKeys deserialize(key) error")));
+            })
             .ok()?;
 
         self.db_iter.next();
@@ -747,7 +769,8 @@ impl<'a, V: 'a + Clone + Serialize + DeserializeOwned> Iterator for NestedValues
         // Deserialize the value.
         let value = unchecked_deserialize(value)
             .map_err(|err| {
-                err.log_error("RocksDB NestedValues deserialize(value) error");
+                let err: anyhow::Error = err.into();
+                error!("{}", &flatten_error(err.context("RocksDB  NestedValues deserialize(values) error")));
             })
             .ok()?;
 

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -37,6 +37,9 @@ workspace = true
 [dependencies.bincode]
 workspace = true
 
+[dependencies.colored]
+workspace = true
+
 [dependencies.num_cpus]
 version = "1"
 
@@ -74,6 +77,9 @@ default-features = false
 [dependencies.zeroize]
 workspace = true
 features = [ "derive" ]
+
+[dev-dependencies.tracing-test]
+workspace = true
 
 [features]
 default = [ "derive" ]

--- a/utilities/src/errors.rs
+++ b/utilities/src/errors.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{borrow::Borrow, fmt::Display};
+use colored::Colorize;
+use std::borrow::Borrow;
 
 /// Generates an `io::Error` from the given string.
 #[inline]
@@ -27,40 +28,19 @@ pub fn io_error<S: ToString>(err: S) -> std::io::Error {
 #[inline]
 pub fn into_io_error<E: Into<anyhow::Error>>(err: E) -> std::io::Error {
     let err: anyhow::Error = err.into();
-    std::io::Error::other(flatten_anyhow_error(&err))
+    std::io::Error::other(flatten_error(&err))
 }
 
-/// Helper function for `log_error` and `log_warning`.
+/// Converts an `anyhow::Error` into a single-line string.
+///
+/// This follows the existing convention in the codebase that joins errors using em dashes.
+/// For example, an error "Invalid transaction" with a cause "Proof failed" would be logged
+/// as "Invalid transaction — Proof failed".
 #[inline]
-fn flatten_anyhow_error<E: Borrow<anyhow::Error>>(error: E) -> String {
+pub fn flatten_error<E: Borrow<anyhow::Error>>(error: E) -> String {
     let error = error.borrow();
-    let mut output = error.to_string();
-    for next in error.chain().skip(1) {
-        output = format!("{output} — {next}");
-    }
-    output
-}
-
-/// Logs `anyhow::Error`'s its error chain using the `ERROR` log level.
-///
-/// This follows the existing convention in the codebase that joins errors using em dashes.
-/// For example, an error "Invalid transaction" with a cause "Proof failed" would be logged
-/// as "Invalid transaction — Proof failed".
-#[inline]
-#[track_caller]
-pub fn log_error<E: Borrow<anyhow::Error>>(error: E) {
-    tracing::error!("{}", flatten_anyhow_error(error));
-}
-
-/// Logs `anyhow::Error`'s its error chain using the `WARN` log level.
-///
-/// This follows the existing convention in the codebase that joins errors using em dashes.
-/// For example, an error "Invalid transaction" with a cause "Proof failed" would be logged
-/// as "Invalid transaction — Proof failed".
-#[inline]
-#[track_caller]
-pub fn log_warning<E: Borrow<anyhow::Error>>(error: E) {
-    tracing::warn!("{}", flatten_anyhow_error(error));
+    let chain = error.chain().skip(1).map(|next| next.to_string()).collect::<Vec<String>>().join(" — ");
+    format!("{error}{}", format!(" — {chain}").dimmed())
 }
 
 /// Displays an `anyhow::Error`'s main error and its error chain to stderr.
@@ -68,7 +48,8 @@ pub fn log_warning<E: Borrow<anyhow::Error>>(error: E) {
 /// This can be used to show a "pretty" error to the end user.
 #[track_caller]
 #[inline]
-pub fn display_error(error: &anyhow::Error) {
+pub fn display_error<E: Borrow<anyhow::Error>>(error: E) {
+    let error = error.borrow();
     eprintln!("⚠️ {error}");
     error.chain().skip(1).for_each(|cause| eprintln!("     ↳ {cause}"));
 }
@@ -86,55 +67,6 @@ macro_rules! ensure_equals {
             anyhow::bail!("{}: Was {} but expected {}.", $message, $actual, $expected);
         }
     };
-}
-
-/// A trait that allows printing the entire error chain of an Error (it is implemented for [`anyhow::Error`]) along with a custom context message.
-///
-/// This reduces the need for custom error printing code and ensures consistency across log messages.
-///
-/// # Example
-/// The following code will log `user-facing message - low level error` as an error.
-///
-/// ```rust
-/// use anyhow::anyhow;
-/// use snarkvm_utilities::LoggableError;
-///
-/// let my_error = anyhow!("low level problem");
-/// my_error.log_error("user-facing message");
-/// ```
-pub trait LoggableError {
-    /// Log the error with the given context and log level `ERROR`.
-    fn log_error<S: Send + Sync + Display + 'static>(self, context: S);
-    /// Log the error with the given context and log level `WARNING`.
-    fn log_warning<S: Send + Sync + Display + 'static>(self, context: S);
-    /// Log the error with the given context and log level `DEBUG`.
-    fn log_debug<S: Send + Sync + Display + 'static>(self, context: S);
-}
-
-impl<E: Into<anyhow::Error>> LoggableError for E {
-    /// Log the error with the given context and log level `ERROR`.
-    #[track_caller]
-    #[inline]
-    fn log_error<S: Send + Sync + Display + 'static>(self, context: S) {
-        let err: anyhow::Error = self.into();
-        log_error(err.context(context));
-    }
-
-    /// Log the error with the given context and log level `WARNING`.
-    #[track_caller]
-    #[inline]
-    fn log_warning<S: Send + Sync + Display + 'static>(self, context: S) {
-        let err: anyhow::Error = self.into();
-        log_warning(err.context(context));
-    }
-
-    /// Log the error with the given context and log level `DEBUG`.
-    #[track_caller]
-    #[inline]
-    fn log_debug<S: Send + Sync + Display + 'static>(self, context: S) {
-        let err: anyhow::Error = self.into();
-        log_warning(err.context(context));
-    }
 }
 
 /// A trait to provide a nicer way to unwarp `anyhow::Result`.
@@ -187,18 +119,20 @@ impl<T> PrettyUnwrap for anyhow::Result<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{PrettyUnwrap, flatten_anyhow_error, pretty_panic};
+    use super::{PrettyUnwrap, flatten_error, pretty_panic};
 
     use anyhow::{Context, Result, anyhow, bail};
+    use colored::Colorize;
 
     const ERRORS: [&str; 3] = ["Third error", "Second error", "First error"];
 
     #[test]
-    fn flatten_error() {
-        let expected = format!("{} — {} — {}", ERRORS[0], ERRORS[1], ERRORS[2]);
+    fn test_flatten_error() {
+        // First error should be printed regularly, the other two dimmed.
+        let expected = format!("{}{}", ERRORS[0], format!(" — {} — {}", ERRORS[1], ERRORS[2]).dimmed());
 
         let my_error = anyhow!(ERRORS[2]).context(ERRORS[1]).context(ERRORS[0]);
-        let result = flatten_anyhow_error(&my_error);
+        let result = flatten_error(&my_error);
 
         assert_eq!(result, expected);
     }


### PR DESCRIPTION
Following the discussion in #2992, this PR removes the `LoggableError` trait. To get a similar behavior, one can still call `flatten_error` and pass it to a logging macro, such as `error!`.