### PR TITLE
[Feat] Facilitate RocksDB's secondary instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,11 +426,13 @@ path = "wasm"
 version = "=4.3.0"
 
 [workspace.dependencies.aleo-std]
-version = "1.0.1"
+git = "https://github.com/ljedrz/aleo-std.git"
+branch = "feat/secondary_storage"
+features = ["storage"]
 
 [workspace.dependencies.aleo-std-storage]
-default-features=false
-version = "1.0.1"
+git = "https://github.com/ljedrz/aleo-std.git"
+branch = "feat/secondary_storage"
 
 [workspace.dependencies.anyhow]
 version = "1.0.73"

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -92,7 +92,7 @@ workspace = true
 workspace = true
 
 [dependencies.rocksdb]
-version = "0.21"
+version = "0.24"
 default-features = false
 features = [ "lz4" ]
 optional = true

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -136,10 +136,48 @@ impl Database for RocksDB {
     fn open<S: Into<StorageMode>>(network_id: u16, storage: S) -> Result<Self> {
         let storage = storage.into();
 
-        // Retrieve the database.
-        let db_path = aleo_std_storage::aleo_ledger_dir(network_id, &storage);
+        // Obtain the path to the primary instance.
+        let primary_path = aleo_std_storage::aleo_ledger_dir(network_id, &storage);
+        // Obtain the path to the secondary instance, if applicable.
+        let secondary_path = aleo_std_storage::aleo_secondary_ledger_dir(network_id, &storage);
+
+        // If the secondary path is given, open the database in secondary mode.
+        if let Some(secondary_path) = secondary_path {
+            let mut databases = DATABASES.lock();
+            let database = if let Some(db) = databases.get(&secondary_path) {
+                db.clone()
+            } else {
+                // Customize database options.
+                let mut db_opts = rocksdb::Options::default();
+                db_opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+
+                // Register the prefix length.
+                let prefix_extractor = rocksdb::SliceTransform::create_fixed_prefix(PREFIX_LEN);
+                db_opts.set_prefix_extractor(prefix_extractor);
+
+                let rocksdb = Arc::new(rocksdb::DB::open_as_secondary(&db_opts, &primary_path, &secondary_path)?);
+
+                let db = RocksDB {
+                    rocksdb,
+                    network_id,
+                    storage_mode: storage.clone(),
+                    atomic_batch: Default::default(),
+                    atomic_depth: Default::default(),
+                    atomic_writes_paused: Default::default(),
+                    default_readopts: Default::default(),
+                };
+
+                databases.insert(secondary_path.clone(), db.clone());
+
+                db
+            };
+
+            return Ok(database);
+        }
+
+        // Open the database in primary mode.
         let mut databases = DATABASES.lock();
-        let database = if let Some(db) = databases.get(&db_path) {
+        let database = if let Some(db) = databases.get(&primary_path) {
             db.clone()
         } else {
             // Customize database options.
@@ -156,7 +194,7 @@ impl Database for RocksDB {
                 options.create_if_missing(true);
                 options.set_max_open_files(8192);
 
-                Arc::new(rocksdb::DB::open(&options, &db_path)?)
+                Arc::new(rocksdb::DB::open(&options, &primary_path)?)
             };
 
             let db = RocksDB {
@@ -169,7 +207,7 @@ impl Database for RocksDB {
                 default_readopts: Default::default(),
             };
 
-            databases.insert(db_path.clone(), db.clone());
+            databases.insert(primary_path.clone(), db.clone());
 
             db
         };

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -673,10 +673,12 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
         // Initialize the deployment storage.
         let storage = D::open(fee_store)?;
 
-        // Insert `credits.aleo`, which is the default program.
-        let credits_id = ProgramID::from_str("credits.aleo")?;
-        storage.edition_map().insert(credits_id, 0)?;
-        storage.program_map().insert((credits_id, 0), Program::credits()?)?;
+        if !matches!(storage.storage_mode(), StorageMode::Custom(_, Some(_))) {
+            // Insert `credits.aleo`, which is the default program.
+            let credits_id = ProgramID::from_str("credits.aleo")?;
+            storage.edition_map().insert(credits_id, 0)?;
+            storage.program_map().insert((credits_id, 0), Program::credits()?)?;
+        }
 
         // Return the deployment store.
         Ok(Self { storage, _phantom: PhantomData })

--- a/ledger/testchain-generator/src/main.rs
+++ b/ledger/testchain-generator/src/main.rs
@@ -88,7 +88,7 @@ fn generate_testchain<N: Network>(args: Args) -> Result<()> {
     };
 
     let storage_mode = if let Some(path) = args.storage_path.clone() {
-        StorageMode::Custom(path.into())
+        StorageMode::Custom(path.into(), None)
     } else {
         StorageMode::Development(0)
     };

--- a/synthesizer/src/vm/helpers/history.rs
+++ b/synthesizer/src/vm/helpers/history.rs
@@ -31,7 +31,7 @@ pub fn history_directory_path(network: u16, storage_mode: &StorageMode) -> PathB
     // Create the name of the history directory.
     let directory_name = match &storage_mode {
         StorageMode::Development(id) => format!(".{HISTORY_DIRECTORY_NAME}-{network}-{id}"),
-        StorageMode::Production | StorageMode::Custom(_) => format!("{HISTORY_DIRECTORY_NAME}-{network}"),
+        StorageMode::Production | StorageMode::Custom(..) => format!("{HISTORY_DIRECTORY_NAME}-{network}"),
         StorageMode::Test(_) => unimplemented!(),
     };
 


### PR DESCRIPTION
This PR enables support for RocksDB's [secondary instances](https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances). This could be used by all sorts of tools that require an insight into the storage of a running node.

Filing as a draft, as it depends on a pending [`aleo-std` PR](https://github.com/ProvableHQ/aleo-std/pull/17).