### PR TITLE
Add Semgrep to the CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,29 @@ commands:
             - target
           key: cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
 
+  run_semgrep:
+    description: "Run Semgrep static analysis"
+    steps:
+      - checkout
+      - run:
+          name: Install Semgrep
+          command: |
+            set -euo pipefail
+
+            python3 -m pip install --user semgrep
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+      - run:
+          name: Run Semgrep (Rust + YAML/TOML + Markdown + Shell + JSON)
+          command: |
+            set -euo pipefail
+            semgrep \
+              --config semgrep-rules/rust.yml \
+              --config semgrep-rules/yaml-toml.yml \
+              --config semgrep-rules/markdown.yml \
+              --config semgrep-rules/shell.yml \
+              --config semgrep-rules/json.yml \
+              --error .
+
   setup_environment:
     description: "Setup testing environment"
     parameters:
@@ -1151,6 +1174,12 @@ jobs:
       - check_windows:
           workspace_member: << parameters.workspace_member >>
 
+  semgrep-scan:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.small >>
+    steps:
+      - run_semgrep
+
 workflows:
   version: 2
 
@@ -1162,6 +1191,7 @@ workflows:
       - check-cargo-audit
       - check-cargo-semver-checks
       - check-all-targets
+      - semgrep-scan
 
   circuit-workflow:
     jobs:

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+target/
+**/target/
+.git/

--- a/semgrep-rules/json.yml
+++ b/semgrep-rules/json.yml
@@ -1,0 +1,25 @@
+rules:
+  ###############################################
+  # JSON RULES (*.json)
+  ###############################################
+
+  - id: json-merge-conflict
+    message: >
+      Merge conflict markers detected in JSON.
+    languages: [json]
+    severity: ERROR
+    pattern-regex: '^(<<<<<<< |>>>>>>> )'
+    paths:
+      include:
+        - "**/*.json"
+
+  - id: json-suspect-secrets
+    message: >
+      Possible secret-like value in JSON. Verify it should be committed.
+    languages: [json]
+    severity: WARNING
+    pattern-regex: '(?i)(api[_-]?key|secret|token|password)"\s*:\s*"[A-Za-z0-9/+]{20,}"'
+    paths:
+      include:
+        - "**/*.json"
+

--- a/semgrep-rules/markdown.yml
+++ b/semgrep-rules/markdown.yml
@@ -1,0 +1,25 @@
+rules:
+  ###############################################
+  # MARKDOWN RULES (*.md via generic language)
+  ###############################################
+
+  - id: md-merge-conflict
+    message: >
+      Merge conflict markers detected in Markdown.
+    languages: [generic]
+    severity: ERROR
+    # Only match real Git markers, not Markdown underlines.
+    pattern-regex: '^(<<<<<<< |>>>>>>> )'
+    paths:
+      include:
+        - "**/*.md"
+
+  - id: md-suspect-secrets
+    message: >
+      Possible secret-like value in Markdown. Verify it should be committed.
+    languages: [generic]
+    severity: WARNING
+    pattern-regex: '(?i)(api[_-]?key|secret|token|password)[^ \t\n]{0,20}[:=]\s*["''][A-Za-z0-9/+]{20,}["'']?'
+    paths:
+      include:
+        - "**/*.md"

--- a/semgrep-rules/rust.yml
+++ b/semgrep-rules/rust.yml
@@ -1,0 +1,73 @@
+rules:
+  # We can add unimplemented! and unreachable!, todo! or other similar if we decide
+  #- id: rust-no-todo
+  #  message: >
+  #    Avoid todo!/unimplemented!/unreachable! in non-test code.
+  #    Prefer Result/Option-based error handling.
+  #  languages: [rust]
+  #  severity: ERROR
+  #  pattern-regex: '\b(todo!|unimplemented!|unreachable!)\s*\('
+  #  paths:
+  #    exclude:
+  #      - "tests/**"
+  #      - "**/tests/**"
+  #      - "benches/**"
+  #      - "examples/**"
+
+  # We can use that if we decide to remove println! from src code as a rule
+  #- id: rust-no-println-dbg
+  #  message: >
+  #    Avoid println!/eprintln!/dbg! in library or production code.
+  #    Use structured logging (e.g. tracing::info!/debug!) instead.
+  #  languages: [rust]
+  #  severity: WARNING
+  #  pattern-regex: '\b(println!|eprintln!|dbg!)\s*\('
+  #  paths:
+  #    exclude:
+  #      - "tests/**"
+  #      - "**/tests/**"
+  #      - "benches/**"
+  #      - "examples/**"
+
+  - id: rust-unsafe-block
+    message: >
+      Unsafe block detected. Make sure this is carefully audited and justified.
+    languages: [rust]
+    severity: WARNING
+    pattern: |
+      unsafe { $BODY }
+    paths:
+      exclude:
+        - "tests/**"
+        - "**/tests/**"
+        - "benches/**"
+        - "examples/**"
+        - "algorithms/**"
+
+  - id: rust-unsafe-fn
+    message: >
+      Unsafe function definition detected. Document invariants and audit call sites.
+    languages: [rust]
+    severity: WARNING
+    pattern-regex: '\bunsafe\s+fn\b'
+    paths:
+      exclude:
+        - "tests/**"
+        - "**/tests/**"
+        - "benches/**"
+        - "examples/**"
+        - "algorithms/**"
+
+  - id: rust-no-transmute
+    message: >
+      std::mem::transmute is highly unsafe. Prefer safer abstractions or well-reviewed wrappers.
+    languages: [rust]
+    severity: ERROR
+    pattern: std::mem::transmute($EXPR)
+    paths:
+      exclude:
+        - "tests/**"
+        - "**/tests/**"
+        - "benches/**"
+        - "examples/**"
+

--- a/semgrep-rules/shell.yml
+++ b/semgrep-rules/shell.yml
@@ -1,0 +1,55 @@
+rules:
+  ###############################################
+  # SHELL / BASH RULES (*.sh)
+  ###############################################
+
+  - id: sh-curl-pipe-sh
+    message: >
+      Piping curl output directly to sh/bash is dangerous. Download, verify, then execute.
+    languages: [bash]
+    severity: ERROR
+    pattern-regex: 'curl[^|]+\|\s*(sh|bash)\b'
+    paths:
+      include:
+        - "**/*.sh"
+
+  - id: sh-wget-pipe-sh
+    message: >
+      Piping wget output directly to sh/bash is dangerous. Download, verify, then execute.
+    languages: [bash]
+    severity: ERROR
+    pattern-regex: 'wget[^|]+\|\s*(sh|bash)\b'
+    paths:
+      include:
+        - "**/*.sh"
+
+  - id: sh-no-sudo
+    message: >
+      Avoid using sudo in reusable scripts. Prefer running the script with the right user/permissions.
+    languages: [bash]
+    severity: WARNING
+    pattern-regex: '\bsudo\b'
+    paths:
+      include:
+        - "**/*.sh"
+
+  - id: sh-merge-conflict
+    message: >
+      Merge conflict markers detected in shell script.
+    languages: [bash]
+    severity: ERROR
+    pattern-regex: '^(<<<<<<< |>>>>>>> )'
+    paths:
+      include:
+        - "**/*.sh"
+
+  - id: sh-suspect-secrets
+    message: >
+      Possible secret in shell script. Verify it should be committed.
+    languages: [bash]
+    severity: WARNING
+    pattern-regex: '(?i)(api[_-]?key|secret|token|password)[^=]{0,20}=\s*["''][A-Za-z0-9/+]{20,}["'']'
+    paths:
+      include:
+        - "**/*.sh"
+

--- a/semgrep-rules/yaml-toml.yml
+++ b/semgrep-rules/yaml-toml.yml
@@ -1,0 +1,71 @@
+rules:
+
+  ###############################################
+  # YAML RULES
+  ###############################################
+
+  - id: yaml-no-tabs
+    message: >
+      YAML file contains tabs. Use spaces — tabs break many parsers.
+    languages: [yaml]
+    severity: ERROR
+    pattern-regex: '\t'
+
+  - id: yaml-suspect-secrets
+    message: >
+      Possible secret key in YAML. Verify it should be committed.
+    languages: [yaml]
+    severity: WARNING
+    pattern-regex: '(?i)(api[_-]?key|secret|token|password|private[_-]?key)\s*:\s*["'']?[A-Za-z0-9]{16,}'
+
+  - id: yaml-merge-conflict
+    message: >
+      Merge conflict markers detected in YAML.
+    languages: [yaml]
+    severity: ERROR
+    pattern-regex: '^(<<<<<|=====|>>>>>)'
+
+
+  ###############################################
+  # "TOML" RULES
+  ###############################################
+
+  - id: toml-forbid-wildcard-deps
+    message: >
+      Avoid wildcard dependency versions like "*". Use explicit semver constraints.
+    languages: [generic]
+    severity: ERROR
+    pattern-regex: 'version\s*=\s*["'']\*["'']'
+    paths:
+      include:
+        - "**/*.toml"
+
+  - id: toml-suspect-secrets
+    message: >
+      Possible secret-like value in TOML. Verify it should be committed.
+    languages: [generic]
+    severity: WARNING
+    pattern-regex: '(?i)(api[_-]?key|secret|token|password|private[_-]?key)\s*=\s*["''][A-Za-z0-9]{16,}["'']'
+    paths:
+      include:
+        - "**/*.toml"
+
+  - id: toml-merge-conflict
+    message: >
+      Merge conflict markers detected in TOML.
+    languages: [generic]
+    severity: ERROR
+    pattern-regex: '^(<<<<<|=====|>>>>>)'
+    paths:
+      include:
+        - "**/*.toml"
+
+  - id: toml-empty-feature
+    message: >
+      Feature declared with an empty array. Check if this was intended.
+    languages: [generic]
+    severity: INFO
+    pattern-regex: 'features\s*=\s*\{[^}]*[A-Za-z0-9_\-]+\s*=\s*\[\s*\][^}]*\}'
+    paths:
+      include:
+        - "**/Cargo.toml"


### PR DESCRIPTION
## Motivation

Following https://github.com/ProvableHQ/snarkVM/issues/2983 we are testing some of the tools suggested there and Semgrep seems to makes sense for additional analysis of the files.

This PR adds it and also a set of custom rules to be applied by it.

## Test Plan

The CI passes the new workflow.

## Documentation

The tool semgrep is a fast static analysis tool that scans source code and configuration files using simple rule-based patterns, regexes mainly. Unlike compiler-level tools, it works purely on the structure of files, which makes it extremely quick (4-5s with the custom rules in this PR)

It is good for enforcing project-specific conventions.

It adds the following:

Additional safety layer on top of Clippy and tests.
Semgrep catches patterns that the Rust compiler and Clippy don’t cover - such as forbidden unwrap(), panic!, println!, unsafe patterns, and other conventions we choose to enforce. 

It doesn’t just analyze Rust code: Semgrep also inspects YAML, TOML, Markdown, JSON, and shell scripts, which allows us to detect issues in CI configs, Cargo metadata, documentation, and helper scripts.

Semgrep reliably flags leftover <<<<<<< HEAD / >>>>>>> branch markers in all supported file types, preventing accidental commits of broken files. In source files the CI breaks but in some markdown or config files it may pass and break runtime (for the JSON, toml, yaml).

It allows custom repository-specific rules.
