### PR TITLE
[Feat] Facilitate record queries

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -168,6 +168,9 @@ workspace = true
 [dependencies.rayon]
 workspace = true
 
+[dependencies.serde]
+workspace = true
+
 [dependencies.time]
 workspace = true
 

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -382,15 +382,15 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns a tuple containing the number of all the input records and all the output records.
-    pub fn get_record_count(&self) -> (usize, usize) {
+    pub fn get_record_count(&self) -> RecordCount {
         let transition_store = self.vm.block_store().transition_store();
         let num_input_records = transition_store.input_store().record_map().len_confirmed();
         let num_output_records = transition_store.output_store().record_map().len_confirmed();
-        (num_input_records, num_output_records)
+        RecordCount { input: num_input_records, output: num_output_records }
     }
 
     /// Returns the list of input and output records applicable to the given block height.
-    pub fn get_num_block_records(&self, height: u32) -> Result<(usize, usize)> {
+    pub fn get_num_block_records(&self, height: u32) -> Result<RecordCount> {
         let block_store = self.vm.block_store();
         let block_hash = match block_store.get_block_hash(height)? {
             Some(block_hash) => block_hash,
@@ -463,6 +463,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
         }
 
-        Ok((num_input_records, num_output_records))
+        Ok(RecordCount { input: num_input_records, output: num_output_records })
     }
+}
+
+/// An object representing the number of input and output records.
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize, serde::Serialize)]
+pub struct RecordCount {
+    pub input: usize,
+    pub output: usize,
 }

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -378,4 +378,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             _ => bail!("Invalid bond_state in finalize storage."),
         }
     }
+
+    /// Returns a tuple containing the number of all the input records and all the output records.
+    pub fn get_record_count(&self) -> (usize, usize) {
+        let transition_store = self.vm.block_store().transition_store();
+        let num_input_records = transition_store.input_store().record_map().len_confirmed();
+        let num_output_records = transition_store.output_store().record_map().len_confirmed();
+        (num_input_records, num_output_records)
+    }
 }

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use crate::store::TransactionType;
+
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the committee for the given `block height`.
     pub fn get_committee(&self, block_height: u32) -> Result<Option<Committee<N>>> {
@@ -385,5 +387,82 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let num_input_records = transition_store.input_store().record_map().len_confirmed();
         let num_output_records = transition_store.output_store().record_map().len_confirmed();
         (num_input_records, num_output_records)
+    }
+
+    /// Returns the list of input and output records applicable to the given block height.
+    pub fn get_num_block_records(&self, height: u32) -> Result<(usize, usize)> {
+        let block_store = self.vm.block_store();
+        let block_hash = match block_store.get_block_hash(height)? {
+            Some(block_hash) => block_hash,
+            None => bail!("Block {height} does not exist in storage"),
+        };
+
+        let Some(block_transaction_ids) = block_store.transactions_map().get_confirmed(&block_hash)? else {
+            return Ok(Default::default());
+        };
+
+        let transaction_store = block_store.transaction_store();
+        let mut transaction_ids_with_type = Vec::with_capacity(block_transaction_ids.len());
+        for tx_id in block_transaction_ids.iter() {
+            let Some(tx_ty) = transaction_store.id_map().get_confirmed(tx_id)? else {
+                bail!("Missing type for transaction {tx_id}");
+            };
+            transaction_ids_with_type.push((*tx_id, tx_ty));
+        }
+
+        let transition_store = transaction_store.transition_store();
+        let execution_store = transaction_store.execution_store();
+        let fee_store = transaction_store.fee_store();
+        let input_store = transition_store.input_store();
+        let output_store = transition_store.output_store();
+
+        let mut num_input_records = 0usize;
+        let mut num_output_records = 0usize;
+
+        let mut process_transition_ids = |transition_ids: &[N::TransitionID]| -> Result<()> {
+            for transition_id in transition_ids {
+                let input_ids = transition_store.get_input_ids(transition_id)?;
+                let output_ids = transition_store.get_output_ids(transition_id)?;
+
+                for id in input_ids {
+                    if input_store.record_map().contains_key_confirmed(&id)? {
+                        num_input_records += 1;
+                    }
+                }
+                for id in output_ids {
+                    if output_store.record_map().contains_key_confirmed(&id)? {
+                        num_output_records += 1;
+                    }
+                }
+            }
+
+            Ok(())
+        };
+
+        for (tx_id, tx_ty) in transaction_ids_with_type {
+            match *tx_ty {
+                TransactionType::Deploy => {
+                    continue;
+                }
+                TransactionType::Execute => {
+                    let Some(transition_ids_w_fee) = execution_store.id_map().get_confirmed(&tx_id)? else {
+                        continue;
+                    };
+                    let (transition_ids, _fee) = &*transition_ids_w_fee;
+
+                    process_transition_ids(transition_ids)?;
+                }
+                TransactionType::Fee => {
+                    let Some(transition_id_w_root_and_proof) = fee_store.fee_map().get_confirmed(&tx_id)? else {
+                        continue;
+                    };
+                    let (transition_id, _root, _proof) = &*transition_id_w_root_and_proof;
+
+                    process_transition_ids(&[*transition_id])?;
+                }
+            }
+        }
+
+        Ok((num_input_records, num_output_records))
     }
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -60,7 +60,7 @@ use snarkvm_ledger_committee::Committee;
 use snarkvm_ledger_narwhal::{BatchCertificate, Subdag, Transmission, TransmissionID};
 use snarkvm_ledger_puzzle::{Puzzle, PuzzleSolutions, Solution, SolutionID};
 use snarkvm_ledger_query::QueryTrait;
-use snarkvm_ledger_store::{ConsensusStorage, ConsensusStore};
+use snarkvm_ledger_store::{ConsensusStorage, ConsensusStore, helpers::MapRead};
 use snarkvm_synthesizer::{
     program::{FinalizeGlobalState, Program},
     vm::VM,

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1204,6 +1204,11 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     pub fn backup_database<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), String> {
         self.storage.backup_database(path)
     }
+
+    /// Returns a reference to the transactions map.
+    pub fn transactions_map(&self) -> &B::TransactionsMap {
+        self.storage.transactions_map()
+    }
 }
 
 impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -736,6 +736,11 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
     pub fn storage_mode(&self) -> &StorageMode {
         self.storage.storage_mode()
     }
+
+    /// Returns a reference to the program map.
+    pub fn program_map(&self) -> &D::ProgramMap {
+        self.storage.program_map()
+    }
 }
 
 impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {

--- a/ledger/store/src/transaction/execution.rs
+++ b/ledger/store/src/transaction/execution.rs
@@ -355,6 +355,11 @@ impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {
     pub fn storage_mode(&self) -> &StorageMode {
         self.storage.storage_mode()
     }
+
+    /// Returns a reference to the ID map.
+    pub fn id_map(&self) -> &E::IDMap {
+        self.storage.id_map()
+    }
 }
 
 impl<N: Network, E: ExecutionStorage<N>> ExecutionStore<N, E> {

--- a/ledger/store/src/transaction/fee.rs
+++ b/ledger/store/src/transaction/fee.rs
@@ -236,6 +236,11 @@ impl<N: Network, F: FeeStorage<N>> FeeStore<N, F> {
     pub fn storage_mode(&self) -> &StorageMode {
         self.storage.storage_mode()
     }
+
+    /// Returns a reference to the fee map.
+    pub fn fee_map(&self) -> &F::FeeMap {
+        self.storage.fee_map()
+    }
 }
 
 impl<N: Network, F: FeeStorage<N>> FeeStore<N, F> {

--- a/ledger/store/src/transaction/mod.rs
+++ b/ledger/store/src/transaction/mod.rs
@@ -321,6 +321,21 @@ impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {
     pub fn storage_mode(&self) -> &StorageMode {
         self.storage.storage_mode()
     }
+
+    /// Returns a reference to the transaction ID map.
+    pub fn id_map(&self) -> &T::IDMap {
+        self.storage.id_map()
+    }
+
+    /// Returns a reference to the execution store.
+    pub fn execution_store(&self) -> &ExecutionStore<N, T::ExecutionStorage> {
+        self.storage.execution_store()
+    }
+
+    /// Returns a reference to the fee store.
+    pub fn fee_store(&self) -> &FeeStore<N, T::FeeStorage> {
+        self.storage.fee_store()
+    }
 }
 
 impl<N: Network, T: TransactionStorage<N>> TransactionStore<N, T> {

--- a/ledger/store/src/transition/input.rs
+++ b/ledger/store/src/transition/input.rs
@@ -384,6 +384,11 @@ impl<N: Network, I: InputStorage<N>> InputStore<N, I> {
     pub fn storage_mode(&self) -> &StorageMode {
         self.storage.storage_mode()
     }
+
+    /// Returns a reference to the map of the records.
+    pub fn record_map(&self) -> &I::RecordMap {
+        &self.record
+    }
 }
 
 impl<N: Network, I: InputStorage<N>> InputStore<N, I> {

--- a/ledger/store/src/transition/mod.rs
+++ b/ledger/store/src/transition/mod.rs
@@ -370,6 +370,16 @@ impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {
     pub fn storage_mode(&self) -> &StorageMode {
         self.storage.storage_mode()
     }
+
+    /// Returns a reference to the input store.
+    pub fn input_store(&self) -> &InputStore<N, T::InputStorage> {
+        &self.inputs
+    }
+
+    /// Returns a reference to the output store.
+    pub fn output_store(&self) -> &OutputStore<N, T::OutputStorage> {
+        &self.outputs
+    }
 }
 
 impl<N: Network, T: TransitionStorage<N>> TransitionStore<N, T> {

--- a/ledger/store/src/transition/output.rs
+++ b/ledger/store/src/transition/output.rs
@@ -439,6 +439,11 @@ impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {
     pub fn storage_mode(&self) -> &StorageMode {
         self.storage.storage_mode()
     }
+
+    /// Returns a reference to the map of the records.
+    pub fn record_map(&self) -> &O::RecordMap {
+        &self.record
+    }
 }
 
 impl<N: Network, O: OutputStorage<N>> OutputStore<N, O> {


### PR DESCRIPTION
This PR introduces 2 new methods, `Ledger::{get_record_count, get_num_block_records}`, and a few helper "getter" methods that they require to work.

A snarkOS-side counterpart PR will follow.