### PR TITLE
Fixed `mint_and_split.aleo` test

### DIFF
--- a/synthesizer/tests/expectations/vm/execute_and_finalize/mint_and_split.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/mint_and_split.out
@@ -9,7 +9,14 @@ outputs:
   add_next_block: succeeded.
 - execute: Commitment '1266307482263846358970326041806201638141701138269282465033372005968041137990field' does not exist
 - execute: Input record for 'mint_and_split.aleo' must belong to the signer
-- execute: Commitment '5664701406562067552828344114098303767897965604026128467062564698122653063423field' does not exist
+- verified: true
+  execute:
+    mint_and_split.aleo/split:
+      outputs:
+      - '{"type":"record","id":"5711723459005820981975862871140952223873534572260023215726411264627797857125field","checksum":"7426836894154832978065174041780401502920907623365044077441298261049696843678field","value":"record1qvqsphj7awr9axkuj67nrc3yfd0lrfyh9pkf5fj74ad3hq8c3v64qwsyqyxx66trwfhkxun9v35hguerqqpqzqq32rg970t2glcjzyeyp3yqxqu6gjf5yjrdhq94jje6v0dfvtrsp5r8gen52205vxwtkcdtlmvav72m7m8d9cymnk3th3e0yfney6tqkq6jfes","sender_ciphertext":"5992012307728800570843571958867469829169633066634794745646494503342494952580field"}'
+      - '{"type":"record","id":"2213487432824001390431408830043269590784753533496623567500878503662933507215field","checksum":"2692323425225928138743508637728544125794817366053668719849166035510149473559field","value":"record1qvqsq3re3gefcu5sqe6gshqfhhqm502cwyxhjn56xv207pnjxrsj5wstqyxx66trwfhkxun9v35hguerqqpqzqz72umqq4kh6l549trzq0cavr34tjugjsnq8s6qxkmvye8pp7qjztjaa33nme8m0jzu2n9q25y5ymf6xmhu2e7gzh5um3g6szq90rysqlsrj4w","sender_ciphertext":"6265020822528923584308281396445892775724890664798206670322396687381779785825field"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
 additional:
 - child_outputs:
     credits.aleo/fee_public:

--- a/synthesizer/tests/tests/vm/execute_and_finalize/mint_and_split.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/mint_and_split.aleo
@@ -17,7 +17,7 @@ cases:
     private_key: APrivateKey1zkpJhviKDvvm7yu7SZuhSudVR7zjCRG2HznuAHwuGYc1xqN
   - program: mint_and_split.aleo
     function: split
-    inputs: [ "{ owner: aleo1j2hfs6yru47h2nvsjdefwtw6nwaj0y4zcl02juyy29txm7nt6y9qln7uhp.private, microcredits: 100u64.private, _nonce: 4745749250363947745807119124444606639539806979883854068889616498365610280135group.public, _version: 1u8.public }", 50u64]
+    inputs: [ "{ owner: aleo1j2hfs6yru47h2nvsjdefwtw6nwaj0y4zcl02juyy29txm7nt6y9qln7uhp.private, microcredits: 100u64.private, _nonce: 8328661033496413191179695268319516441428135407695959353783510885778770196235group.public, _version: 1u8.public }", 50u64]
     private_key: APrivateKey1zkpFbGDx4znwxo1zrxfUscfGn1Vy3My3ia5gRHx3XwaLtCR
 */
 


### PR DESCRIPTION
As far as I can tell, this is the only test in `test_vm_execute_and_finalize` which involves inclusion proofs (it consumes a record). One reason this is relevant is testing fee estimation, which involves proof sizes and therefore should also be tested on batch proofs that include inclusion proofs.

The test case which consumes a record was added in https://github.com/ProvableHQ/snarkVM/commit/d394f44de5a7ff23091867ea0b7308959c9f2a04 and was broken soon after. Here broken means that the transaction consuming the record now failed, but since expectations were regenerated (here: https://github.com/ProvableHQ/snarkVM/commit/fd6191d072adbeeb89b076645be4f3897b771d87), the test still passes.

In this commit, I updated the record to actually be consumed again, as well as the expectation.

For the future, we can think of a way to ensure this transaction actually consumes a record (which doesn't get overwritten by regenerated expectations; so perhaps hardcoded at the test-function level); or let it be and assume future updates may mean there are no tests involving inclusion proofs in that file.

