### PR TITLE
[Feat] Restore PendingBlocks API

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-BASELINE_REV=5eb528f # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=acd55ad100550 # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked

--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -2,10 +2,12 @@
 
 set -x
 
+BASELINE_REV=5eb528f # UPDATE ME ON NECESSARY BREAKING CHANGES
+
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=5eb528f # UPDATE ME ON NECESSARY BREAKING CHANGES
+# Ensure we can find the baseline revision
+git fetch --unshallow || true
 
-# Exclude CLI as it has been removed
 cargo semver-checks --workspace --default-features --baseline-rev $BASELINE_REV

--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -1,10 +1,11 @@
 #! /bin/bash
 
+set -x
+
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked
 
-BASELINE_REV=dec54170ce # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=5eb528f # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Exclude CLI as it has been removed
-cargo semver-checks --workspace --default-features \
-  --exclude=snarkvm-cli --baseline-rev $BASELINE_REV
+cargo semver-checks --workspace --default-features --baseline-rev $BASELINE_REV

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -19,24 +19,111 @@ use crate::narwhal::BatchHeader;
 
 use anyhow::{Context, bail};
 
+/// Wrapper for a block that has a valid subDAG, but where the block header,
+/// solutions, and transmissions have not been verified yet.
+///
+/// This type is created by `Ledger::check_block_subdag` and consumed by `Ledger::check_block_content`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PendingBlock<N: Network>(Block<N>);
+
+impl<N: Network> Deref for PendingBlock<N> {
+    type Target = Block<N>;
+
+    fn deref(&self) -> &Block<N> {
+        &self.0
+    }
+}
+
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
-    /// Checks the given block is valid next block.
+    /// Checks that the subDAG in a given block is valid, but does not fully verify the block.
+    ///
+    /// # Arguments
+    /// * `block` - The block to check.
+    /// * `pending_block` - A sequence of blocks between the block to check and the current height of the ledger.
+    ///
+    /// # Notes
+    /// * This does *not* check that the header of the block is correct or execute/verify any of the transmissions contained within it.
+    ///
+    /// * In most cases, you want to use [`Self::check_next_block`] instead to perform a full verification.
+    ///
+    /// * This will reject any blocks with a height <= the current height and any blocks with a height >= the current height + GC.
+    ///   For the former, a valid block already exists and,
+    ///   for the latter, the comittte is still unknown.
+    pub fn check_block_subdag(&self, block: Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        self.check_block_subdag_inner(&block, pending_blocks)?;
+        Ok(PendingBlock(block))
+    }
+
+    fn check_block_subdag_inner(&self, block: &Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<()> {
+        // First check that the heights and hashes of the pending block sequence and of the new block are correct.
+        // The hash checks should be redundant, but we perform them out of extra caution.
+        let mut expected_height = self.latest_height() + 1;
+        for pending in pending_blocks {
+            if pending.height() != expected_height {
+                bail!(
+                    "Pending block has invalid height. Expected {expected_height}, but got {actual}.",
+                    actual = pending.height()
+                );
+            }
+
+            if self.contains_block_hash(&pending.hash())? {
+                bail!("Hash for pending block '{}' already exists in the ledger", block.hash())
+            }
+
+            expected_height += 1;
+        }
+
+        if self.contains_block_hash(&block.hash())? {
+            bail!("Block hash '{}' already exists in the ledger", block.hash())
+        }
+
+        if block.height() != expected_height {
+            bail!("Block has invalid height. Expected {expected_height}, but got {}.", block.height());
+        }
+
+        // Ensure the certificates in the block subdag have met quorum requirements.
+        self.check_block_subdag_quorum(block)?;
+
+        // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
+        self.check_block_subdag_atomicity(block)?;
+
+        // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
+        self.check_block_subdag_leaves(block, pending_blocks)?;
+
+        Ok(())
+    }
+
+    /// Checks the given block is a valid next block with regard to the current state/height of the Ledger.
     ///
     /// # Panics
     /// This function panics if called from an async context.
     pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
-        let height = block.height();
+        self.check_block_subdag_inner(block, &[])?;
+        self.check_block_content_inner(block, rng)?;
+
+        Ok(())
+    }
+
+    /// Takes a pending block and performs the remaining checks to full verify it.
+    ///
+    /// # Arguments
+    /// This takes a [`PendingBlock`] as input, which is the output of a successful call to [`Self::check_block_subdag`].
+    /// The latter already verified the block's DAG and certificate signatures.
+    ///
+    /// # Return Value
+    /// This returns a [`Block`] on success representing the fully verified block.
+    ///
+    /// # Panics
+    /// This function panics if called from an async context.
+    pub fn check_block_content<R: CryptoRng + Rng>(&self, block: PendingBlock<N>, rng: &mut R) -> Result<Block<N>> {
+        self.check_block_content_inner(&block.0, rng)?;
+        Ok(block.0)
+    }
+
+    /// # Panics
+    /// This function panics if called from an async context.
+    fn check_block_content_inner<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
         let latest_block = self.latest_block();
-
-        // Check that this is actually the next block.
-        if height != latest_block.height() + 1 {
-            bail!("Block height is {height}, but expected {}", latest_block.height() + 1);
-        }
-
-        // Ensure the block hash does not already exist.
-        if self.contains_block_hash(&block.hash())? {
-            bail!("Block hash '{}' already exists in the ledger", block.hash())
-        }
 
         // Ensure the solutions do not already exist.
         for solution_id in block.solutions().solution_ids() {
@@ -115,15 +202,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
         }
 
-        // Ensure the certificates in the block subdag have met quorum requirements.
-        self.check_block_subdag_quorum(block)?;
-
-        // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
-        self.check_block_subdag_atomicity(block)?;
-
-        // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
-        self.check_block_subdag_leaves(block)?;
-
         // Ensure that each existing solution ID from the block exists in the ledger.
         for existing_solution_id in expected_existing_solution_ids {
             if !self.contains_solution_id(&existing_solution_id)? {
@@ -145,11 +223,20 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// This does not verify that the batches are signed correctly or that the edges are valid
     /// (only point to the previous round), as those checks already happened when the node received the batch.
-    fn check_block_subdag_leaves(&self, block: &Block<N>) -> Result<()> {
+    fn check_block_subdag_leaves(&self, block: &Block<N>, previous_blocks: &[PendingBlock<N>]) -> Result<()> {
         // Check if the block has a subdag.
         let Authority::Quorum(subdag) = block.authority() else {
             return Ok(());
         };
+
+        let previous_certs: HashSet<_> = previous_blocks
+            .iter()
+            .filter_map(|block| match block.authority() {
+                Authority::Quorum(subdag) => Some(subdag.certificate_ids()),
+                Authority::Beacon(_) => None,
+            })
+            .flatten()
+            .collect();
 
         // Store the IDs of all certificates in this subDAG.
         // This allows determining which edges point to other subDAGs/blocks.
@@ -173,7 +260,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
 
             // Ensure that the certificate is associated with a previous block.
-            if !self.vm.block_store().contains_block_for_certificate(prev_id)? {
+            if !previous_certs.contains(prev_id) && !self.vm.block_store().contains_block_for_certificate(prev_id)? {
                 bail!(
                     "Batch(es) in the block point(s) to a certificate {prev_id} in round {prev_round} that is not associated with a previous block"
                 )
@@ -184,6 +271,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Check that the certificates in the block subdag have met quorum requirements.
+    ///
+    /// Called by [`Self::check_block_subdag`]
     fn check_block_subdag_quorum(&self, block: &Block<N>) -> Result<()> {
         // Check if the block has a subdag.
         let subdag = match block.authority() {
@@ -226,6 +315,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Checks that the block subdag can not be split into multiple valid subdags.
+    ///
+    /// Called by [`Self::check_block_subdag`]
     fn check_block_subdag_atomicity(&self, block: &Block<N>) -> Result<()> {
         // Returns `true` if there is a path from the previous certificate to the current certificate.
         fn is_linked<N: Network>(

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -37,8 +37,10 @@ pub use helpers::*;
 
 pub use crate::block::*;
 
-mod advance;
 mod check_next_block;
+pub use check_next_block::PendingBlock;
+
+mod advance;
 mod check_transaction_basic;
 mod contains;
 mod find;

--- a/ledger/tests/helpers/mod.rs
+++ b/ledger/tests/helpers/mod.rs
@@ -1,0 +1,300 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use aleo_std::StorageMode;
+use snarkvm_console::{
+    account::{Address, PrivateKey},
+    network::MainnetV0,
+    prelude::*,
+};
+use snarkvm_ledger::{Block, Ledger};
+use snarkvm_ledger_narwhal::{BatchCertificate, BatchHeader, Subdag};
+use snarkvm_ledger_store::ConsensusStore;
+use snarkvm_synthesizer::vm::VM;
+
+use indexmap::{IndexMap, IndexSet};
+use std::collections::{BTreeMap, HashMap};
+use time::OffsetDateTime;
+
+pub type CurrentNetwork = MainnetV0;
+
+#[cfg(not(feature = "rocks"))]
+pub type LedgerType<N> = snarkvm_ledger_store::helpers::memory::ConsensusMemory<N>;
+#[cfg(feature = "rocks")]
+pub type LedgerType<N> = snarkvm_ledger_store::helpers::rocksdb::ConsensusDB<N>;
+
+/// Helper to build chains with custom structures for testing.
+pub struct TestChainBuilder {
+    /// The keys of all validators.
+    private_keys: Vec<PrivateKey<CurrentNetwork>>,
+    /// The underlying ledger.
+    ledger: Ledger<CurrentNetwork, LedgerType<CurrentNetwork>>,
+    /// The round containing the leader certificate for the most recent block we generated.
+    last_block_round: u64,
+    /// The batch certificates of the last round we generated.
+    round_to_certificates: HashMap<u64, IndexMap<usize, BatchCertificate<CurrentNetwork>>>,
+    /// The batch certificate of the last leader (if any).
+    previous_leader_certificate: Option<BatchCertificate<CurrentNetwork>>,
+    /// The last round for each committee member where they created a batch.
+    /// Invariant: for any validator i, last_batch[i] <= last_committed_batch[i]
+    last_batch_round: HashMap<usize, u64>,
+    /// The last batch of a validator that was included in a block.
+    last_committed_batch_round: HashMap<usize, u64>,
+    /// The start of the test chain.
+    genesis_block: Block<CurrentNetwork>,
+}
+
+/// Additional options you can pass to the builder when generating blocks.
+#[derive(Default)]
+pub struct BlockOptions {
+    /// Do not include votes to the previous leader certificate
+    pub skip_votes: bool,
+    /// Do not generate certificates for the specific node indices (to simulate a partition).
+    pub skip_nodes: Vec<usize>,
+}
+
+impl TestChainBuilder {
+    pub fn new(committee_size: usize, rng: &mut TestRng) -> Self {
+        // Sample the genesis private key.
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        // Initialize the store.
+        let store = ConsensusStore::<_, LedgerType<_>>::open(StorageMode::new_test(None)).unwrap();
+        // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
+        let seed: u64 = rng.r#gen();
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let genesis_block = VM::from(store).unwrap().genesis_beacon(&private_key, genesis_rng).unwrap();
+
+        // Extract the private keys from the genesis committee by using the same RNG to sample private keys.
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let private_keys = (0..committee_size).map(|_| PrivateKey::new(genesis_rng).unwrap()).collect();
+
+        Self::from_genesis(private_keys, genesis_block)
+    }
+
+    /// Initialize the builder with the specified committee and gensis block
+    pub fn from_genesis(private_keys: Vec<PrivateKey<CurrentNetwork>>, genesis_block: Block<CurrentNetwork>) -> Self {
+        // Initialize the ledger with the genesis block.
+        let ledger = Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(
+            genesis_block.clone(),
+            StorageMode::new_test(None),
+        )
+        .unwrap();
+
+        Self {
+            private_keys,
+            ledger,
+
+            genesis_block,
+            last_batch_round: Default::default(),
+            last_committed_batch_round: Default::default(),
+            last_block_round: 0,
+            round_to_certificates: Default::default(),
+            previous_leader_certificate: Default::default(),
+        }
+    }
+
+    /// Create multiple blocks, with fully-connected DAGs.
+    #[allow(dead_code)]
+    pub fn generate_blocks(&mut self, num_blocks: usize, rng: &mut TestRng) -> Vec<Block<CurrentNetwork>> {
+        self.generate_blocks_with_opts(num_blocks, &BlockOptions::default(), rng)
+    }
+
+    /// Create multiple blocks, with additional parameters.
+    pub fn generate_blocks_with_opts(
+        &mut self,
+        num_blocks: usize,
+        options: &BlockOptions,
+        rng: &mut TestRng,
+    ) -> Vec<Block<CurrentNetwork>> {
+        assert!(num_blocks > 0, "Need to build at least one block");
+
+        (0..num_blocks).map(|_| self.generate_block_with_opts(options, rng)).collect()
+    }
+
+    /// Create a new block, with a fully-connected DAG.
+    ///
+    /// This will "fill in" any gaps left in earlier rounds from non participating nodes.
+    pub fn generate_block(&mut self, rng: &mut TestRng) -> Block<CurrentNetwork> {
+        self.generate_block_with_opts(&BlockOptions::default(), rng)
+    }
+
+    /// Same as `generate_block` but with additional options/parameters.
+    pub fn generate_block_with_opts(&mut self, options: &BlockOptions, rng: &mut TestRng) -> Block<CurrentNetwork> {
+        assert!(
+            options.skip_nodes.len() * 3 < self.private_keys.len(),
+            "Cannot mark more than f nodes as unavailable/skipped"
+        );
+
+        let next_block_round = self.last_block_round + 2;
+
+        // SubDAGs can be at most GC rounds long.
+        let mut round = if next_block_round < BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64 {
+            // Batches from genesis round cannot be included in any block that isn't genesis
+            1
+        } else {
+            next_block_round - BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64
+        };
+
+        // =======================================
+        // Create certificates for the new block.
+        // =======================================
+        loop {
+            let mut created_anchor = false;
+
+            let previous_certificate_ids = if round == 1 {
+                IndexSet::default()
+            } else {
+                self.round_to_certificates
+                    .get(&(round - 1))
+                    .unwrap()
+                    .iter()
+                    .filter_map(|(_, cert)| {
+                        // If votes are skipped, remove previous leader cert from the set.
+                        let skip = if let Some(leader) = &self.previous_leader_certificate {
+                            options.skip_votes && leader.id() == cert.id()
+                        } else {
+                            false
+                        };
+
+                        if skip { None } else { Some(cert.id()) }
+                    })
+                    .collect()
+            };
+
+            let committee = self.ledger.get_committee_lookback_for_round(round).unwrap().unwrap_or_else(|| {
+                panic!("No committee for round {round}");
+            });
+
+            for (key1_idx, private_key_1) in self.private_keys.iter().enumerate() {
+                if options.skip_nodes.contains(&key1_idx) {
+                    continue;
+                }
+                // Don't recreate batches that already exist.
+                if self.last_batch_round.get(&key1_idx).unwrap_or(&0) >= &round {
+                    continue;
+                }
+
+                let batch_header = BatchHeader::new(
+                    private_key_1,
+                    round,
+                    OffsetDateTime::now_utc().unix_timestamp(),
+                    committee.id(),
+                    Default::default(),
+                    previous_certificate_ids.clone(),
+                    rng,
+                )
+                .unwrap();
+
+                // Add signatures for the batch header.
+                let signatures = self
+                    .private_keys
+                    .iter()
+                    .enumerate()
+                    .filter(|&(key2_idx, _)| key1_idx != key2_idx)
+                    .map(|(_, private_key_2)| private_key_2.sign(&[batch_header.batch_id()], rng).unwrap())
+                    .collect();
+
+                // Update the round at which this validator last created a batch.
+                self.last_batch_round.insert(key1_idx, round);
+
+                // Insert certificate into the round_to_certificates mapping.
+                self.round_to_certificates
+                    .entry(round)
+                    .or_default()
+                    .insert(key1_idx, BatchCertificate::from(batch_header, signatures).unwrap());
+
+                // Check if this batch was an anchor.
+                if round % 2 == 0 {
+                    let leader = committee.get_leader(round).unwrap();
+                    if leader == Address::try_from(private_key_1).unwrap() {
+                        created_anchor = true;
+                    }
+                }
+            }
+
+            // Anchor was confirmed by more than a third of the validators.
+            if created_anchor && round % 2 == 0 && self.last_block_round < round {
+                self.last_block_round = round;
+                break;
+            }
+
+            round += 1;
+        }
+
+        // ==============================================================
+        // Build a subdag from the new certificates and create the block.
+        // ==============================================================
+        let commit_round = round;
+
+        let leader_committee = self.ledger.get_committee_lookback_for_round(round).unwrap().unwrap();
+        let leader = leader_committee.get_leader(commit_round).unwrap();
+        let (leader_idx, leader_certificate) =
+            self.round_to_certificates.get(&commit_round).unwrap().iter().find(|(_, c)| c.author() == leader).unwrap();
+        let leader_idx = *leader_idx;
+        let leader_certificate = leader_certificate.clone();
+
+        // Construct the subdag for the new block.
+        let mut subdag_map = BTreeMap::new();
+
+        // Figure out what the earliest round for the subDAG could be.
+        let start_round = if commit_round < BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64 {
+            1
+        } else {
+            commit_round - BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64 + 2
+        };
+
+        for round in start_round..commit_round {
+            let mut to_insert = IndexSet::new();
+            for idx in 0..self.private_keys.len() {
+                // Some of the batches we in previous rounds might not be new,
+                // and already included in a previous block.
+                let cround = self.last_committed_batch_round.entry(idx).or_default();
+                // Batch already included in another block
+                if *cround >= round {
+                    continue;
+                }
+
+                if let Some(cert) = self.round_to_certificates.entry(round).or_default().get(&idx) {
+                    to_insert.insert(cert.clone());
+                    *cround = round;
+                }
+            }
+            if !to_insert.is_empty() {
+                subdag_map.insert(round, to_insert);
+            }
+        }
+
+        // Add the leader certificate.
+        // (special case, because it is the only cert included from the commit round)
+        subdag_map.insert(commit_round, [leader_certificate.clone()].into());
+        self.last_committed_batch_round.insert(leader_idx, commit_round);
+
+        // Construct the block.
+        let subdag = Subdag::from(subdag_map).unwrap();
+        let block = self.ledger.prepare_advance_to_next_quorum_block(subdag, Default::default(), rng).unwrap();
+        self.ledger.check_next_block(&block, rng).unwrap();
+
+        // Update th ledger state.
+        self.ledger.advance_to_next_block(&block).unwrap();
+        self.previous_leader_certificate = Some(leader_certificate.clone());
+
+        block
+    }
+
+    /// Return the genesis block associated with the test chain
+    pub fn genesis_block(&self) -> &Block<CurrentNetwork> {
+        &self.genesis_block
+    }
+}

--- a/ledger/tests/pending_blocks.rs
+++ b/ledger/tests/pending_blocks.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod helpers;
+use helpers::{BlockOptions, CurrentNetwork, LedgerType, TestChainBuilder};
+
+use snarkvm_ledger::Ledger;
+
+use aleo_std::StorageMode;
+use snarkvm_utilities::TestRng;
+
+#[test]
+fn test_preprocess_block() {
+    let rng = &mut TestRng::default();
+
+    let mut builder = TestChainBuilder::new(4, rng);
+
+    // Construct the ledger.
+    let ledger = Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(
+        builder.genesis_block().clone(),
+        StorageMode::new_test(None),
+    )
+    .unwrap();
+
+    // Generate a bunch of blocks that do not contain votes
+    let mut pending_blocks = vec![];
+
+    for block in builder.generate_blocks_with_opts(5, &BlockOptions { skip_votes: true, ..Default::default() }, rng) {
+        if !pending_blocks.is_empty() {
+            // We shoud only be able to pre-process a pending block if the previous
+            // blocks are applied to the ledger or in the pending set
+            assert!(ledger.check_block_subdag(block.clone(), &[]).is_err());
+        }
+
+        let pending_block = ledger.check_block_subdag(block, &pending_blocks).unwrap();
+        pending_blocks.push(pending_block);
+    }
+
+    // Now, create a "vote block" that contains sufficient votes to the previous leader block
+    let vote_block = builder.generate_block(rng);
+    assert!(ledger.check_next_block(&vote_block, rng).is_err());
+
+    for pending in pending_blocks.into_iter() {
+        let block = ledger.check_block_content(pending, rng).expect("Pending block should be accepted");
+        assert!(ledger.advance_to_next_block(&block).is_ok());
+    }
+
+    // Now the commit block should be accepted
+    assert!(ledger.check_next_block(&vote_block, rng).is_ok());
+    assert!(ledger.advance_to_next_block(&vote_block).is_ok());
+}


### PR DESCRIPTION
Now that #2975 and #2971 are merged, we can also re-enable the API to pre-process blocks.

There is a companion PR in snarkOS (https://github.com/ProvableHQ/snarkOS/pull/3983) to test these changes.