### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/sync-snarkvm-documentation.yml
+++ b/.github/workflows/sync-snarkvm-documentation.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Fetch branch name
         run: echo Running on branch ${GITHUB_REF#refs/heads/}

--- a/.github/workflows/sync-snarkvm-to-welcome-documentation.yml
+++ b/.github/workflows/sync-snarkvm-to-welcome-documentation.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Fetch branch name
         run: echo Running on branch ${GITHUB_REF#refs/heads/}


### PR DESCRIPTION
Routine update of checkout action to the latest stable version (v6).

https://github.com/actions/checkout/releases/tag/v6.0.0