### PR TITLE
Skip proof and certificate generation and verification if building with dev_skip_checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ dev_skip_checks = [
 save_r1cs_hashes = [ "snarkvm-circuit/save_r1cs_hashes" ]
 test_exports = [ "snarkvm-algorithms/test_exports" ]
 test_targets = [ "snarkvm-console/test_targets" ]
-test_consensus_heights = [ "snarkvm-console/test_consensus_heights" ]
+test_consensus_heights = [ "snarkvm-console/test_consensus_heights", "snarkvm-synthesizer/test_consensus_heights" ]
 
 [workspace.dependencies.snarkvm-algorithms]
 path = "algorithms"

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -60,6 +60,7 @@ wasm = [
 ]
 dev-print = [ "snarkvm-utilities/dev-print" ]
 dev_skip_checks = [ "snarkvm-synthesizer-process/dev_skip_checks" ]
+test_consensus_heights = [ "snarkvm-synthesizer-process/test_consensus_heights" ]
 
 [[bench]]
 name = "kary_merkle_tree"

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -47,6 +47,7 @@ test = [ "snarkvm-console/test" ]
 timer = [ "aleo-std/timer" ]
 dev-print = [ "snarkvm-utilities/dev-print" ]
 dev_skip_checks = [ ]
+test_consensus_heights = [ ]
 
 [[bench]]
 name = "stack_operations"

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -64,10 +64,18 @@ impl<N: Network> Stack<N> {
     ) -> Result<()> {
         let timer = timer!("Stack::verify_deployment");
 
+        // NOTE: As developer, you will likely still want to confirm that your
+        // deployment is within R1CS constraint and variable limits using
+        // targeted and parallelized synthesis.
+        if cfg!(feature = "dev_skip_checks") {
+            return Ok(());
+        }
+
         // Sanity Checks //
 
         // Ensure the deployment is ordered.
         deployment.check_is_ordered()?;
+
         // Ensure the program in the stack and deployment matches.
         ensure!(&self.program == deployment.program(), "The stack program does not match the deployment program");
         // If the deployment contains a checksum, ensure it matches the one computed by the stack.

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -67,7 +67,7 @@ impl<N: Network> Stack<N> {
         // NOTE: As developer, you will likely still want to confirm that your
         // deployment is within R1CS constraint and variable limits using
         // targeted and parallelized synthesis.
-        if cfg!(feature = "dev_skip_checks") {
+        if cfg!(all(feature = "dev_skip_checks", feature = "test_consensus_heights")) {
             return Ok(());
         }
 

--- a/synthesizer/process/src/trace/mod.rs
+++ b/synthesizer/process/src/trace/mod.rs
@@ -237,7 +237,7 @@ impl<N: Network> Trace<N> {
         verifier_inputs: Vec<(VerifyingKey<N>, Vec<Vec<N::Field>>)>,
         execution: &Execution<N>,
     ) -> Result<()> {
-        if cfg!(feature = "dev_skip_checks") {
+        if cfg!(all(feature = "dev_skip_checks", feature = "test_consensus_heights")) {
             return Ok(());
         }
         // Retrieve the global state root.
@@ -271,7 +271,7 @@ impl<N: Network> Trace<N> {
         verifier_inputs: (VerifyingKey<N>, Vec<Vec<N::Field>>),
         fee: &Fee<N>,
     ) -> Result<()> {
-        if cfg!(feature = "dev_skip_checks") {
+        if cfg!(all(feature = "dev_skip_checks", feature = "test_consensus_heights")) {
             return Ok(());
         }
         // Retrieve the global state root.


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/ProvableHQ/snarkVM/pull/2998

In order to accelerate testing of Leo programs, as well as extend prototyping in unit tests, we extend a feature flag `dev_skip_checks` to skip proof and certificate generation and verification.

NOTE: As developer, you will likely still want to confirm that your deployment is within R1CS constraint and variable limits, so we should build tooling for `leo synthesize` which synthesizes and checks all functions in parallel. 

## Test Plan

- [x] Integrate in `leo devnode`
