### PR TITLE
[Perf] More unchecked deserialization from the DB

### DIFF
--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -686,6 +686,11 @@ impl<E: PairingEngine> FromBytes for BatchLCProof<E> {
         CanonicalDeserialize::deserialize_compressed(&mut reader)
             .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize struct")))
     }
+
+    fn read_le_unchecked<R: Read>(mut reader: R) -> io::Result<Self> {
+        CanonicalDeserialize::deserialize_compressed_unchecked(&mut reader)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize struct")))
+    }
 }
 
 impl<E: PairingEngine> ToBytes for BatchLCProof<E> {

--- a/algorithms/src/snark/varuna/data_structures/certificate.rs
+++ b/algorithms/src/snark/varuna/data_structures/certificate.rs
@@ -44,4 +44,9 @@ impl<E: PairingEngine> FromBytes for Certificate<E> {
         Self::deserialize_compressed(&mut r)
             .map_err(|err| into_io_error(anyhow::Error::from(err).context("Failed to deserialize certificate")))
     }
+
+    fn read_le_unchecked<R: Read>(mut r: R) -> io::Result<Self> {
+        Self::deserialize_compressed_unchecked(&mut r)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("Failed to deserialize certificate")))
+    }
 }

--- a/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/varuna/data_structures/circuit_verifying_key.rs
@@ -43,6 +43,11 @@ impl<E: PairingEngine> FromBytes for CircuitVerifyingKey<E> {
         Self::deserialize_compressed(r)
             .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize CircuitVerifyingKey")))
     }
+
+    fn read_le_unchecked<R: Read>(r: R) -> io::Result<Self> {
+        Self::deserialize_compressed_unchecked(r)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize CircuitVerifyingKey")))
+    }
 }
 
 impl<E: PairingEngine> ToBytes for CircuitVerifyingKey<E> {

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -379,6 +379,11 @@ impl<E: PairingEngine> FromBytes for Proof<E> {
         Self::deserialize_compressed(&mut r)
             .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize Proof")))
     }
+
+    fn read_le_unchecked<R: Read>(mut r: R) -> io::Result<Self> {
+        Self::deserialize_compressed_unchecked(&mut r)
+            .map_err(|err| into_io_error(anyhow::Error::from(err).context("could not deserialize Proof")))
+    }
 }
 
 /// Computes the size in bytes of a Varuna proof as produced by

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -34,7 +34,7 @@ use console::{
         Error,
         Formatter,
         FromBytes,
-        FromBytesDeserializer,
+        FromBytesUncheckedDeserializer,
         FromStr,
         IoResult,
         Read,

--- a/ledger/authority/src/serialize.rs
+++ b/ledger/authority/src/serialize.rs
@@ -59,7 +59,7 @@ impl<'de, N: Network> Deserialize<'de> for Authority<N> {
                     _ => Err(de::Error::custom(error("Invalid authority type"))),
                 }
             }
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "authority"),
+            false => FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "authority"),
         }
     }
 }

--- a/synthesizer/snark/src/certificate/bytes.rs
+++ b/synthesizer/snark/src/certificate/bytes.rs
@@ -29,6 +29,19 @@ impl<N: Network> FromBytes for Certificate<N> {
         // Return the certificate.
         Ok(Self { certificate })
     }
+
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid certificate version"));
+        }
+        // Read the certificate.
+        let certificate = FromBytes::read_le_unchecked(&mut reader)?;
+        // Return the certificate.
+        Ok(Self { certificate })
+    }
 }
 
 impl<N: Network> ToBytes for Certificate<N> {

--- a/synthesizer/snark/src/certificate/serialize.rs
+++ b/synthesizer/snark/src/certificate/serialize.rs
@@ -30,7 +30,9 @@ impl<'de, N: Network> Deserialize<'de> for Certificate<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "certificate"),
+            false => {
+                FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "certificate")
+            }
         }
     }
 }

--- a/synthesizer/snark/src/proof/bytes.rs
+++ b/synthesizer/snark/src/proof/bytes.rs
@@ -29,6 +29,19 @@ impl<N: Network> FromBytes for Proof<N> {
         // Return the proof.
         Ok(Self { proof })
     }
+
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid proof version"));
+        }
+        // Read the proof.
+        let proof = FromBytes::read_le_unchecked(&mut reader)?;
+        // Return the proof.
+        Ok(Self { proof })
+    }
 }
 
 impl<N: Network> ToBytes for Proof<N> {

--- a/synthesizer/snark/src/proof/serialize.rs
+++ b/synthesizer/snark/src/proof/serialize.rs
@@ -30,7 +30,7 @@ impl<'de, N: Network> Deserialize<'de> for Proof<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "proof"),
+            false => FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "proof"),
         }
     }
 }

--- a/synthesizer/snark/src/verifying_key/bytes.rs
+++ b/synthesizer/snark/src/verifying_key/bytes.rs
@@ -31,6 +31,21 @@ impl<N: Network> FromBytes for VerifyingKey<N> {
         // Return the verifying key.
         Ok(Self { verifying_key, num_variables })
     }
+
+    fn read_le_unchecked<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the version.
+        let version = u8::read_le(&mut reader)?;
+        // Ensure the version is valid.
+        if version != 1 {
+            return Err(error("Invalid verifying key version"));
+        }
+        // Read the verifying key.
+        let verifying_key = Arc::new(FromBytes::read_le_unchecked(&mut reader)?);
+        // Read the number of variables.
+        let num_variables = u64::read_le(&mut reader)?;
+        // Return the verifying key.
+        Ok(Self { verifying_key, num_variables })
+    }
 }
 
 impl<N: Network> ToBytes for VerifyingKey<N> {

--- a/synthesizer/snark/src/verifying_key/serialize.rs
+++ b/synthesizer/snark/src/verifying_key/serialize.rs
@@ -30,7 +30,9 @@ impl<'de, N: Network> Deserialize<'de> for VerifyingKey<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         match deserializer.is_human_readable() {
             true => FromStr::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom),
-            false => FromBytesDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "verifying key"),
+            false => {
+                FromBytesUncheckedDeserializer::<Self>::deserialize_with_size_encoding(deserializer, "verifying key")
+            }
         }
     }
 }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ProvableHQ/snarkVM/pull/3030 building on its findings, but can be handled individually.

These changes are very similar to those from https://github.com/ProvableHQ/snarkVM/pull/2789, and may improve block retrieval performance even further.

Below are the figures for the loading of a modestly-sized (413'697 blocks) local ledger:
```
before: 2.90s
after:  2.55s (down 12%)
```

I'd expect the impact of these changes to be similar with larger ledgers.