### PR TITLE
[Chore] baseline revision for semver checks

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -3,7 +3,7 @@
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=d25622e60 # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=678e813 # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Exclude CLI as it has been removed
 cargo semver-checks --workspace --default-features \


### PR DESCRIPTION
Currently, the baseline revision for semver checks is incorrect (maybe because a branch got deleted?). This PR updates the baseline revision to the most recent commit on `staging`.